### PR TITLE
conv3d cache fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -237,9 +237,17 @@ Tensor Conv3dDeviceOperation::create_output_tensors(
 ttsl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& weight_tensor = tensor_args.weight_tensor;
+    const auto& bias_tensor = tensor_args.bias_tensor;
     operation::Hash hash = operation::hash_operation<Conv3dDeviceOperation>(
-        args, input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
+        args,
+        input_tensor.dtype(),
+        input_tensor.memory_config(),
+        input_tensor.logical_shape(),
+        weight_tensor.dtype(),
+        weight_tensor.memory_config(),
+        weight_tensor.logical_shape(),
+        bias_tensor.has_value());
 
     return hash;
 }


### PR DESCRIPTION
### Ticket
Fixing [issue](https://github.com/tenstorrent/tt-metal/issues/40192)

### Problem description
`Conv3dDeviceOperation::compute_program_hash` d**oes not include** `bias_tensor.has_value()`. When two `conv3d` ops share identical input/weight shapes and parameters but differ only in whether bias is present, they
produce the same hash. More details can be seen [here](https://github.com/tenstorrent/tt-metal/issues/40192).

### What's changed

`Conv3dDeviceOperation::compute_program_hash` now includes `bias_tensor.has_value()` along with full input, weight, and bias tensor metadata (`dtype`, `memory_config`, `logical_shape`).

Previously the hash only used `args`, `input_tensor.dtype()`, `input_tensor.memory_config()`, and `input_shape.volume()`. When two `conv3d` ops had identical shapes and parameters but differed only in whether `bias` was present, they produced the same hash. The second op got a cache HIT and reused the first op's compiled program - which expected a bias buffer - reading garbage memory as bias and producing wrong output.

If we run the same program as described in the [issue](https://github.com/tenstorrent/tt-metal/issues/40192), instead of getting HIT for second `conv3d`, we will get MISS as well (since it doesn't have bias):
```
[CACHE] op=TilizeWithValPaddingDeviceOperation      hash=0x00000000256bd8c4 MISS
[CACHE] op=TilizeDeviceOperation                    hash=0xffffffff9d03ebf8 MISS
[CACHE] op=TilizeWithValPaddingDeviceOperation      hash=0x00000000440ac430 MISS
[CACHE] op=PermuteDeviceOperation                   hash=0x0000000012749440 MISS
[CACHE] op=PermuteDeviceOperation                   hash=0x00000000041cb8ab MISS
[CACHE] op=UntilizeDeviceOperation                  hash=0x000000006a416e6f MISS
[CACHE] op=Conv3dDeviceOperation                    hash=0x000000004fc69692 MISS
[CACHE] op=PermuteDeviceOperation                   hash=0x000000000ab628dc MISS
[CACHE] op=TilizeDeviceOperation                    hash=0xffffffff9d03ebf8 HIT
[CACHE]   tensor[0] logical=[96,8,64,64] padded=[96,8,64,64]
[CACHE] op=TilizeWithValPaddingDeviceOperation      hash=0x00000000440ac430 HIT
[CACHE]   tensor[0] logical=[9216,1,1,1] padded=[9216,1,1,1]
[CACHE] op=PermuteDeviceOperation                   hash=0x0000000012749440 HIT
[CACHE]   tensor[0] logical=[96,96,1,1,1] padded=[96,96,1,32,32]
[CACHE] op=PermuteDeviceOperation                   hash=0x00000000041cb8ab HIT
[CACHE]   tensor[0] logical=[1,96,8,64,64] padded=[1,96,8,64,64]
[CACHE] op=UntilizeDeviceOperation                  hash=0x000000006a416e6f HIT
[CACHE]   tensor[0] logical=[8,64,64,96] padded=[8,64,64,96]
[CACHE] op=Conv3dDeviceOperation                    hash=0x000000004fc69653 MISS
[CACHE] op=PermuteDeviceOperation                   hash=0x000000000ab628dc HIT
[CACHE]   tensor[0] logical=[1,8,64,64,96] padded=[1,8,64,64,96]
[CACHE] op=TilizeDeviceOperation                    hash=0xffffffff9d03ebf8 HIT
[CACHE]   tensor[0] logical=[96,8,64,64] padded=[96,8,64,64]
```

And `pcc` measured is good:
```
=== Conv3d Bias Cache Collision Repro ===
  conv_a(96→96, bias=True) → conv_b(96→96, bias=False)
  PCC=0.999992, inf=False
  Result: PASS
  ```
  
  ### Checklist
- [x] [Sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/23253080808)
