### PR TITLE
Add support for nightly debug run with LLK ASSERTS enabled

### DIFF
--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -1,6 +1,6 @@
 name: "Sanity tests nightly debug run"
 
-run-name: "Sanity tests nightly debug run${{ github.event.schedule == '0 1 * * *' && ' with watcher' || (inputs.enable-watcher && ' with watcher' || '') }}"
+run-name: "Sanity tests nightly debug run${{ github.event.schedule == '0 1 * * *' && ' with watcher' || (inputs.enable-watcher && ' with watcher' || '') }}${{ github.event.schedule == '0 2 * * *' && ' with LLK asserts' || (inputs.enable-llk-asserts && ' with LLK asserts' || '') }}"
 
 on:
   schedule:
@@ -8,6 +8,8 @@ on:
     - cron: "0 0 * * *"
     # Runs nightly at 1:00 AM UTC with watcher enabled
     - cron: "0 1 * * *"
+    # Runs nightly at 2:00 AM UTC with LLK asserts enabled
+    - cron: "0 2 * * *"
 
   workflow_dispatch:
     inputs:
@@ -19,6 +21,10 @@ on:
         default: false
         type: boolean
         description: "Enable watcher"
+      enable-llk-asserts:
+        default: false
+        type: boolean
+        description: "Enable LLK asserts"
       run-wormhole-tests:
         default: true
         type: boolean
@@ -38,10 +44,12 @@ permissions:
   checks: write
 
 jobs:
-  determine-watcher:
+  determine-debug-flags:
+    name: Determine debug flags
     runs-on: ubuntu-latest
     outputs:
       enable-watcher: ${{ steps.check.outputs.enable-watcher }}
+      enable-llk-asserts: ${{ steps.check.outputs.enable-llk-asserts }}
     steps:
       - id: check
         run: |
@@ -50,11 +58,16 @@ jobs:
           else
             echo "enable-watcher=false" >> "$GITHUB_OUTPUT"
           fi
+          if [[ "${{ github.event.schedule }}" == "0 2 * * *" || "${{ inputs.enable-llk-asserts }}" == "true" ]]; then
+            echo "enable-llk-asserts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enable-llk-asserts=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Shared build jobs - one per platform to enable artifact forwarding
   build-artifacts-ubuntu-22:
     name: Build artifacts (Ubuntu 22.04)
-    needs: determine-watcher
+    needs: determine-debug-flags
     if: ${{ github.event_name == 'schedule' || inputs.run-wormhole-tests || inputs.run-blackhole-tests }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -71,7 +84,7 @@ jobs:
 
   build-artifacts-ubuntu-24:
     name: Build artifacts (Ubuntu 24.04)
-    needs: determine-watcher
+    needs: determine-debug-flags
     if: ${{ github.event_name == 'schedule' || inputs.run-wormhole-tests || inputs.run-blackhole-tests }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -88,8 +101,8 @@ jobs:
 
   # Ubuntu 22.04 test jobs - both Sanity and Blackhole share artifacts
   wormhole-nightly-debug-ubuntu-22:
-    name: Sanity tests nightly debug run (Ubuntu 22.04${{ needs.determine-watcher.outputs.enable-watcher == 'true' && ' with watcher' || '' }})
-    needs: [determine-watcher, build-artifacts-ubuntu-22]
+    name: Sanity tests nightly debug run (Ubuntu 22.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})
+    needs: [determine-debug-flags, build-artifacts-ubuntu-22]
     if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || inputs.run-wormhole-tests) }}
     uses: ./.github/workflows/sanity-tests.yaml
     secrets: inherit
@@ -97,17 +110,18 @@ jobs:
       build-type: RelWithDebInfo
       platform: "Ubuntu 22.04"
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-t3000-apc-fast-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
+      run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-t3000-apc-fast-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}
 
   blackhole-nightly-debug-ubuntu-22:
-    name: blackhole nightly debug run (Ubuntu 22.04${{ needs.determine-watcher.outputs.enable-watcher == 'true' && ' with watcher' || '' }})
-    needs: [determine-watcher, build-artifacts-ubuntu-22]
+    name: blackhole nightly debug run (Ubuntu 22.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})
+    needs: [determine-debug-flags, build-artifacts-ubuntu-22]
     if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || inputs.run-blackhole-tests) }}
     uses: ./.github/workflows/blackhole-post-commit.yaml
     secrets: inherit
@@ -115,16 +129,17 @@ jobs:
       build-type: RelWithDebInfo
       platform: "Ubuntu 22.04"
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
+      run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}
 
   # Ubuntu 24.04 test jobs - both Sanity and Blackhole share artifacts
   wormhole-nightly-debug-ubuntu-24:
-    name: Sanity tests nightly debug run (Ubuntu 24.04${{ needs.determine-watcher.outputs.enable-watcher == 'true' && ' with watcher' || '' }})
-    needs: [determine-watcher, build-artifacts-ubuntu-24]
+    name: Sanity tests nightly debug run (Ubuntu 24.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})
+    needs: [determine-debug-flags, build-artifacts-ubuntu-24]
     if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || inputs.run-wormhole-tests) }}
     uses: ./.github/workflows/sanity-tests.yaml
     secrets: inherit
@@ -132,17 +147,18 @@ jobs:
       build-type: RelWithDebInfo
       platform: "Ubuntu 24.04"
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-t3000-apc-fast-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
+      run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-t3000-apc-fast-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.wheel-artifact-name }}
 
   blackhole-nightly-debug-ubuntu-24:
-    name: blackhole nightly debug run (Ubuntu 24.04${{ needs.determine-watcher.outputs.enable-watcher == 'true' && ' with watcher' || '' }})
-    needs: [determine-watcher, build-artifacts-ubuntu-24]
+    name: blackhole nightly debug run (Ubuntu 24.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})
+    needs: [determine-debug-flags, build-artifacts-ubuntu-24]
     if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || inputs.run-blackhole-tests) }}
     uses: ./.github/workflows/blackhole-post-commit.yaml
     secrets: inherit
@@ -150,8 +166,8 @@ jobs:
       build-type: RelWithDebInfo
       platform: "Ubuntu 24.04"
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40205https://github.com/tenstorrent/tt-metal/issues/40205
https://github.com/tenstorrent/tt-metal/issues/40205https://github.com/tenstorrent/tt-metal/issues/40206

### Problem description
Currently, there is no official run with enabled LLK ASSERTS

### What's changed
In this PR, the support for running nightly debug tests with LLK ASSERTS is added.
Here is a test run showing that action is scheduled successfully:
https://github.com/tenstorrent/tt-metal/actions/runs/23251744131
Tests that are currently failing will be fixed - that is a separate effort in progress

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/add_nightly_run_for_llk_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/add_nightly_run_for_llk_asserts)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
