### PR TITLE
Add tests for printing simple strings in device_print functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,9 @@ tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicT
 tt_metal/hw/ckernels/**/llk_api/llk_sfpu @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @fvranicTT @nmauriceTT @tenstorrent/codeowner-bypass
 tt_metal/hw/firmware/src/tt-1xx/*erisc* @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/ @abhullar-tt @jbaumanTT @kstevensTT @nathan-TT @vvukomanovicTT @atatuzunerTT @ruizhangTT @arikTT @tenstorrent/codeowner-bypass
+tt_metal/hw/inc/api/debug/device_print.h @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
+tt_metal/hw/inc/hostdev/device_print_common.h @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
+tt_metal/hw/inc/hostdev/device_print_structures.h @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/internal/ethernet/ @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/internal/tt-1xx/wormhole/eth_l1_address_map.h @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/**/tensor/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
@@ -78,7 +81,7 @@ tt_metal/impl/buffers/ @abhullar-tt @jbaumanTT @cfjchu @TT-BrianLiu @tenstorrent
 tt_metal/impl/context/ @jbaumanTT @nhuang-tt @aliuTT @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/impl/data_format/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @fvranicTT @tenstorrent/codeowner-bypass
 tt_metal/impl/dataflow_buffer/ @abhullar-tt @arikTT @tenstorrent/codeowner-bypass
-tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @sidnadTT @tenstorrent/codeowner-bypass
+tt_metal/impl/debug/ @abhullar-tt @ruizhangTT @sidnadTT @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 tt_metal/impl/debug/inspector/ @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 tt_metal/impl/device/ @abhullar-tt @aliuTT @tt-asaigal @tt-aho @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/impl/dispatch/ @jbaumanTT @nhuang-tt @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
@@ -147,6 +150,8 @@ tests/tt_metal/multihost/**/CMakeLists.txt @tenstorrent/metalium-developers-meta
 tests/tt_metal/tools/profiler/ @mo-tenstorrent @nhuang-tt @tenstorrent/codeowner-bypass
 tests/tt_metal/tools/**/CMakeLists.txt @mo-tenstorrent @nhuang-tt @tenstorrent/metalium-developers-infra
 tests/tt_metal/tt_metal/debug_tools/inspector @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_metal/debug_tools/device_print @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_metal/test_kernels/device_print @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 
 # misc tests
 tests/didt/ @rdjogoTT @ttmtrajkovic @tenstorrent/codeowner-bypass

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -65,6 +65,15 @@ public:
     }
 };
 
+TEST_F(DevicePrintFormatUpdatesFixture, PrintSimpleString) {
+    std::vector<std::string_view> messages = {
+        "Hello world!\n"sv,
+    };
+
+    TestFormatUpdate(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp", ttsl::make_span(messages));
+}
+
 TEST_F(DevicePrintFormatUpdatesFixture, PrintSingleUintArg) {
     std::vector<std::string_view> messages = {
         "Printing uint32_t from arg: {0,I}\n"sv,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -21,6 +21,14 @@ public:
     }
 };
 
+TEST_F(DevicePrintOutputFixture, PrintSimpleString) {
+    std::vector<std::string> messages = {
+        "Hello world!",
+    };
+
+    TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp", messages);
+}
+
 TEST_F(DevicePrintOutputFixture, PrintSingleUintArg) {
     std::vector<uint32_t> runtime_args = {42};
     std::vector<std::string> messages = {

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+/*
+ * Test printing from a kernel running on BRISC.
+ */
+
+void kernel_main() { DEVICE_PRINT("Hello world!\n"); }

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -51,31 +51,31 @@ struct bf16_t {
 };
 
 #ifdef UCK_CHLKC_UNPACK
-#define DEVICE_PRINT_UNPACK(format, ...) DEVICE_PRINT(format, __VA_ARGS__)
+#define DEVICE_PRINT_UNPACK(format, ...) DEVICE_PRINT(format, ##__VA_ARGS__)
 #else
 #define DEVICE_PRINT_UNPACK(format, ...)
 #endif
 
 #ifdef UCK_CHLKC_MATH
-#define DEVICE_PRINT_MATH(format, ...) DEVICE_PRINT(format, __VA_ARGS__)
+#define DEVICE_PRINT_MATH(format, ...) DEVICE_PRINT(format, ##__VA_ARGS__)
 #else
 #define DEVICE_PRINT_MATH(format, ...)
 #endif
 
 #ifdef UCK_CHLKC_PACK
-#define DEVICE_PRINT_PACK(format, ...) DEVICE_PRINT(format, __VA_ARGS__)
+#define DEVICE_PRINT_PACK(format, ...) DEVICE_PRINT(format, ##__VA_ARGS__)
 #else
 #define DEVICE_PRINT_PACK(format, ...)
 #endif
 
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_DM)
-#define DEVICE_PRINT_DATA0(format, ...)    \
-    if (noc_index == 0) {                  \
-        DEVICE_PRINT(format, __VA_ARGS__); \
+#define DEVICE_PRINT_DATA0(format, ...)      \
+    if (noc_index == 0) {                    \
+        DEVICE_PRINT(format, ##__VA_ARGS__); \
     }
-#define DEVICE_PRINT_DATA1(format, ...)    \
-    if (noc_index == 1) {                  \
-        DEVICE_PRINT(format, __VA_ARGS__); \
+#define DEVICE_PRINT_DATA1(format, ...)      \
+    if (noc_index == 1) {                    \
+        DEVICE_PRINT(format, ##__VA_ARGS__); \
     }
 #else
 #define DEVICE_PRINT_DATA0(format, ...)
@@ -126,7 +126,7 @@ struct bf16_t {
         /* For indexed placeholders, validate all arguments are referenced */                                         \
         static_assert(                                                                                                \
             !device_print_detail::checks::has_indexed_placeholders(format) ||                                         \
-                device_print_detail::checks::all_arguments_referenced(format, __VA_ARGS__),                           \
+                device_print_detail::checks::all_arguments_referenced(format, ##__VA_ARGS__),                         \
             "All arguments must be referenced when using indexed placeholders");                                      \
         /* For non-indexed placeholders, count must match argument count */                                           \
         static_assert(                                                                                                \
@@ -136,7 +136,7 @@ struct bf16_t {
             "Number of {} placeholders must match number of arguments");                                              \
         /* Update format to include all necessary data */                                                             \
         constexpr auto updated_format =                                                                               \
-            device_print_detail::formatting::update_format_string_from_args(format, __VA_ARGS__);                     \
+            device_print_detail::formatting::update_format_string_from_args(format, ##__VA_ARGS__);                   \
         /* Store updated format string in a special section for device_print */                                       \
         DEVICE_PRINT_GET_STRING_INDEX(device_print_info_index, updated_format);                                       \
         /* Get buffer lock (once we change to be single buffer per L1 instead of per risc)*/                          \
@@ -161,7 +161,7 @@ struct bf16_t {
             auto device_print_buffer_ptr = &(device_print_buffer->data[0]) + write_position;                          \
             device_print_detail::formatting::device_print_type<decltype(header_value)>::serialize(                    \
                 device_print_buffer_ptr, 0, header_value);                                                            \
-            device_print_detail::serialization::serialize_arguments(device_print_buffer_ptr, __VA_ARGS__);            \
+            device_print_detail::serialization::serialize_arguments(device_print_buffer_ptr, ##__VA_ARGS__);          \
             /* Move write pointer in device_print buffer */                                                           \
             asm volatile("" ::: "memory");                                                                            \
             device_print_buffer->aux.wpos = write_position + message_size;                                            \

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -516,14 +516,16 @@ DevicePrintParser::ParsedStringInfo* DevicePrintParser::get_string_info(uint32_t
                 format_strings_bytes.data() + (info.format_string_ptr - format_strings_address));
             parsed_info.format_string = format_string;
             std::tie(parsed_info.plain_text_parts, parsed_info.placeholders) = parse_format_string(format_string);
-            uint32_t max_arg_id = 0;
-            for (const auto& placeholder : parsed_info.placeholders) {
-                max_arg_id = std::max(max_arg_id, placeholder.arg_id);
-            }
-            parsed_info.argument_types.resize(max_arg_id + 1);
-            for (const auto& placeholder : parsed_info.placeholders) {
-                parsed_info.argument_types[placeholder.arg_id] = placeholder.type_id;
-                parsed_info.arguments_size += get_argument_size_from_type_id(placeholder.type_id);
+            if (!parsed_info.placeholders.empty()) {
+                uint32_t max_arg_id = 0;
+                for (const auto& placeholder : parsed_info.placeholders) {
+                    max_arg_id = std::max(max_arg_id, placeholder.arg_id);
+                }
+                parsed_info.argument_types.resize(max_arg_id + 1);
+                for (const auto& placeholder : parsed_info.placeholders) {
+                    parsed_info.argument_types[placeholder.arg_id] = placeholder.type_id;
+                    parsed_info.arguments_size += get_argument_size_from_type_id(placeholder.type_id);
+                }
             }
         }
         if (info.file >= format_strings_address && info.file < format_strings_address + format_strings_bytes.size()) {


### PR DESCRIPTION
Fixing printing simple string (`DEVICE_PRINT("Hello world!\n");`) and adding test to validate it works as expected.
Updating `CODEOWNERS` for `DEVICE_PRINT`.