### PR TITLE
ring causal tests

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -93,7 +93,7 @@ fabric:
 
 shield:
   e2e:
-    wh_llmbox: 15
+    wh_llmbox: 25
 
 scaleout:
   e2e:

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -129,6 +129,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_torch_dispatch_combine.py -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2' -vvv --tb=short
             timeout: 15
             test-type: loudbox
             owner_id: U08E1JCMAJF # Marko Bezulj
@@ -140,6 +141,7 @@ jobs:
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_torch_dispatch_combine.py -vvv --tb=short
               pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short
+              pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2' -vvv --tb=short
             timeout: 15
             test-type: qb
             owner_id: U08E1JCMAJF # Marko Bezulj

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -28,7 +28,6 @@ on:
           - gemma3-small
           - dits
           - deepseek
-          - deepseek prefill
           - gpt-oss
           - tttv2 modules
       platform:

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -344,11 +344,14 @@ def run_ring_joint_sdpa(
 
     if not skip_check:
         # Only use main tensors for host reference (no joint tensors since joint_seq_len=0)
-        logger.debug("Running on host...")
-        gt_out = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=is_causal)
-        logger.debug("Done running on host...")
-        logger.debug("Host output shape: ", gt_out.shape)
+        # Do check with host on unit not determinism tests
+        if n_iters == 1:
+            logger.debug("Running on host...")
+            gt_out = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=is_causal)
+            logger.debug("Done running on host...")
+            logger.debug("Host output shape: ", gt_out.shape)
 
+        expected_output = None
         for i in range(n_iters):
             logger.debug("Synchronize call...")
             ttnn.synchronize_device(submesh)
@@ -371,33 +374,55 @@ def run_ring_joint_sdpa(
                 # Slice out any tile-padding
                 tt_out = tt_out[:, :, :base_seq_len, :]
 
+            if n_iters > 1:
+                if expected_output is None:
+                    expected_output = tt_out
+                elif not torch.equal(expected_output, tt_out):
+                    diff_mask = expected_output != tt_out
+                    num_diffs = diff_mask.sum().item()
+                    max_diff = (expected_output - tt_out).abs().max().item()
+                    pytest.fail(
+                        f"Ring joint SDPA output at iteration {i} differs from iteration 0: "
+                        f"{num_diffs} differing elements, max diff = {max_diff}"
+                    )
+                else:
+                    logger.debug(f"Iteration {i} passed determinism check")
+
             logger.debug(f"tt_out: {tt_out.shape}")
 
-            passing = True
-            out_pass, out_pcc = comp_pcc(tt_out, gt_out, pcc_threshold)
-            logger.debug(f"{out_pcc}")
-            mse = ((gt_out - tt_out) ** 2).mean()
-            logger.debug(f"mse: {mse}")
-            if max_mse is not None and mse > max_mse:
-                passing = False
-            passing = passing and out_pass
+            if n_iters == 1:
+                passing = True
+                out_pass, out_pcc = comp_pcc(tt_out, gt_out, pcc_threshold)
+                logger.debug(f"{out_pcc}")
+                mse = ((gt_out - tt_out) ** 2).mean()
+                logger.debug(f"mse: {mse}")
+                if max_mse is not None and mse > max_mse:
+                    passing = False
+                passing = passing and out_pass
 
-            assert passing
+                assert passing
 
 
+#  Note: seq_len and nhq_v will be scaled down to the hw test runs on, inputs are for 32x4 devices configuration
 @pytest.mark.parametrize("q_dtype, kv_dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)], ids=["q_bf16_kv_bf8"])
 @pytest.mark.parametrize(
-    "b, nhq, nhk, nhv, base_seq_len, head_dim_q, head_dim_k, head_dim_v",
+    "seq_len, q_chunk_size, k_chunk_size",
     [
-        (1, 64, 1, 64, 4 * 4 * 1024, 576, 576, 128),
+        (128 * 1024, 256, 128),
+        (100 * 1024, 320, 32),
     ],
 )
-@pytest.mark.parametrize("q_chunk_size", [32], ids=["q32"])
-@pytest.mark.parametrize("k_chunk_size", [32], ids=["k32"])
 @pytest.mark.parametrize(
-    "n_iters, trace_enabled, skip_check",
+    "b, nhq_v, nhk, head_dim_q_k, head_dim_v",
     [
-        (1, False, False),
+        (1, 128, 1, 576, 128),
+    ],
+)
+@pytest.mark.parametrize("n_iters", [1, 3], ids=["single_run", "determinism_check"])
+@pytest.mark.parametrize(
+    "trace_enabled, skip_check",
+    [
+        (False, False),
     ],
     ids=["no_trace"],
 )
@@ -417,30 +442,28 @@ def run_ring_joint_sdpa(
 )
 @pytest.mark.parametrize(
     "mesh_device",
-    [(2, 4)],
-    ids=["2x4"],
+    [(4, 2), (2, 2)],
+    ids=["4x2", "2x2"],
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "rp_axis, rp_factor, up_axis, up_factor",
+    "rp_axis, up_axis",
     [
-        [1, 4, 0, 2],
+        [0, 1],
     ],
     ids=[
-        "4rpx2p",
+        "rpxup",
     ],
 )
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["no_balancing", "balanced"])
 def test_mla_sdpa(
     mesh_device,
     b,
-    nhq,
+    nhq_v,
     nhk,
-    nhv,
-    base_seq_len,
-    head_dim_q,
-    head_dim_k,
+    head_dim_q_k,
     head_dim_v,
+    seq_len,
     q_chunk_size,
     k_chunk_size,
     q_dtype,
@@ -449,20 +472,24 @@ def test_mla_sdpa(
     trace_enabled,
     num_links,
     rp_axis,
-    rp_factor,
     up_axis,
-    up_factor,
     all_gather_topology,
     skip_check,
     is_balanced,
     reset_seeds,
 ):
+    production_shape = [32, 4]  # hardcoded for now
+
     mesh_device_shape = list(mesh_device.shape)
-    assert mesh_device_shape[rp_axis] >= rp_factor and mesh_device_shape[up_axis] >= up_factor
+
+    rp_factor = mesh_device_shape[rp_axis]
+    up_factor = mesh_device_shape[up_axis]
 
     submesh = create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_factor)
 
-    padded_seq_len = get_padded_vision_seq_len(base_seq_len, mesh_device_shape[rp_axis])
+    seq_len = (seq_len // production_shape[0]) * rp_factor
+    nhq_v = (nhq_v // production_shape[1]) * up_factor
+    padded_seq_len = get_padded_vision_seq_len(seq_len, mesh_device_shape[rp_axis])
 
     logger.debug(f"RP axis: {rp_axis} factor: {rp_factor}, UP axis: {up_axis} factor: {up_factor}")
     logger.debug(f"submesh: {submesh.shape}")
@@ -472,14 +499,14 @@ def test_mla_sdpa(
     run_ring_joint_sdpa(
         submesh,
         b,
-        nhq,
+        nhq_v,
         nhk,
-        nhv,
-        base_seq_len,
+        nhq_v,
+        seq_len,
         padded_seq_len,
         joint_seq_len,
-        head_dim_q,
-        head_dim_k,
+        head_dim_q_k,
+        head_dim_q_k,
         head_dim_v,
         q_chunk_size,
         k_chunk_size,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -409,7 +409,7 @@ def run_ring_joint_sdpa(
     "seq_len, q_chunk_size, k_chunk_size",
     [
         (128 * 1024, 256, 128),
-        (100 * 1024, 320, 32),
+        (100 * 1024, 320, 64),
     ],
 )
 @pytest.mark.parametrize(
@@ -431,7 +431,7 @@ def run_ring_joint_sdpa(
     "device_params, all_gather_topology",
     [
         (
-            {"worker_l1_size": 1344544, "trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {"trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
             ttnn.Topology.Linear,
         ),
     ],

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -119,6 +119,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py -vvv  --tb=short -k random
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k random
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' -vvv --tb=short
   skus:
     wh_llmbox:
       timeout: 15

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -122,7 +122,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' -vvv --tb=short
   skus:
     wh_llmbox:
-      timeout: 15
+      timeout: 25
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield
   model-name: deepseek_prefill

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -206,15 +206,6 @@
   team: models
   model-name: deepseek
 
-- name: t3k_deepseek_prefill_tests
-  cmd: run_t3000_deepseek_prefill_tests
-  skus:
-    wh_llmbox:
-      timeout: 10
-  owner_id: U07N3CUUN05 # Iva Potkonjak
-  team: models
-  model-name: deepseek prefill
-
 - name: t3k_tttv2_fast_unit_tests
   cmd: run_t3000_tttv2_fast_unit_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -568,7 +568,7 @@ run_t3000_deepseek_tests() {
 }
 
 run_t3000_deepseek_prefill_tests() {
-  pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests --timeout 600 --durations=0
+  pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' --timeout 600 --durations=0
 }
 
 run_t3000_ccl_tests() {

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -567,10 +567,6 @@ run_t3000_deepseek_tests() {
   MESH_DEVICE=T3K pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
 }
 
-run_t3000_deepseek_prefill_tests() {
-  pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' --timeout 600 --durations=0
-}
-
 run_t3000_ccl_tests() {
   # Record the start time
   fail=0


### PR DESCRIPTION
### What's changed
Added unit and determinism tests for 128k and 100K on BH LB/QB. Updated WH T3K tests.

Currently for ring causal attention we test:

- determinism and unit tests for both sequences on BH LB/QB
- unit tests for both sequences on WH T3K, to keep the functionality

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/ring_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/ring_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/ring_tests)
- [x] [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23263513408)
- [x] [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/23263657128)

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/ring_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/ring_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/ring_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/ring_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
