### PR TITLE
Fix ttnn.softmax producing all-zeros for bfloat8_b on General H/W paths (#32934)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -451,12 +451,18 @@ def test_softmax_dtypes(device, shape, dim, dtype):
 @pytest.mark.parametrize(
     "shape, dim, dtype",
     [
-        ([32, 32], -1, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
-        ([32, 32, 32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
-        ([32, 32, 32, 32], 1, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
-        ([32, 32, 32, 32], 3, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
-        ([32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # Fails (issue #32934)
-        ([32, 32, 32, 32], 2, [torch.bfloat16, ttnn.bfloat8_b]),  # Fails (issue #32934)
+        ([32, 32], -1, [torch.bfloat16, ttnn.bfloat8_b]),  # AttentionOptimized path
+        ([32, 32, 32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralCLarge path
+        ([32, 32, 32, 32], 1, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralCLarge path
+        ([32, 32, 32, 32], 3, [torch.bfloat16, ttnn.bfloat8_b]),  # AttentionOptimized path
+        ([32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralH path (issue #32934)
+        ([32, 32, 32, 32], 2, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralH path (issue #32934)
+        (
+            [1, 1, 32, 32, 32],
+            -1,
+            [torch.bfloat16, ttnn.bfloat8_b],
+        ),  # GeneralW path (rank>4 bypasses AttentionOptimized)
+        ([1, 1, 32, 32, 32], 3, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralH path via rank>4
     ],
 )
 def test_softmax_bfloat8_dims(device, shape, dim, dtype):

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -451,7 +451,7 @@ def test_softmax_dtypes(device, shape, dim, dtype):
 @pytest.mark.parametrize(
     "shape, dim, dtype",
     [
-        ([32, 32], -1, [torch.bfloat16, ttnn.bfloat8_b]),  # AttentionOptimized path
+        ([32, 32], -1, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralW path (rank!=4)
         ([32, 32, 32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralCLarge path
         ([32, 32, 32, 32], 1, [torch.bfloat16, ttnn.bfloat8_b]),  # GeneralCLarge path
         ([32, 32, 32, 32], 3, [torch.bfloat16, ttnn.bfloat8_b]),  # AttentionOptimized path

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -449,6 +449,36 @@ def test_softmax_dtypes(device, shape, dim, dtype):
 
 
 @pytest.mark.parametrize(
+    "shape, dim, dtype",
+    [
+        ([32, 32], -1, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
+        ([32, 32, 32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
+        ([32, 32, 32, 32], 1, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
+        ([32, 32, 32, 32], 3, [torch.bfloat16, ttnn.bfloat8_b]),  # Passes
+        ([32, 32], 0, [torch.bfloat16, ttnn.bfloat8_b]),  # Fails (issue #32934)
+        ([32, 32, 32, 32], 2, [torch.bfloat16, ttnn.bfloat8_b]),  # Fails (issue #32934)
+    ],
+)
+def test_softmax_bfloat8_dims(device, shape, dim, dtype):
+    """Regression test for issue #32934: softmax bfloat8 fails for certain dims (output all zeros)."""
+    torch.manual_seed(0)
+
+    torch_dtype, ttnn_dtype = dtype
+
+    torch_tensor = torch.rand(shape, dtype=torch_dtype)
+    ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn_dtype)
+
+    torch_output = torch.softmax(
+        torch_tensor,
+        dim=dim,
+    )
+    ttnn_output = ttnn.softmax(ttnn_tensor, dim=dim)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.997)
+
+
+@pytest.mark.parametrize(
     "fp32_acc_en, math_approx_mode, expected_ulp, numeric_stable",
     [
         (True, False, 3, False),

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -48,16 +48,19 @@ bool is_softmax_general_w_small_available(
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
-    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Must match the format logic in softmax_program_factory_general_w_small
+    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     auto tile_size = tt::tile_size(data_format);
     auto intermed_tile_size = tt::tile_size(intermed_data_format);
+    auto mask_scaler_tile_size = tt::tile_size(mask_scaler_format);
 
     // Calculate total circular buffer memory requirements
-    int32_t cb_usage = 0;        // bytes
-    cb_usage += Wt * tile_size;  // input buffer
-    cb_usage += 1 * tile_size;   // mask buffer
-    cb_usage += 1 * tile_size;   // scaler buffer
+    int32_t cb_usage = 0;                   // bytes
+    cb_usage += Wt * tile_size;             // input buffer
+    cb_usage += 1 * mask_scaler_tile_size;  // mask buffer
+    cb_usage += 1 * mask_scaler_tile_size;  // scaler buffer
 
     cb_usage += Wt * tile_size;  // output buffer
 
@@ -86,15 +89,18 @@ bool is_softmax_general_h_small_available(
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
-    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Must match the format logic in softmax_program_factory_general_h_small
+    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     auto tile_size = tt::tile_size(data_format);
     auto intermed_tile_size = tt::tile_size(intermed_data_format);
+    auto mask_scaler_tile_size = tt::tile_size(mask_scaler_format);
 
-    int32_t cb_usage = 0;        // bytes
-    cb_usage += Ht * tile_size;  // input;
-    cb_usage += 1 * tile_size;   // mask;
-    cb_usage += 1 * tile_size;   // scaler;
+    int32_t cb_usage = 0;                   // bytes
+    cb_usage += Ht * tile_size;             // input;
+    cb_usage += 1 * mask_scaler_tile_size;  // mask;
+    cb_usage += 1 * mask_scaler_tile_size;  // scaler;
 
     cb_usage += Ht * tile_size;  // output;
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -408,9 +408,7 @@ Tensor softmax(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     bool numeric_stable) {
     // Constants
-    // BFLOAT8_B on general (H/W/C) paths uses Float16_b for mask/scaler CBs and needs fp32 accumulation for correctness
-    // (issue #32934)
-    const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT8_B;
+    const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
     TT_FATAL(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -408,7 +408,9 @@ Tensor softmax(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     bool numeric_stable) {
     // Constants
-    const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32;
+    // BFLOAT8_B on general (H/W/C) paths uses Float16_b for mask/scaler CBs and needs fp32 accumulation for correctness
+    // (issue #32934)
+    const auto is_fp32 = input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT8_B;
     TT_FATAL(
         input_tensor.device() != nullptr,
         "input_tensor.device() == nullptr, No device found, move input_tensor to device");

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
@@ -54,6 +54,10 @@ SoftmaxProgramFactoryGeneralHLarge::cached_program_t SoftmaxProgramFactoryGenera
     // Circular buffer
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
+    // input is BFloat8_B so tile size matches; BFloat8_B tile layout is different and would be overflowed (issue
+    // #32934).
+    const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
         program,
@@ -61,8 +65,8 @@ SoftmaxProgramFactoryGeneralHLarge::cached_program_t SoftmaxProgramFactoryGenera
         data_format,
         {
             {tt::CBIndex::c_0, 2},                         // input
-            {tt::CBIndex::c_1, 1},                         // mask
-            {tt::CBIndex::c_2, 1},                         // scaler
+            {tt::CBIndex::c_1, 1, mask_scaler_format},     // mask
+            {tt::CBIndex::c_2, 1, mask_scaler_format},     // scaler
             {tt::CBIndex::c_16, 2},                        // output
             {tt::CBIndex::c_24, 2, intermed_data_format},  // exp(x)
             {tt::CBIndex::c_25, 1, intermed_data_format},  // reduce

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
@@ -53,10 +53,11 @@ SoftmaxProgramFactoryGeneralHLarge::cached_program_t SoftmaxProgramFactoryGenera
 
     // Circular buffer
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Use Float16_b for intermediates when not accumulating in fp32, matching the AttentionOptimized path.
+    // This avoids using Bfp8_b for intermediate computations where it lacks precision (issue #32934).
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
-    // input is BFloat8_B so tile size matches; BFloat8_B tile layout is different and would be overflowed (issue
-    // #32934).
+    // input is Bfp8_b so tile size matches; Bfp8_b tile layout is smaller and would be overflowed (issue #32934).
     const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
@@ -98,7 +99,9 @@ SoftmaxProgramFactoryGeneralHLarge::cached_program_t SoftmaxProgramFactoryGenera
     // Kernel constants
     std::map<std::string, std::string> compute_defines;
     compute_defines["SOFTMAX"] = "1";
-    if (fp32_dest_acc_en) {
+    // Enable FP32_DEST_ACC_EN for format reconfiguration in moreh compute helpers when using mixed
+    // data formats (Bfp8_b input with Float16_b intermediates/mask/scaler) (issue #32934).
+    if (fp32_dest_acc_en || data_format == tt::DataFormat::Bfp8_b) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
@@ -54,6 +54,10 @@ SoftmaxProgramFactoryGeneralHSmall::cached_program_t SoftmaxProgramFactoryGenera
     // Circular buffers
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
+    // input is BFloat8_B so tile size matches; BFloat8_B tile layout is different and would be overflowed (issue
+    // #32934).
+    const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
         program,
@@ -61,8 +65,8 @@ SoftmaxProgramFactoryGeneralHSmall::cached_program_t SoftmaxProgramFactoryGenera
         data_format,
         {
             {tt::CBIndex::c_0, Ht},                         // input
-            {tt::CBIndex::c_1, 1},                          // mask
-            {tt::CBIndex::c_2, 1},                          // scaler
+            {tt::CBIndex::c_1, 1, mask_scaler_format},      // mask
+            {tt::CBIndex::c_2, 1, mask_scaler_format},      // scaler
             {tt::CBIndex::c_16, Ht},                        // output
             {tt::CBIndex::c_24, Ht, intermed_data_format},  // exp(x)
             {tt::CBIndex::c_25, 1, intermed_data_format},   // reduce

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
@@ -53,10 +53,11 @@ SoftmaxProgramFactoryGeneralHSmall::cached_program_t SoftmaxProgramFactoryGenera
 
     // Circular buffers
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Use Float16_b for intermediates when not accumulating in fp32, matching the AttentionOptimized path.
+    // This avoids using Bfp8_b for intermediate computations where it lacks precision (issue #32934).
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
-    // input is BFloat8_B so tile size matches; BFloat8_B tile layout is different and would be overflowed (issue
-    // #32934).
+    // input is Bfp8_b so tile size matches; Bfp8_b tile layout is smaller and would be overflowed (issue #32934).
     const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
@@ -98,7 +99,9 @@ SoftmaxProgramFactoryGeneralHSmall::cached_program_t SoftmaxProgramFactoryGenera
     // Kernel constants
     std::map<std::string, std::string> compute_defines;
     compute_defines["SOFTMAX"] = "1";
-    if (fp32_dest_acc_en) {
+    // Enable FP32_DEST_ACC_EN for format reconfiguration in moreh compute helpers when using mixed
+    // data formats (Bfp8_b input with Float16_b intermediates/mask/scaler) (issue #32934).
+    if (fp32_dest_acc_en || data_format == tt::DataFormat::Bfp8_b) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
@@ -52,7 +52,12 @@ SoftmaxProgramFactoryGeneralWLarge::cached_program_t SoftmaxProgramFactoryGenera
 
     // Circular buffers
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Use Float16_b for intermediates when not accumulating in fp32, matching the AttentionOptimized path.
+    // This avoids using Bfp8_b for intermediate computations where it lacks precision (issue #32934).
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
+    // input is Bfp8_b so tile size matches; Bfp8_b tile layout is smaller and would be overflowed (issue #32934).
+    const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
         program,
@@ -60,8 +65,8 @@ SoftmaxProgramFactoryGeneralWLarge::cached_program_t SoftmaxProgramFactoryGenera
         data_format,
         {
             {tt::CBIndex::c_0, 2},                         // input
-            {tt::CBIndex::c_1, 1},                         // mask
-            {tt::CBIndex::c_2, 1},                         // scaler
+            {tt::CBIndex::c_1, 1, mask_scaler_format},     // mask
+            {tt::CBIndex::c_2, 1, mask_scaler_format},     // scaler
             {tt::CBIndex::c_16, 2},                        // output
             {tt::CBIndex::c_24, 2, intermed_data_format},  // exp(x)
             {tt::CBIndex::c_25, 1, intermed_data_format},  // reduce
@@ -92,8 +97,9 @@ SoftmaxProgramFactoryGeneralWLarge::cached_program_t SoftmaxProgramFactoryGenera
 
     std::map<std::string, std::string> compute_defines;
     compute_defines["SOFTMAX"] = "1";
-
-    if (fp32_dest_acc_en) {
+    // Enable FP32_DEST_ACC_EN for format reconfiguration in moreh compute helpers when using mixed
+    // data formats (Bfp8_b input with Float16_b intermediates/mask/scaler) (issue #32934).
+    if (fp32_dest_acc_en || data_format == tt::DataFormat::Bfp8_b) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
@@ -53,7 +53,12 @@ SoftmaxProgramFactoryGeneralWSmall::cached_program_t SoftmaxProgramFactoryGenera
 
     // Circular buffers
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
+    // Use Float16_b for intermediates when not accumulating in fp32, matching the AttentionOptimized path.
+    // This avoids using Bfp8_b for intermediate computations where it lacks precision (issue #32934).
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    // Reader generates mask/scaler with uint16_t (1024 elements = 2048 bytes). Use Float16_b for these CBs when
+    // input is Bfp8_b so tile size matches; Bfp8_b tile layout is smaller and would be overflowed (issue #32934).
+    const auto mask_scaler_format = (data_format == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : data_format;
 
     operations::CreateCircularBuffer(
         program,
@@ -61,8 +66,8 @@ SoftmaxProgramFactoryGeneralWSmall::cached_program_t SoftmaxProgramFactoryGenera
         data_format,
         {
             {tt::CBIndex::c_0, Wt},                         // input
-            {tt::CBIndex::c_1, 1},                          // mask
-            {tt::CBIndex::c_2, 1},                          // scaler
+            {tt::CBIndex::c_1, 1, mask_scaler_format},      // mask
+            {tt::CBIndex::c_2, 1, mask_scaler_format},      // scaler
             {tt::CBIndex::c_16, Wt},                        // output
             {tt::CBIndex::c_24, Wt, intermed_data_format},  // exp(x)
             {tt::CBIndex::c_25, 1, intermed_data_format},   // reduce
@@ -94,7 +99,9 @@ SoftmaxProgramFactoryGeneralWSmall::cached_program_t SoftmaxProgramFactoryGenera
     // Kernel constants
     std::map<std::string, std::string> compute_defines;
     compute_defines["SOFTMAX"] = "1";
-    if (fp32_dest_acc_en) {
+    // Enable FP32_DEST_ACC_EN for format reconfiguration in moreh compute helpers when using mixed
+    // data formats (Bfp8_b input with Float16_b intermediates/mask/scaler) (issue #32934).
+    if (fp32_dest_acc_en || data_format == tt::DataFormat::Bfp8_b) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 


### PR DESCRIPTION
### Ticket
Closes #32934.

### Problem description

`ttnn.softmax` produces a tensor of all zeros for `bfloat8_b` inputs when the softmax dimension routes through the General H or General W program factories (the `moreh_softmax_h` / `moreh_softmax_w` kernels). This is triggered by specific shape/dim combinations, e.g. `[32, 32]` with `dim=0`, or `[32, 32, 32, 32]` with `dim=2`.

**Root cause — two independent bugs in the General H/W paths:**

1. **Circular buffer overflow for mask/scaler tiles.** The reader kernels (`reader_moreh_softmax_h.cpp`, `reader_moreh_softmax_w.cpp`) generate mask and scaler tiles using `uint16_t` writes — 1024 elements × 2 bytes = 2048 bytes per tile, which matches `Float16_b` tile size. However, the mask (`cb_1`) and scaler (`cb_2`) circular buffers inherited the input's data format. For `bfloat8_b` input, these CBs were allocated as `Bfp8_b` — only 1088 bytes per tile (1024 mantissa + 64 exponent bytes). The 2048-byte write overflowed the 1088-byte CB by 960 bytes, corrupting adjacent L1 memory and producing all-zero outputs.

2. **Missing data format reconfiguration in compute kernel.** The `moreh_common.hpp` compute helpers (`pack_tile_with_dt`, `copy_tile_init_with_dt`, etc.) only reconfigure the unpacker/packer data formats when the `FP32_DEST_ACC_EN` compile-time define is set. Without it, the hardware packer/unpacker stays configured for the initial format set by `binary_op_init_common` and cannot correctly switch between `Bfp8_b` input tiles and `Float16_b` intermediate tiles.

The AttentionOptimized path (used for last-dim softmax on rank≤4 tensors) was unaffected because it hardcodes `Float16_b` for all intermediates and scalars, and uses different compute kernels that handle format reconfiguration independently.

### What's changed

Three changes in the General H and General W program factories (`softmax_program_factory_general_{h,w}_{small,large}.cpp`):

1. **Float16_b for mask/scaler CBs** — When the input format is `Bfp8_b`, `cb_1` (mask) and `cb_2` (scaler) are explicitly set to `Float16_b` so their tile size (2048 bytes) matches the reader's `uint16_t` writes.

2. **Float16_b for intermediate CBs** — Changed `intermed_data_format` to fall back to `Float16_b` instead of inheriting `data_format`, matching the approach used by the AttentionOptimized path. This avoids using `Bfp8_b` for intermediate computations (exp, reduce, divide) where it lacks precision.

3. **`FP32_DEST_ACC_EN` compile define for format reconfiguration** — The define is now set when `data_format == Bfp8_b`, even when `fp32_dest_acc_en` is false. This enables data format reconfiguration in the moreh compute helpers (needed to correctly read/write between `Bfp8_b` input and `Float16_b` intermediate CBs) without enabling fp32 hardware accumulation. The `FP32_DEST_ACC_EN` compile-time define and the `fp32_dest_acc_en` hardware flag are passed independently to `CreateComputeKernel`, so decoupling them is safe.

Added a regression test `test_softmax_bfloat8_dims` covering all five softmax code paths with `bfloat8_b` input: AttentionOptimized, GeneralCLarge, GeneralHSmall/Large, and GeneralWSmall/Large.

### Checklist
- [x] All submitted GH actions on the [branch](https://github.com/tenstorrent/tt-metal/actions?query=branch%3Agchoudhary%2F32934-fix-softmax-bfloat8-failures)
- [x] New tests provide coverage for changes: `tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims`
    * Before:
    ```
    ================================================================================== short test summary info ===================================================================================
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32]-dim=-1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=0-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=3-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    FAILED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32]-dim=0-dtype=[torch.bfloat16, DataType.BFLOAT8_B]] - AssertionError: 0.0
    FAILED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=2-dtype=[torch.bfloat16, DataType.BFLOAT8_B]] - AssertionError: 0.0
    FAILED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[1, 1, 32, 32, 32]-dim=-1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]] - AssertionError: 0.0
    FAILED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[1, 1, 32, 32, 32]-dim=3-dtype=[torch.bfloat16, DataType.BFLOAT8_B]] - AssertionError: 0.0
    ================================================================================ 4 failed, 4 passed in 3.57s =================================================================================
    ```
    * After:
    ```
    ================================================================================== short test summary info ===================================================================================
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32]-dim=-1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=0-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=3-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32]-dim=0-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[32, 32, 32, 32]-dim=2-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[1, 1, 32, 32, 32]-dim=-1-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    PASSED tests/ttnn/unit_tests/operations/fused/test_softmax.py::test_softmax_bfloat8_dims[shape=[1, 1, 32, 32, 32]-dim=3-dtype=[torch.bfloat16, DataType.BFLOAT8_B]]
    ===================================================================================== 8 passed in 1.96s ======================================================================================
    ```