### PR TITLE
Fix for the 'Unable to convert function return value to a Python type…

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/llama_reduce_scatter_create_heads_nanobind.cpp
@@ -9,6 +9,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/tuple.h>
 
 #include "llama_reduce_scatter_create_heads.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
@@ -36,7 +37,7 @@ void bind_llama_rs_create_heads(nb::module_& mod) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
            Returns:
-               ttnn.Tensor: the output tensor.
+               Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]: Q, K, and V output tensors.
 
             Example:
 


### PR DESCRIPTION
### Problem description
Llama 70B is failing on CI demo tests on Galaxy machines: https://github.com/tenstorrent/tt-metal/actions/runs/23223002230/job/67500288228

Error log:
...
_while users_decoding:
                if iteration == 0:  # First iteration also accounts for compile time
                    profiler.start(f"compile_decode", iteration=batch_idx)
                else:
                    profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
    
                # Determine whether to enable trace
                if apc_test:
                    is_enable_trace = iteration != 0  # First iteration is compile time and checks PCC
                else:
                    is_enable_trace = enable_trace if not pcc_check else False
    
                # Run decode forward
                try:
                    # Save logits only for PCC check when tracing is disabled
                    tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
                    tt_out_tok, read_event = generator.decode_forward(
                        out_tok,
                        current_pos,
                        enable_trace=is_enable_trace,
                        page_table=page_table,
                        kv_cache=tt_kv_cache,
                        read_from_device=True,
                        async_read=True,
                        sampling_params=device_sampling_params,
                        reset_inputs=iteration == 0,
                        tt_out_logits_saved=tt_out_logits_saved,
                        is_cur_pos_sharded=is_cur_pos_sharded,
                        is_page_table_sharded=is_page_table_sharded,
                        prompt_tokens=input_tokens_prefill_pt,
                        output_tokens=prefilled_token,
                    )
                    read_events.append(read_event)
                    tt_out_toks.append(tt_out_tok)
                    if apc_test and iteration == 0:
                        tt_out_logits_saved_iter_0 = tt_out_logits_saved
                except Exception as e:
>                   pytest.fail(f"Decode forward failed at iteration {iteration}: {str(e)}")
E                   Failed: Decode forward failed at iteration 0: Unable to convert function return value to a Python type! The signature was
E                       __call__(self, input_tensor: ttnn._ttnn.tensor.Tensor, intermediate_packet_buffer: ttnn._ttnn.tensor.Tensor, dim: int, cross_device_semaphore: ttnn._ttnn.global_semaphore.global_semaphore, subdevice_id: ttnn._ttnn.device.SubDeviceId, cluster_axis: int, mesh_device: ttnn._ttnn.multi_device.MeshDevice, topology: ttnn._ttnn.operations.ccl.Topology, *, num_links: int = 1, num_heads: int, num_kv_heads: int, memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None, qkv_memory_config: ttnn._ttnn.tensor.MemoryConfig | None = None, use_noc1_only: bool = False, use_optimal_ccl_for_llama: bool = False) -> std::tuple<tt::tt_metal::Tensor, tt::tt_metal::Tensor, tt::tt_metal::Tensor>_

### What's changed
The issue was nanobind issue introduced in this commit: https://github.com/tenstorrent/tt-metal/commit/a1daa7e4b9aebb108dd542e265801b285d0c8120

The binding file "llama_reduce_scatter_create_heads_nanobind.cpp" was missing the tuple type cast include for std::tuple and this caused Python runtime binding to fail during the test.

#### Model tests

Test passes successfully on local Galaxy machine (wh-glx6u-08) and CI test I being ran as well on the link below.

- [x] Galaxy demo (Llama 70B)  - https://github.com/tenstorrent/tt-metal/actions/runs/23253745289
