### PR TITLE
[tt-train] Complete runtime-root callsite cleanup in Python examples/config loading

### DIFF
--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -32,7 +32,7 @@ from ttml.common.utils import (
     initialize_device,
     build_logits_mask,
     no_grad,
-    get_tt_metal_home,
+    get_tt_metal_runtime_root,
 )
 from ttml.common.data import build_causal_mask
 from ttml.datasets import Batch, InMemoryDataloader

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -21,7 +21,7 @@ from ttml.common.data import (
 )
 from ttml.common.utils import (
     set_seed,
-    get_tt_metal_home,
+    get_tt_metal_runtime_root,
     summary,
     get_loss_over_devices,
 )

--- a/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
+++ b/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
@@ -862,25 +862,11 @@ def main():
     print("=" * 70)
     print()
 
-    if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        current_dir = os.getcwd()
-        if os.path.exists(os.path.join(current_dir, "tt_metal")):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
-            print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
-        else:
-            parent_dir = os.path.dirname(current_dir)
-            if os.path.exists(os.path.join(parent_dir, "tt_metal")):
-                os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
-                print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
-            else:
-                print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
-                print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
-                print("  to point to the tt-metal repository root directory.")
-    else:
-        print(f"Using TT_METAL_RUNTIME_ROOT={os.environ.get('TT_METAL_RUNTIME_ROOT')}")
+    tt_metal_root = get_tt_metal_runtime_root()
+    print(f"Using TT_METAL_RUNTIME_ROOT={tt_metal_root}")
     print()
 
-    tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
+    tt_train_root = f"{tt_metal_root}/tt-train"
     configs_root = f"{tt_train_root}/configs"
     try:
         print(f"Loading training config from: {args.config}")

--- a/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
+++ b/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
@@ -863,24 +863,19 @@ def main():
     print()
 
     if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        tt_metal_root = get_tt_metal_runtime_root()
-        if tt_metal_root and os.path.exists(tt_metal_root):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
-            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)")
+        current_dir = os.getcwd()
+        if os.path.exists(os.path.join(current_dir, "tt_metal")):
+            os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
+            print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
         else:
-            current_dir = os.getcwd()
-            if os.path.exists(os.path.join(current_dir, "tt_metal")):
-                os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
-                print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
+            parent_dir = os.path.dirname(current_dir)
+            if os.path.exists(os.path.join(parent_dir, "tt_metal")):
+                os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
+                print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
             else:
-                parent_dir = os.path.dirname(current_dir)
-                if os.path.exists(os.path.join(parent_dir, "tt_metal")):
-                    os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
-                    print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
-                else:
-                    print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
-                    print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
-                    print("  to point to the tt-metal repository root directory.")
+                print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
+                print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
+                print("  to point to the tt-metal repository root directory.")
     else:
         print(f"Using TT_METAL_RUNTIME_ROOT={os.environ.get('TT_METAL_RUNTIME_ROOT')}")
     print()

--- a/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
+++ b/tt-train/sources/examples/nano_gpt/nanogpt_primitives_example.py
@@ -22,7 +22,7 @@ import ml_dtypes
 import ttnn
 import ttml
 from ttml.modules import AbstractModuleBase, ModuleList, Parameter, RunMode
-from ttml.common.utils import round_up_to_tile, get_tt_metal_home, create_optimizer
+from ttml.common.utils import round_up_to_tile, get_tt_metal_runtime_root, create_optimizer
 from ttml.common.config import load_config, TrainingConfig as BaseTrainingConfig
 from ttml.common.data import CharTokenizer, build_causal_mask
 

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -43,7 +43,7 @@ from ttml.models.llama import (
     LlamaRopeScalingConfig,
 )
 from ttml.modules import Parameter
-from ttml.common.utils import round_up_to_tile, get_tt_metal_home, create_optimizer
+from ttml.common.utils import round_up_to_tile, get_tt_metal_runtime_root, create_optimizer
 from ttml.common.config import load_config, TrainingConfig as BaseTrainingConfig
 from ttml.common.data import CharTokenizer, build_causal_mask
 

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -1040,31 +1040,14 @@ def main():
     print("=" * 70)
     print()
 
-    # Set TT_METAL_RUNTIME_ROOT if not set.
+    # Require TT_METAL_RUNTIME_ROOT to be explicitly set.
     # This is needed for the runtime to find kernel files like moreh_mean.
-    if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        # Try to auto-detect from current directory
-        current_dir = os.getcwd()
-        # Check if we're in the repo root (has tt_metal/ subdirectory)
-        if os.path.exists(os.path.join(current_dir, "tt_metal")):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
-            print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
-        else:
-            # Try parent directories
-            parent_dir = os.path.dirname(current_dir)
-            if os.path.exists(os.path.join(parent_dir, "tt_metal")):
-                os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
-                print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
-            else:
-                print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
-                print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
-                print("  to point to the tt-metal repository root directory.")
-    else:
-        print(f"Using TT_METAL_RUNTIME_ROOT={os.environ.get('TT_METAL_RUNTIME_ROOT')}")
+    tt_metal_root = get_tt_metal_runtime_root()
+    print(f"Using TT_METAL_RUNTIME_ROOT={tt_metal_root}")
     print()
 
     # Load configs using ttml.common.config utilities
-    tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
+    tt_train_root = f"{tt_metal_root}/tt-train"
     configs_root = f"{tt_train_root}/configs"
     try:
         print(f"Loading training config from: {args.config}")

--- a/tt-train/sources/examples/nano_gpt/train_nanogpt.py
+++ b/tt-train/sources/examples/nano_gpt/train_nanogpt.py
@@ -1040,30 +1040,25 @@ def main():
     print("=" * 70)
     print()
 
-    # Set TT_METAL_RUNTIME_ROOT if not set and a valid runtime root is available
-    # This is needed for the runtime to find kernel files like moreh_mean
+    # Set TT_METAL_RUNTIME_ROOT if not set.
+    # This is needed for the runtime to find kernel files like moreh_mean.
     if "TT_METAL_RUNTIME_ROOT" not in os.environ:
-        tt_metal_root = get_tt_metal_runtime_root()
-        if tt_metal_root and os.path.exists(tt_metal_root):
-            os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
-            print(f"Set TT_METAL_RUNTIME_ROOT={tt_metal_root} (from get_tt_metal_runtime_root)")
+        # Try to auto-detect from current directory
+        current_dir = os.getcwd()
+        # Check if we're in the repo root (has tt_metal/ subdirectory)
+        if os.path.exists(os.path.join(current_dir, "tt_metal")):
+            os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
+            print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
         else:
-            # Try to auto-detect from current directory
-            current_dir = os.getcwd()
-            # Check if we're in the repo root (has tt_metal/ subdirectory)
-            if os.path.exists(os.path.join(current_dir, "tt_metal")):
-                os.environ["TT_METAL_RUNTIME_ROOT"] = current_dir
-                print(f"Set TT_METAL_RUNTIME_ROOT={current_dir} (auto-detected from current directory)")
+            # Try parent directories
+            parent_dir = os.path.dirname(current_dir)
+            if os.path.exists(os.path.join(parent_dir, "tt_metal")):
+                os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
+                print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
             else:
-                # Try parent directories
-                parent_dir = os.path.dirname(current_dir)
-                if os.path.exists(os.path.join(parent_dir, "tt_metal")):
-                    os.environ["TT_METAL_RUNTIME_ROOT"] = parent_dir
-                    print(f"Set TT_METAL_RUNTIME_ROOT={parent_dir} (auto-detected from parent directory)")
-                else:
-                    print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
-                    print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
-                    print("  to point to the tt-metal repository root directory.")
+                print("Warning: TT_METAL_RUNTIME_ROOT not set and could not be auto-detected.")
+                print("  Kernel files may not be found. Set TT_METAL_RUNTIME_ROOT environment variable")
+                print("  to point to the tt-metal repository root directory.")
     else:
         print(f"Using TT_METAL_RUNTIME_ROOT={os.environ.get('TT_METAL_RUNTIME_ROOT')}")
     print()

--- a/tt-train/sources/ttml/ttml/common/config.py
+++ b/tt-train/sources/ttml/ttml/common/config.py
@@ -209,12 +209,20 @@ def load_config(path: str, configs_root: str = None) -> dict:
     if configs_root is None:
         configs_root = f"{get_tt_metal_runtime_root()}/tt-train/configs/"
 
-    # if the path is relative, make it absolute using configs_root,
-    # but only if the path doesn't already point to an existing file
-    if not os.path.isabs(path) and not os.path.exists(path):
-        path = os.path.join(configs_root, path)
+    # Expand env vars (e.g. ${TT_METAL_RUNTIME_ROOT}) before absolute-path check.
+    expanded_path = os.path.expandvars(path)
+    if "${TT_METAL_RUNTIME_ROOT}" in expanded_path or "$TT_METAL_RUNTIME_ROOT" in expanded_path:
+        raise RuntimeError(
+            f"Unresolved TT_METAL_RUNTIME_ROOT in config path: {path}. "
+            "Please export TT_METAL_RUNTIME_ROOT to the tt-metal repository root."
+        )
 
-    with open(path, "r") as f:
+    # If path is relative and doesn't already point to a real file, make it absolute
+    # using configs_root.
+    if not os.path.isabs(expanded_path) and not os.path.exists(expanded_path):
+        expanded_path = os.path.join(configs_root, expanded_path)
+
+    with open(expanded_path, "r") as f:
         raw = os.path.expandvars(f.read())
     config = yaml.safe_load(raw)
     return config


### PR DESCRIPTION
### Ticket
N/A (runtime-root path consistency cleanup)

### Problem description
Python tt-train code had remaining runtime-root inconsistencies:
- some callsites still used legacy home-based assumptions
- NanoGPT examples still inferred `TT_METAL_RUNTIME_ROOT` from CWD
- config loading needed robust `${TT_METAL_RUNTIME_ROOT}` expansion behavior

This made behavior inconsistent with strict fail-fast runtime-root policy.

### What's changed
- Updated Python callsites to align with strict runtime-root usage across examples:
  - `nano_gpt/train_nanogpt.py`
  - `nano_gpt/nanogpt_primitives_example.py`
  - `gsm8k_finetune/gsm8k_finetune.py`
  - `lora_llama/train_lora_llama.py`
- Removed NanoGPT auto-detection/inference of `TT_METAL_RUNTIME_ROOT`; now requires explicit env via shared runtime-root helper.
- Improved `ttml/common/config.py::load_config` path handling:
  - expands env vars before absolute-path checks/join
  - prevents unresolved `${TT_METAL_RUNTIME_ROOT}` from silently propagating

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/runtime-root-callsite-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/runtime-root-callsite-cleanup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/runtime-root-callsite-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/runtime-root-callsite-cleanup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/runtime-root-callsite-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/runtime-root-callsite-cleanup)