### PR TITLE
Blitz add full decoder

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -4086,8 +4086,6 @@ class AttentionBlock:
                 ccl_receiver_group = kernel_result.get_group_by_arg("is_ccl_receiver_core", 1)
 
                 sender_brisc_kernel_idx = ccl_sender_group.brisc_kernel_index
-                sender_ncrisc_kernel_idx = ccl_sender_group.ncrisc_kernel_index
-                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
 
                 ccl_sender_ncrisc_rt_args_ref = program.kernels[ccl_sender_group.ncrisc_kernel_index].runtime_args[
                     ccl_sender_core.x
@@ -4117,11 +4115,6 @@ class AttentionBlock:
                     ccl_sender_core,
                 )
                 extend_fabric_args(sender_brisc_rt_args_ref, sender_fabric_args)
-
-                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
-                receiver_ncrisc_rt_args_ref = program.kernels[receiver_ncrisc_kernel_idx].runtime_args[gather_core.x][
-                    gather_core.y
-                ]
 
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
 

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -209,7 +209,7 @@ class AttentionBlock:
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
         position_ids_tensor,
-        scale,
+        sdpa_scale,
         output_tensor,
         sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer,
@@ -230,7 +230,6 @@ class AttentionBlock:
         bcast_secondary_cluster_axis=1,
         reduce_cluster_axis=1,
         sdpa_cluster_axis=0,
-        sdpa_scale_fp32=1.0,
         num_links=1,
         epsilon=1e-6,
         fp32_dest_acc_en=False,
@@ -693,10 +692,7 @@ class AttentionBlock:
         sdpa_bwd_r1_sem_id = 10
         sdpa_bwd_r2_sem_id = 11
 
-        # Convert scale to FP32 bits
-        import struct
-
-        sdpa_scale_fp32_bits = struct.unpack(">I", struct.pack(">f", sdpa_scale_fp32))[0]
+        sdpa_scale_fp32_bits = float_to_uint32(sdpa_scale)
 
         # ========================================================================
         # Matmul4 parameters: [1, 512] x [512, 128] -> [1, 128]
@@ -1660,7 +1656,7 @@ class AttentionBlock:
             ("k_chunk_size", k_chunk_size),
             ("num_cores_per_head", num_cores_per_head),
             ("q_heads_parallel_factor", B),
-            ("scale_fp32", float_to_uint32(scale)),
+            ("scale_fp32", sdpa_scale_fp32_bits),
             ("num_tree_reduction_steps", optimized_mla_grid.NUM_TREE_REDUCTION_STEPS),
             ("dst_size", mla_dst_size),
             ("mla_q_in_cb", mla_q_in_cb),
@@ -3857,7 +3853,7 @@ class AttentionBlock:
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
         position_ids_tensor,
-        scale,
+        sdpa_scale,
         output_tensor,
         sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer,
@@ -3878,7 +3874,6 @@ class AttentionBlock:
         bcast_secondary_cluster_axis=1,
         reduce_cluster_axis=1,
         sdpa_cluster_axis=0,
-        sdpa_scale_fp32=1.0,
         num_links=1,
         epsilon=1e-6,
         fp32_dest_acc_en=False,
@@ -3905,7 +3900,7 @@ class AttentionBlock:
             dkv_rmsnorm_gamma_tensor,
             kv_cache_tensor,
             position_ids_tensor,
-            scale,
+            sdpa_scale,
             output_tensor,
             sdpa_kv_cache_buffer,
             sdpa_out_interm_buffer,
@@ -3926,7 +3921,6 @@ class AttentionBlock:
             bcast_secondary_cluster_axis,
             reduce_cluster_axis,
             sdpa_cluster_axis,
-            sdpa_scale_fp32,
             num_links,
             epsilon,
             fp32_dest_acc_en,

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -1701,7 +1701,8 @@ void kernel_main() {
             using GateMMCTArgs = deepseek_b1_ops::Matmul::ComputeCTArgs<
                 get_named_compile_time_arg_val("gate_mm_out_w"),
                 false,  // transpose
-                get_named_compile_time_arg_val("gate_mm_fused_activation")>;
+                get_named_compile_time_arg_val("gate_mm_fused_activation"),
+                get_named_compile_time_arg_val("gate_mm_fused_activation_approx_mode")>;
             deepseek_b1_ops::Matmul::ComputeArgs gate_mm_args{
                 get_named_compile_time_arg_val("gate_mm_in0"),
                 get_named_compile_time_arg_val("gate_mm_in1"),

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -1,0 +1,2740 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Pre-SDPA unified kernel
+// Single kernel file, compiles correctly for all RISC cores
+// Each RISC has its own CTArgs struct with different compile-time arg layout
+//
+// Implements: CCL Broadcast + RMSNorm + Mcast + Matmul + Gather + RMSNorm2 + Mcast2 + Matmul2 + Matmul3 + RoPE +
+// CreateQHeads
+// - NCRISC: CCL Broadcast Reader + RMSNorm reader + Mcast receiver (on matmul cores), Matmul reader + Gather sender (on
+// matmul cores),
+//           RMSNorm2 reader + Mcast2 receiver (on matmul2 cores), Matmul2 reader (on matmul2 cores),
+//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores), CreateQHeads sender (on qnope/qrope cores)
+// - BRISC: CCL Broadcast Writer + RMSNorm writer + Mcast sender (on input core), Matmul writer (on matmul cores),
+// Gather receiver (on
+//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores),
+//          CreateQHeads receiver (on sdpa input cores) - matching gather pattern: NCRISC sender, BRISC receiver
+// - TRISC: RMSNorm compute (on input core), Matmul compute (on matmul cores), RMSNorm2 compute (on input core),
+//          Matmul2 compute (on matmul2 cores), Matmul3 compute (on qnope cores), RoPE compute (on qrope cores)
+//
+// Matmul2 output uses interleaved Qnope/Qrope layout (with shuffled weights):
+// - Grid: 12 cols × 8 rows = 96 cores (P150)
+// - Qnope cores (cols 0-7): 64 cores, 1 head × 128 elements per core
+// - Qrope cores (cols 8-11): 32 cores, 2 heads × 64 elements per core
+// - Each row: [Qnope heads 0-7 (1024)] [Qrope heads 0-7 (512)] = 1536 elements
+// - Total: 8 rows × 1536 = 12288 elements
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/rmsnorm.hpp"
+#include "../../../unified_kernels/mcast.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/gather_reduce.hpp"
+#include "../../../unified_kernels/kn_sliced_matmul.hpp"
+#include "../../../unified_kernels/create_q_heads.hpp"
+#include "../../../unified_kernels/rope.hpp"
+#include "../../../unified_kernels/broadcast.hpp"
+#include "../../../unified_kernels/kv_cache_update.hpp"
+#include "../../../unified_kernels/flash_mla.hpp"
+#include "../../../micro_ops/flash_mla/kernels/rt_args_common.hpp"
+
+#include "../../../unified_kernels/sdpa_reduce_worker.hpp"
+#include "../../../unified_kernels/sdpa_reduce_forwarder.hpp"
+#include "../../../unified_kernels/all_reduce_sender.hpp"
+#include "../../../unified_kernels/all_reduce_receiver.hpp"
+
+#include "../../../unified_kernels/moe_gather.hpp"
+#include "../../../unified_kernels/deepseek_moe_gate.hpp"
+#if defined(COMPILE_FOR_TRISC)
+#undef REDUCE_OP
+#undef REDUCE_DIM
+#endif
+#include "../../../unified_kernels/dram_streaming_matmul.hpp"
+#include "../../../unified_kernels/eltwise_mul.hpp"
+#include "../../../unified_kernels/eltwise_add.hpp"
+#include "../../../unified_kernels/gated_reduce.hpp"
+#include "../../../unified_kernels/residual_add.hpp"
+#ifdef ENABLE_REDUCE_TO_ONE
+#include "../../../unified_kernels/reduce_to_one_b1.hpp"
+#endif
+
+// Compile-time role flags for dead code elimination via if constexpr
+// Defined at namespace scope (local classes cannot have static data members)
+struct Core {
+    static constexpr bool is_input_core = get_named_compile_time_arg_val("is_input_core") == 1;
+    static constexpr bool is_full_mcast_grid_core = get_named_compile_time_arg_val("is_full_mcast_grid_core") == 1;
+    static constexpr bool is_matmul_core = get_named_compile_time_arg_val("is_matmul_core") == 1;
+    static constexpr bool is_matmul2_core = get_named_compile_time_arg_val("is_matmul2_core") == 1;
+    // Qnope/Qrope core differentiation for interleaved Q head layout after matmul2
+    // Qnope cores: 64 cores (8x8 grid), each handles 1 head of 128 elements
+    // Qrope cores: 32 cores (4x8 grid), each handles 2 heads of 64 elements
+    static constexpr bool is_qnope_core = get_named_compile_time_arg_val("is_qnope_core") == 1;
+    static constexpr bool is_qrope_core = get_named_compile_time_arg_val("is_qrope_core") == 1;
+    // SDPA Input core: receives interleaved QNOPE/QROPE, runs create q heads (4×2 grid = 8 cores)
+    static constexpr bool is_sdpa_input_core = get_named_compile_time_arg_val("is_sdpa_input_core") == 1;
+
+    // DKV Matmul core: 9x2 grid, each core handles 1 head of 32 dim
+    static constexpr bool is_dkv_matmul_core = get_named_compile_time_arg_val("is_dkv_matmul_core") == 1;
+    static constexpr bool is_kv_rmsnorm_core = get_named_compile_time_arg_val("is_kv_rmsnorm_core") == 1;
+    static constexpr bool is_knope_core = get_named_compile_time_arg_val("is_knope_core") == 1;
+    static constexpr bool is_krope_core = get_named_compile_time_arg_val("is_krope_core") == 1;
+    static constexpr bool skip_ccl = get_named_compile_time_arg_val("skip_ccl") == 1;
+
+    // MLA
+    static constexpr bool is_mla_core = get_named_compile_time_arg_val("is_mla_core") == 1;
+
+    // Sequence Parallel configs
+    static constexpr uint32_t kv_cache_device_chunk_size = get_named_compile_time_arg_val("kv_cache_device_chunk_size");
+    static constexpr uint32_t kv_cache_sp_device_idx = get_named_compile_time_arg_val("kv_cache_sp_device_idx");
+    static constexpr uint32_t kv_cache_num_sp_devices = get_named_compile_time_arg_val("kv_cache_num_sp_devices");
+
+    // Post SDPA
+    // SDPA output cores 8 cores - run SDPA reduction and scatter
+    static constexpr bool is_sdpa_worker_core = get_named_compile_time_arg_val("is_sdpa_worker_core") == 1;
+    // SDPA forwarder cores (6,9), (7,9) = 2 cores - forward fabric packets for SDPA CCL
+    static constexpr bool is_sdpa_forwarder_core = get_named_compile_time_arg_val("is_sdpa_forwarder_core") == 1;
+
+    // First matmul on kv_b2 grid (5x8 + 12x2 = 64 cores) - receives scatter data from SDPA workers
+    static constexpr bool is_matmul4_core = get_named_compile_time_arg_val("is_matmul4_core") == 1;
+    // Gather core (12, 9) - receives gather2, sends mcast3, receives gather3, CCL receiver
+    static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    // Active matmul5 cores (112 cores: o_proj grid 12x8 + 8x2)
+    static constexpr bool is_matmul5_core = get_named_compile_time_arg_val("is_matmul5_core") == 1;
+    // CCL sender core (11, 9) - reads from gather core, sends via fabric
+    static constexpr bool is_ccl_sender_core = get_named_compile_time_arg_val("is_ccl_sender_core") == 1;
+    // CCL receiver core = gather core (12, 9) - receives remote data, performs reduction
+    static constexpr bool is_ccl_receiver_core = get_named_compile_time_arg_val("is_ccl_receiver_core") == 1;
+
+    // MoE core roles
+    static constexpr bool is_sender_core = get_named_compile_time_arg_val("is_sender_core") == 1;
+    static constexpr bool is_mcast_grid_core = get_named_compile_time_arg_val("is_mcast_grid_core") == 1;
+
+    struct Routed {
+        static constexpr bool is_gate_mm_core = get_named_compile_time_arg_val("is_gate_mm_core") == 1;
+        static constexpr bool is_gate_proj_core = get_named_compile_time_arg_val("is_gate_proj_core") == 1;
+    };
+    struct Shared {
+        static constexpr bool is_compute_core = get_named_compile_time_arg_val("is_shared_compute_core") == 1;
+        static constexpr bool is_gate_compute_core = get_named_compile_time_arg_val("is_shared_gate_compute_core") == 1;
+        static constexpr bool is_up_compute_core = get_named_compile_time_arg_val("is_shared_up_compute_core") == 1;
+        static constexpr bool is_gated_reduce_core = get_named_compile_time_arg_val("is_shared_gated_reduce_core") == 1;
+        static constexpr bool is_mcast_receiver_core =
+            get_named_compile_time_arg_val("is_shared_mcast_receiver_core") == 1;
+    };
+    static constexpr bool is_input_mcast_receiver =
+        Routed::is_gate_mm_core || Routed::is_gate_proj_core || Shared::is_compute_core;
+
+    static constexpr bool is_reduce_worker_core = get_named_compile_time_arg_val("is_reduce_worker_core") == 1;
+    static constexpr bool is_reduce_fabric_core = get_named_compile_time_arg_val("is_reduce_fabric_core") == 1;
+};
+
+void kernel_main() {
+    // ============================================================================
+    // NCRISC (Reader + Mcast Receiver) - ReaderConfigDescriptor compiles as NCRISC
+    // Named compile-time args: rmsnorm reader, mcast receiver, matmul reader, gather sender
+    // Runtime args: []
+    // ============================================================================
+    constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
+    constexpr uint32_t mla_cb_config_l1_addr = get_named_compile_time_arg_val("mla_reconfig_cb_config_l1_addr");
+    uint32_t tt_l1_ptr* mla_cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(mla_cb_config_l1_addr);
+    constexpr uint32_t moe_cb_config_l1_addr = get_named_compile_time_arg_val("moe_reconfig_cb_config_l1_addr");
+    uint32_t tt_l1_ptr* moe_cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(moe_cb_config_l1_addr);
+    // This is needed at the start because mcast is getting the cb ptrs for src/dst addresses
+    unified_kernels::reconfig_cb_interfaces(mla_cb_config);
+
+    uint32_t per_core_rta_arg_idx = 0;
+#if defined(COMPILE_FOR_NCRISC)
+    // CTArgs type aliases (required for Op templates)
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
+    using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
+    using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+
+    // RMSNorm reader runtime args
+    deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
+
+    // Mcast receiver args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast_dst_cb"),
+        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    };
+
+    // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
+    using MatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    using Matmul2CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    using Matmul3CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+
+    // Matmul reader args (NCRISC is no-op)
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul_args{};
+
+    // Gather sender args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::GatherReduce::SenderArgs gather_reduce_args{
+        get_named_compile_time_arg_val("gather_reduce_dest_noc_x"),
+        get_named_compile_time_arg_val("gather_reduce_dest_noc_y"),
+        get_named_compile_time_arg_val("gather_reduce_data_size_bytes"),
+        get_named_compile_time_arg_val("gather_reduce_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("gather_reduce_src_cb"),
+        get_named_compile_time_arg_val("gather_reduce_src_num_pages"),
+        get_named_compile_time_arg_val("gather_reduce_grid_start_x"),
+        get_named_compile_time_arg_val("gather_reduce_grid_start_y"),
+        get_named_compile_time_arg_val("gather_reduce_grid_end_x"),
+        get_named_compile_time_arg_val("gather_reduce_grid_end_y"),
+        get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
+    };
+
+    // RMSNorm2 reader args
+    deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm2_args{};
+
+    // Matmul2 reader args (NCRISC is no-op)
+    deepseek_b1_ops::Matmul::ReaderArgs matmul2_args{};
+
+    // Mcast2 receiver args (for matmul2 cores to receive matmul2 input from input core)
+    // Uses same semaphore as first mcast
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("matmul2_in0"),
+        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    };
+
+    // Matmul3 reader args (NCRISC is no-op)
+    deepseek_b1_ops::Matmul::ReaderArgs matmul3_args{};
+
+    // Qrope CTArgs type alias (NCRISC uses ReaderCTArgs)
+    using QRopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<
+        get_named_compile_time_arg_val("qrope_Wt"),
+        get_named_compile_time_arg_val("qrope_Ht"),
+        get_named_compile_time_arg_val("qrope_cos_sin_page_size"),
+        get_named_compile_time_arg_val("qrope_total_Wt"),
+        get_named_compile_time_arg_val("qrope_start_tile_offset")>;
+
+    deepseek_b1_ops::Rope::ReaderArgs qrope_args{
+        .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
+        .cos_tensor_address = get_named_compile_time_arg_val("qrope_cos_tensor_address"),
+        .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
+        .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
+    };
+
+    // NCRISC: Sender args for QNOPE/QROPE cores
+    // Senders write to intermediate CB, then compute tilizes to output CB
+    // 3-phase synchronization: nope_phase1, nope_phase2, rope semaphores
+    constexpr uint32_t cqh_receiver_in_cb = get_named_compile_time_arg_val("cqh_receiver_in_cb");
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+        get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
+        get_named_compile_time_arg_val("cqh_qrope_head_size_bytes")>;
+    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
+        0,  // sender_grid_start_x (logical 0)
+        0,  // sender_grid_start_y (logical 0)
+        get_named_compile_time_arg_val("cqh_head_stride_bytes"),
+        get_named_compile_time_arg_val("cqh_qnope_cols"),
+        get_named_compile_time_arg_val("cqh_qnope_src_cb"),
+        get_named_compile_time_arg_val("cqh_qrope_src_cb"),
+        Core::is_qnope_core ? get_named_compile_time_arg_val("cqh_qnope_src_num_pages")
+                            : get_named_compile_time_arg_val("cqh_qrope_src_num_pages"),
+        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
+        {
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row0"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row1"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row2"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row3"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row4"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row5"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row6"),
+            get_named_compile_time_arg_val("cqh_target_noc_coords_row7"),
+        },
+        get_write_ptr(cqh_receiver_in_cb),
+    };
+
+    // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+
+    // Matmul reader args (NCRISC is no-op)
+    deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
+
+    // Gather sender args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("dkv_gather_src_cb"),
+        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("dkv_gather_row_major"),
+        get_write_ptr(get_named_compile_time_arg_val(
+            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    };
+
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
+    // kv cache rmsnorm reader args
+    deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{};
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<
+        get_named_compile_time_arg_val("krope_Wt"),
+        get_named_compile_time_arg_val("krope_Ht"),
+        get_named_compile_time_arg_val("krope_cos_sin_page_size"),
+        get_named_compile_time_arg_val("krope_total_Wt"),
+        get_named_compile_time_arg_val("krope_start_tile_offset")>;
+
+    deepseek_b1_ops::Rope::ReaderArgs krope_args{
+        .in_cb = get_named_compile_time_arg_val("krope_in_cb"),
+        .cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb"),
+        .cos_tensor_address = get_named_compile_time_arg_val("krope_cos_tensor_address"),
+        .sin_tensor_address = get_named_compile_time_arg_val("krope_sin_tensor_address"),
+        .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
+    };
+
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
+
+    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
+    if constexpr (Core::is_mla_core) {
+        flash_mla_args = {
+            .k_addr = get_common_arg_val<uint32_t>(13),
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
+            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .St = get_named_compile_time_arg_val("St"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
+            .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
+            .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
+            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
+            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
+            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_semaphore_addr =
+                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
+            .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+        };
+    }
+
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
+
+    // Matmul4 CTArgs
+    using Matmul4CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul4_args{};
+
+    // Gather2 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
+    // via gather2_sender_idx, avoiding gaps from the non-rectangular kv_b2 grid)
+    deepseek_b1_ops::Gather::SenderArgs gather2_args{
+        get_named_compile_time_arg_val("gather2_dest_noc_x"),
+        get_named_compile_time_arg_val("gather2_dest_noc_y"),
+        get_named_compile_time_arg_val("gather2_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather2_src_cb"),
+        get_named_compile_time_arg_val("gather2_src_num_pages"),
+        get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather2_row_major"),
+        get_common_arg_val<uint32_t>(15),  // gather2_receiver_data_addr
+        get_named_compile_time_arg_val("gather2_sender_idx"),
+    };
+
+    // Mcast3 receiver args
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast3_args{
+        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+        get_named_compile_time_arg_val("mcast3_dst_cb"),
+        get_named_compile_time_arg_val("mcast3_dst_num_pages"),
+    };
+
+    // Matmul5 CTArgs
+    using Matmul5CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul5_args{};
+
+    // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
+    // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
+    deepseek_b1_ops::Gather::SenderArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_dest_noc_x"),
+        get_named_compile_time_arg_val("gather3_dest_noc_y"),
+        get_named_compile_time_arg_val("gather3_data_size_bytes"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_src_cb"),
+        get_named_compile_time_arg_val("gather3_src_num_pages"),
+        get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather3_row_major"),
+        get_common_arg_val<uint32_t>(16),  // gather3_receiver_data_addr
+        get_named_compile_time_arg_val("gather3_sender_idx"),
+    };
+
+    // ========================================================================o
+    // All CCLs are placed after other ops setup due to appended fabric rtas
+    // ========================================================================
+    // CCL Broadcast CTArgs type alias
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
+        get_named_compile_time_arg_val("bcast_cb0_id"),
+        get_named_compile_time_arg_val("bcast_num_pages_to_read"),
+        get_named_compile_time_arg_val("bcast_tensor0_page_size"),
+        get_named_compile_time_arg_val("bcast_num_targets_forward_direction"),
+        get_named_compile_time_arg_val("bcast_num_targets_backward_direction"),
+        get_named_compile_time_arg_val("bcast_is_sender"),
+        get_named_compile_time_arg_val("bcast_core_noc_x"),
+        get_named_compile_time_arg_val("bcast_core_noc_y"),
+        get_named_compile_time_arg_val("bcast_is_secondary_sender"),
+        get_named_compile_time_arg_val("bcast_has_secondary_target"),
+        get_named_compile_time_arg_val("bcast_start_distance_in_hops_forward"),
+        get_named_compile_time_arg_val("bcast_range_hops_forward"),
+        get_named_compile_time_arg_val("bcast_start_distance_in_hops_backward"),
+        get_named_compile_time_arg_val("bcast_range_hops_backward")>;
+
+    deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
+
+    if constexpr (!Core::skip_ccl && Core::is_input_core) {
+        uint32_t offset_fabric_args = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
+            get_common_arg_val<uint32_t>(0),   // tensor_address0
+            get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
+            get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
+            get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
+            get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
+            get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
+            get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
+            get_common_arg_val<uint32_t>(7),   // barrier_sem
+            get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
+            get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
+            get_common_arg_val<uint32_t>(10),  // ring_index
+            get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
+            get_common_arg_val<uint32_t>(12),  // num_connections (computed from len(dst_nodes))
+            per_core_rta_arg_idx,
+        };
+        per_core_rta_arg_idx += offset_fabric_args;
+    }
+
+    using SdpaReduceWorkerCTArgs = deepseek_b1_ops::SdpaReduceWorker::ReaderCTArgs<
+        get_named_compile_time_arg_val("sdpa_cb_local_l"),
+        get_named_compile_time_arg_val("sdpa_cb_local_ms"),
+        get_named_compile_time_arg_val("sdpa_cb_neighbor_l"),
+        get_named_compile_time_arg_val("sdpa_cb_neighbor_ms"),
+        get_named_compile_time_arg_val("sdpa_ms_tile_size_bytes"),
+        get_named_compile_time_arg_val("sdpa_l_chunk_size_bytes"),
+        get_named_compile_time_arg_val("sdpa_num_l_chunks"),
+        get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
+        get_named_compile_time_arg_val("sdpa_position_enabled"),
+        get_named_compile_time_arg_val("sdpa_per_device_chunk_size")>;
+
+    deepseek_b1_ops::SdpaReduceWorker::ReaderArgs sdpa_reduce_worker_args;
+    if constexpr (Core::is_sdpa_worker_core) {
+        sdpa_reduce_worker_args = {
+            .r1_neighbor_sem_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_neighbor_sem_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_recv_buffer_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_recv_buffer_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+        };
+        if constexpr (SdpaReduceWorkerCTArgs::position_enabled) {
+            sdpa_reduce_worker_args.pos_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+            sdpa_reduce_worker_args.r1_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+            sdpa_reduce_worker_args.r2_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+            sdpa_reduce_worker_args.r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        }
+    }
+
+    using SdpaReduceForwarderCTArgs = deepseek_b1_ops::SdpaReduceForwarder::CTArgs<
+        get_named_compile_time_arg_val("sdpa_fwd_slots_per_round"),
+        get_named_compile_time_arg_val("sdpa_fwd_slot_size"),
+        get_named_compile_time_arg_val("sdpa_fwd_r2_buffer_offset")>;
+
+    deepseek_b1_ops::SdpaReduceForwarder::ForwarderArgs sdpa_reduce_forwarder_args;
+    if constexpr (Core::is_sdpa_forwarder_core) {
+        sdpa_reduce_forwarder_args = {
+            .buffer_base = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .buffer_offset = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+            .r2_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+        };
+        uint32_t fabric_args_offset = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_forwarder_args.rta_offset = per_core_rta_arg_idx;
+        per_core_rta_arg_idx += fabric_args_offset;
+    }
+
+    // CCL Sender NCRISC CTArgs (reads from gather core)
+    using CCLSenderReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<
+        get_named_compile_time_arg_val("ccl_sender_cb0_id"),
+        get_named_compile_time_arg_val("ccl_sender_num_tiles"),
+        get_named_compile_time_arg_val("ccl_sender_tensor_page_size"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_y")>;
+
+    // CCL Receiver NCRISC CTArgs (waits for remote data)
+    // Note: skip_local_push=1 because gather3 already pushed to CB7 (gather3_dst_cb)
+    using CCLReceiverReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<
+        get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_in2"),
+        get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_x"),
+        get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_y"),
+        get_named_compile_time_arg_val("ccl_receiver_num_standard_tiles"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_has_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_skip_local_push")>;
+
+    deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
+    deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
+
+    if constexpr (Core::is_ccl_sender_core) {
+        ccl_sender_args = {
+            .tensor_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+        };
+    }
+
+    if constexpr (Core::is_ccl_receiver_core) {
+        ccl_receiver_args = {
+            .sender_semaphore_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+        };
+    }
+// ============================================================================
+// BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
+// Named compile-time args: bcast writer + rmsnorm writer, mcast sender, matmul writer, gather receiver
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+
+    // CTArgs type aliases (required for Op templates)
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+    using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;  // BRISC is no-op
+    using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid"),
+        Core::is_input_core && Core::is_full_mcast_grid_core>;  // loopback = false
+
+    // RMSNorm writer args (BRISC is no-op)
+    deepseek_b1_ops::RMSNorm::WriterArgs rmsnorm_args{};
+
+    // RMSNorm2 writer args (BRISC is no-op)
+    deepseek_b1_ops::RMSNorm::WriterArgs rmsnorm2_args{};
+
+    // Mcast CB indices from named compile-time args
+    constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+    constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
+
+    // Mcast sender args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast_data_size_bytes"),
+        mcast_src_cb,
+        get_named_compile_time_arg_val("mcast_src_num_pages"),
+        get_read_ptr(mcast_src_cb),
+        get_write_ptr(mcast_dst_cb),
+    };
+
+    // Matmul CTArgs type alias (BRISC uses WriterCTArgs)
+    using MatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+    using Matmul2CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    using Matmul3CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+
+    // Matmul writer args (BRISC is no-op)
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul_args{};
+
+    // Gather receiver args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::GatherReduce::ReceiverArgs gather_reduce_args{
+        get_named_compile_time_arg_val("gather_reduce_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather_reduce_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather_reduce_noc0_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
+    };
+
+    // BRISC: Receiver args for SDPA input cores
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
+    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
+        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_num_nope_senders"),
+        get_named_compile_time_arg_val("cqh_num_rope_senders"),
+        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
+        get_named_compile_time_arg_val("cqh_out_cb"),
+        get_named_compile_time_arg_val("cqh_nope_tiles"),
+        get_named_compile_time_arg_val("cqh_rope_tiles"),
+    };
+
+    // Matmul2 writer args (BRISC is no-op)
+    deepseek_b1_ops::Matmul::WriterArgs matmul2_args{};
+
+    // Matmul2 CB indices and parameters from named compile-time args
+    constexpr uint32_t matmul2_in0 = get_named_compile_time_arg_val("matmul2_in0");
+
+    // Matmul3 writer args (BRISC is no-op)
+    deepseek_b1_ops::Matmul::WriterArgs matmul3_args{};
+
+    // Qrope CTArgs type alias (BRISC uses WriterCTArgs, no-op)
+    using QRopeCTArgs = deepseek_b1_ops::Rope::WriterCTArgs;
+
+    // Qrope writer args (BRISC is no-op)
+    deepseek_b1_ops::Rope::WriterArgs qrope_args{};
+
+    // Mcast2 sender args (for input core to mcast rmsnorm2 output to all matmul2 cores)
+    // Uses same grid and semaphores as first mcast
+    // Reads from rmsnorm2_output_cb, writes to matmul2_in0 with loopback
+    constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("rmsnorm2_output_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+        mcast2_src_cb,  // Wait for rmsnorm2_output_cb
+        get_named_compile_time_arg_val("mcast2_src_num_pages"),
+        get_read_ptr(mcast2_src_cb),  // Read from rmsnorm2_output_cb
+        get_write_ptr(matmul2_in0),   // Write to matmul2_in0 (loopback)
+    };
+
+    // Matmul writer args (BRISC is no-op)
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
+
+    // Gather receiver args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    };
+
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+    deepseek_b1_ops::RMSNorm::WriterArgs kv_rmsnorm_args{};
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::WriterCTArgs;
+
+    // Writer args (empty - no-op)
+    deepseek_b1_ops::Rope::WriterArgs krope_args{};
+
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
+        .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
+        .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+        .kv_cache_cur_pos_ready_semaphore_addr =
+            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+    };
+
+    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
+    if constexpr (Core::is_mla_core) {
+        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
+        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
+        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
+
+        flash_mla_args = {
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
+            .cur_batch = cur_batch,
+            .core_num_in_reduce = core_num_in_reduce,
+            .is_output_core = is_output_core,
+            .is_mcast_sender = is_mcast_sender,
+            .output_core_noc_x = output_core_noc_x,
+            .output_core_noc_y = output_core_noc_y,
+            .mcast_start_x = mcast_start_x,
+            .mcast_start_y = mcast_start_y,
+            .mcast_end_x = mcast_end_x,
+            .mcast_end_y = mcast_end_y,
+            .tree_reduction_info = tree_reduction_info,
+            .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
+            .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
+            .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
+            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
+            .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
+            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
+            .num_tree_reduction_steps = num_tree_reduction_steps,
+            .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
+            .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
+            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
+            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
+            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
+            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
+        };
+    }
+
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
+        get_named_compile_time_arg_val("k_page_size"),
+        get_named_compile_time_arg_val("vDHt"),
+        get_named_compile_time_arg_val("mla_out_o_cb")>;
+
+    // Matmul4/2 CTArgs (BRISC is no-op for matmul)
+    using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    using Matmul5CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs matmul4_args{};
+    deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
+
+    // Gather2 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs gather2_args{
+        get_named_compile_time_arg_val("gather2_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather2_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather2_dst_cb"),
+        get_named_compile_time_arg_val("gather2_dst_num_pages"),
+    };
+
+    // Mcast3 sender args
+    constexpr uint32_t mcast3_src_cb = get_named_compile_time_arg_val("mcast3_src_cb");
+    constexpr uint32_t mcast3_dst_cb = get_named_compile_time_arg_val("mcast3_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast3_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),
+        get_semaphore(get_named_compile_time_arg_val("mcast3_data_receiver_semaphore")),
+        get_named_compile_time_arg_val("mcast3_data_size_bytes"),
+        mcast3_src_cb,
+        get_named_compile_time_arg_val("mcast3_src_num_pages"),
+        get_read_ptr(mcast3_src_cb),
+        get_write_ptr(mcast3_dst_cb),  // CB 4 address (now allocated on gather core too)
+    };
+
+    // Gather3 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs gather3_args{
+        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+        get_named_compile_time_arg_val("gather3_dst_cb"),
+        get_named_compile_time_arg_val("gather3_dst_num_pages"),
+    };
+
+    // ========================================================================o
+    // All CCLs are placed after other ops setup due to appended fabric rtas
+    // ========================================================================
+    // CCL Broadcast CTArgs type alias
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
+        get_named_compile_time_arg_val("bcast_cb0_id"),
+        get_named_compile_time_arg_val("bcast_num_pages_to_read"),
+        get_named_compile_time_arg_val("bcast_is_sender"),
+        get_named_compile_time_arg_val("bcast_use_socket")>;
+
+    // CCL Broadcast reader runtime args (only populated when not skip_ccl)
+    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
+
+    if constexpr (!Core::skip_ccl) {
+        bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{
+            get_named_compile_time_arg_val("bcast_socket_config_addr"),  // socket_config_addr
+            get_named_compile_time_arg_val("bcast_socket_page_size"),    // socket_page_size
+            get_named_compile_time_arg_val("bcast_socket_num_pages"),    // socket_num_pages
+        };
+    }
+
+    using SdpaReduceWorkerCTArgs = deepseek_b1_ops::SdpaReduceWorker::WriterCTArgs<
+        get_named_compile_time_arg_val("sdpa_cb_local_l"),
+        get_named_compile_time_arg_val("sdpa_cb_local_ms"),
+        get_named_compile_time_arg_val("sdpa_cb_r1_result_l"),
+        get_named_compile_time_arg_val("sdpa_cb_r1_result_ms"),
+        get_named_compile_time_arg_val("sdpa_l1_alignment"),
+        get_named_compile_time_arg_val("sdpa_page_size_bytes"),
+        get_named_compile_time_arg_val("sdpa_slot_size"),
+        get_named_compile_time_arg_val("sdpa_ms_tile_size_bytes"),
+        get_named_compile_time_arg_val("sdpa_l_chunk_size_bytes"),
+        get_named_compile_time_arg_val("sdpa_num_l_chunks"),
+        get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
+        get_named_compile_time_arg_val("sdpa_cb_l_out"),
+        get_named_compile_time_arg_val("sdpa_scatter_num_tiles"),
+        get_named_compile_time_arg_val("sdpa_scatter_src_tile_size"),
+        get_named_compile_time_arg_val("sdpa_scatter_dst_tile_size"),
+        get_named_compile_time_arg_val("sdpa_scatter_face_size"),
+        get_named_compile_time_arg_val("sdpa_scatter_row_face_size"),
+        get_named_compile_time_arg_val("sdpa_scatter_num_rows"),
+        1>;  // scatter_arrival_enabled=1 (signal matmul4 cores after each scatter row)
+
+    deepseek_b1_ops::SdpaReduceWorker::WriterArgs sdpa_reduce_worker_args;
+    if constexpr (Core::is_sdpa_worker_core) {
+        sdpa_reduce_worker_args = {
+            .r1_dst_mesh_id = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_dst_chip_id = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_neighbor_dst_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_neighbor_sem_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_dst_mesh_id = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_dst_chip_id = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_neighbor_dst_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_neighbor_sem_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .current_core_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .current_core_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .fwd_core_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .fwd_core_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_fwd_slot_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_fwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+            .r1_base_slot_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_fwd_slot_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r2_fwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+            .r2_base_slot_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .scatter_dest_l1_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .scatter_dest_coords_addr = get_arg_addr(per_core_rta_arg_idx),
+            // scatter_arrival_enabled=1, so we need to pass the semaphore address
+            .scatter_arrival_sem_addr = get_semaphore(get_named_compile_time_arg_val("scatter_arrival_semaphore_id")),
+        };
+        per_core_rta_arg_idx += SdpaReduceWorkerCTArgs::scatter_num_rows * 2;  // x, y value per dest
+    }
+
+    using SdpaReduceForwarderCTArgs = deepseek_b1_ops::SdpaReduceForwarder::CTArgs<
+        get_named_compile_time_arg_val("sdpa_fwd_slots_per_round"),
+        get_named_compile_time_arg_val("sdpa_fwd_slot_size"),
+        get_named_compile_time_arg_val("sdpa_fwd_r2_buffer_offset")>;
+
+    deepseek_b1_ops::SdpaReduceForwarder::ForwarderArgs sdpa_reduce_forwarder_args;
+    if constexpr (Core::is_sdpa_forwarder_core) {
+        sdpa_reduce_forwarder_args = {
+            .buffer_base = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .buffer_offset = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .r1_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+            .r2_sem_addr = get_semaphore(get_arg_val<uint32_t>(per_core_rta_arg_idx++)),
+        };
+        uint32_t fabric_args_offset = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_forwarder_args.rta_offset = per_core_rta_arg_idx;
+        per_core_rta_arg_idx += fabric_args_offset;
+    }
+
+    // CCL Sender BRISC CTArgs (sends via fabric)
+    using CCLSenderWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<
+        get_named_compile_time_arg_val("ccl_sender_packet_cb_id"),
+        get_named_compile_time_arg_val("ccl_sender_input_num_tiles"),
+        get_named_compile_time_arg_val("ccl_sender_page_size_bytes"),
+        get_named_compile_time_arg_val("ccl_sender_payload_size_bytes"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_y"),
+        get_named_compile_time_arg_val("ccl_sender_remote_receiver_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_remote_receiver_noc_y"),
+        get_named_compile_time_arg_val("ccl_sender_dst_num_hops"),
+        get_named_compile_time_arg_val("ccl_sender_num_connections")>;
+
+    deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
+    if constexpr (Core::is_ccl_sender_core) {
+        ccl_sender_args = {
+            .receiver_base_address = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .receive_semaphore_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+        };
+        uint32_t fabric_args_offset = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        ccl_sender_args.fabric_args_start_index = per_core_rta_arg_idx;
+        per_core_rta_arg_idx += fabric_args_offset;
+    }
+
+// ============================================================================
+// TRISC (Compute) - ComputeConfigDescriptor compiles as TRISC
+// Named compile-time args: rmsnorm compute, matmul compute
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    // CTArgs type aliases (required for Op templates)
+
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("rmsnorm_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("rmsnorm_output_cb")>;
+    using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("rmsnorm2_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("rmsnorm2_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm2_gamma_cb"),
+        get_named_compile_time_arg_val("rmsnorm2_output_cb")>;
+    using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+
+    // RMSNorm compute runtime args
+    deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+        get_common_arg_val<uint32_t>(0),   // epsilon
+        get_common_arg_val<float>(1),      // scalar (1/sqrt(7168))
+        get_common_arg_val<uint32_t>(15),  // rmsnorm_gamma_addr
+    };
+
+    // Mcast compute args (no-op for TRISC)
+    deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+    // Matmul CTArgs type alias (out_w is compile-time for TRISC)
+    const auto matmul_half_info = unified_kernels::get_split_half_core_info<true>(
+        get_named_compile_time_arg_val("matmul_grid_start_x"),
+        get_named_compile_time_arg_val("matmul_grid_start_y"),
+        get_named_compile_time_arg_val("matmul_grid_end_x"),
+        get_named_compile_time_arg_val("matmul_grid_end_y"),
+        get_named_compile_time_arg_val("matmul_half_num_cores"));
+    constexpr uint32_t matmul_k_offset_half1 = get_named_compile_time_arg_val("matmul_k_offset_half1");
+    uint32_t k_offset = matmul_half_info.is_half0 ? 0 : matmul_k_offset_half1;
+
+    using MatmulCTArgs =
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul_out_w_per_core")>;
+
+    // Matmul compute args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul_args{
+        get_named_compile_time_arg_val("matmul_in0"),
+        get_named_compile_time_arg_val("matmul_in1"),
+        get_named_compile_time_arg_val("matmul_out"),
+        k_offset,
+        get_named_compile_time_arg_val("matmul_k_per_core"),
+        get_named_compile_time_arg_val("matmul_act_total_tiles"),
+        get_common_arg_val<uint32_t>(8),  // matmul_weights_addr
+    };
+
+    // Gather reduce compute args
+    deepseek_b1_ops::GatherReduce::ComputeArgs gather_reduce_args{
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_out_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
+    };
+
+    // RMSNorm2 compute args (separate CBs with exact sizes for testing)
+    deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
+        get_common_arg_val<uint32_t>(0),   // epsilon (same as rmsnorm1)
+        get_common_arg_val<float>(2),      // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(16),  // rmsnorm2_gamma_addr
+    };
+
+    // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)
+    using Matmul2CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul2_out_w_per_core")>;
+
+    // Matmul2 compute args (from compile-time args)
+    deepseek_b1_ops::Matmul::ComputeArgs matmul2_args{
+        get_named_compile_time_arg_val("matmul2_in0"),
+        get_named_compile_time_arg_val("matmul2_in1"),
+        get_named_compile_time_arg_val("matmul2_out"),
+        get_named_compile_time_arg_val("matmul2_k_num_tiles"),
+        get_common_arg_val<uint32_t>(9),  // matmul2_weights_addr
+    };
+
+    // Mcast2 compute args (no-op for TRISC)
+    deepseek_b1_ops::Mcast::ComputeArgs mcast2_args{};
+
+    // Matmul3 CTArgs type alias (out_w is compile-time for TRISC)
+    using Matmul3CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul3_out_w_per_core")>;
+
+    // Matmul3 compute args (from compile-time args)
+    deepseek_b1_ops::Matmul::ComputeArgs matmul3_args{
+        get_named_compile_time_arg_val("matmul3_in0"),
+        get_named_compile_time_arg_val("matmul3_in1"),
+        get_named_compile_time_arg_val("matmul3_out"),
+        get_named_compile_time_arg_val("matmul3_k_num_tiles"),
+        get_common_arg_val<uint32_t>(11),  // matmul3_weights_addr
+    };
+
+    // Qrope CTArgs type alias
+    using QRopeCTArgs = deepseek_b1_ops::Rope::
+        ComputeCTArgs<get_named_compile_time_arg_val("qrope_Wt"), get_named_compile_time_arg_val("qrope_Ht")>;
+
+    // Qrope compute args (from compile-time args)
+    deepseek_b1_ops::Rope::ComputeArgs qrope_args{
+        get_named_compile_time_arg_val("qrope_in_cb"),  // Input from matmul2 output
+        get_named_compile_time_arg_val("qkv_rope_cos_sin_cb"),
+        get_named_compile_time_arg_val("qrope_trans_mat_cb"),
+        get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
+        get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
+        get_named_compile_time_arg_val("qrope_output_cb"),
+        get_common_arg_val<uint32_t>(14),  // qrope_trans_mat_addr
+    };
+
+    // CreateQHeads compute args (tilization on SDPA input cores)
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
+    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
+        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
+        get_named_compile_time_arg_val("cqh_out_cb"),
+        get_named_compile_time_arg_val("cqh_nope_tiles"),
+        get_named_compile_time_arg_val("cqh_rope_tiles"),
+    };
+
+    // DKV Matmul compute args
+    using DKV_MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("dkv_matmul_out_w_per_core")>;
+
+    // DKV Matmul compute args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Matmul::ComputeArgs dkv_matmul_args{
+        get_named_compile_time_arg_val("dkv_matmul_in0"),
+        get_named_compile_time_arg_val("dkv_matmul_in1"),
+        get_named_compile_time_arg_val("dkv_matmul_out"),
+        get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
+        get_common_arg_val<uint32_t>(10),  // dkv_matmul_weights_addr
+    };
+
+    // Gather compute args (no-op for TRISC)
+    deepseek_b1_ops::Gather::ComputeArgs dkv_gather_args{};
+
+    // CTArgs type aliases (required for Op templates)
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_output_cb")>;
+
+    // RMSNorm compute runtime args
+    deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
+        get_common_arg_val<uint32_t>(0),   // epsilon
+        get_common_arg_val<float>(3),      // kv_scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(17),  // kv_rmsnorm_gamma_addr
+    };
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::
+        ComputeCTArgs<get_named_compile_time_arg_val("krope_Wt"), get_named_compile_time_arg_val("krope_Ht")>;
+
+    // CB indices (passed as runtime args to ComputeArgs)
+    constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
+    constexpr uint32_t krope_cos_sin_cb = get_named_compile_time_arg_val("krope_cos_sin_cb");
+    constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
+    constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
+    constexpr uint32_t krope_cos_sin_interm_cb = get_named_compile_time_arg_val("krope_cos_sin_interm_cb");
+    constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
+
+    // Compute args: all CB indices
+    deepseek_b1_ops::Rope::ComputeArgs krope_args{
+        .in_cb = krope_input_cb,
+        .cos_sin_cb = krope_cos_sin_cb,
+        .trans_mat_cb = krope_trans_mat_cb,
+        .rotated_in_interm_cb = krope_rotated_in_interm_cb,
+        .cos_sin_interm_cb = krope_cos_sin_interm_cb,
+        .out_cb = krope_output_cb,
+        .trans_mat_address_override = get_common_arg_val<uint32_t>(14),
+    };
+
+    deepseek_b1_ops::KVCacheUpdate::ComputeArgs kv_cache_update_args{
+        .kv_cache_input_cb = get_common_arg_val<uint32_t>(4),
+        .kv_cache_output_cb = get_common_arg_val<uint32_t>(5),
+        .kv_cache_intermed_cb = get_common_arg_val<uint32_t>(6),
+    };
+    deepseek_b1_ops::FlashMLADecode::ComputeArgs flash_mla_args;
+    if constexpr (Core::is_mla_core) {
+        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
+        uint32_t do_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t do_output = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_sender_after_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
+        per_core_rta_arg_idx += num_tree_reduction_steps * 2;
+
+        flash_mla_args = {
+            .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
+            .do_reduce = do_reduce,
+            .do_output = do_output,
+            .cur_batch = cur_batch,
+            .core_num_in_reduce = core_num_in_reduce,
+            .is_sender_after_reduce = is_sender_after_reduce,
+            .tree_reduction_info = tree_reduction_info,
+            .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .num_tree_reduction_steps = num_tree_reduction_steps,
+        };
+    }
+
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ComputeCTArgs<
+        get_named_compile_time_arg_val("mla_q_in_cb"),
+        get_named_compile_time_arg_val("mla_k_in_cb"),
+        get_named_compile_time_arg_val("mla_mask_cb"),
+        get_named_compile_time_arg_val("mla_interm_out_cb"),
+        get_named_compile_time_arg_val("mla_interm_ms_cb"),
+        get_named_compile_time_arg_val("mla_out_in_cb"),
+        get_named_compile_time_arg_val("mla_ms_in_cb"),
+        get_named_compile_time_arg_val("mla_out_o_cb"),
+        get_named_compile_time_arg_val("mla_out_ms_cb"),
+        get_named_compile_time_arg_val("mla_out_final_cb")>;
+
+    // Matmul4 CTArgs
+    using Matmul4CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul4_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul4_args{
+        get_named_compile_time_arg_val("matmul4_in0"),
+        get_named_compile_time_arg_val("matmul4_in1"),
+        get_named_compile_time_arg_val("matmul4_out"),
+        get_named_compile_time_arg_val("matmul4_k_num_tiles"),
+        get_common_arg_val<uint32_t>(12),  // matmul4_weights_addr
+    };
+
+    // Gather2 compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs gather2_args{};
+
+    // Mcast3 CTArgs (no-op)
+    deepseek_b1_ops::Mcast::ComputeArgs mcast3_args{};
+
+    // Matmul5 CTArgs
+    using Matmul5CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul5_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul5_args{
+        get_named_compile_time_arg_val("matmul5_in0"),
+        get_named_compile_time_arg_val("matmul5_in1"),
+        get_named_compile_time_arg_val("matmul5_out"),
+        get_named_compile_time_arg_val("matmul5_k_num_tiles"),
+        get_common_arg_val<uint32_t>(13),  // matmul5_weights_addr
+    };
+
+    // Gather3 compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs gather3_args{};
+
+    // CCL Broadcast CTArgs (no-op for TRISC)
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::ComputeCTArgs;
+    deepseek_b1_ops::Broadcast::ComputeArgs bcast_args{};
+
+    using SdpaReduceWorkerCTArgs = deepseek_b1_ops::SdpaReduceWorker::ComputeCTArgs<
+        get_named_compile_time_arg_val("sdpa_cb_local_l"),
+        get_named_compile_time_arg_val("sdpa_cb_local_ms"),
+        get_named_compile_time_arg_val("sdpa_cb_neighbor_l"),
+        get_named_compile_time_arg_val("sdpa_cb_neighbor_ms"),
+        get_named_compile_time_arg_val("sdpa_cb_r1_result_l"),
+        get_named_compile_time_arg_val("sdpa_cb_r1_result_ms"),
+        get_named_compile_time_arg_val("sdpa_cb_l_out"),
+        get_named_compile_time_arg_val("sdpa_scale_fp32"),
+        get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
+        get_named_compile_time_arg_val("sdpa_num_l_chunks"),
+        get_named_compile_time_arg_val("sdpa_position_enabled"),
+        get_named_compile_time_arg_val("sdpa_per_device_chunk_size"),
+        1>;  // final_reduction=1 (always normalize in post_sdpa, untilize constraint)
+    deepseek_b1_ops::SdpaReduceWorker::ComputeArgs sdpa_reduce_worker_args;
+    if constexpr (Core::is_sdpa_worker_core) {
+        sdpa_reduce_worker_args.pos_addr = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.r1_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.r2_neighbor_device_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.swap_r1_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        sdpa_reduce_worker_args.swap_r2_reduction_order = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+    }
+
+    using SdpaReduceForwarderCTArgs = deepseek_b1_ops::SdpaReduceForwarder::CTArgs<0, 0, 0>;
+    deepseek_b1_ops::SdpaReduceForwarder::ForwarderArgs sdpa_reduce_forwarder_args;
+
+    // CCL Receiver compute CTArgs (reduction)
+    using CCLReceiverComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<
+        get_named_compile_time_arg_val("ccl_receiver_cb_in0"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_out0"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_has_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_num_tiles")>;
+
+    deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
+#endif
+
+    // Reconfigure MoE CB interfaces since some args use the cb ptrs
+    unified_kernels::reconfig_cb_interfaces(moe_cb_config);
+
+#if defined(COMPILE_FOR_NCRISC)
+
+    struct Moe {
+        struct Routed {
+            // Mcast (receiver)
+            using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+            deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("moe_mcast_dst_cb"),
+                get_named_compile_time_arg_val("moe_mcast_dst_num_pages"),
+            };
+
+#ifdef ENABLE_ROUTING
+            // Gate Matmul (reader — no-op)
+            using GateMMCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+            deepseek_b1_ops::Matmul::ReaderArgs gate_mm_args{};
+
+            // Gather (receiver — MoeGather: receiver on NCRISC)
+            deepseek_b1_ops::MoeGather::ReceiverArgs gather_args{
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            };
+
+            // Gate (reader — no-op)
+            using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ReaderCTArgs;
+
+            // Index Mcast (receiver)
+            deepseek_b1_ops::Mcast::ReceiverArgs index_mcast_args{
+                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("gate_proj_cb_index"),
+                get_named_compile_time_arg_val("index_mcast_num_pages"),
+            };
+
+            // Expert Scale Mcast (receiver)
+            deepseek_b1_ops::Mcast::ReceiverArgs expert_scale_mcast_args{
+                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("mul_cb_scalar_src"),
+                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+            };
+#endif  // ENABLE_ROUTING
+
+            // gate_proj DRAM Streaming Matmul (reader)
+            using GateProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ReaderCTArgs<
+                get_named_compile_time_arg_val("gate_proj_cb_in1"),
+                get_named_compile_time_arg_val("gate_proj_cb_out"),
+                get_named_compile_time_arg_val("gate_proj_in1_tensor_addr"),
+                get_named_compile_time_arg_val("gate_proj_in1_page_size"),
+                get_named_compile_time_arg_val("gate_proj_in1_num_pages"),
+                get_named_compile_time_arg_val("gate_proj_subblock_k"),
+                get_named_compile_time_arg_val("gate_proj_per_core_n"),
+                get_named_compile_time_arg_val("gate_proj_in1_block_size_bytes"),
+                get_named_compile_time_arg_val("gate_proj_out_num_tiles"),
+                get_named_compile_time_arg_val("gate_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("gate_proj_bank_id"),
+                get_named_compile_time_arg_val("gate_proj_vc"),
+                get_named_compile_time_arg_val("enable_routing"),  // enable_indexing
+                get_named_compile_time_arg_val("gate_proj_cb_index"),
+                get_named_compile_time_arg_val("gate_proj_index_offset"),
+                get_named_compile_time_arg_val("use_hardcoded_expert_index")>;
+
+            // up_proj DRAM Streaming Matmul (reader) — shares CB with gate_proj
+            using UpProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ReaderCTArgs<
+                get_named_compile_time_arg_val("up_proj_cb_in1"),
+                get_named_compile_time_arg_val("up_proj_cb_mm_out"),
+                get_named_compile_time_arg_val("up_proj_in1_tensor_addr"),
+                get_named_compile_time_arg_val("up_proj_in1_page_size"),
+                get_named_compile_time_arg_val("up_proj_in1_num_pages"),
+                get_named_compile_time_arg_val("up_proj_subblock_k"),
+                get_named_compile_time_arg_val("up_proj_per_core_n"),
+                get_named_compile_time_arg_val("up_proj_in1_block_size_bytes"),
+                get_named_compile_time_arg_val("up_proj_out_num_tiles"),
+                get_named_compile_time_arg_val("up_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("up_proj_bank_id"),
+                get_named_compile_time_arg_val("up_proj_vc"),
+                get_named_compile_time_arg_val("enable_routing"),  // enable_indexing
+                get_named_compile_time_arg_val("up_proj_cb_index"),
+                get_named_compile_time_arg_val("up_proj_index_offset"),
+                get_named_compile_time_arg_val("use_hardcoded_expert_index")>;
+
+            // Eltwise Mul (reader — no-op)
+            using MulCTArgs = deepseek_b1_ops::EltwiseMul::ReaderCTArgs;
+
+            // down_proj Gather (receiver — MoeGather: receiver on NCRISC)
+            deepseek_b1_ops::MoeGather::ReceiverArgs down_proj_gather_args{
+                get_named_compile_time_arg_val("down_proj_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("down_proj_gather_noc1_num_senders"),
+                get_named_compile_time_arg_val("down_proj_gather_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("down_proj_gather_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("down_proj_gather_dst_cb"),
+                get_named_compile_time_arg_val("down_proj_gather_dst_num_pages"),
+            };
+
+            // down_proj Mcast (receiver)
+            deepseek_b1_ops::Mcast::ReceiverArgs down_proj_mcast_args{
+                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("down_proj_mcast_dst_cb"),
+                get_named_compile_time_arg_val("down_proj_mcast_dst_num_pages"),
+            };
+
+            // down_proj DRAM Streaming Matmul (reader)
+            using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ReaderCTArgs<
+                get_named_compile_time_arg_val("down_proj_cb_in1"),
+                get_named_compile_time_arg_val("down_proj_cb_out"),
+                get_named_compile_time_arg_val("down_proj_in1_tensor_addr"),
+                get_named_compile_time_arg_val("down_proj_in1_page_size"),
+                get_named_compile_time_arg_val("down_proj_in1_num_pages"),
+                get_named_compile_time_arg_val("down_proj_subblock_k"),
+                get_named_compile_time_arg_val("down_proj_per_core_n"),
+                get_named_compile_time_arg_val("down_proj_in1_block_size_bytes"),
+                get_named_compile_time_arg_val("down_proj_out_num_tiles"),
+                get_named_compile_time_arg_val("down_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("down_proj_bank_id"),
+                get_named_compile_time_arg_val("down_proj_vc"),
+                get_named_compile_time_arg_val("enable_routing"),  // enable_indexing
+                get_named_compile_time_arg_val("down_proj_cb_index"),
+                get_named_compile_time_arg_val("down_proj_index_offset"),
+                get_named_compile_time_arg_val("use_hardcoded_expert_index")>;
+
+            // Eltwise Add (reader — no-op)
+            using AddCTArgs = deepseek_b1_ops::EltwiseAdd::ReaderCTArgs;
+
+            // Residual Mcast — receiver (input from sender → residual CB)
+            using ResidualMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+            deepseek_b1_ops::Mcast::ReceiverArgs residual_mcast_args{
+                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_residual_cb"),
+                get_named_compile_time_arg_val("shared_residual_num_pages"),
+            };
+
+            // RMSNorm (reader — no-op)
+            using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
+            deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
+
+#ifdef ENABLE_REDUCE_TO_ONE
+            // ReduceToOneB1 (reader — receives data from fabric via semaphore waits)
+            using ReduceToOneCTArgs = deepseek_b1_ops::ReduceToOneB1::ReaderCTArgs<
+                get_named_compile_time_arg_val("reduce_device_role"),
+                get_named_compile_time_arg_val("reduce_num_tiles"),
+                get_named_compile_time_arg_val("reduce_local_cb"),
+                get_named_compile_time_arg_val("reduce_received_cb"),
+                get_named_compile_time_arg_val("is_reduce_fabric_core")>;
+
+            // Reader runtime args (common RT args at configurable base)
+            deepseek_b1_ops::ReduceToOneB1::ReaderArgs reduce_rt_args{
+                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("reduce_ncrisc_common_rt_arg_base") + 0),
+                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("reduce_ncrisc_common_rt_arg_base") + 1),
+                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("reduce_ncrisc_common_rt_arg_base") + 2),
+            };
+#endif
+        } routed;
+
+        struct Shared {
+            // KN-sliced matmul (reader — no-op for NCRISC)
+            using GUMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+            deepseek_b1_ops::KNSlicedMatmul::ReaderArgs gu_matmul_args{};
+
+            // Gate Gather (A) receiver (MoeGather: receiver on NCRISC)
+            deepseek_b1_ops::MoeGather::ReceiverArgs ag_args{
+                get_named_compile_time_arg_val("shared_ag_noc0_num_senders"),
+                0,  // noc1_num_senders
+                get_named_compile_time_arg_val("shared_ag_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_ag_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_ag_dst_cb"),
+                get_named_compile_time_arg_val("shared_ag_dst_num_pages"),
+            };
+
+            // Up Gather (B) receiver (MoeGather: receiver on NCRISC)
+            deepseek_b1_ops::MoeGather::ReceiverArgs bg_args{
+                get_named_compile_time_arg_val("shared_bg_noc0_num_senders"),
+                0,  // noc1_num_senders
+                get_named_compile_time_arg_val("shared_bg_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_bg_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_bg_dst_cb"),
+                get_named_compile_time_arg_val("shared_bg_dst_num_pages"),
+            };
+
+            // Gated Reduce (reader — no-op for NCRISC)
+            using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ReaderCTArgs;
+            deepseek_b1_ops::GatedReduce::ReaderArgs gated_reduce_args{};
+
+            // Down Mcast — receiver (gated reduce output → all 130 cores)
+            using DownMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+            deepseek_b1_ops::Mcast::ReceiverArgs down_mcast_args{
+                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_down_mcast_dst_cb"),
+                get_named_compile_time_arg_val("shared_down_mcast_dst_num_pages"),
+            };
+
+            // Down Proj Matmul — reader (no-op for NCRISC)
+            using DownMatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+            deepseek_b1_ops::Matmul::ReaderArgs down_matmul_args{};
+
+            // Residual Add — reader (no-op for NCRISC)
+            using ResidualAddCTArgs = deepseek_b1_ops::ResidualAdd::ReaderCTArgs;
+            deepseek_b1_ops::ResidualAdd::ReaderArgs residual_add_args{};
+
+            // Output Gather — receiver (MoeGather: receiver on NCRISC)
+            deepseek_b1_ops::MoeGather::ReceiverArgs og_args{
+                get_named_compile_time_arg_val("shared_og_noc0_num_senders"),
+                get_named_compile_time_arg_val("shared_og_noc1_num_senders"),
+                get_named_compile_time_arg_val("shared_og_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_og_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_og_dst_cb"),
+                get_named_compile_time_arg_val("shared_og_dst_num_pages"),
+            };
+
+            // Output Mcast — receiver (DRAM cores receive into add_cb_in1)
+            using OutputMcastCTArgs = Routed::McastCTArgs;
+            deepseek_b1_ops::Mcast::ReceiverArgs output_mcast_args{
+                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("add_cb_in1"),
+                get_named_compile_time_arg_val("shared_output_mcast_dst_num_pages"),
+            };
+        } shared;
+    } moe;
+
+#elif defined(COMPILE_FOR_BRISC)
+
+    struct Moe {
+        struct Routed {
+            // Mcast (sender)
+            using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+                get_named_compile_time_arg_val("moe_mcast_num_cores"),
+                get_named_compile_time_arg_val("moe_mcast_is_part_of_receiver_grid"),
+                Core::is_sender_core && Core::is_mcast_grid_core>;
+            deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("moe_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("moe_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("moe_mcast_src_cb"),
+                get_named_compile_time_arg_val("moe_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("moe_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("moe_mcast_dst_cb")),
+            };
+
+#ifdef ENABLE_ROUTING
+            // Gate Matmul (writer — no-op)
+            using GateMMCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+            deepseek_b1_ops::Matmul::WriterArgs gate_mm_args{};
+
+            // Gather (sender — MoeGather: sender on BRISC)
+            deepseek_b1_ops::MoeGather::SenderArgs gather_args{
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_named_compile_time_arg_val("gather_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                get_named_compile_time_arg_val("gather_receiver_data_addr"),
+                0,  // sender_idx (unused when UsePerCoreSenderIdx=false)
+            };
+
+            // Gate (writer)
+            using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::WriterCTArgs<
+                get_named_compile_time_arg_val("gate_output_cb"),
+                get_named_compile_time_arg_val("gate_output_indices_cb")>;
+
+            // Index Mcast (sender)
+            deepseek_b1_ops::Mcast::SenderArgs index_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("index_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("index_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("gate_output_indices_cb"),
+                get_named_compile_time_arg_val("index_mcast_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("gate_output_indices_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("gate_proj_cb_index")),
+            };
+
+            // Expert Scale Mcast (sender)
+            deepseek_b1_ops::Mcast::SenderArgs expert_scale_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("expert_scale_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("expert_scale_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("gate_output_cb"),
+                get_named_compile_time_arg_val("expert_scale_mcast_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("gate_output_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("mul_cb_scalar_src")),
+            };
+#endif  // ENABLE_ROUTING
+
+            // DRAM Streaming Matmul (writer — no-op for BRISC)
+            using GateProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
+            using UpProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
+
+            // Eltwise Mul (writer)
+            using MulCTArgs = deepseek_b1_ops::EltwiseMul::WriterCTArgs<
+                get_named_compile_time_arg_val("mul_cb_out"),
+                get_named_compile_time_arg_val("mul_num_tiles"),
+                get_named_compile_time_arg_val("mul_cb_scalar"),
+                get_named_compile_time_arg_val("mul_cb_scalar_src"),
+                get_named_compile_time_arg_val("mul_scalar_index_offset"),
+                get_named_compile_time_arg_val("enable_routing")>;  // enable_scalar
+
+            // down_proj Gather (receiver)
+            // down_proj Gather (sender — MoeGather: sender on BRISC)
+            deepseek_b1_ops::MoeGather::SenderArgs down_proj_gather_args{
+                get_named_compile_time_arg_val("down_proj_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("down_proj_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("down_proj_gather_data_size_bytes"),
+                get_named_compile_time_arg_val("down_proj_gather_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("down_proj_gather_src_cb"),
+                get_named_compile_time_arg_val("down_proj_gather_src_num_pages"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("down_proj_gather_row_major"),
+                get_named_compile_time_arg_val("down_proj_gather_receiver_data_addr"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_idx"),
+            };
+
+            // down_proj Mcast (sender)
+            deepseek_b1_ops::Mcast::SenderArgs down_proj_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("down_proj_mcast_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("down_proj_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("down_proj_mcast_src_cb"),
+                get_named_compile_time_arg_val("down_proj_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("down_proj_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("down_proj_mcast_dst_cb")),
+            };
+
+            // down_proj DRAM Matmul (writer — no-op for BRISC)
+            using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::WriterCTArgs;
+
+            // Eltwise Add (writer — no-op)
+            using AddCTArgs = deepseek_b1_ops::EltwiseAdd::WriterCTArgs;
+
+            // Residual Mcast — sender (input from sender → residual CB, pop_src=false)
+            using ResidualMcastCTArgs = McastCTArgs;
+            deepseek_b1_ops::Mcast::SenderArgs residual_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("shared_residual_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_residual_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
+                get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("shared_residual_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("shared_residual_mcast_dst_cb")),
+            };
+
+            // RMSNorm (writer — no-op)
+            using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+            deepseek_b1_ops::RMSNorm::WriterArgs rmsnorm_args{};
+
+#ifdef ENABLE_REDUCE_TO_ONE
+            // ReduceToOneB1 (writer — sends data via fabric or NOC)
+            using ReduceToOneCTArgs = deepseek_b1_ops::ReduceToOneB1::WriterCTArgs<
+                get_named_compile_time_arg_val("reduce_device_role"),
+                get_named_compile_time_arg_val("reduce_num_tiles"),
+                get_named_compile_time_arg_val("reduce_payload_size_bytes"),
+                get_named_compile_time_arg_val("reduce_local_cb"),
+                get_named_compile_time_arg_val("reduce_scratch_cb"),
+                get_named_compile_time_arg_val("reduce_packet_cb"),
+                get_named_compile_time_arg_val("reduce_num_hops"),
+                get_named_compile_time_arg_val("reduce_dst_fabric_node_chip_id"),
+                get_named_compile_time_arg_val("reduce_dst_fabric_node_mesh_id"),
+                get_named_compile_time_arg_val("reduce_output_core_noc_x"),
+                get_named_compile_time_arg_val("reduce_output_core_noc_y"),
+                get_named_compile_time_arg_val("reduce_num_workers"),
+                get_named_compile_time_arg_val("reduce_slot_size_bytes"),
+                get_named_compile_time_arg_val("is_reduce_fabric_core"),
+                get_named_compile_time_arg_val("reduce_brisc_fabric_rt_arg_base"),
+                get_named_compile_time_arg_val("reduce_total_num_workers"),
+                get_named_compile_time_arg_val("reduce_agg_output_size_bytes"),
+                get_named_compile_time_arg_val("reduce_persistent_fabric_rt_arg_base"),
+                get_named_compile_time_arg_val("reduce_persistent_fabric_signal_enable")>;
+
+            deepseek_b1_ops::ReduceToOneB1::WorkerWriterArgs reduce_rt_args{};
+            // Populated below after struct initialization
+#endif
+        } routed;
+
+        struct Shared {
+            // KN-sliced matmul (writer — no-op for BRISC)
+            using GUMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+            deepseek_b1_ops::KNSlicedMatmul::WriterArgs gu_matmul_args{};
+
+            // Gate Gather (A) sender (MoeGather: sender on BRISC)
+            deepseek_b1_ops::MoeGather::SenderArgs ag_args{
+                get_named_compile_time_arg_val("shared_ag_dest_noc_x"),
+                get_named_compile_time_arg_val("shared_ag_dest_noc_y"),
+                get_named_compile_time_arg_val("shared_ag_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_ag_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_ag_src_cb"),
+                get_named_compile_time_arg_val("shared_ag_src_num_pages"),
+                0,
+                0,
+                0,
+                0,  // sender_grid (unused with UsePerCoreSenderIdx)
+                0,  // row_major (unused)
+                get_named_compile_time_arg_val("shared_ag_receiver_data_addr"),
+                get_named_compile_time_arg_val("shared_ag_sender_idx"),
+            };
+
+            // Up Gather (B) sender (MoeGather: sender on BRISC)
+            deepseek_b1_ops::MoeGather::SenderArgs bg_args{
+                get_named_compile_time_arg_val("shared_bg_dest_noc_x"),
+                get_named_compile_time_arg_val("shared_bg_dest_noc_y"),
+                get_named_compile_time_arg_val("shared_bg_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_bg_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_bg_src_cb"),
+                get_named_compile_time_arg_val("shared_bg_src_num_pages"),
+                0,
+                0,
+                0,
+                0,
+                0,
+                get_named_compile_time_arg_val("shared_bg_receiver_data_addr"),
+                get_named_compile_time_arg_val("shared_bg_sender_idx"),
+            };
+
+            // Gated Reduce (writer — no-op for BRISC)
+            using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::WriterCTArgs;
+            deepseek_b1_ops::GatedReduce::WriterArgs gated_reduce_args{};
+
+            // Down Mcast — sender (reuse Routed::McastCTArgs: same grid, same persistent sender)
+            using DownMcastCTArgs = Routed::McastCTArgs;
+            deepseek_b1_ops::Mcast::SenderArgs down_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("shared_down_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_down_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_down_mcast_src_cb"),
+                get_named_compile_time_arg_val("shared_down_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("shared_down_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("shared_down_mcast_dst_cb")),
+            };
+
+            // Down Proj Matmul — writer (no-op for BRISC)
+            using DownMatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+            deepseek_b1_ops::Matmul::WriterArgs down_matmul_args{};
+
+            // Residual Add — writer (no-op for BRISC)
+            using ResidualAddCTArgs = deepseek_b1_ops::ResidualAdd::WriterCTArgs;
+            deepseek_b1_ops::ResidualAdd::WriterArgs residual_add_args{};
+
+            // Output Gather — sender (MoeGather: sender on BRISC)
+            deepseek_b1_ops::MoeGather::SenderArgs og_args{
+                get_named_compile_time_arg_val("shared_og_dest_noc_x"),
+                get_named_compile_time_arg_val("shared_og_dest_noc_y"),
+                get_named_compile_time_arg_val("shared_og_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_og_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_og_src_cb"),
+                get_named_compile_time_arg_val("shared_og_src_num_pages"),
+                0,  // sender_grid_start_x (unused with UsePerCoreSenderIdx)
+                0,  // sender_grid_start_y
+                0,  // sender_grid_end_x
+                0,  // sender_grid_end_y
+                0,  // row_major (unused)
+                get_named_compile_time_arg_val("shared_og_receiver_data_addr"),
+                get_named_compile_time_arg_val("shared_residual_add_core_idx"),  // reuse matmul core index
+            };
+
+            // Output Mcast — sender (sender core → 130 cores)
+            using OutputMcastCTArgs = Routed::McastCTArgs;
+            deepseek_b1_ops::Mcast::SenderArgs output_mcast_args{
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_start_y"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_x"),
+                get_named_compile_time_arg_val("moe_mcast_dest_noc_end_y"),
+                get_named_compile_time_arg_val("mcast_data_sender_semaphore_addr"),  // Initialized by MLA
+                get_named_compile_time_arg_val("shared_output_mcast_data_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("shared_output_mcast_data_size_bytes"),
+                get_named_compile_time_arg_val("shared_output_mcast_src_cb"),
+                get_named_compile_time_arg_val("shared_output_mcast_src_num_pages"),
+                get_read_ptr(get_named_compile_time_arg_val("shared_output_mcast_src_cb")),
+                get_write_ptr(get_named_compile_time_arg_val("add_cb_in1")),
+            };
+        } shared;
+    } moe;
+
+#ifdef ENABLE_REDUCE_TO_ONE
+    // Populate BRISC reduce runtime args (must be outside struct initializer)
+    constexpr size_t reduce_brisc_arg_start = get_named_compile_time_arg_val("reduce_brisc_rt_arg_base");
+    if constexpr (Core::is_reduce_worker_core) {
+        moe.routed.reduce_rt_args = deepseek_b1_ops::ReduceToOneB1::WorkerWriterArgs{
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 0),   // fabric_core_noc_x
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 1),   // fabric_core_noc_y
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 2),   // my_slot_idx
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 3),   // worker_sem_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 4),   // dst_l1_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 5),   // dst_sem_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 6),   // output_base_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 7),   // shard_idx
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 8),   // socket_config_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 9),   // agg_sem_l1_addr
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 10),  // agg_core_noc_x
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 11),  // agg_core_noc_y
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 12),  // persistent_enable
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 13),  // persistent_dst_noc_x
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 14),  // persistent_dst_noc_y
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 15),  // persistent_dst_mesh_id
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 16),  // persistent_dst_chip_id
+            get_arg_val<uint32_t>(reduce_brisc_arg_start + 17),  // persistent_dst_sem_addr
+        };
+    }
+#endif
+
+#elif defined(COMPILE_FOR_TRISC)
+
+    struct Moe {
+        struct Routed {
+            // Mcast (compute — no-op)
+            using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+            deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+#ifdef ENABLE_ROUTING
+            // Gate Matmul (compute)
+            using GateMMCTArgs = deepseek_b1_ops::Matmul::ComputeCTArgs<
+                get_named_compile_time_arg_val("gate_mm_out_w"),
+                false,  // transpose
+                get_named_compile_time_arg_val("gate_mm_fused_activation")>;
+            deepseek_b1_ops::Matmul::ComputeArgs gate_mm_args{
+                get_named_compile_time_arg_val("gate_mm_in0"),
+                get_named_compile_time_arg_val("gate_mm_in1"),
+                get_named_compile_time_arg_val("gate_mm_out"),
+                get_named_compile_time_arg_val("gate_mm_k_num_tiles"),
+            };
+
+            // Gather (compute — no-op)
+            deepseek_b1_ops::MoeGather::ComputeArgs gather_args{};
+
+            // Gate (compute)
+            using GateCTArgs = deepseek_b1_ops::DeepseekMoeGate::ComputeCTArgs<
+                get_named_compile_time_arg_val("gate_input_cb"),
+                get_named_compile_time_arg_val("gate_bias_cb"),
+                get_named_compile_time_arg_val("gate_input_indices_cb"),
+                get_named_compile_time_arg_val("gate_output_cb"),
+                get_named_compile_time_arg_val("gate_output_indices_cb"),
+                get_named_compile_time_arg_val("gate_eps"),
+                get_named_compile_time_arg_val("gate_scaling_factor"),
+                get_named_compile_time_arg_val("gate_enable_sigmoid")>;
+
+            // Index Mcast (compute — no-op)
+            deepseek_b1_ops::Mcast::ComputeArgs index_mcast_args{};
+
+            // Expert Scale Mcast (compute — no-op)
+            deepseek_b1_ops::Mcast::ComputeArgs expert_scale_mcast_args{};
+#endif  // ENABLE_ROUTING
+
+            // gate_proj DRAM Streaming Matmul (compute)
+            using GateProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ComputeCTArgs<
+                get_named_compile_time_arg_val("gate_proj_cb_in0"),
+                get_named_compile_time_arg_val("gate_proj_cb_in1"),
+                get_named_compile_time_arg_val("gate_proj_cb_out"),
+                get_named_compile_time_arg_val("gate_proj_subblock_k"),
+                get_named_compile_time_arg_val("gate_proj_per_core_n"),
+                get_named_compile_time_arg_val("gate_proj_subblock_w"),
+                get_named_compile_time_arg_val("gate_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("gate_proj_tile_r_dim"),
+                get_named_compile_time_arg_val("gate_proj_fuse_silu"),
+                get_named_compile_time_arg_val("gate_proj_fp32_dest_acc_en")>;
+
+            // up_proj DRAM Streaming Matmul (compute) — shares CB with gate_proj
+            using UpProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ComputeCTArgs<
+                get_named_compile_time_arg_val("up_proj_cb_in0"),
+                get_named_compile_time_arg_val("up_proj_cb_in1"),
+                get_named_compile_time_arg_val("up_proj_cb_mm_out"),
+                get_named_compile_time_arg_val("up_proj_subblock_k"),
+                get_named_compile_time_arg_val("up_proj_per_core_n"),
+                get_named_compile_time_arg_val("up_proj_subblock_w"),
+                get_named_compile_time_arg_val("up_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("up_proj_tile_r_dim"),
+                get_named_compile_time_arg_val("up_proj_fuse_silu"),
+                get_named_compile_time_arg_val("up_proj_fp32_dest_acc_en")>;
+
+            // Eltwise Mul (compute)
+            using MulCTArgs = deepseek_b1_ops::EltwiseMul::ComputeCTArgs<
+                get_named_compile_time_arg_val("mul_cb_in0"),
+                get_named_compile_time_arg_val("mul_cb_in1"),
+                get_named_compile_time_arg_val("mul_cb_out"),
+                get_named_compile_time_arg_val("mul_num_tiles"),
+                get_named_compile_time_arg_val("up_proj_cb_mm_out"),     // cb_in0_wait (actual producer)
+                get_named_compile_time_arg_val("up_proj_per_core_n"),    // cb_in0_wait_tiles
+                get_named_compile_time_arg_val("gate_proj_cb_out"),      // cb_in1_wait (actual producer)
+                get_named_compile_time_arg_val("gate_proj_per_core_n"),  // cb_in1_wait_tiles
+                get_named_compile_time_arg_val("mul_cb_scalar"),
+                get_named_compile_time_arg_val("mul_fp32_dest_acc_en"),
+                get_named_compile_time_arg_val("enable_routing")>;  // enable_scalar
+
+            // down_proj Gather (compute — no-op)
+            deepseek_b1_ops::MoeGather::ComputeArgs down_proj_gather_args{};
+
+            // down_proj Mcast (compute — no-op)
+            deepseek_b1_ops::Mcast::ComputeArgs down_proj_mcast_args{};
+
+            // down_proj DRAM Streaming Matmul (compute)
+            using DownProjCTArgs = deepseek_b1_ops::DRAMStreamingMatmul::ComputeCTArgs<
+                get_named_compile_time_arg_val("down_proj_cb_in0"),
+                get_named_compile_time_arg_val("down_proj_cb_in1"),
+                get_named_compile_time_arg_val("down_proj_cb_out"),
+                get_named_compile_time_arg_val("down_proj_subblock_k"),
+                get_named_compile_time_arg_val("down_proj_per_core_n"),
+                get_named_compile_time_arg_val("down_proj_subblock_w"),
+                get_named_compile_time_arg_val("down_proj_num_subblocks_k"),
+                get_named_compile_time_arg_val("down_proj_tile_r_dim"),
+                get_named_compile_time_arg_val("down_proj_fuse_silu"),
+                get_named_compile_time_arg_val("down_proj_fp32_dest_acc_en")>;
+
+            // Eltwise Add (compute)
+            using AddCTArgs = deepseek_b1_ops::EltwiseAdd::ComputeCTArgs<
+                get_named_compile_time_arg_val("add_cb_in0"),
+                get_named_compile_time_arg_val("add_cb_in1"),
+                get_named_compile_time_arg_val("add_cb_out"),
+                get_named_compile_time_arg_val("add_num_tiles"),
+                get_named_compile_time_arg_val("down_proj_cb_out"),      // cb_in0_wait (actual producer)
+                get_named_compile_time_arg_val("down_proj_per_core_n"),  // cb_in0_wait_tiles
+                get_named_compile_time_arg_val("add_cb_in1_wait_tiles"),
+                get_named_compile_time_arg_val("add_sender_index"),
+                get_named_compile_time_arg_val("add_slice_size_bytes")>;
+
+            // Residual Mcast (compute — no-op)
+            using ResidualMcastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+            deepseek_b1_ops::Mcast::ComputeArgs residual_mcast_args{};
+
+            // RMSNorm (compute — sender core only)
+            // Input: residual_mcast_src_cb (raw activation), Output: rmsnorm_output_cb
+            using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+                get_named_compile_time_arg_val("moe_rmsnorm_fp32_acc") == 1,
+                get_named_compile_time_arg_val("moe_rmsnorm_num_tiles"),
+                get_named_compile_time_arg_val("moe_rmsnorm_rsqrt_fast_approx") == 1,
+                get_named_compile_time_arg_val("moe_rmsnorm_input_cb"),  // residual_mcast_src_cb
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_cb"),
+                get_named_compile_time_arg_val("moe_rmsnorm_output_cb")>;  // rmsnorm_output_cb
+            deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+                get_common_arg_val<uint32_t>(
+                    get_named_compile_time_arg_val("moe_rmsnorm_trisc_common_rt_arg_base") + 0),
+                get_common_arg_val<float>(get_named_compile_time_arg_val("moe_rmsnorm_trisc_common_rt_arg_base") + 1),
+            };
+
+#ifdef ENABLE_REDUCE_TO_ONE
+            // ReduceToOneB1 (compute — performs reduction)
+            using ReduceToOneCTArgs = deepseek_b1_ops::ReduceToOneB1::ComputeCTArgs<
+                get_named_compile_time_arg_val("reduce_device_role"),
+                get_named_compile_time_arg_val("reduce_num_tiles"),
+                get_named_compile_time_arg_val("reduce_local_cb"),
+                get_named_compile_time_arg_val("reduce_received_cb"),
+                get_named_compile_time_arg_val("reduce_output_cb"),
+                get_named_compile_time_arg_val("reduce_scratch_cb"),
+                get_named_compile_time_arg_val("is_reduce_fabric_core")>;
+
+            // Compute has no runtime args
+            deepseek_b1_ops::ReduceToOneB1::ComputeArgs reduce_rt_args{};
+#endif
+        } routed;
+
+        struct Shared {
+            // KN-sliced matmul (compute)
+            using GUMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<>;
+            deepseek_b1_ops::KNSlicedMatmul::ComputeArgs gu_matmul_args{
+                get_named_compile_time_arg_val("shared_gu_act_cb"),
+                get_named_compile_time_arg_val("shared_gu_weights_cb"),
+                get_named_compile_time_arg_val("shared_gu_out_cb"),
+                get_named_compile_time_arg_val("shared_gu_k_offset"),
+                get_named_compile_time_arg_val("shared_gu_k_per_core"),
+                get_named_compile_time_arg_val("shared_gu_act_total_tiles"),
+                get_named_compile_time_arg_val("shared_gu_weights_cb_addr"),
+            };
+
+            // Gather (compute — no-op for TRISC)
+            deepseek_b1_ops::MoeGather::ComputeArgs ag_args{};
+            deepseek_b1_ops::MoeGather::ComputeArgs bg_args{};
+
+            // Gated Reduce (compute)
+            using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ComputeCTArgs<
+                get_named_compile_time_arg_val("shared_gated_reduce_tiles_per_k"),
+                get_named_compile_time_arg_val("shared_gated_reduce_k_num_tiles")>;
+            deepseek_b1_ops::GatedReduce::ComputeArgs gated_reduce_args{
+                get_named_compile_time_arg_val("shared_gated_reduce_group1_cb"),
+                get_named_compile_time_arg_val("shared_gated_reduce_group2_cb"),
+                get_named_compile_time_arg_val("shared_gated_reduce_intermed_cb"),
+                get_named_compile_time_arg_val("shared_gated_reduce_mcast_src_cb"),
+            };
+
+            // Down Mcast — compute no-op
+            using DownMcastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+            deepseek_b1_ops::Mcast::ComputeArgs down_mcast_args{};
+
+            // Down Proj Matmul (compute)
+            using DownMatmulCTArgs = deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val(
+                "shared_down_matmul_out_w_per_core")>;
+            deepseek_b1_ops::Matmul::ComputeArgs down_matmul_args{
+                get_named_compile_time_arg_val("shared_down_matmul_in0"),
+                get_named_compile_time_arg_val("shared_down_matmul_in1"),
+                get_named_compile_time_arg_val("shared_down_matmul_out"),
+                get_named_compile_time_arg_val("shared_down_matmul_k_num_tiles"),
+                get_named_compile_time_arg_val("shared_down_matmul_weights_cb_addr"),
+            };
+
+            // Residual Add (compute)
+            using ResidualAddCTArgs = deepseek_b1_ops::ResidualAdd::ComputeCTArgs<get_named_compile_time_arg_val(
+                "shared_residual_add_out_w")>;
+            deepseek_b1_ops::ResidualAdd::ComputeArgs residual_add_args{
+                get_named_compile_time_arg_val("shared_residual_add_in0"),
+                get_named_compile_time_arg_val("shared_residual_add_in1"),
+                get_named_compile_time_arg_val("shared_residual_add_out"),
+                get_named_compile_time_arg_val("shared_residual_add_total_in1_tiles"),
+                get_named_compile_time_arg_val("shared_residual_add_core_idx"),
+            };
+
+            // Output Gather (compute — no-op)
+            deepseek_b1_ops::MoeGather::ComputeArgs og_args{};
+
+            // Output Mcast (compute — no-op)
+            using OutputMcastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+            deepseek_b1_ops::Mcast::ComputeArgs output_mcast_args{};
+        } shared;
+    } moe;
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+    deepseek_compute_kernel_init();
+#endif
+
+    // Setup all tensor-backed sharded buffers (marks pre-loaded tiles as ready)
+    auto setup_mla_sharded_buffers = [&]() __attribute__((always_inline)) {};
+
+    // Setup all tensor-backed sharded buffers (marks pre-loaded tiles as ready)
+    auto setup_moe_sharded_buffers = [&]() __attribute__((always_inline)) {
+#if defined(COMPILE_FOR_NCRISC)
+        if constexpr (Core::is_sender_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
+                get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"));
+
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_cb"),
+                get_named_compile_time_arg_val("moe_rmsnorm_gamma_num_pages"));
+#ifdef ENABLE_ROUTING
+            unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_bias_cb"), 1);
+            unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_input_indices_cb"), 1);
+#endif
+        }
+#ifdef ENABLE_ROUTING
+        if constexpr (Core::Routed::is_gate_mm_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("gate_mm_in1"),
+                get_named_compile_time_arg_val("gate_mm_k_num_tiles") *
+                    get_named_compile_time_arg_val("gate_mm_out_w"));
+        }
+#endif
+        if constexpr (Core::Routed::is_gate_proj_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("mul_cb_in1"), get_named_compile_time_arg_val("mul_num_tiles"));
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("add_cb_in0"), get_named_compile_time_arg_val("add_cb_in0_wait_tiles"));
+        }
+#endif
+    };
+
+#if defined(COMPILE_FOR_BRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(1);
+#elif defined(COMPILE_FOR_NCRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(14);
+#elif defined(COMPILE_FOR_TRISC)
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(7);
+#endif
+    volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
+
+    // ====================================================================
+    // Mcast: Initialize persistent mcast
+    // ====================================================================
+    deepseek_b1_ops::Mcast::Op<
+        McastCTArgs,
+        Core::is_input_core,
+        // Receive on the whole grid. This is used to block downstream ccls
+        Core::is_full_mcast_grid_core,
+        Core::is_matmul_core || Core::is_dkv_matmul_core,
+        true>
+        mcast;
+
+    deepseek_b1_ops::Mcast::Op<
+        Moe::Routed::ResidualMcastCTArgs,
+        Core::is_sender_core,
+        Core::is_mcast_grid_core,
+        Core::Shared::is_mcast_receiver_core,
+        false>  // pop_src=false: keep input for RMSNorm
+        residual_mcast;
+
+    // Mcast object reused for step 1 (RMSNorm mcast) and step 5 (index mcast)
+    deepseek_b1_ops::Mcast::Op<
+        Moe::Routed::McastCTArgs,
+        Core::is_sender_core,
+        Core::is_mcast_grid_core,
+        Core::is_input_mcast_receiver,
+        true>
+        moe_mcast;
+
+    auto mla_body = [&]() __attribute__((always_inline)) {
+        // ========================================================================
+        // CCL Broadcast (optional, skip if single-device mode)
+        // ========================================================================
+        if constexpr (!Core::skip_ccl) {
+            {
+                DeviceZoneScopedN("CCL_BROADCAST");
+                deepseek_b1_ops::Broadcast::Op<BcastCTArgs, Core::is_input_core> bcast;
+                bcast(bcast_args);
+            }
+        }
+
+#if defined(COMPILE_FOR_NCRISC)
+        if constexpr (Core::is_input_core) {
+            // Gamma CBs are already set up by NCRISC via setup_sharded_buffer
+            constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
+            constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
+
+            cb_reserve_back(rmsnorm_input_cb, rmsnorm_num_tiles);
+            cb_push_back(rmsnorm_input_cb, rmsnorm_num_tiles);
+        }
+#endif
+
+        // SP position handling.
+        // Read the global position from L1 and decide whether this device has
+        // work / owns the current KV-cache slot. The normalized (device-local)
+        // local_cur_pos is used for kv cache update and flash mla.
+        invalidate_l1_cache();
+        uint32_t cur_pos = pos_ptr[0];
+
+        const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(
+            cur_pos, Core::kv_cache_sp_device_idx, Core::kv_cache_device_chunk_size, Core::kv_cache_num_sp_devices);
+
+        using FlashMLAOp = deepseek_b1_ops::FlashMLADecode::Op<FlashMLACTArgs, Core::is_mla_core>;
+        // The first mcast is also used to synchronize downstream ccls, so must always run.
+        // Can revisit this later
+        // ====================================================================
+        // Input core: RMSNorm + Mcast send
+        // ====================================================================
+        {
+            DeviceZoneScopedN("RMSNORM");
+            deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_input_core, true> rmsnorm;
+            rmsnorm(rmsnorm_args);
+        }
+
+        {
+            DeviceZoneScopedN("MCAST");
+            mcast(mcast_args);
+        }
+
+        if constexpr (!Core::is_input_core) {
+#if defined(COMPILE_FOR_NCRISC)
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            // The wait below is for safety if this runs on the same core as another doing the same sync
+            // If that is the case we don't actually need to do another sync
+            noc_semaphore_wait(ccl_sync_sem, INVALID);
+            noc_semaphore_set(ccl_sync_sem, VALID);
+#elif defined(COMPILE_FOR_BRISC)
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            noc_semaphore_wait(ccl_sync_sem, VALID);
+            noc_semaphore_set(ccl_sync_sem, INVALID);
+#endif
+        }
+
+        if (!skip_attention) {
+            // ====================================================================
+            // Matmul operation
+            // ====================================================================
+            {
+                DeviceZoneScopedN("MATMUL");
+                deepseek_b1_ops::KNSlicedMatmul::Op<MatmulCTArgs, Core::is_matmul_core, false, false> matmul;
+                matmul(matmul_args);
+            }
+
+            // ====================================================================
+            // GatherReduce: matmul cores (senders) -> input core (receiver/reducer)
+            // ====================================================================
+            {
+                DeviceZoneScopedN("GATHER");
+                deepseek_b1_ops::GatherReduce::Op<Core::is_matmul_core, Core::is_input_core, Core::is_input_core, true>
+                    gather_reduce;
+                gather_reduce(gather_reduce_args);
+            }
+
+            // ====================================================================
+            // RMSNorm2
+            // ====================================================================
+            {
+                DeviceZoneScopedN("RMSNORM2");
+                deepseek_b1_ops::RMSNorm::Op<RMSNorm2CTArgs, Core::is_input_core, true> rmsnorm2;
+                rmsnorm2(rmsnorm2_args);
+            }
+
+            // ====================================================================
+            // Mcast2: Broadcast rmsnorm2 output to matmul2 cores
+            // ====================================================================
+            {
+                DeviceZoneScopedN("MCAST2");
+                deepseek_b1_ops::Mcast::
+                    Op<McastCTArgs, Core::is_input_core, Core::is_matmul2_core, Core::is_matmul2_core, true>
+                        mcast2;
+                mcast2(mcast2_args);
+            }
+
+            // ====================================================================
+            // Matmul2
+            // ====================================================================
+            {
+                DeviceZoneScopedN("MATMUL2");
+                deepseek_b1_ops::Matmul::Op<Matmul2CTArgs, Core::is_matmul2_core, true, false> matmul2;
+                matmul2(matmul2_args);
+            }
+
+            {
+                DeviceZoneScopedN("Q_HEADS") static_assert(
+                    !(Core::is_qnope_core && Core::is_qrope_core), "Core cannot be both QNOPE and QROPE");
+
+                // ================================================================
+                // Matmul3 (QNoPE)
+                // ================================================================
+                {
+                    DeviceZoneScopedN("QNOPE/MATMUL3");
+                    deepseek_b1_ops::Matmul::Op<Matmul3CTArgs, Core::is_qnope_core, true, false> matmul3;
+                    matmul3(matmul3_args);
+                }
+
+                // ================================================================
+                // RoPE (Qrope)
+                // ================================================================
+                {
+                    DeviceZoneScopedN("QROPE");
+                    deepseek_b1_ops::Rope::Op<QRopeCTArgs, Core::is_qrope_core> rope;
+                    rope(qrope_args);
+                }
+
+                // ================================================================
+                // CreateQHeads
+                // ================================================================
+                {
+                    DeviceZoneScopedN("CREATE_Q_HEADS");
+                    constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
+                    deepseek_b1_ops::CreateQHeads::
+                        Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                            create_q_heads;
+                    create_q_heads(create_q_heads_args);
+                }
+            }
+
+            // ====================================================================
+            // KV Cache Branch
+            // Non-owning SP devices skip the entire branch and just signal the
+            // KV-cache-ready semaphore so FlashMLA can proceed.
+            // ====================================================================
+            deepseek_b1_ops::KVCacheUpdate::Op<Core::is_kv_rmsnorm_core, Core::is_krope_core> kv_cache_update;
+            kv_cache_update.set_local_cur_pos(kv_cache_update_args, local_cur_pos);
+            if (!skip_kv_cache_update) {
+                DeviceZoneScopedN("KV CACHE");
+                // ================================================================
+                // DKV Matmul: 9x2 grid, each core handles 1 head of 32 dim
+                // ================================================================
+                {
+                    DeviceZoneScopedN("DKV_MATMUL");
+                    // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
+                    deepseek_b1_ops::Matmul::Op<DKV_MatmulCTArgs, Core::is_dkv_matmul_core, false, false> dkv_matmul;
+                    dkv_matmul(dkv_matmul_args);
+                }
+
+                // ================================================================
+                // Gather: dkv matmul cores (senders) -> rmsnorm core (receiver)
+                // NCRISC sends from knope grid, BRISC receives on rmsnorm grid
+                // ================================================================
+                {
+                    DeviceZoneScopedN("DKV_GATHER");
+                    deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+                    dkv_gather(dkv_gather_args);
+                }
+
+                // ================================================================
+                // RMSNorm: Apply RMSNorm to the gathered data
+                // ================================================================
+                {
+                    DeviceZoneScopedN("KV_RMSNORM");
+                    deepseek_b1_ops::RMSNorm::Op<KV_RMSNormCTArgs, Core::is_kv_rmsnorm_core, true> kv_rmsnorm;
+                    kv_rmsnorm(kv_rmsnorm_args);
+                }
+
+                // ================================================================
+                // RoPE
+                // ================================================================
+                {
+                    DeviceZoneScopedN("K_ROPE");
+                    deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> krope;
+                    krope(krope_args);
+                }
+
+                // ================================================================
+                // KV Cache Update: Write results to DRAM interleaved tensor
+                // BRISC handles writing from output CBs to DRAM
+                // ================================================================
+                {
+                    DeviceZoneScopedN("KV_CACHE_UPDATE");
+                    kv_cache_update(kv_cache_update_args);
+                }
+            }
+            {
+                DeviceZoneScopedN("KV_CACHE_SIGNAL_READY");
+                kv_cache_update.signal_cache_ready(kv_cache_update_args);
+            }
+
+            // ====================================================================
+            // Flash MLA: Compute
+            // ====================================================================
+            {
+                DeviceZoneScopedN("FLASH_MLA");
+                FlashMLAOp flash_mla;
+                flash_mla.set_local_cur_pos(flash_mla_args, local_cur_pos);
+                flash_mla(flash_mla_args);
+            }
+        } else {
+            // This device has no sequence data (e.g. SP2/SP3 with seq_len = 2047 and per_device_chunk_size = 1024).
+            // Push dummy tiles into the hand-off CBs so SDPA reduce does not hang.
+            // TODO: Fuse the final SP reduce into Flash MLA and handle this internally,
+            // eliminating the need for this explicit dummy push.
+            if constexpr (Core::is_sdpa_worker_core) {
+                FlashMLAOp::push_dummy_sdpa_inputs();
+            }
+        }
+
+        // ========================================================================
+        // Post SDPA: Reduce-to-All + Matmul4 + Gather2 + Mcast3 + Matmul5 + Gather3 + CCL All-Reduce
+        // ========================================================================
+        {
+            DeviceZoneScopedN("POST_SDPA");
+            if constexpr (Core::is_sdpa_worker_core) {
+                deepseek_b1_ops::SdpaReduceWorker::Op<SdpaReduceWorkerCTArgs> sdpa_reduce_worker;
+                sdpa_reduce_worker(sdpa_reduce_worker_args);
+            }
+            if constexpr (Core::is_sdpa_forwarder_core) {
+                deepseek_b1_ops::SdpaReduceForwarder::Op<SdpaReduceForwarderCTArgs> sdpa_reduce_forwarder;
+                sdpa_reduce_forwarder(sdpa_reduce_forwarder_args);
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+                constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore_addr");
+                constexpr uint32_t input_noc_coord_x = get_named_compile_time_arg_val("input_noc_coord_x");
+                constexpr uint32_t input_noc_coord_y = get_named_compile_time_arg_val("input_noc_coord_y");
+                uint64_t ccl_sync_sem_noc_addr = get_noc_addr(input_noc_coord_x, input_noc_coord_y, ccl_sync_sem_addr);
+                noc_semaphore_inc(ccl_sync_sem_noc_addr, 1);
+                noc_async_atomic_barrier();
+#endif
+            }
+#if defined(COMPILE_FOR_NCRISC)
+            if constexpr (Core::is_matmul4_core) {
+                constexpr uint32_t scatter_arrival_semaphore_id =
+                    get_named_compile_time_arg_val("scatter_arrival_semaphore_id");
+                volatile tt_l1_ptr uint32_t* scatter_arrival_sem_addr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(scatter_arrival_semaphore_id));
+                noc_semaphore_wait(scatter_arrival_sem_addr, 1);
+                noc_semaphore_set(scatter_arrival_sem_addr, 0);
+                constexpr uint32_t matmul4_in0 = get_named_compile_time_arg_val("matmul4_in0");
+                constexpr uint32_t matmul4_k_num_tiles = get_named_compile_time_arg_val("matmul4_k_num_tiles");
+                unified_kernels::setup_sharded_buffer(matmul4_in0, matmul4_k_num_tiles);
+            }
+#endif
+        }
+        // ========================================================================
+        // Matmul4: [1, 512] x [512, 128] -> [1, 128] per core (kv_b2 grid)
+        // ========================================================================
+        {
+            DeviceZoneScopedN("MATMUL4");
+            deepseek_b1_ops::Matmul::Op<Matmul4CTArgs, Core::is_matmul4_core, true, false> matmul4;
+            matmul4(matmul4_args);
+        }
+
+        // ========================================================================
+        // Gather2: matmul4 cores (kv_b2 grid) -> gather core (12, 9)
+        // Collects [1, 128] * 64 = [1, 8192]
+        // ========================================================================
+        {
+            DeviceZoneScopedN("GATHER2");
+            deepseek_b1_ops::Gather::Op<Core::is_matmul4_core, Core::is_gather_receiver_core, true, true> gather2;
+            gather2(gather2_args);
+        }
+
+        // ========================================================================
+        // Mcast3: gather core -> 13x10 mcast3 grid (130 cores)
+        // Broadcasts [1, 8192] to each core in mcast3 grid
+        // Source: gather2_dst_cb (CB 3), Destination: mcast3_dst_cb = matmul5_in0 (CB 4)
+        // Note: 18 inactive grid cores only do semaphore handshake; only matmul5 cores do full CB receive
+        // ========================================================================
+        deepseek_b1_ops::Mcast::
+            Op<McastCTArgs, Core::is_gather_receiver_core, Core::is_matmul5_core, Core::is_matmul5_core, true>
+                mcast3;
+        {
+            DeviceZoneScopedN("MCAST3");
+            mcast3(mcast3_args);
+        }
+
+        // ========================================================================
+        // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)
+        // Input: mcast3_dst_cb (CB 4), Weights: matmul5_in1 (CB 5), Output: matmul5_out (CB 6)
+        // Only runs on 112 active cores (is_matmul5_core=true), 18 inactive cores skip
+        // ========================================================================
+        {
+            DeviceZoneScopedN("MATMUL5");
+            // pop_in0 = true (mcast3 output consumed), pop_in1 = false (weights persistent)
+            deepseek_b1_ops::Matmul::Op<Matmul5CTArgs, Core::is_matmul5_core, true, false> matmul5;
+            matmul5(matmul5_args);
+        }
+
+        // ========================================================================
+        // Gather3: 112 active matmul5 cores -> gather core (12, 9)
+        // Collects [1, 64] * 112 = [1, 7168]
+        // ========================================================================
+        {
+            DeviceZoneScopedN("GATHER3");
+            deepseek_b1_ops::Gather::Op<Core::is_matmul5_core, Core::is_gather_receiver_core, true, true> gather3;
+            gather3(gather3_args);
+        }
+
+#if defined(COMPILE_FOR_BRISC)
+        // Signal CCL sender that gather3 is complete (gather receiver only)
+        if constexpr (Core::is_gather_receiver_core && Core::is_ccl_receiver_core) {
+            static_assert(noc_mode == DM_DYNAMIC_NOC, "CCL signal must be sent on dynamic NOC");
+            constexpr uint8_t CCL_SIGNAL_NOC = 0;
+            constexpr uint32_t gather3_completion_semaphore_id =
+                get_named_compile_time_arg_val("gather3_completion_semaphore_id");
+            constexpr uint32_t ccl_sender_noc_x = get_named_compile_time_arg_val("ccl_sender_noc_x");
+            constexpr uint32_t ccl_sender_noc_y = get_named_compile_time_arg_val("ccl_sender_noc_y");
+            uint64_t ccl_sender_semaphore_addr = get_noc_addr(
+                ccl_sender_noc_x, ccl_sender_noc_y, get_semaphore(gather3_completion_semaphore_id), CCL_SIGNAL_NOC);
+            noc_semaphore_inc(ccl_sender_semaphore_addr, 1, CCL_SIGNAL_NOC);
+            noc_async_atomic_barrier(CCL_SIGNAL_NOC);
+        }
+#endif
+
+        // ========================================================================
+        // CCL All-Reduce: Exchange [1, 7168] between devices
+        // - CCL Sender (11, 9): Reads gather3 output from gather core, sends via fabric
+        // - CCL Receiver (12, 9): Receives remote data, performs reduction
+
+        // Note: skip_local_push=1 is set for CCLReceiverReaderCTArgs because
+        // gather3 already pushed to CB7 (gather3_dst_cb). The receiver just
+        // needs to wait for remote data and perform the reduction.
+        // ========================================================================
+        if constexpr (Core::is_ccl_sender_core) {
+            DeviceZoneScopedN("CCL_SENDER_SEND");
+#if defined(COMPILE_FOR_NCRISC)
+            // Wait for gather3 to complete before reading from gather core
+            constexpr uint32_t gather3_completion_semaphore_id =
+                get_named_compile_time_arg_val("ccl_sender_gather3_completion_semaphore_id");
+            volatile tt_l1_ptr uint32_t* gather3_completion_semaphore_addr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(gather3_completion_semaphore_id));
+            noc_semaphore_wait(gather3_completion_semaphore_addr, 1);
+            noc_semaphore_set(gather3_completion_semaphore_addr, 0);
+
+            deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs> ccl_sender_reader;
+            ccl_sender_reader(ccl_sender_args);
+#elif defined(COMPILE_FOR_BRISC)
+            deepseek_b1_ops::AllReduceSender::Op<CCLSenderWriterCTArgs> ccl_sender_writer;
+            ccl_sender_writer(ccl_sender_args);
+            constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore_addr");
+            constexpr uint32_t input_noc_coord_x = get_named_compile_time_arg_val("input_noc_coord_x");
+            constexpr uint32_t input_noc_coord_y = get_named_compile_time_arg_val("input_noc_coord_y");
+            uint64_t ccl_sync_sem_noc_addr = get_noc_addr(input_noc_coord_x, input_noc_coord_y, ccl_sync_sem_addr);
+            noc_semaphore_inc(ccl_sync_sem_noc_addr, 1);
+            noc_async_atomic_barrier();
+#endif
+        }
+
+        if constexpr (Core::is_ccl_receiver_core) {
+            DeviceZoneScopedN("CCL_RECEIVER");
+#if defined(COMPILE_FOR_NCRISC)
+            // TODO: We're popping the RMSNorm input and then re-pushing it here as the residual
+            // Should avoid this and not pop in RMSNorm
+            deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs> ccl_receiver_reader;
+            ccl_receiver_reader(ccl_receiver_args);
+#elif defined(COMPILE_FOR_TRISC)
+            deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverComputeCTArgs> ccl_receiver_compute;
+            ccl_receiver_compute(ccl_receiver_args);
+#elif defined(COMPILE_FOR_BRISC)
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            // SDPA forwarder cores use both riscs to send over fabric, so we need to wait for both
+            noc_semaphore_wait(
+                ccl_sync_sem,
+                2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores") +
+                    get_named_compile_time_arg_val("ccl_sender_num_cores"));
+            noc_semaphore_set(ccl_sync_sem, 0);
+#endif
+        }
+    };
+
+    auto moe_body = [&]() __attribute__((always_inline)) {
+        // 0. Residual Mcast: Broadcast input as residual to mcast receiver cores (pop_src=false)
+        {
+            DeviceZoneScopedN("RESIDUAL_MCAST");
+            residual_mcast(moe.routed.residual_mcast_args);
+        }
+        if constexpr (!Core::is_input_core) {
+#if defined(COMPILE_FOR_NCRISC)
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            // The wait below is for safety if this runs on the same core as another doing the same sync
+            // If that is the case we don't actually need to do another sync
+            noc_semaphore_wait(ccl_sync_sem, INVALID);
+            noc_semaphore_set(ccl_sync_sem, VALID);
+#elif defined(COMPILE_FOR_BRISC)
+            volatile tt_l1_ptr uint32_t* ccl_sync_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+            noc_semaphore_wait(ccl_sync_sem, VALID);
+            noc_semaphore_set(ccl_sync_sem, INVALID);
+#endif
+        }
+
+        // 0b. RMSNorm: normalize input on sender core (residual_mcast_src → rmsnorm_output)
+        {
+            DeviceZoneScopedN("RMSNORM");
+            deepseek_b1_ops::RMSNorm::Op<
+                Moe::Routed::RMSNormCTArgs,
+                Core::is_sender_core,
+                false>  // pop_input=false: tensor-backed CB, keep for next iteration
+                rmsnorm;
+            rmsnorm(moe.routed.rmsnorm_args);
+        }
+
+        // 1. RMSNorm Mcast: Broadcast normalized input from sender core to all receiver cores
+        {
+            DeviceZoneScopedN("MCAST");
+            moe_mcast(moe.routed.mcast_args);
+        }
+
+#ifdef ENABLE_ROUTING
+        // 2. Matmul + Activation: Routing matmul on gate_mm cores
+        {
+            DeviceZoneScopedN("MATMUL");
+            deepseek_b1_ops::Matmul::Op<Moe::Routed::GateMMCTArgs, Core::Routed::is_gate_mm_core, false, false> gate_mm;
+            gate_mm(moe.routed.gate_mm_args);
+        }
+
+        // 3. Gather: Collect matmul outputs from compute cores to sender core
+        {
+            DeviceZoneScopedN("GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_mm_core, Core::is_sender_core, true> gather;
+            gather(moe.routed.gather_args);
+        }
+#endif  // ENABLE_ROUTING
+
+        // 3a. Shared Expert: Gate/Up KN-sliced matmul on 128 compute cores
+        //     CB 1 (act) is shared: on gate_proj cores it is also consumed by gate_proj (step 6)
+        //     and up_proj (step 7, which pops it). So we only pop here on non-gate_proj cores.
+        {
+            DeviceZoneScopedN("SHARED_GU_MATMUL");
+            deepseek_b1_ops::KNSlicedMatmul::Op<
+                Moe::Shared::GUMatmulCTArgs,
+                Core::Shared::is_compute_core,
+                !Core::Routed::is_gate_proj_core,  // pop_act
+                false>                             // pop_weights
+                shared_gu_matmul;
+            shared_gu_matmul(moe.shared.gu_matmul_args);
+        }
+
+#ifdef ENABLE_ROUTING
+        // 4. Gate: Top-K expert selection (on sender core only)
+        {
+            DeviceZoneScopedN("GATE");
+            deepseek_b1_ops::DeepseekMoeGate::Op<Moe::Routed::GateCTArgs, Core::is_sender_core> gate;
+            gate();
+        }
+
+        // 5. Mcast Index: Broadcast expert indices to gate_proj cores only
+        // Uses dedicated mcast with IsReceiverCore=is_gate_proj_core so only gate_proj
+        // cores push to CB 10. Other grid cores just drain the semaphore (no CB ops).
+        {
+            DeviceZoneScopedN("MCAST_INDEX");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Routed::McastCTArgs,
+                Core::is_sender_core,
+                Core::is_mcast_grid_core,
+                Core::Routed::is_gate_proj_core,
+                true>
+                index_mcast;
+            index_mcast(moe.routed.index_mcast_args);
+        }
+
+        // 5b. Mcast Expert Scale: Broadcast expert scale to gate_proj cores
+        {
+            DeviceZoneScopedN("MCAST_EXPERT_SCALE");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Routed::McastCTArgs,
+                Core::is_sender_core,
+                Core::is_mcast_grid_core,
+                Core::Routed::is_gate_proj_core,
+                true>  // pop_src
+                expert_scale_mcast;
+            expert_scale_mcast(moe.routed.expert_scale_mcast_args);
+        }
+#endif  // ENABLE_ROUTING
+
+        // 5c. Shared Expert: Gate Gather (A) — 64 gate cores send to sender core
+        //     Uses MoeGather (sender=BRISC) to avoid NOC contention with DRAM matmul (NCRISC)
+        {
+            DeviceZoneScopedN("SHARED_GATE_GATHER");
+            deepseek_b1_ops::MoeGather::Op<
+                Core::Shared::is_gate_compute_core,
+                Core::Shared::is_gated_reduce_core,
+                true,  // pop_src
+                true>  // UsePerCoreSenderIdx
+                shared_gate_gather;
+            shared_gate_gather(moe.shared.ag_args);
+        }
+
+        // 5d. Shared Expert: Up Gather (B) — 64 up cores send to sender core
+        {
+            DeviceZoneScopedN("SHARED_UP_GATHER");
+            deepseek_b1_ops::MoeGather::Op<
+                Core::Shared::is_up_compute_core,
+                Core::Shared::is_gated_reduce_core,
+                true,  // pop_src
+                true>  // UsePerCoreSenderIdx
+                shared_up_gather;
+            shared_up_gather(moe.shared.bg_args);
+        }
+
+        // 5e. Shared Expert: Gated Reduce — SiLU(sum(gate)) * sum(up)
+        //     Runs on sender core after receiving both gathers
+        {
+            DeviceZoneScopedN("SHARED_GATED_REDUCE");
+            deepseek_b1_ops::GatedReduce::Op<Moe::Shared::GatedReduceCTArgs, Core::Shared::is_gated_reduce_core>
+                gated_reduce;
+            gated_reduce(moe.shared.gated_reduce_args);
+        }
+
+        // 6. gate_proj: DRAM Streaming Matmul + SiLU (PopIn0=false, keep input for up_proj)
+        {
+            DeviceZoneScopedN("GATE_PROJ");
+            constexpr uint32_t gate_proj_cb_in1_addr = get_named_compile_time_arg_val("gate_proj_in1_buf_addr");
+            deepseek_b1_ops::DRAMStreamingMatmul::
+                Op<Moe::Routed::GateProjCTArgs, Core::Routed::is_gate_proj_core, false, true, gate_proj_cb_in1_addr>
+                    gate_proj_mm;
+            gate_proj_mm();
+        }
+
+        // 7. up_proj: DRAM Streaming Matmul (PopIn0=true, ResetCBIn1=true, WaitForOutput=true)
+        {
+            DeviceZoneScopedN("UP_PROJ");
+            constexpr uint32_t cb_in1_addr = get_named_compile_time_arg_val("gate_proj_in1_buf_addr");
+            deepseek_b1_ops::DRAMStreamingMatmul::
+                Op<Moe::Routed::UpProjCTArgs, Core::Routed::is_gate_proj_core, true, true, cb_in1_addr, false, true>
+                    up_proj;
+            up_proj();
+        }
+
+        // 8. Mul: Element-wise multiply (up_proj * gate_proj * expert_scale)
+        {
+            DeviceZoneScopedN("MUL");
+            deepseek_b1_ops::EltwiseMul::Op<Moe::Routed::MulCTArgs, Core::Routed::is_gate_proj_core> mul_op;
+            mul_op();
+        }
+
+        // 9. down_proj Gather: Gather fused output from gate_proj cores to sender core
+        {
+            DeviceZoneScopedN("DOWN_PROJ_GATHER");
+            deepseek_b1_ops::MoeGather::Op<Core::Routed::is_gate_proj_core, Core::is_sender_core, true, true>
+                down_proj_gather;
+            down_proj_gather(moe.routed.down_proj_gather_args);
+        }
+
+        // 10. down_proj Mcast: Broadcast gathered fused output to gate_proj cores
+        {
+            DeviceZoneScopedN("DOWN_PROJ_MCAST");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Routed::McastCTArgs,
+                Core::is_sender_core,
+                Core::is_mcast_grid_core,
+                Core::Routed::is_gate_proj_core,
+                true>  // pop_src
+                down_proj_mcast;
+            down_proj_mcast(moe.routed.down_proj_mcast_args);
+        }
+
+        // 11. down_proj: DRAM Streaming Matmul (PopIndex=true: last consumer of expert index CB)
+        {
+            DeviceZoneScopedN("DOWN_PROJ");
+            constexpr uint32_t down_proj_cb_in1_addr = get_named_compile_time_arg_val("down_proj_in1_buf_addr");
+            deepseek_b1_ops::DRAMStreamingMatmul::Op<
+                Moe::Routed::DownProjCTArgs,
+                Core::Routed::is_gate_proj_core,
+                true,
+                true,
+                down_proj_cb_in1_addr,
+                true>
+                down_proj;
+            down_proj();
+        }
+
+        // 11b. Shared: Down Mcast — broadcast gated reduce output [1, K_down] to all 130 cores
+        //      Source is mcast_src_cb (CB 31) filled by gated reduce, pop_src=true
+        {
+            DeviceZoneScopedN("SHARED_DOWN_MCAST");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Shared::DownMcastCTArgs,
+                Core::is_sender_core,
+                Core::is_mcast_grid_core,
+                Core::Shared::is_mcast_receiver_core,
+                true>
+                shared_down_mcast;
+            shared_down_mcast(moe.shared.down_mcast_args);
+        }
+
+        // 11c. Shared: Down Proj Matmul — SRAM matmul [1, K_down] x [K_down, N_per_core] on 112 cores
+        {
+            DeviceZoneScopedN("SHARED_DOWN_MATMUL");
+            deepseek_b1_ops::Matmul::Op<
+                Moe::Shared::DownMatmulCTArgs,
+                Core::Shared::is_mcast_receiver_core,
+                /*pop_in0=*/true,
+                /*pop_in1=*/false>
+                shared_down_matmul;
+            shared_down_matmul(moe.shared.down_matmul_args);
+        }
+
+        // 11d. Shared: Residual Add — matmul_out + shard(residual) on 112 cores
+        //      When multi-device reduce is enabled, only the ROOT1 device performs
+        //      the actual add so the residual is counted exactly once after the
+        //      cross-device sum.  Non-root devices pass matmul output through.
+        {
+            DeviceZoneScopedN("SHARED_RESIDUAL_ADD");
+#ifdef ENABLE_REDUCE_TO_ONE
+            constexpr bool skip_residual_add =
+                get_named_compile_time_arg_val("reduce_device_role") != deepseek_b1_ops::MESH_ROOT1;
+            deepseek_b1_ops::ResidualAdd::
+                Op<Moe::Shared::ResidualAddCTArgs, Core::Shared::is_mcast_receiver_core, skip_residual_add>
+                    shared_residual_add;
+#else
+            deepseek_b1_ops::ResidualAdd::Op<Moe::Shared::ResidualAddCTArgs, Core::Shared::is_mcast_receiver_core>
+                shared_residual_add;
+#endif
+            shared_residual_add(moe.shared.residual_add_args);
+        }
+
+        // 11e. Shared: Output Gather — 112 matmul cores → sender core
+        {
+            DeviceZoneScopedN("SHARED_OUTPUT_GATHER");
+            deepseek_b1_ops::MoeGather::Op<
+                Core::Shared::is_mcast_receiver_core,  // IsSenderCore: 112 matmul cores
+                Core::is_sender_core,                  // IsReceiverCore: sender core
+                /*pop_src=*/true,
+                /*UsePerCoreSenderIdx=*/true>
+                shared_output_gather;
+            shared_output_gather(moe.shared.og_args);
+        }
+
+        // 11f. Shared: Output Mcast — sender core → 130 cores (DRAM cores receive into add_cb_in1)
+        {
+            DeviceZoneScopedN("SHARED_OUTPUT_MCAST");
+            deepseek_b1_ops::Mcast::Op<
+                Moe::Shared::OutputMcastCTArgs,
+                Core::is_sender_core,             // IsSenderCore
+                Core::is_mcast_grid_core,         // IsMcastGridCore (all 130 cores for semaphore ack)
+                Core::Routed::is_gate_proj_core,  // IsReceiverCore (8 DRAM cores receive into add_cb_in1)
+                /*pop_src=*/true>
+                shared_output_mcast;
+            shared_output_mcast(moe.shared.output_mcast_args);
+        }
+
+        // 12. Eltwise Add: down_proj + shared_expert_output
+        {
+            DeviceZoneScopedN("ELTWISE_ADD");
+            constexpr bool add_pop_output =
+#ifdef ENABLE_REDUCE_TO_ONE
+                false;  // reduce_local_cb aliases add_cb_out — reduce will consume it
+#else
+                true;  // pop for looping
+#endif
+            deepseek_b1_ops::EltwiseAdd::Op<
+                Moe::Routed::AddCTArgs,
+                Core::Routed::is_gate_proj_core,
+                true,            // PopInputs
+                add_pop_output>  // PopOutput
+                add_op;
+            add_op();
+        }
+
+        // 13. ReduceToOneB1: Multi-device reduce-to-one across 4x2 mesh
+        //     Reduces final_output from all 8 devices to ROOT1 device
+#ifdef ENABLE_REDUCE_TO_ONE
+        {
+            DeviceZoneScopedN("REDUCE_TO_ONE");
+            // IsReduceCore includes both worker cores and fabric cores
+            constexpr bool is_reduce_core = Core::is_reduce_worker_core || Core::is_reduce_fabric_core;
+            deepseek_b1_ops::ReduceToOneB1::Op<Moe::Routed::ReduceToOneCTArgs, is_reduce_core, true> reduce_op;
+            reduce_op(moe.routed.reduce_rt_args);
+        }
+#endif
+
+        // Reduce fabric cores signal sender core that fabric sends are done.
+        // Sender core NCRISC waits before starting next iteration.
+#ifdef ENABLE_REDUCE_TO_ONE
+#if defined(COMPILE_FOR_BRISC)
+        if constexpr (Core::is_reduce_fabric_core) {
+            constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
+            constexpr uint32_t sync_noc_x = get_named_compile_time_arg_val("reduce_sync_noc_x");
+            constexpr uint32_t sync_noc_y = get_named_compile_time_arg_val("reduce_sync_noc_y");
+            uint64_t sync_sem_noc_addr = get_noc_addr(sync_noc_x, sync_noc_y, sync_sem_addr);
+            noc_semaphore_inc(sync_sem_noc_addr, 1);
+        }
+#elif defined(COMPILE_FOR_NCRISC)
+        if constexpr (Core::is_sender_core) {
+            constexpr uint32_t sync_sem_addr = get_named_compile_time_arg_val("reduce_sync_sem_addr");
+            constexpr uint32_t num_fabric_cores = get_named_compile_time_arg_val("reduce_sync_num_fabric_cores");
+            volatile tt_l1_ptr uint32_t* sync_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_sem_addr);
+            noc_semaphore_wait(sync_sem_ptr, num_fabric_cores);
+            noc_semaphore_set(sync_sem_ptr, 0);  // reset for next iteration
+        }
+#endif
+#endif
+    };
+
+    // ====================================================================
+    // Mcast: Initialize persistent mcast
+    // ====================================================================
+    {
+        DeviceZoneScopedN("MCAST_INIT");
+        mcast.init(mcast_args);
+    }
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+#if defined(COMPILE_FOR_BRISC)
+        constexpr uint32_t persistent_mode = get_named_compile_time_arg_val("persistent_mode");
+        constexpr uint32_t persistent_next_iter_sem_addr =
+            get_named_compile_time_arg_val("persistent_next_iter_sem_addr");
+        if constexpr (persistent_mode) {
+            constexpr bool is_bcast_sender = get_named_compile_time_arg_val("bcast_is_sender") == 1;
+            if constexpr (is_bcast_sender && Core::is_sender_core) {
+                auto next_iter_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(persistent_next_iter_sem_addr);
+                noc_semaphore_wait(next_iter_sem, 1);
+                noc_semaphore_set(next_iter_sem, 0);
+            }
+        }
+#endif
+        unified_kernels::reconfig_cb_interfaces(mla_cb_config);
+        setup_mla_sharded_buffers();
+        mla_body();
+        unified_kernels::reconfig_cb_interfaces(moe_cb_config);
+#if defined(COMPILE_FOR_BRISC)
+        *pos_ptr += 1;
+#endif
+        setup_moe_sharded_buffers();
+        moe_body();
+    }
+
+    // ====================================================================
+    // Mcast: Teardown persistent mcast
+    // ====================================================================
+    {
+        DeviceZoneScopedN("MCAST_TEARDOWN");
+        mcast.teardown();
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -57,10 +57,6 @@ class DecoderBlock:
         moe_gate_eps=1e-20,
         moe_gate_scaling_factor=2.5,
         moe_enable_routing=True,
-        moe_use_hardcoded_expert_index=False,
-        moe_hardcoded_expert_index=0,
-        moe_num_devices=1,
-        moe_reduce_root_device_idx=0,
     ):
         full_q, new_kv, attn_output = AttentionBlock.golden(
             input_tensor,
@@ -96,59 +92,27 @@ class DecoderBlock:
         moe_golden_kwargs = dict(
             rmsnorm_gamma=moe_rmsnorm_gamma,
             rmsnorm_epsilon=moe_rmsnorm_epsilon,
-            enable_routing=moe_enable_routing,
             routing_weights_tensor=moe_routing_weights,
             bias_tensor=moe_bias,
             eps=moe_gate_eps,
             scaling_factor=moe_gate_scaling_factor,
-            use_hardcoded_expert_index=moe_use_hardcoded_expert_index,
         )
 
-        if moe_num_devices <= 1:
-            moe_scores, moe_indices, moe_output = MoeOp.golden(
-                attn_output,
-                shared_gate_weights=moe_shared_gate_weights,
-                shared_up_weights=moe_shared_up_weights,
-                shared_down_weights=moe_shared_down_weights,
-                gate_proj_weights_dict=moe_gate_proj_weights_dict,
-                up_proj_weights_dict=moe_up_proj_weights_dict,
-                down_proj_weights_dict=moe_down_proj_weights_dict,
-                hardcoded_expert_index=moe_hardcoded_expert_index,
-                **moe_golden_kwargs,
-            )
-            return full_q, new_kv, attn_output, moe_scores, moe_indices, moe_output
-
-        K_down_per_device = moe_shared_gate_weights.shape[1] // moe_num_devices
-        is_moe = moe_enable_routing
-        per_device_outputs = []
-        for dev_idx in range(moe_num_devices):
-            shard_start = dev_idx * K_down_per_device
-            shard_end = shard_start + K_down_per_device
-            # MoE: weights are replicated; each device selects its expert by device index.
-            # Dense MLP: each device owns a unique expert shard; remap it to key 0
-            # so MoeRoutedExpertOp.golden (which always picks key 0 when enable_routing=False)
-            # reads the correct per-device expert.
-            expert_idx = dev_idx if is_moe else 0
-            gate_dict = moe_gate_proj_weights_dict if is_moe else {0: moe_gate_proj_weights_dict[dev_idx]}
-            up_dict = moe_up_proj_weights_dict if is_moe else {0: moe_up_proj_weights_dict[dev_idx]}
-            down_dict = moe_down_proj_weights_dict if is_moe else {0: moe_down_proj_weights_dict[dev_idx]}
-
-            scores, indices, dev_output = MoeOp.golden(
-                attn_output,
-                shared_gate_weights=moe_shared_gate_weights[:, shard_start:shard_end],
-                shared_up_weights=moe_shared_up_weights[:, shard_start:shard_end],
-                shared_down_weights=moe_shared_down_weights[shard_start:shard_end, :],
-                gate_proj_weights_dict=gate_dict,
-                up_proj_weights_dict=up_dict,
-                down_proj_weights_dict=down_dict,
-                hardcoded_expert_index=expert_idx,
-                include_residual=(dev_idx == moe_reduce_root_device_idx),
-                **moe_golden_kwargs,
-            )
-            per_device_outputs.append(dev_output)
-
-        moe_output = sum(per_device_outputs)
-        return full_q, new_kv, attn_output, scores, indices, moe_output
+        # Golden path models the logical block semantics directly:
+        # h = x + Attention(x), y = h + MoE(h). No per-device decomposition here.
+        moe_scores, moe_indices, moe_output = MoeOp.golden(
+            attn_output,
+            shared_gate_weights=moe_shared_gate_weights,
+            shared_up_weights=moe_shared_up_weights,
+            shared_down_weights=moe_shared_down_weights,
+            gate_proj_weights_dict=moe_gate_proj_weights_dict,
+            up_proj_weights_dict=moe_up_proj_weights_dict,
+            down_proj_weights_dict=moe_down_proj_weights_dict,
+            routing_mode=moe_enable_routing,
+            include_residual=True,
+            **moe_golden_kwargs,
+        )
+        return full_q, new_kv, attn_output, moe_scores, moe_indices, moe_output
 
     @staticmethod
     def get_num_semaphores():

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -1,0 +1,599 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import Optional
+
+import ttnn
+from models.demos.deepseek_v3_b1.circular_buffer_utils import (
+    CircularBufferIdManager,
+    build_cb_reconfig_tensor,
+    record_cb_metadata,
+)
+from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock, extend_fabric_args
+from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp, MoeSem
+from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import _extend_runtime_args
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreRuntimeArgsDescriptor, UnifiedKernelDescriptor
+
+
+class DecoderBlock:
+    @staticmethod
+    def golden(
+        input_tensor,
+        gamma_tensor,
+        matmul_weights_tensor,
+        rmsnorm2_gamma_tensor,
+        matmul2_weights_tensor,
+        matmul3_weights_tensor,
+        sin_tensor,
+        cos_tensor,
+        position_ids,
+        dkv_matmul_weights_tensor,
+        dkv_rmsnorm_gamma_tensor,
+        kv_cache_tensor,
+        scale,
+        post_sdpa_weights1,
+        post_sdpa_weights2,
+        epsilon=1e-6,
+        num_qnope_heads=64,
+        num_qrope_heads=64,
+        qnope_head_dim=128,
+        qrope_head_dim=64,
+        heads_per_row=8,
+        nope_dim=512,
+        rope_dim=64,
+        # MoE parameters (when None, only attention golden is computed)
+        moe_shared_gate_weights=None,
+        moe_shared_up_weights=None,
+        moe_shared_down_weights=None,
+        moe_gate_proj_weights_dict=None,
+        moe_up_proj_weights_dict=None,
+        moe_down_proj_weights_dict=None,
+        moe_rmsnorm_gamma=None,
+        moe_rmsnorm_epsilon=None,
+        moe_routing_weights=None,
+        moe_bias=None,
+        moe_gate_eps=1e-20,
+        moe_gate_scaling_factor=2.5,
+        moe_enable_routing=True,
+        moe_use_hardcoded_expert_index=False,
+        moe_hardcoded_expert_index=0,
+        moe_num_devices=1,
+        moe_reduce_root_device_idx=0,
+    ):
+        full_q, new_kv, attn_output = AttentionBlock.golden(
+            input_tensor,
+            gamma_tensor,
+            matmul_weights_tensor,
+            rmsnorm2_gamma_tensor,
+            matmul2_weights_tensor,
+            matmul3_weights_tensor,
+            sin_tensor,
+            cos_tensor,
+            position_ids,
+            dkv_matmul_weights_tensor,
+            dkv_rmsnorm_gamma_tensor,
+            kv_cache_tensor,
+            scale,
+            post_sdpa_weights1,
+            post_sdpa_weights2,
+            epsilon=epsilon,
+            num_qnope_heads=num_qnope_heads,
+            num_qrope_heads=num_qrope_heads,
+            qnope_head_dim=qnope_head_dim,
+            qrope_head_dim=qrope_head_dim,
+            heads_per_row=heads_per_row,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+        )
+        if moe_shared_gate_weights is None:
+            return full_q, new_kv, attn_output, None, None, None
+
+        if moe_rmsnorm_epsilon is None:
+            moe_rmsnorm_epsilon = epsilon
+
+        moe_golden_kwargs = dict(
+            rmsnorm_gamma=moe_rmsnorm_gamma,
+            rmsnorm_epsilon=moe_rmsnorm_epsilon,
+            enable_routing=moe_enable_routing,
+            routing_weights_tensor=moe_routing_weights,
+            bias_tensor=moe_bias,
+            eps=moe_gate_eps,
+            scaling_factor=moe_gate_scaling_factor,
+            use_hardcoded_expert_index=moe_use_hardcoded_expert_index,
+        )
+
+        if moe_num_devices <= 1:
+            moe_scores, moe_indices, moe_output = MoeOp.golden(
+                attn_output,
+                shared_gate_weights=moe_shared_gate_weights,
+                shared_up_weights=moe_shared_up_weights,
+                shared_down_weights=moe_shared_down_weights,
+                gate_proj_weights_dict=moe_gate_proj_weights_dict,
+                up_proj_weights_dict=moe_up_proj_weights_dict,
+                down_proj_weights_dict=moe_down_proj_weights_dict,
+                hardcoded_expert_index=moe_hardcoded_expert_index,
+                **moe_golden_kwargs,
+            )
+            return full_q, new_kv, attn_output, moe_scores, moe_indices, moe_output
+
+        K_down_per_device = moe_shared_gate_weights.shape[1] // moe_num_devices
+        is_moe = moe_enable_routing
+        per_device_outputs = []
+        for dev_idx in range(moe_num_devices):
+            shard_start = dev_idx * K_down_per_device
+            shard_end = shard_start + K_down_per_device
+            # MoE: weights are replicated; each device selects its expert by device index.
+            # Dense MLP: each device owns a unique expert shard; remap it to key 0
+            # so MoeRoutedExpertOp.golden (which always picks key 0 when enable_routing=False)
+            # reads the correct per-device expert.
+            expert_idx = dev_idx if is_moe else 0
+            gate_dict = moe_gate_proj_weights_dict if is_moe else {0: moe_gate_proj_weights_dict[dev_idx]}
+            up_dict = moe_up_proj_weights_dict if is_moe else {0: moe_up_proj_weights_dict[dev_idx]}
+            down_dict = moe_down_proj_weights_dict if is_moe else {0: moe_down_proj_weights_dict[dev_idx]}
+
+            scores, indices, dev_output = MoeOp.golden(
+                attn_output,
+                shared_gate_weights=moe_shared_gate_weights[:, shard_start:shard_end],
+                shared_up_weights=moe_shared_up_weights[:, shard_start:shard_end],
+                shared_down_weights=moe_shared_down_weights[shard_start:shard_end, :],
+                gate_proj_weights_dict=gate_dict,
+                up_proj_weights_dict=up_dict,
+                down_proj_weights_dict=down_dict,
+                hardcoded_expert_index=expert_idx,
+                include_residual=(dev_idx == moe_reduce_root_device_idx),
+                **moe_golden_kwargs,
+            )
+            per_device_outputs.append(dev_output)
+
+        moe_output = sum(per_device_outputs)
+        return full_q, new_kv, attn_output, scores, indices, moe_output
+
+    @staticmethod
+    def get_num_semaphores():
+        return AttentionBlock.get_num_semaphores() + MoeSem.NUM_SEMAPHORES
+
+    @staticmethod
+    def create_semaphores(mesh_device):
+        return AttentionBlock.create_semaphores(mesh_device) + MoeOp.create_semaphores(mesh_device)
+
+    @staticmethod
+    def op(
+        # AttentionBlock parameters
+        input_tensor_mesh,
+        gamma_tensor,
+        matmul_weights_tensor,
+        rmsnorm2_gamma_tensor,
+        matmul2_weights_tensor,
+        matmul3_weights_tensor,
+        qrope_sin_tensor,
+        qrope_cos_tensor,
+        trans_mat_tensor,
+        krope_cos_tensor,
+        krope_sin_tensor,
+        dkv_matmul_weights_tensor,
+        dkv_rmsnorm_gamma_tensor,
+        kv_cache_tensor,
+        position_ids_tensor,
+        sdpa_scale,
+        sdpa_kv_cache_buffer,
+        sdpa_out_interm_buffer,
+        sender_coord,
+        post_sdpa_weights1_tensor,
+        post_sdpa_weights2_tensor,
+        sdpa_input_l_mesh,
+        sdpa_input_ms_mesh,
+        sdpa_output_l_mesh,
+        sdpa_intermediate_recv_mesh,
+        sdpa_forwarder_scratch_mesh,
+        sdpa_per_device_chunk_size,
+        attention_block_output_tensor,
+        attention_block_semaphores=None,
+        bcast_cluster_axis=0,
+        bcast_secondary_cluster_axis=1,
+        reduce_cluster_axis=1,
+        sdpa_cluster_axis=0,
+        num_links=1,
+        # MoE parameters
+        shared_residual_mcast_src_tensor=None,
+        gate_mm_weights_tensor=None,
+        gate_bias_tensor=None,
+        gate_indices_tensor=None,
+        gate_output_scores_tensor=None,
+        gate_output_indices_tensor=None,
+        gate_proj_weights_tensor=None,
+        up_proj_weights_tensor=None,
+        down_proj_weights_tensor=None,
+        moe_final_output_tensor=None,
+        rmsnorm_gamma_tensor=None,
+        shared_gate_weights_overlapped=None,
+        shared_up_weights_overlapped=None,
+        shared_down_weights_tensor=None,
+        shared_k_parallel=None,
+        shared_n_parallel=None,
+        moe_semaphores=None,
+        reduce_intermediate_tensors=None,
+        reduce_output_tensor: Optional[ttnn.Tensor] = None,
+        reduce_semaphores: Optional[list] = None,
+        reduce_root_coord: Optional[ttnn.MeshCoordinate] = None,
+        # Shared parameters
+        epsilon=1e-6,
+        fp32_dest_acc_en=False,
+        skip_ccl=False,
+        enable_routing=True,
+        use_hardcoded_expert_index=False,
+        noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
+        num_iterations=1,
+        upstream_socket=None,
+        downstream_socket=None,
+        persistent_next_iter_semaphore=None,
+        persistent_mode=False,
+        is_torus=True,
+    ):
+        cb_id_manager = CircularBufferIdManager()
+        mla_cb_id_context = cb_id_manager.create_context()
+        moe_cb_id_context = cb_id_manager.create_context()
+        full_device_grid, decoder_cbs, decoder_per_device_contexts = AttentionBlock.get_program_context(
+            input_tensor_mesh,
+            gamma_tensor,
+            matmul_weights_tensor,
+            rmsnorm2_gamma_tensor,
+            matmul2_weights_tensor,
+            matmul3_weights_tensor,
+            qrope_sin_tensor,
+            qrope_cos_tensor,
+            trans_mat_tensor,
+            krope_cos_tensor,
+            krope_sin_tensor,
+            dkv_matmul_weights_tensor,
+            dkv_rmsnorm_gamma_tensor,
+            kv_cache_tensor,
+            position_ids_tensor,
+            sdpa_scale,
+            None,
+            sdpa_kv_cache_buffer,
+            sdpa_out_interm_buffer,
+            sender_coord,
+            # Post-SDPA parameters
+            post_sdpa_weights1_tensor,
+            post_sdpa_weights2_tensor,
+            sdpa_input_l_mesh,
+            sdpa_input_ms_mesh,
+            sdpa_output_l_mesh,
+            sdpa_intermediate_recv_mesh,
+            sdpa_forwarder_scratch_mesh,
+            sdpa_per_device_chunk_size,
+            attention_block_output_tensor,
+            # Shared semaphores, and some default values
+            attention_block_semaphores,
+            bcast_cluster_axis,
+            bcast_secondary_cluster_axis,
+            reduce_cluster_axis,
+            sdpa_cluster_axis,
+            num_links,
+            epsilon,
+            fp32_dest_acc_en,
+            skip_ccl,
+            noc_mode,
+            mla_cb_id_context,
+            upstream_socket=upstream_socket,
+        )
+
+        moe = MoeOp(
+            shared_residual_mcast_src_tensor,
+            gate_mm_weights_tensor=gate_mm_weights_tensor,
+            gate_bias_tensor=gate_bias_tensor,
+            gate_indices_tensor=gate_indices_tensor,
+            gate_output_scores_tensor=gate_output_scores_tensor,
+            gate_output_indices_tensor=gate_output_indices_tensor,
+            gate_proj_weights_tensor=gate_proj_weights_tensor,
+            up_proj_weights_tensor=up_proj_weights_tensor,
+            down_proj_weights_tensor=down_proj_weights_tensor,
+            final_output_tensor=moe_final_output_tensor,
+            rmsnorm_gamma_tensor=rmsnorm_gamma_tensor,
+            shared_gate_weights_overlapped=shared_gate_weights_overlapped,
+            shared_up_weights_overlapped=shared_up_weights_overlapped,
+            shared_down_weights_tensor=shared_down_weights_tensor,
+            shared_k_parallel=shared_k_parallel,
+            shared_n_parallel=shared_n_parallel,
+            epsilon=epsilon,
+            enable_routing=enable_routing,
+            use_hardcoded_expert_index=use_hardcoded_expert_index,
+            sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
+            sdpa_out_interm_buffer=sdpa_out_interm_buffer,
+            reduce_intermediate_tensors=reduce_intermediate_tensors,
+            reduce_output_tensor=reduce_output_tensor,
+            reduce_semaphores=reduce_semaphores,
+            reduce_root_coord=reduce_root_coord,
+            reconfig_moe_cbs=True,
+            semaphores=moe_semaphores,
+            noc_mode=noc_mode,
+            cb_id_context=moe_cb_id_context,
+            downstream_socket=downstream_socket,
+            persistent_next_iter_semaphore=persistent_next_iter_semaphore,
+            persistent_mode=persistent_mode,
+            bcast_sender_coord=sender_coord,
+            is_torus=is_torus,
+        )
+
+        moe._build_descriptors()
+        moe_ctx = moe.ctx
+
+        io_tensors = []
+        cb_metadata = record_cb_metadata(decoder_cbs)
+        reconfig_tensor = build_cb_reconfig_tensor(cb_metadata, full_device_grid, input_tensor_mesh.device())
+        io_tensors.append(reconfig_tensor)
+        cbs_list = cb_id_manager.build_dummy_cb_descriptors(full_device_grid)
+
+        # TODO: Passing the address here as a named compile time arg is not ideal. Done for simplicity.
+        additional_named_compile_time_args = [
+            ("mla_reconfig_cb_config_l1_addr", reconfig_tensor.buffer_address()),
+            ("num_iterations", num_iterations),
+        ]
+
+        io_tensors += [
+            input_tensor_mesh,
+            gamma_tensor.fused_tensor,
+            matmul_weights_tensor.fused_tensor,
+            matmul3_weights_tensor.fused_tensor,
+            trans_mat_tensor,
+            qrope_cos_tensor,
+            qrope_sin_tensor,
+            krope_cos_tensor,
+            krope_sin_tensor,
+            position_ids_tensor,
+            kv_cache_tensor,
+            sdpa_kv_cache_buffer,
+            sdpa_out_interm_buffer,
+            attention_block_output_tensor,
+        ]
+        io_tensors += moe.io_tensors
+
+        def _patch_named_compile_time_args(named_args, overrides):
+            """Replace selected named compile-time args while preserving order."""
+            return [(name, overrides.get(name, value)) for name, value in named_args]
+
+        def _adapt_moe_ct_args(named_args):
+            """Rename/filter MoE CT args that conflict with attention CT args."""
+            result = []
+            for name, value in named_args:
+                if name == "num_iterations":
+                    continue
+                if name == "reconfig_cb_config_l1_addr":
+                    result.append(("moe_reconfig_cb_config_l1_addr", value))
+                else:
+                    result.append((name, value))
+            return result
+
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+        for ctx in decoder_per_device_contexts:
+            mesh_coord = ctx["mesh_coord"]
+            row = mesh_coord[0]
+            col = mesh_coord[1]
+            chip_id = row * moe_ctx.mesh_cols + col
+
+            # ── MoE per-device setup ──
+            moe._setup_per_device_args(chip_id, num_iterations, reduce_root_coord, mesh_coord, row, col)
+
+            moe_ncrisc_ct = _adapt_moe_ct_args(moe.ncrisc_args)
+            moe_brisc_ct = _adapt_moe_ct_args(moe.brisc_args)
+            moe_trisc_ct = _adapt_moe_ct_args(moe.trisc_args)
+            attn_ncrisc_common = ctx["ncrisc_common_runtime_args"]
+            attn_trisc_common = ctx["trisc_common_runtime_args"]
+            moe_ncrisc_ct = _patch_named_compile_time_args(
+                moe_ncrisc_ct, {"reduce_ncrisc_common_rt_arg_base": len(attn_ncrisc_common)}
+            )
+            moe_trisc_ct = _patch_named_compile_time_args(
+                moe_trisc_ct, {"moe_rmsnorm_trisc_common_rt_arg_base": len(attn_trisc_common)}
+            )
+            attn_per_core_brisc = ctx["per_core_brisc_args"]
+            attn_brisc_prefix_len_by_core = {}
+            for core_coord, args in attn_per_core_brisc:
+                core_key = (core_coord.x, core_coord.y)
+                attn_brisc_prefix_len_by_core[core_key] = attn_brisc_prefix_len_by_core.get(core_key, 0) + len(args)
+            moe_per_core_brisc = moe.device_rt_args_desc.brisc_args if moe.device_rt_args_desc else []
+
+            # Compute the correct bases and patch directly into moe_brisc_ct.
+            # Both worker and fabric cores start reading their moe per-core args immediately after
+            # the attn per-core args, so both bases equal attn_base. All reduce cores (worker and
+            # fabric) must have the same attn_base since attn assigns the same per-core args to
+            # every core on the device.
+            if moe_per_core_brisc:
+                attn_bases = {attn_brisc_prefix_len_by_core.get((c.x, c.y), 0) for c, _ in moe_per_core_brisc}
+                assert (
+                    len(attn_bases) == 1
+                ), f"All reduce cores must have the same attn per-core arg count, got: {attn_bases}"
+                reduce_rt_arg_base = next(iter(attn_bases))
+            else:
+                reduce_rt_arg_base = 0
+            moe_brisc_ct = _patch_named_compile_time_args(
+                moe_brisc_ct,
+                {
+                    "reduce_brisc_rt_arg_base": reduce_rt_arg_base,
+                    "reduce_brisc_fabric_rt_arg_base": reduce_rt_arg_base,
+                },
+            )
+            merged_ucd = ctx["unified_compile_time_core_descriptors"] + moe.device_unified_core_descs
+            merged_pcd = ctx["per_core_compile_time_descriptors"] + moe.device_per_core_descs
+            mesh_coord_args = [("mesh_row", row), ("mesh_col", col)]
+
+            my_defines = moe.kernel_defines
+            if ctx["device_kernel_defines"] is not None:
+                my_defines = ctx["device_kernel_defines"] + moe.kernel_defines
+            unified_kernel = UnifiedKernelDescriptor(
+                kernel_source="models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp",
+                core_ranges=full_device_grid,
+                defines=my_defines,
+                ncrisc_compile_time_args=ctx["ncrisc_compile_time_args"],
+                brisc_compile_time_args=ctx["brisc_compile_time_args"],
+                ncrisc_named_compile_time_args=mesh_coord_args
+                + ctx["ncrisc_named_compile_time_args"]
+                + moe_ncrisc_ct
+                + additional_named_compile_time_args,
+                ncrisc_common_runtime_args=ctx["ncrisc_common_runtime_args"] + moe.ncrisc_common_rt_args,
+                brisc_named_compile_time_args=mesh_coord_args
+                + ctx["brisc_named_compile_time_args"]
+                + moe_brisc_ct
+                + additional_named_compile_time_args,
+                brisc_common_runtime_args=ctx["brisc_common_runtime_args"],
+                trisc_named_compile_time_args=mesh_coord_args
+                + ctx["trisc_named_compile_time_args"]
+                + moe_trisc_ct
+                + additional_named_compile_time_args,
+                trisc_common_runtime_args=ctx["trisc_common_runtime_args"]
+                + [moe_ctx.rmsnorm_epsilon_packed, moe_ctx.rmsnorm_scalar_packed],
+                trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                    math_fidelity=ttnn.MathFidelity.LoFi,
+                    math_approx_mode=False,
+                    fp32_dest_acc_en=fp32_dest_acc_en,
+                    dst_full_sync_en=fp32_dest_acc_en,
+                ),
+                unified_compile_time_core_descriptors=merged_ucd,
+                per_core_compile_time_descriptors=merged_pcd,
+                per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
+                    ncrisc_args=ctx["per_core_ncrisc_args"]
+                    + (moe.device_rt_args_desc.ncrisc_args if moe.device_rt_args_desc else []),
+                    brisc_args=ctx["per_core_brisc_args"]
+                    + (moe.device_rt_args_desc.brisc_args if moe.device_rt_args_desc else []),
+                    trisc_args=ctx["per_core_trisc_args"]
+                    + (moe.device_rt_args_desc.trisc_args if moe.device_rt_args_desc else []),
+                ),
+                noc_mode=noc_mode,
+            )
+            kernel_result = unified_kernel.get_kernel_descriptors()
+            program = ttnn.ProgramDescriptor(
+                kernels=kernel_result.kernels,
+                cbs=cbs_list,
+                semaphores=ctx["semaphore_list"] + moe.device_sem_descs,
+            )
+            broadcast_worker_core = ctx["broadcast_worker_core"]
+            dst_nodes = ctx["dst_nodes"]
+            if not skip_ccl and len(dst_nodes) > 0:
+                for idx, kernel in enumerate(program.kernels):
+                    if kernel.core_ranges.contains(broadcast_worker_core) and (
+                        isinstance(kernel.config, ttnn.ReaderConfigDescriptor)
+                        or (
+                            isinstance(kernel.config, ttnn.DataMovementConfigDescriptor)
+                            and kernel.config.processor == ttnn.DataMovementProcessor.RISCV_1
+                        )
+                    ):
+                        writer_rt_args_ref = kernel.runtime_args[broadcast_worker_core.x][broadcast_worker_core.y]
+                        fabric_args = ttnn.setup_routing_plane_connection(
+                            ctx["fabric_node_id"], dst_nodes, [0], program, idx, broadcast_worker_core
+                        )
+                        extend_fabric_args(writer_rt_args_ref, fabric_args)
+                        break
+            # ==================================================================
+            # SDPA runtime args and fabric connection setup
+            # ==================================================================
+            if ctx["sdpa"]:
+                sdpa = ctx["sdpa"]
+                sdpa_forwarder_cores = ctx["sdpa_forwarder_cores"]
+
+                for group in kernel_result.groups:
+                    if group.compile_time_arg_values.get("is_sdpa_worker_core") == 1:
+                        crs = group.core_range_set
+                        _extend_runtime_args(
+                            program.kernels[group.ncrisc_kernel_index].runtime_args, sdpa["worker_ncrisc_rt_args"], crs
+                        )
+                        _extend_runtime_args(
+                            program.kernels[group.brisc_kernel_index].runtime_args, sdpa["worker_brisc_rt_args"], crs
+                        )
+                        if sdpa["worker_trisc_rt_args"] is not None:
+                            _extend_runtime_args(
+                                program.kernels[group.trisc_kernel_index].runtime_args,
+                                sdpa["worker_trisc_rt_args"],
+                                crs,
+                            )
+
+                sdpa_forwarder_brisc_rt_args = ttnn.RuntimeArgs()
+                sdpa_forwarder_ncrisc_rt_args = ttnn.RuntimeArgs()
+
+                for fwd_idx, fwd_core in enumerate(sdpa_forwarder_cores):
+                    sdpa_forwarder_brisc_rt_args[fwd_core.x][fwd_core.y] = list(
+                        sdpa["forwarder_brisc_base_args"][(fwd_core.x, fwd_core.y)]
+                    )
+                    brisc_fabric_args = ttnn.setup_fabric_connection(
+                        src_fabric_node_id=sdpa["fabric_node_id"],
+                        dst_fabric_node_id=sdpa["fwd_fabric_node_id"],
+                        link_idx=fwd_idx,
+                        program_descriptor=program,
+                        worker_core=fwd_core,
+                    )
+                    extend_fabric_args(sdpa_forwarder_brisc_rt_args[fwd_core.x][fwd_core.y], brisc_fabric_args)
+
+                    sdpa_forwarder_ncrisc_rt_args[fwd_core.x][fwd_core.y] = list(
+                        sdpa["forwarder_ncrisc_base_args"][(fwd_core.x, fwd_core.y)]
+                    )
+                    ncrisc_fabric_args = ttnn.setup_fabric_connection(
+                        src_fabric_node_id=sdpa["fabric_node_id"],
+                        dst_fabric_node_id=sdpa["bwd_fabric_node_id"],
+                        link_idx=fwd_idx,
+                        program_descriptor=program,
+                        worker_core=fwd_core,
+                    )
+                    extend_fabric_args(sdpa_forwarder_ncrisc_rt_args[fwd_core.x][fwd_core.y], ncrisc_fabric_args)
+
+                for group in kernel_result.groups:
+                    if group.compile_time_arg_values.get("is_sdpa_forwarder_core") == 1:
+                        crs = group.core_range_set
+                        _extend_runtime_args(
+                            program.kernels[group.brisc_kernel_index].runtime_args, sdpa_forwarder_brisc_rt_args, crs
+                        )
+                        _extend_runtime_args(
+                            program.kernels[group.ncrisc_kernel_index].runtime_args, sdpa_forwarder_ncrisc_rt_args, crs
+                        )
+
+            if ctx["ccl"]:
+                ccl = ctx["ccl"]
+                ccl_sender_core = ctx["ccl_sender_core"]
+                gather_core = ctx["gather_core"]
+
+                ccl_sender_group = kernel_result.get_group_by_arg("is_ccl_sender_core", 1)
+                ccl_receiver_group = kernel_result.get_group_by_arg("is_ccl_receiver_core", 1)
+
+                sender_brisc_kernel_idx = ccl_sender_group.brisc_kernel_index
+                sender_ncrisc_kernel_idx = ccl_sender_group.ncrisc_kernel_index
+                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
+
+                ccl_sender_ncrisc_rt_args_ref = program.kernels[ccl_sender_group.ncrisc_kernel_index].runtime_args[
+                    ccl_sender_core.x
+                ][ccl_sender_core.y]
+                ccl_sender_ncrisc_rt_args_ref.extend(ccl["sender_ncrisc_common_rt_args"])
+                ccl_sender_brisc_rt_args_ref = program.kernels[ccl_sender_group.brisc_kernel_index].runtime_args[
+                    ccl_sender_core.x
+                ][ccl_sender_core.y]
+                ccl_sender_brisc_rt_args_ref.extend(ccl["sender_brisc_common_rt_args"])
+                ccl_receiver_ncrisc_rt_args_ref = program.kernels[ccl_receiver_group.ncrisc_kernel_index].runtime_args[
+                    gather_core.x
+                ][gather_core.y]
+                ccl_receiver_ncrisc_rt_args_ref.extend(ccl["receiver_ncrisc_common_rt_args"])
+
+                fabric_node_id = ccl["fabric_node_id"]
+                neighbor_fabric_node_id = ccl["neighbor_fabric_node_id"]
+
+                sender_brisc_rt_args_ref = program.kernels[sender_brisc_kernel_idx].runtime_args[ccl_sender_core.x][
+                    ccl_sender_core.y
+                ]
+                sender_fabric_args = ttnn.setup_routing_plane_connection(
+                    fabric_node_id,
+                    [neighbor_fabric_node_id],
+                    [ccl["sender_link"]],
+                    program,
+                    sender_brisc_kernel_idx,
+                    ccl_sender_core,
+                )
+                extend_fabric_args(sender_brisc_rt_args_ref, sender_fabric_args)
+
+                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
+                receiver_ncrisc_rt_args_ref = program.kernels[receiver_ncrisc_kernel_idx].runtime_args[gather_core.x][
+                    gather_core.y
+                ]
+
+            # MoE fabric connections (reduce-to-one)
+            moe._setup_fabric_connections(mesh_coord, row, col, reduce_root_coord, kernel_result, program)
+            mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
+        print("Running DecoderBlock op")
+        result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
+        return result, attention_block_output_tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -554,8 +554,6 @@ class DecoderBlock:
                 ccl_receiver_group = kernel_result.get_group_by_arg("is_ccl_receiver_core", 1)
 
                 sender_brisc_kernel_idx = ccl_sender_group.brisc_kernel_index
-                sender_ncrisc_kernel_idx = ccl_sender_group.ncrisc_kernel_index
-                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
 
                 ccl_sender_ncrisc_rt_args_ref = program.kernels[ccl_sender_group.ncrisc_kernel_index].runtime_args[
                     ccl_sender_core.x
@@ -585,11 +583,6 @@ class DecoderBlock:
                     ccl_sender_core,
                 )
                 extend_fabric_args(sender_brisc_rt_args_ref, sender_fabric_args)
-
-                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
-                receiver_ncrisc_rt_args_ref = program.kernels[receiver_ncrisc_kernel_idx].runtime_args[gather_core.x][
-                    gather_core.y
-                ]
 
             # MoE fabric connections (reduce-to-one)
             moe._setup_fabric_connections(mesh_coord, row, col, reduce_root_coord, kernel_result, program)

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -551,6 +551,5 @@ class DecoderBlock:
             # MoE fabric connections (reduce-to-one)
             moe._setup_fabric_connections(mesh_coord, row, col, reduce_root_coord, kernel_result, program)
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
-        print("Running DecoderBlock op")
         result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
         return result, attention_block_output_tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -1044,6 +1044,7 @@ class MoeRoutedExpertOp:
                 weights_overlapped=gate_mm_weights_tensor,
                 k_num_tiles=num_tiles_k,
                 fused_activation=MoeRoutedExpertOp.ACTIVATION_SIGMOID,
+                fused_activation_approx_mode=False,
             )
 
             # Gate MM Gather
@@ -1748,6 +1749,10 @@ class MoeRoutedExpertOp:
             ("gate_mm_k_num_tiles", ctx.gate_mm_params["k_num_tiles"] if ctx.enable_routing else 0),
             ("gate_mm_out_w", ctx.gate_mm_params["out_w"] if ctx.enable_routing else 0),
             ("gate_mm_fused_activation", ctx.gate_mm_params["fused_activation"] if ctx.enable_routing else 0),
+            (
+                "gate_mm_fused_activation_approx_mode",
+                ctx.gate_mm_params["fused_activation_approx_mode"] if ctx.enable_routing else 0,
+            ),
             # Gate compute (routing only)
             ("gate_input_cb", ctx.gate_params["input_cb"] if ctx.enable_routing else 0),
             ("gate_bias_cb", ctx.gate_params["bias_cb"] if ctx.enable_routing else 0),
@@ -3009,6 +3014,7 @@ class MoeOp:
         output_tensor=None,
         k_num_tiles=0,
         fused_activation=0,
+        fused_activation_approx_mode=True,
         weights_core_ranges_override=None,
     ):
         """
@@ -3026,7 +3032,7 @@ class MoeOp:
                            will be created by the overlap function.
             k_num_tiles: K dimension in tiles
             fused_activation: Activation to fuse (0=none, 1=sigmoid, 2=silu)
-
+            fused_activation_approx_mode: Whether to use approximate activation (default False)
         Returns:
             Dictionary with matmul parameters and CB descriptors
         """
@@ -3059,6 +3065,7 @@ class MoeOp:
             "k_num_tiles": k_num_tiles,
             "out_w": out_w,
             "fused_activation": fused_activation,
+            "fused_activation_approx_mode": fused_activation_approx_mode,
             "core_grid": core_grid,
             "num_cores": core_grid.num_cores(),
             "weights_cb_descriptor": weights_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -3074,7 +3074,7 @@ class MoeOp:
         }
 
     @staticmethod
-    def golden(
+    def golden_single_device(
         input_tensor,
         shared_gate_weights,
         shared_up_weights,
@@ -3159,6 +3159,122 @@ class MoeOp:
             hardcoded_expert_index=hardcoded_expert_index,
             explicit_expert_scale=explicit_expert_scale,
         )
+
+    @staticmethod
+    def golden(
+        input_tensor,
+        shared_gate_weights,
+        shared_up_weights,
+        shared_down_weights,
+        gate_proj_weights_dict,
+        up_proj_weights_dict,
+        down_proj_weights_dict,
+        rmsnorm_gamma,
+        routing_weights_tensor,
+        bias_tensor,
+        rmsnorm_epsilon=1e-6,
+        routing_mode=True,
+        eps=1e-20,
+        scaling_factor=2.5,
+        include_residual=True,
+        top_k=8,
+        topk_groups=4,
+    ):
+        """
+        Clean PyTorch golden for post-attention MoE: y = h + MoE(h).
+
+        routing_mode controls all modes:
+          - True: normal routed MoE (grouped noaux gate + top-k weighted experts)
+          - False: dense MLP mode (single expert 0 with unit scale)
+          - list[int]: hardcoded expert indices; weights come from gate scores for those experts
+        """
+        print("MoEOp golden")
+        import torch
+
+        def _as_2d(t: torch.Tensor) -> torch.Tensor:
+            return t.reshape(1, -1).to(torch.bfloat16)
+
+        def _reshape_weight(w: torch.Tensor, in_dim: int):
+            # Supports [K, N] and [1,1,K,N] tensors.
+            w2 = w.to(torch.bfloat16)
+            if w2.ndim == 2:
+                return w2
+            return w2.reshape(in_dim, -1)
+
+        def _compute_grouped_topk(scores_flat: torch.Tensor, bias_flat: torch.Tensor):
+            n_routed = scores_flat.shape[-1]
+            n_groups = int(bias_tensor.shape[-2])
+            experts_per_group = n_routed // n_groups
+            scores_for_choice = scores_flat + bias_flat
+
+            grouped = scores_for_choice.reshape(1, n_groups, experts_per_group)
+            summed_experts_per_group = min(2, experts_per_group)
+            group_scores = torch.topk(grouped, k=summed_experts_per_group, dim=-1, sorted=True)[0].sum(dim=-1)
+            sel_topk_groups = min(topk_groups, n_groups)
+            group_idx = torch.topk(group_scores, k=sel_topk_groups, dim=-1, sorted=True)[1]
+
+            group_mask = torch.zeros_like(group_scores)
+            group_mask.scatter_(1, group_idx, 1)
+            score_mask = group_mask.unsqueeze(-1).expand(1, n_groups, experts_per_group).reshape(1, n_routed)
+            masked_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+
+            sel_top_k = min(top_k, n_routed)
+            topk_idx = torch.topk(masked_scores, k=sel_top_k, dim=-1, sorted=True)[1]
+            topk_weight = scores_flat.gather(1, topk_idx)
+            if sel_top_k > 1:
+                topk_weight = topk_weight / (topk_weight.sum(dim=-1, keepdim=True) + eps)
+            topk_weight = topk_weight * scaling_factor
+            return topk_weight, topk_idx
+
+        # RMSNorm(h) for MoE input.
+        x = _as_2d(input_tensor)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        norm_x = (x * torch.rsqrt(variance + rmsnorm_epsilon)) * _as_2d(rmsnorm_gamma)
+
+        # Shared expert branch: (SiLU(hWg) * (hWu))Wd + residual.
+        sh_gate = _reshape_weight(shared_gate_weights, norm_x.shape[-1])
+        sh_up = _reshape_weight(shared_up_weights, norm_x.shape[-1])
+        sh_down = _reshape_weight(shared_down_weights, sh_gate.shape[-1])
+        shared_hidden = torch.nn.functional.silu(norm_x @ sh_gate) * (norm_x @ sh_up)
+        shared_output = shared_hidden @ sh_down
+        if include_residual:
+            shared_output = shared_output + x
+
+        # Routed branch selection/weights.
+        topk_scores = None
+        topk_indices = None
+        if routing_mode is False:
+            selected_experts = [0]
+            selected_scales = [torch.tensor(1.0, dtype=torch.bfloat16)]
+        else:
+            logits = norm_x @ routing_weights_tensor.to(norm_x.dtype)
+            scores = torch.sigmoid(logits)
+            print("golden all scores", scores)
+            scores_flat = scores.reshape(1, -1)
+            bias_flat = bias_tensor.reshape(1, -1).to(scores_flat.dtype)
+            # Hardware gate produces top-k slots; both expert-index selection and
+            # expert-scale mcast are indexed by per-device slot offset.
+            # Keep this available for hardcoded mode parity.
+            gate_topk_scores, gate_topk_indices = _compute_grouped_topk(scores_flat, bias_flat)
+
+            topk_scores, topk_indices = gate_topk_scores, gate_topk_indices
+            selected_experts = [int(i) for i in topk_indices[0].tolist()]
+            selected_scales = [topk_scores[0, i] for i in range(len(selected_experts))]
+            print("golden selected experts", selected_experts)
+            print("golden selected scales", selected_scales)
+
+        routed_sum = torch.zeros_like(shared_output)
+        for expert_idx, expert_scale in zip(selected_experts, selected_scales, strict=True):
+            gate_w = _reshape_weight(gate_proj_weights_dict[expert_idx], norm_x.shape[-1])
+            up_w = _reshape_weight(up_proj_weights_dict[expert_idx], norm_x.shape[-1])
+            down_w = _reshape_weight(down_proj_weights_dict[expert_idx], gate_w.shape[-1])
+            gate_out = torch.nn.functional.silu(norm_x @ gate_w)
+            up_out = norm_x @ up_w
+            routed_hidden = gate_out * up_out * expert_scale
+            routed_sum = routed_sum + (routed_hidden @ down_w)
+
+        final_output = (shared_output + routed_sum).reshape(1, 1, 1, -1)
+        return topk_scores, topk_indices, final_output
 
     @staticmethod
     def _overlap_cbs_with_sdpa_buffer(

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -39,7 +39,7 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
-from models.demos.deepseek_v3_b1.utils import float_to_uint32
+from models.demos.deepseek_v3_b1.utils import float_to_uint32, get_pinned_optimal_dram_bank_to_logical_worker_assignment
 
 
 class MoeSem:
@@ -832,7 +832,7 @@ class MoeRoutedExpertOp:
         mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
         device = ttnn.get_device_tensors(shared_residual_mcast_src_tensor)[0].device()
 
-        gate_proj_worker_cores = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+        gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(device, ttnn.NOC.NOC_0)
         gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
         mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core)])
         sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
@@ -1361,7 +1361,7 @@ class MoeRoutedExpertOp:
         # ==================================================================
         # Per-core bank_id, vc, sender_idx
         # ==================================================================
-        gate_proj_optimal_workers = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+        gate_proj_optimal_workers = get_pinned_optimal_dram_bank_to_logical_worker_assignment(device, ttnn.NOC.NOC_0)
         core_to_bank_id = {}
         for bank_id, core in enumerate(gate_proj_optimal_workers):
             core_to_bank_id[(core.x, core.y)] = bank_id

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -3244,8 +3244,8 @@ class MoeOp:
         topk_scores = None
         topk_indices = None
         if routing_mode is False:
-            selected_experts = [0]
-            selected_scales = [torch.tensor(1.0, dtype=torch.bfloat16)]
+            selected_experts = sorted(gate_proj_weights_dict.keys())
+            selected_scales = [torch.tensor(1.0, dtype=torch.bfloat16)] * len(selected_experts)
         else:
             logits = norm_x @ routing_weights_tensor.to(norm_x.dtype)
             scores = torch.sigmoid(logits)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
@@ -466,7 +466,8 @@ void kernel_main() {
     using GateMMCTArgs = deepseek_b1_ops::Matmul::ComputeCTArgs<
         get_named_compile_time_arg_val("gate_mm_out_w"),
         false,  // transpose
-        get_named_compile_time_arg_val("gate_mm_fused_activation")>;
+        get_named_compile_time_arg_val("gate_mm_fused_activation"),
+        get_named_compile_time_arg_val("gate_mm_fused_activation_approx_mode")>;
     deepseek_b1_ops::Matmul::ComputeArgs gate_mm_args{
         get_named_compile_time_arg_val("gate_mm_in0"),
         get_named_compile_time_arg_val("gate_mm_in1"),

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -441,6 +441,7 @@ def setup_sram_matmul(
     output_tensor,
     k_num_tiles,
     fused_activation=0,
+    fused_activation_approx_mode=False,
 ):
     """
     Set up parameters for an SRAM matmul operation.
@@ -456,7 +457,7 @@ def setup_sram_matmul(
         output_tensor: Output tensor (WIDTH_SHARDED in L1)
         k_num_tiles: K dimension in tiles
         fused_activation: Activation to fuse (0=none, 1=sigmoid, 2=silu)
-
+        fused_activation_approx_mode: Whether to use approximate activation (default False)
     Returns:
         Dictionary with matmul parameters and CB descriptors
     """
@@ -477,6 +478,7 @@ def setup_sram_matmul(
         "k_num_tiles": k_num_tiles,
         "out_w": out_w,
         "fused_activation": fused_activation,
+        "fused_activation_approx_mode": fused_activation_approx_mode,
         # Core grid
         "core_grid": core_grid,
         "num_cores": core_grid.num_cores(),
@@ -1005,6 +1007,7 @@ class MoeRoutedExpert:
             output_tensor=gate_mm_output_tensor,
             k_num_tiles=num_tiles_k,
             fused_activation=MoeRoutedExpert.ACTIVATION_SIGMOID,
+            fused_activation_approx_mode=False,
         )
 
         # CB descriptors
@@ -1511,6 +1514,7 @@ class MoeRoutedExpert:
             ("gate_mm_k_num_tiles", gate_mm_params["k_num_tiles"]),
             ("gate_mm_out_w", gate_mm_params["out_w"]),
             ("gate_mm_fused_activation", gate_mm_params["fused_activation"]),
+            ("gate_mm_fused_activation_approx_mode", gate_mm_params["fused_activation_approx_mode"]),
             # Gate compute args (sender core)
             ("gate_input_cb", gate_params["input_cb"]),
             ("gate_bias_cb", gate_params["bias_cb"]),

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -610,14 +610,15 @@ def prepare_moe_layer_weights(
     layer_idx: int,
     *,
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
+    move_to_device: bool = False,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer."""
     logger.info("Preparing MoE layer {}...", layer_idx)
     t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=True)
-    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True)
+    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=True, move_to_device=move_to_device)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True, move_to_device=move_to_device)
     routed = prepare_routed_expert_weights(
-        bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts
+        bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts, move_to_device=move_to_device
     )
     assert isinstance(attn.gate_mm, OverlappedTensor)
     assert attn.gate_bias is not None

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
@@ -27,6 +27,11 @@ _REF_HF_SHARED_GATE_UP = (2048, 7168)
 _REF_K = 7168
 
 
+def _scaled_randn(*shape, generator, dtype=torch.bfloat16):
+    """Generate random weights scaled by 1/sqrt(inner_dim), matching generate_mm_weights convention."""
+    return (torch.randn(*shape, generator=generator, dtype=torch.float32) / (shape[-2] ** 0.5)).to(dtype)
+
+
 def _reference_layer_state_dict(
     layer_idx: int,
     *,
@@ -37,20 +42,27 @@ def _reference_layer_state_dict(
     """Build one layer state_dict in HF key convention with deterministic random weights (Generator)."""
     g = torch.Generator().manual_seed(seed)
     state = {
-        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(
-            1536, _REF_K, generator=g, dtype=torch.bfloat16
+        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": _scaled_randn(
+            1536,
+            _REF_K,
+            generator=g,
         ),
-        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(
-            *_REF_HF_Q_B, generator=g, dtype=torch.bfloat16
+        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": _scaled_randn(
+            *_REF_HF_Q_B,
+            generator=g,
         ),
-        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(
-            576, _REF_K, generator=g, dtype=torch.bfloat16
+        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": _scaled_randn(
+            576,
+            _REF_K,
+            generator=g,
         ),
-        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(
-            *_REF_HF_KV_B, generator=g, dtype=torch.bfloat16
+        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": _scaled_randn(
+            *_REF_HF_KV_B,
+            generator=g,
         ),
-        f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(
-            *_REF_HF_O_PROJ, generator=g, dtype=torch.bfloat16
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": _scaled_randn(
+            *_REF_HF_O_PROJ,
+            generator=g,
         ),
         f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(_REF_K, generator=g, dtype=torch.bfloat16),
         f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(
@@ -64,20 +76,23 @@ def _reference_layer_state_dict(
         ),
     }
     if is_moe:
-        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, _REF_K, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = _scaled_randn(256, _REF_K, generator=g)
         state[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = torch.randn(
             256, generator=g, dtype=torch.bfloat16
-        )
-        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(
-            *_REF_HF_SHARED_GATE_UP, generator=g, dtype=torch.bfloat16
-        )
-        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(
-            *_REF_HF_SHARED_GATE_UP, generator=g, dtype=torch.bfloat16
-        )
-        state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = torch.randn(
-            7168, _REF_HF_SHARED_GATE_UP[0], generator=g, dtype=torch.bfloat16
-        )
-        # Expert weights: deterministic per-expert seeds (gate_seed, up_seed, down_seed) for golden parity
+        ).clamp(-2, 2)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = _scaled_randn(
+            *_REF_HF_SHARED_GATE_UP,
+            generator=g,
+        ).clamp(-2, 2)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = _scaled_randn(
+            *_REF_HF_SHARED_GATE_UP,
+            generator=g,
+        ).clamp(-2, 2)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = _scaled_randn(
+            7168,
+            _REF_HF_SHARED_GATE_UP[0],
+            generator=g,
+        ).clamp(-2, 2)
         gate_seed = seed + 0
         up_seed = seed + 256
         down_seed = seed + 512
@@ -85,24 +100,36 @@ def _reference_layer_state_dict(
             g_gate = torch.Generator().manual_seed(gate_seed + e)
             g_up = torch.Generator().manual_seed(up_seed + e)
             g_down = torch.Generator().manual_seed(down_seed + e)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
-                2048, _REF_K, generator=g_gate, dtype=torch.bfloat16
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = _scaled_randn(
+                2048,
+                _REF_K,
+                generator=g_gate,
             ).clamp(-2, 2)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = torch.randn(
-                2048, _REF_K, generator=g_up, dtype=torch.bfloat16
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = _scaled_randn(
+                2048,
+                _REF_K,
+                generator=g_up,
             ).clamp(-2, 2)
-            state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = torch.randn(
-                7168, 2048, generator=g_down, dtype=torch.bfloat16
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = _scaled_randn(
+                7168,
+                2048,
+                generator=g_down,
             ).clamp(-2, 2)
     else:
-        state[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = torch.randn(
-            18432, _REF_K, generator=g, dtype=torch.bfloat16
+        state[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = _scaled_randn(
+            18432,
+            _REF_K,
+            generator=g,
         )
-        state[f"model.layers.{layer_idx}.mlp.up_proj.weight"] = torch.randn(
-            18432, _REF_K, generator=g, dtype=torch.bfloat16
+        state[f"model.layers.{layer_idx}.mlp.up_proj.weight"] = _scaled_randn(
+            18432,
+            _REF_K,
+            generator=g,
         )
-        state[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = torch.randn(
-            _REF_K, 18432, generator=g, dtype=torch.bfloat16
+        state[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = _scaled_randn(
+            _REF_K,
+            18432,
+            generator=g,
         )
     return state
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
@@ -29,7 +29,7 @@ _REF_K = 7168
 
 def _scaled_randn(*shape, generator, dtype=torch.bfloat16):
     """Generate random weights scaled by 1/sqrt(inner_dim), matching generate_mm_weights convention."""
-    return (torch.randn(*shape, generator=generator, dtype=torch.float32) / (shape[-2] ** 0.5)).to(dtype)
+    return (torch.randn(*shape, generator=generator, dtype=torch.float32) / (shape[-1] ** 0.5)).to(dtype)
 
 
 def _reference_layer_state_dict(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -892,7 +892,6 @@ def test_attention_block(
             bcast_secondary_cluster_axis,
             reduce_cluster_axis,
             0,  # sdpa_cluster_axis
-            1.0,  # sdpa_scale_fp32
             1,  # num_links
             epsilon,
             use_fp32,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     create_shared_expert_tensors,
     extract_routed_expert_output,
 )
+from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
 
 
 def create_fabric_router_config(max_payload_size):
@@ -121,7 +122,7 @@ def test_bcast_moe_reduce_pipeline(
     # ── Core setup for reduce aggregation ──
     stage_entry_device = None
     gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, gate_proj_noc)
     num_gate_proj_cores = len(gate_proj_worker_cores)
     reduce_payload_per_shard = embedding_size_bytes // num_gate_proj_cores
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
@@ -629,7 +630,7 @@ def test_persistent_mode_pipeline(
     # ── Core setup for reduce aggregation ──
     stage_entry_device = None
     gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
     shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
     aggregator_core = shard_cores_list[0]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_reduce_pipeline.py
@@ -450,7 +450,7 @@ def test_bcast_moe_reduce_pipeline(
             shared_up_shard = s.torch_up_weights[:, dev_idx * K_down : (dev_idx + 1) * K_down]
             shared_down_shard = s.torch_down_weights[dev_idx * K_down : (dev_idx + 1) * K_down, :]
 
-            _, _, expected_final = MoeOp.golden(
+            _, _, expected_final = MoeOp.golden_single_device(
                 torch_input_row,
                 shared_gate_weights=shared_gate_shard,
                 shared_up_weights=shared_up_shard,
@@ -513,7 +513,7 @@ def test_bcast_moe_reduce_pipeline(
             shared_up_shard = s.torch_up_weights[:, dev_idx * K_down : (dev_idx + 1) * K_down]
             shared_down_shard = s.torch_down_weights[dev_idx * K_down : (dev_idx + 1) * K_down, :]
 
-            _, _, expected_final = MoeOp.golden(
+            _, _, expected_final = MoeOp.golden_single_device(
                 torch_input_row,
                 shared_gate_weights=shared_gate_shard,
                 shared_up_weights=shared_up_shard,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -862,8 +862,6 @@ def test_decoder(
     get_reference_model_state_dict,
 ):
     """Test TTNN decoder fused operation with CCL broadcast, kv cache, mla, reduce, residual add"""
-    if not use_hardcoded_expert_index:
-        pytest.skip("Full routing is not supported for now")
     torch.manual_seed(0)
     num_devices = mesh_rows * mesh_cols
     logger.info(f"Number of devices: {num_devices}")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -64,6 +64,7 @@ def create_decoder_block_tensors(
     is_moe: bool = True,
     num_routed_experts: int = 0,
     preloaded_weights=None,
+    rigged_experts: bool = False,
 ):
     """Create all tensors required by DecoderBlock.op().
 
@@ -171,7 +172,33 @@ def create_decoder_block_tensors(
         tile=ttnn.Tile([8, 32]),
     )
 
-    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    if rigged_experts:
+        # Use deterministic RMS-normalized input to avoid oversized constant-direction activations.
+        # (all-ones can produce brittle saturation in downstream low-precision paths)
+        torch_input_f32 = torch.randn(shape, dtype=torch.float32)
+        torch_input_f32 = torch_input_f32 / torch.sqrt(torch_input_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-6)
+        torch_input = torch_input_f32.to(torch.bfloat16)
+    else:
+        torch_input = torch.randn(shape, dtype=torch.bfloat16)
+
+    rigged_group_ids = None
+    rigged_expert_ids = None
+    if rigged_experts and is_moe and preloaded_weights is None:
+        # Deterministically pick 4 groups and 2 experts/group, then bias-rig gate selection.
+        g = torch.Generator()
+        g.manual_seed(2026)
+        rigged_group_ids = torch.randperm(8, generator=g)[:4].tolist()
+        rigged_expert_ids = {grp: torch.randperm(32, generator=g)[:2].tolist() for grp in rigged_group_ids}
+
+        rigged_bias = torch.full((8, 32), -10.0, dtype=torch.bfloat16)
+        for grp in rigged_group_ids:
+            for exp in rigged_expert_ids[grp]:
+                rigged_bias[grp, exp] = 10.0
+        state_dict[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = rigged_bias.reshape(-1).contiguous()
+        logger.info(
+            f"Rigged experts enabled: groups={rigged_group_ids}, "
+            f"experts={[(grp, rigged_expert_ids[grp]) for grp in rigged_group_ids]}"
+        )
 
     # ══════════════════════════════════════════════════════════════════════════
     # All weights via a single BDW instance or preloaded
@@ -693,6 +720,8 @@ def create_decoder_block_tensors(
             "golden_moe_gate_proj_dict": golden_moe_gate_proj_dict,
             "golden_moe_up_proj_dict": golden_moe_up_proj_dict,
             "golden_moe_down_proj_dict": golden_moe_down_proj_dict,
+            "rigged_group_ids": rigged_group_ids,
+            "rigged_expert_ids": rigged_expert_ids,
         }
 
     # ── Routed weight tensors differ between MoE (list) and dense (single tensor) ──
@@ -816,14 +845,15 @@ def create_decoder_block_tensors(
 )
 @pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
 @pytest.mark.parametrize("num_internal_iterations", [1])
+@pytest.mark.parametrize("rigged_experts", [False, True], ids=["normal_gate", "fixed_experts"])
 @pytest.mark.parametrize(
     "enable_routing, use_hardcoded_expert_index, num_routed_experts",
     [
-        (True, True, 8),
+        # (True, True, 8),
         pytest.param(True, False, 256, marks=pytest.mark.skip_post_commit),
     ],
     ids=[
-        "hardcoded_experts",
+        # "hardcoded_experts",
         "full_routing",
     ],
 )
@@ -854,6 +884,7 @@ def test_decoder(
     position_id,
     noc_mode,
     num_internal_iterations,
+    rigged_experts,
     enable_routing,
     use_hardcoded_expert_index,
     num_routed_experts,
@@ -892,6 +923,7 @@ def test_decoder(
         max_seq_len=max_seq_len,
         is_moe=True,
         num_routed_experts=num_routed_experts,
+        rigged_experts=rigged_experts,
     )
 
     num_cores = device_grid_size.x * device_grid_size.y
@@ -1029,7 +1061,6 @@ def test_decoder(
             epsilon=epsilon,
             fp32_dest_acc_en=use_fp32,
             skip_ccl=False,
-            use_hardcoded_expert_index=use_hardcoded_expert_index,
             noc_mode=noc_mode,
             num_iterations=num_internal_iterations,
             upstream_socket=None,
@@ -1176,10 +1207,6 @@ def test_decoder(
         moe_gate_eps=RoutedExpert.GATE_EPS,
         moe_gate_scaling_factor=RoutedExpert.GATE_SCALING_FACTOR,
         moe_enable_routing=enable_routing,
-        moe_use_hardcoded_expert_index=use_hardcoded_expert_index,
-        moe_hardcoded_expert_index=0,
-        moe_num_devices=num_devices,
-        moe_reduce_root_device_idx=root_coord_tuple[0] * mesh_cols + root_coord_tuple[1],
     )
 
     logger.info(f"MLA output: {mla_output}")
@@ -1506,8 +1533,6 @@ def test_decoder_mlp(
         moe_rmsnorm_gamma=d["golden_moe_rmsnorm_gamma"],
         moe_rmsnorm_epsilon=epsilon,
         moe_enable_routing=False,
-        moe_num_devices=num_devices,
-        moe_reduce_root_device_idx=root_device_idx,
     )
 
     # ========================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -1,0 +1,1526 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN DecoderBlock Test
+Tests decoder fused operation with full pipeline:
+- CCL Broadcast -> RMSNorm -> Matmul -> Gather -> RMSNorm2 -> Matmul2 (shuffled) -> Matmul3 (Qnope only) & RoPE (Qrope only) -> Interleaved Pre-SDPA Output
+- Qnope output: [64, 1, 512] after matmul3
+- Qrope output: [64, 1, 64] after RoPE
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
+from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
+from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    create_gate_indices_tensor,
+    prepare_dense_layer_weights,
+    prepare_moe_layer_weights,
+)
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
+    DENSE_LAYER_IDX,
+    DENSE_SHARED_N,
+    ROUTED_EXPERT_LAYER_IDX,
+    RoutedExpert,
+    SharedExpert,
+    extract_routed_expert_output,
+)
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_post_sdpa import compute_forwarder_scratch_size
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
+from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
+
+
+def create_fabric_router_config(max_payload_size):
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
+# ============================================================================
+# Unified decoder block tensor setup (single BDW instance for all L1 weights)
+# ============================================================================
+def create_decoder_block_tensors(
+    submesh,
+    mesh_rows,
+    mesh_cols,
+    sender_row,
+    sender_col,
+    position_id,
+    state_dict,
+    layer_idx,
+    max_seq_len,
+    reduce_root_coord=ttnn.MeshCoordinate(1, 1),
+    *,
+    is_moe: bool = True,
+    num_routed_experts: int = 0,
+    preloaded_weights=None,
+):
+    """Create all tensors required by DecoderBlock.op().
+
+    Three modes of operation:
+    - **preloaded_weights mode** (production): pass a DeepSeekV3MoELayerWeights from
+      load_moe_layer. Skips BDW allocation, weight processing, and golden tensors.
+    - **state_dict + is_moe=True** (MoE tests): allocates BDW, calls
+      prepare_moe_layer_weights, builds MoE golden tensors.
+    - **state_dict + is_moe=False** (dense tests): allocates BDW, calls
+      prepare_dense_layer_weights, builds dense golden tensors.
+
+    Returns a dict with all attention + FFN + shared expert + reduce tensors.
+    """
+    if preloaded_weights is None and state_dict is None:
+        raise ValueError("Either state_dict or preloaded_weights must be provided")
+    torch.manual_seed(0)
+    num_devices = mesh_rows * mesh_cols
+    device_grid_size = submesh.compute_with_storage_grid_size()
+    mesh_mapper = ttnn.ReplicateTensorToMesh(submesh)
+
+    # ── Constants for runtime tensors ──
+    QNOPE_HEAD_DIM = 128
+    QROPE_HEAD_DIM = 64
+    QNOPE_OUT_DIM = 512
+    KNOPE_DIM = 512
+    KROPE_DIM = 64
+
+    M = 1
+    K = 7168
+    output_size = 7168
+    shape = (1, K)
+    scale = (QNOPE_HEAD_DIM + QROPE_HEAD_DIM) ** -0.5
+    kvpe_dim = KNOPE_DIM + KROPE_DIM
+
+    QNOPE_GRID_COLS = 8
+    QROPE_GRID_COLS = 4
+    matmul2_grid_y = 8
+    qrope_num_cores = QROPE_GRID_COLS * matmul2_grid_y
+
+    NUM_SDPA_WORKERS = 8
+    SDPA_L_HEIGHT = 8
+    SDPA_L_WIDTH = 512 * NUM_SDPA_WORKERS
+    SDPA_MS_WIDTH = 32 * NUM_SDPA_WORKERS
+
+    mcast_core_x = device_grid_size.x - 1
+    mcast_core_y = 9
+    mcast_core = ttnn.CoreCoord(mcast_core_x, mcast_core_y)
+    tile = ttnn.Tile([1, 32])
+
+    kv_cache_branch_start_offset = (0, 8)
+    kv_cache_branch_rope_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], 1 + kv_cache_branch_start_offset[1]),
+            )
+        }
+    )
+
+    # ── SDPA KV cache buffer ──
+    kv_cache_num_cores_x = device_grid_size.x
+    kv_cache_num_cores_y = device_grid_size.y
+    kv_cache_num_cores = kv_cache_num_cores_x * kv_cache_num_cores_y
+    kv_cache_shard_height = 256
+    kv_cache_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(kv_cache_num_cores_x - 1, kv_cache_num_cores_y - 1))}
+        ),
+        (kv_cache_shard_height, kvpe_dim),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sdpa_kv_cache_buffer = ttnn.from_torch(
+        torch.randn((kv_cache_shard_height * kv_cache_num_cores, kvpe_dim), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, kv_cache_shard_spec
+        ),
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── SDPA output intermediate buffer ──
+    sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
+    sdpa_out_interm_num_slots = 5  # MoE needs 36864 bytes/shard; 5 slots × 17 tiles × 512 = 43520
+    sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8
+    sdpa_out_interm_shard_width = 17 * 32
+    sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores
+    sdpa_out_interm_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
+        ),
+        (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sdpa_out_interm_buffer = ttnn.from_torch(
+        torch.zeros((sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_out_interm_shard_spec
+        ),
+        mesh_mapper=mesh_mapper,
+        tile=ttnn.Tile([8, 32]),
+    )
+
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # All weights via a single BDW instance or preloaded
+    # ══════════════════════════════════════════════════════════════════════════
+    if preloaded_weights is not None:
+        layer = preloaded_weights
+    else:
+        bdw = BlitzDecodeWeights(submesh)
+        if is_moe:
+            layer = prepare_moe_layer_weights(
+                bdw,
+                state_dict,
+                layer_idx,
+                num_routed_experts=num_routed_experts,
+                move_to_device=True,
+            )
+        else:
+            layer = prepare_dense_layer_weights(bdw, state_dict, layer_idx, move_to_device=True)
+
+    # ── FFN final output config (DRAM streaming matmul output grid) ──
+    gate_proj_noc = ttnn.NOC.NOC_0
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(submesh, gate_proj_noc)
+    gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
+    num_gate_proj_cores = len(gate_proj_worker_cores)
+    final_output_width_per_core = RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE
+    final_output_total_width = final_output_width_per_core * num_gate_proj_cores
+    num_banks = submesh.dram_grid_size().x
+    tile_w = RoutedExpert.TILE_W
+    down_proj_N_padded = ((K + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    per_core_down_proj_N = down_proj_N_padded // num_banks
+
+    final_output_shard_spec = ttnn.ShardSpec(
+        gate_proj_core_ranges,
+        (1, final_output_width_per_core),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    final_output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, final_output_shard_spec
+    )
+
+    # ── MoE-only: gate indices and output buffers ──
+    if is_moe:
+        input_core = ttnn.CoreCoord(device_grid_size.x - 1, RoutedExpert.INPUT_CORE_Y)
+        input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(input_core, input_core)])
+
+        ttnn_gate_indices = create_gate_indices_tensor(submesh, input_core_grid, mesh_mapper=mesh_mapper)
+
+        tile_1x16 = ttnn.Tile((1, 16))
+        gate_output_shard_spec = ttnn.ShardSpec(input_core_grid, (1, 16), ttnn.ShardOrientation.ROW_MAJOR)
+        gate_output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gate_output_shard_spec
+        )
+        gate_output_scores_tensor = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+        gate_output_indices_tensor = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.uint16),
+            dtype=ttnn.uint16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+        moe_ref_gate_output_scores = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+        moe_ref_gate_output_indices = ttnn.from_torch(
+            torch.zeros((1, 16), dtype=torch.uint16),
+            dtype=ttnn.uint16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=gate_output_mem_config,
+            tile=tile_1x16,
+            mesh_mapper=mesh_mapper,
+        )
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Attention input/intermediate/output mesh tensors
+    # ══════════════════════════════════════════════════════════════════════════
+    sender_coord = ttnn.MeshCoordinate(sender_row, sender_col)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(mcast_core, mcast_core)}), shape, ttnn.ShardOrientation.ROW_MAJOR
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    device_tensors = []
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            if row == sender_row and col == sender_col:
+                device_tensors.append(torch_input)
+            else:
+                device_tensors.append(torch.zeros_like(torch_input))
+
+    input_tensor_mesh = ttnn.from_torch(
+        torch.cat(device_tensors, dim=0),
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=ttnn.bfloat16,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(submesh, dim=0),
+    )
+
+    # ── RoPE TTNN tensors ──
+    qrope_dram_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    position_ids = torch.tensor([position_id])
+    base = 10000.0
+    inv_freq = 1.0 / (base ** (torch.arange(0, QROPE_HEAD_DIM, 2, dtype=torch.float32) / QROPE_HEAD_DIM))
+    t = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    torch_cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)
+    torch_sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)
+    torch_trans_mat = get_rot_transformation_mat()
+
+    ttnn_qrope_cos = ttnn.from_torch(
+        torch_cos.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_qrope_sin = ttnn.from_torch(
+        torch_sin.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_krope_cos = ttnn.from_torch(
+        torch_cos.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+    ttnn_krope_sin = ttnn.from_torch(
+        torch_sin.unsqueeze(0).unsqueeze(0),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=qrope_dram_mem,
+        tile=tile,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── Trans mat ──
+    qrope_grid = ttnn.CoreRange(
+        ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
+    )
+    trans_mat_crs = kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
+    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
+    trans_shard_spec = ttnn.ShardSpec(trans_mat_crs, (ttnn.TILE_SIZE, ttnn.TILE_SIZE), ttnn.ShardOrientation.ROW_MAJOR)
+    trans_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
+    trans_mat_replicated = torch_trans_mat.repeat(1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1)
+    ttnn_trans_mat = ttnn.from_torch(
+        trans_mat_replicated,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=trans_mem,
+        tile=trans_tile,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── Position IDs ──
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32),
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=submesh,
+        memory_config=pos_mem,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # ── KV Cache (ND sharded DRAM) ──
+    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
+    grid = program_config.grid
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, program_config.k_chunk_size, kvpe_dim],
+        grid=grid.optimal_dram_grid(),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=kv_nd_shard_spec)
+    num_sp = mesh_rows
+    dcs = program_config.device_chunk_size
+    torch_kv_cache = torch.zeros((1, 1, max_seq_len, kvpe_dim), dtype=torch.bfloat16)
+    torch_kv_cache[:, :, :position_id, :] = torch.randn(1, 1, position_id, kvpe_dim, dtype=torch.bfloat16)
+    torch_kv_cache_shuffled = deinterleave_kv_cache(torch_kv_cache, dcs, num_sp)
+    kv_cache_2d_mesh_mapper = ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(2, None))
+    ttnn_kv_cache = ttnn.from_torch(
+        torch_kv_cache_shuffled,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=kv_mem,
+        mesh_mapper=kv_cache_2d_mesh_mapper,
+    )
+    kv_cache_bfp8_before_op = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+
+    # ── KV cache clone for standalone AttentionBlock.op sanity check ──
+    ttnn_kv_cache_attn_ref = ttnn.from_torch(
+        torch_kv_cache_shuffled,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=kv_mem,
+        mesh_mapper=kv_cache_2d_mesh_mapper,
+    )
+
+    # ── SDPA output tensor ──
+    s1_cores, _ = FlashMLADecode.ProgramConfig.grid.BLOCKS[0]
+    sdpa_input_output_grid_crs = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in s1_cores]
+    )
+    HEADS_PER_ROW = 8
+    SDPA_INPUT_NUM_CORES = len(s1_cores)
+    sdpa_tile = ttnn.Tile([8, 32])
+    sdpa_input_output_shard_spec = ttnn.ShardSpec(
+        sdpa_input_output_grid_crs, (HEADS_PER_ROW, QNOPE_OUT_DIM), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    sdpa_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, sdpa_input_output_shard_spec
+    )
+    ttnn_sdpa_output = ttnn.from_torch(
+        torch.zeros((SDPA_INPUT_NUM_CORES * HEADS_PER_ROW, QNOPE_OUT_DIM), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=sdpa_mem,
+        mesh_mapper=mesh_mapper,
+        tile=sdpa_tile,
+    )
+
+    # ── Post-SDPA tensors ──
+    a_tile = ttnn.Tile([M, 32])
+    shard_mesh_mapper = ttnn.ShardTensorToMesh(submesh, dim=0)
+    gather_core = ttnn.CoreCoord(12, 9)
+    gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+
+    # ── Attention block output / MoE residual input (overlapped with sdpa_kv_cache_buffer) ──
+    # These are temporally disjoint: the kv cache on core (12,9) is done after SDPA,
+    # so the attention output and MoE residual input can reuse that L1 region.
+    a_tile_size = a_tile.get_tile_size(ttnn.bfloat16)  # 1×32 tile → 64 bytes
+    num_output_tiles = output_size // 32  # 7168 / 32 = 224 tiles
+    output_shard_spec = ttnn.ShardSpec(gather_core_grid, (M, output_size), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+    mesh_output_torch = torch.cat([torch.zeros((M, output_size), dtype=torch.bfloat16)] * num_devices, dim=0)
+    attn_output = ttnn.from_torch(
+        mesh_output_torch,
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=a_tile,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        mesh_mapper=shard_mesh_mapper,
+    )
+    attn_ref_output = ttnn.from_torch(
+        mesh_output_torch,
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=a_tile,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        mesh_mapper=shard_mesh_mapper,
+    )
+
+    # ── SDPA worker/forwarder tensors ──
+    sdpa_output_cores = FlashMLADecode.ProgramConfig.grid.output_cores(0, NUM_SDPA_WORKERS)
+    sdpa_worker_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in sdpa_output_cores]
+    )
+    sdpa_l_per_worker = SDPA_L_WIDTH // NUM_SDPA_WORKERS
+    sdpa_ms_per_worker = SDPA_MS_WIDTH // NUM_SDPA_WORKERS
+
+    sdpa_recv_per_worker = sdpa_l_per_worker + sdpa_ms_per_worker
+    sdpa_recv_shard_shape = (2 * SDPA_L_HEIGHT, sdpa_recv_per_worker)
+    sdpa_recv_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sdpa_worker_grid, sdpa_recv_shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    sdpa_recv_full_width = sdpa_recv_per_worker * NUM_SDPA_WORKERS
+    mesh_recv = torch.cat(
+        [torch.zeros((2 * SDPA_L_HEIGHT, sdpa_recv_full_width), dtype=torch.bfloat16)] * num_devices, dim=0
+    )
+    ttnn_sdpa_intermediate_recv = ttnn.from_torch(
+        mesh_recv,
+        device=submesh,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=sdpa_recv_mem,
+        tile=sdpa_tile,
+        mesh_mapper=shard_mesh_mapper,
+    )
+
+    sdpa_forwarder_cores = [ttnn.CoreCoord(9, 8), ttnn.CoreCoord(10, 8)]
+    sdpa_forwarder_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in sdpa_forwarder_cores])
+    sdpa_fwd_buffer_bytes = compute_forwarder_scratch_size(
+        batch_size=SDPA_L_HEIGHT,
+        l_width=sdpa_l_per_worker,
+        num_cores=NUM_SDPA_WORKERS,
+    )
+    sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
+    sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // 2
+    sdpa_forwarder_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(sdpa_forwarder_grid, (1, sdpa_fwd_per_forwarder), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mesh_fwd_scratch = torch.cat([torch.zeros((1, sdpa_fwd_total_elements), dtype=torch.bfloat16)] * num_devices, dim=0)
+    ttnn_sdpa_forwarder_scratch = ttnn.from_torch(
+        mesh_fwd_scratch,
+        device=submesh,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=sdpa_forwarder_mem,
+        mesh_mapper=shard_mesh_mapper,
+    )
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Reduce-to-one tensors
+    # ══════════════════════════════════════════════════════════════════════════
+    reduce_mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh.shape)
+    reduce_mesh_mapper = ttnn.create_mesh_mapper(submesh, reduce_mesh_mapper_config)
+    tile_1x32 = ttnn.Tile([1, 32])
+
+    # Single intermediate tensor with 3x shard width for all 3 reduction rounds
+    orig_shard_spec = final_output_mem_config.shard_spec
+    intermediate_shard_shape = [orig_shard_spec.shape[0], orig_shard_spec.shape[1] * 3]
+    intermediate_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            orig_shard_spec.grid,
+            intermediate_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    intermediate_tensors = ttnn.from_torch(
+        torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=intermediate_mem_config,
+        tile=tile_1x32,
+        mesh_mapper=reduce_mesh_mapper,
+    )
+
+    shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
+    aggregator_core = shard_cores_list[0]
+    reduce_output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(aggregator_core, aggregator_core)})
+    reduce_output_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(reduce_output_shard_grid, (1, final_output_total_width), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    reduce_output_tensor = ttnn.from_torch(
+        torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=reduce_output_mem,
+        tile=tile_1x32,
+        mesh_mapper=reduce_mesh_mapper,
+    )
+
+    # ── Standalone MoE ref reduce tensors (MoE only) ──
+    if is_moe:
+        moe_ref_reduce_intermediate = ttnn.from_torch(
+            torch.zeros([4, 2, final_output_total_width * 3], dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=intermediate_mem_config,
+            tile=tile_1x32,
+            mesh_mapper=reduce_mesh_mapper,
+        )
+        moe_ref_reduce_output = ttnn.from_torch(
+            torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=submesh,
+            memory_config=reduce_output_mem,
+            tile=tile_1x32,
+            mesh_mapper=reduce_mesh_mapper,
+        )
+
+    sender_core_from_residual = attn_output.memory_config().shard_spec.grid.bounding_box().end
+    mcast_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), sender_core_from_residual)])
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Golden model PyTorch tensors (only when state_dict is available)
+    # ══════════════════════════════════════════════════════════════════════════
+    golden = {}
+    if state_dict is not None:
+
+        def _sd_key(suffix):
+            return f"model.layers.{layer_idx}.{suffix}"
+
+        golden_torch_gamma = state_dict[_sd_key("input_layernorm.weight")].unsqueeze(0)
+        golden_torch_matmul_weights = state_dict[_sd_key("self_attn.q_a_proj.weight")].T.contiguous()
+        golden_torch_rmsnorm2_gamma = state_dict[_sd_key("self_attn.q_a_layernorm.weight")].unsqueeze(0)
+        golden_torch_matmul2_weights = state_dict[_sd_key("self_attn.q_b_proj.weight")].T.contiguous()
+        golden_torch_dkv_matmul_weights = state_dict[_sd_key("self_attn.kv_a_proj_with_mqa.weight")].T.contiguous()
+        golden_torch_dkv_rmsnorm_gamma = state_dict[_sd_key("self_attn.kv_a_layernorm.weight")].unsqueeze(0)
+        golden_torch_o_proj_weights = state_dict[_sd_key("self_attn.o_proj.weight")].T.contiguous()
+
+        V_HEAD_DIM = 128
+        KV_B_PROJ_HEAD_DIM = QNOPE_HEAD_DIM + V_HEAD_DIM  # 256
+        kv_b_proj_raw = state_dict[_sd_key("self_attn.kv_b_proj.weight")]
+        kv_b_out, kv_lora_rank = kv_b_proj_raw.shape
+        total_kv_heads = kv_b_out // KV_B_PROJ_HEAD_DIM
+        kv_b_3d = kv_b_proj_raw.reshape(total_kv_heads, KV_B_PROJ_HEAD_DIM, kv_lora_rank).contiguous()
+        golden_kv_b1 = kv_b_3d[:, :QNOPE_HEAD_DIM, :].reshape(-1, kv_lora_rank)
+        golden_kv_b2 = kv_b_3d[:, QNOPE_HEAD_DIM:, :].reshape(-1, kv_lora_rank).T.contiguous()
+        golden_torch_matmul3_weights = golden_kv_b1.reshape(total_kv_heads, QNOPE_HEAD_DIM, kv_lora_rank)
+
+        golden_total_qnope_heads = total_kv_heads
+        golden_total_qrope_heads = total_kv_heads
+
+        # ── Golden FFN tensors (MoE vs dense differ in key paths and weight layout) ──
+        golden_moe_rmsnorm_gamma = (
+            state_dict[_sd_key("post_attention_layernorm.weight")].reshape(1, K).to(torch.bfloat16).float()
+        )
+        if is_moe:
+            golden_moe_shared_gate = state_dict[_sd_key("mlp.shared_experts.gate_proj.weight")].T.contiguous()
+            golden_moe_shared_up = state_dict[_sd_key("mlp.shared_experts.up_proj.weight")].T.contiguous()
+            golden_moe_shared_down = state_dict[_sd_key("mlp.shared_experts.down_proj.weight")].T.contiguous()
+            golden_moe_routing_weights = state_dict[_sd_key("mlp.gate.weight")].T.contiguous()
+            golden_moe_bias = (
+                state_dict[_sd_key("mlp.gate.e_score_correction_bias")]
+                .reshape(1, 8, 32)
+                .contiguous()
+                .to(torch.bfloat16)
+            )
+            golden_moe_gate_proj_dict = {}
+            golden_moe_up_proj_dict = {}
+            golden_moe_down_proj_dict = {}
+            for e in range(num_routed_experts):
+                w_g = state_dict[_sd_key(f"mlp.experts.{e}.gate_proj.weight")].T.contiguous()
+                golden_moe_gate_proj_dict[e] = w_g.reshape(1, 1, K, -1)
+                w_u = state_dict[_sd_key(f"mlp.experts.{e}.up_proj.weight")].T.contiguous()
+                golden_moe_up_proj_dict[e] = w_u.reshape(1, 1, K, -1)
+                w_d = state_dict[_sd_key(f"mlp.experts.{e}.down_proj.weight")].T.contiguous()
+                golden_moe_down_proj_dict[e] = w_d.reshape(1, 1, -1, K)
+        else:
+            gate_full = state_dict[_sd_key("mlp.gate_proj.weight")].T.contiguous()
+            up_full = state_dict[_sd_key("mlp.up_proj.weight")].T.contiguous()
+            down_full = state_dict[_sd_key("mlp.down_proj.weight")].T.contiguous()
+            golden_moe_shared_gate = gate_full[:, :DENSE_SHARED_N].contiguous()
+            golden_moe_shared_up = up_full[:, :DENSE_SHARED_N].contiguous()
+            golden_moe_shared_down = down_full[:DENSE_SHARED_N, :].contiguous()
+            golden_moe_routing_weights = None
+            golden_moe_bias = None
+            golden_moe_gate_proj_dict = {}
+            golden_moe_up_proj_dict = {}
+            golden_moe_down_proj_dict = {}
+            for e in range(8):
+                start = DENSE_SHARED_N + e * RoutedExpert.GATE_PROJ_N
+                end = start + RoutedExpert.GATE_PROJ_N
+                golden_moe_gate_proj_dict[e] = gate_full[:, start:end].reshape(1, 1, K, -1)
+                golden_moe_up_proj_dict[e] = up_full[:, start:end].reshape(1, 1, K, -1)
+                golden_moe_down_proj_dict[e] = down_full[start:end, :].reshape(1, 1, -1, K)
+
+        golden = {
+            "golden_torch_input": torch_input,
+            "golden_torch_gamma": golden_torch_gamma,
+            "golden_torch_matmul_weights": golden_torch_matmul_weights,
+            "golden_torch_rmsnorm2_gamma": golden_torch_rmsnorm2_gamma,
+            "golden_torch_matmul2_weights": golden_torch_matmul2_weights,
+            "golden_torch_matmul3_weights": golden_torch_matmul3_weights,
+            "golden_torch_sin": torch_sin,
+            "golden_torch_cos": torch_cos,
+            "golden_position_ids": position_ids,
+            "golden_torch_dkv_matmul_weights": golden_torch_dkv_matmul_weights,
+            "golden_torch_dkv_rmsnorm_gamma": golden_torch_dkv_rmsnorm_gamma,
+            "golden_torch_kv_cache": torch_kv_cache,
+            "golden_scale": scale,
+            "golden_torch_kv_b2_proj_weights": golden_kv_b2,
+            "golden_torch_o_proj_weights": golden_torch_o_proj_weights,
+            "golden_total_qnope_heads": golden_total_qnope_heads,
+            "golden_total_qrope_heads": golden_total_qrope_heads,
+            "golden_kv_cache_bfp8_before_op": kv_cache_bfp8_before_op,
+            "golden_sdpa_slice_size": SDPA_INPUT_NUM_CORES * HEADS_PER_ROW,
+            "golden_moe_rmsnorm_gamma": golden_moe_rmsnorm_gamma,
+            "golden_moe_shared_gate": golden_moe_shared_gate,
+            "golden_moe_shared_up": golden_moe_shared_up,
+            "golden_moe_shared_down": golden_moe_shared_down,
+            "golden_moe_routing_weights": golden_moe_routing_weights,
+            "golden_moe_bias": golden_moe_bias,
+            "golden_moe_gate_proj_dict": golden_moe_gate_proj_dict,
+            "golden_moe_up_proj_dict": golden_moe_up_proj_dict,
+            "golden_moe_down_proj_dict": golden_moe_down_proj_dict,
+        }
+
+    # ── Routed weight tensors differ between MoE (list) and dense (single tensor) ──
+    routed_gate = layer.routed_gate_proj[0] if is_moe else layer.routed_gate_proj
+    routed_up = layer.routed_up_proj[0] if is_moe else layer.routed_up_proj
+    routed_down = layer.routed_down_proj[0] if is_moe else layer.routed_down_proj
+
+    result = {
+        # Attention weights (from prepare_*_layer_weights via BDW)
+        "gamma_overlapped": layer.attn_norm,
+        "matmul_weights_overlapped": layer.q_a_proj,
+        "rmsnorm2_gamma_overlapped": layer.q_norm,
+        "matmul2_weights_overlapped": layer.q_b_proj,
+        "matmul3_weights_overlapped": layer.kv_b1_proj,
+        "dkv_matmul_weights_overlapped": layer.kv_a_proj,
+        "dkv_rmsnorm_gamma_overlapped": layer.kv_norm,
+        "kv_b2_overlapped": layer.kv_b2_proj,
+        "o_proj_overlapped": layer.o_proj,
+        "ffn_norm_overlapped": layer.ffn_norm,
+        # Attention activation/buffer tensors
+        "input_tensor_mesh": input_tensor_mesh,
+        "ttnn_qrope_sin": ttnn_qrope_sin,
+        "ttnn_qrope_cos": ttnn_qrope_cos,
+        "ttnn_trans_mat": ttnn_trans_mat,
+        "ttnn_krope_cos": ttnn_krope_cos,
+        "ttnn_krope_sin": ttnn_krope_sin,
+        "ttnn_kv_cache": ttnn_kv_cache,
+        "ttnn_kv_cache_attn_ref": ttnn_kv_cache_attn_ref,
+        "ttnn_position_ids": ttnn_position_ids,
+        "scale": scale,
+        "sdpa_kv_cache_buffer": sdpa_kv_cache_buffer,
+        "sdpa_out_interm_buffer": sdpa_out_interm_buffer,
+        "ttnn_sdpa_output": ttnn_sdpa_output,
+        "sender_coord": sender_coord,
+        "ttnn_sdpa_input_l": None,
+        "ttnn_sdpa_input_ms": None,
+        "ttnn_sdpa_output_l": None,
+        "ttnn_sdpa_intermediate_recv": ttnn_sdpa_intermediate_recv,
+        "ttnn_sdpa_forwarder_scratch": ttnn_sdpa_forwarder_scratch,
+        "device_chunk_size": program_config.device_chunk_size,
+        "ttnn_attention_block_output": attn_output,
+        "ttnn_attn_ref_output": attn_ref_output,
+        # FFN tensors (attn_output IS the FFN residual input — overlapped with kv cache)
+        "ttnn_residual_mcast_src": attn_output,
+        "gate_proj_weights": routed_gate,
+        "up_proj_weights": routed_up,
+        "down_proj_weights": routed_down,
+        "final_output_mem_config": final_output_mem_config,
+        "final_output_total_width": final_output_total_width,
+        # Shared expert weights
+        "shared_gate_weights_overlapped": layer.shared_gate_proj,
+        "shared_up_weights_overlapped": layer.shared_up_proj,
+        "shared_down_weights_tensor": layer.shared_down_proj,
+        "shared_k_parallel": SharedExpert.K_PARALLEL,
+        "shared_n_parallel": SharedExpert.N_PARALLEL,
+        # Reduce-to-one
+        "reduce_intermediate_tensors": intermediate_tensors,
+        "reduce_output_tensor": reduce_output_tensor,
+        "reduce_root_coord": reduce_root_coord,
+        "num_gate_proj_cores": num_gate_proj_cores,
+        "per_core_down_proj_N": per_core_down_proj_N,
+        "mcast_grid": mcast_grid,
+        **golden,
+    }
+    # MoE-only keys
+    if is_moe:
+        result.update(
+            {
+                "gate_mm_overlapped": layer.gate_mm,
+                "ttnn_gate_bias": layer.gate_bias,
+                "ttnn_gate_indices": ttnn_gate_indices,
+                "gate_output_scores_tensor": gate_output_scores_tensor,
+                "gate_output_indices_tensor": gate_output_indices_tensor,
+                "moe_ref_gate_output_scores": moe_ref_gate_output_scores,
+                "moe_ref_gate_output_indices": moe_ref_gate_output_indices,
+                "moe_ref_reduce_intermediate": moe_ref_reduce_intermediate,
+                "moe_ref_reduce_output": moe_ref_reduce_output,
+            }
+        )
+    return result
+
+
+@pytest.mark.parametrize(
+    "sender_row, sender_col",
+    [
+        (1, 0),
+    ],
+)
+@pytest.mark.parametrize("epsilon", [1e-6])
+@pytest.mark.parametrize("use_fp32", [False])
+@pytest.mark.parametrize("bcast_cluster_axis", [0])
+@pytest.mark.parametrize("bcast_secondary_cluster_axis", [1])
+@pytest.mark.parametrize("reduce_cluster_axis", [1])
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
+@pytest.mark.parametrize("num_iters", [(1)])
+@pytest.mark.parametrize("max_seq_len", [32 * 1024])
+@pytest.mark.parametrize(
+    "position_id",
+    [
+        0,
+        127,
+        511,
+        1023,
+        2047,
+        4096,  # (1 + partial,1,1,1): partial into dev0 (if SP = 4)
+        pytest.param(6644, marks=pytest.mark.skip_post_commit),  # (2,2,1 + partial,1): partial into dev2 (if SP = 4)
+        pytest.param(9916, marks=pytest.mark.skip_post_commit),  # (3,2 + partial,2,2): partial into dev1 (if SP = 4)
+        pytest.param(11664, marks=pytest.mark.skip_post_commit),  # (3,3,3,2 + partial): partial into dev3 (if SP = 4)
+    ],
+)  # Must test 128 chunk aligned decode positions, add other tests when causal masks are in for SDPA
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "worker_l1_size": 1431568,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
+@pytest.mark.parametrize("num_internal_iterations", [1])
+@pytest.mark.parametrize(
+    "enable_routing, use_hardcoded_expert_index, num_routed_experts",
+    [
+        (True, True, 8),
+        pytest.param(True, False, 256, marks=pytest.mark.skip_post_commit),
+    ],
+    ids=[
+        "hardcoded_experts",
+        "full_routing",
+    ],
+)
+@pytest.mark.parametrize(
+    "validate_standalone_mla",
+    [pytest.param(True, marks=pytest.mark.skip_post_commit), False],
+    ids=["validate_standalone_mla", "just_decoder_mla"],
+)
+@pytest.mark.parametrize(
+    "validate_standalone_moe",
+    [pytest.param(True, marks=pytest.mark.skip_post_commit), False],
+    ids=["validate_standalone_moe", "just_decoder_moe"],
+)
+@pytest.mark.requires_grid_size((13, 10))
+def test_decoder(
+    bh_2d_mesh_device,
+    mesh_rows,
+    mesh_cols,
+    sender_row,
+    sender_col,
+    epsilon,
+    use_fp32,
+    bcast_cluster_axis,
+    bcast_secondary_cluster_axis,
+    reduce_cluster_axis,
+    num_iters,
+    max_seq_len,
+    position_id,
+    noc_mode,
+    num_internal_iterations,
+    enable_routing,
+    use_hardcoded_expert_index,
+    num_routed_experts,
+    validate_standalone_mla,
+    validate_standalone_moe,
+    get_reference_model_state_dict,
+):
+    """Test TTNN decoder fused operation with CCL broadcast, kv cache, mla, reduce, residual add"""
+    if not use_hardcoded_expert_index:
+        pytest.skip("Full routing is not supported for now")
+    torch.manual_seed(0)
+    num_devices = mesh_rows * mesh_cols
+    logger.info(f"Number of devices: {num_devices}")
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than available")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    device_grid_size = submesh.compute_with_storage_grid_size()
+
+    logger.info("Preparing model state dict...")
+    state_dict = get_reference_model_state_dict(
+        layer_idx=ROUTED_EXPERT_LAYER_IDX,
+        is_moe=True,
+        seed=RoutedExpert.SEED,
+        num_routed_experts=num_routed_experts,
+    )
+
+    logger.info("Creating decoder block tensors...")
+    d = create_decoder_block_tensors(
+        submesh,
+        mesh_rows,
+        mesh_cols,
+        sender_row,
+        sender_col,
+        position_id,
+        state_dict,
+        layer_idx=ROUTED_EXPERT_LAYER_IDX,
+        max_seq_len=max_seq_len,
+        is_moe=True,
+        num_routed_experts=num_routed_experts,
+    )
+
+    num_cores = device_grid_size.x * device_grid_size.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid_size, row_wise=True)
+    ttnn.synchronize_device(submesh)
+    reduce_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(4)]
+    persistent_next_iter_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 1)
+    ttnn.synchronize_device(submesh)
+
+    attn_semaphores = AttentionBlock.create_semaphores(submesh)
+    moe_semaphores = MoeOp.create_semaphores(submesh)
+
+    # ========================================================================
+    # Run standalone AttentionBlock.op as sanity reference (uses cloned KV cache)
+    # ========================================================================
+    ttnn_attn_ref_output_torch = None
+    if validate_standalone_mla:
+        logger.info(f"Running standalone AttentionBlock.op with position_id={position_id}...")
+        attn_ref_semaphores = AttentionBlock.create_semaphores(submesh)
+        ttnn_attn_ref_result = AttentionBlock.op(
+            d["input_tensor_mesh"],
+            d["gamma_overlapped"],
+            d["matmul_weights_overlapped"],
+            d["rmsnorm2_gamma_overlapped"],
+            d["matmul2_weights_overlapped"],
+            d["matmul3_weights_overlapped"],
+            d["ttnn_qrope_sin"],
+            d["ttnn_qrope_cos"],
+            d["ttnn_trans_mat"],
+            d["ttnn_krope_cos"],
+            d["ttnn_krope_sin"],
+            d["dkv_matmul_weights_overlapped"],
+            d["dkv_rmsnorm_gamma_overlapped"],
+            d["ttnn_kv_cache_attn_ref"],
+            d["ttnn_position_ids"],
+            d["scale"],
+            d["ttnn_sdpa_output"],
+            d["sdpa_kv_cache_buffer"],
+            d["sdpa_out_interm_buffer"],
+            d["sender_coord"],
+            d["kv_b2_overlapped"],
+            d["o_proj_overlapped"],
+            d["ttnn_sdpa_input_l"],
+            d["ttnn_sdpa_input_ms"],
+            d["ttnn_sdpa_output_l"],
+            d["ttnn_sdpa_intermediate_recv"],
+            d["ttnn_sdpa_forwarder_scratch"],
+            d["device_chunk_size"],
+            d["ttnn_attn_ref_output"],
+            attn_ref_semaphores,
+            bcast_cluster_axis,
+            bcast_secondary_cluster_axis,
+            reduce_cluster_axis,
+            0,  # sdpa_cluster_axis
+            1,  # num_links
+            epsilon,
+            use_fp32,
+            False,  # skip_ccl
+            noc_mode,
+            num_iterations=1,
+        )
+        ttnn.synchronize_device(submesh)
+        ttnn_attn_ref_output_torch = ttnn.to_torch(
+            d["ttnn_attn_ref_output"], mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)
+        )
+        logger.info("Standalone AttentionBlock.op completed.")
+
+    # ========================================================================
+    # Run decoder operation
+    # ========================================================================
+    logger.info(f"Running decoder operation with position_id={position_id}...")
+    for i in range(num_iters):
+        moe_final_output_tensor, attention_block_output_tensor = DecoderBlock.op(
+            # AttentionBlock parameters
+            d["input_tensor_mesh"],
+            d["gamma_overlapped"],
+            d["matmul_weights_overlapped"],
+            d["rmsnorm2_gamma_overlapped"],
+            d["matmul2_weights_overlapped"],
+            d["matmul3_weights_overlapped"],
+            d["ttnn_qrope_sin"],
+            d["ttnn_qrope_cos"],
+            d["ttnn_trans_mat"],
+            d["ttnn_krope_cos"],
+            d["ttnn_krope_sin"],
+            d["dkv_matmul_weights_overlapped"],
+            d["dkv_rmsnorm_gamma_overlapped"],
+            d["ttnn_kv_cache"],
+            d["ttnn_position_ids"],
+            d["scale"],
+            d["sdpa_kv_cache_buffer"],
+            d["sdpa_out_interm_buffer"],
+            d["sender_coord"],
+            # Post-SDPA parameters
+            # Post-SDPA
+            d["kv_b2_overlapped"],
+            d["o_proj_overlapped"],
+            d["ttnn_sdpa_input_l"],
+            d["ttnn_sdpa_input_ms"],
+            d["ttnn_sdpa_output_l"],
+            d["ttnn_sdpa_intermediate_recv"],
+            d["ttnn_sdpa_forwarder_scratch"],
+            d["device_chunk_size"],
+            d["ttnn_attention_block_output"],
+            attention_block_semaphores=attn_semaphores,
+            # MoE parameters
+            shared_residual_mcast_src_tensor=d["ttnn_residual_mcast_src"],
+            gate_mm_weights_tensor=d["gate_mm_overlapped"],
+            gate_bias_tensor=d["ttnn_gate_bias"],
+            gate_indices_tensor=d["ttnn_gate_indices"],
+            gate_output_scores_tensor=d["gate_output_scores_tensor"],
+            gate_output_indices_tensor=d["gate_output_indices_tensor"],
+            gate_proj_weights_tensor=d["gate_proj_weights"],
+            up_proj_weights_tensor=d["up_proj_weights"],
+            down_proj_weights_tensor=d["down_proj_weights"],
+            moe_final_output_tensor=None,
+            rmsnorm_gamma_tensor=d["ffn_norm_overlapped"],
+            shared_gate_weights_overlapped=d["shared_gate_weights_overlapped"],
+            shared_up_weights_overlapped=d["shared_up_weights_overlapped"],
+            shared_down_weights_tensor=d["shared_down_weights_tensor"],
+            shared_k_parallel=d["shared_k_parallel"],
+            shared_n_parallel=d["shared_n_parallel"],
+            moe_semaphores=moe_semaphores,
+            reduce_intermediate_tensors=d["reduce_intermediate_tensors"],
+            reduce_output_tensor=d["reduce_output_tensor"],
+            reduce_semaphores=reduce_semaphores,
+            reduce_root_coord=d["reduce_root_coord"],
+            # Shared parameters
+            enable_routing=True,
+            bcast_cluster_axis=bcast_cluster_axis,
+            bcast_secondary_cluster_axis=bcast_secondary_cluster_axis,
+            reduce_cluster_axis=reduce_cluster_axis,
+            sdpa_cluster_axis=0,  # sdpa_cluster_axis
+            num_links=1,  # num_links
+            epsilon=epsilon,
+            fp32_dest_acc_en=use_fp32,
+            skip_ccl=False,
+            use_hardcoded_expert_index=use_hardcoded_expert_index,
+            noc_mode=noc_mode,
+            num_iterations=num_internal_iterations,
+            upstream_socket=None,
+            downstream_socket=None,
+            persistent_next_iter_semaphore=persistent_next_iter_semaphore,
+            persistent_mode=True,
+        )
+    ttnn.synchronize_device(submesh)
+
+    kv_cache_output_torch = ttnn.to_torch(d["ttnn_kv_cache"], mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+
+    ttnn_attention_output = ttnn.to_torch(
+        attention_block_output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)
+    )
+
+    # ========================================================================
+    # Extract decoder MoE output and reduce root info (always needed for golden)
+    # ========================================================================
+    decoder_moe_output = ttnn.to_torch(moe_final_output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+    root_coord_tuple = d["reduce_root_coord"]
+    root_device_idx = root_coord_tuple[0] * mesh_cols + root_coord_tuple[1]
+    decoder_moe_output_root = decoder_moe_output[root_device_idx]
+    decoder_moe_output_valid = extract_routed_expert_output(
+        decoder_moe_output_root.unsqueeze(0),
+        d["num_gate_proj_cores"],
+        RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE,
+        d["per_core_down_proj_N"],
+    )
+
+    # ========================================================================
+    # Run standalone MoeOp.op on MLA output (validate golden MoE path)
+    # ========================================================================
+    moe_device_output_valid = None
+    if validate_standalone_moe:
+        logger.info(
+            f"Running standalone MoeOp.op (enable_routing={enable_routing}, hardcoded={use_hardcoded_expert_index})..."
+        )
+        moe_ref_semaphores = MoeOp.create_semaphores(submesh)
+        moe_ref_reduce_sems = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(4)]
+        ttnn.synchronize_device(submesh)
+
+        moe_ref_result = MoeOp.op(
+            attention_block_output_tensor,
+            gate_mm_weights_tensor=d["gate_mm_overlapped"],
+            gate_bias_tensor=d["ttnn_gate_bias"],
+            gate_indices_tensor=d["ttnn_gate_indices"],
+            gate_output_scores_tensor=d["moe_ref_gate_output_scores"],
+            gate_output_indices_tensor=d["moe_ref_gate_output_indices"],
+            gate_proj_weights_tensor=d["gate_proj_weights"],
+            up_proj_weights_tensor=d["up_proj_weights"],
+            down_proj_weights_tensor=d["down_proj_weights"],
+            rmsnorm_gamma_tensor=d["ffn_norm_overlapped"],
+            shared_gate_weights_overlapped=d["shared_gate_weights_overlapped"],
+            shared_up_weights_overlapped=d["shared_up_weights_overlapped"],
+            shared_down_weights_tensor=d["shared_down_weights_tensor"],
+            shared_k_parallel=d["shared_k_parallel"],
+            shared_n_parallel=d["shared_n_parallel"],
+            enable_routing=enable_routing,
+            use_hardcoded_expert_index=use_hardcoded_expert_index,
+            sdpa_kv_cache_buffer=d["sdpa_kv_cache_buffer"],
+            sdpa_out_interm_buffer=d["sdpa_out_interm_buffer"],
+            num_iterations=1,
+            reduce_intermediate_tensors=d["moe_ref_reduce_intermediate"],
+            reduce_output_tensor=d["moe_ref_reduce_output"],
+            reduce_semaphores=moe_ref_reduce_sems,
+            reduce_root_coord=ttnn.MeshCoordinate(d["reduce_root_coord"]),
+            semaphores=moe_ref_semaphores,
+            noc_mode=noc_mode,
+        )
+        ttnn.synchronize_device(submesh)
+        logger.info("Standalone MoeOp.op completed.")
+
+        if enable_routing:
+            moe_ref_scores_tensor, moe_ref_indices_tensor, moe_ref_result = moe_ref_result
+            moe_ref_scores_torch = ttnn.to_torch(
+                moe_ref_scores_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)
+            )
+            moe_ref_indices_torch = ttnn.to_torch(
+                moe_ref_indices_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)
+            )
+        else:
+            moe_ref_scores_torch = None
+            moe_ref_indices_torch = None
+
+        moe_reduce_torch = ttnn.to_torch(moe_ref_result, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+        moe_reduce_root = moe_reduce_torch[root_device_idx]
+        moe_device_output_valid = extract_routed_expert_output(
+            moe_reduce_root.unsqueeze(0),
+            d["num_gate_proj_cores"],
+            RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE,
+            d["per_core_down_proj_N"],
+        )
+
+    # ========================================================================
+    # Compute golden reference
+    # ========================================================================
+    logger.info("Computing golden reference...")
+
+    device_chunk_size = d["device_chunk_size"]
+    num_sp = mesh_rows
+    owning_sp_device = (position_id // device_chunk_size) % num_sp
+
+    QNOPE_HEAD_DIM = 128
+    QROPE_HEAD_DIM = 64
+    KNOPE_DIM = 512
+    KROPE_DIM = 64
+    HEADS_PER_ROW = 8
+
+    full_q, golden_new_kv, mla_output, moe_scores, moe_indices, moe_output = DecoderBlock.golden(
+        d["golden_torch_input"],
+        d["golden_torch_gamma"],
+        d["golden_torch_matmul_weights"],
+        d["golden_torch_rmsnorm2_gamma"],
+        d["golden_torch_matmul2_weights"],
+        d["golden_torch_matmul3_weights"],
+        d["golden_torch_sin"],
+        d["golden_torch_cos"],
+        d["golden_position_ids"],
+        d["golden_torch_dkv_matmul_weights"],
+        d["golden_torch_dkv_rmsnorm_gamma"],
+        d["golden_torch_kv_cache"],
+        d["golden_scale"],
+        d["golden_torch_kv_b2_proj_weights"],
+        d["golden_torch_o_proj_weights"],
+        epsilon=epsilon,
+        num_qnope_heads=d["golden_total_qnope_heads"],
+        num_qrope_heads=d["golden_total_qrope_heads"],
+        qnope_head_dim=QNOPE_HEAD_DIM,
+        qrope_head_dim=QROPE_HEAD_DIM,
+        heads_per_row=HEADS_PER_ROW,
+        nope_dim=KNOPE_DIM,
+        rope_dim=KROPE_DIM,
+        # MoE golden parameters
+        moe_shared_gate_weights=d["golden_moe_shared_gate"],
+        moe_shared_up_weights=d["golden_moe_shared_up"],
+        moe_shared_down_weights=d["golden_moe_shared_down"],
+        moe_gate_proj_weights_dict=d["golden_moe_gate_proj_dict"],
+        moe_up_proj_weights_dict=d["golden_moe_up_proj_dict"],
+        moe_down_proj_weights_dict=d["golden_moe_down_proj_dict"],
+        moe_rmsnorm_gamma=d["golden_moe_rmsnorm_gamma"],
+        moe_rmsnorm_epsilon=epsilon,
+        moe_routing_weights=d["golden_moe_routing_weights"],
+        moe_bias=d["golden_moe_bias"],
+        moe_gate_eps=RoutedExpert.GATE_EPS,
+        moe_gate_scaling_factor=RoutedExpert.GATE_SCALING_FACTOR,
+        moe_enable_routing=enable_routing,
+        moe_use_hardcoded_expert_index=use_hardcoded_expert_index,
+        moe_hardcoded_expert_index=0,
+        moe_num_devices=num_devices,
+        moe_reduce_root_device_idx=root_coord_tuple[0] * mesh_cols + root_coord_tuple[1],
+    )
+
+    logger.info(f"MLA output: {mla_output}")
+
+    logger.info(f"Golden computed (owning_sp_device={owning_sp_device}, device_chunk_size={device_chunk_size})")
+
+    def get_local_seq_len(sp_idx):
+        """Return how many KV positions SP device sp_idx holds for the current global position_id."""
+        sp_block = device_chunk_size * num_sp
+        num_full_blocks = position_id // sp_block
+        remainder = position_id % sp_block
+        dev_start = sp_idx * device_chunk_size
+        dev_end = dev_start + device_chunk_size
+        dev_contrib = max(0, min(remainder, dev_end) - dev_start)
+        return num_full_blocks * device_chunk_size + dev_contrib
+
+    # ========================================================================
+    # Validate KV cache outputs (per SP device)
+    # ========================================================================
+    for device_idx in range(mesh_rows * mesh_cols):
+        sp_group = device_idx // mesh_cols
+        local_seq_len = get_local_seq_len(sp_group)
+
+        if local_seq_len == 0 and sp_group != owning_sp_device:
+            logger.info(f"Device {device_idx} (SP={sp_group}) no data yet, skipped")
+            continue
+
+        assert torch.equal(
+            d["golden_kv_cache_bfp8_before_op"][device_idx, ..., :local_seq_len, :],
+            kv_cache_output_torch[device_idx, ..., :local_seq_len, :],
+        ), f"Device {device_idx} (SP={sp_group}) KV Cache before and after op mismatch"
+        logger.info(f"Device {device_idx} (SP={sp_group}) old cache validation passed")
+
+        if sp_group == owning_sp_device:
+            compare_kv_cache = kv_cache_output_torch[device_idx, ..., local_seq_len, :]
+            expected_nope = golden_new_kv[..., :KNOPE_DIM]
+            expected_rope = golden_new_kv[..., KNOPE_DIM:]
+            compare_nope = compare_kv_cache[..., :KNOPE_DIM]
+            compare_rope = compare_kv_cache[..., KNOPE_DIM:]
+
+            nope_passing, nope_pcc = comp_pcc(compare_nope, expected_nope, 0.98)
+            logger.info(f"Device {device_idx} (SP={sp_group}) KV Cache NOPE PCC: {nope_pcc}")
+            assert nope_passing, f"Device {device_idx} (SP={sp_group}) KV Cache NOPE PCC check failed: {nope_pcc}"
+
+            rope_passing, rope_pcc = comp_pcc(compare_rope, expected_rope, 0.98)
+            logger.info(f"Device {device_idx} (SP={sp_group}) KV Cache ROPE PCC: {rope_pcc}")
+            assert rope_passing, f"Device {device_idx} (SP={sp_group}) KV Cache ROPE PCC check failed: {rope_pcc}"
+
+    if moe_scores is not None:
+        logger.info(f"Golden MoE scores: {moe_scores}")
+        logger.info(f"Golden MoE indices: {moe_indices}")
+
+    # ========================================================================
+    # Validate decoder MLA output (full pipeline)
+    # ========================================================================
+    for device_idx in range(mesh_rows * mesh_cols):
+        received = ttnn_attention_output[device_idx : device_idx + 1, :]
+        passing, pcc = comp_pcc(mla_output, received, 0.98)
+        logger.info(f"Device {device_idx} DecoderBlock Output PCC: {pcc}")
+        logger.info(f"Golden MLA output: {mla_output}")
+        logger.info(f"DecoderBlock MLA output: {received}")
+        if validate_standalone_mla:
+            pure_mla = ttnn_attn_ref_output_torch[device_idx : device_idx + 1, :]
+            pure_mla_passing, pure_mla_pcc = comp_pcc(mla_output, pure_mla, 0.98)
+            logger.info(f"Pure MLA PCC: {pure_mla_pcc}")
+            logger.info(f"Pure MLA output: {pure_mla}")
+        assert passing, f"Device {device_idx} DecoderBlock Output PCC check failed: {pcc}"
+
+    # ========================================================================
+    # Validate MoE output vs DecoderBlock golden MoE output
+    # ========================================================================
+    # Golden with moe_num_devices>1 computes per-device golden with TP-sharded shared
+    # weights and per-device expert indices, then sums — matching reduce-to-one exactly.
+    passing, pcc = comp_pcc(moe_output.flatten(), decoder_moe_output_valid.flatten(), 0.97)
+    logger.info(f"MoE PCC (decoder vs golden): {pcc}")
+    logger.info(f"Golden MoE output: {moe_output.flatten()[:8]}")
+    logger.info(f"DecoderBlock MoE output: {decoder_moe_output_valid.flatten()[:8]}")
+
+    if validate_standalone_moe:
+        pure_moe_passing, pure_moe_pcc = comp_pcc(moe_output.flatten(), moe_device_output_valid.flatten(), 0.97)
+        logger.info(f"Pure MoE PCC (standalone vs golden): {pure_moe_pcc}")
+        logger.info(f"Pure MoE output: {moe_device_output_valid.flatten()[:8]}")
+
+        device_passing, device_pcc = comp_pcc(
+            decoder_moe_output_valid.flatten(), moe_device_output_valid.flatten(), 0.996
+        )
+        logger.info(f"Pure MoE vs Decoder MoE PCC: {device_pcc}")
+
+        if use_hardcoded_expert_index:
+            assert pure_moe_passing, f"Standalone MoE PCC check failed: {pure_moe_pcc}"
+        assert device_passing, f"Pure MoE vs Decoder MoE PCC check failed: {device_pcc}"
+    assert passing, f"DecoderBlock MoE PCC check failed: {pcc}"
+    logger.info("✓ DecoderBlock mesh test passed!")
+    ttnn.synchronize_device(submesh)
+
+
+@pytest.mark.parametrize(
+    "sender_row, sender_col",
+    [
+        (1, 0),
+    ],
+)
+@pytest.mark.parametrize("epsilon", [1e-6])
+@pytest.mark.parametrize("use_fp32", [False])
+@pytest.mark.parametrize("bcast_cluster_axis", [0])
+@pytest.mark.parametrize("bcast_secondary_cluster_axis", [1])
+@pytest.mark.parametrize("reduce_cluster_axis", [1])
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
+@pytest.mark.parametrize("num_iters", [(1)])
+@pytest.mark.parametrize("max_seq_len", [32 * 1024])
+@pytest.mark.parametrize(
+    "position_id",
+    [
+        0,
+        127,
+        pytest.param(511, marks=pytest.mark.skip_post_commit),
+        pytest.param(1023, marks=pytest.mark.skip_post_commit),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "worker_l1_size": 1374544,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
+@pytest.mark.parametrize("num_internal_iterations", [1])
+@pytest.mark.requires_grid_size((13, 10))
+def test_decoder_mlp(
+    bh_2d_mesh_device,
+    mesh_rows,
+    mesh_cols,
+    sender_row,
+    sender_col,
+    epsilon,
+    use_fp32,
+    bcast_cluster_axis,
+    bcast_secondary_cluster_axis,
+    reduce_cluster_axis,
+    num_iters,
+    max_seq_len,
+    position_id,
+    noc_mode,
+    num_internal_iterations,
+    get_reference_model_state_dict,
+):
+    """Test TTNN decoder fused operation for a dense (MLP) layer with enable_routing=False."""
+    torch.manual_seed(0)
+    num_devices = mesh_rows * mesh_cols
+    logger.info(f"Number of devices: {num_devices}")
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than available")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    device_grid_size = submesh.compute_with_storage_grid_size()
+
+    logger.info("Preparing dense MLP model state dict...")
+    state_dict = get_reference_model_state_dict(
+        layer_idx=DENSE_LAYER_IDX,
+        is_moe=False,
+        seed=RoutedExpert.SEED,
+    )
+
+    logger.info("Creating dense decoder block tensors...")
+    d = create_decoder_block_tensors(
+        submesh,
+        mesh_rows,
+        mesh_cols,
+        sender_row,
+        sender_col,
+        position_id,
+        state_dict,
+        layer_idx=DENSE_LAYER_IDX,
+        max_seq_len=max_seq_len,
+        is_moe=False,
+    )
+
+    num_cores = device_grid_size.x * device_grid_size.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid_size, row_wise=True)
+    ttnn.synchronize_device(submesh)
+    reduce_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(4)]
+    persistent_next_iter_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 1)
+    ttnn.synchronize_device(submesh)
+
+    attn_semaphores = AttentionBlock.create_semaphores(submesh)
+    moe_semaphores = MoeOp.create_semaphores(submesh)
+
+    logger.info(f"Running dense decoder operation with position_id={position_id}...")
+    for i in range(num_iters):
+        moe_final_output_tensor, attention_block_output_tensor = DecoderBlock.op(
+            # AttentionBlock parameters
+            d["input_tensor_mesh"],
+            d["gamma_overlapped"],
+            d["matmul_weights_overlapped"],
+            d["rmsnorm2_gamma_overlapped"],
+            d["matmul2_weights_overlapped"],
+            d["matmul3_weights_overlapped"],
+            d["ttnn_qrope_sin"],
+            d["ttnn_qrope_cos"],
+            d["ttnn_trans_mat"],
+            d["ttnn_krope_cos"],
+            d["ttnn_krope_sin"],
+            d["dkv_matmul_weights_overlapped"],
+            d["dkv_rmsnorm_gamma_overlapped"],
+            d["ttnn_kv_cache"],
+            d["ttnn_position_ids"],
+            d["scale"],
+            d["sdpa_kv_cache_buffer"],
+            d["sdpa_out_interm_buffer"],
+            d["sender_coord"],
+            # Post-SDPA parameters
+            d["kv_b2_overlapped"],
+            d["o_proj_overlapped"],
+            d["ttnn_sdpa_input_l"],
+            d["ttnn_sdpa_input_ms"],
+            d["ttnn_sdpa_output_l"],
+            d["ttnn_sdpa_intermediate_recv"],
+            d["ttnn_sdpa_forwarder_scratch"],
+            d["device_chunk_size"],
+            d["ttnn_attention_block_output"],
+            attention_block_semaphores=attn_semaphores,
+            # MoE parameters (no gate_mm / routing tensors for dense MLP)
+            shared_residual_mcast_src_tensor=d["ttnn_residual_mcast_src"],
+            gate_mm_weights_tensor=None,
+            gate_bias_tensor=None,
+            gate_indices_tensor=None,
+            gate_output_scores_tensor=None,
+            gate_output_indices_tensor=None,
+            gate_proj_weights_tensor=d["gate_proj_weights"],
+            up_proj_weights_tensor=d["up_proj_weights"],
+            down_proj_weights_tensor=d["down_proj_weights"],
+            moe_final_output_tensor=None,
+            rmsnorm_gamma_tensor=d["ffn_norm_overlapped"],
+            shared_gate_weights_overlapped=d["shared_gate_weights_overlapped"],
+            shared_up_weights_overlapped=d["shared_up_weights_overlapped"],
+            shared_down_weights_tensor=d["shared_down_weights_tensor"],
+            shared_k_parallel=d["shared_k_parallel"],
+            shared_n_parallel=d["shared_n_parallel"],
+            moe_semaphores=moe_semaphores,
+            reduce_intermediate_tensors=d["reduce_intermediate_tensors"],
+            reduce_output_tensor=d["reduce_output_tensor"],
+            reduce_semaphores=reduce_semaphores,
+            reduce_root_coord=ttnn.MeshCoordinate(d["reduce_root_coord"]),
+            # Shared parameters
+            enable_routing=False,
+            bcast_cluster_axis=bcast_cluster_axis,
+            bcast_secondary_cluster_axis=bcast_secondary_cluster_axis,
+            reduce_cluster_axis=reduce_cluster_axis,
+            sdpa_cluster_axis=0,
+            num_links=1,
+            epsilon=epsilon,
+            fp32_dest_acc_en=use_fp32,
+            skip_ccl=False,
+            use_hardcoded_expert_index=False,
+            noc_mode=noc_mode,
+            num_iterations=num_internal_iterations,
+            upstream_socket=None,
+            downstream_socket=None,
+            persistent_next_iter_semaphore=persistent_next_iter_semaphore,
+            persistent_mode=True,
+        )
+    ttnn.synchronize_device(submesh)
+
+    # ========================================================================
+    # Extract decoder MLP output from reduce root
+    # ========================================================================
+    root_coord_tuple = d["reduce_root_coord"]
+    root_device_idx = root_coord_tuple[0] * mesh_cols + root_coord_tuple[1]
+    root_device_tensor = ttnn.get_device_tensors(moe_final_output_tensor)[root_device_idx]
+    decoder_mlp_output = ttnn.to_torch(root_device_tensor)
+    decoder_mlp_output_valid = extract_routed_expert_output(
+        decoder_mlp_output.unsqueeze(0),
+        d["num_gate_proj_cores"],
+        RoutedExpert.FINAL_OUTPUT_WIDTH_PER_CORE,
+        d["per_core_down_proj_N"],
+    )
+
+    # ========================================================================
+    # Compute golden reference via DecoderBlock.golden (MLA → MLP full pipeline)
+    # ========================================================================
+    logger.info("Computing golden reference...")
+
+    QNOPE_HEAD_DIM = 128
+    QROPE_HEAD_DIM = 64
+    KNOPE_DIM = 512
+    KROPE_DIM = 64
+    HEADS_PER_ROW = 8
+
+    _full_q, _new_kv, _mla_output, _scores, _indices, moe_output = DecoderBlock.golden(
+        d["golden_torch_input"],
+        d["golden_torch_gamma"],
+        d["golden_torch_matmul_weights"],
+        d["golden_torch_rmsnorm2_gamma"],
+        d["golden_torch_matmul2_weights"],
+        d["golden_torch_matmul3_weights"],
+        d["golden_torch_sin"],
+        d["golden_torch_cos"],
+        d["golden_position_ids"],
+        d["golden_torch_dkv_matmul_weights"],
+        d["golden_torch_dkv_rmsnorm_gamma"],
+        d["golden_torch_kv_cache"],
+        d["golden_scale"],
+        d["golden_torch_kv_b2_proj_weights"],
+        d["golden_torch_o_proj_weights"],
+        epsilon=epsilon,
+        num_qnope_heads=d["golden_total_qnope_heads"],
+        num_qrope_heads=d["golden_total_qrope_heads"],
+        qnope_head_dim=QNOPE_HEAD_DIM,
+        qrope_head_dim=QROPE_HEAD_DIM,
+        heads_per_row=HEADS_PER_ROW,
+        nope_dim=KNOPE_DIM,
+        rope_dim=KROPE_DIM,
+        moe_shared_gate_weights=d["golden_moe_shared_gate"],
+        moe_shared_up_weights=d["golden_moe_shared_up"],
+        moe_shared_down_weights=d["golden_moe_shared_down"],
+        moe_gate_proj_weights_dict=d["golden_moe_gate_proj_dict"],
+        moe_up_proj_weights_dict=d["golden_moe_up_proj_dict"],
+        moe_down_proj_weights_dict=d["golden_moe_down_proj_dict"],
+        moe_rmsnorm_gamma=d["golden_moe_rmsnorm_gamma"],
+        moe_rmsnorm_epsilon=epsilon,
+        moe_enable_routing=False,
+        moe_num_devices=num_devices,
+        moe_reduce_root_device_idx=root_device_idx,
+    )
+
+    # ========================================================================
+    # Validate MLP output vs DecoderBlock golden
+    # ========================================================================
+    passing, pcc = comp_pcc(moe_output.flatten(), decoder_mlp_output_valid.float().flatten(), 0.975)
+    logger.info(f"MLP PCC (decoder vs golden): {pcc}")
+    logger.info(f"Golden MLP output: {moe_output.flatten()[:8]}")
+    logger.info(f"DecoderBlock MLP output: {decoder_mlp_output_valid.flatten()[:8]}")
+    assert passing, f"DecoderBlock MLP Output PCC check failed: {pcc}"
+
+    logger.info("✓ DecoderBlock MLP mesh test passed!")
+
+    ttnn.synchronize_device(submesh)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_15_stages.py
@@ -31,6 +31,7 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     create_routed_expert_tensors,
     create_shared_expert_tensors,
 )
+from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
 
 
 def create_fabric_router_config(max_payload_size):
@@ -119,7 +120,7 @@ def test_moe_15_stages(mesh_device, vocab_size, embedding_dim, token_id, device_
     # ── Core setup for reduce aggregation ──
     stage_entry_device = None
     gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
     shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
     # Aggregator is the first worker core (shard_idx == 0)
@@ -495,7 +496,7 @@ def test_persistent_moe_15_stages(
 
     stage_entry_device = None
     gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
     shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
     aggregator_core = shard_cores_list[0]
@@ -875,7 +876,7 @@ def test_persistent_moe_multi_token(
 
     stage_entry_device = None
     gate_proj_noc = ttnn.NOC.NOC_0
-    gate_proj_worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(gate_proj_noc)
+    gate_proj_worker_cores = get_pinned_optimal_dram_bank_to_logical_worker_assignment(mesh_device, gate_proj_noc)
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in gate_proj_worker_cores])
     shard_cores_list = ttnn.corerange_to_cores(gate_proj_core_ranges, row_wise=True)
     aggregator_core = shard_cores_list[0]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -693,6 +693,34 @@ def create_reference_mlp_models(state_dict, layer_idx):
     return expert_mlp, shared_mlp
 
 
+def rig_moe_gate_for_expected_experts(
+    state_dict,
+    layer_idx,
+    winning_groups,
+    winning_experts_by_group,
+    *,
+    low_bias=-10.0,
+    high_bias=10.0,
+    zero_gate_weights=True,
+):
+    """Rig grouped gate so top-k deterministically selects requested experts."""
+    gate_key = f"model.layers.{layer_idx}.mlp.gate.weight"
+    bias_key = f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"
+
+    if zero_gate_weights:
+        state_dict[gate_key] = torch.zeros_like(state_dict[gate_key])
+
+    bias_2d = torch.full((8, 32), low_bias, dtype=state_dict[bias_key].dtype)
+    expected_expert_ids = []
+    for group_id in winning_groups:
+        for expert_id in winning_experts_by_group[group_id]:
+            bias_2d[group_id, expert_id] = high_bias
+            expected_expert_ids.append(group_id * 32 + expert_id)
+
+    state_dict[bias_key] = bias_2d.reshape(-1).contiguous()
+    return expected_expert_ids
+
+
 @pytest.mark.parametrize(
     "use_hardcoded_expert_index",
     [True, pytest.param(False, marks=pytest.mark.skip_post_commit)],
@@ -823,7 +851,7 @@ def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs, noc_mod
     )
 
     # Compute fused MoE golden (routed + shared expert + eltwise add)
-    torch_expected_scores, torch_expected_indices, torch_expected_final = MoeOp.golden(
+    torch_expected_scores, torch_expected_indices, torch_expected_final = MoeOp.golden_single_device(
         r.torch_input,
         shared_gate_weights=s.torch_gate_weights,
         shared_up_weights=s.torch_up_weights,
@@ -874,24 +902,18 @@ def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs, noc_mod
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
-@pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
 @pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
 @pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
 @pytest.mark.requires_grid_size((13, 10))
 @pytest.mark.timeout(1200)
-def test_moe_fused_with_reduce(
-    bh_2d_mesh_device, use_hardcoded_expert_index, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict
-):
+def test_moe_fused_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict):
     """
     Test fused MoE with reduce_to_one on 4x2 mesh.
 
     Each of 8 devices runs the full fused MoE (routed + shared expert),
     then results are reduced (summed) across all devices to ROOT1.
 
-    When use_hardcoded_expert_index=True, each device uses expert index = chip_id (0..7)
-    and the gate is only used for scaling; this is not the same as the reference model,
-    which uses the gate to select the actual top-8 experts. The reference comparison
-    is therefore skipped in that case and only runs when use_hardcoded_expert_index=False.
+    Gate is rigged so grouped top-k picks deterministic winners.
     """
     num_devices = TestConfig.NUM_DEVICES_4x2
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
@@ -915,12 +937,24 @@ def test_moe_fused_with_reduce(
         num_routed_experts=256,
         include_global=False,
     )
+    winning_groups = [0, 2, 5, 7]
+    winning_experts_by_group = {
+        0: [1, 9],
+        2: [4, 19],
+        5: [7, 23],
+        7: [3, 28],
+    }
+    expected_expert_ids = rig_moe_gate_for_expected_experts(
+        state_dict,
+        ROUTED_EXPERT_LAYER_IDX,
+        winning_groups,
+        winning_experts_by_group,
+    )
 
     # ── Create MoE tensors (replicated across mesh) ──
     mesh_mapper = ttnn.ReplicateTensorToMesh(submesh)
     r = create_routed_expert_tensors(
         submesh,
-        use_hardcoded_expert_index,
         mesh_mapper=mesh_mapper,
         create_final_output=False,
         state_dict=state_dict,
@@ -956,6 +990,7 @@ def test_moe_fused_with_reduce(
         ),
     )
 
+    device_grid_size = submesh.compute_with_storage_grid_size()
     sdpa_out_interm_shard_height = SDPA.OUT_INTERM_SHARD_HEIGHT
     sdpa_out_interm_shard_width = SDPA.OUT_INTERM_SHARD_WIDTH
     full_device_grid = ttnn.CoreRangeSet(
@@ -1068,7 +1103,7 @@ def test_moe_fused_with_reduce(
         shared_down_weights_tensor=s.ttnn_down_weights,
         shared_k_parallel=s.k_parallel,
         shared_n_parallel=s.n_parallel,
-        use_hardcoded_expert_index=use_hardcoded_expert_index,
+        use_hardcoded_expert_index=False,
         sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer=sdpa_out_interm_buffer,
         num_iterations=num_iterations,
@@ -1085,57 +1120,35 @@ def test_moe_fused_with_reduce(
     logger.info(f"Fused MoE with reduce: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # ── Verify results ──
-    # Read gate scores/indices from device (needed for per-device golden)
+    # Read gate scores/indices from device
     device_gate_indices = ttnn.to_torch(ttnn_result_indices, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
-    device_gate_scores = ttnn.to_torch(ttnn_result_scores, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
-
-    # Compute expected output for each device, then sum.
-    # Residual is only added on ROOT1 device; non-root devices skip it.
-    K_down = s.K_down
+    _ = ttnn.to_torch(ttnn_result_scores, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
     root_device_idx = root_coord[0] * submesh.shape[1] + root_coord[1]
-    expected_final_outputs = []
-    for device_idx in range(num_devices):
-        chip_id = device_idx
+    tt_top8 = device_gate_indices[0].flatten()[:8].to(torch.int64)
+    tt_top8_sorted = torch.sort(tt_top8).values
+    expected_top8_sorted = torch.sort(torch.tensor(expected_expert_ids, dtype=torch.int64)).values
+    assert torch.equal(tt_top8_sorted, expected_top8_sorted), (
+        f"Rigged gate experts mismatch: expected={expected_top8_sorted.tolist()}, " f"got={tt_top8_sorted.tolist()}"
+    )
 
-        if use_hardcoded_expert_index:
-            actual_expert_idx = chip_id
-            actual_expert_scale = device_gate_scores[0].flatten()[chip_id].float()
-        else:
-            actual_expert_idx = int(device_gate_indices[0].flatten()[chip_id].item())
-            actual_expert_scale = device_gate_scores[0].flatten()[chip_id].float()
-
-        shared_gate_shard = s.torch_gate_weights[:, device_idx * K_down : (device_idx + 1) * K_down]
-        shared_up_shard = s.torch_up_weights[:, device_idx * K_down : (device_idx + 1) * K_down]
-        shared_down_shard = s.torch_down_weights[device_idx * K_down : (device_idx + 1) * K_down, :]
-
-        _, _, torch_expected_final = MoeOp.golden(
-            r.torch_input,
-            shared_gate_weights=shared_gate_shard,
-            shared_up_weights=shared_up_shard,
-            shared_down_weights=shared_down_shard,
-            gate_proj_weights_dict=r.expert_weights_dict,
-            up_proj_weights_dict=r.up_proj_weights_dict,
-            down_proj_weights_dict=r.down_proj_weights_dict,
-            rmsnorm_gamma=r.torch_rmsnorm_gamma,
-            rmsnorm_epsilon=1e-6,
-            routing_weights_tensor=r.torch_gate_mm_weights,
-            bias_tensor=r.torch_bias,
-            eps=r.gate_eps,
-            scaling_factor=r.gate_scaling_factor,
-            use_hardcoded_expert_index=True,
-            hardcoded_expert_index=actual_expert_idx,
-            explicit_expert_scale=actual_expert_scale,
-            include_residual=(device_idx == root_device_idx),
-        )
-        expected_final_outputs.append(torch_expected_final)
-        logger.info(
-            f"Device {device_idx}: expert_idx={actual_expert_idx}, "
-            f"expert_scale={actual_expert_scale:.4f}, "
-            f"output range=[{torch_expected_final.min():.4f}, {torch_expected_final.max():.4f}]"
-        )
-
-    # Expected reduce output = sum of all per-device outputs
-    expected_reduce_output = sum(expected_final_outputs)
+    # One logical golden call (h + MoE(h)); no per-device golden loop needed.
+    _, _, expected_reduce_output = MoeOp.golden(
+        r.torch_input,
+        shared_gate_weights=s.torch_gate_weights,
+        shared_up_weights=s.torch_up_weights,
+        shared_down_weights=s.torch_down_weights,
+        gate_proj_weights_dict=r.expert_weights_dict,
+        up_proj_weights_dict=r.up_proj_weights_dict,
+        down_proj_weights_dict=r.down_proj_weights_dict,
+        rmsnorm_gamma=r.torch_rmsnorm_gamma,
+        routing_weights_tensor=r.torch_gate_mm_weights,
+        bias_tensor=r.torch_bias,
+        rmsnorm_epsilon=1e-6,
+        routing_mode=True,
+        eps=r.gate_eps,
+        scaling_factor=r.gate_scaling_factor,
+        include_residual=True,
+    )
 
     # Get actual reduce output from ROOT1 device
     reduce_output_torch = ttnn.to_torch(
@@ -1158,11 +1171,9 @@ def test_moe_fused_with_reduce(
     logger.info(f"Reduce output PCC: {pcc_output}")
     assert passing, f"Reduce output PCC check failed: {pcc_output}"
 
-    # --- Reference model comparison (when doing same op as reference: gate-selected experts) ---
-    # Skip when use_hardcoded_expert_index=True: B1 then uses fixed experts 0..7 (one per device),
-    # while the reference uses gate-selected top-8 experts; they are not the same operation.
+    # --- Reference model comparison ---
     num_experts_in_state_dict = sum(1 for k in state_dict if ".mlp.experts." in k and "gate_proj" in k)
-    if num_experts_in_state_dict >= 256 and not use_hardcoded_expert_index:
+    if num_experts_in_state_dict >= 256:
         reference_moe, _ = create_reference_moe_model(state_dict, ROUTED_EXPERT_LAYER_IDX)
 
         # Apply RMSNorm (same as B1 fused op does internally)
@@ -1322,8 +1333,10 @@ def test_mlp(device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict)
         up_proj_weights_dict=r.up_proj_weights_dict,
         down_proj_weights_dict=r.down_proj_weights_dict,
         rmsnorm_gamma=r.torch_rmsnorm_gamma,
+        routing_weights_tensor=r.torch_gate_mm_weights,
+        bias_tensor=r.torch_bias,
         rmsnorm_epsilon=1e-6,
-        enable_routing=False,
+        routing_mode=False,
     )
 
     passing, pcc = comp_pcc(torch_expected, output_final_valid, 0.97)
@@ -1340,8 +1353,8 @@ def test_mlp(device, reconfig_moe_cbs, noc_mode, get_reference_model_state_dict)
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
-@pytest.mark.parametrize("use_mlp_weights", [True, False], ids=["mlp", "moe"])
-@pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
+@pytest.mark.parametrize("use_mlp_weights", [True], ids=["mlp"])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True])
 @pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
 @pytest.mark.requires_grid_size((13, 10))
 @pytest.mark.timeout(1200)
@@ -1424,6 +1437,7 @@ def test_mlp_with_reduce(
         ),
     )
 
+    device_grid_size = submesh.compute_with_storage_grid_size()
     sdpa_out_interm_shard_height = SDPA.OUT_INTERM_SHARD_HEIGHT
     sdpa_out_interm_shard_width = SDPA.OUT_INTERM_SHARD_WIDTH
     full_device_grid = ttnn.CoreRangeSet(
@@ -1565,7 +1579,7 @@ def test_mlp_with_reduce(
             up_dict = r.up_proj_weights_dict
             down_dict = r.down_proj_weights_dict
 
-        _, _, device_expected = MoeOp.golden(
+        _, _, device_expected = MoeOp.golden_single_device(
             r.torch_input,
             shared_gate_weights=shared_gate_shard,
             shared_up_weights=shared_up_shard,

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -57,13 +57,18 @@ struct Matmul {
     struct WriterCTArgs {};
 
     // Compute CTArgs (TRISC): out_w (output width in tiles), transpose, fused_activation
-    template <uint32_t out_w_, bool transpose_ = false, uint32_t fused_activation_ = 0>
+    template <
+        uint32_t out_w_,
+        bool transpose_ = false,
+        uint32_t fused_activation_ = 0,
+        bool fused_activation_approx_mode_ = false>
     struct ComputeCTArgs {
         static constexpr uint32_t out_w = out_w_;
         static constexpr bool transpose = transpose_;
         static constexpr FusedActivation fused_activation = static_cast<FusedActivation>(fused_activation_);
         static constexpr bool fuse_sigmoid = fused_activation == FusedActivation::SIGMOID;
         static constexpr bool fuse_silu = fused_activation == FusedActivation::SILU;
+        static constexpr bool fused_activation_approx_mode = fused_activation_approx_mode_;
     };
 
     // ========================================================================
@@ -137,9 +142,9 @@ struct Matmul {
             if constexpr (CTArgs::fuse_sigmoid || CTArgs::fuse_silu) {
                 // Initialize activation on PACK thread
                 if constexpr (CTArgs::fuse_sigmoid) {
-                    PACK((ckernel::llk_math_eltwise_unary_sfpu_sigmoid_init<true>()));
+                    PACK((ckernel::llk_math_eltwise_unary_sfpu_sigmoid_init<CTArgs::fused_activation_approx_mode>()));
                 } else {
-                    PACK((ckernel::llk_math_eltwise_unary_sfpu_silu_init<true>()));
+                    PACK((ckernel::llk_math_eltwise_unary_sfpu_silu_init<CTArgs::fused_activation_approx_mode>()));
                 }
 
                 // Per-tile: matmul -> activation on PACK -> pack
@@ -159,9 +164,12 @@ struct Matmul {
 
                     // Use 2 iterations for 1x32 tiny tiles
                     if constexpr (CTArgs::fuse_sigmoid) {
-                        PACK((ckernel::llk_math_eltwise_unary_sfpu_sigmoid<true, false, 2>(0, (int)VectorMode::R)));
+                        PACK((ckernel::
+                                  llk_math_eltwise_unary_sfpu_sigmoid<CTArgs::fused_activation_approx_mode, false, 2>(
+                                      0, (int)VectorMode::R)));
                     } else {
-                        PACK((ckernel::llk_math_eltwise_unary_sfpu_silu<true, false, 2>(0, (int)VectorMode::R)));
+                        PACK((ckernel::llk_math_eltwise_unary_sfpu_silu<CTArgs::fused_activation_approx_mode, false, 2>(
+                            0, (int)VectorMode::R)));
                     }
 
                     PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -33,3 +33,21 @@ def generate_mm_weights(shape, dtype):
     # # Alternatively, we could pass the original shape and use fan_out
     # torch.nn.init.kaiming_normal_(torch_mm_weights.T, mode="fan_in", nonlinearity="linear")
     # return torch_mm_weights
+
+
+# Hardcoded optimal DRAM bank to logical worker assignment for Blackhole to avoid differences from harvesting
+def get_pinned_optimal_dram_bank_to_logical_worker_assignment(device, noc):
+    import ttnn
+
+    assert noc == ttnn.NOC.NOC_0, "Only NOC_0 is supported for now"
+    assert device.arch() == ttnn.Arch.BLACKHOLE, "Only Blackhole is supported for now"
+    return [
+        ttnn.CoreCoord(0, 9),
+        ttnn.CoreCoord(0, 0),
+        ttnn.CoreCoord(0, 7),
+        ttnn.CoreCoord(0, 3),
+        ttnn.CoreCoord(7, 9),
+        ttnn.CoreCoord(7, 1),
+        ttnn.CoreCoord(7, 6),
+        ttnn.CoreCoord(7, 4),
+    ]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to fuse attention block and moe for full decoder.

### What's changed
Fused full decoder.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/full-decoder)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/full-decoder)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/full-decoder)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/full-decoder)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/full-decoder)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/full-decoder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/full-decoder)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
