### PR TITLE
#40195: fix num users per row for deepseek multi-host

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -204,7 +204,7 @@ def hf_config_short(request, hf_config):
     if max_seq_len_override is not None:
         hf_config_out.max_seq_len = int(max_seq_len_override)
     else:
-        hf_config_out.max_seq_len = 128
+        hf_config_out.max_seq_len = 512
     return hf_config_out
 
 

--- a/models/demos/deepseek_v3/tests/pytest_utils.py
+++ b/models/demos/deepseek_v3/tests/pytest_utils.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-DEFAULT_PREFILL_SEQ_LEN = 128
+DEFAULT_PREFILL_SEQ_LEN = 512
 
 
 def expand_test_cases_with_position_ids_ranges(base_cases):

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -209,7 +209,7 @@ def _generate_reference_case_entry(
     reference_model.load_state_dict(state_dict)
     reference_model = reference_model.to(torch.bfloat16)
 
-    decode_input_caches = None
+    decode_kv_caches = None
     if mode == "decode":
         prefill_len = int(position_ids.max().item()) if position_ids is not None else 0
         cache_dim = hf_config.kv_lora_rank + hf_config.qk_rope_head_dim
@@ -226,9 +226,9 @@ def _generate_reference_case_entry(
                 False,
                 collect_output=False,
             )
-            decode_input_caches = torch_cache_from_transformers(prefill_cache)
+            decode_kv_caches = torch_cache_from_transformers(prefill_cache)
         else:
-            decode_input_caches = tuple(
+            decode_kv_caches = tuple(
                 torch.empty((batch_size, 1, 0, cache_dim), dtype=torch.bfloat16)
                 for _ in range(hf_config.num_hidden_layers)
             )
@@ -248,7 +248,7 @@ def _generate_reference_case_entry(
                 position_ids=position_ids_2d,
                 output_attentions=False,
                 use_cache=True,
-                past_key_values=transformers_cache_from_torch(decode_input_caches),
+                past_key_values=transformers_cache_from_torch(decode_kv_caches),
             )
         reference_output = model_output.logits.transpose(1, 0).float().cpu()
     else:
@@ -264,7 +264,7 @@ def _generate_reference_case_entry(
         "entry_version": REFERENCE_ENTRY_VERSION,
         "source": "reference",
         "reference_output": reference_output,
-        "decode_input_caches": list(decode_input_caches) if mode == "decode" else None,
+        "decode_kv_caches": list(decode_kv_caches) if mode == "decode" else None,
     }
 
 
@@ -364,7 +364,7 @@ def run_test_forward_pass_dpmodel(
         or cached_case.get("source") != "reference"
         or not isinstance(cached_reference_output, torch.Tensor)
         or cached_shape != expected_reference_output_shape
-        or (mode == "decode" and cached_case.get("decode_input_caches") is None)
+        or (mode == "decode" and cached_case.get("decode_kv_caches") is None)
     )
     if needs_regen:
         logger.warning(f"Reference cache miss for case '{case_key}'. Generating reference output.")
@@ -388,11 +388,11 @@ def run_test_forward_pass_dpmodel(
     paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, dp_factor)
 
     if mode == "decode":
-        decode_input_caches = cached_case.get("decode_input_caches")
-        if decode_input_caches is None:
-            pytest.fail(f"Missing decode_input_caches in reference baseline for case '{case_key}'")
-        if not isinstance(decode_input_caches, tuple):
-            decode_input_caches = tuple(decode_input_caches)
+        decode_kv_caches = cached_case.get("decode_kv_caches")
+        if decode_kv_caches is None:
+            pytest.fail(f"Missing decode_kv_caches in reference baseline for case '{case_key}'")
+        if not isinstance(decode_kv_caches, tuple):
+            decode_kv_caches = tuple(decode_kv_caches)
 
         denom = mesh_rows * dp_factor
         assert batch_size % denom == 0, f"batch_size={batch_size} not divisible by mesh_rows*dp_factor={denom}"
@@ -408,7 +408,7 @@ def run_test_forward_pass_dpmodel(
         )
         mappings = tuple(mapping for _ in range(hf_config_short.num_hidden_layers))
         paged_input_caches, torch_page_tables = paged_caches_from_torch(
-            decode_input_caches, tuple(mesh_device.shape), paged_config, user_id=None, mappings=mappings
+            decode_kv_caches, tuple(mesh_device.shape), paged_config, user_id=None, mappings=mappings
         )
         tt_page_tables = tuple(
             MLA2D.create_page_table(page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -15,7 +15,7 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -112,10 +112,10 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "mode,num_tokens",
+    "mode, batch_size_per_row, seq_len",
     [
-        ("decode", 128),
-        ("prefill", _prefill_seq_len),
+        ("decode", USERS_PER_ROW, 1),
+        ("prefill", 1, _prefill_seq_len),
     ],
 )
 @pytest.mark.parametrize(
@@ -128,7 +128,8 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 def test_forward_pass(
     device_params,
     mode,
-    num_tokens,
+    batch_size_per_row,
+    seq_len,
     set_deterministic_env,
     reference_model,
     hf_config,
@@ -144,6 +145,7 @@ def test_forward_pass(
 
     module_path = "model.layers.3.mlp" if weight_type == "real" else None
     checkpoint_state_dict = request.getfixturevalue("state_dict") if weight_type == "real" else None
+    num_tokens = batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len
     state_dict, torch_input, reference_output = generate_reference_io(
         mode=mode,
         num_tokens=num_tokens,

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -16,7 +16,7 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MLP as ReferenceExpert
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.experts import Experts as TTExperts
-from models.demos.deepseek_v3.utils.config_helpers import even_int_div, sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, run_module_forward
 
@@ -69,10 +69,10 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 
 
 @pytest.mark.parametrize(
-    "mode, seq_len",
+    "mode, batch_size_per_row, seq_len",
     [
-        ("decode", 128),
-        ("prefill", _prefill_seq_len),
+        ("decode", USERS_PER_ROW, 1),
+        ("prefill", 1, _prefill_seq_len),
     ],
 )
 @pytest.mark.parametrize(
@@ -85,6 +85,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 )
 def test_forward_pass(
     mode: str,
+    batch_size_per_row: int,
     seq_len: int,
     hf_config: Any,
     cache_path: Path,
@@ -96,11 +97,11 @@ def test_forward_pass(
     set_deterministic_env,
     state_dict: dict[str, torch.Tensor],
 ):
-    batch_size = 1
+    num_tokens = batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len
     num_experts_per_device = even_int_div(hf_config.n_routed_experts, mesh_device.get_num_devices())
 
     reference_model = DeepseekV3MoEExperts(hf_config).eval().to(torch.bfloat16)
-    torch_input = torch.randn(batch_size, 1, seq_len, hf_config.hidden_size, dtype=torch.bfloat16)
+    torch_input = torch.randn(1, 1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
 
     if weight_type == "random":
         state_dict = reference_model.state_dict()

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -12,6 +12,7 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.moe_gate import MoEGate
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, run_module_forward
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -21,10 +22,10 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 
 
 @pytest.mark.parametrize(
-    "mode,seq_len",
+    "mode,batch_size_per_row,seq_len",
     [
-        ("decode", 128),
-        ("prefill", _prefill_seq_len),
+        ("decode", USERS_PER_ROW, 1),
+        ("prefill", 1, _prefill_seq_len),
     ],
 )
 @pytest.mark.parametrize(
@@ -35,6 +36,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 )
 def test_forward_pass(
     mode,
+    batch_size_per_row,
     seq_len,
     hf_config,
     topk_fallback,
@@ -45,7 +47,7 @@ def test_forward_pass(
 ):
     """Test forward pass against reference model."""
 
-    batch_size = 1
+    num_tokens = batch_size_per_row * mesh_device.shape[0] if mode == "decode" else seq_len
 
     # Get state dict from actual model - pass directly to convert_weights
     torch.use_deterministic_algorithms(True)
@@ -75,7 +77,7 @@ def test_forward_pass(
     run_config = create_run_config(model_config, weight_config, model_state)
 
     # Create input tensor
-    torch_input = torch.randn(batch_size, seq_len, hf_config.hidden_size, dtype=torch.bfloat16)
+    torch_input = torch.randn(1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
 
     # Reference forward pass
     reference_model.eval()

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -12,7 +12,7 @@ from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3RMSNo
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm import RMSNorm
-from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
@@ -33,7 +33,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 @pytest.mark.parametrize(
     "mode, seq_len",
     [
-        ("decode", 32),
+        ("decode", USERS_PER_ROW),
         ("prefill", _prefill_seq_len),
     ],
 )


### PR DESCRIPTION
Updates DeepSeek-V3 test parameters to better reflect multi-host mesh shapes (where total “decode users” scale with mesh rows), and adjusts the default prefill sequence length used by multiple DeepSeek tests.

Changes:

Update test_moe.py decode test to derive num_tokens from USERS_PER_ROW * mesh_device.shape[0] (mesh rows), instead of a fixed value.
Refactor test_moe.py parametrization to separate batch_size_per_row and seq_len.
Increase DEFAULT_PREFILL_SEQ_LEN from 128 to 512 in DeepSeek pytest utilities.
