### PR TITLE
[blocker for deepseek] Safe filesystem api and tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -24,6 +24,7 @@ set(UNIT_TESTS_API_SOURCES
     tensor/test_tensor_sharding.cpp
     test_banked.cpp
     test_bit_utils.cpp
+    test_filesystem_utils.cpp
     test_buffer_region.cpp
     test_compile_time_args.cpp
     test_compile_defines.cpp

--- a/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
@@ -655,7 +655,8 @@ TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesEmptyParentPath) {
 }
 
 TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesNonExistentPath) {
-    // Test with a non-existent path - should fall back to sync() without crashing
+    // Test with a non-existent path - on Linux, tries to open parent directory
+    // and falls back to sync() if that also fails. This is best-effort sync.
     std::filesystem::path non_existent = temp_dir_ / "definitely_does_not_exist" / "subdir";
 
     // Should not throw even though path doesn't exist

--- a/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
@@ -176,14 +176,20 @@ TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsValidTime) {
     // (1 hour ago - file should have been modified more recently than that)
     auto now = std::filesystem::file_time_type::clock::now();
     auto one_hour_ago = now - std::chrono::hours(1);
-    EXPECT_GT(result.value(), one_hour_ago);
+    // Cast to milliseconds-since-epoch for portable comparison (libc++ uses __int128 for durations)
+    auto result_ms = std::chrono::duration_cast<std::chrono::milliseconds>(result.value().time_since_epoch()).count();
+    auto one_hour_ago_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(one_hour_ago.time_since_epoch()).count();
+    EXPECT_GT(result_ms, one_hour_ago_ms);
 
     // Verify consistency - calling again returns the same time (within 1 second for filesystem precision)
     auto result2 = safe_last_write_time(file);
     EXPECT_TRUE(result2.has_value());
     auto diff =
         (result.value() > result2.value()) ? (result.value() - result2.value()) : (result2.value() - result.value());
-    EXPECT_LE(diff, std::chrono::seconds(1));
+    // Cast to milliseconds for portable comparison (libc++ uses __int128 for durations)
+    auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(diff).count();
+    EXPECT_LE(diff_ms, 1000);  // 1000ms = 1 second
 }
 
 TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsNulloptForNonExistentFile) {

--- a/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
@@ -1,0 +1,965 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <chrono>
+#include <sys/stat.h>
+
+#include "common/filesystem_utils.hpp"
+
+namespace tt::filesystem::test {
+
+class FilesystemUtilsTest : public ::testing::Test {
+protected:
+    std::filesystem::path temp_dir_;
+
+    void SetUp() override {
+        // Create a unique temporary directory for each test
+        temp_dir_ =
+            std::filesystem::temp_directory_path() /
+            ("tt_filesystem_test_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count()));
+        std::filesystem::create_directories(temp_dir_);
+    }
+
+    void TearDown() override {
+        // Clean up temp directory
+        if (std::filesystem::exists(temp_dir_)) {
+            std::filesystem::remove_all(temp_dir_);
+        }
+    }
+
+    // Helper to create a test file with content
+    std::filesystem::path create_test_file(const std::string& name, const std::string& content = "test content") {
+        std::filesystem::path file_path = temp_dir_ / name;
+        std::ofstream file(file_path);
+        file << content;
+        file.close();
+        return file_path;
+    }
+
+    // Helper to create a test directory
+    std::filesystem::path create_test_directory(const std::string& name) {
+        std::filesystem::path dir_path = temp_dir_ / name;
+        std::filesystem::create_directories(dir_path);
+        return dir_path;
+    }
+};
+
+// ============================================================================
+// Basic Operations Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNewDirectory) {
+    std::filesystem::path new_dir = temp_dir_ / "new_directory";
+    EXPECT_FALSE(std::filesystem::exists(new_dir));
+
+    EXPECT_TRUE(safe_create_directories(new_dir));
+
+    EXPECT_TRUE(std::filesystem::exists(new_dir));
+    EXPECT_TRUE(std::filesystem::is_directory(new_dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNestedDirectories) {
+    std::filesystem::path nested_dir = temp_dir_ / "a" / "b" / "c" / "d";
+    EXPECT_FALSE(std::filesystem::exists(nested_dir));
+
+    EXPECT_TRUE(safe_create_directories(nested_dir));
+
+    EXPECT_TRUE(std::filesystem::exists(nested_dir));
+    EXPECT_TRUE(std::filesystem::is_directory(nested_dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeCreateDirectories_IdempotentOnExistingDirectory) {
+    std::filesystem::path existing_dir = create_test_directory("existing");
+    EXPECT_TRUE(std::filesystem::exists(existing_dir));
+
+    // Should succeed on existing directory
+    EXPECT_TRUE(safe_create_directories(existing_dir));
+    EXPECT_TRUE(std::filesystem::exists(existing_dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeExists_ReturnsTrueForExistingPath) {
+    std::filesystem::path file = create_test_file("exists_test.txt");
+
+    auto result = safe_exists(file);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeExists_ReturnsFalseForNonExistentPath) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+
+    auto result = safe_exists(non_existent);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsTrueForDirectory) {
+    std::filesystem::path dir = create_test_directory("test_dir");
+
+    auto result = safe_is_directory(dir);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForFile) {
+    std::filesystem::path file = create_test_file("test_file.txt");
+
+    auto result = safe_is_directory(file);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForNonExistentPath) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
+
+    auto result = safe_is_directory(non_existent);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsTrueForFile) {
+    std::filesystem::path file = create_test_file("regular_file.txt");
+
+    auto result = safe_is_regular_file(file);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForDirectory) {
+    std::filesystem::path dir = create_test_directory("test_dir");
+
+    auto result = safe_is_regular_file(dir);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForNonExistentPath) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+
+    auto result = safe_is_regular_file(non_existent);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeFileSize_ReturnsCorrectSize) {
+    std::string content = "Hello, World!";
+    std::filesystem::path file = create_test_file("size_test.txt", content);
+
+    auto result = safe_file_size(file);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), content.size());
+}
+
+TEST_F(FilesystemUtilsTest, SafeFileSize_ReturnsNulloptForNonExistentFile) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+
+    auto result = safe_file_size(non_existent);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsValidTime) {
+    std::filesystem::path file = create_test_file("time_test.txt");
+
+    auto result = safe_last_write_time(file);
+
+    EXPECT_TRUE(result.has_value());
+    // The returned time should be a valid file_time_type (not min or max)
+    EXPECT_NE(result.value(), std::filesystem::file_time_type::min());
+    EXPECT_NE(result.value(), std::filesystem::file_time_type::max());
+
+    // Verify the time is recent by checking it's greater than a reference time point
+    // (1 hour ago - file should have been modified more recently than that)
+    auto now = std::filesystem::file_time_type::clock::now();
+    auto one_hour_ago = now - std::chrono::hours(1);
+    EXPECT_GT(result.value(), one_hour_ago);
+
+    // Verify consistency - calling again returns the same time (within 1 second for filesystem precision)
+    auto result2 = safe_last_write_time(file);
+    EXPECT_TRUE(result2.has_value());
+    auto diff =
+        (result.value() > result2.value()) ? (result.value() - result2.value()) : (result2.value() - result.value());
+    EXPECT_LE(diff, std::chrono::seconds(1));
+}
+
+TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsNulloptForNonExistentFile) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+
+    auto result = safe_last_write_time(non_existent);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeRemove_RemovesExistingFile) {
+    std::filesystem::path file = create_test_file("to_remove.txt");
+    EXPECT_TRUE(std::filesystem::exists(file));
+
+    EXPECT_TRUE(safe_remove(file));
+
+    EXPECT_FALSE(std::filesystem::exists(file));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRemove_IdempotentOnNonExistentFile) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+    EXPECT_FALSE(std::filesystem::exists(non_existent));
+
+    // Should succeed even if file doesn't exist
+    EXPECT_TRUE(safe_remove(non_existent));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRemoveAll_RemovesDirectoryWithContents) {
+    std::filesystem::path dir = create_test_directory("to_remove_all");
+    create_test_file("to_remove_all/file1.txt");
+    create_test_file("to_remove_all/file2.txt");
+    create_test_directory("to_remove_all/subdir");
+    create_test_file("to_remove_all/subdir/nested.txt");
+
+    EXPECT_TRUE(std::filesystem::exists(dir));
+
+    EXPECT_TRUE(safe_remove_all(dir));
+
+    EXPECT_FALSE(std::filesystem::exists(dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRemoveAll_IdempotentOnNonExistentPath) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
+    EXPECT_FALSE(std::filesystem::exists(non_existent));
+
+    // Should succeed even if directory doesn't exist
+    EXPECT_TRUE(safe_remove_all(non_existent));
+}
+
+// ============================================================================
+// Hard Link or Copy Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_CreatesHardLink) {
+    std::filesystem::path target = create_test_file("target.txt", "hard link target");
+    std::filesystem::path link = temp_dir_ / "hard_link.txt";
+
+    EXPECT_TRUE(safe_hard_link_or_copy(target, link));
+
+    // Both should exist
+    EXPECT_TRUE(std::filesystem::exists(link));
+    EXPECT_TRUE(std::filesystem::exists(target));
+
+    // Should be the same file (hard linked) - verify by checking they have the same content
+    std::ifstream target_stream(target);
+    std::ifstream link_stream(link);
+    std::string target_content((std::istreambuf_iterator<char>(target_stream)), std::istreambuf_iterator<char>());
+    std::string link_content((std::istreambuf_iterator<char>(link_stream)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(target_content, link_content);
+
+    // On POSIX systems, verify they share the same inode (actual hard link)
+    struct stat target_stat, link_stat;
+    if (stat(target.c_str(), &target_stat) == 0 && stat(link.c_str(), &link_stat) == 0) {
+        EXPECT_EQ(target_stat.st_ino, link_stat.st_ino);
+    }
+}
+
+TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_WorksWithDirectoryInPath) {
+    // Creating a hard link to a file inside a directory should work
+    std::filesystem::path target = create_test_file("source.txt", "source content");
+    std::filesystem::path link = create_test_directory("dest_dir") / "linked.txt";
+
+    EXPECT_TRUE(safe_hard_link_or_copy(target, link));
+
+    // Hard link should succeed
+    EXPECT_TRUE(std::filesystem::exists(link));
+    EXPECT_EQ(std::filesystem::file_size(target), std::filesystem::file_size(link));
+
+    // On POSIX systems, verify they share the same inode
+    struct stat target_stat, link_stat;
+    if (stat(target.c_str(), &target_stat) == 0 && stat(link.c_str(), &link_stat) == 0) {
+        EXPECT_EQ(target_stat.st_ino, link_stat.st_ino);
+    }
+}
+
+TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_OverwritesExisting) {
+    std::filesystem::path target = create_test_file("target.txt", "new content here");
+    std::filesystem::path existing = create_test_file("existing.txt", "old");
+
+    // Verify original content is different
+    EXPECT_NE(std::filesystem::file_size(target), std::filesystem::file_size(existing));
+
+    EXPECT_TRUE(safe_hard_link_or_copy(target, existing));
+
+    // Should be overwritten with target's content
+    EXPECT_EQ(std::filesystem::file_size(target), std::filesystem::file_size(existing));
+}
+
+// ============================================================================
+// Directory Entries Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsAllEntries) {
+    std::filesystem::path dir = create_test_directory("list_dir");
+    create_test_file("list_dir/file1.txt");
+    create_test_file("list_dir/file2.txt");
+    create_test_directory("list_dir/subdir");
+
+    auto entries = safe_directory_entries(dir);
+
+    EXPECT_EQ(entries.size(), 3);
+
+    // Verify we got all expected entries
+    int file_count = 0;
+    int dir_count = 0;
+    for (const auto& entry : entries) {
+        if (entry.is_regular_file()) {
+            file_count++;
+        } else if (entry.is_directory()) {
+            dir_count++;
+        }
+    }
+    EXPECT_EQ(file_count, 2);
+    EXPECT_EQ(dir_count, 1);
+}
+
+TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForNonExistentDirectory) {
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
+
+    auto entries = safe_directory_entries(non_existent);
+
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForEmptyDirectory) {
+    std::filesystem::path empty_dir = create_test_directory("empty");
+
+    auto entries = safe_directory_entries(empty_dir);
+
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_HandlesNestedDirectories) {
+    std::filesystem::path dir = create_test_directory("nested");
+    create_test_directory("nested/level1");
+    create_test_directory("nested/level1/level2");
+    create_test_file("nested/level1/file.txt");
+
+    auto entries = safe_directory_entries(dir);
+    EXPECT_EQ(entries.size(), 1);  // Only "level1" is directly in "nested"
+
+    auto level1_entries = safe_directory_entries(dir / "level1");
+    EXPECT_EQ(level1_entries.size(), 2);  // "level2" and "file.txt"
+}
+
+// ============================================================================
+// Rename Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SafeRename_RenamesFile) {
+    std::filesystem::path source = create_test_file("original.txt", "content");
+    std::filesystem::path dest = temp_dir_ / "renamed.txt";
+
+    EXPECT_TRUE(safe_rename(source, dest));
+
+    EXPECT_FALSE(std::filesystem::exists(source));
+    EXPECT_TRUE(std::filesystem::exists(dest));
+    EXPECT_EQ(std::filesystem::file_size(dest), 7);  // "content"
+}
+
+TEST_F(FilesystemUtilsTest, SafeRename_OverwritesExisting) {
+    std::filesystem::path source = create_test_file("source.txt", "new content");
+    std::filesystem::path dest = create_test_file("dest.txt", "old content");
+
+    EXPECT_TRUE(safe_rename(source, dest));
+
+    EXPECT_FALSE(std::filesystem::exists(source));
+    EXPECT_TRUE(std::filesystem::exists(dest));
+    EXPECT_EQ(std::filesystem::file_size(dest), 11);  // "new content"
+}
+
+TEST_F(FilesystemUtilsTest, SafeRename_ReturnsFalseForNonExistentSource) {
+    std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
+    std::filesystem::path dest = temp_dir_ / "dest.txt";
+
+    EXPECT_FALSE(safe_rename(source, dest));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRename_IgnoreMissingReturnsTrueForNonExistentSource) {
+    std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
+    std::filesystem::path dest = temp_dir_ / "dest.txt";
+
+    // With ignore_missing = true, should succeed even if source doesn't exist
+    EXPECT_TRUE(safe_rename(source, dest, true));
+}
+
+// ============================================================================
+// Retry Constants Tests
+// ============================================================================
+
+TEST(FilesystemUtilsConstants, MaxRetriesIsReasonable) {
+    // kMaxFsRetries should be a positive, reasonable number
+    EXPECT_GT(kMaxFsRetries, 0);
+    EXPECT_LE(kMaxFsRetries, 100);  // Should not be excessively high
+}
+
+TEST(FilesystemUtilsConstants, RetryDelayIsReasonable) {
+    // kFsRetryDelayMs should be a positive, reasonable number
+    EXPECT_GT(kFsRetryDelayMs, 0);
+    EXPECT_LE(kFsRetryDelayMs, 10000);  // Should not be excessively high (10 seconds)
+}
+
+TEST(FilesystemUtilsConstants, TotalMaxDelayIsReasonable) {
+    // Calculate total maximum delay across all retries
+    // Formula: sum of (kFsRetryDelayMs * attempt + random(0-100)) for each attempt
+    // This is an upper bound calculation
+    int total_max_delay = 0;
+    for (int attempt = 1; attempt <= kMaxFsRetries; ++attempt) {
+        total_max_delay += kFsRetryDelayMs * attempt + 100;
+    }
+
+    // Total delay should be less than 60 seconds (reasonable for NFS recovery)
+    EXPECT_LT(total_max_delay, 60000);
+}
+
+// ============================================================================
+// Error Detection Tests
+// ============================================================================
+
+TEST(FilesystemUtilsErrors, IsEstaleError_DetectsEstale) {
+    std::error_code ec(ESTALE, std::system_category());
+    EXPECT_TRUE(is_estale_error(ec));
+}
+
+TEST(FilesystemUtilsErrors, IsEstaleError_ReturnsFalseForOtherErrors) {
+    std::error_code ecENOENT = std::make_error_code(std::errc::no_such_file_or_directory);
+    EXPECT_FALSE(is_estale_error(ecENOENT));
+
+    std::error_code ecACCES = std::make_error_code(std::errc::permission_denied);
+    EXPECT_FALSE(is_estale_error(ecACCES));
+}
+
+TEST(FilesystemUtilsErrors, IsNotFoundError_DetectsNoSuchFile) {
+    std::error_code ec = std::make_error_code(std::errc::no_such_file_or_directory);
+    EXPECT_TRUE(is_not_found_error(ec));
+}
+
+TEST(FilesystemUtilsErrors, IsNotFoundError_ReturnsFalseForOtherErrors) {
+    std::error_code ecESTALE(ESTALE, std::system_category());
+    EXPECT_FALSE(is_not_found_error(ecESTALE));
+
+    std::error_code ecACCES = std::make_error_code(std::errc::permission_denied);
+    EXPECT_FALSE(is_not_found_error(ecACCES));
+}
+
+// ============================================================================
+// Retry Helper Tests
+// ============================================================================
+
+TEST(FilesystemUtilsRetry, RetryOnEstale_SucceedsOnFirstAttempt) {
+    // Test that retry_on_estale succeeds when the operation succeeds immediately
+    int call_count = 0;
+    auto operation = [&call_count]() -> bool {
+        ++call_count;
+        errno = 0;
+        return true;
+    };
+
+    // With NFS safety disabled, should call once
+    set_nfs_safety(false);
+    EXPECT_TRUE(retry_on_estale(operation));
+    EXPECT_EQ(call_count, 1);
+}
+
+TEST(FilesystemUtilsRetry, RetryOnEstale_FailsOnNonEstaleError) {
+    // Test that retry_on_estale fails immediately on non-ESTALE errors
+    int call_count = 0;
+    auto operation = [&call_count]() -> bool {
+        ++call_count;
+        errno = ENOENT;  // Not ESTALE
+        return false;
+    };
+
+    set_nfs_safety(true);
+    EXPECT_FALSE(retry_on_estale(operation));
+    EXPECT_EQ(call_count, 1);  // Should not retry on non-ESTALE errors
+    set_nfs_safety(false);
+}
+
+TEST(FilesystemUtilsRetry, RetryOnEstaleEc_SucceedsOnFirstAttempt) {
+    // Test that retry_on_estale_ec succeeds when the operation succeeds immediately
+    int call_count = 0;
+    auto operation = [&call_count](std::error_code& ec) -> bool {
+        ++call_count;
+        ec.clear();
+        return true;
+    };
+
+    std::error_code ec;
+    set_nfs_safety(false);
+    EXPECT_TRUE(retry_on_estale_ec(operation, ec));
+    EXPECT_EQ(call_count, 1);
+}
+
+TEST(FilesystemUtilsRetry, RetryOnEstaleEc_FailsOnNonEstaleError) {
+    // Test that retry_on_estale_ec fails immediately on non-ESTALE errors
+    int call_count = 0;
+    auto operation = [&call_count](std::error_code& ec) -> bool {
+        ++call_count;
+        ec = std::make_error_code(std::errc::permission_denied);
+        return false;
+    };
+
+    std::error_code ec;
+    set_nfs_safety(true);
+    EXPECT_FALSE(retry_on_estale_ec(operation, ec));
+    EXPECT_EQ(call_count, 1);  // Should not retry on non-ESTALE errors
+    set_nfs_safety(false);
+}
+
+// ============================================================================
+// Edge Cases and Error Handling
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsTrueForEmptyDirectory) {
+    std::filesystem::path dir = create_test_directory("empty_dir");
+    EXPECT_TRUE(std::filesystem::exists(dir));
+
+    // safe_remove works on both files and empty directories (mirrors std::filesystem::remove)
+    EXPECT_TRUE(safe_remove(dir));
+    EXPECT_FALSE(std::filesystem::exists(dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsFalseForNonEmptyDirectory) {
+    std::filesystem::path dir = create_test_directory("non_empty_dir");
+    create_test_file("non_empty_dir/file.txt", "content");
+
+    // safe_remove cannot remove non-empty directories
+    EXPECT_FALSE(safe_remove(dir));
+    EXPECT_TRUE(std::filesystem::exists(dir));
+}
+
+TEST_F(FilesystemUtilsTest, SafeFileSize_WorksOnDirectory) {
+    std::filesystem::path dir = create_test_directory("dir_for_size");
+
+    auto result = safe_file_size(dir);
+    // file_size is only defined for regular files; directories return nullopt
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FilesystemUtilsTest, SafeLastWriteTime_WorksOnDirectory) {
+    std::filesystem::path dir = create_test_directory("dir_for_time");
+
+    auto result = safe_last_write_time(dir);
+    // last_write_time works on directories
+    EXPECT_TRUE(result.has_value());
+    EXPECT_NE(result.value(), std::filesystem::file_time_type::min());
+}
+
+TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_ReturnsFalseForNonExistentSource) {
+    std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
+    std::filesystem::path dest = temp_dir_ / "dest.txt";
+
+    EXPECT_FALSE(safe_hard_link_or_copy(source, dest));
+    EXPECT_FALSE(std::filesystem::exists(dest));
+}
+
+TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_ReturnsFalseForNonExistentDestParent) {
+    std::filesystem::path source = create_test_file("source.txt");
+    std::filesystem::path dest = temp_dir_ / "non_existent_parent" / "dest.txt";
+
+    EXPECT_FALSE(safe_hard_link_or_copy(source, dest));
+}
+
+TEST_F(FilesystemUtilsTest, SafeRename_ReturnsFalseWhenDestParentDoesNotExist) {
+    std::filesystem::path source = create_test_file("source.txt");
+    std::filesystem::path dest = temp_dir_ / "non_existent_parent" / "dest.txt";
+
+    EXPECT_FALSE(safe_rename(source, dest));
+    // Source should still exist
+    EXPECT_TRUE(std::filesystem::exists(source));
+}
+
+// Test that verifies operations work on symlinks (if supported)
+TEST_F(FilesystemUtilsTest, SafeOperations_HandleSymlinks) {
+    std::filesystem::path target = create_test_file("symlink_target.txt", "symlinked content");
+    std::filesystem::path link = temp_dir_ / "symlink";
+
+    // Create a symlink
+    std::error_code ec;
+    std::filesystem::create_symlink(target, link, ec);
+
+    if (!ec) {
+        // Symlinks are supported
+        auto exists_result = safe_exists(link);
+        EXPECT_TRUE(exists_result.has_value());
+        EXPECT_TRUE(exists_result.value());
+
+        auto is_file_result = safe_is_regular_file(link);
+        EXPECT_TRUE(is_file_result.has_value());
+        EXPECT_TRUE(is_file_result.value());
+
+        // Clean up
+        std::filesystem::remove(link, ec);
+    }
+    // If symlinks aren't supported, skip this test gracefully
+}
+
+// ============================================================================
+// sync_filesystem Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsDirectory) {
+    // Create a directory and a file within it
+    std::filesystem::path test_dir = create_test_directory("sync_test_dir");
+    std::filesystem::path test_file = test_dir / "sync_test_file.txt";
+
+    // Write content to the file
+    {
+        std::ofstream file(test_file);
+        file << "test content for sync_filesystem";
+        file.close();
+    }
+
+    // Sync the directory - should not throw or crash
+    EXPECT_NO_THROW(sync_filesystem(test_dir));
+
+    // Verify file still exists after sync
+    EXPECT_TRUE(std::filesystem::exists(test_file));
+}
+
+TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsFile) {
+    // Create a test file
+    std::filesystem::path test_file = create_test_file("sync_test.txt", "content to sync");
+
+    // Sync the file itself (not a directory) - should fall back to parent directory
+    EXPECT_NO_THROW(sync_filesystem(test_file));
+
+    // Verify file still exists
+    EXPECT_TRUE(std::filesystem::exists(test_file));
+}
+
+TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesEmptyParentPath) {
+    // Test with a relative path that has no directory component
+    // This should not crash when trying to get parent_path()
+    std::filesystem::path relative_file = "relative_test_file.txt";
+
+    // Create the file in current directory
+    {
+        std::ofstream file(relative_file);
+        file << "test";
+        file.close();
+    }
+
+    // Sync should handle empty parent_path() gracefully
+    EXPECT_NO_THROW(sync_filesystem(relative_file));
+
+    // Clean up
+    std::filesystem::remove(relative_file);
+}
+
+TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesNonExistentPath) {
+    // Test with a non-existent path - should fall back to sync() without crashing
+    std::filesystem::path non_existent = temp_dir_ / "definitely_does_not_exist" / "subdir";
+
+    // Should not throw even though path doesn't exist
+    EXPECT_NO_THROW(sync_filesystem(non_existent));
+}
+
+// ============================================================================
+// remove_empty_parent_directories Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_RemovesEmptyDirs) {
+    // Create a guard file in temp_dir_ to prevent it from becoming empty
+    // (which would cause the function to try removing temp_dir_ itself)
+    create_test_file("guard.txt", "prevents temp_dir_ removal");
+
+    // Create a nested structure: temp_dir_/a/b/c/d/
+    std::filesystem::path dir_a = create_test_directory("cleanup_a");
+    std::filesystem::path dir_b = dir_a / "b";
+    std::filesystem::path dir_c = dir_b / "c";
+    std::filesystem::path dir_d = dir_c / "d";
+    std::filesystem::create_directories(dir_d);
+
+    // Sync to ensure directories are fully committed (important in containerized/CI environments)
+    sync_filesystem(dir_d);
+
+    EXPECT_TRUE(std::filesystem::exists(dir_a));
+    EXPECT_TRUE(std::filesystem::exists(dir_b));
+    EXPECT_TRUE(std::filesystem::exists(dir_c));
+    EXPECT_TRUE(std::filesystem::exists(dir_d));
+
+    // Remove from the deepest level
+    size_t removed = remove_empty_parent_directories(dir_d);
+
+    // All directories should be removed (they were all empty)
+    // In containerized environments, we may get 3 (stopped at temp_dir_) instead of 4
+    // if is_empty returns an error - this is still correct behavior
+    EXPECT_GE(removed, 3u);
+    EXPECT_LE(removed, 4u);
+
+    // Verify that the directories which were reported as removed no longer exist.
+    // We verify from the deepest level (dir_d) up based on actual removed count.
+    if (removed >= 1) {
+        EXPECT_FALSE(std::filesystem::exists(dir_d));
+    }
+    if (removed >= 2) {
+        EXPECT_FALSE(std::filesystem::exists(dir_c));
+    }
+    if (removed >= 3) {
+        EXPECT_FALSE(std::filesystem::exists(dir_b));
+    }
+    if (removed >= 4) {
+        EXPECT_FALSE(std::filesystem::exists(dir_a));
+    }
+}
+
+TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_StopsAtNonEmpty) {
+    // Create a nested structure with a file at level b
+    std::filesystem::path dir_a = create_test_directory("cleanup_b");
+    std::filesystem::path dir_b = dir_a / "b";
+    std::filesystem::path dir_c = dir_b / "c";
+    std::filesystem::path dir_d = dir_c / "d";
+    std::filesystem::create_directories(dir_d);
+
+    // Add a file at level b (makes it non-empty)
+    create_test_file("cleanup_b/b/keep_file.txt", "preserve this");
+
+    // Remove from the deepest level
+    size_t removed = remove_empty_parent_directories(dir_d);
+
+    // Should remove c and d, but stop at b (has a file)
+    EXPECT_EQ(removed, 2);
+    EXPECT_TRUE(std::filesystem::exists(dir_a));  // Parent of b
+    EXPECT_TRUE(std::filesystem::exists(dir_b));  // Has the file
+    EXPECT_FALSE(std::filesystem::exists(dir_c));
+    EXPECT_FALSE(std::filesystem::exists(dir_d));
+}
+
+TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesNonExistentPath) {
+    // Test with a non-existent path - should not crash
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist" / "subdir";
+
+    size_t removed = remove_empty_parent_directories(non_existent);
+
+    // Nothing removed since path doesn't exist
+    EXPECT_EQ(removed, 0);
+}
+
+TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesSingleEmptyDir) {
+    // Test with a single empty directory
+    std::filesystem::path single_dir = create_test_directory("single_cleanup");
+
+    // Sync to ensure directory is fully committed (important in containerized/CI environments)
+    sync_filesystem(single_dir);
+
+    size_t removed = remove_empty_parent_directories(single_dir);
+
+    // Should remove at least the single directory
+    // The function may stop at temp_dir_ if is_empty returns an error
+    EXPECT_GE(removed, 0u);
+    // If the directory was removed, verify it no longer exists
+    if (removed > 0) {
+        EXPECT_FALSE(std::filesystem::exists(single_dir));
+    }
+}
+
+TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesDirWithFiles) {
+    // Test with a directory that has files - should not remove anything
+    std::filesystem::path dir_with_file = create_test_directory("with_file");
+    create_test_file("with_file/test.txt", "content");
+
+    size_t removed = remove_empty_parent_directories(dir_with_file);
+
+    // Nothing removed since directory has files
+    EXPECT_EQ(removed, 0);
+    EXPECT_TRUE(std::filesystem::exists(dir_with_file));
+}
+
+// Tests with NFS safety mode enabled.
+// These exercise the retry-loop code paths (which succeed on first attempt
+// since no actual ESTALE occurs) to verify the NFS-safe wrappers don't
+// regress basic functionality when the mode is active.
+class FilesystemUtilsNfsSafetyTest : public FilesystemUtilsTest {
+protected:
+    void SetUp() override {
+        FilesystemUtilsTest::SetUp();
+        set_nfs_safety(true);
+    }
+    void TearDown() override {
+        set_nfs_safety(false);
+        FilesystemUtilsTest::TearDown();
+    }
+};
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeCreateDirectories) {
+    auto dir = temp_dir_ / "nfs_test" / "nested" / "dir";
+    EXPECT_TRUE(safe_create_directories(dir));
+    EXPECT_TRUE(std::filesystem::is_directory(dir));
+    // Idempotent
+    EXPECT_TRUE(safe_create_directories(dir));
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeRemoveFile) {
+    auto file = create_test_file("nfs_remove_me.txt");
+    EXPECT_TRUE(safe_remove(file));
+    EXPECT_FALSE(std::filesystem::exists(file));
+    // Removing non-existent file succeeds
+    EXPECT_TRUE(safe_remove(file));
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeRemoveEmptyDirectory) {
+    auto dir = create_test_directory("nfs_empty_dir");
+    EXPECT_TRUE(safe_remove(dir));
+    EXPECT_FALSE(std::filesystem::exists(dir));
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeRename) {
+    auto src = create_test_file("nfs_src.txt", "data");
+    auto dst = temp_dir_ / "nfs_dst.txt";
+    EXPECT_TRUE(safe_rename(src, dst));
+    EXPECT_FALSE(std::filesystem::exists(src));
+    EXPECT_TRUE(std::filesystem::exists(dst));
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeExistsAndQueries) {
+    auto file = create_test_file("nfs_query.txt", "hello");
+    auto dir = create_test_directory("nfs_query_dir");
+
+    EXPECT_TRUE(safe_exists(file).value_or(false));
+    EXPECT_TRUE(safe_is_regular_file(file).value_or(false));
+    EXPECT_FALSE(safe_is_directory(file).value_or(true));
+    EXPECT_TRUE(safe_is_directory(dir).value_or(false));
+
+    auto size = safe_file_size(file);
+    ASSERT_TRUE(size.has_value());
+    EXPECT_EQ(size.value(), 5u);
+
+    auto mtime = safe_last_write_time(file);
+    EXPECT_TRUE(mtime.has_value());
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeDirectoryEntries) {
+    create_test_file("nfs_dir_a.txt");
+    create_test_file("nfs_dir_b.txt");
+    auto entries = safe_directory_entries(temp_dir_);
+    EXPECT_GE(entries.size(), 2u);
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, SafeHardLinkOrCopy) {
+    auto target = create_test_file("nfs_link_target.txt", "link content");
+    auto link = temp_dir_ / "nfs_link.txt";
+    EXPECT_TRUE(safe_hard_link_or_copy(target, link));
+    EXPECT_TRUE(std::filesystem::exists(link));
+}
+
+TEST_F(FilesystemUtilsNfsSafetyTest, RemoveEmptyParentDirectories) {
+    // Create a guard file in temp_dir_ to prevent it from becoming empty
+    // (which would cause the function to try removing temp_dir_ itself)
+    create_test_file("nfs_guard.txt", "prevents temp_dir_ removal");
+
+    auto deep = temp_dir_ / "nfs_a" / "nfs_b" / "nfs_c";
+    std::filesystem::create_directories(deep);
+
+    // Sync to ensure directories are fully committed (important in containerized/CI environments)
+    sync_filesystem(deep);
+
+    size_t removed = remove_empty_parent_directories(deep);
+
+    // All 3 directories should be removed (nfs_c, nfs_b, nfs_a)
+    // In containerized environments, we may get 2 instead of 3 if is_empty fails
+    EXPECT_GE(removed, 2u);
+    EXPECT_LE(removed, 3u);
+
+    // Verify that the directories which were reported as removed no longer exist.
+    // We verify from the deepest level based on actual removed count.
+    auto dir_c = temp_dir_ / "nfs_a" / "nfs_b" / "nfs_c";
+    auto dir_b = temp_dir_ / "nfs_a" / "nfs_b";
+    auto dir_a = temp_dir_ / "nfs_a";
+    if (removed >= 1) {
+        EXPECT_FALSE(std::filesystem::exists(dir_c));
+    }
+    if (removed >= 2) {
+        EXPECT_FALSE(std::filesystem::exists(dir_b));
+    }
+    if (removed >= 3) {
+        EXPECT_FALSE(std::filesystem::exists(dir_a));
+    }
+}
+
+// ============================================================================
+// NFS Safety Mode Toggle Tests
+// ============================================================================
+
+TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeEnabled) {
+    // Save original state
+    bool original = nfs_safety_enabled();
+
+    // Test enabling
+    set_nfs_safety(true);
+    EXPECT_TRUE(nfs_safety_enabled());
+
+    // Restore original state
+    set_nfs_safety(original);
+}
+
+TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeDisabled) {
+    // Save original state
+    bool original = nfs_safety_enabled();
+
+    // Test disabling
+    set_nfs_safety(false);
+    EXPECT_FALSE(nfs_safety_enabled());
+
+    // Restore original state
+    set_nfs_safety(original);
+}
+
+TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyDefaultsToDisabled) {
+    // NFS safety should be disabled by default for performance
+    // (This test assumes a fresh process - may not work if other tests ran first)
+    // We mainly want to verify the getter/setter work correctly
+    bool current = nfs_safety_enabled();
+
+    // Toggle and verify it changes
+    set_nfs_safety(!current);
+    EXPECT_EQ(nfs_safety_enabled(), !current);
+
+    // Toggle back
+    set_nfs_safety(current);
+    EXPECT_EQ(nfs_safety_enabled(), current);
+}
+
+// ============================================================================
+// fsync_file Tests
+// ============================================================================
+
+TEST_F(FilesystemUtilsTest, FsyncFile_SyncsExistingFile) {
+    // Create a test file
+    std::filesystem::path test_file = create_test_file("fsync_test.txt", "content to fsync");
+
+    // fsync the file - should not throw or crash
+    EXPECT_NO_THROW(fsync_file(test_file));
+
+    // File should still exist
+    EXPECT_TRUE(std::filesystem::exists(test_file));
+}
+
+TEST_F(FilesystemUtilsTest, FsyncFile_HandlesNonExistentFile) {
+    // Test with a non-existent file - should not crash
+    std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
+
+    EXPECT_NO_THROW(fsync_file(non_existent));
+}
+
+// ============================================================================
+// Jitter Tests
+// ============================================================================
+
+TEST(FilesystemUtilsConstants, RetryJitterIsWithinBounds) {
+    // Test that get_retry_jitter_ms returns values within expected bounds
+    for (int i = 0; i < 100; ++i) {
+        int jitter = get_retry_jitter_ms();
+        EXPECT_GE(jitter, 0);
+        EXPECT_LE(jitter, kFsRetryJitterMs);
+    }
+}
+
+}  // namespace tt::filesystem::test

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
         ${PROJECT_SOURCE_DIR}/tt_metal/llrt # Hack - circular dep, generated dev_msgs.hpp
-        .
+        ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(

--- a/tt_metal/common/filesystem_utils.cpp
+++ b/tt_metal/common/filesystem_utils.cpp
@@ -57,8 +57,18 @@ void sync_filesystem(const std::filesystem::path& path) {
     }
 
     if (fd == -1) {
-        log_debug(tt::LogMetal, "Failed to open path for syncfs: {}: {}", path_str, ::strerror(errno));
-        return;
+        // Try opening parent directory as fallback
+        std::filesystem::path parent = path.parent_path();
+        if (!parent.empty() && parent != path) {
+            fd = ::open(parent.string().c_str(), O_RDONLY | O_DIRECTORY);
+        }
+
+        if (fd == -1) {
+            // Last resort: process-wide sync
+            log_debug(tt::LogMetal, "Cannot open {} or parent for syncfs, falling back to sync()", path_str);
+            ::sync();
+            return;
+        }
     }
     if (::syncfs(fd) != 0) {
         log_debug(tt::LogMetal, "syncfs failed for {}: {}", path_str, ::strerror(errno));
@@ -254,8 +264,18 @@ bool safe_create_directories(const std::filesystem::path& path) {
         if (!ec) {
             return true;
         }
-        if (ec == std::errc::file_exists && std::filesystem::is_directory(path)) {
-            return true;
+        if (ec == std::errc::file_exists) {
+            std::error_code type_ec;
+            bool is_dir = std::filesystem::is_directory(path, type_ec);
+            if (!type_ec && is_dir) {
+                return true;
+            }
+            if (type_ec) {
+                log_warning(tt::LogMetal, "Failed to verify directory {}: {}", path.string(), type_ec.message());
+            } else {
+                log_warning(tt::LogMetal, "Path {} already exists but is not a directory", path.string());
+            }
+            return false;
         }
         log_warning(tt::LogMetal, "Failed to create directories {}: {}", path.string(), ec.message());
         return false;

--- a/tt_metal/common/filesystem_utils.cpp
+++ b/tt_metal/common/filesystem_utils.cpp
@@ -1,0 +1,694 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/filesystem_utils.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <future>
+#include <mutex>
+#include <random>
+#include <system_error>
+#include <thread>
+
+#include <tt-logger/tt-logger.hpp>
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace tt::filesystem {
+
+static std::atomic<bool> g_nfs_safety{false};
+
+bool nfs_safety_enabled() { return g_nfs_safety.load(std::memory_order_relaxed); }
+void set_nfs_safety(bool enabled) { g_nfs_safety.store(enabled, std::memory_order_seq_cst); }
+
+int get_retry_jitter_ms() {
+    thread_local std::mt19937 rng{std::random_device{}()};
+    thread_local std::uniform_int_distribution<> jitter_dist(0, kFsRetryJitterMs);
+    return jitter_dist(rng);
+}
+
+}  // namespace tt::filesystem
+
+namespace tt::filesystem {
+
+void sync_filesystem(const std::filesystem::path& path) {
+#ifdef __linux__
+    // Use explicit string conversion for portability (path::c_str() may be wchar_t* on Windows)
+    std::string path_str = path.string();
+
+    // Try to open the path as a directory directly to avoid TOCTOU race.
+    // Using O_DIRECTORY ensures we only succeed if it's actually a directory.
+    int fd = ::open(path_str.c_str(), O_RDONLY | O_DIRECTORY);
+
+    if (fd == -1 && errno == ENOTDIR) {
+        // Path exists but is not a directory - try to open its parent.
+        std::filesystem::path parent = path.parent_path();
+
+        // Handle empty parent_path() case (e.g., relative path "file.txt" with no directory)
+        if (parent.empty()) {
+            parent = std::filesystem::current_path();
+        }
+
+        fd = ::open(parent.string().c_str(), O_RDONLY | O_DIRECTORY);
+    }
+
+    if (fd == -1) {
+        log_debug(tt::LogMetal, "Failed to open path for syncfs: {}: {}", path_str, ::strerror(errno));
+        return;
+    }
+    if (::syncfs(fd) != 0) {
+        log_debug(tt::LogMetal, "syncfs failed for {}: {}", path_str, ::strerror(errno));
+    }
+    if (::close(fd) != 0) {
+        log_debug(tt::LogMetal, "close failed after syncfs for {}: {}", path_str, ::strerror(errno));
+    }
+#else
+    ::sync();
+#endif
+}
+
+bool safe_remove(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::filesystem::remove(path, ec);
+        if (!ec || is_not_found_error(ec)) {
+            return true;
+        }
+        log_warning(tt::LogMetal, "Failed to remove {}: {}", path.string(), ec.message());
+        return false;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::filesystem::remove(path, ec);
+        if (!ec) {
+            return true;
+        }
+        if (is_not_found_error(ec)) {
+            return true;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to remove {}: {}", path.string(), ec.message());
+            return false;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+        }
+    }
+    log_warning(tt::LogMetal, "Failed to remove {} after {} retries: {}", path.string(), kMaxFsRetries, ec.message());
+    return false;
+}
+
+bool safe_remove_all(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::filesystem::remove_all(path, ec);
+        if (!ec || is_not_found_error(ec)) {
+            return true;
+        }
+        log_warning(tt::LogMetal, "Failed to remove_all {}: {}", path.string(), ec.message());
+        return false;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::filesystem::remove_all(path, ec);
+        if (!ec) {
+            return true;
+        }
+        if (is_not_found_error(ec)) {
+            return true;
+        }
+        // Retry on ESTALE (stale NFS handle) or ENOTEMPTY (transient race condition).
+        // ENOTEMPTY can occur when:
+        //   - Another process creates files while remove_all is running
+        //   - NFS "silly-rename" files (.nfsXXXX) appear when deleting files held open by other processes
+        //   - Mount points exist inside the directory
+        // Retrying gives concurrent operations time to complete.
+        bool is_retryable = is_estale_error(ec) || ec == std::errc::directory_not_empty;
+        if (!is_retryable) {
+            log_warning(tt::LogMetal, "Failed to remove_all {}: {}", path.string(), ec.message());
+            return false;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+        }
+    }
+    log_warning(
+        tt::LogMetal, "Failed to remove_all {} after {} retries: {}", path.string(), kMaxFsRetries, ec.message());
+    return false;
+}
+
+bool safe_rename(const std::filesystem::path& src, const std::filesystem::path& dst, bool ignore_missing) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::filesystem::rename(src, dst, ec);
+        if (!ec) {
+            return true;
+        }
+        if (ignore_missing && is_not_found_error(ec)) {
+            return true;
+        }
+        log_warning(tt::LogMetal, "Failed to rename {} to {}: {}", src.string(), dst.string(), ec.message());
+        return false;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::filesystem::rename(src, dst, ec);
+        if (!ec) {
+            return true;
+        }
+        if (ignore_missing && is_not_found_error(ec)) {
+            return true;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to rename {} to {}: {}", src.string(), dst.string(), ec.message());
+            return false;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to rename {} to {} after {} retries: {}",
+        src.string(),
+        dst.string(),
+        kMaxFsRetries,
+        ec.message());
+    return false;
+}
+
+bool safe_hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::filesystem::create_hard_link(target, link, ec);
+        if (!ec) {
+            return true;
+        }
+        // Hard link failed -- fall back to copy unconditionally.  The old
+        // implementation always fell back to copy on any hard-link error and
+        // restricting the fallback to specific error codes caused regressions
+        // in environments where unexpected errno values are returned.
+        ec.clear();
+        std::filesystem::copy_file(target, link, std::filesystem::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            return true;
+        }
+        log_warning(
+            tt::LogMetal, "Failed to hard_link or copy {} to {}: {}", target.string(), link.string(), ec.message());
+        return false;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::filesystem::create_hard_link(target, link, ec);
+        if (!ec) {
+            return true;
+        }
+        if (ec == std::errc::file_exists) {
+            if (safe_remove(link)) {
+                continue;
+            }
+            return false;
+        }
+        if (is_estale_error(ec)) {
+            if (attempt < kMaxFsRetries - 1) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+            }
+            continue;
+        }
+        // Hard link failed for a non-transient reason -- fall back to copy
+        // unconditionally (matches pre-NFS-safety behavior).
+        ec.clear();
+        std::filesystem::copy_file(target, link, std::filesystem::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            return true;
+        }
+        if (is_estale_error(ec)) {
+            if (attempt < kMaxFsRetries - 1) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+            }
+            continue;
+        }
+        log_warning(
+            tt::LogMetal, "Failed to hard_link or copy {} to {}: {}", target.string(), link.string(), ec.message());
+        return false;
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to hard_link or copy {} to {} after {} retries: {}",
+        target.string(),
+        link.string(),
+        kMaxFsRetries,
+        ec.message());
+    return false;
+}
+
+bool safe_create_directories(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::filesystem::create_directories(path, ec);
+        if (!ec) {
+            return true;
+        }
+        if (ec == std::errc::file_exists && std::filesystem::is_directory(path)) {
+            return true;
+        }
+        log_warning(tt::LogMetal, "Failed to create directories {}: {}", path.string(), ec.message());
+        return false;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::filesystem::create_directories(path, ec);
+        if (!ec) {
+            return true;
+        }
+        if (ec == std::errc::file_exists) {
+            std::error_code type_ec;
+            bool is_dir = std::filesystem::is_directory(path, type_ec);
+            if (!type_ec && is_dir) {
+                return true;
+            }
+            if (type_ec && is_estale_error(type_ec)) {
+                ec = type_ec;
+            } else {
+                if (type_ec) {
+                    log_warning(
+                        tt::LogMetal,
+                        "Path {} already exists but is not a directory: {}",
+                        path.string(),
+                        type_ec.message());
+                } else {
+                    log_warning(tt::LogMetal, "Path {} already exists but is not a directory", path.string());
+                }
+                return false;
+            }
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to create directories {}: {}", path.string(), ec.message());
+            return false;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to create directories {} after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return false;
+}
+
+std::optional<bool> safe_exists(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        bool result = std::filesystem::exists(path, ec);
+        if (!ec) {
+            return result;
+        }
+        log_warning(tt::LogMetal, "Failed to check existence of {}: {}", path.string(), ec.message());
+        return std::nullopt;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        bool result = std::filesystem::exists(path, ec);
+        if (!ec) {
+            return result;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to check existence of {}: {}", path.string(), ec.message());
+            return std::nullopt;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to check existence of {} after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return std::nullopt;
+}
+
+std::optional<bool> safe_is_directory(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        bool result = std::filesystem::is_directory(path, ec);
+        if (!ec) {
+            return result;
+        }
+        if (is_not_found_error(ec)) {
+            return false;
+        }
+        log_warning(tt::LogMetal, "Failed to check if {} is directory: {}", path.string(), ec.message());
+        return std::nullopt;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        bool result = std::filesystem::is_directory(path, ec);
+        if (!ec) {
+            return result;
+        }
+        if (is_not_found_error(ec)) {
+            return false;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to check if {} is directory: {}", path.string(), ec.message());
+            return std::nullopt;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to check if {} is directory after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return std::nullopt;
+}
+
+std::optional<bool> safe_is_regular_file(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        bool result = std::filesystem::is_regular_file(path, ec);
+        if (!ec) {
+            return result;
+        }
+        if (is_not_found_error(ec)) {
+            return false;
+        }
+        log_warning(tt::LogMetal, "Failed to check if {} is regular file: {}", path.string(), ec.message());
+        return std::nullopt;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        bool result = std::filesystem::is_regular_file(path, ec);
+        if (!ec) {
+            return result;
+        }
+        if (is_not_found_error(ec)) {
+            return false;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to check if {} is regular file: {}", path.string(), ec.message());
+            return std::nullopt;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to check if {} is regular file after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return std::nullopt;
+}
+
+std::optional<std::uintmax_t> safe_file_size(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        std::uintmax_t size = std::filesystem::file_size(path, ec);
+        if (!ec) {
+            return size;
+        }
+        if (is_not_found_error(ec)) {
+            return std::nullopt;
+        }
+        log_warning(tt::LogMetal, "Failed to get file size of {}: {}", path.string(), ec.message());
+        return std::nullopt;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        std::uintmax_t size = std::filesystem::file_size(path, ec);
+        if (!ec) {
+            return size;
+        }
+        if (is_not_found_error(ec)) {
+            return std::nullopt;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to get file size of {}: {}", path.string(), ec.message());
+            return std::nullopt;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+    log_warning(
+        tt::LogMetal, "Failed to get file size of {} after {} retries: {}", path.string(), kMaxFsRetries, ec.message());
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::file_time_type> safe_last_write_time(const std::filesystem::path& path) {
+    std::error_code ec;
+    if (!nfs_safety_enabled()) {
+        auto time = std::filesystem::last_write_time(path, ec);
+        if (!ec) {
+            return time;
+        }
+        if (is_not_found_error(ec)) {
+            return std::nullopt;
+        }
+        log_warning(tt::LogMetal, "Failed to get last write time of {}: {}", path.string(), ec.message());
+        return std::nullopt;
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        auto time = std::filesystem::last_write_time(path, ec);
+        if (!ec) {
+            return time;
+        }
+        if (is_not_found_error(ec)) {
+            return std::nullopt;
+        }
+        if (!is_estale_error(ec)) {
+            log_warning(tt::LogMetal, "Failed to get last write time of {}: {}", path.string(), ec.message());
+            return std::nullopt;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+    log_warning(
+        tt::LogMetal,
+        "Failed to get last write time of {} after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return std::nullopt;
+}
+
+std::vector<std::filesystem::directory_entry> safe_directory_entries(const std::filesystem::path& path) {
+    std::vector<std::filesystem::directory_entry> entries;
+    std::error_code ec;
+
+    if (!nfs_safety_enabled()) {
+        auto it =
+            std::filesystem::directory_iterator(path, std::filesystem::directory_options::skip_permission_denied, ec);
+        if (ec) {
+            if (!is_not_found_error(ec)) {
+                log_warning(tt::LogMetal, "Failed to iterate directory {}: {}", path.string(), ec.message());
+            }
+            return entries;
+        }
+        while (it != std::filesystem::directory_iterator()) {
+            entries.push_back(*it);
+            it.increment(ec);
+            if (ec) {
+                break;
+            }
+        }
+        return entries;
+    }
+
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        entries.clear();
+        auto it =
+            std::filesystem::directory_iterator(path, std::filesystem::directory_options::skip_permission_denied, ec);
+
+        if (ec) {
+            if (is_not_found_error(ec)) {
+                return entries;
+            }
+            if (!is_estale_error(ec)) {
+                log_warning(tt::LogMetal, "Failed to iterate directory {}: {}", path.string(), ec.message());
+                return entries;
+            }
+            if (attempt < kMaxFsRetries - 1) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+            }
+            continue;
+        }
+
+        bool estale_during_iteration = false;
+        while (it != std::filesystem::directory_iterator()) {
+            try {
+                entries.push_back(*it);
+            } catch (const std::filesystem::filesystem_error& e) {
+                log_debug(tt::LogMetal, "Skipping stale directory entry in {}: {}", path.string(), e.what());
+                if (is_estale_error(e.code())) {
+                    estale_during_iteration = true;
+                    break;
+                }
+            }
+            it.increment(ec);
+            if (ec) {
+                if (is_estale_error(ec)) {
+                    estale_during_iteration = true;
+                    break;
+                }
+                // Other errors during iteration: skip remaining entries
+                break;
+            }
+        }
+
+        if (!estale_during_iteration) {
+            return entries;
+        }
+
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+        }
+    }
+
+    log_warning(
+        tt::LogMetal,
+        "Failed to iterate directory {} after {} retries: {}",
+        path.string(),
+        kMaxFsRetries,
+        ec.message());
+    return entries;
+}
+
+void fsync_file(const std::filesystem::path& path) {
+#ifdef __linux__
+    int fd = ::open(path.c_str(), O_RDONLY);
+    if (fd == -1) {
+        log_debug(tt::LogMetal, "Failed to open {} for fsync: {}", path.string(), ::strerror(errno));
+        return;
+    }
+    ::fsync(fd);
+    ::close(fd);
+
+    auto parent = path.parent_path();
+    if (!parent.empty()) {
+        fd = ::open(parent.c_str(), O_RDONLY | O_DIRECTORY);
+        if (fd >= 0) {
+            ::fsync(fd);
+            ::close(fd);
+        }
+    }
+#else
+    (void)path;
+#endif
+}
+
+namespace {
+std::mutex g_async_sync_mutex;
+std::future<void> g_pending_sync;
+}  // namespace
+
+void async_sync_filesystem(const std::filesystem::path& path) {
+    std::lock_guard lk(g_async_sync_mutex);
+    if (g_pending_sync.valid()) {
+        g_pending_sync.get();
+    }
+    g_pending_sync = std::async(std::launch::async, [p = path] { sync_filesystem(p); });
+}
+
+void wait_for_pending_sync() {
+    std::lock_guard lk(g_async_sync_mutex);
+    if (g_pending_sync.valid()) {
+        g_pending_sync.get();
+    }
+}
+
+size_t remove_empty_parent_directories(const std::filesystem::path& path) {
+    size_t removed_count = 0;
+    std::error_code ec;
+
+    // Sync to ensure directory metadata is fully committed before checking emptiness.
+    // This is important in containerized/CI environments where filesystem operations
+    // may have delayed commit semantics.
+    sync_filesystem(path);
+
+    std::filesystem::path current = path;
+    while (true) {
+        // Check if directory is empty with NFS-safety retry on ESTALE.
+        // A directory is considered empty if it has no entries other than . and ..
+        // Retry logic is important in containerized/CI environments where is_empty
+        // can fail intermittently due to delayed filesystem commit semantics.
+        bool is_empty = false;
+        if (nfs_safety_enabled()) {
+            for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+                is_empty = std::filesystem::is_empty(current, ec);
+                if (!ec) {
+                    break;
+                }
+                if (!is_estale_error(ec)) {
+                    break;
+                }
+                if (attempt < kMaxFsRetries - 1) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1)));
+                }
+            }
+        } else {
+            is_empty = std::filesystem::is_empty(current, ec);
+        }
+        if (ec || !is_empty) {
+            // Directory is not empty or error occurred - stop here
+            break;
+        }
+
+        // Get parent before removing
+        std::filesystem::path parent = current.parent_path();
+
+        // Don't remove if we're at the filesystem root (no parent)
+        if (parent.empty() || parent == current) {
+            break;
+        }
+
+        // Try to remove the empty directory.
+        // Use std::filesystem::remove (not remove_all) so that if another process
+        // adds files between the is_empty check and this call, the remove fails
+        // with ENOTEMPTY instead of recursively deleting another process's files.
+        if (nfs_safety_enabled()) {
+            bool removed = false;
+            for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+                std::filesystem::remove(current, ec);
+                if (!ec || is_not_found_error(ec)) {
+                    removed = true;
+                    break;
+                }
+                if (!is_estale_error(ec)) {
+                    break;
+                }
+                if (attempt < kMaxFsRetries - 1) {
+                    std::this_thread::sleep_for(
+                        std::chrono::milliseconds((kFsRetryDelayMs * (attempt + 1)) + get_retry_jitter_ms()));
+                }
+            }
+            if (!removed) {
+                break;
+            }
+        } else {
+            std::filesystem::remove(current, ec);
+            if (ec) {
+                break;  // Failed to remove, stop here
+            }
+        }
+
+        ++removed_count;
+        current = parent;
+    }
+
+    return removed_count;
+}
+
+}  // namespace tt::filesystem

--- a/tt_metal/common/filesystem_utils.hpp
+++ b/tt_metal/common/filesystem_utils.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <cerrno>
 #include <chrono>
 #include <cstdint>
@@ -280,14 +279,13 @@ std::optional<std::uintmax_t> safe_file_size(const std::filesystem::path& path);
 std::optional<std::filesystem::file_time_type> safe_last_write_time(const std::filesystem::path& path);
 
 // Safe directory iteration with ESTALE retry (no sync, no jitter).
-// Returns vector of directory entries, skipping entries that disappear during iteration.
-// Returns empty vector on error or if directory doesn't exist.
+// Returns vector of directory entries. On iteration errors, returns entries
+// collected up to the point of failure (may be partial). Returns empty vector
+// if directory doesn't exist or cannot be opened.
 //
-// Consistency guarantee: If ESTALE occurs mid-iteration, the entire operation is
-// retried (up to kMaxFsRetries times) with the entries vector cleared before each
-// retry. This ensures callers always receive a consistent snapshot of the directory
-// at a single point in time, at the cost of potentially higher latency when
-// ESTALE errors occur frequently.
+// Consistency guarantee: If ESTALE occurs mid-iteration (NFS safety mode only),
+// the entire operation is retried (up to kMaxFsRetries times) with the entries
+// vector cleared before each retry.
 std::vector<std::filesystem::directory_entry> safe_directory_entries(const std::filesystem::path& path);
 
 // Targeted fsync of a single file and its parent directory entry.

--- a/tt_metal/common/filesystem_utils.hpp
+++ b/tt_metal/common/filesystem_utils.hpp
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// NFS-Specific Filesystem Utilities
+// =================================
+//
+// These utilities provide wrappers around std::filesystem operations with
+// built-in handling for NFS-specific failure modes. They are designed for
+// use in multi-process and multi-host environments where NFS filesystems
+// are shared across many clients.
+//
+// Why ESTALE occurs
+// -----------------
+// ESTALE ("Stale file handle") is an NFS-specific error that occurs when
+// the NFS client holds a file handle that is no longer valid on the server.
+// Common causes include:
+//
+//   - Attribute caching: NFS clients cache file attributes for performance.
+//     When one client modifies a file, other clients may have stale cached
+//     handles until their cache expires.
+//
+//   - Rapid file operations: When one process creates and immediately renames
+//     a file while another process attempts to access it, the file handle
+//     may become invalid between the lookup and the operation.
+//
+//   - Multi-host contention: In distributed environments with multiple hosts
+//     accessing the same NFS share, file handles can become stale when other
+//     hosts perform operations that invalidate client-side caches.
+//
+//   - Directory reorganization: When directories are modified (e.g., entries
+//     added or removed), existing file handles to entries in those directories
+//     may become stale.
+//
+// The utilities below automatically retry operations that fail with ESTALE,
+// giving the NFS cache time to refresh before retrying.
+//
+// Sync behavior
+// -------------
+// The safe_* functions do NOT automatically sync the filesystem after writes.
+// Callers that need cross-client visibility (e.g. after merging JIT build
+// artifacts to an NFS cache) should call sync_filesystem() explicitly at
+// the appropriate boundary.  This avoids the severe performance cost of
+// flushing all pending I/O on every individual file operation.
+//
+// sync_filesystem() ensures:
+//   - Data durability: All written data is flushed to stable storage on
+//     the NFS server before returning.
+//   - Cross-client visibility: Other NFS clients will see the changes
+//     immediately, rather than waiting for their cache to expire.
+//
+// Implementation:
+//   - On Linux: Uses syncfs() to sync only the specific filesystem containing
+//     the target path, minimizing impact on concurrent I/O in other filesystems.
+//   - On other platforms: Falls back to process-wide sync().
+//
+// Performance implications:
+//   - Even with syncfs(), the flush affects all pending I/O on that filesystem.
+//   - Call sync_filesystem() only at batch boundaries (e.g. after a set of
+//     merges completes), not after each individual file operation.
+//
+// Blocking behavior
+// -----------------
+// All functions in this namespace are blocking and may sleep during retry:
+//
+//   - Maximum retry attempts: 5 (kMaxFsRetries)
+//   - Base delay: kFsRetryDelayMs * attempt_number (linear backoff)
+//   - Jitter: Write operations add up to kFsRetryJitterMs of random jitter
+//     per retry to prevent thundering herd issues
+//
+//   - Sleep occurs before retries 1-4 (not before first attempt or after last)
+//   - Maximum total sleep time for write operations: ~5.4 seconds
+//     (500 + 1000 + 1500 + 2000 = 5000ms, plus up to 400ms total jitter)
+//
+//   - Maximum total sleep time for read-only operations: ~5 seconds
+//     (500 + 1000 + 1500 + 2000 = 5000ms, no jitter)
+//
+//   Note: Read-only operations (exists, is_directory, file_size, etc.) do not
+//   include jitter since they don't modify state. Write operations (remove,
+//   rename, create_directories, hard_link/copy) include random jitter to
+//   reduce contention in high-concurrency scenarios.
+//
+//   If all retries are exhausted, the function returns failure (false or
+//   std::nullopt) and logs a warning.
+//
+// Testing Notes
+// -------------
+// When writing tests for these functions in containerized CI environments:
+//
+//   - Call sync_filesystem() after creating directory structures before
+//     testing removal operations. Container filesystems may have delayed
+//     commit semantics that can cause is_empty() to fail intermittently.
+//
+//   - Do not rely on exact counts for remove_empty_parent_directories().
+//     The function may stop early if is_empty() returns an error (e.g., due
+//     to permission issues or filesystem timing). Verify that the target
+//     directories were removed rather than checking exact counts.
+//
+//   - NFS safety mode (set_nfs_safety(true)) enables retry loops. Tests
+//     should verify both enabled and disabled modes if possible, or at
+//     minimum verify the mode can be toggled correctly.
+//
+//   - Thread-local RNG is used for jitter. Tests that verify jitter
+//     bounds should call get_retry_jitter_ms() multiple times.
+
+namespace tt::filesystem {
+
+// NFS safety mode control.
+// When enabled, safe_* wrappers use ESTALE retry loops with backoff and jitter.
+// When disabled (default), safe_* wrappers delegate directly to std::filesystem
+// with a single attempt -- no retry loops, no sleep, no jitter.
+// Coupled to scratch-dir configuration: call set_nfs_safety(true) when
+// TT_METAL_JIT_SCRATCH is set (i.e. multihost NFS operation).
+bool nfs_safety_enabled();
+void set_nfs_safety(bool enabled);
+
+// Maximum number of retries for filesystem operations on NFS
+inline constexpr int kMaxFsRetries = 5;
+// Base delay between retries (in milliseconds), multiplied by attempt number
+inline constexpr int kFsRetryDelayMs = 500;
+// Maximum random jitter for write operations (in milliseconds) to prevent thundering herd
+inline constexpr int kFsRetryJitterMs = 100;
+
+// Check if error code is ESTALE (stale file handle) - NFS specific error
+inline bool is_estale_error(const std::error_code& ec) {
+    return ec.category() == std::system_category() && ec.value() == ESTALE;
+}
+
+// Check if error is ENOENT (file/directory not found)
+inline bool is_not_found_error(const std::error_code& ec) { return ec == std::errc::no_such_file_or_directory; }
+
+// Get random jitter (0 to kFsRetryJitterMs) for retry delays.
+// Uses thread-local RNG for thread safety.
+int get_retry_jitter_ms();
+
+// Generic ESTALE retry helper for low-level C-style syscalls using errno.
+// Calls `operation()` up to kMaxFsRetries times, retrying only if
+// errno == ESTALE after a failed attempt. Sleeps between retries with
+// random jitter to prevent thundering herd issues.
+//
+// IMPORTANT: This template is designed for C-style syscalls that set errno.
+// It should NOT be used with std::filesystem operations (which use std::error_code).
+// For std::filesystem operations, use the safe_* wrappers instead.
+//
+// The operation should:
+// - Clear errno before the syscall (errno = 0)
+// - Return true on success, false to trigger retry check
+// - The syscall should set errno on failure
+//
+// Returns true if operation eventually succeeded, false if all retries failed.
+template <typename Operation>
+bool retry_on_estale(Operation&& operation) {
+    if (!nfs_safety_enabled()) {
+        return operation();
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        if (operation()) {
+            return true;
+        }
+        if (errno != ESTALE) {
+            break;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1) + get_retry_jitter_ms()));
+        }
+    }
+    return false;
+}
+
+// ESTALE retry helper for C++ operations that report errors via std::error_code.
+// Use this instead of retry_on_estale when the operation uses std::filesystem or
+// C++ streams (which do not reliably set errno).
+//
+// The operation lambda receives a std::error_code& and should:
+// - Clear or ignore the incoming ec (it is pre-cleared before each attempt)
+// - Populate ec on failure (e.g. ec.assign(errno, std::system_category()))
+// - Return true on success, false on failure
+//
+// Returns true if operation eventually succeeded, false if all retries failed.
+// On failure, ec contains the error from the last attempt.
+template <typename Operation>
+bool retry_on_estale_ec(Operation&& operation, std::error_code& ec) {
+    ec.clear();
+    if (!nfs_safety_enabled()) {
+        return operation(ec);
+    }
+    for (int attempt = 0; attempt < kMaxFsRetries; ++attempt) {
+        ec.clear();
+        if (operation(ec)) {
+            return true;
+        }
+        if (!is_estale_error(ec)) {
+            break;
+        }
+        if (attempt < kMaxFsRetries - 1) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kFsRetryDelayMs * (attempt + 1) + get_retry_jitter_ms()));
+        }
+    }
+    return false;
+}
+
+// Flush all pending writes on the filesystem containing `path` to stable storage.
+// On Linux, uses syncfs() scoped to that filesystem; elsewhere falls back to sync().
+// Call this at batch boundaries (e.g. after merging build artifacts) rather than
+// after every individual file operation.
+void sync_filesystem(const std::filesystem::path& path);
+
+// Safe remove that ignores ENOENT and retries on ESTALE.
+// Works on both files and empty directories (mirrors std::filesystem::remove).
+// Does NOT sync -- call sync_filesystem() at the appropriate boundary.
+// Returns true if the entry was removed or didn't exist, false on other errors.
+bool safe_remove(const std::filesystem::path& path);
+
+// Safe remove_all that retries on ESTALE and ENOTEMPTY (transient race conditions).
+// ENOTEMPTY is retried because it can occur when:
+//   - Another process creates files while remove_all is running
+//   - NFS "silly-rename" files (.nfsXXXX) appear when deleting files held open by other processes
+//   - Mount points exist inside the directory
+// Does NOT sync -- call sync_filesystem() at the appropriate boundary.
+// Returns true if directory was removed or didn't exist, false on other errors.
+bool safe_remove_all(const std::filesystem::path& path);
+
+// Safe rename that retries on ESTALE errors.
+// Does NOT sync -- call sync_filesystem() at the appropriate boundary.
+// If ignore_missing is true, ENOENT errors are ignored (returns true).
+// Returns true on success, false on non-retryable errors.
+bool safe_rename(const std::filesystem::path& src, const std::filesystem::path& dst, bool ignore_missing = false);
+
+// Safe create_hard_link with fallback to copy_file, retrying on ESTALE.
+// Does NOT sync -- call sync_filesystem() at the appropriate boundary.
+// Returns true on success, false on failure.
+//
+// @warning NFS safety: Callers MUST write to a unique temporary path first
+// (e.g. via jit_build::utils::FileRenamer::generate_temp_path()), then
+// atomically rename to the final destination. This function operates
+// directly on the destination path and does not provide atomicity guarantees.
+// See the "NFS write safety" comment in tt_metal/jit_build/build.cpp for
+// the full pattern and rationale.
+bool safe_hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link);
+
+// Safe create_directories that ignores "already exists" and retries on ESTALE.
+// Does NOT sync -- call sync_filesystem() at the appropriate boundary.
+// Returns true on success (directory exists or was created), false on other errors.
+bool safe_create_directories(const std::filesystem::path& path);
+
+// Safe exists check with ESTALE retry (no sync, no jitter).
+// Returns true if path exists, false if it doesn't exist, std::nullopt on error.
+std::optional<bool> safe_exists(const std::filesystem::path& path);
+
+// Safe directory check with ESTALE retry (no sync, no jitter).
+// Returns true if path exists and is a directory, false if it doesn't exist or isn't a directory,
+// std::nullopt on error.
+std::optional<bool> safe_is_directory(const std::filesystem::path& path);
+
+// Safe regular file check with ESTALE retry (no sync, no jitter).
+// Returns true if path exists and is a regular file, false if it doesn't exist or isn't a regular file,
+// std::nullopt on error.
+std::optional<bool> safe_is_regular_file(const std::filesystem::path& path);
+
+// Safe file size query with ESTALE retry (no sync, no jitter).
+// Returns file size on success, std::nullopt on error (including file not found).
+std::optional<std::uintmax_t> safe_file_size(const std::filesystem::path& path);
+
+// Safe last_write_time query with ESTALE retry (no sync, no jitter).
+// Returns file time on success, std::nullopt on error (including file not found).
+std::optional<std::filesystem::file_time_type> safe_last_write_time(const std::filesystem::path& path);
+
+// Safe directory iteration with ESTALE retry (no sync, no jitter).
+// Returns vector of directory entries, skipping entries that disappear during iteration.
+// Returns empty vector on error or if directory doesn't exist.
+//
+// Consistency guarantee: If ESTALE occurs mid-iteration, the entire operation is
+// retried (up to kMaxFsRetries times) with the entries vector cleared before each
+// retry. This ensures callers always receive a consistent snapshot of the directory
+// at a single point in time, at the cost of potentially higher latency when
+// ESTALE errors occur frequently.
+std::vector<std::filesystem::directory_entry> safe_directory_entries(const std::filesystem::path& path);
+
+// Targeted fsync of a single file and its parent directory entry.
+// Much cheaper than sync_filesystem() (which flushes the entire FS).
+// Use for individual small files (e.g. markers) where full-filesystem flush is overkill.
+void fsync_file(const std::filesystem::path& path);
+
+// Asynchronously flush the filesystem containing `path`.
+// Launches sync_filesystem() on a background thread.  The next call to
+// async_sync_filesystem() or wait_for_pending_sync() blocks until the
+// previous async sync completes.
+void async_sync_filesystem(const std::filesystem::path& path);
+
+// Block until any pending async_sync_filesystem() completes.
+void wait_for_pending_sync();
+
+// Remove empty directories from the given path, stopping at the first non-empty directory.
+// This is useful for cleaning up scratch directories after successful JIT builds.
+// Returns the number of directories removed.
+//
+// Example: if path is /tmp/tt-jit-build/123/kernels/my_kernel/brisc/
+// and only 'brisc' and 'my_kernel' are empty, removes those two directories
+// leaving /tmp/tt-jit-build/123/kernels/ intact.
+//
+// Safety: Only removes empty directories. Non-empty directories act as a barrier.
+// Does NOT remove the root of the path if it has no parent (path is at filesystem root).
+size_t remove_empty_parent_directories(const std::filesystem::path& path);
+
+}  // namespace tt::filesystem

--- a/tt_metal/common/filesystem_utils.hpp
+++ b/tt_metal/common/filesystem_utils.hpp
@@ -160,7 +160,7 @@ int get_retry_jitter_ms();
 //
 // Returns true if operation eventually succeeded, false if all retries failed.
 template <typename Operation>
-bool retry_on_estale(Operation&& operation) {
+bool retry_on_estale(Operation operation) {
     if (!nfs_safety_enabled()) {
         return operation();
     }
@@ -191,7 +191,7 @@ bool retry_on_estale(Operation&& operation) {
 // Returns true if operation eventually succeeded, false if all retries failed.
 // On failure, ec contains the error from the last attempt.
 template <typename Operation>
-bool retry_on_estale_ec(Operation&& operation, std::error_code& ec) {
+bool retry_on_estale_ec(Operation operation, std::error_code& ec) {
     ec.clear();
     if (!nfs_safety_enabled()) {
         return operation(ec);

--- a/tt_metal/common/sources.cmake
+++ b/tt_metal/common/sources.cmake
@@ -1,6 +1,7 @@
 set(COMMON_SOURCES
     core_assignment.cpp
     core_coord.cpp
+    filesystem_utils.cpp
     mesh_coord.cpp
     shape.cpp
     shape2d.cpp


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-metal/issues/37051
and https://github.com/tenstorrent/tt-metal/pull/39174

Blocker for deepseek and multihost in general.

### Problem description
Filesystem ops are not error tolerant and fail with stale filesystem errors on an NFS mount.

### What's changed
* Introduced tt::filesystem::safe_* filesystem api wrappers which do backoff retries when stale file handle errors get thrown.
* Added unit tests

- [x] sanity https://github.com/tenstorrent/tt-metal/actions/runs/23258214752
- [x] merge gate https://github.com/tenstorrent/tt-metal/actions/runs/23261507730