### PR TITLE
[skip ci] Temporarily disable BH ubench - Fabric BW & Latency

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -72,12 +72,17 @@ jobs:
             name: "Fabric Collectives ubench - Point to Point",
             cmd: "tests/tt_metal/tt_fabric/benchmark/collectives/unicast/ci_run_unicast.sh"
           }, # Tomer Levin
-          {
-            arch: blackhole,
-            runs-on: ["BH", "pipeline-perf", "in-service"],
-            name: "BH ubench - Fabric BW & Latency",
-            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
-          }, # Nolen Zhao
+          # Disabled temporarily for deterministic CI abort in test_tt_fabric on BH.
+          # TODO(#39820): Re-enable this BH matrix entry once sync core setup failure is fixed.
+          # Evidence:
+          # - https://github.com/tenstorrent/tt-metal/actions/runs/23224882499/job/67505851835
+          # - https://github.com/tenstorrent/tt-metal/actions/runs/23124299750/job/67164581483
+          # {
+          #   arch: blackhole,
+          #   runs-on: ["BH", "pipeline-perf", "in-service"],
+          #   name: "BH ubench - Fabric BW & Latency",
+          #   cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+          # }, # Nolen Zhao
         ]
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
## Summary
- Temporarily disables only the `BH ubench - Fabric BW & Latency` matrix entry in `metal-run-microbenchmarks-impl`.
- This is the narrowest CI-only mitigation for deterministic aborts in `test_tt_fabric` on BH (`sync_workers_.size() == 1`, exit code 134).
- Other microbenchmark matrix entries remain enabled.

## Evidence
- Explicit job input: https://github.com/tenstorrent/tt-metal/actions/runs/23224882499/job/67505851835
- Issue context: https://github.com/tenstorrent/tt-metal/issues/39820
- Prior matching failure from issue body: https://github.com/tenstorrent/tt-metal/actions/runs/23124299750/job/67164581483

## Scope minimization rationale
- The failure is specific to the BH matrix leaf running:
  - `TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config .../test_fabric_ubench_at_least_2x2_mesh.yaml`
- Disabling only this one matrix entry avoids broad impact on other arches/jobs that share the workflow.

## Re-enable criteria
- Re-enable this matrix entry after issue #39820 is resolved and at least one main-branch run for this job passes without the `sync_workers_` assertion abort.

Refs #39820

Made with [Cursor](https://cursor.com)