### PR TITLE
Disabling quad tests from multihost nightly CI due to stale NFS issue

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -11,7 +11,7 @@ on:
         default: both
         options:
           - dual
-          # - quad
+          - quad
           - both
       deepseekv3_unit_tests:
         description: 'Run DeepSeek V3 unit tests'
@@ -179,29 +179,29 @@ jobs:
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
 
-      # - name: Run quad DeepSeek V3 unit tests
-      #   if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: 60
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
+      - name: Run quad DeepSeek V3 unit tests
+        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
 
       # ── DeepSeek V3 module tests ────────────────────────────────────────
       - name: Run dual DeepSeek V3 module tests
@@ -228,29 +228,29 @@ jobs:
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
 
-      # - name: Run quad DeepSeek V3 module tests
-      #   if: ${{ (inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: 150
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
+      - name: Run quad DeepSeek V3 module tests
+        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 150
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
 
       # ── Teacher forced accuracy tests ───────────────────────────────────
       - name: Run dual teacher forced accuracy test
@@ -287,39 +287,39 @@ jobs:
             generated/artifacts/dual_teacher_forced_output.log
           if-no-files-found: warn
 
-      # - name: Run quad teacher forced accuracy test
-      #   if: ${{ (inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
+      - name: Run quad teacher forced accuracy test
+        if: ${{ inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
 
-      # - name: Upload quad teacher forced accuracy artifacts
-      #   if: ${{ always() && ((inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: quad-teacher-forced-accuracy-${{ github.run_id }}
-      #     path: |
-      #       generated/artifacts/quad_teacher_forced_accuracy.txt
-      #       generated/artifacts/quad_teacher_forced_output.log
-      #     if-no-files-found: warn
+      - name: Upload quad teacher forced accuracy artifacts
+        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-teacher-forced-accuracy-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_teacher_forced_accuracy.txt
+            generated/artifacts/quad_teacher_forced_output.log
+          if-no-files-found: warn
 
       # ── Demo tests ──────────────────────────────────────────────────────
       - name: Run dual demo test (256 prompts, 1 batch)
@@ -390,73 +390,73 @@ jobs:
             generated/artifacts/dual_demo_full_results_mtp.json
           if-no-files-found: warn
 
-      # - name: Run quad demo test (512 prompts, 1 batch)
-      #   if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
+      - name: Run quad demo test (512 prompts, 1 batch)
+        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
 
-      # - name: Upload quad demo output artifacts
-      #   if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: quad-demo-output-${{ github.run_id }}
-      #     path: |
-      #       generated/artifacts/quad_demo_output.log
-      #       generated/artifacts/quad_demo_full_results.json
-      #     if-no-files-found: warn
+      - name: Upload quad demo output artifacts
+        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-demo-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_demo_output.log
+            generated/artifacts/quad_demo_full_results.json
+          if-no-files-found: warn
 
-      # - name: Run quad MTP demo parity smoke test
-      #   if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
+      - name: Run quad MTP demo parity smoke test
+        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
 
-      # - name: Upload quad MTP demo output artifacts
-      #   if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: quad-demo-mtp-output-${{ github.run_id }}
-      #     path: |
-      #       generated/artifacts/quad_demo_mtp_output.log
-      #       generated/artifacts/quad_demo_full_results_mtp.json
-      #     if-no-files-found: warn
+      - name: Upload quad MTP demo output artifacts
+        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-demo-mtp-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_demo_mtp_output.log
+            generated/artifacts/quad_demo_full_results_mtp.json
+          if-no-files-found: warn
 
       # ── Demo stress tests ───────────────────────────────────────────────
       - name: Run dual demo stress test (56 prompts, 20 batches)
@@ -493,36 +493,36 @@ jobs:
             generated/artifacts/dual_demo_stress_results.json
           if-no-files-found: warn
 
-      # - name: Run quad demo stress test (56 prompts, 20 batches)
-      #   if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-      #   uses: ./.github/actions/docker-run
-      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
-      #   with:
-      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
-      #     docker_opts: |
-      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e TT_METAL_HOME=${{ github.workspace }}
-      #       -e ARCH_NAME=wormhole_b0
-      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-      #       -v /etc/mpirun:/etc/mpirun:ro
-      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-      #       --device /dev/tenstorrent
-      #       --pid=host
-      #       --hostname=mpirun-host
-      #     install_wheel: true
-      #     run_args: |
-      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
+      - name: Run quad demo stress test (56 prompts, 20 batches)
+        if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
 
-      # - name: Upload quad demo stress output artifacts
-      #   if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: quad-demo-stress-output-${{ github.run_id }}
-      #     path: |
-      #       generated/artifacts/quad_demo_stress_output.log
-      #       generated/artifacts/quad_demo_stress_results.json
-      #     if-no-files-found: warn
+      - name: Upload quad demo stress output artifacts
+        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-demo-stress-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_demo_stress_output.log
+            generated/artifacts/quad_demo_stress_results.json
+          if-no-files-found: warn

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -11,7 +11,7 @@ on:
         default: both
         options:
           - dual
-          - quad
+          # - quad
           - both
       deepseekv3_unit_tests:
         description: 'Run DeepSeek V3 unit tests'
@@ -179,29 +179,29 @@ jobs:
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
 
-      - name: Run quad DeepSeek V3 unit tests
-        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 60
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
+      # - name: Run quad DeepSeek V3 unit tests
+      #   if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: 60
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
 
       # ── DeepSeek V3 module tests ────────────────────────────────────────
       - name: Run dual DeepSeek V3 module tests
@@ -228,29 +228,29 @@ jobs:
             eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
 
-      - name: Run quad DeepSeek V3 module tests
-        if: ${{ (inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 150
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
+      # - name: Run quad DeepSeek V3 module tests
+      #   if: ${{ (inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: 150
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
 
       # ── Teacher forced accuracy tests ───────────────────────────────────
       - name: Run dual teacher forced accuracy test
@@ -287,39 +287,39 @@ jobs:
             generated/artifacts/dual_teacher_forced_output.log
           if-no-files-found: warn
 
-      - name: Run quad teacher forced accuracy test
-        if: ${{ (inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
+      # - name: Run quad teacher forced accuracy test
+      #   if: ${{ (inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
 
-      - name: Upload quad teacher forced accuracy artifacts
-        if: ${{ always() && ((inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-teacher-forced-accuracy-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_teacher_forced_accuracy.txt
-            generated/artifacts/quad_teacher_forced_output.log
-          if-no-files-found: warn
+      # - name: Upload quad teacher forced accuracy artifacts
+      #   if: ${{ always() && ((inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: quad-teacher-forced-accuracy-${{ github.run_id }}
+      #     path: |
+      #       generated/artifacts/quad_teacher_forced_accuracy.txt
+      #       generated/artifacts/quad_teacher_forced_output.log
+      #     if-no-files-found: warn
 
       # ── Demo tests ──────────────────────────────────────────────────────
       - name: Run dual demo test (256 prompts, 1 batch)
@@ -390,73 +390,73 @@ jobs:
             generated/artifacts/dual_demo_full_results_mtp.json
           if-no-files-found: warn
 
-      - name: Run quad demo test (512 prompts, 1 batch)
-        if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
+      # - name: Run quad demo test (512 prompts, 1 batch)
+      #   if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
 
-      - name: Upload quad demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-demo-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_demo_output.log
-            generated/artifacts/quad_demo_full_results.json
-          if-no-files-found: warn
+      # - name: Upload quad demo output artifacts
+      #   if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: quad-demo-output-${{ github.run_id }}
+      #     path: |
+      #       generated/artifacts/quad_demo_output.log
+      #       generated/artifacts/quad_demo_full_results.json
+      #     if-no-files-found: warn
 
-      - name: Run quad MTP demo parity smoke test
-        if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
+      # - name: Run quad MTP demo parity smoke test
+      #   if: ${{ (inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
 
-      - name: Upload quad MTP demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-demo-mtp-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_demo_mtp_output.log
-            generated/artifacts/quad_demo_full_results_mtp.json
-          if-no-files-found: warn
+      # - name: Upload quad MTP demo output artifacts
+      #   if: ${{ always() && ((inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: quad-demo-mtp-output-${{ github.run_id }}
+      #     path: |
+      #       generated/artifacts/quad_demo_mtp_output.log
+      #       generated/artifacts/quad_demo_full_results_mtp.json
+      #     if-no-files-found: warn
 
       # ── Demo stress tests ───────────────────────────────────────────────
       - name: Run dual demo stress test (56 prompts, 20 batches)
@@ -493,36 +493,36 @@ jobs:
             generated/artifacts/dual_demo_stress_results.json
           if-no-files-found: warn
 
-      - name: Run quad demo stress test (56 prompts, 20 batches)
-        if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
+      # - name: Run quad demo stress test (56 prompts, 20 batches)
+      #   if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+      #   uses: ./.github/actions/docker-run
+      #   timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
+      #   with:
+      #     docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      #     docker_password: ${{ secrets.GITHUB_TOKEN }}
+      #     docker_opts: |
+      #       -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e TT_METAL_HOME=${{ github.workspace }}
+      #       -e ARCH_NAME=wormhole_b0
+      #       -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+      #       -e DEEPSEEK_V3_CACHE_OVERRIDE=${{ steps.cache-config.outputs.cache_override }}
+      #       -v /etc/mpirun:/etc/mpirun:ro
+      #       -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+      #       --device /dev/tenstorrent
+      #       --pid=host
+      #       --hostname=mpirun-host
+      #     install_wheel: true
+      #     run_args: |
+      #       eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+      #       ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
 
-      - name: Upload quad demo stress output artifacts
-        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-demo-stress-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_demo_stress_output.log
-            generated/artifacts/quad_demo_stress_results.json
-          if-no-files-found: warn
+      # - name: Upload quad demo stress output artifacts
+      #   if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: quad-demo-stress-output-${{ github.run_id }}
+      #     path: |
+      #       generated/artifacts/quad_demo_stress_output.log
+      #       generated/artifacts/quad_demo_stress_results.json
+      #     if-no-files-found: warn


### PR DESCRIPTION
### Ticket
[#40216](https://github.com/tenstorrent/tt-metal/issues/40216)

### Problem description
stale NFS issue is causing failing quad tests, which in turn causes the nightly run to stop executing after the first failing test. Since it is run like dual unit --> quad unit --> dual module --> quad module --> etc, after first quad failure, none of the following dual tests are run / pass. 

### What's changed
Removing quad tests from nightly CI until the stale NFS issue is resolved to at least have functional dual CI.

### Checklist

[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-multihost-quad-off)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-multihost-quad-off)
[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=ds-multihost-quad-off)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:ds-multihost-quad-off)