### PR TITLE
MoE Dispatch and Combine optimizations

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -93,7 +93,7 @@ fabric:
 
 shield:
   e2e:
-    wh_llmbox: 15
+    wh_llmbox: 30
 
 scaleout:
   e2e:

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -55,7 +55,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2",
+            id="linear-2-1link",
+        ),
+        pytest.param(
+            (2, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
+            id="linear-2-2link",
         ),
         pytest.param(
             (4, 1),
@@ -66,7 +77,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
+            id="linear-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4-2link",
         ),
         pytest.param(
             (4, 1),
@@ -77,7 +99,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4",
+            id="ring-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="ring-4-2link",
         ),
         pytest.param(
             (8, 1),
@@ -88,7 +121,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            id="linear-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-2link",
         ),
         pytest.param(
             (8, 1),
@@ -99,7 +143,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8",
+            id="ring-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="ring-8-2link",
         ),
         pytest.param(
             (4, 2),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -157,6 +157,17 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             id="ring-8-2link",
         ),
         pytest.param(
+            (2, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-4x2"),
+            id="mesh-2x2",
+        ),
+        pytest.param(
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -204,6 +204,17 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             id="ring-8-2link",
         ),
         pytest.param(
+            (2, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-4x2"),
+            id="mesh-2x2",
+        ),
+        pytest.param(
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -102,7 +102,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2",
+            id="linear-2-1link",
+        ),
+        pytest.param(
+            (2, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
+            id="linear-2-2link",
         ),
         pytest.param(
             (4, 1),
@@ -113,7 +124,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
+            id="linear-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4-2link",
         ),
         pytest.param(
             (4, 1),
@@ -124,7 +146,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4",
+            id="ring-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="ring-4-2link",
         ),
         pytest.param(
             (8, 1),
@@ -135,7 +168,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            id="linear-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-2link",
         ),
         pytest.param(
             (8, 1),
@@ -146,7 +190,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8",
+            id="ring-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="ring-8-2link",
         ),
         pytest.param(
             (4, 2),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -55,7 +55,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2",
+            id="linear-2-1link",
+        ),
+        pytest.param(
+            (2, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
+            id="linear-2-2link",
         ),
         pytest.param(
             (4, 1),
@@ -66,7 +77,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
+            id="linear-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4-2link",
         ),
         pytest.param(
             (4, 1),
@@ -77,7 +99,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4",
+            id="ring-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="ring-4-2link",
         ),
         pytest.param(
             (8, 1),
@@ -88,7 +121,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            id="linear-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-2link",
         ),
         pytest.param(
             (8, 1),
@@ -99,7 +143,18 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             1,
             ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8",
+            id="ring-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="ring-8-2link",
         ),
         pytest.param(
             (4, 2),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -157,6 +157,17 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             id="ring-8-2link",
         ),
         pytest.param(
+            (2, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-4x2"),
+            id="mesh-2x2",
+        ),
+        pytest.param(
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -121,7 +121,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k random
   skus:
     wh_llmbox:
-      timeout: 15
+      timeout: 30
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield
   model-name: deepseek_prefill

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -115,10 +115,10 @@
 
 - name: t3k_DeepSeek_PREFILL
   cmd: |
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py -vvv --tb=short -k random
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py -vvv  --tb=short -k random
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k random
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py -vvv  --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
   skus:
     wh_llmbox:
       timeout: 30

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
@@ -37,8 +37,8 @@ ttnn::Tensor combine(
         "cluster_axis must be 0 (current value: {}). Other values are not tested.",
         cluster_axis.value_or(0));
     TT_FATAL(
-        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 2,
-        "num_links must be 1 or 2 (current value: {}).",
+        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 4,
+        "num_links must be between 1 and 4 (current value: {}).",
         num_links.value_or(1));
     auto topology_ = topology.value_or(tt::tt_fabric::Topology::Linear);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
@@ -37,8 +37,8 @@ ttnn::Tensor combine(
         "cluster_axis must be 0 (current value: {}). Other values are not tested.",
         cluster_axis.value_or(0));
     TT_FATAL(
-        num_links.value_or(1) == 1,
-        "num_links must be 1 (current value: {}). Other values are not tested.",
+        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 2,
+        "num_links must be 1 or 2 (current value: {}).",
         num_links.value_or(1));
     auto topology_ = topology.value_or(tt::tt_fabric::Topology::Linear);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -78,12 +78,10 @@ CombineProgramFactory::cached_mesh_workload_t CombineProgramFactory::create_mesh
 
     auto* mesh_device = tensor_args.dispatched_buffer.device();
 
-    // Create global semaphore for cross-device synchronization (fabric init barrier)
     auto init_barrier_semaphore =
         ttnn::global_semaphore::create_global_semaphore(mesh_device, operation_attributes.worker_core_range_set, 0);
     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
 
-    // Create a program for each device in the mesh
     for (const auto& coord : tensor_coords.coords()) {
         auto cached_program = create_at(
             operation_attributes, coord, tensor_args, tensor_return_value, tensor_coords, init_barrier_semaphore);
@@ -102,7 +100,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     const GlobalSemaphore& init_semaphore) {
     tt::tt_metal::Program program{};
 
-    // Extract input tensors
     const auto& dispatched_buffer = tensor_args.dispatched_buffer;
     const auto& dispatched_metadata = tensor_args.dispatched_metadata;
     const auto& expert_token_counts = tensor_args.expert_token_counts;
@@ -111,7 +108,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto* mesh_device = dispatched_buffer.device();
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
-    // Extract mesh information for this specific device
     const auto& mesh_view = mesh_device->get_view();
     auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
     uint32_t src_mesh_id = *src_fabric_node_id.mesh_id;
@@ -137,104 +133,117 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         topology,
         num_links);
 
-    // Get fabric configuration and connection information
     auto fabric_max_packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
     auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
-    // Get neighbor connections for fabric
     const auto [neighbors, directions] =
         ccl::common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
 
-    // Figure out tensor dimensions
     auto dispatched_shape = dispatched_buffer.logical_shape();
     auto hidden_size = dispatched_shape[-1];
     auto max_dispatched_tokens_per_expert = dispatched_shape[-2];
 
-    // Calculate work distribution
-    // For combine, we iterate over (chips, experts, tokens_per_expert)
-    // Start with single-core implementation, can parallelize later
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    TT_FATAL(!subdevice_cores.empty(), "Need at least one core for combine operation");
+    uint32_t effective_num_links = num_links >= 2 ? 2u : 1u;
+    TT_FATAL(
+        subdevice_cores.size() >= effective_num_links,
+        "Not enough cores {} for {} links",
+        subdevice_cores.size(),
+        effective_num_links);
 
-    // Use first available core for now (single-core implementation)
-    CoreCoord worker_core = subdevice_cores.at(0);
-    CoreRangeSet worker_core_grid = CoreRangeSet({CoreRange(worker_core, worker_core)});
+    uint32_t num_cores = effective_num_links;
+    uint32_t experts_per_core_range = tt::div_up(operation_attributes.experts_per_chip, num_cores);
 
-    // Create local semaphore for reader→writer zero-init synchronization (same core, no cross-device)
-    auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_grid, 0);
+    auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+        subdevice_cores.at(0), num_cores, worker_core_range_set, true);
+    std::vector<CoreCoord> sender_cores = corerange_to_cores(sender_core_grid);
 
-    log_debug(tt::LogOp, "Creating prefill combine program with hidden_size: {} on core: {}", hidden_size, worker_core);
+    log_debug(
+        tt::LogOp,
+        "Combine program: hidden_size: {} num_cores: {} experts_per_core_range: {} cores: {}",
+        hidden_size,
+        num_cores,
+        experts_per_core_range,
+        sender_cores);
 
-    // Create input CBs (readers)
+    auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
+    auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
+
+    constexpr uint32_t read_batch_size = 8;
+
+    // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
-        worker_core_grid,
+        sender_core_grid,
         dispatched_buffer,
-        /*buffering_factor=*/2,
+        /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_0,
-        "dispatched_buffer");
-
+        "dispatched_buffer_scratch");
+    // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
         program,
-        worker_core_grid,
+        sender_core_grid,
         dispatched_metadata,
-        /*buffering_factor=*/2,
+        /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
-        "dispatched_metadata");
-
+        "dispatched_metadata_scratch");
+    // c_2: expert_token_counts (reader-only, full tensor)
     detail::create_tensor_cb(
         program,
-        worker_core_grid,
+        sender_core_grid,
         expert_token_counts,
-        /*buffering_factor=*/detail::get_num_pages(expert_token_counts),  // Read entire counter
+        /*buffering_factor=*/detail::get_num_pages(expert_token_counts),
         /*cb_id=*/tt::CBIndex::c_2,
         "expert_token_counts");
 
-    // Create output CB (writer)
+    // c_3: route_info (reader->writer, 4 x uint32_t per entry)
+    {
+        uint32_t route_info_page_size = l1_alignment;
+        constexpr uint32_t route_info_buffering = 16;
+        tt::tt_metal::CircularBufferConfig route_info_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                route_info_buffering * route_info_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_3, route_info_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+    }
+
+    // c_4: output_for_writer (reader->writer, output pages for fabric sends)
     detail::create_tensor_cb(
         program,
-        worker_core_grid,
-        output_tensor,
-        /*buffering_factor=*/2,
-        /*cb_id=*/tt::CBIndex::c_3,
-        "output_tensor");
+        sender_core_grid,
+        dispatched_buffer,
+        /*buffering_factor=*/16,
+        /*cb_id=*/tt::CBIndex::c_4,
+        "output_for_writer");
 
-    // Create packet header CB for fabric communication (if fabric is enabled)
+    // c_5: packet header CB for fabric sends (writer-only)
     if (num_links > 0) {
-        constexpr uint32_t num_packet_headers = 1;  // Only need unicast header for combine
+        constexpr uint32_t num_packet_headers = 2;
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
         uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
 
         tt::tt_metal::CircularBufferConfig packet_header_cb_config =
-            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
-                .set_page_size(tt::CBIndex::c_4, packet_header_size_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, worker_core_grid, packet_header_cb_config);
-
-        log_debug(
-            tt::LogOp,
-            "Created packet header CB with size {} bytes for {} headers",
-            packet_header_cb_size,
-            num_packet_headers);
+            tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_5, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_5, packet_header_size_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
     }
 
-    // Generate destination chip and mesh IDs for fabric connections
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
     for (const auto& coord : tensor_coords.coords()) {
         auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
         dest_mesh_id.push_back(*dest_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)dest_fabric_node_id.chip_id);
     }
-    log_debug(tt::LogOp, "dest_chip_id: {}", ccl::common::stringify(dest_chip_id));
-    log_debug(tt::LogOp, "dest_mesh_id: {}", ccl::common::stringify(dest_mesh_id));
-    log_debug(tt::LogOp, "directions: {}", ccl::common::stringify(directions));
 
-    // Create reader kernel compile-time args
-    std::vector<uint32_t> reader_compile_time_args = {
-        // CB IDs (4)
+    // Compile-time args shared by reader and writer
+    std::vector<uint32_t> compile_time_args = {
+        // CB IDs (6)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_dispatched_buffer_id
         static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_dispatched_metadata_id
-        static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_expert_token_counts_id
-        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_output_id
+        static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_experts_tok_counter_id
+        static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_route_info_id
+        static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_output_for_writer_id
+        static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_packet_header_id
 
         // Page counts (4)
         detail::get_num_pages(dispatched_buffer),
@@ -274,39 +283,42 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // Fabric configuration (4)
         (uint32_t)fabric_max_packet_size,
         l1_alignment,
-        num_links,
+        (uint32_t)std::min(num_links, 1u),
         static_cast<uint32_t>(topology),
     };
 
-    // Append TensorAccessorArgs for all tensors
-    tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(dispatched_metadata.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(expert_token_counts.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(reader_compile_time_args);
+    // Append TensorAccessorArgs for all 4 tensors
+    tt::tt_metal::TensorAccessorArgs(dispatched_buffer.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dispatched_metadata.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(expert_token_counts.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(compile_time_args);
 
-    // Generate defines for reader kernel
-    std::map<std::string, std::string> reader_defines;
+    // Both reader and writer get fabric defines so the reader can compute routes
+    std::map<std::string, std::string> fabric_defines;
+    if (num_links > 0) {
+        fabric_defines["DEST_CHIP_ID"] = ccl::common::stringify(dest_chip_id);
+        fabric_defines["DEST_MESH_ID"] = ccl::common::stringify(dest_mesh_id);
+        fabric_defines["DIRECTIONS"] = ccl::common::stringify(directions);
+    }
+    if (operation_attributes.axis.has_value()) {
+        fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
+    }
+
+    std::map<std::string, std::string> reader_defines = fabric_defines;
     reader_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
 
-    // Check if output is L1 interleaved and add multicast defines
     bool is_l1_output = output_tensor.buffer()->buffer_type() == BufferType::L1;
     reader_defines["IS_L1_OUTPUT"] = is_l1_output ? "1" : "0";
 
     if (is_l1_output && operation_attributes.init_zeros) {
-        // Get compute_with_storage_grid for L1 bank cores
         auto compute_grid = mesh_device->compute_with_storage_grid_size();
         uint32_t num_l1_banks = compute_grid.x * compute_grid.y;
 
-        // Get NOC coordinates for the bank core grid
-        // Start is (0,0), end is (grid_x-1, grid_y-1) in logical coords
-        // Convert to virtual/NOC coords
         CoreCoord logical_start(0, 0);
         CoreCoord logical_end(compute_grid.x - 1, compute_grid.y - 1);
         CoreCoord noc_start = mesh_device->virtual_core_from_logical_core(logical_start, tt::CoreType::WORKER);
         CoreCoord noc_end = mesh_device->virtual_core_from_logical_core(logical_end, tt::CoreType::WORKER);
 
-        // Calculate bytes per bank based on lock-step allocator behavior:
-        // Each bank reserves space for ceil(num_pages / num_banks) pages
         uint32_t num_pages = detail::get_num_pages(output_tensor);
         uint32_t aligned_page_size = detail::get_aligned_page_size(output_tensor);
         uint32_t pages_per_bank = (num_pages + num_l1_banks - 1) / num_l1_banks;
@@ -318,115 +330,113 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         reader_defines["L1_BANK_NOC_Y_START"] = std::to_string(noc_start.y);
         reader_defines["L1_BANK_NOC_X_END"] = std::to_string(noc_end.x);
         reader_defines["L1_BANK_NOC_Y_END"] = std::to_string(noc_end.y);
-
-        log_debug(
-            tt::LogOp,
-            "L1 multicast zero-init: num_banks={} bytes_per_bank={} grid=({},{}) to ({},{})",
-            num_l1_banks,
-            bytes_per_bank,
-            noc_start.x,
-            noc_start.y,
-            noc_end.x,
-            noc_end.y);
     }
 
-    // Create reader kernel
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp",
-        worker_core_grid,
+        sender_core_grid,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-            .compile_args = reader_compile_time_args,
+            .compile_args = compile_time_args,
             .defines = reader_defines});
-
-    // Create writer kernel - shares same compile time args
-    const auto& writer_compile_time_args = reader_compile_time_args;
-
-    // Generate fabric defines for writer kernel
-    std::map<std::string, std::string> writer_defines;
-    if (num_links > 0) {
-        writer_defines["DEST_CHIP_ID"] = ccl::common::stringify(dest_chip_id);
-        writer_defines["DEST_MESH_ID"] = ccl::common::stringify(dest_mesh_id);
-        writer_defines["DIRECTIONS"] = ccl::common::stringify(directions);
-    }
-
-    if (operation_attributes.axis.has_value()) {
-        writer_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
-    }
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp",
-        worker_core_grid,
+        sender_core_grid,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = writer_compile_time_args,
-            .defines = writer_defines});
+            .compile_args = compile_time_args,
+            .defines = fabric_defines});
 
-    // Set runtime args
-    // Base tensor addresses (shared between reader and writer)
-    std::vector<uint32_t> base_runtime_args = {
-        dispatched_buffer.buffer()->address(),
-        dispatched_metadata.buffer()->address(),
-        expert_token_counts.buffer()->address(),
-        output_tensor.buffer()->address(),
-    };
-
-    // Reader needs: base + zero_init semaphore ID (kernel uses get_semaphore() to convert to address)
-    std::vector<uint32_t> reader_runtime_args = base_runtime_args;
-    reader_runtime_args.push_back(zero_init_semaphore_id);
-
-    // Writer needs: base + zero_init semaphore ID + init_semaphore address (global)
-    std::vector<uint32_t> writer_runtime_args = base_runtime_args;
-    writer_runtime_args.push_back(zero_init_semaphore_id);
-    writer_runtime_args.push_back((uint32_t)init_semaphore.address());
-
-    // Append fabric connection args (only if fabric is enabled)
-    if (num_links > 0) {
-        for (const auto& neighbor_coordinate : neighbors) {
-            // Skip self-connections
-            if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
-                log_debug(
-                    tt::LogOp,
-                    "Skipping self-connection for mesh coord ({}, {}) at core {}",
-                    mesh_coordinate[0],
-                    mesh_coordinate[1],
-                    worker_core);
-                continue;
-            }
-
-            log_debug(
-                tt::LogOp,
-                "Connection between mesh coord ({}, {}) and ({}, {}) at core {}",
-                mesh_coordinate[0],
-                mesh_coordinate[1],
-                neighbor_coordinate[0],
-                neighbor_coordinate[1],
-                worker_core);
-
-            tt::tt_fabric::append_fabric_connection_rt_args(
-                src_fabric_node_id,
-                mesh_device->get_fabric_node_id(neighbor_coordinate),
-                0,  // link_id - use 0 for single link
-                program,
-                worker_core,
-                writer_runtime_args);
-        }
+    // Pre-compute NOC coordinates for all sender cores (for inter-core barrier signaling)
+    std::vector<std::pair<uint32_t, uint32_t>> sender_noc_coords;
+    for (const auto& sc : sender_cores) {
+        auto noc_coord = mesh_device->virtual_core_from_logical_core(sc, tt::CoreType::WORKER);
+        sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
     }
 
-    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, worker_core, reader_runtime_args);
-    tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, worker_core, writer_runtime_args);
+    uint32_t core_idx = 0;
+    for (const auto& sender_core : sender_cores) {
+        uint32_t expert_start = core_idx * experts_per_core_range;
+        uint32_t expert_end = std::min((core_idx + 1) * experts_per_core_range, operation_attributes.experts_per_chip);
+
+        std::vector<uint32_t> reader_runtime_args = {
+            dispatched_buffer.buffer()->address(),
+            dispatched_metadata.buffer()->address(),
+            expert_token_counts.buffer()->address(),
+            output_tensor.buffer()->address(),
+            zero_init_semaphore_id,
+            zero_init_barrier_semaphore_id,
+            num_cores,
+            expert_start,
+            expert_end,
+        };
+
+        std::vector<uint32_t> writer_runtime_args = {
+            dispatched_buffer.buffer()->address(),
+            dispatched_metadata.buffer()->address(),
+            expert_token_counts.buffer()->address(),
+            output_tensor.buffer()->address(),
+            zero_init_semaphore_id,
+            (uint32_t)init_semaphore.address(),
+            zero_init_barrier_semaphore_id,
+            num_cores,
+            expert_start,
+            expert_end,
+        };
+
+        // Append NOC coordinates of all cores for inter-core barrier signaling
+        for (const auto& [noc_x, noc_y] : sender_noc_coords) {
+            writer_runtime_args.push_back(noc_x);
+            writer_runtime_args.push_back(noc_y);
+        }
+
+        if (num_links > 0) {
+            uint32_t core_link = core_idx % num_links;
+            for (const auto& neighbor_coordinate : neighbors) {
+                if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
+                    continue;
+                }
+
+                log_debug(
+                    tt::LogOp,
+                    "Combine connection: ({}, {}) -> ({}, {}) core {} link {} experts [{}, {})",
+                    mesh_coordinate[0],
+                    mesh_coordinate[1],
+                    neighbor_coordinate[0],
+                    neighbor_coordinate[1],
+                    sender_core,
+                    core_link,
+                    expert_start,
+                    expert_end);
+
+                tt::tt_fabric::append_fabric_connection_rt_args(
+                    src_fabric_node_id,
+                    mesh_device->get_fabric_node_id(neighbor_coordinate),
+                    core_link,
+                    program,
+                    sender_core,
+                    writer_runtime_args);
+            }
+        }
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, sender_core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
+        core_idx++;
+    }
 
     return {
         std::move(program),
         {.reader_kernel_id = reader_kernel_id,
          .writer_kernel_id = writer_kernel_id,
-         .worker_core = worker_core,
+         .cores = sender_cores,
          .init_semaphore = init_semaphore,
-         .zero_init_semaphore_id = zero_init_semaphore_id}};
+         .zero_init_semaphore_id = zero_init_semaphore_id,
+         .zero_init_barrier_semaphore_id = zero_init_barrier_semaphore_id}};
 }
 
 void CombineProgramFactory::override_runtime_arguments(
@@ -434,32 +444,24 @@ void CombineProgramFactory::override_runtime_arguments(
     const CombineParams& /*operation_attributes*/,
     const CombineInputs& tensor_args,
     ttnn::Tensor& tensor_return_value) {
-    // Update buffer addresses in runtime args when tensors are reallocated
     for (auto& [range, program] : cached_workload.workload.get_programs()) {
         const auto& shared_variables = cached_workload.shared_variables.at(range);
 
-        std::vector<uint32_t> reader_runtime_args = {
-            tensor_args.dispatched_buffer.buffer()->address(),
-            tensor_args.dispatched_metadata.buffer()->address(),
-            tensor_args.expert_token_counts.buffer()->address(),
-            tensor_return_value.buffer()->address(),
-            shared_variables.zero_init_semaphore_id,
-        };
+        for (const auto& core : shared_variables.cores) {
+            auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
+            auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
 
-        std::vector<uint32_t> writer_runtime_args = {
-            tensor_args.dispatched_buffer.buffer()->address(),
-            tensor_args.dispatched_metadata.buffer()->address(),
-            tensor_args.expert_token_counts.buffer()->address(),
-            tensor_return_value.buffer()->address(),
-        };
-        writer_runtime_args.push_back(shared_variables.zero_init_semaphore_id);
-        writer_runtime_args.push_back((uint32_t)shared_variables.init_semaphore.address());
-        // Note: Fabric connection args are not updated here as they don't change
+            reader_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
+            reader_runtime_args.at(1) = tensor_args.dispatched_metadata.buffer()->address();
+            reader_runtime_args.at(2) = tensor_args.expert_token_counts.buffer()->address();
+            reader_runtime_args.at(3) = tensor_return_value.buffer()->address();
 
-        tt::tt_metal::SetRuntimeArgs(
-            program, shared_variables.reader_kernel_id, shared_variables.worker_core, reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(
-            program, shared_variables.writer_kernel_id, shared_variables.worker_core, writer_runtime_args);
+            writer_runtime_args.at(0) = tensor_args.dispatched_buffer.buffer()->address();
+            writer_runtime_args.at(1) = tensor_args.dispatched_metadata.buffer()->address();
+            writer_runtime_args.at(2) = tensor_args.expert_token_counts.buffer()->address();
+            writer_runtime_args.at(3) = tensor_return_value.buffer()->address();
+            writer_runtime_args.at(5) = (uint32_t)shared_variables.init_semaphore.address();
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -283,7 +283,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         // Fabric configuration (4)
         (uint32_t)fabric_max_packet_size,
         l1_alignment,
-        (uint32_t)std::min(num_links, 1u),
+        static_cast<uint32_t>(num_links),
         static_cast<uint32_t>(topology),
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -144,7 +144,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto max_dispatched_tokens_per_expert = dispatched_shape[-2];
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    uint32_t effective_num_links = num_links >= 2 ? 2u : 1u;
+    uint32_t effective_num_links = std::min(num_links, 4u);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.hpp
@@ -14,9 +14,10 @@ namespace ttnn::operations::experimental::deepseek_prefill::combine {
 struct CombineSharedVariables {
     tt::tt_metal::KernelHandle reader_kernel_id = 0;
     tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    CoreCoord worker_core;
+    std::vector<CoreCoord> cores;
     GlobalSemaphore init_semaphore;       // Initialized in create_at()
     uint32_t zero_init_semaphore_id = 0;  // Local semaphore ID for reader->writer sync
+    uint32_t zero_init_barrier_semaphore_id = 0;  // Barrier: writer signals reader after global init
 };
 
 struct CombineProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Prefill combine reader kernel
-// This kernel reads expert outputs and metadata, then routes them back to original token positions
-
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
-// Debug print control - set to 0 to disable combine debug prints, 1 to enable
 #define ENABLE_COMBINE_DEBUG 0
 #if ENABLE_COMBINE_DEBUG
 #define DPRINT_COMBINE DPRINT
@@ -19,7 +17,8 @@
     DebugPrinter()
 #endif
 
-// Zero a DRAM/L1 page by writing zeros from L1's MEM_ZEROS_BASE (unicast)
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
 void zero_page_async(uint64_t noc_addr, uint32_t page_size) {
     uint32_t bytes = page_size;
     while (bytes > 0) {
@@ -30,7 +29,6 @@ void zero_page_async(uint64_t noc_addr, uint32_t page_size) {
     }
 }
 
-// L1 multicast zero-init is enabled when all required defines are present
 #if defined(IS_L1_OUTPUT) && IS_L1_OUTPUT && defined(L1_BANK_NOC_X_START) && defined(NUM_L1_BANKS)
 #define USE_L1_MULTICAST_ZERO 1
 #else
@@ -38,43 +36,60 @@ void zero_page_async(uint64_t noc_addr, uint32_t page_size) {
 #endif
 
 void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-3)
+    // CB IDs (indices 0-5)
     constexpr uint32_t cb_dispatched_buffer_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_dispatched_metadata_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_output_for_writer_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(5);
 
-    // Page counts (indices 4-7)
-    constexpr uint32_t dispatched_buffer_pages = get_compile_time_arg_val(4);
-    constexpr uint32_t dispatched_metadata_pages = get_compile_time_arg_val(5);
-    constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(7);
+    // Page counts (indices 6-9)
+    constexpr uint32_t dispatched_buffer_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t dispatched_metadata_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(9);
 
-    // Page sizes (indices 8-11)
-    constexpr uint32_t dispatched_buffer_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t dispatched_metadata_page_size = get_compile_time_arg_val(9);
-    constexpr uint32_t experts_tok_counter_page_size = get_compile_time_arg_val(10);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(11);
+    // Page sizes (indices 10-13)
+    constexpr uint32_t dispatched_buffer_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t dispatched_metadata_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t experts_tok_counter_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(13);
 
-    // Operation parameters (indices 12-16)
-    constexpr uint32_t num_chips = get_compile_time_arg_val(12);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(13);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(14);
-    constexpr uint32_t seq_len_per_chip = get_compile_time_arg_val(15);
-    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(16);
+    // Operation parameters (indices 14-18)
+    constexpr uint32_t num_chips = get_compile_time_arg_val(14);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(16);
+    constexpr uint32_t seq_len_per_chip = get_compile_time_arg_val(17);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(18);
 
-    // Hidden dimension (index 17)
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(17);
+    // Hidden dimension (index 19)
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(19);
 
-    // Aligned page sizes (indices 18-21)
-    constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(20);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(21);
+    // Aligned page sizes (indices 20-23)
+    constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(20);
+    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(21);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(22);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(23);
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 31)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<31>();
+    // Mesh information (indices 24-28)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(28);
+
+    // Fabric configuration (indices 29-32)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(29);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(30);
+    constexpr uint32_t num_links = get_compile_time_arg_val(31);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(32);
+
+    // TensorAccessorArgs for all 4 tensors (starting at index 33)
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<33>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =
@@ -88,74 +103,73 @@ void kernel_main() {
     uint32_t experts_tok_counter_addr = get_arg_val<uint32_t>(rt_args++);
     uint32_t output_addr = get_arg_val<uint32_t>(rt_args++);
     uint32_t zero_init_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t zero_init_barrier_semaphore_id = get_arg_val<uint32_t>(rt_args++);
+    uint32_t num_cores = get_arg_val<uint32_t>(rt_args++);
+    uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args++);
+    uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args++);
     uint32_t zero_init_semaphore_address = get_semaphore(zero_init_semaphore_id);
+    uint32_t zero_init_barrier_address = get_semaphore(zero_init_barrier_semaphore_id);
 
-    // Print key compile time args for debugging (RISCV_1)
-    DPRINT_COMBINE << "Combine Reader: CBs=" << cb_dispatched_buffer_id << "," << cb_dispatched_metadata_id << ","
-                   << cb_experts_tok_counter_id << "," << cb_output_id << " num_chips=" << num_chips
-                   << " experts_per_chip=" << experts_per_chip << " num_experts_per_tok=" << num_experts_per_tok
-                   << " seq_len_per_chip=" << seq_len_per_chip
-                   << " max_dispatched_tokens_per_expert=" << max_dispatched_tokens_per_expert
-                   << " hidden_size=" << hidden_size << ENDL();
+    DPRINT_COMBINE << "Combine Reader: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
+                   << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
-    // Zero-initialize output buffer before reading inputs
-    // This overlaps with fabric initialization in the writer kernel
-    // Each chip initializes its own output tensor to ensure predictable values
     const auto output_addr_gen = TensorAccessor(output_args, output_addr, aligned_output_page_size);
+
+    // Only core 0 (expert_start_idx == 0) performs zero-init to avoid race between cores
 #if INIT_ZEROS
+    if (expert_start_idx == 0) {
 #if USE_L1_MULTICAST_ZERO
-    // L1 interleaved: use multicast to zero all bank cores at once
-    // This is faster than per-page unicast since one multicast covers all cores
-    constexpr uint32_t per_bank_bytes = OUTPUT_BYTES_PER_BANK;
-    DPRINT_COMBINE << "Zero-init L1 (multicast): per_bank_bytes=" << per_bank_bytes << " num_banks=" << NUM_L1_BANKS
-                   << ENDL();
-    // Inline multicast loop - zeros same L1 offset on ALL bank cores simultaneously
-    for (uint32_t offset = 0; offset < per_bank_bytes; offset += MEM_ZEROS_SIZE) {
-        uint32_t chunk_size = ((uint32_t)MEM_ZEROS_SIZE < (per_bank_bytes - offset)) ? (uint32_t)MEM_ZEROS_SIZE
-                                                                                     : (per_bank_bytes - offset);
-        uint64_t mcast_addr = get_noc_multicast_addr(
-            L1_BANK_NOC_X_START, L1_BANK_NOC_Y_START, L1_BANK_NOC_X_END, L1_BANK_NOC_Y_END, output_addr + offset);
-        noc_async_write_multicast_loopback_src(MEM_ZEROS_BASE, mcast_addr, chunk_size, NUM_L1_BANKS);
-    }
-    noc_async_write_barrier();
+        constexpr uint32_t per_bank_bytes = OUTPUT_BYTES_PER_BANK;
+        for (uint32_t offset = 0; offset < per_bank_bytes; offset += MEM_ZEROS_SIZE) {
+            uint32_t chunk_size = ((uint32_t)MEM_ZEROS_SIZE < (per_bank_bytes - offset)) ? (uint32_t)MEM_ZEROS_SIZE
+                                                                                         : (per_bank_bytes - offset);
+            uint64_t mcast_addr = get_noc_multicast_addr(
+                L1_BANK_NOC_X_START, L1_BANK_NOC_Y_START, L1_BANK_NOC_X_END, L1_BANK_NOC_Y_END, output_addr + offset);
+            noc_async_write_multicast_loopback_src(MEM_ZEROS_BASE, mcast_addr, chunk_size, NUM_L1_BANKS);
+        }
+        noc_async_write_barrier();
 #else
-    // DRAM interleaved or L1 without multicast defines: use per-page unicast
-    DPRINT_COMBINE << "Zero-init (unicast): pages=" << output_pages << " page_size=" << aligned_output_page_size
-                   << ENDL();
-    for (uint32_t page = 0; page < output_pages; page++) {
-        uint64_t page_noc_addr = get_noc_addr(page, output_addr_gen);
-        zero_page_async(page_noc_addr, aligned_output_page_size);
-    }
-    noc_async_write_barrier();
+        for (uint32_t page = 0; page < output_pages; page++) {
+            uint64_t page_noc_addr = get_noc_addr(page, output_addr_gen);
+            zero_page_async(page_noc_addr, aligned_output_page_size);
+        }
+        noc_async_write_barrier();
 #endif
-    DPRINT_COMBINE << "Zero-init done" << ENDL();
+    }
 #endif
 
-    // Signal local writer that zero-init is complete (or skipped if INIT_ZEROS=0)
-    // Reader is RISCV_1, Writer is RISCV_0 - they use different NOC buses but share L1.
-    // noc_semaphore_wait in writer calls invalidate_l1_cache() so it will see this value.
-    DPRINT_COMBINE << "Signaling writer zero-init complete..." << ENDL();
+    // Signal writer that zero-init is complete (or skipped for non-core-0)
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_set(zero_init_sem_ptr, 1);
 
-    // ==== Read experts token counter (chips/fractured ==1, experts_per_chip) ====
+    // Wait for ALL writers (all cores) to complete init exchange.
+    // Each writer signals all readers' barrier sems via noc_semaphore_inc,
+    // so this reader waits for num_cores signals before proceeding.
+    volatile tt_l1_ptr uint32_t* barrier_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_barrier_address);
+    noc_semaphore_wait(barrier_sem_ptr, num_cores);
+    noc_semaphore_set(barrier_sem_ptr, 0);
+
+    // Read expert token counts
     const auto experts_tok_counter_addr_gen =
         TensorAccessor(experts_tok_counter_args, experts_tok_counter_addr, aligned_experts_tok_counter_page_size);
-    // Reserve all pages upfront, then manually increment write address per page
     cb_reserve_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_experts_tok_counter_id);
+    uint32_t counter_base_addr = get_write_ptr(cb_experts_tok_counter_id);
     for (uint32_t i = 0; i < experts_tok_counter_pages; i++) {
-        DPRINT_COMBINE << "Fetching experts token counter; page=" << i << ENDL();
-        noc_async_read_page(i, experts_tok_counter_addr_gen, l1_write_addr);
-        l1_write_addr += aligned_experts_tok_counter_page_size;
+        noc_async_read_page(
+            i, experts_tok_counter_addr_gen, counter_base_addr + i * aligned_experts_tok_counter_page_size);
     }
     noc_async_read_barrier();
-    cb_push_back(cb_experts_tok_counter_id, experts_tok_counter_pages);
+    volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr);
 
-    // read dispatched buffers and metadata
-    // dispatch buffer (chips/fractured ==1, experts_per_chip, max_dispatched_tokens_per_expert, hidden_size)
-    // dispatch metadata buffer (chips/fractured ==1, experts_per_chip, max_dispatched_tokens_per_expert, metadata_len)
+    // Set up scratch buffers for batched reads
+    constexpr uint32_t read_batch_size = 8;
+    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
+    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
+    cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
+    uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
 
     const auto dispatched_buffer_addr_gen =
         TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
@@ -164,32 +178,112 @@ void kernel_main() {
 
     constexpr auto expert_stride = max_dispatched_tokens_per_expert;
 
-    // Set up packet headers from CB (cb_packet_header_id from compile-time args)
-    uint32_t experts_tok_counter_l1_addr = get_read_ptr(cb_experts_tok_counter_id);
-    volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(experts_tok_counter_l1_addr);
-
-    for (uint32_t local_expert = 0; local_expert < experts_per_chip; local_expert++) {
-        DPRINT_COMBINE << "Local expert=" << local_expert << ENDL();
+    // Process each expert in assigned range
+    for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
         uint32_t end_page = start_page + expert_tokens;
 
-        DPRINT_COMBINE << "  Tokens for expert: " << expert_tokens << " (pages [" << start_page << "," << end_page
-                       << "))" << ENDL();
+        DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();
 
-        for (uint32_t token = start_page; token < end_page; token++) {
-            // DPRINT_COMBINE << "    Fetching token index/page: " << token << ENDL();
-            cb_reserve_back(cb_dispatched_buffer_id, 1);
-            cb_reserve_back(cb_dispatched_metadata_id, 1);
-
-            uint32_t l1_buffer_write_addr = get_write_ptr(cb_dispatched_buffer_id);
-            noc_async_read_page(token, dispatched_buffer_addr_gen, l1_buffer_write_addr);
-            uint32_t l1_metadata_write_addr = get_write_ptr(cb_dispatched_metadata_id);
-            noc_async_read_page(token, dispatched_metadata_addr_gen, l1_metadata_write_addr);
+        // Prefetch first batch
+        uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
+        uint32_t first_batch_count = first_batch_end - start_page;
+        if (first_batch_count > 0) {
+            for (uint32_t t = 0; t < first_batch_count; t++) {
+                noc_async_read_page(
+                    start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
+                noc_async_read_page(
+                    start_page + t,
+                    dispatched_metadata_addr_gen,
+                    metadata_base + t * aligned_dispatched_metadata_page_size);
+            }
             noc_async_read_barrier();
-            cb_push_back(cb_dispatched_buffer_id, 1);
-            cb_push_back(cb_dispatched_metadata_id, 1);
+        }
+
+        for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
+            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
+            uint32_t batch_count = batch_end - batch_start;
+            bool batch_did_local_write = false;
+
+            for (uint32_t t = 0; t < batch_count; t++) {
+                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
+                uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
+                volatile tt_l1_ptr uint32_t* metadata =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_scratch_addr);
+
+                auto dst_chip = metadata[0];
+                auto dst_token_idx = metadata[1];
+                auto dst_topk_indice = metadata[2];
+                uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
+
+                if (dst_chip == linearized_mesh_coord) {
+                    noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
+                    noc_async_writes_flushed();
+                    batch_did_local_write = true;
+                } else {
+                    if constexpr (is_1d_topology<topology>()) {
+                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
+                        uint32_t distance =
+                            manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
+
+                        // Push route info to writer
+                        cb_reserve_back(cb_route_info_id, 1);
+                        volatile tt_l1_ptr uint32_t* route_info =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
+                        route_info[0] = route;
+                        route_info[1] = distance;
+                        route_info[2] = output_page_idx;
+                        route_info[3] = 0;
+                        cb_push_back(cb_route_info_id, 1);
+
+                        // Push output payload to writer
+                        cb_reserve_back(cb_output_for_writer_id, 1);
+                        uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
+                        noc_async_read(
+                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_output_for_writer_id, 1);
+                    }
+                }
+            }
+
+            // Issue next batch reads BEFORE write barrier
+            uint32_t next_batch_start = batch_start + read_batch_size;
+            bool has_next_batch = (next_batch_start < end_page);
+            if (has_next_batch) {
+                uint32_t next_batch_end =
+                    (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
+                uint32_t next_batch_count = next_batch_end - next_batch_start;
+                for (uint32_t t = 0; t < next_batch_count; t++) {
+                    noc_async_read_page(
+                        next_batch_start + t,
+                        dispatched_buffer_addr_gen,
+                        buffer_base + t * aligned_dispatched_buffer_page_size);
+                    noc_async_read_page(
+                        next_batch_start + t,
+                        dispatched_metadata_addr_gen,
+                        metadata_base + t * aligned_dispatched_metadata_page_size);
+                }
+            }
+
+            if (batch_did_local_write) {
+                noc_async_write_barrier();
+            }
+
+            if (has_next_batch) {
+                noc_async_read_barrier();
+            }
         }
     }
+
+    // Push sentinel to signal writer that all dispatches are done
+    cb_reserve_back(cb_route_info_id, 1);
+    volatile tt_l1_ptr uint32_t* route_info =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
+    route_info[0] = ROUTE_INFO_SENTINEL;
+    route_info[1] = 0;
+    route_info[2] = 0;
+    route_info[3] = 0;
+    cb_push_back(cb_route_info_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -2,20 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Prefill combine writer kernel
-// This kernel receives combined data from CBs and writes to output tensor
-
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
-#include "api/debug/assert.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
-// Debug print control - set to 0 to disable combine debug prints, 1 to enable
 #define ENABLE_COMBINE_DEBUG 0
-
 #if ENABLE_COMBINE_DEBUG
 #define DPRINT_COMBINE DPRINT
 #else
@@ -24,57 +18,63 @@
     DebugPrinter()
 #endif
 
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
 void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-3)
+    // CB IDs (indices 0-5)
     constexpr uint32_t cb_dispatched_buffer_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_dispatched_metadata_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_output_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_output_for_writer_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(5);
 
-    // Page counts (indices 4-7)
-    constexpr uint32_t dispatched_buffer_pages = get_compile_time_arg_val(4);
-    constexpr uint32_t dispatched_metadata_pages = get_compile_time_arg_val(5);
-    constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(7);
+    // Page counts (indices 6-9)
+    constexpr uint32_t dispatched_buffer_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t dispatched_metadata_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(9);
 
-    // Page sizes (indices 8-11)
-    constexpr uint32_t dispatched_buffer_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t dispatched_metadata_page_size = get_compile_time_arg_val(9);
-    constexpr uint32_t experts_tok_counter_page_size = get_compile_time_arg_val(10);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(11);
+    // Page sizes (indices 10-13)
+    constexpr uint32_t dispatched_buffer_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t dispatched_metadata_page_size = get_compile_time_arg_val(11);
+    constexpr uint32_t experts_tok_counter_page_size = get_compile_time_arg_val(12);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(13);
 
-    // Operation parameters (indices 12-16)
-    constexpr uint32_t num_chips = get_compile_time_arg_val(12);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(13);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(14);
-    constexpr uint32_t seq_len_per_chip = get_compile_time_arg_val(15);
-    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(16);
+    // Operation parameters (indices 14-18)
+    constexpr uint32_t num_chips = get_compile_time_arg_val(14);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(16);
+    constexpr uint32_t seq_len_per_chip = get_compile_time_arg_val(17);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(18);
 
-    // Hidden dimension (index 17)
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(17);
+    // Hidden dimension (index 19)
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(19);
 
-    // Aligned page sizes (indices 18-21)
-    constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(20);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(21);
+    // Aligned page sizes (indices 20-23)
+    constexpr uint32_t aligned_dispatched_buffer_page_size = get_compile_time_arg_val(20);
+    constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(21);
+    constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(22);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(23);
 
-    // Mesh information (indices 22-26)
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(22);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(23);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(24);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(25);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(26);
+    // Mesh information (indices 24-28)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(28);
 
-    // Fabric configuration (indices 27-30)
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(27);
-    constexpr uint32_t l1_alignment = get_compile_time_arg_val(28);
-    constexpr uint32_t num_links = get_compile_time_arg_val(29);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(30);
+    // Fabric configuration (indices 29-32)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(29);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(30);
+    constexpr uint32_t num_links = get_compile_time_arg_val(31);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(32);
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 31)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<31>();
+    // TensorAccessorArgs for all 4 tensors (starting at index 33)
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<33>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =
@@ -88,80 +88,56 @@ void kernel_main() {
     uint32_t experts_tok_counter_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t output_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t zero_init_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t zero_init_semaphore_address = get_semaphore(zero_init_semaphore_id);  // Local semaphore
-    uint32_t init_semaphore_address =
-        get_arg_val<uint32_t>(rt_args_idx++);  // Global semaphore (address passed directly)
+    uint32_t init_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t zero_init_barrier_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_cores = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
 
-    // Fabric connection args follow (appended by append_fabric_connection_rt_args)
+    uint32_t zero_init_semaphore_address = get_semaphore(zero_init_semaphore_id);
+    uint32_t zero_init_barrier_l1_offset = get_semaphore(zero_init_barrier_semaphore_id);
 
-    // Print key compile time args for debugging (RISCV_0)
-    DPRINT_COMBINE << "Combine Writer: CBs=" << cb_dispatched_buffer_id << "," << cb_dispatched_metadata_id << ","
-                   << cb_experts_tok_counter_id << "," << cb_output_id << " num_chips=" << num_chips
-                   << " experts_per_chip=" << experts_per_chip << " num_experts_per_tok=" << num_experts_per_tok
-                   << " seq_len_per_chip=" << seq_len_per_chip
-                   << " max_dispatched_tokens_per_expert=" << max_dispatched_tokens_per_expert
-                   << " hidden_size=" << hidden_size << " linearized_mesh_coord" << linearized_mesh_coord
-                   << " src_mesh_id=" << src_mesh_id << " src_chip_id=" << src_chip_id << " mesh_rows=" << mesh_rows
-                   << " mesh_cols=" << mesh_cols << ENDL();
-
-#ifdef DEST_CHIP_ID
-    // Fabric is enabled - set up connections
-    using namespace ttnn::operations::ccl::common;
+    // Read NOC coordinates for all cores (for inter-core barrier signaling)
+    uint64_t all_core_barrier_noc_addrs[2];
+    for (uint32_t c = 0; c < num_cores; c++) {
+        uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+        all_core_barrier_noc_addrs[c] = get_noc_addr(noc_x, noc_y, zero_init_barrier_l1_offset);
+    }
 
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
-    constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
-    constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
-    constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
-
-    constexpr uint32_t dispatch_index = axis == ReplicateGroup::COLS ? row : col;
-    constexpr uint32_t device_begin_idx = axis == ReplicateGroup::COLS ? col : row * mesh_cols;
-    constexpr uint32_t device_end_idx =
-        (axis == ReplicateGroup::COLS) ? (col + mesh_rows * mesh_cols) : (row * mesh_cols + mesh_cols);
-    constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
+    constexpr uint32_t combine_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
 #else
     constexpr ReplicateGroup axis = ReplicateGroup::NONE;
-    constexpr uint32_t dispatch_devices = num_chips;
-    constexpr uint32_t dispatch_index = linearized_mesh_coord;
-    constexpr uint32_t device_begin_idx = 0;
-    constexpr uint32_t device_end_idx = num_chips;
-    constexpr uint32_t device_stride = 1;
+    constexpr uint32_t combine_devices = num_chips;
 #endif
 
-    DPRINT_COMBINE << "dispatch_devices=" << dispatch_devices << " axis=" << (int)axis
-                   << " device_begin_idx=" << device_begin_idx << " device_end_idx=" << device_end_idx
-                   << " device_stride=" << device_stride << ENDL();
+    DPRINT_COMBINE << "Combine Writer: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
+                   << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
-    DPRINT_COMBINE << "Fabric enabled: num_links=" << num_links << " topology=" << (uint32_t)topology << ENDL();
-
-    constexpr uint32_t num_devices = mesh_rows * mesh_cols;
-    constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
-    constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
-    constexpr std::array<bool, 4> directions = DIRECTIONS;
-
-    DPRINT_COMBINE << "Opening fabric connections async..." << ENDL();
-    std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
-    open_direction_connections_async(directions, fabric_connections, rt_args_idx);
-
-    // Set up packet header from CB (cb_id 4)
-    constexpr uint32_t cb_packet_header_id = 4;
-    uint32_t packet_header_buffer_address = get_read_ptr(cb_packet_header_id);
-    auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
-
-    DPRINT_COMBINE << "Waiting for fabric connections barrier..." << ENDL();
-    open_direction_connections_barrier(directions, fabric_connections);
-
-    // Wait for local reader to complete zero-init (or signal if INIT_ZEROS=0)
-    DPRINT_COMBINE << "Waiting for local reader zero-init..." << ENDL();
+    // Wait for reader to complete zero-init
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_wait(zero_init_sem_ptr, 1);
-    noc_semaphore_set(zero_init_sem_ptr, 0);
-    DPRINT_COMBINE << "Local reader zero-init done" << ENDL();
 
-    // Send init semaphore to all devices (fabric aand zeros completed)
+#ifdef DEST_CHIP_ID
+    constexpr uint8_t dest_chip_ids[num_chips] = DEST_CHIP_ID;
+    constexpr uint8_t dest_mesh_ids[num_chips] = DEST_MESH_ID;
+    constexpr std::array<bool, 4> directions = DIRECTIONS;
+
+    std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
+    open_direction_connections_async(directions, fabric_connections, rt_args_idx);
+
+    uint32_t packet_header_buffer_address = get_read_ptr(cb_packet_header_id);
+    auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
+    auto* sem_packet_header =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
+
+    open_direction_connections_barrier(directions, fabric_connections);
+
+    // Init semaphore exchange
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-    DPRINT_COMBINE << "Sending init semaphore to configured targets..." << ENDL();
     send_init_semaphore_to_configured_targets<
         linearized_mesh_coord,
         topology,
@@ -169,93 +145,66 @@ void kernel_main() {
         mesh_rows,
         mesh_cols,
         axis,
-        num_devices>(fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
+        num_chips>(fabric_connections, sem_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
 
-    // Wait for all devices to complete fabric initialization
-    DPRINT_COMBINE << "Waiting for all devices to complete fabric init..." << ENDL();
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
-    noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
+    noc_semaphore_wait(init_sem_ptr, combine_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
 
-    DPRINT_COMBINE << "Fabric and zero-init setup complete" << ENDL();
+    DPRINT_COMBINE << "Fabric setup complete" << ENDL();
 #endif
 
-    cb_wait_front(cb_experts_tok_counter_id, 1);
-    DPRINT_COMBINE << "cb_experts_tok_counter_id: " << cb_experts_tok_counter_id << ENDL();
-    uint32_t experts_tok_counter_cb_addr = get_read_ptr(cb_experts_tok_counter_id);
-    volatile tt_l1_ptr uint32_t* experts_tok_counter =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(experts_tok_counter_cb_addr);
+    // Signal ALL readers that global init exchange is done.
+    // Each writer increments every reader's barrier sem so each reader
+    // collects num_cores signals before proceeding.
+    for (uint32_t c = 0; c < num_cores; c++) {
+        noc_semaphore_inc(all_core_barrier_noc_addrs[c], 1);
+    }
+    noc_async_write_barrier();
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr, aligned_output_page_size);
 
-    for (uint32_t expert_idx = 0; expert_idx < experts_per_chip; ++expert_idx) {
-        DPRINT_COMBINE << "Processing expert " << expert_idx << "/" << experts_per_chip << ENDL();
-        for (uint32_t tok_idx = 0; tok_idx < experts_tok_counter[expert_idx]; ++tok_idx) {
-            cb_wait_front(cb_dispatched_buffer_id, 1);
-            cb_wait_front(cb_dispatched_metadata_id, 1);
+    // Sentinel-terminated fabric send loop
+    while (true) {
+        cb_wait_front(cb_route_info_id, 1);
+        volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
-            uint32_t buffer_cb_addr = get_read_ptr(cb_dispatched_buffer_id);
-            uint32_t metadata_cb_addr = get_read_ptr(cb_dispatched_metadata_id);
-            volatile tt_l1_ptr uint32_t* metadata = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_cb_addr);
-
-            auto dst_chip = metadata[0];
-            auto dst_token_idx = metadata[1];
-            auto dst_topk_indice = metadata[2];
-
-            DPRINT_COMBINE << "  Token " << tok_idx << "/" << experts_tok_counter[expert_idx]
-                           << ": dst_chip=" << dst_chip << " dst_token_idx=" << dst_token_idx
-                           << " dst_topk_indice=" << dst_topk_indice << ENDL();
-
-            // Calculate output page index
-            // Output shape: (num_chips, seq_len_per_chip, num_experts_per_tok, hidden_dim)
-            // Pages are laid out as: token * num_experts_per_tok + topk_indice
-            uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
-
-            if (dst_chip == linearized_mesh_coord) {
-                // DPRINT_COMBINE << "    Token" << dst_token_idx << " is local to this chip." << ENDL();
-                // Local write - direct NOC write to DRAM
-                noc_async_write_page(output_page_idx, output_addr_gen, buffer_cb_addr);
-                noc_async_writes_flushed();
-            } else {
-                // Remote write via fabric
-                // DPRINT_COMBINE << "    Token" << dst_token_idx << " is remote to this chip. Destination chip: "
-                //                << dst_chip << ENDL();
-#ifdef DEST_CHIP_ID
-                if constexpr (is_1d_topology<topology>()) {
-                    fabric_send_chip_unicast_noc_unicast_1d<
-                        linearized_mesh_coord,
-                        topology,
-                        mesh_rows,
-                        mesh_cols,
-                        fabric_max_packet_size>(
-                        output_addr_gen,
-                        fabric_connections,
-                        unicast_packet_header,
-                        dst_chip,
-                        buffer_cb_addr,
-                        output_page_idx,
-                        (int)aligned_output_page_size,
-                        l1_alignment);
-                } else {
-                    // Not implemented
-                    DPRINT << "Error: 2D topology fabric not implemented." << ENDL();
-                    ASSERT(false, "2D topology fabric not implemented");
-                    return;
-                }
-#endif
-            }
-
-            noc_async_write_barrier();
-
-            cb_pop_front(cb_dispatched_buffer_id, 1);
-            cb_pop_front(cb_dispatched_metadata_id, 1);
+        uint32_t route = route_info[0];
+        if (route == ROUTE_INFO_SENTINEL) {
+            cb_pop_front(cb_route_info_id, 1);
+            break;
         }
+        uint32_t distance = route_info[1];
+        uint32_t output_page_idx = route_info[2];
+        cb_pop_front(cb_route_info_id, 1);
+
+        cb_wait_front(cb_output_for_writer_id, 1);
+        uint32_t output_data_addr = get_read_ptr(cb_output_for_writer_id);
+
+        DPRINT_COMBINE << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << output_page_idx
+                       << ENDL();
+
+#ifdef DEST_CHIP_ID
+        fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+        fabric_send_noc_unicast<fabric_max_packet_size>(
+            output_addr_gen,
+            fabric_connections[route],
+            unicast_packet_header,
+            output_data_addr,
+            output_page_idx,
+            (int)aligned_output_page_size,
+            l1_alignment);
+
+        noc_async_write_barrier();
+#endif
+
+        cb_pop_front(cb_output_for_writer_id, 1);
     }
 
+#ifdef DEST_CHIP_ID
+    // Exit semaphore exchange
     {
-        // Send exit semaphore to all devices
-        const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-        DPRINT_COMBINE << "Sending exit semaphore to configured targets..." << ENDL();
+        const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
             topology,
@@ -263,21 +212,15 @@ void kernel_main() {
             mesh_rows,
             mesh_cols,
             axis,
-            num_devices>(
-            fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
+            num_chips>(
+            fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, exit_noc_semaphore_addr);
 
-        // Wait for all devices to complete fabric initialization
-        DPRINT_COMBINE << "Waiting for all devices to complete fabric transfers..." << ENDL();
-        volatile tt_l1_ptr uint32_t* init_sem_ptr =
+        volatile tt_l1_ptr uint32_t* exit_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
-        noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
-        noc_semaphore_set(init_sem_ptr, 0);
-
-        DPRINT_COMBINE << "Fabric transfers complete" << ENDL();
+        noc_semaphore_wait(exit_sem_ptr, combine_devices - 1);
+        noc_semaphore_set(exit_sem_ptr, 0);
     }
 
-#ifdef DEST_CHIP_ID
-    // Close fabric connections to prevent resource conflicts with subsequent operations
     close_direction_connections(directions, fabric_connections);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -122,8 +122,9 @@ void kernel_main() {
     noc_semaphore_wait(zero_init_sem_ptr, 1);
 
 #ifdef DEST_CHIP_ID
-    constexpr uint8_t dest_chip_ids[num_chips] = DEST_CHIP_ID;
-    constexpr uint8_t dest_mesh_ids[num_chips] = DEST_MESH_ID;
+    constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;
+    constexpr uint8_t dest_chip_ids[total_mesh_devices] = DEST_CHIP_ID;
+    constexpr uint8_t dest_mesh_ids[total_mesh_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
@@ -145,7 +146,8 @@ void kernel_main() {
         mesh_rows,
         mesh_cols,
         axis,
-        num_chips>(fabric_connections, sem_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
+        total_mesh_devices>(
+        fabric_connections, sem_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
 
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, combine_devices - 1);
@@ -212,7 +214,7 @@ void kernel_main() {
             mesh_rows,
             mesh_cols,
             axis,
-            num_chips>(
+            total_mesh_devices>(
             fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, exit_noc_semaphore_addr);
 
         volatile tt_l1_ptr uint32_t* exit_sem_ptr =

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -120,6 +120,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_wait(zero_init_sem_ptr, 1);
+    noc_semaphore_set(zero_init_sem_ptr, 0);
 
 #ifdef DEST_CHIP_ID
     constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -350,7 +350,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         // Fabric configuration (4)
         (uint32_t)fabric_max_packet_size,
         l1_alignment,
-        (uint32_t)std::min(operation_attributes.num_links, 1u),
+        static_cast<uint32_t>(operation_attributes.num_links),
         static_cast<uint32_t>(topology),
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -149,28 +149,24 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    // When num_links=0 (fabric disabled), we use 1 core for local dispatch
-    uint32_t effective_num_links = std::max(num_links, 1u);
+    uint32_t effective_num_links = num_links >= 2 ? 2u : 1u;
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
-        "Not enough cores {} to send all links {}",
+        "Not enough cores {} for {} links",
         subdevice_cores.size(),
         effective_num_links);
 
-    // Figure out worker cores
     auto logical_volume = input_tensor.logical_shape().volume();
     auto hidden_size = input_tensor.logical_shape()[-1];
     auto tokens_per_device = logical_volume / hidden_size;
 
-    // effective_num_links already calculated above (when num_links=0, use 1 core for local dispatch)
-    uint32_t tokens_per_core = tt::div_up(tokens_per_device, effective_num_links);
-    uint32_t num_cores = std::min<uint32_t>(effective_num_links, tt::div_up(tokens_per_device, tokens_per_core));
+    uint32_t num_cores = effective_num_links;
     log_debug(
         tt::LogOp,
-        "num_links{}: tokens_per_device: {}, tokens_per_core: {}, num_cores: {}",
+        "num_links: {}, effective_num_links: {}, tokens_per_device: {}, num_cores: {}",
         num_links,
+        effective_num_links,
         tokens_per_device,
-        tokens_per_core,
         num_cores);
     auto sender_core_grid = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
         subdevice_cores.at(0), num_cores, worker_core_range_set, true);
@@ -182,67 +178,83 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         mesh_coordinate[1],
         sender_cores);
 
-    // Create reader CBs
+    constexpr uint32_t read_batch_size = 8;
+    const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
+
+    // c_0: input scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
-        program, sender_core_grid, input_tensor, /*buffering_factor=*/3, /*cb_id=*/tt::CBIndex::c_0, "input_tensor");
+        program,
+        sender_core_grid,
+        input_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_0,
+        "input_scratch");
+    // c_1: indices scratch (reader-only)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         indices_tensor,
-        /*buffering_factor=*/3,
+        /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_1,
-        "indices_tensor");
+        "indices_scratch");
+    // c_2: weights scratch (reader-only)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         weights_tensor,
-        /*buffering_factor=*/3,
+        /*buffering_factor=*/read_batch_size,
         /*cb_id=*/tt::CBIndex::c_2,
-        "weights_tensor");
+        "weights_scratch");
+    // c_3: offsets (reader-only, full tensor)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         offsets_tensor,
-        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),  // everyone reads entire offsets tensor
+        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
         /*cb_id=*/tt::CBIndex::c_3,
         "offsets_tensor");
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        dispatch_table_tensor,
-        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),  // everyone reads entire dispatch table
-        /*cb_id=*/tt::CBIndex::c_9,
-        "dispatch_table_tensor");
 
-    // create writer CBs
+    // c_4: route_info (reader->writer, 4 x uint32_t per entry)
+    {
+        uint32_t route_info_page_size = l1_alignment;
+        constexpr uint32_t route_info_buffering = 16;
+        tt::tt_metal::CircularBufferConfig route_info_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                route_info_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
+                .set_page_size(tt::CBIndex::c_4, route_info_page_size);
+        tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
+    }
+
+    // c_5: payload_for_writer (reader->writer, input pages for fabric sends)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/2,
-        /*cb_id=*/tt::CBIndex::c_4,
-        "output_tensor");
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        metadata_tensor,
-        /*buffering_factor=*/2,
+        input_tensor,
+        /*buffering_factor=*/16,
         /*cb_id=*/tt::CBIndex::c_5,
-        "metadata_tensor");
-
-    // Create CB for temporary metadata buffer (used by writer kernel)
+        "payload_for_writer");
+    // c_6: metadata_for_writer (reader->writer, metadata pages for fabric sends)
     detail::create_tensor_cb(
         program,
         sender_core_grid,
         metadata_tensor,
-        /*buffering_factor=*/1,  // Only need 1 page at a time
+        /*buffering_factor=*/16,
+        /*cb_id=*/tt::CBIndex::c_6,
+        "metadata_for_writer");
+
+    // c_7: metadata_temp (reader-only, for constructing metadata locally)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        metadata_tensor,
+        /*buffering_factor=*/1,
         /*cb_id=*/tt::CBIndex::c_7,
         "metadata_temp_buffer");
 
     const auto [neighbors, directions] =
         ccl::common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
 
-    // Create packet header CB for fabric sends (if fabric is enabled)
+    // c_8: packet header CB for fabric sends (writer-only)
     if (operation_attributes.num_links > 0) {
         constexpr uint32_t num_packet_headers = 2;  // unicast + metadata
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
@@ -252,15 +264,17 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
             tt::tt_metal::CircularBufferConfig(packet_header_cb_size, {{tt::CBIndex::c_8, tt::DataFormat::UInt8}})
                 .set_page_size(tt::CBIndex::c_8, packet_header_size_bytes);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, packet_header_cb_config);
-
-        log_debug(
-            tt::LogOp,
-            "Created packet header CB: packet_header_size_bytes={}, total_cb_size={}, num_headers={}, topology={}",
-            packet_header_size_bytes,
-            packet_header_cb_size,
-            num_packet_headers,
-            static_cast<int>(topology));
     }
+
+    // c_9: dispatch_table (reader-only, full tensor)
+    detail::create_tensor_cb(
+        program,
+        sender_core_grid,
+        dispatch_table_tensor,
+        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
+        /*cb_id=*/tt::CBIndex::c_9,
+        "dispatch_table_tensor");
+
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
     for (const auto& coord : tensor_coords.coords()) {
         auto dest_fabric_node_id = mesh_device->get_fabric_node_id(coord);
@@ -272,21 +286,19 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     log_debug(tt::LogOp, "directions: {}", ccl::common::stringify(directions));
 
     auto fabric_max_packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
-    const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     log_debug(
         tt::LogOp, "Fabric max packet size: {} bytes, L1 alignment: {} bytes", fabric_max_packet_size, l1_alignment);
 
-    // tt::tt_metal::KernelHandle reader_kernel_id{};  // placeholder
-    // tt::tt_metal::KernelHandle writer_kernel_id{};  // placeholder
-    // std::vector<CoreCoord> cores;                   // placeholder
-
-    // create reader kernel
-    std::vector<uint32_t> reader_compile_time_args = {
-        // CB IDs (7)
+    // Compile-time args shared by reader and writer
+    std::vector<uint32_t> compile_time_args = {
+        // CB IDs (10)
         static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id
         static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
         static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
         static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
+        static_cast<uint32_t>(tt::CBIndex::c_4),  // cb_route_info_id
+        static_cast<uint32_t>(tt::CBIndex::c_5),  // cb_payload_for_writer_id
+        static_cast<uint32_t>(tt::CBIndex::c_6),  // cb_metadata_for_writer_id
         static_cast<uint32_t>(tt::CBIndex::c_7),  // cb_metadata_temp_id
         static_cast<uint32_t>(tt::CBIndex::c_8),  // cb_packet_header_id
         static_cast<uint32_t>(tt::CBIndex::c_9),  // cb_dispatch_table_id
@@ -338,23 +350,30 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         // Fabric configuration (4)
         (uint32_t)fabric_max_packet_size,
         l1_alignment,
-        operation_attributes.num_links,
+        (uint32_t)std::min(operation_attributes.num_links, 1u),
         static_cast<uint32_t>(topology),
     };
 
     // Append TensorAccessorArgs for all 7 tensors
-    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(compile_time_args);
 
-    std::map<std::string, std::string> reader_defines;
-    if (operation_attributes.axis.has_value()) {
-        reader_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
+    // Both reader and writer get fabric defines so the reader can compute routes
+    std::map<std::string, std::string> fabric_defines;
+    if (operation_attributes.num_links > 0) {
+        fabric_defines["DEST_CHIP_ID"] = ccl::common::stringify(dest_chip_id);
+        fabric_defines["DEST_MESH_ID"] = ccl::common::stringify(dest_mesh_id);
+        fabric_defines["DIRECTIONS"] = ccl::common::stringify(directions);
     }
+    if (operation_attributes.axis.has_value()) {
+        fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
+    }
+
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
@@ -363,28 +382,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-            .compile_args = reader_compile_time_args,
-            .defines = reader_defines});
-
-    // create writer kernel - shares same compile time args as reader
-    const auto& writer_compile_time_args = reader_compile_time_args;
-
-    // Code-gen a mesh-position to fabric chip ID array for the writer kernel
-    // Code-gen a mesh-position to mesh-id array for the writer kernel
-    // Code-gen a direction array that is set to true when a direction has a valid connection (when a neighbor exists or
-    // if it's along a valid cluster axis)
-    std::map<std::string, std::string> writer_defines;
-
-    // Only enable fabric if num_links > 0 (explicitly requested by user)
-    if (operation_attributes.num_links > 0) {
-        writer_defines["DEST_CHIP_ID"] = ccl::common::stringify(dest_chip_id);
-        writer_defines["DEST_MESH_ID"] = ccl::common::stringify(dest_mesh_id);
-        writer_defines["DIRECTIONS"] = ccl::common::stringify(directions);
-    }
-
-    if (operation_attributes.axis.has_value()) {
-        writer_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
-    }
+            .compile_args = compile_time_args,
+            .defines = fabric_defines});
 
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -394,11 +393,11 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
-            .compile_args = writer_compile_time_args,
-            .defines = writer_defines});
+            .compile_args = compile_time_args,
+            .defines = fabric_defines});
 
-    // Set up runtime args for all cores
-    std::vector<uint32_t> reader_runtime_args = {
+    // Runtime args: all cores process all tokens, experts split round-robin
+    std::vector<uint32_t> base_runtime_args = {
         input_tensor.buffer()->address(),
         indices_tensor.buffer()->address(),
         weights_tensor.buffer()->address(),
@@ -408,53 +407,40 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         dispatch_table_tensor.buffer()->address(),
         (uint32_t)cross_device_semaphore.address(),
         (uint32_t)init_semaphore.address(),
-        0,  // token_start_idx (set per core)
-        0,  // token_end_idx (set per core)
+        0,                            // token_start_idx (all tokens)
+        (uint32_t)tokens_per_device,  // token_end_idx (all tokens)
+        0,                            // dispatch_core_idx (set per core)
+        num_cores,                    // num_dispatch_cores
     };
 
-    // Distribute work across cores
-    uint32_t tokens_per_core_start = 0;
+    uint32_t core_idx = 0;
     for (const auto& sender_core : sender_cores) {
-        std::vector<uint32_t> writer_runtime_args = reader_runtime_args;  // Copy base args
+        std::vector<uint32_t> reader_runtime_args = base_runtime_args;
+        std::vector<uint32_t> writer_runtime_args = base_runtime_args;
 
-        // Set token range for this core
-        reader_runtime_args[9] = tokens_per_core_start;  // token_start_idx
-        reader_runtime_args[10] =
-            std::min(tokens_per_core_start + tokens_per_core, (uint32_t)tokens_per_device);  // token_end_idx
-        writer_runtime_args[9] = tokens_per_core_start;
-        writer_runtime_args[10] = reader_runtime_args[10];
+        reader_runtime_args[11] = core_idx;
+        writer_runtime_args[11] = core_idx;
 
-        tokens_per_core_start = reader_runtime_args[10];
-
-        // Append fabric connection args for each neighbor (only if fabric is enabled)
         if (operation_attributes.num_links > 0) {
+            uint32_t core_link = core_idx % num_links;
             for (const auto& neighbor_coordinate : neighbors) {
-                // Skip self-connections (same chip)
                 if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
-                    log_debug(
-                        tt::LogOp,
-                        "Skipping self-connection for mesh coord ({}, {}) at core {}",
-                        mesh_coordinate[0],
-                        mesh_coordinate[1],
-                        sender_core);
                     continue;
                 }
 
                 log_debug(
                     tt::LogOp,
-                    "Connection between mesh coord ({}, {}) and ({}, {}) at core {} and handles "
-                    "token indices from {} to {}",
+                    "Connection between mesh coord ({}, {}) and ({}, {}) at core {} link {}",
                     mesh_coordinate[0],
                     mesh_coordinate[1],
                     neighbor_coordinate[0],
                     neighbor_coordinate[1],
                     sender_core,
-                    reader_runtime_args[9],
-                    reader_runtime_args[10]);
+                    core_link);
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     src_fabric_node_id,
                     mesh_device->get_fabric_node_id(neighbor_coordinate),
-                    0,  // link_id - use 0 for single link
+                    core_link,
                     program,
                     sender_core,
                     writer_runtime_args);
@@ -463,7 +449,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
 
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, sender_core, reader_runtime_args);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, sender_core, writer_runtime_args);
-        // link_id++;  // Unused when fabric connection setup is disabled
+        core_idx++;
     }
 
     return {
@@ -493,7 +479,6 @@ void DispatchProgramFactory::override_runtime_arguments(
             auto& reader_runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
             auto& writer_runtime_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_id, core);
 
-            // Update buffer addresses for all 7 tensors (indices 0-6)
             reader_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
             reader_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
             reader_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
@@ -501,12 +486,9 @@ void DispatchProgramFactory::override_runtime_arguments(
             reader_runtime_args.at(4) = output_tensor.buffer()->address();
             reader_runtime_args.at(5) = metadata_tensor.buffer()->address();
             reader_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
-
-            // Update semaphore addresses (indices 7-8)
             reader_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
             reader_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
 
-            // Update writer runtime args (same first 9 args)
             writer_runtime_args.at(0) = tensor_args.input_tensor.buffer()->address();
             writer_runtime_args.at(1) = tensor_args.indices_tensor.buffer()->address();
             writer_runtime_args.at(2) = tensor_args.weights_tensor.buffer()->address();
@@ -516,8 +498,6 @@ void DispatchProgramFactory::override_runtime_arguments(
             writer_runtime_args.at(6) = tensor_args.expert_dispatch_table_tensor.buffer()->address();
             writer_runtime_args.at(7) = (uint32_t)shared_variables.cross_device_semaphore.address();
             writer_runtime_args.at(8) = (uint32_t)shared_variables.init_semaphore.address();
-
-            // Note: token ranges (indices 9-10) and fabric args remain unchanged
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -149,7 +149,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    uint32_t effective_num_links = num_links >= 2 ? 2u : 1u;
+    uint32_t effective_num_links = std::min(num_links, 4u);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Prefill dispatch reader kernel
-
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
-// Debug print control - set to 0 to disable dispatch debug prints, 1 to enable
 #define ENABLE_DISPATCH_DEBUG 0
 
 #if ENABLE_DISPATCH_DEBUG
@@ -20,69 +18,76 @@
     DebugPrinter()
 #endif
 
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
 void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-6)
+    // CB IDs (indices 0-9)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
     constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(4);  // Added but not used by reader
-    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(5);  // Added but not used by reader
-    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
 
-    // Page counts (indices 7-13)
-    constexpr uint32_t input_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(8);
-    constexpr uint32_t weights_pages = get_compile_time_arg_val(9);
-    constexpr uint32_t offsets_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(12);
-    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(13);
+    // Page counts (indices 10-16)
+    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(13);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(14);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
 
-    // Page sizes (indices 14-20)
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t weights_page_size = get_compile_time_arg_val(16);
-    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(20);
+    // Page sizes (indices 17-23)
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
+    constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(20);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(21);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
+    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(23);
 
-    // Operation parameters (indices 21-28)
-    constexpr uint32_t num_devices = get_compile_time_arg_val(21);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(22);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(23);
-    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(24);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(25);
-    constexpr uint32_t metadata_len = get_compile_time_arg_val(26);
-    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(27);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(28);
+    // Operation parameters (indices 24-31)
+    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(27);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(28);
+    constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(30);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(31);
 
-    // Mesh information (indices 29-33)
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(29);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(30);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(31);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(32);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(33);
+    // Mesh information (indices 32-36)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(32);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(33);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(34);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(35);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    // Aligned page sizes (indices 34-40)
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(34);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(35);
-    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(36);
-    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(37);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(38);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(40);
+    // Aligned page sizes (indices 37-43)
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(37);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(38);
+    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(39);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(41);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(42);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(43);
 
-    // Fabric configuration (indices 41-44)
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(41);
-    constexpr uint32_t l1_alignment = get_compile_time_arg_val(42);
-    constexpr uint32_t num_links = get_compile_time_arg_val(43);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(44);
+    // Fabric configuration (indices 44-47)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(44);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(45);
+    constexpr uint32_t num_links = get_compile_time_arg_val(46);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(47);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 45)
-    constexpr auto input_args = TensorAccessorArgs<45>();
+    // TensorAccessorArgs for all 7 tensors (starting at index 48)
+    constexpr auto input_args = TensorAccessorArgs<48>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
@@ -103,77 +108,194 @@ void kernel_main() {
     uint32_t init_semaphore_address = get_arg_val<uint32_t>(rt_args++);
     uint32_t token_start_idx = get_arg_val<uint32_t>(rt_args++);
     uint32_t token_end_idx = get_arg_val<uint32_t>(rt_args++);
+    uint32_t dispatch_core_idx = get_arg_val<uint32_t>(rt_args++);
+    uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args++);
+    uint32_t core_mask = num_dispatch_cores - 1;
 
-    // Print key compile time args for debugging (using DPRINT_DATA1 - reader runs on RISCV_1)
-    DPRINT_DISPATCH << "Reader kernel: CBs=" << cb_input_id << "," << cb_indices_id << "," << cb_weights_id << ","
-                    << cb_offsets_id << " tokens=[" << token_start_idx << "," << token_end_idx << ")"
-                    << " hidden_size=" << hidden_size << " experts_per_chip=" << experts_per_chip
-                    << " token_start_idx=" << token_start_idx << " token_end_idx=" << token_end_idx << ENDL();
+#ifdef AXIS
+    constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
+    constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
+    constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
+    constexpr uint32_t device_begin_idx = axis == ReplicateGroup::COLS ? col : row * mesh_cols;
+    constexpr uint32_t device_end_idx =
+        (axis == ReplicateGroup::COLS) ? (col + mesh_rows * mesh_cols) : (row * mesh_cols + mesh_cols);
+    constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
+#else
+    constexpr ReplicateGroup axis = ReplicateGroup::NONE;
+    constexpr uint32_t device_begin_idx = 0;
+    constexpr uint32_t device_end_idx = num_devices;
+    constexpr uint32_t device_stride = 1;
+#endif
 
-    // =====
-    // input (chips/fractured ==1, seq_len_per_chip, hidden_size)
-    // indices (chips/fractured ==1, seq_len_per_chip, k) - topk indices
-    // weights (chips/fractured ==1, seq_len_per_chip, k) - topk weights
-    // dispatch buffer (chips/fractured ==1, experts_per_chip, max_dispatched_tokens_per_expert, hidden_size)
-    // dispatch metadata buffer (chips/fractured ==1, experts_per_chip, max_dispatched_tokens_per_expert, metadata_len)
-    // offsets (chips/fractured==1, n_routed_experts) - TODO: optimization dim-1 should be only experts this chip can
-    // dispatch to; experts counter (chips/fractured ==1, experts_per_chip)
-    // =====
+    DPRINT_DISPATCH << "Reader kernel: tokens=[" << token_start_idx << "," << token_end_idx << ")"
+                    << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores << ENDL();
 
-    // =====
-    // read offsets
-    DPRINT_DISPATCH << "Fetching offset tensor offsets_pages=" << offsets_pages
-                    << " offset_page_size=" << offsets_page_size << ENDL();
+    // Read offsets into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address, offsets_page_size);
-    // Reserve all pages upfront, then manually increment write address per page
     cb_reserve_back(cb_offsets_id, offsets_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_offsets_id);
+    uint32_t offsets_base_addr = get_write_ptr(cb_offsets_id);
     for (uint32_t i = 0; i < offsets_pages; i++) {
-        DPRINT_DISPATCH << "Fetching offsets tensor index: " << i << ENDL();
-        noc_async_read_page(i, offsets_addr_gen, l1_write_addr);
-        l1_write_addr += aligned_offsets_page_size;
+        noc_async_read_page(i, offsets_addr_gen, offsets_base_addr + i * aligned_offsets_page_size);
     }
     noc_async_read_barrier();
-    cb_push_back(cb_offsets_id, offsets_pages);
+    int32_t* offsets = (int32_t*)offsets_base_addr;
 
-    // =====
-    // read expert dispatch table
-    DPRINT_DISPATCH << "Fetching dispatch table tensor dispatch_table_pages=" << dispatch_table_pages
-                    << " dispatch_table_page_size=" << dispatch_table_page_size << ENDL();
+    // Read dispatch table into local scratch
     const auto dispatch_table_addr_gen =
         TensorAccessor(dispatch_table_args, dispatch_table_tensor_address, dispatch_table_page_size);
-    // Reserve all pages upfront, then manually increment write address per page
     cb_reserve_back(cb_dispatch_table_id, dispatch_table_pages);
-    l1_write_addr = get_write_ptr(cb_dispatch_table_id);
+    uint32_t dispatch_table_base_addr = get_write_ptr(cb_dispatch_table_id);
     for (uint32_t i = 0; i < dispatch_table_pages; i++) {
-        DPRINT_DISPATCH << "Fetching dispatch table tensor index: " << i << ENDL();
-        noc_async_read_page(i, dispatch_table_addr_gen, l1_write_addr);
-        l1_write_addr += aligned_dispatch_table_page_size;
+        noc_async_read_page(
+            i, dispatch_table_addr_gen, dispatch_table_base_addr + i * aligned_dispatch_table_page_size);
     }
     noc_async_read_barrier();
-    cb_push_back(cb_dispatch_table_id, dispatch_table_pages);
+    int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
 
-    // =====
-    // read input, indices and weights and push to writer core CB
+    // Set up batched scratch buffers
+    constexpr uint32_t read_batch_size = 8;
+    cb_reserve_back(cb_indices_id, read_batch_size);
+    uint32_t indices_base = get_write_ptr(cb_indices_id);
+    cb_reserve_back(cb_weights_id, read_batch_size);
+    uint32_t weights_base = get_write_ptr(cb_weights_id);
+    cb_reserve_back(cb_input_id, read_batch_size);
+    uint32_t input_base = get_write_ptr(cb_input_id);
+
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
     const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
-    for (uint32_t token = token_start_idx; token < token_end_idx; token++) {
-        DPRINT_DISPATCH << "Fetching token index: " << token << ENDL();
-        cb_reserve_back(cb_indices_id, 1);
-        cb_reserve_back(cb_weights_id, 1);
-        cb_reserve_back(cb_input_id, 1);
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, aligned_output_page_size);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, aligned_metadata_page_size);
 
-        uint32_t l1_write_addr = get_write_ptr(cb_indices_id);
-        noc_async_read_page(token, indices_addr_gen, l1_write_addr);
-        l1_write_addr = get_write_ptr(cb_weights_id);
-        noc_async_read_page(token, weights_addr_gen, l1_write_addr);
-        l1_write_addr = get_write_ptr(cb_input_id);
-        noc_async_read_page(token, input_addr_gen, l1_write_addr);
+    // Reserve metadata temp for constructing metadata locally
+    cb_reserve_back(cb_metadata_temp_id, 1);
+    uint32_t metadata_temp_addr = get_write_ptr(cb_metadata_temp_id);
+
+    // Prefetch first batch of DRAM reads
+    uint32_t first_batch_end =
+        (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
+    uint32_t first_batch_count = first_batch_end - token_start_idx;
+    if (first_batch_count > 0) {
+        for (uint32_t t = 0; t < first_batch_count; t++) {
+            noc_async_read_page(token_start_idx + t, input_addr_gen, input_base + t * aligned_input_page_size);
+            noc_async_read_page(token_start_idx + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+            noc_async_read_page(token_start_idx + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+        }
         noc_async_read_barrier();
-        cb_push_back(cb_indices_id, 1);
-        cb_push_back(cb_weights_id, 1);
-        cb_push_back(cb_input_id, 1);
-        // Fetch input, weights and indices and push it to the writer core
     }
+
+    // Main batch loop
+    for (uint32_t batch_start = token_start_idx; batch_start < token_end_idx; batch_start += read_batch_size) {
+        uint32_t batch_end =
+            (batch_start + read_batch_size < token_end_idx) ? batch_start + read_batch_size : token_end_idx;
+        uint32_t batch_count = batch_end - batch_start;
+        bool batch_did_local_write = false;
+
+        for (uint32_t t = 0; t < batch_count; t++) {
+            uint32_t token_idx = batch_start + t;
+            uint32_t input_scratch_addr = input_base + t * aligned_input_page_size;
+            int32_t* indices = (int32_t*)(indices_base + t * aligned_indices_page_size);
+            uint16_t* weights = (uint16_t*)(weights_base + t * aligned_weights_page_size);
+
+            for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
+                auto routed_expert = indices[k];
+
+                if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
+                    continue;
+                }
+
+                auto expert_chip_og = expert_dispatch_table[routed_expert];
+                if (expert_chip_og == -1) {
+                    continue;
+                }
+                auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
+                auto expert_index_within_chip = routed_expert % experts_per_chip;
+                auto& offset = offsets[routed_expert];
+                auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + offset;
+
+                // Construct metadata
+                volatile tt_l1_ptr int32_t* metadata =
+                    reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
+                metadata[0] = linearized_mesh_coord;
+                metadata[1] = token_idx;
+                metadata[2] = k;
+                metadata[3] = routed_expert;
+                metadata[4] = static_cast<int16_t>(weights[k]);
+
+                if (expert_chip == linearized_mesh_coord) {
+                    noc_async_write_page(page_idx, output_addr_gen, input_scratch_addr);
+                    noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
+                    noc_async_writes_flushed();
+                    batch_did_local_write = true;
+                } else {
+                    if constexpr (is_1d_topology<topology>()) {
+                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                        uint32_t distance =
+                            manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+
+                        // Push route info to writer
+                        cb_reserve_back(cb_route_info_id, 1);
+                        volatile tt_l1_ptr uint32_t* route_info =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
+                        route_info[0] = route;
+                        route_info[1] = distance;
+                        route_info[2] = page_idx;
+                        route_info[3] = 0;
+                        cb_push_back(cb_route_info_id, 1);
+
+                        // Push payload to writer
+                        cb_reserve_back(cb_payload_for_writer_id, 1);
+                        uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
+                        noc_async_read(get_noc_addr(input_scratch_addr), payload_dst, aligned_input_page_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_payload_for_writer_id, 1);
+
+                        // Push metadata to writer
+                        cb_reserve_back(cb_metadata_for_writer_id, 1);
+                        uint32_t metadata_dst = get_write_ptr(cb_metadata_for_writer_id);
+                        noc_async_read(get_noc_addr(metadata_temp_addr), metadata_dst, aligned_metadata_page_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_metadata_for_writer_id, 1);
+                    }
+                }
+
+                offset++;
+            }
+        }
+
+        // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
+        uint32_t next_batch_start = batch_start + read_batch_size;
+        bool has_next_batch = (next_batch_start < token_end_idx);
+        if (has_next_batch) {
+            uint32_t next_batch_end = (next_batch_start + read_batch_size < token_end_idx)
+                                          ? next_batch_start + read_batch_size
+                                          : token_end_idx;
+            uint32_t next_batch_count = next_batch_end - next_batch_start;
+            for (uint32_t t = 0; t < next_batch_count; t++) {
+                noc_async_read_page(next_batch_start + t, input_addr_gen, input_base + t * aligned_input_page_size);
+                noc_async_read_page(
+                    next_batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+                noc_async_read_page(
+                    next_batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+            }
+        }
+
+        if (batch_did_local_write) {
+            noc_async_write_barrier();
+        }
+
+        if (has_next_batch) {
+            noc_async_read_barrier();
+        }
+    }
+
+    // Push sentinel to signal writer that all dispatches are done
+    cb_reserve_back(cb_route_info_id, 1);
+    volatile tt_l1_ptr uint32_t* route_info =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
+    route_info[0] = ROUTE_INFO_SENTINEL;
+    route_info[1] = 0;
+    route_info[2] = 0;
+    route_info[3] = 0;
+    cb_push_back(cb_route_info_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Prefill dispatch writer kernel
-
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -12,7 +10,6 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
-// Debug print control - set to 0 to disable dispatch debug prints, 1 to enable
 #define ENABLE_DISPATCH_DEBUG 0
 
 #if ENABLE_DISPATCH_DEBUG
@@ -23,71 +20,76 @@
     DebugPrinter()
 #endif
 
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
 void kernel_main() {
     using namespace ttnn::operations::ccl::common;
 
     // ===== Compile Time Args =====
-    // CB IDs (indices 0-6)
+    // CB IDs (indices 0-9)
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_indices_id = get_compile_time_arg_val(1);
     constexpr uint32_t cb_weights_id = get_compile_time_arg_val(2);
     constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_route_info_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_payload_for_writer_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_metadata_for_writer_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_metadata_temp_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(9);
 
-    // Page counts (indices 7-13)
-    constexpr uint32_t input_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(8);
-    constexpr uint32_t weights_pages = get_compile_time_arg_val(9);
-    constexpr uint32_t offsets_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(12);
-    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(13);
+    // Page counts (indices 10-16)
+    constexpr uint32_t input_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t indices_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t weights_pages = get_compile_time_arg_val(12);
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(13);
+    constexpr uint32_t output_pages = get_compile_time_arg_val(14);
+    constexpr uint32_t metadata_pages = get_compile_time_arg_val(15);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(16);
 
-    // Page sizes (indices 14-20)
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t weights_page_size = get_compile_time_arg_val(16);
-    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(17);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(18);
-    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(20);
+    // Page sizes (indices 17-23)
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(17);
+    constexpr uint32_t indices_page_size = get_compile_time_arg_val(18);
+    constexpr uint32_t weights_page_size = get_compile_time_arg_val(19);
+    constexpr uint32_t offsets_page_size = get_compile_time_arg_val(20);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(21);
+    constexpr uint32_t metadata_page_size = get_compile_time_arg_val(22);
+    constexpr uint32_t dispatch_table_page_size = get_compile_time_arg_val(23);
 
-    // Operation parameters (indices 21-28)
-    constexpr uint32_t num_devices = get_compile_time_arg_val(21);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(22);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(23);
-    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(24);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(25);
-    constexpr uint32_t metadata_len = get_compile_time_arg_val(26);
-    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(27);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(28);
+    // Operation parameters (indices 24-31)
+    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
+    constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(27);
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(28);
+    constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
+    constexpr uint32_t max_dispatched_tokens_per_expert = get_compile_time_arg_val(30);
+    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(31);
 
-    // Mesh information (indices 29-33)
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(29);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(30);
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(31);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(32);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(33);
+    // Mesh information (indices 32-36)
+    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(32);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(33);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(34);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(35);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(36);
 
-    // Aligned page sizes (indices 34-40)
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(34);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(35);
-    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(36);
-    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(37);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(38);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(39);
-    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(40);
+    // Aligned page sizes (indices 37-43)
+    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(37);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(38);
+    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(39);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(40);
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(41);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(42);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(43);
 
-    // Fabric configuration (indices 41-44)
-    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(41);
-    constexpr uint32_t l1_alignment = get_compile_time_arg_val(42);
-    constexpr uint32_t num_links = get_compile_time_arg_val(43);
-    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(44);
+    // Fabric configuration (indices 44-47)
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(44);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(45);
+    constexpr uint32_t num_links = get_compile_time_arg_val(46);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(47);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 45)
-    constexpr auto input_args = TensorAccessorArgs<45>();
+    // TensorAccessorArgs for all 7 tensors (starting at index 48)
+    constexpr auto input_args = TensorAccessorArgs<48>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
@@ -108,104 +110,37 @@ void kernel_main() {
     uint32_t init_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t token_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t token_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
-
-    // Fabric connection args follow (appended by append_fabric_connection_rt_args)
-    // These will be read by fabric API calls
-
-    // Print key compile time args for debugging (using DPRINT_DATA0 - writer runs on RISCV_0)
-    DPRINT_DISPATCH << "linearized_mesh_coord=" << linearized_mesh_coord << " src_mesh_id=" << src_mesh_id
-                    << " src_chip_id=" << src_chip_id << " mesh_rows=" << mesh_rows << " mesh_cols=" << mesh_cols
-                    << ENDL();
-
-    DPRINT_DISPATCH << "Writer kernel: CBs=" << cb_input_id << "," << cb_indices_id << "," << cb_weights_id << ","
-                    << cb_offsets_id << " tokens=[" << token_start_idx << "," << token_end_idx << ")"
-                    << " hidden_size=" << hidden_size << " experts_per_chip=" << experts_per_chip << ENDL();
+    uint32_t dispatch_core_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args_idx++);
 
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
-    constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
-    constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
-
-    constexpr uint32_t dispatch_index = axis == ReplicateGroup::COLS ? row : col;
-    // Based on cluster axis, we only need to dispatch to the devices that are along the axis
-    // If ReplicateGroup is COLs/AXIS is 1, then we dispatch alonw the ROW, and vice versa
-    // For ReplicateGroup COLs/AXIS is 1, the device_begin_idx is the start of the row, and the device_end_idx is the
-    // end of the row For ReplicateGroup ROWs/AXIS is 0, the device_begin_idx is the start of the column, and the
-    // device_end_idx is the end of the column
-    constexpr uint32_t device_begin_idx = axis == ReplicateGroup::COLS ? col : row * mesh_cols;
-    constexpr uint32_t device_end_idx =
-        (axis == ReplicateGroup::COLS)
-            ? (col + mesh_rows * mesh_cols)   // last is col+(mesh_rows-1)*mesh_cols; add one stride
-            : (row * mesh_cols + mesh_cols);  // last is row*mesh_cols+(mesh_cols-1); add one
-    constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
 #else
     constexpr ReplicateGroup axis = ReplicateGroup::NONE;
     constexpr uint32_t dispatch_devices = num_devices;
-    constexpr uint32_t dispatch_index = linearized_mesh_coord;
-    constexpr uint32_t device_begin_idx = 0;
-    constexpr uint32_t device_end_idx = num_devices;
-    constexpr uint32_t device_stride = 1;
 #endif
 
-    DPRINT_DISPATCH << "dispatch_devices=" << dispatch_devices << ". axis=" << (int)axis << " mesh_rows=" << mesh_rows
-                    << " mesh_cols=" << mesh_cols << ENDL();
-    DPRINT_DISPATCH << "Fabric configuration: max_packet_size=" << fabric_max_packet_size
-                    << " l1_alignment=" << l1_alignment << " num_links=" << num_links
-                    << " topology=" << (uint32_t)topology << " device_begin_idx=" << device_begin_idx
-                    << " device_end_idx=" << device_end_idx << " device_stride=" << device_stride << ENDL();
-
-    if constexpr (is_1d_topology<topology>()) {
-        DPRINT_DISPATCH << "Using 1D topology fabric send" << ENDL();
-    } else {
-        DPRINT_DISPATCH << "Using non-1D topology fabric send" << ENDL();
-    }
+    DPRINT_DISPATCH << "Writer kernel: dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
+                    << " dispatch_devices=" << dispatch_devices << ENDL();
 
 #ifdef DEST_CHIP_ID
-    // Fabric is enabled - set up connections
-    DPRINT_DISPATCH << "Fabric enabled: num_links=" << num_links << " topology=" << (uint32_t)topology << ENDL();
-    DPRINT_DISPATCH << "DEBUG: Before creating dest arrays, rt_args_idx=" << rt_args_idx << ENDL();
-
     constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
     constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
-    DPRINT_DISPATCH << "dst_chip_ids: ";
-    for (uint32_t i = 0; i < num_devices; ++i) {
-        DPRINT_DISPATCH << (uint32_t)dest_chip_ids[i] << " ";
-    }
-    DPRINT_DISPATCH << ENDL();
-    DPRINT_DISPATCH << "dst_mesh_ids: ";
-    for (uint32_t i = 0; i < num_devices; ++i) {
-        DPRINT_DISPATCH << (uint32_t)dest_mesh_ids[i] << " ";
-    }
-    DPRINT_DISPATCH << ENDL();
-    DPRINT_DISPATCH << "directions: ";
-    for (uint32_t i = 0; i < directions.size(); ++i) {
-        DPRINT_DISPATCH << (int)directions[i] << " ";
-    }
-    DPRINT_DISPATCH << ENDL();
-    //
-
-    DPRINT_DISPATCH << "DEBUG: Before open_direction_connections_async" << ENDL();
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
-    DPRINT_DISPATCH << "DEBUG: After open_direction_connections_async" << ENDL();
 
-    // Set up packet headers from CB (cb_packet_header_id from compile-time args)
     uint32_t packet_header_buffer_address = get_read_ptr(cb_packet_header_id);
     auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
-    auto* metadata_packet_header =
+    auto* sem_packet_header =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
 
-    DPRINT_DISPATCH << "DEBUG: Before open_direction_connections_barrier" << ENDL();
     open_direction_connections_barrier(directions, fabric_connections);
-    DPRINT_DISPATCH << "DEBUG: After open_direction_connections_barrier" << ENDL();
 
-    // CRITICAL: Send init semaphore increments to other devices BEFORE waiting
-    // Each device sends to configured targets, then waits for (num_devices - 1) increments
+    // Init semaphore exchange
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-    DPRINT_DISPATCH << "DEBUG: Before send_init_semaphore_to_configured_targets" << ENDL();
     send_init_semaphore_to_configured_targets<
         linearized_mesh_coord,
         topology,
@@ -213,174 +148,74 @@ void kernel_main() {
         mesh_rows,
         mesh_cols,
         axis,
-        num_devices>(fabric_connections, metadata_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
-    DPRINT_DISPATCH << "DEBUG: After send_init_semaphore_to_configured_targets" << ENDL();
+        num_devices>(fabric_connections, sem_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
 
-    // Wait for all devices to complete fabric initialization
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
-    noc_semaphore_set(init_sem_ptr, 0);  // clear if needed for later use
+    noc_semaphore_set(init_sem_ptr, 0);
 
     DPRINT_DISPATCH << "Fabric setup complete" << ENDL();
 #endif
 
-    // ====
-    // wait for offsets to be ready
-    cb_wait_front(cb_offsets_id, offsets_pages);
-    int32_t* offsets = (int32_t*)(get_read_ptr(cb_offsets_id));
-
-    for (uint32_t o = 0; o < n_routed_experts; ++o) {
-        DPRINT_DISPATCH << "Offset for expert " << o << " is " << offsets[o] << ENDL();
-    }
-
-    // ====
-    // wait for expert dispatch table to be ready
-    cb_wait_front(cb_dispatch_table_id, dispatch_table_pages);
-    int32_t* expert_dispatch_table = (int32_t*)(get_read_ptr(cb_dispatch_table_id));
-
-    for (uint32_t e = 0; e < n_routed_experts; ++e) {
-        DPRINT_DISPATCH << "Dispatch table for expert " << e << " is " << expert_dispatch_table[e] << ENDL();
-    }
-
-    DPRINT_DISPATCH << "aligned_metadata_page_size=" << aligned_metadata_page_size
-                    << " metadata_page_size=" << metadata_page_size << ENDL();
-
-    // ====
-    // process tokens/indices/weights one by one as they arrive to CB
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, aligned_output_page_size);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, aligned_metadata_page_size);
 
-    DPRINT_DISPATCH << "metadata_tensor_address=" << HEX() << metadata_tensor_address << DEC()
-                    << " aligned_metadata_page_size=" << aligned_metadata_page_size << ENDL();
+    // Sentinel-terminated fabric send loop
+    while (true) {
+        cb_wait_front(cb_route_info_id, 1);
+        volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
-    // Reserve CB for metadata buffer (using L1 memory accessible by NOC)
-    cb_reserve_back(cb_metadata_temp_id, 1);
-
-    for (uint32_t token_idx = token_start_idx; token_idx < token_end_idx; ++token_idx) {
-        DPRINT_DISPATCH << "Processing token_idx: " << token_idx << ENDL();
-
-        cb_wait_front(cb_indices_id, 1);
-        cb_wait_front(cb_weights_id, 1);
-        cb_wait_front(cb_input_id, 1);
-
-        uint32_t input_token_read_addr = get_read_ptr(cb_input_id);
-        int32_t* indices = (int32_t*)(get_read_ptr(cb_indices_id));
-        uint16_t* weights = (uint16_t*)(get_read_ptr(cb_weights_id));  // this is really a bfloat16 data
-        for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
-            auto routed_expert = indices[k];
-
-            // Use expert dispatch table to map expert ID to destination chip
-            auto expert_chip_og = expert_dispatch_table[routed_expert];
-            if (expert_chip_og == -1) {
-                // Expert not present in this EP rank, skip
-                DPRINT_DISPATCH << "token" << token_idx << "  Expert [" << k << "]=" << routed_expert
-                                << " not in this EP rank, skipping" << ENDL();
-                continue;
-            }
-            auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
-            auto expert_index_within_chip = routed_expert % experts_per_chip;
-
-            DPRINT_DISPATCH << "token" << token_idx << "  Expert [" << k << "]=" << routed_expert
-                            << "  (chip=" << expert_chip_og << " =>" << expert_chip << ")" << ENDL();
-
-            auto& offset = offsets[routed_expert];
-
-            // Calculate byte offsets from page indices
-            // aligned_page_size is in elements, need to multiply by element size to get bytes
-            auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + offset;
-            auto output_token_write_addr =
-                output_addr_gen.get_noc_addr(0) + page_idx * aligned_output_page_size * 2;  // bfloat16 = 2 bytes
-            auto metadata_write_addr =
-                metadata_addr_gen.get_noc_addr(0) + page_idx * aligned_metadata_page_size * 4;  // int32 = 4 bytes
-
-            if (expert_chip == linearized_mesh_coord) {
-                noc_async_write_page(page_idx, output_addr_gen, input_token_read_addr);
-                noc_async_writes_flushed();
-
-                uint32_t metadata_cb_addr = get_write_ptr(cb_metadata_temp_id);
-                volatile tt_l1_ptr int32_t* metadata = reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_cb_addr);
-
-                // Set actual metadata values
-                metadata[0] = linearized_mesh_coord;
-                metadata[1] = token_idx;
-                metadata[2] = k;
-                metadata[3] = routed_expert;
-                metadata[4] = static_cast<int16_t>(weights[k]);
-
-                // Write metadata from CB to output tensor
-                noc_async_write_page(page_idx, metadata_addr_gen, metadata_cb_addr);
-                noc_async_writes_flushed();
-
-            } else {
-                if constexpr (is_1d_topology<topology>()) {
-                    fabric_send_chip_unicast_noc_unicast_1d<
-                        linearized_mesh_coord,
-                        topology,
-                        mesh_rows,
-                        mesh_cols,
-                        fabric_max_packet_size>(
-                        output_addr_gen,
-                        fabric_connections,
-                        unicast_packet_header,
-                        expert_chip,  // linearized_dest_mesh_coord
-                        input_token_read_addr,
-                        page_idx,
-                        (int)aligned_output_page_size,  // bfloat16 = 2 bytes
-                        l1_alignment);
-
-                    uint32_t metadata_cb_addr = get_write_ptr(cb_metadata_temp_id);
-                    volatile tt_l1_ptr int32_t* metadata =
-                        reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_cb_addr);
-
-                    // Set actual metadata values
-                    metadata[0] = linearized_mesh_coord;
-                    metadata[1] = token_idx;
-                    metadata[2] = k;
-                    metadata[3] = routed_expert;
-                    metadata[4] = static_cast<int16_t>(weights[k]);
-
-                    fabric_send_chip_unicast_noc_unicast_1d<
-                        linearized_mesh_coord,
-                        topology,
-                        mesh_rows,
-                        mesh_cols,
-                        fabric_max_packet_size>(
-                        metadata_addr_gen,
-                        fabric_connections,
-                        metadata_packet_header,
-                        expert_chip,  // linearized_dest_mesh_coord
-                        metadata_cb_addr,
-                        page_idx,
-                        (int)aligned_metadata_page_size,  // int32 = 4 bytes
-                        l1_alignment);
-                } else {
-                    // Not implemented
-                    DPRINT << "Error: 2D topology fabric not implemented." << ENDL();
-                    ASSERT(false, "2D topology fabric not implemented");
-                    return;
-                }
-            }
-
-            offset++;
+        uint32_t route = route_info[0];
+        if (route == ROUTE_INFO_SENTINEL) {
+            cb_pop_front(cb_route_info_id, 1);
+            break;
         }
-        noc_async_write_barrier();
+        uint32_t distance = route_info[1];
+        uint32_t page_idx = route_info[2];
+        cb_pop_front(cb_route_info_id, 1);
 
-        cb_pop_front(cb_indices_id, 1);
-        cb_pop_front(cb_weights_id, 1);
-        cb_pop_front(cb_input_id, 1);
+        cb_wait_front(cb_payload_for_writer_id, 1);
+        cb_wait_front(cb_metadata_for_writer_id, 1);
+        uint32_t payload_addr = get_read_ptr(cb_payload_for_writer_id);
+        uint32_t metadata_addr = get_read_ptr(cb_metadata_for_writer_id);
+
+        DPRINT_DISPATCH << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << page_idx
+                        << ENDL();
+
+#ifdef DEST_CHIP_ID
+        // Send payload
+        fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+        fabric_send_noc_unicast<fabric_max_packet_size>(
+            output_addr_gen,
+            fabric_connections[route],
+            unicast_packet_header,
+            payload_addr,
+            page_idx,
+            (int)aligned_output_page_size,
+            l1_alignment);
+
+        // Send metadata
+        fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+        fabric_send_noc_unicast<fabric_max_packet_size>(
+            metadata_addr_gen,
+            fabric_connections[route],
+            unicast_packet_header,
+            metadata_addr,
+            page_idx,
+            (int)aligned_metadata_page_size,
+            l1_alignment);
+
+        noc_async_write_barrier();
+#endif
+
+        cb_pop_front(cb_payload_for_writer_id, 1);
+        cb_pop_front(cb_metadata_for_writer_id, 1);
     }
 
-    // Release CB for next use
-    cb_push_back(cb_metadata_temp_id, 1);
-
-    // Pop the offsets and dispatch table CBs that were read at the beginning
-    cb_pop_front(cb_offsets_id, offsets_pages);
-    cb_pop_front(cb_dispatch_table_id, dispatch_table_pages);
-
+#ifdef DEST_CHIP_ID
+    // Exit semaphore exchange
     {
-        // Send exit semaphore to all devices
-        const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-        DPRINT_DISPATCH << "Sending exit semaphore to configured targets..." << ENDL();
+        const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
             topology,
@@ -389,20 +224,14 @@ void kernel_main() {
             mesh_cols,
             axis,
             num_devices>(
-            fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
+            fabric_connections, unicast_packet_header, dest_chip_ids, dest_mesh_ids, exit_noc_semaphore_addr);
 
-        // Wait for all devices to complete fabric initialization
-        DPRINT_DISPATCH << "Waiting for all devices to complete fabric transfers..." << ENDL();
-        volatile tt_l1_ptr uint32_t* init_sem_ptr =
+        volatile tt_l1_ptr uint32_t* exit_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
-        noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
-        noc_semaphore_set(init_sem_ptr, 0);
-
-        DPRINT_DISPATCH << "Fabric transfers complete" << ENDL();
+        noc_semaphore_wait(exit_sem_ptr, dispatch_devices - 1);
+        noc_semaphore_set(exit_sem_ptr, 0);
     }
 
-#ifdef DEST_CHIP_ID
-    // Close fabric connections to prevent resource conflicts with subsequent operations
     close_direction_connections(directions, fabric_connections);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -39,8 +39,8 @@ std::array<ttnn::Tensor, 2> dispatch(
         "cluster_axis must be 0 (current value: {}). Other values are not tested.",
         cluster_axis.value_or(0));
     TT_FATAL(
-        num_links.value_or(1) == 1,
-        "num_links must be 1 (current value: {}). Other values are not tested.",
+        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 2,
+        "num_links must be 1 or 2 (current value: {}).",
         num_links.value_or(1));
     auto topology_ = topology.value_or(tt::tt_fabric::Topology::Linear);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -39,8 +39,8 @@ std::array<ttnn::Tensor, 2> dispatch(
         "cluster_axis must be 0 (current value: {}). Other values are not tested.",
         cluster_axis.value_or(0));
     TT_FATAL(
-        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 2,
-        "num_links must be 1 or 2 (current value: {}).",
+        num_links.value_or(1) >= 1 && num_links.value_or(1) <= 4,
+        "num_links must be between 1 and 4 (current value: {}).",
         num_links.value_or(1));
     auto topology_ = topology.value_or(tt::tt_fabric::Topology::Linear);
     TT_FATAL(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/39620)

### Problem description
MoE dispatch and combine ops can be improved to run faster. This PR specifically addresses the multilink implementation from the issue.

### What's changed
-Enabled another ethernet link and split workload on 2 cores
-Rebalanced workload among DRAM banks
-Rebalanced workload between BRISC and NCRISC
-Updated tests to support 2 link case

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/prefill_dispatch_combine_optimized)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/prefill_dispatch_combine_optimized)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ianastasijevic/prefill_dispatch_combine_optimized)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ianastasijevic/prefill_dispatch_combine_optimized)
- [x] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ianastasijevic/prefill_dispatch_combine_optimized)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ianastasijevic/prefill_dispatch_combine_optimized)
