### PR TITLE
Fix convert_to_chw flaky test caused by NOC read / CB race condition

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
@@ -38,6 +38,7 @@ void kernel_main() {
             tile_index++;
             l1_read_addr_tile += in_transpose_tile_size;
         }
+        noc_async_read_barrier();
         cb_pop_front(cb_in_transpose, BATCH_SIZE);
     }
 
@@ -50,6 +51,7 @@ void kernel_main() {
             l1_read_addr += STICK_SIZE;
         }
         tile_index++;
+        noc_async_read_barrier();
         cb_pop_front(cb_in_transpose, 1);
     }
     noc_async_read_barrier();


### PR DESCRIPTION
## Summary

Fixes a latent race condition in the `convert_to_chw` writer kernel that caused flaky test failures with `Max ATOL Delta: 6.15625, Max RTOL Delta: nan`.

**Failing test:** `test_convert_to_chw[HW=168960-core_grid=ttnn.CoreGrid(x=8, y=6)-C=8-input_data_type=DataType.BFLOAT16]`

### Root cause

The writer kernel issues `noc_async_read_one_packet_with_state` to scatter-copy sticks from `cb_in_transpose` to `cb_out`, then calls `cb_pop_front` **without** a `noc_async_read_barrier()`. This frees the CB space immediately, allowing the compute kernel's `pack_untilize_dest` to overwrite the source data before the NOC reads complete.

With the 16-tile double buffer (2×8 batches), the freed slot is immediately reused by the stalled compute kernel's `cb_reserve_back`.

**Why only C=8 triggers it:** The number of NOC read packets per batch is `BATCH_SIZE × C`. For C=1 (8 packets) or C=2 (16 packets), reads complete fast enough. For C=8 (64 packets per batch), the reads take long enough to overlap with the next compute pack.

**Why it's flaky:** Timing-dependent — the NOC pipeline depth and pack latency vary non-deterministically. The conv group test passed in all other recent CI runs; this was the first failure.

### Fix

Add `noc_async_read_barrier()` before each `cb_pop_front(cb_in_transpose, ...)` in the writer kernel. The inverse operation (`convert_to_hwc`) already has this barrier in the correct position.

## Test plan
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Ffix_convert_to_chw_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix_convert_to_chw_race)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Ffix_convert_to_chw_race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix_convert_to_chw_race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)