### PR TITLE
[cleanup] extend fabric datastructures to support up to 3 VCs

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -59,7 +59,8 @@ namespace tt::tt_fabric::fabric_router_tests {
 // ============================================================================
 // Type alias for the capture results struct used throughout these tests
 // ============================================================================
-using CaptureResults = FabricDatapathUsageL1Results<true, builder_config::num_max_receiver_channels, builder_config::num_max_sender_channels>;
+using CaptureResults =
+    FabricDatapathUsageL1Results<true, builder_config::MAX_NUM_VCS, builder_config::num_max_sender_channels>;
 
 // ============================================================================
 // Helper: Result of reading capture data from a single ETH core

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_channel_mapping.cpp
@@ -62,7 +62,21 @@ namespace tt::tt_fabric {
  * │                             │ IntermeshConfig_XYIntermesh_3Channels    │ XY 3 channels│
  * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
  *
- * Total: 31 tests across 8 categories
+ * ├─────────────────────────────┼──────────────────────────────────────────┼──────────────┤
+ * │ VC2 Channel Mapping         │ VC2_NonZMesh_NoZOnDevice_HasThreeVCs     │ 3 VCs        │
+ * │                             │ VC2_NonZMesh_NoZOnDevice_SenderAtLast    │ Sender idx   │
+ * │                             │ VC2_NonZMesh_NoZOnDevice_ReceiverAtIdx2  │ Receiver idx │
+ * │                             │ VC2_NonZMesh_WithZOnDevice_SenderAtLast  │ Z offset     │
+ * │                             │ VC2_ZRouter_SenderAtLastFlatIndex        │ Z sender     │
+ * │                             │ VC2_ZRouter_NoReceiver                   │ No receiver  │
+ * │                             │ VC2_GetAllSenderMappings_IncludesVC2     │ All senders  │
+ * │                             │ VC2_GetAllSenderMappings_ZRouter         │ Z all send   │
+ * │                             │ VC2_Disabled_NoVC2Channels               │ Disabled     │
+ * │                             │ VC2_NonZMesh_ExistingVC0VC1Unchanged     │ Regression   │
+ * │                             │ VC2_ZRouter_ExistingVC0VC1Unchanged      │ Z regression │
+ * └─────────────────────────────┴──────────────────────────────────────────┴──────────────┘
+ *
+ * Total: 42 tests across 9 categories
  */
 class RouterChannelMappingTest : public ::testing::Test {
 protected:
@@ -144,7 +158,7 @@ TEST_F(RouterChannelMappingTest, ZRouter_Has2VirtualChannels) {
     EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
 }
 
-TEST_F(RouterChannelMappingTest, ZRouter_VC0_Has4SenderChannels) {
+TEST_F(RouterChannelMappingTest, ZRouter_VC0_Has5SenderChannels) {
     auto intermesh_config = IntermeshVCConfig::full_mesh();
     FabricRouterChannelMapping mapping(
         Topology::Mesh,
@@ -152,11 +166,11 @@ TEST_F(RouterChannelMappingTest, ZRouter_VC0_Has4SenderChannels) {
         RouterVariant::Z_ROUTER,
         &intermesh_config);  // Z routers require intermesh config
 
-    // VC0 should have 4 sender channels (same as 2D mesh)
-    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+    // VC0 should have 5 sender channels (0=Worker, 1-4=E/W/N/S)
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 5);
 
-    // Verify VC0 channels map to erisc 0-3
-    for (uint32_t i = 0; i < 4; ++i) {
+    // Verify VC0 channels map to erisc 0-4
+    for (uint32_t i = 0; i < 5; ++i) {
         auto mapping_result = mapping.get_sender_mapping(0, i);
         EXPECT_EQ(mapping_result.builder_type, BuilderType::ERISC);
         EXPECT_EQ(mapping_result.internal_sender_channel_id, i);
@@ -183,11 +197,12 @@ TEST_F(RouterChannelMappingTest, ZRouter_VC1_SenderChannels_MapToErisc4Through7)
         RouterVariant::Z_ROUTER,
         &intermesh_config);  // Z routers require intermesh config
 
-    // VC1 sender channels 0-3 should map to erisc internal channels 4-7
+    // VC1 sender channels 0-3 should map to erisc internal channels 5-8
+    // (Z router VC0 has 5 channels, so VC1 base = 5)
     for (uint32_t i = 0; i < 4; ++i) {
         auto mapping_result = mapping.get_sender_mapping(1, i);
         EXPECT_EQ(mapping_result.builder_type, BuilderType::ERISC);
-        EXPECT_EQ(mapping_result.internal_sender_channel_id, 4 + i);
+        EXPECT_EQ(mapping_result.internal_sender_channel_id, 5 + i);
     }
 }
 
@@ -201,7 +216,7 @@ TEST_F(RouterChannelMappingTest, ZRouterNoTensix_VC0_VC1_ReceiverChannel_MapsToE
 
 
     EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
-    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 5);
     EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
 
     // VC0 receiver channel should still map to erisc receiver 0
@@ -459,9 +474,9 @@ TEST_F(RouterChannelMappingTest, ZRouter_CompleteChannelLayout) {
 
     // Verify complete channel layout for Z router
 
-    // VC0: 4 sender channels → erisc 0-3
-    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
-    for (uint32_t i = 0; i < 4; ++i) {
+    // VC0: 5 sender channels → erisc 0-4
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 5);
+    for (uint32_t i = 0; i < 5; ++i) {
         auto s = mapping.get_sender_mapping(0, i);
         EXPECT_EQ(s.builder_type, BuilderType::ERISC);
         EXPECT_EQ(s.internal_sender_channel_id, i);
@@ -472,12 +487,12 @@ TEST_F(RouterChannelMappingTest, ZRouter_CompleteChannelLayout) {
     EXPECT_EQ(vc0_r.builder_type, BuilderType::ERISC);
     EXPECT_EQ(vc0_r.internal_receiver_channel_id, 0);
 
-    // VC1: 4 sender channels → erisc 4-7
+    // VC1: 4 sender channels → erisc 5-8 (base = 5, after 5 VC0 channels)
     EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
     for (uint32_t i = 0; i < 4; ++i) {
         auto s = mapping.get_sender_mapping(1, i);
         EXPECT_EQ(s.builder_type, BuilderType::ERISC);
-        EXPECT_EQ(s.internal_sender_channel_id, 4 + i);
+        EXPECT_EQ(s.internal_sender_channel_id, 5 + i);
     }
 
     // VC1: 1 receiver channel → erisc 1
@@ -485,7 +500,7 @@ TEST_F(RouterChannelMappingTest, ZRouter_CompleteChannelLayout) {
     EXPECT_EQ(vc1_r.builder_type, BuilderType::ERISC);
     EXPECT_EQ(vc1_r.internal_receiver_channel_id, 1);
 
-    // Total: 8 sender channels, 2 receiver channels
+    // Total: 9 sender channels, 2 receiver channels
     EXPECT_EQ(mapping.get_num_virtual_channels(), 2);
 }
 
@@ -520,20 +535,199 @@ TEST_F(RouterChannelMappingTest, GetAllSenderMappings_ZRouter) {
 
     auto all_mappings = mapping.get_all_sender_mappings();
 
-    // Z router: VC0 (4 channels) + VC1 (4 channels) = 8 total
-    EXPECT_EQ(all_mappings.size(), 8);
+    // Z router: VC0 (5 channels) + VC1 (4 channels) = 9 total
+    EXPECT_EQ(all_mappings.size(), 9);
 
-    // First 4 should be VC0 → erisc 0-3
-    for (size_t i = 0; i < 4; ++i) {
+    // First 5 should be VC0 → erisc 0-4
+    for (size_t i = 0; i < 5; ++i) {
         EXPECT_EQ(all_mappings[i].builder_type, BuilderType::ERISC);
         EXPECT_EQ(all_mappings[i].internal_sender_channel_id, i);
     }
 
-    // Next 4 should be VC1 → erisc 4-7
+    // Next 4 should be VC1 → erisc 5-8
     for (size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(all_mappings[4 + i].builder_type, BuilderType::ERISC);
-        EXPECT_EQ(all_mappings[4 + i].internal_sender_channel_id, 4 + i);
+        EXPECT_EQ(all_mappings[5 + i].builder_type, BuilderType::ERISC);
+        EXPECT_EQ(all_mappings[5 + i].internal_sender_channel_id, 5 + i);
     }
+}
+
+// ============ VC2 Channel Mapping Tests ============
+
+TEST_F(RouterChannelMappingTest, VC2_NonZMesh_NoZOnDevice_HasThreeVCs) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,  // no tensix
+        RouterVariant::MESH,
+        &config,
+        false);  // has_z_on_device = false
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 3);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(2), 1);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_NonZMesh_NoZOnDevice_SenderAtLastFlatIndex) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        &config,
+        false);  // has_z_on_device = false
+
+    // VC2 sender should be at flat index 7 (VC0:4 + VC1:3 = 7)
+    auto vc2_sender = mapping.get_sender_mapping(2, 0);
+    EXPECT_EQ(vc2_sender.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc2_sender.internal_sender_channel_id, 7);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_NonZMesh_NoZOnDevice_ReceiverAtIndex2) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::MESH, &config, false);
+
+    // VC2 receiver at index 2 (after VC0=0, VC1=1)
+    auto vc2_receiver = mapping.get_receiver_mapping(2, 0);
+    EXPECT_EQ(vc2_receiver.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc2_receiver.internal_receiver_channel_id, 2);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_NonZMesh_WithZOnDevice_SenderAtLastFlatIndex) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(
+        Topology::Mesh,
+        false,
+        RouterVariant::MESH,
+        &config,
+        true);  // has_z_on_device = true
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 3);
+
+    // VC2 sender should be at flat index 8 (VC0:4 + VC1:4 = 8)
+    auto vc2_sender = mapping.get_sender_mapping(2, 0);
+    EXPECT_EQ(vc2_sender.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc2_sender.internal_sender_channel_id, 8);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_ZRouter_SenderAtLastFlatIndex) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::Z_ROUTER, &config);
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 3);
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(2), 1);
+
+    // VC2 sender at flat index 9 (VC0:5 + VC1:4 = 9)
+    auto vc2_sender = mapping.get_sender_mapping(2, 0);
+    EXPECT_EQ(vc2_sender.builder_type, BuilderType::ERISC);
+    EXPECT_EQ(vc2_sender.internal_sender_channel_id, 9);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_ZRouter_NoReceiver) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::Z_ROUTER, &config);
+
+    // Z router VC2 has no receiver -- should throw
+    EXPECT_THROW(mapping.get_receiver_mapping(2, 0), std::exception);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_GetAllSenderMappings_IncludesVC2Last) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::MESH, &config,
+                                       false);  // no Z on device
+
+    auto all_mappings = mapping.get_all_sender_mappings();
+
+    // VC0:4 + VC1:3 + VC2:1 = 8
+    EXPECT_EQ(all_mappings.size(), 8);
+
+    // Last element should be VC2 sender at flat index 7
+    EXPECT_EQ(all_mappings.back().builder_type, BuilderType::ERISC);
+    EXPECT_EQ(all_mappings.back().internal_sender_channel_id, 7);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_GetAllSenderMappings_ZRouter_IncludesVC2Last) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::Z_ROUTER, &config);
+
+    auto all_mappings = mapping.get_all_sender_mappings();
+
+    // VC0:5 + VC1:4 + VC2:1 = 10
+    EXPECT_EQ(all_mappings.size(), 10);
+
+    // Last element should be VC2 sender at flat index 9
+    EXPECT_EQ(all_mappings.back().builder_type, BuilderType::ERISC);
+    EXPECT_EQ(all_mappings.back().internal_sender_channel_id, 9);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_Disabled_NoVC2Channels) {
+    // full_mesh() does NOT set requires_vc2 by default
+    auto config = IntermeshVCConfig::full_mesh();
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::MESH, &config);
+
+    EXPECT_EQ(mapping.get_num_virtual_channels(), 2);  // Only VC0 + VC1
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(2), 0);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_NonZMesh_ExistingVC0VC1Unchanged) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::MESH, &config,
+                                       false);  // no Z on device
+
+    // VC0: 4 senders at indices 0-3
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 4);
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto s = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(s.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(s.internal_sender_channel_id, i);
+    }
+
+    // VC1: 3 senders at indices 4-6
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 3);
+    for (uint32_t i = 0; i < 3; ++i) {
+        auto s = mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(s.builder_type, BuilderType::ERISC);
+        EXPECT_EQ(s.internal_sender_channel_id, 4 + i);
+    }
+
+    // VC0 receiver at 0, VC1 receiver at 1
+    auto vc0_r = mapping.get_receiver_mapping(0, 0);
+    EXPECT_EQ(vc0_r.internal_receiver_channel_id, 0);
+    auto vc1_r = mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(vc1_r.internal_receiver_channel_id, 1);
+}
+
+TEST_F(RouterChannelMappingTest, VC2_ZRouter_ExistingVC0VC1Unchanged) {
+    auto config = IntermeshVCConfig::full_mesh();
+    config.requires_vc2 = true;
+    FabricRouterChannelMapping mapping(Topology::Mesh, false, RouterVariant::Z_ROUTER, &config);
+
+    // VC0: 5 senders at indices 0-4
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(0), 5);
+    for (uint32_t i = 0; i < 5; ++i) {
+        auto s = mapping.get_sender_mapping(0, i);
+        EXPECT_EQ(s.internal_sender_channel_id, i);
+    }
+
+    // VC1: 4 senders at indices 5-8
+    EXPECT_EQ(mapping.get_num_sender_channels_for_vc(1), 4);
+    for (uint32_t i = 0; i < 4; ++i) {
+        auto s = mapping.get_sender_mapping(1, i);
+        EXPECT_EQ(s.internal_sender_channel_id, 5 + i);
+    }
+
+    // VC0 receiver at 0, VC1 receiver at 1
+    auto vc0_r = mapping.get_receiver_mapping(0, 0);
+    EXPECT_EQ(vc0_r.internal_receiver_channel_id, 0);
+    auto vc1_r = mapping.get_receiver_mapping(1, 0);
+    EXPECT_EQ(vc1_r.internal_receiver_channel_id, 1);
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -75,17 +75,27 @@ static constexpr std::size_t num_sender_channels_1d = 2;
 static constexpr std::size_t num_sender_channels_2d = 8;
 // Max including VC2 — used only for array sizing
 static constexpr std::size_t num_sender_channels_2d_with_vc2 = num_sender_channels_2d + num_sender_channels_vc2;
-// Max without VC2 — feeds L1 layout, firmware CT args, and host-side array sizing
-// VC2 will increase these when actually wired through (Phase 4+)
-static constexpr std::size_t num_max_sender_channels =
+// Without VC2 — used for firmware CT args and L1 layout when VC2 is disabled
+static constexpr std::size_t num_max_sender_channels_without_vc2 =
     std::max({num_sender_channels_1d, num_sender_channels_2d, num_sender_channels_z_router});
+// = max(2, 8, 9) = 9
+// Absolute maximum — used for host-side array sizing (always big enough for any config)
+static constexpr std::size_t num_max_sender_channels =
+    std::max({num_sender_channels_1d, num_sender_channels_2d_with_vc2, num_sender_channels_z_router_with_vc2});
+// = max(2, 9, 10) = 10
 static constexpr std::size_t num_receiver_channels_1d = 1;
 // Without VC2 — VC2 receiver added dynamically
 static constexpr std::size_t num_receiver_channels_2d = 2;  // VC0(1) + VC1(1)
 // Max including VC2 — used only for array sizing
 static constexpr std::size_t num_receiver_channels_2d_with_vc2 = num_receiver_channels_2d + num_receiver_channels_vc2;
-// Max without VC2 — feeds L1 layout, firmware CT args, and host-side array sizing
-static constexpr std::size_t num_max_receiver_channels = std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
+// Without VC2 — used for firmware CT args and L1 layout when VC2 is disabled
+static constexpr std::size_t num_max_receiver_channels_without_vc2 =
+    std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
+// = max(1, 2, 2) = 2
+// Absolute maximum — used for host-side array sizing (always big enough for any config)
+static constexpr std::size_t num_max_receiver_channels =
+    std::max({num_receiver_channels_1d, num_receiver_channels_2d_with_vc2, num_receiver_channels_z_router});
+// = max(1, 3, 2) = 3
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;
 static constexpr std::size_t num_downstream_edms_2d_vc0 = 3;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -56,18 +56,24 @@ static constexpr std::size_t num_sender_channels_2d_mesh = 4;
 // VC1: 4 sender channels (Z→mesh, one per direction: 0=E, 1=W, 2=N, 3=S) + 0 receiver (skipped)
 static constexpr std::size_t num_sender_channels_z_router_vc0 = 5;
 static constexpr std::size_t num_sender_channels_z_router_vc1 = 4;
-static constexpr std::size_t num_sender_channels_z_router = num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1;
+// VC2: 1 sender channel (worker-type, neighbour exchange) + 1 receiver (non-Z only)
+static constexpr std::size_t num_sender_channels_vc2 = 1;
+static constexpr std::size_t num_receiver_channels_vc2 = 1;
+static constexpr std::size_t num_sender_channels_z_router_vc2 = 1;
+static constexpr std::size_t num_sender_channels_z_router =
+    num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1 + num_sender_channels_z_router_vc2;
 static constexpr std::size_t num_receiver_channels_z_router = 2;  // 1 for VC0, 1 for VC1
 
 static constexpr std::size_t num_sender_channels_1d = 2;
 // VC0: Worker + 3 of [N/E/S/W] = 4 channels
 // VC1: Up to 3 of [N/E/S/W] for inter-mesh = 3 channels, 1 for Z→mesh
-// Total 2D: 4 + 3 +1 = 8 channels
-static constexpr std::size_t num_sender_channels_2d = 8;
+// VC2: 1 sender channel (neighbour exchange)
+// Total 2D: 4 + 3 + 1 + 1(VC2) = 9 channels
+static constexpr std::size_t num_sender_channels_2d = 9;
 static constexpr std::size_t num_max_sender_channels =
     std::max({num_sender_channels_1d, num_sender_channels_2d, num_sender_channels_z_router});
 static constexpr std::size_t num_receiver_channels_1d = 1;
-static constexpr std::size_t num_receiver_channels_2d = 2;
+static constexpr std::size_t num_receiver_channels_2d = 3;  // VC0(1) + VC1(1) + VC2(1)
 static constexpr std::size_t num_max_receiver_channels = std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -60,20 +60,31 @@ static constexpr std::size_t num_sender_channels_z_router_vc1 = 4;
 static constexpr std::size_t num_sender_channels_vc2 = 1;
 static constexpr std::size_t num_receiver_channels_vc2 = 1;
 static constexpr std::size_t num_sender_channels_z_router_vc2 = 1;
+// Aggregate without VC2 — VC2 channels are added dynamically by channel mapping when requires_vc2 is true
 static constexpr std::size_t num_sender_channels_z_router =
-    num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1 + num_sender_channels_z_router_vc2;
+    num_sender_channels_z_router_vc0 + num_sender_channels_z_router_vc1;
+// Max including VC2 — used only for array sizing
+static constexpr std::size_t num_sender_channels_z_router_with_vc2 =
+    num_sender_channels_z_router + num_sender_channels_z_router_vc2;
 static constexpr std::size_t num_receiver_channels_z_router = 2;  // 1 for VC0, 1 for VC1
 
 static constexpr std::size_t num_sender_channels_1d = 2;
 // VC0: Worker + 3 of [N/E/S/W] = 4 channels
 // VC1: Up to 3 of [N/E/S/W] for inter-mesh = 3 channels, 1 for Z→mesh
-// VC2: 1 sender channel (neighbour exchange)
-// Total 2D: 4 + 3 + 1 + 1(VC2) = 9 channels
-static constexpr std::size_t num_sender_channels_2d = 9;
+// Total 2D without VC2: 4 + 3 + 1 = 8 channels (VC2 added dynamically)
+static constexpr std::size_t num_sender_channels_2d = 8;
+// Max including VC2 — used only for array sizing
+static constexpr std::size_t num_sender_channels_2d_with_vc2 = num_sender_channels_2d + num_sender_channels_vc2;
+// Max without VC2 — feeds L1 layout, firmware CT args, and host-side array sizing
+// VC2 will increase these when actually wired through (Phase 4+)
 static constexpr std::size_t num_max_sender_channels =
     std::max({num_sender_channels_1d, num_sender_channels_2d, num_sender_channels_z_router});
 static constexpr std::size_t num_receiver_channels_1d = 1;
-static constexpr std::size_t num_receiver_channels_2d = 3;  // VC0(1) + VC1(1) + VC2(1)
+// Without VC2 — VC2 receiver added dynamically
+static constexpr std::size_t num_receiver_channels_2d = 2;  // VC0(1) + VC1(1)
+// Max including VC2 — used only for array sizing
+static constexpr std::size_t num_receiver_channels_2d_with_vc2 = num_receiver_channels_2d + num_receiver_channels_vc2;
+// Max without VC2 — feeds L1 layout, firmware CT args, and host-side array sizing
 static constexpr std::size_t num_max_receiver_channels = std::max({num_receiver_channels_1d, num_receiver_channels_2d, num_receiver_channels_z_router});
 
 static constexpr std::size_t num_downstream_edms_vc0 = 1;

--- a/tt_metal/fabric/builder/fabric_builder_config.hpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.hpp
@@ -41,7 +41,7 @@ struct FabricEriscDatamoverOptions {
 
 namespace builder_config {
 // Number of Virtual Channels supported (VC0 and VC1)
-static constexpr std::size_t MAX_NUM_VCS = 2;
+static constexpr std::size_t MAX_NUM_VCS = 3;
 
 // linear/mesh/ring/torus: for fabric with tensix extension, only one sender channel will be present on fabric router
 static constexpr std::size_t num_sender_channels_with_tensix_config = 1;

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -108,7 +108,11 @@ public:
      * @return Total number of used receiver channels
      */
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc_[0] + num_used_receiver_channels_per_vc_[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_receiver_channels_per_vc_[vc];
+        }
+        return total;
     }
 
     /**

--- a/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp
@@ -122,7 +122,7 @@ private:
         remote_receiver_channels_base_address_ = {};
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>
         remote_receiver_channels_num_buffers_ = {};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc_ = {};
 };
 
 inline void FabricRemoteChannelsAllocator::print(std::ostream& os) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -444,11 +444,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         if (topology == Topology::Mesh || topology == Topology::Torus) {
             if (num_active_vcs >= 3) {
                 return vc0_vc1_vc2_mesh_slots.get()[arch_index];
-            } else if (num_active_vcs >= 2) {
-                return vc0_vc1_mesh_slots.get()[arch_index];
-            } else {
-                return vc0_only_mesh_slots.get()[arch_index];
             }
+            if (num_active_vcs >= 2) {
+                return vc0_vc1_mesh_slots.get()[arch_index];
+            }
+            return vc0_only_mesh_slots.get()[arch_index];
         }
         return other_slots.get()[arch_index];
     };

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -285,12 +285,14 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
         num_receiver_buffer_slots_per_vc,
     std::array<std::array<size_t, builder_config::num_max_receiver_channels>, builder_config::MAX_NUM_VCS>&
         num_remote_receiver_buffer_slots_per_vc) {
-    // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
+    // Per-VC buffer slot configuration: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver, vc2_sender, vc2_receiver}
     struct PerVcBufferSlots {
         size_t vc0_sender_slots;
         size_t vc0_receiver_slots;
         size_t vc1_sender_slots;
         size_t vc1_receiver_slots;
+        size_t vc2_sender_slots;
+        size_t vc2_receiver_slots;
     };
 
     // fabric with tensix extension uses different buffer slots options, since only one or two sender channels are
@@ -299,109 +301,154 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     static const std::vector<std::vector<PerVcBufferSlots>> default_with_tensix_buffer_slot_options = {
         // WORMHOLE_B0
         {
-            {16, 16, 0, 0},  // Option 1
-            {8, 16, 0, 0},   // Option 2
-            {8, 8, 0, 0},    // Option 3
-            {4, 8, 0, 0},    // Option 4
-            {4, 4, 0, 0},    // Option 5: VC0 only, smaller
-            {2, 4, 0, 0},    // Option 6: VC0 only, smaller
-            {2, 2, 0, 0},    // Option 7: VC0 only, smaller
-            {1, 2, 0, 0},    // Option 8: VC0 only, smallest
-            {1, 1, 0, 0},    // Option 9: VC0 only, smallest
-            {4, 8, 4, 4},    // Option 10: supports both VCs
-            {4, 8, 2, 2},    // Option 11: supports both VCs
-            {4, 4, 2, 2},    // Option 12: supports both VCs
-            {2, 2, 2, 2}     // Option 13: supports both VCs
+            {16, 16, 0, 0, 0, 0},  // Option 1
+            {8, 16, 0, 0, 0, 0},   // Option 2
+            {8, 8, 0, 0, 0, 0},    // Option 3
+            {4, 8, 0, 0, 0, 0},    // Option 4
+            {4, 4, 0, 0, 0, 0},    // Option 5: VC0 only, smaller
+            {2, 4, 0, 0, 0, 0},    // Option 6: VC0 only, smaller
+            {2, 2, 0, 0, 0, 0},    // Option 7: VC0 only, smaller
+            {1, 2, 0, 0, 0, 0},    // Option 8: VC0 only, smallest
+            {1, 1, 0, 0, 0, 0},    // Option 9: VC0 only, smallest
+            {4, 8, 4, 4, 0, 0},    // Option 10: supports VC0+VC1
+            {4, 8, 2, 2, 0, 0},    // Option 11: supports VC0+VC1
+            {4, 4, 2, 2, 0, 0},    // Option 12: supports VC0+VC1
+            {2, 2, 2, 2, 0, 0}     // Option 13: supports VC0+VC1
         },
         // BLACKHOLE
         {
-            {32, 32, 0, 0},  // Option 1
-            {16, 32, 0, 0},  // Option 2
-            {16, 16, 0, 0},  // Option 3
-            {8, 16, 0, 0},   // Option 4
-            {8, 8, 0, 0},    // Option 5
-            {4, 8, 0, 0},    // Option 6
-            {4, 4, 0, 0},    // Option 7
-            {2, 4, 0, 0},    // Option 8
-            {2, 2, 0, 0},    // Option 9
-            {1, 2, 0, 0},    // Option 10
-            {1, 1, 0, 0},    // Option 11
-            {4, 8, 2, 4},    // Option 12: supports both VCs
-            {4, 8, 2, 2},    // Option 13: supports both VCs, smaller VC1 receiver
-            {2, 4, 2, 2},    // Option 14: supports both VCs, smaller overall
-            {2, 4, 1, 1},    // Option 15: supports both VCs, smaller overall
-            {2, 2, 1, 1},    // Option 16: supports both VCs, smaller overall
-            {1, 1, 1, 1}     // Option 17: supports both VCs, smaller overall
+            {32, 32, 0, 0, 0, 0},  // Option 1
+            {16, 32, 0, 0, 0, 0},  // Option 2
+            {16, 16, 0, 0, 0, 0},  // Option 3
+            {8, 16, 0, 0, 0, 0},   // Option 4
+            {8, 8, 0, 0, 0, 0},    // Option 5
+            {4, 8, 0, 0, 0, 0},    // Option 6
+            {4, 4, 0, 0, 0, 0},    // Option 7
+            {2, 4, 0, 0, 0, 0},    // Option 8
+            {2, 2, 0, 0, 0, 0},    // Option 9
+            {1, 2, 0, 0, 0, 0},    // Option 10
+            {1, 1, 0, 0, 0, 0},    // Option 11
+            {4, 8, 2, 4, 0, 0},    // Option 12: supports VC0+VC1
+            {4, 8, 2, 2, 0, 0},    // Option 13: supports VC0+VC1, smaller VC1 receiver
+            {2, 4, 2, 2, 0, 0},    // Option 14: supports VC0+VC1, smaller overall
+            {2, 4, 1, 1, 0, 0},    // Option 15: supports VC0+VC1, smaller overall
+            {2, 2, 1, 1, 0, 0},    // Option 16: supports VC0+VC1, smaller overall
+            {1, 1, 1, 1, 0, 0}     // Option 17: supports VC0+VC1, smaller overall
 
         }};
 
-    auto get_num_buffer_slots = [](Topology topology, size_t arch_index) -> const std::vector<PerVcBufferSlots>& {
-        // Architecture-specific buffer slot configurations per VC
-        // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver}
-        static const std::vector<std::vector<PerVcBufferSlots>> mesh_buffer_slot_options = {
+    auto get_num_buffer_slots =
+        [](Topology topology, size_t arch_index, size_t num_active_vcs) -> const std::vector<PerVcBufferSlots>& {
+        // Architecture-specific buffer slot configurations per VC, split by active VC count
+        // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver, vc2_sender, vc2_receiver}
+
+        // VC0-only mesh options: vc1 slots = 0, vc2 slots = 0
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_only_mesh_buffer_slot_options = {
             // WORMHOLE_B0
             {
-                {7, 11, 0, 0},  // Option 1: VC0 only
-                {4, 8, 0, 0},   // Option 2: VC0 only, smaller
-                {4, 4, 0, 0},   // Option 3: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 5: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 6: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 7: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 8: supports both VCs
-                {4, 8, 2, 2},   // Option 9: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 10: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 11: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 13: supports both VCs, smaller overall
+                {7, 11, 0, 0, 0, 0},  // Option 1: VC0 only
+                {4, 8, 0, 0, 0, 0},   // Option 2: VC0 only, smaller
+                {4, 4, 0, 0, 0, 0},   // Option 3: VC0 only, smaller
+                {2, 4, 0, 0, 0, 0},   // Option 4: VC0 only, smaller
+                {2, 2, 0, 0, 0, 0},   // Option 5: VC0 only, smaller
+                {1, 2, 0, 0, 0, 0},   // Option 6: VC0 only, smallest
+                {1, 1, 0, 0, 0, 0}    // Option 7: VC0 only, smallest
             },
             // BLACKHOLE
             {
-                {8, 16, 0, 0},  // Option 1: VC0 only
-                {8, 8, 0, 0},   // Option 2: VC0 only
-                {4, 8, 0, 0},   // Option 3: VC0 only
-                {4, 4, 0, 0},   // Option 4: VC0 only, smaller
-                {2, 4, 0, 0},   // Option 5: VC0 only, smaller
-                {2, 2, 0, 0},   // Option 6: VC0 only, smaller
-                {1, 2, 0, 0},   // Option 7: VC0 only, smallest
-                {1, 1, 0, 0},   // Option 8: VC0 only, smallest
-                {4, 8, 2, 4},   // Option 9: supports both VCs
-                {4, 8, 2, 2},   // Option 10: supports both VCs, smaller VC1 receiver
-                {2, 4, 2, 2},   // Option 11: supports both VCs, smaller overall
-                {2, 4, 1, 1},   // Option 12: supports both VCs, smaller overall
-                {2, 2, 1, 1},   // Option 13: supports both VCs, smaller overall
-                {1, 1, 1, 1}    // Option 14: supports both VCs, smaller overall
+                {8, 16, 0, 0, 0, 0},  // Option 1: VC0 only
+                {8, 8, 0, 0, 0, 0},   // Option 2: VC0 only
+                {4, 8, 0, 0, 0, 0},   // Option 3: VC0 only
+                {4, 4, 0, 0, 0, 0},   // Option 4: VC0 only, smaller
+                {2, 4, 0, 0, 0, 0},   // Option 5: VC0 only, smaller
+                {2, 2, 0, 0, 0, 0},   // Option 6: VC0 only, smaller
+                {1, 2, 0, 0, 0, 0},   // Option 7: VC0 only, smallest
+                {1, 1, 0, 0, 0, 0}    // Option 8: VC0 only, smallest
             }};
+
+        // VC0+VC1 mesh options: vc1 slots > 0, vc2 slots = 0
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_vc1_mesh_buffer_slot_options = {
+            // WORMHOLE_B0
+            {
+                {4, 8, 2, 4, 0, 0},  // Option 1: supports VC0+VC1
+                {4, 8, 2, 2, 0, 0},  // Option 2: supports VC0+VC1, smaller VC1 receiver
+                {2, 4, 2, 2, 0, 0},  // Option 3: supports VC0+VC1, smaller overall
+                {2, 4, 1, 1, 0, 0},  // Option 4: supports VC0+VC1, smaller overall
+                {2, 2, 1, 1, 0, 0},  // Option 5: supports VC0+VC1, smaller overall
+                {1, 1, 1, 1, 0, 0}   // Option 6: supports VC0+VC1, smallest
+            },
+            // BLACKHOLE
+            {
+                {4, 8, 2, 4, 0, 0},  // Option 1: supports VC0+VC1
+                {4, 8, 2, 2, 0, 0},  // Option 2: supports VC0+VC1, smaller VC1 receiver
+                {2, 4, 2, 2, 0, 0},  // Option 3: supports VC0+VC1, smaller overall
+                {2, 4, 1, 1, 0, 0},  // Option 4: supports VC0+VC1, smaller overall
+                {2, 2, 1, 1, 0, 0},  // Option 5: supports VC0+VC1, smaller overall
+                {1, 1, 1, 1, 0, 0}   // Option 6: supports VC0+VC1, smallest
+            }};
+
+        // VC0+VC1+VC2 mesh options: vc2 mirrors vc1 values in each row
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_vc1_vc2_mesh_buffer_slot_options = {
+            // WORMHOLE_B0
+            {
+                {4, 8, 2, 4, 2, 4},  // Option 1: supports VC0+VC1+VC2
+                {4, 8, 2, 2, 2, 2},  // Option 2: supports VC0+VC1+VC2, smaller VC1/VC2 receiver
+                {2, 4, 2, 2, 2, 2},  // Option 3: supports VC0+VC1+VC2, smaller overall
+                {2, 4, 1, 1, 1, 1},  // Option 4: supports VC0+VC1+VC2, smaller overall
+                {2, 2, 1, 1, 1, 1},  // Option 5: supports VC0+VC1+VC2, smaller overall
+                {1, 1, 1, 1, 1, 1}   // Option 6: supports VC0+VC1+VC2, smallest
+            },
+            // BLACKHOLE
+            {
+                {4, 8, 2, 4, 2, 4},  // Option 1: supports VC0+VC1+VC2
+                {4, 8, 2, 2, 2, 2},  // Option 2: supports VC0+VC1+VC2, smaller VC1/VC2 receiver
+                {2, 4, 2, 2, 2, 2},  // Option 3: supports VC0+VC1+VC2, smaller overall
+                {2, 4, 1, 1, 1, 1},  // Option 4: supports VC0+VC1+VC2, smaller overall
+                {2, 2, 1, 1, 1, 1},  // Option 5: supports VC0+VC1+VC2, smaller overall
+                {1, 1, 1, 1, 1, 1}   // Option 6: supports VC0+VC1+VC2, smallest
+            }};
+
         static const std::vector<std::vector<PerVcBufferSlots>> other_buffer_slot_options = {
             // WORMHOLE_B0
-            {{16, 16, 0, 0},  // Only VC0 for non-mesh topologies.
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}},
+            {{16, 16, 0, 0, 0, 0},  // Only VC0 for non-mesh topologies.
+             {8, 16, 0, 0, 0, 0},
+             {8, 8, 0, 0, 0, 0},
+             {4, 8, 0, 0, 0, 0},
+             {4, 4, 0, 0, 0, 0},
+             {2, 4, 0, 0, 0, 0},
+             {2, 2, 0, 0, 0, 0},
+             {1, 2, 0, 0, 0, 0},
+             {1, 1, 0, 0, 0, 0}},
             // BLACKHOLE
-            {{32, 32, 0, 0},  // Only VC0 for non-mesh topologies.
-             {16, 32, 0, 0},
-             {16, 16, 0, 0},
-             {8, 16, 0, 0},
-             {8, 8, 0, 0},
-             {4, 8, 0, 0},
-             {4, 4, 0, 0},
-             {2, 4, 0, 0},
-             {2, 2, 0, 0},
-             {1, 2, 0, 0},
-             {1, 1, 0, 0}}};
+            {{32, 32, 0, 0, 0, 0},  // Only VC0 for non-mesh topologies.
+             {16, 32, 0, 0, 0, 0},
+             {16, 16, 0, 0, 0, 0},
+             {8, 16, 0, 0, 0, 0},
+             {8, 8, 0, 0, 0, 0},
+             {4, 8, 0, 0, 0, 0},
+             {4, 4, 0, 0, 0, 0},
+             {2, 4, 0, 0, 0, 0},
+             {2, 2, 0, 0, 0, 0},
+             {1, 2, 0, 0, 0, 0},
+             {1, 1, 0, 0, 0, 0}}};
 
-        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> mesh_slots(mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_only_mesh_slots(
+            vc0_only_mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_mesh_slots(
+            vc0_vc1_mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_vc2_mesh_slots(
+            vc0_vc1_vc2_mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(
             other_buffer_slot_options);
 
         if (topology == Topology::Mesh || topology == Topology::Torus) {
-            return mesh_slots.get()[arch_index];
+            if (num_active_vcs >= 3) {
+                return vc0_vc1_vc2_mesh_slots.get()[arch_index];
+            } else if (num_active_vcs >= 2) {
+                return vc0_vc1_mesh_slots.get()[arch_index];
+            } else {
+                return vc0_only_mesh_slots.get()[arch_index];
+            }
         }
         return other_slots.get()[arch_index];
     };
@@ -412,17 +459,24 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                                             size_t num_vc0_receiver_channels,
                                             size_t num_vc1_sender_channels,
                                             size_t num_vc1_receiver_channels,
+                                            size_t num_vc2_sender_channels,
+                                            size_t num_vc2_receiver_channels,
                                             size_t& vc0_sender_buffer_slots,
                                             size_t& vc0_receiver_buffer_slots,
                                             size_t& vc1_sender_buffer_slots,
-                                            size_t& vc1_receiver_buffer_slots) {
+                                            size_t& vc1_receiver_buffer_slots,
+                                            size_t& vc2_sender_buffer_slots,
+                                            size_t& vc2_receiver_buffer_slots) {
         bool vc1_needed = (num_vc1_sender_channels > 0) || (num_vc1_receiver_channels > 0);
+        bool vc2_needed = (num_vc2_sender_channels > 0) || (num_vc2_receiver_channels > 0);
         bool found_valid_option = false;
         for (auto& option : buffer_slot_options) {
             vc0_sender_buffer_slots = option.vc0_sender_slots;
             vc0_receiver_buffer_slots = option.vc0_receiver_slots;
             vc1_sender_buffer_slots = option.vc1_sender_slots;
             vc1_receiver_buffer_slots = option.vc1_receiver_slots;
+            vc2_sender_buffer_slots = option.vc2_sender_slots;
+            vc2_receiver_buffer_slots = option.vc2_receiver_slots;
             // skip the VC0 only options if VC1 is needed (either sender or receiver channels)
             if (vc1_needed) {
                 // Check if we need VC1 sender channels but this option doesn't provide them
@@ -434,15 +488,26 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                     continue;  // Skip this option - VC1 is needed but this option doesn't support it
                 }
             }
+            // skip options without VC2 slots if VC2 is needed
+            if (vc2_needed) {
+                bool skip_due_to_vc2_sender = (num_vc2_sender_channels > 0) && (vc2_sender_buffer_slots == 0);
+                bool skip_due_to_vc2_receiver = (num_vc2_receiver_channels > 0) && (vc2_receiver_buffer_slots == 0);
 
-            // Calculate total slots across both VCs
+                if (skip_due_to_vc2_sender || skip_due_to_vc2_receiver) {
+                    continue;  // Skip this option - VC2 is needed but this option doesn't support it
+                }
+            }
+
+            // Calculate total slots across all VCs
             auto vc0_total_sender_slots = num_vc0_sender_channels * vc0_sender_buffer_slots;
             auto vc0_total_receiver_slots = num_vc0_receiver_channels * vc0_receiver_buffer_slots;
             auto vc1_total_sender_slots = num_vc1_sender_channels * vc1_sender_buffer_slots;
             auto vc1_total_receiver_slots = num_vc1_receiver_channels * vc1_receiver_buffer_slots;
+            auto vc2_total_sender_slots = num_vc2_sender_channels * vc2_sender_buffer_slots;
+            auto vc2_total_receiver_slots = num_vc2_receiver_channels * vc2_receiver_buffer_slots;
 
             auto total_num_bytes = (vc0_total_sender_slots + vc0_total_receiver_slots + vc1_total_sender_slots +
-                                    vc1_total_receiver_slots) *
+                                    vc1_total_receiver_slots + vc2_total_sender_slots + vc2_total_receiver_slots) *
                                    this->channel_buffer_size_bytes;
 
             if (total_num_bytes <= this->available_channel_buffering_space) {
@@ -451,20 +516,25 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             }
         }
 
-        // Validate that we found a valid option, especially if VC1 is needed
+        // Validate that we found a valid option
         if (!found_valid_option) {
             TT_THROW(
-                "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC0 channels: {} senders/{} "
-                "receivers, VC1 channels: {} senders/{} receivers, Available space: {} bytes",
+                "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC2 needed: {}, VC0 channels: {} "
+                "senders/{} "
+                "receivers, VC1 channels: {} senders/{} receivers, VC2 channels: {} senders/{} receivers, Available "
+                "space: {} bytes",
                 vc1_needed,
+                vc2_needed,
                 num_vc0_sender_channels,
                 num_vc0_receiver_channels,
                 num_vc1_sender_channels,
                 num_vc1_receiver_channels,
+                num_vc2_sender_channels,
+                num_vc2_receiver_channels,
                 this->available_channel_buffering_space);
         }
 
-        // Additional validation: ensure VC1 buffer slots are non-zero if VC1 channels are needed
+        // Additional validation: ensure VC1/VC2 buffer slots are non-zero if those channels are needed
     };
 
     // auto axis_index = static_cast<std::size_t>(options.edm_axis);
@@ -484,6 +554,7 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             uint32_t target_channel = get_worker_connected_sender_channel();
             size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
             size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+            size_t vc2_sender_buffer_slots, vc2_receiver_buffer_slots;
 
             // get the optimal buffer slots for MUX mode (per-VC)
             get_optimal_num_slots_per_vc(
@@ -492,20 +563,26 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                 num_used_receiver_channels_per_vc[0],
                 num_used_sender_channels_per_vc[1],
                 num_used_receiver_channels_per_vc[1],
+                num_used_sender_channels_per_vc[2],
+                num_used_receiver_channels_per_vc[2],
                 vc0_sender_buffer_slots,
                 vc0_receiver_buffer_slots,
                 vc1_sender_buffer_slots,
-                vc1_receiver_buffer_slots);
+                vc1_receiver_buffer_slots,
+                vc2_sender_buffer_slots,
+                vc2_receiver_buffer_slots);
 
             // set buffer slots for VC0 worker channel only
             num_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
             num_remote_sender_buffer_slots_per_vc[0][target_channel] = vc0_sender_buffer_slots;
 
-            // Fill receiver buffer slots for both VCs
+            // Fill receiver buffer slots for all VCs
             num_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
             num_remote_receiver_buffer_slots_per_vc[0].fill(vc0_receiver_buffer_slots);
             num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
             num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+            num_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
+            num_remote_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
             return;
         }
         default: break;
@@ -514,18 +591,32 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     // Default case: Configure buffer slots with per-VC options
     size_t vc0_sender_buffer_slots, vc0_receiver_buffer_slots;
     size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
+    size_t vc2_sender_buffer_slots, vc2_receiver_buffer_slots;
 
-    // Get optimal buffer slots considering both VCs
+    // Determine how many VCs are active based on channel usage
+    size_t num_active_vcs = 1;
+    if (num_used_sender_channels_per_vc[1] > 0 || num_used_receiver_channels_per_vc[1] > 0) {
+        num_active_vcs = 2;
+    }
+    if (num_used_sender_channels_per_vc[2] > 0 || num_used_receiver_channels_per_vc[2] > 0) {
+        num_active_vcs = 3;
+    }
+
+    // Get optimal buffer slots considering all VCs
     get_optimal_num_slots_per_vc(
-        get_num_buffer_slots(topology, arch_index),
+        get_num_buffer_slots(topology, arch_index, num_active_vcs),
         num_used_sender_channels_per_vc[0],
         num_used_receiver_channels_per_vc[0],
         num_used_sender_channels_per_vc[1],
         num_used_receiver_channels_per_vc[1],
+        num_used_sender_channels_per_vc[2],
+        num_used_receiver_channels_per_vc[2],
         vc0_sender_buffer_slots,
         vc0_receiver_buffer_slots,
         vc1_sender_buffer_slots,
-        vc1_receiver_buffer_slots);
+        vc1_receiver_buffer_slots,
+        vc2_sender_buffer_slots,
+        vc2_receiver_buffer_slots);
 
     // Apply the buffer slot configuration to each VC
     num_sender_buffer_slots_per_vc[0].fill(vc0_sender_buffer_slots);
@@ -537,6 +628,11 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     num_remote_sender_buffer_slots_per_vc[1].fill(vc1_sender_buffer_slots);
     num_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
     num_remote_receiver_buffer_slots_per_vc[1].fill(vc1_receiver_buffer_slots);
+
+    num_sender_buffer_slots_per_vc[2].fill(vc2_sender_buffer_slots);
+    num_remote_sender_buffer_slots_per_vc[2].fill(vc2_sender_buffer_slots);
+    num_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
+    num_remote_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -107,10 +107,18 @@ public:
     }
     // For total counts: return sum across all VCs
     size_t get_num_sender_channels() const {
-        return num_used_sender_channels_per_vc[0] + num_used_sender_channels_per_vc[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_sender_channels_per_vc[vc];
+        }
+        return total;
     }
     size_t get_num_receiver_channels() const {
-        return num_used_receiver_channels_per_vc[0] + num_used_receiver_channels_per_vc[1];
+        size_t total = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            total += num_used_receiver_channels_per_vc[vc];
+        }
+        return total;
     }
 
     // Override virtual print method from base class
@@ -188,10 +196,22 @@ inline void FabricStaticSizedChannelsAllocator::print(std::ostream& os) const {
 
     // Configuration parameters
     os << "  Configuration:\n";
-    os << "    num_used_sender_channels_per_vc: [" << num_used_sender_channels_per_vc[0] << ", "
-       << num_used_sender_channels_per_vc[1] << "]\n";
-    os << "    num_used_receiver_channels_per_vc: [" << num_used_receiver_channels_per_vc[0] << ", "
-       << num_used_receiver_channels_per_vc[1] << "]\n";
+    os << "    num_used_sender_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_sender_channels_per_vc[vc];
+    }
+    os << "]\n";
+    os << "    num_used_receiver_channels_per_vc: [";
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+        if (vc > 0) {
+            os << ", ";
+        }
+        os << num_used_receiver_channels_per_vc[vc];
+    }
+    os << "]\n";
     os << "    channel_buffer_size_bytes: " << channel_buffer_size_bytes << " B\n";
     os << "    available_channel_buffering_space: " << available_channel_buffering_space << " B\n";
     os << "    buffer_region_start: 0x" << std::hex << buffer_region_start << std::dec << "\n";

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp
@@ -138,8 +138,8 @@ private:
             builder_config::MAX_NUM_VCS>& num_remote_receiver_buffer_slots_per_vc);
 
     // Configuration parameters
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};
-    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {};
+    std::array<size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {};
     size_t channel_buffer_size_bytes = 0;
     size_t available_channel_buffering_space = 0;
     size_t max_l1_loading_size = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -230,11 +230,9 @@ bool requires_forced_assignment_to_noc1() {
 
 FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topology(topology) {
     const bool is_2D_routing = is_2D_topology(topology);
-    // Allocate L1 addresses for MAX sender channels (9) to support all router types
-    // Even though most routers use fewer channels, we need addresses for all possible channels
-    uint32_t num_sender_channels = is_2D_routing
-                                       ? builder_config::num_max_sender_channels
-                                       : builder_config::get_sender_channel_count(false);  // Use MAX (9) instead of 8
+    // Allocate L1 addresses for global max sender channels so layout is stable across all configs
+    uint32_t num_sender_channels =
+        is_2D_routing ? builder_config::num_max_sender_channels : builder_config::get_sender_channel_count(false);
     uint32_t num_downstream_edms = builder_config::get_downstream_edm_count(is_2D_routing);
     // Global
     size_t next_l1_addr = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
@@ -268,6 +266,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
                                                   builder_config::MAX_NUM_VCS,
                                                   builder_config::num_max_sender_channels>);
         next_l1_addr += this->datapath_usage_buffer_size;
+        next_l1_addr = tt::align(next_l1_addr, eth_word_l1_alignment);
     } else {
         this->datapath_usage_l1_address = 0;
         this->datapath_usage_buffer_size = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1017,6 +1017,9 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     auto actual_sender_channels_vc1 = actual_sender_channels_per_vc_.has_value()
                                           ? actual_sender_channels_per_vc_.value()[1]
                                           : config.num_used_sender_channels_per_vc[1];
+    auto actual_sender_channels_vc2 = actual_sender_channels_per_vc_.has_value()
+                                          ? actual_sender_channels_per_vc_.value()[2]
+                                          : config.num_used_sender_channels_per_vc[2];
 
     // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;
@@ -1068,6 +1071,12 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         StreamRegAssignments::IncrementOnWrite::sender_channel_6_free_slots_stream_id;
     named_args["SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID"] =
         StreamRegAssignments::IncrementOnWrite::sender_channel_7_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_8_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc2_sender_free_slots_stream_id;
+    named_args["SENDER_CHANNEL_9_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc2_sender_free_slots_stream_id;
+    named_args["VC2_RECEIVER_FREE_SLOTS_STREAM_ID"] =
+        StreamRegAssignments::IncrementOnWrite::vc2_receiver_free_slots_stream_id;
     named_args["TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID"] =
         StreamRegAssignments::IncrementOnWrite::tensix_relay_local_free_slots_stream_id;
     // --- Stream IDs (scratch registers) ---
@@ -1075,9 +1084,13 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         StreamRegAssignments::Scratch::multi_risc_teardown_sync_stream_id;
     named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = StreamRegAssignments::Scratch::eth_retrain_link_sync_stream_id;
 
-    // --- Max channel counts ---
-    named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;
-    named_args["MAX_NUM_RECEIVER_CHANNELS"] = builder_config::num_max_receiver_channels;
+    // --- Max channel counts (conditional on VC2 enablement) ---
+    bool vc2_enabled = actual_sender_channels_vc2 > 0;
+    named_args["MAX_NUM_SENDER_CHANNELS"] = static_cast<uint32_t>(
+        vc2_enabled ? builder_config::num_max_sender_channels : builder_config::num_max_sender_channels_without_vc2);
+    named_args["MAX_NUM_RECEIVER_CHANNELS"] = static_cast<uint32_t>(
+        vc2_enabled ? builder_config::num_max_receiver_channels
+                    : builder_config::num_max_receiver_channels_without_vc2);
     named_args["MAX_NUM_VCS"] = static_cast<uint32_t>(builder_config::MAX_NUM_VCS);
 
     // --- Downstream tensix connections ---
@@ -1106,6 +1119,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     named_args["VC1_DOWNSTREAM_EDM_SIZE"] = vc1_downstream_edm_size;
     named_args["ACTUAL_VC0_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc0);
     named_args["ACTUAL_VC1_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc1);
+    named_args["ACTUAL_VC2_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc2);
 
     // --- Remote channel info (always emitted; 0 when inactive) ---
     named_args["SKIP_SRC_CH_ID_UPDATE"] = skip_src_ch_id_update ? 1 : 0;
@@ -1245,9 +1259,11 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
             channel_trimming_overrides_->is_receiver_channel_data_forwarded(0) ? 0 : 1;
         named_args["DISABLE_RX_CH1_FORWARDING"] =
             channel_trimming_overrides_->is_receiver_channel_data_forwarded(1) ? 0 : 1;
+        named_args["DISABLE_RX_CH2_FORWARDING"] = 1;  // VC2 receiver never forwards (always disabled)
     } else {
         named_args["DISABLE_RX_CH0_FORWARDING"] = 0;
         named_args["DISABLE_RX_CH1_FORWARDING"] = 0;
+        named_args["DISABLE_RX_CH2_FORWARDING"] = 1;  // VC2 receiver never forwards (always disabled)
     }
 
     // Credit amortization named compile-time args
@@ -1322,6 +1338,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
         static_cast<uint32_t>(this->sender_channels_connection_semaphore_id[6]),
         static_cast<uint32_t>(this->sender_channels_connection_semaphore_id[7]),
         static_cast<uint32_t>(this->sender_channels_connection_semaphore_id[8]),  // 9th channel for Z routers
+        static_cast<uint32_t>(this->sender_channels_connection_semaphore_id[9]),  // 10th channel for VC2
 
         static_cast<uint32_t>(this->downstream_vcs_sender_channel_buffer_index_semaphore_id[0]),
         static_cast<uint32_t>(this->downstream_vcs_sender_channel_buffer_index_semaphore_id[1]),
@@ -1333,6 +1350,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
         static_cast<uint32_t>(this->downstream_vcs_sender_channel_buffer_index_semaphore_id[7]),
         static_cast<uint32_t>(
             this->downstream_vcs_sender_channel_buffer_index_semaphore_id[8]),  // 9th channel for Z routers
+        static_cast<uint32_t>(
+            this->downstream_vcs_sender_channel_buffer_index_semaphore_id[9]),  // 10th channel for VC2
     };
 
     // Pack VC0 runtime args

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -265,7 +265,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
         this->datapath_usage_l1_address = next_l1_addr;
         this->datapath_usage_buffer_size = sizeof(tt::tt_fabric::FabricDatapathUsageL1Results<
                                                   true,
-                                                  builder_config::num_max_receiver_channels,
+                                                  builder_config::MAX_NUM_VCS,
                                                   builder_config::num_max_sender_channels>);
         next_l1_addr += this->datapath_usage_buffer_size;
     } else {
@@ -1078,6 +1078,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // --- Max channel counts ---
     named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;
     named_args["MAX_NUM_RECEIVER_CHANNELS"] = builder_config::num_max_receiver_channels;
+    named_args["MAX_NUM_VCS"] = static_cast<uint32_t>(builder_config::MAX_NUM_VCS);
 
     // --- Downstream tensix connections ---
     named_args["NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS"] = this->num_downstream_tensix_connections;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1084,13 +1084,9 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         StreamRegAssignments::Scratch::multi_risc_teardown_sync_stream_id;
     named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = StreamRegAssignments::Scratch::eth_retrain_link_sync_stream_id;
 
-    // --- Max channel counts (conditional on VC2 enablement) ---
-    bool vc2_enabled = actual_sender_channels_vc2 > 0;
-    named_args["MAX_NUM_SENDER_CHANNELS"] = static_cast<uint32_t>(
-        vc2_enabled ? builder_config::num_max_sender_channels : builder_config::num_max_sender_channels_without_vc2);
-    named_args["MAX_NUM_RECEIVER_CHANNELS"] = static_cast<uint32_t>(
-        vc2_enabled ? builder_config::num_max_receiver_channels
-                    : builder_config::num_max_receiver_channels_without_vc2);
+    // --- Max channel counts (always global max — instance counts use NUM_SENDER/RECEIVER_CHANNELS) ---
+    named_args["MAX_NUM_SENDER_CHANNELS"] = static_cast<uint32_t>(builder_config::num_max_sender_channels);
+    named_args["MAX_NUM_RECEIVER_CHANNELS"] = static_cast<uint32_t>(builder_config::num_max_receiver_channels);
     named_args["MAX_NUM_VCS"] = static_cast<uint32_t>(builder_config::MAX_NUM_VCS);
 
     // --- Downstream tensix connections ---

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -329,8 +329,10 @@ struct FabricEriscDatamoverConfig {
 
     std::size_t num_used_sender_channels = 0;    // Total across all VCs (duplicate in allocator... don't modify)
     std::size_t num_used_receiver_channels = 0;  // Total across all VCs (duplicate in allocator... don't modify)
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc = {0, 0};    // Per-VC sender channel counts
-    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc = {0, 0};  // Per-VC receiver channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_sender_channels_per_vc =
+        {};  // Per-VC sender channel counts
+    std::array<std::size_t, builder_config::MAX_NUM_VCS> num_used_receiver_channels_per_vc =
+        {};  // Per-VC receiver channel counts
     std::size_t num_fwd_paths = 0;
     std::size_t sender_txq_id = 0;
     std::size_t receiver_txq_id = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -160,6 +160,12 @@ struct StreamRegAssignments {
         // Local tensix relay free slots stream ID (UDM mode only)
         // Dual-use: also used as scratch for eth_retrain (see Scratch::eth_retrain_link_sync_stream_id)
         static constexpr uint32_t tensix_relay_local_free_slots_stream_id = 30;
+        // VC2 sender flow control: free-slots from worker (dual-use with tensix_relay at ID 30; VC2 and UDM/mux
+        // mutually exclusive)
+        static constexpr uint32_t vc2_sender_free_slots_stream_id = 30;
+        // VC2 receiver flow control: free-slots from sender (non-Z routers only; dual-use with scratch
+        // multi_risc_teardown at ID 31)
+        static constexpr uint32_t vc2_receiver_free_slots_stream_id = 31;
     };
 
     // Stream registers used as scratch/overlay storage. Writing overwrites the register value.
@@ -204,7 +210,9 @@ struct StreamRegAssignments {
             IncrementOnWrite::sender_channel_5_free_slots_stream_id,
             IncrementOnWrite::sender_channel_6_free_slots_stream_id,
             IncrementOnWrite::sender_channel_7_free_slots_stream_id,
-            IncrementOnWrite::tensix_relay_local_free_slots_stream_id};
+            IncrementOnWrite::tensix_relay_local_free_slots_stream_id,
+            IncrementOnWrite::vc2_sender_free_slots_stream_id,
+            IncrementOnWrite::vc2_receiver_free_slots_stream_id};
         return inc_on_write_ids;
     }
 

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -280,7 +280,6 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     // Set router type based on detection
     config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
 
-    // VC2 requires: VC1 active + Blackhole architecture + no UDM/mux extension
     if (config.requires_vc1) {
         auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
         auto tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
@@ -288,6 +287,12 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
         bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
         bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
         config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
+
+        // VC2 requires: RT option enabled + VC1 active + Blackhole + no UDM/mux
+        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        TT_FATAL(
+            !rtoptions.get_enable_fabric_vc2(),
+            "TT_METAL_ENABLE_FABRIC_VC2 is not yet supported — VC2 feature is under development");
     }
 
     return config;

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -280,6 +280,16 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     // Set router type based on detection
     config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
 
+    // VC2 requires: VC1 active + Blackhole architecture + no UDM/mux extension
+    if (config.requires_vc1) {
+        auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
+        auto tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+        bool is_blackhole = (arch == tt::ARCH::BLACKHOLE);
+        bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
+        bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
+        config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
+    }
+
     return config;
 }
 

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -286,10 +286,8 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
         bool is_blackhole = (arch == tt::ARCH::BLACKHOLE);
         bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
         bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
-        config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
-
-        // VC2 requires: RT option enabled + VC1 active + Blackhole + no UDM/mux
         const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        config.requires_vc2 = rtoptions.get_enable_fabric_vc2() && is_blackhole && !is_udm_mode && !is_mux_extension;
         TT_FATAL(
             !rtoptions.get_enable_fabric_vc2(),
             "TT_METAL_ENABLE_FABRIC_VC2 is not yet supported — VC2 feature is under development");

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -64,6 +64,7 @@ struct IntermeshVCConfig {
     bool requires_vc1 = false;                      // True if VC1 needed for intermesh
     bool requires_vc1_full_mesh = false;            // True if VC1 needed throughout mesh (not just edges)
     bool requires_vc1_mesh_pass_through = false;    // True if VC1 must support inter-mesh pass-through
+    bool requires_vc2 = false;                      // True if VC2 needed (Blackhole + 2D + no UDM/mux)
 
     IntermeshVCConfig() = default;
 
@@ -176,6 +177,7 @@ public:
     bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
     bool requires_intermesh_vc_full_mesh() const { return intermesh_vc_config_.requires_vc1_full_mesh; }
     bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
+    bool requires_vc2() const { return intermesh_vc_config_.requires_vc2; }
 
 private:
 

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -27,6 +27,7 @@ FabricRouterChannelMapping::FabricRouterChannelMapping(
 void FabricRouterChannelMapping::initialize_mappings() {
     initialize_vc0_mappings();
     initialize_vc1_mappings();
+    initialize_vc2_mappings();
 }
 
 void FabricRouterChannelMapping::initialize_vc0_mappings() {
@@ -131,6 +132,46 @@ void FabricRouterChannelMapping::initialize_vc1_mappings() {
     }
 }
 
+void FabricRouterChannelMapping::initialize_vc2_mappings() {
+    const bool is_2d = is_2D_topology(topology_);
+    if (!is_2d) {
+        return;  // VC2 only for 2D topologies
+    }
+
+    if (is_z_router()) {
+        // Z router VC2: sender only, no receiver
+        if (intermesh_vc_config_ == nullptr || !intermesh_vc_config_->requires_vc2) {
+            return;
+        }
+
+        // VC2 sender at last flat index (after VC0 + VC1 senders)
+        constexpr uint32_t z_router_vc2_base_sender_channel =
+            builder_config::num_sender_channels_z_router_vc0 +
+            builder_config::num_sender_channels_z_router_vc1;  // 5 + 4 = 9
+
+        sender_channel_map_[LogicalSenderChannelKey{2, 0}] =
+            InternalSenderChannelMapping{BuilderType::ERISC, z_router_vc2_base_sender_channel};
+        // No receiver for Z router VC2
+    } else {
+        // Mesh router VC2: 1 sender + 1 receiver
+        if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc2) {
+            // VC2 sender at last flat index (after VC0 + VC1 senders)
+            // VC1 mesh sender count depends on whether device has Z router
+            uint32_t mesh_vc1_sender_count = has_z_on_device_ ? 4 : 3;
+            uint32_t mesh_vc2_base_sender_channel =
+                builder_config::num_sender_channels_2d_mesh + mesh_vc1_sender_count;  // 4 + 3|4 = 7|8
+
+            sender_channel_map_[LogicalSenderChannelKey{2, 0}] =
+                InternalSenderChannelMapping{BuilderType::ERISC, mesh_vc2_base_sender_channel};
+
+            // VC2 receiver at index 2 (after VC0=0, VC1=1)
+            constexpr uint32_t mesh_vc2_receiver_channel = 2;
+            receiver_channel_map_[LogicalReceiverChannelKey{2, 0}] =
+                InternalReceiverChannelMapping{BuilderType::ERISC, mesh_vc2_receiver_channel};
+        }
+    }
+}
+
 bool FabricRouterChannelMapping::is_z_router() const {
     return variant_ == RouterVariant::Z_ROUTER;
 }
@@ -155,6 +196,11 @@ InternalReceiverChannelMapping FabricRouterChannelMapping::get_receiver_mapping(
 }
 
 uint32_t FabricRouterChannelMapping::get_num_virtual_channels() const {
+    // Check VC2 first (VC2 requires VC1, so if VC2 is active, VC1 is also active)
+    if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc2) {
+        return 3;
+    }
+
     // Z routers always have 2 VCs: VC0 (mesh traffic) and VC1 (Z traffic)
     if (is_z_router()) {
         return 2;
@@ -205,6 +251,14 @@ uint32_t FabricRouterChannelMapping::get_num_sender_channels_for_vc(uint32_t vc)
                 return count;
             }
             return no_channels;  // 1D topologies don't have VC1
+        case 2:                  // VC2
+            if (!intermesh_vc_config_ || !intermesh_vc_config_->requires_vc2) {
+                return no_channels;
+            }
+            if (is_z_router()) {
+                return builder_config::num_sender_channels_z_router_vc2;  // 1
+            }
+            return builder_config::num_sender_channels_vc2;  // 1
         default:
             return no_channels;
     }

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -131,6 +131,7 @@ private:
     void initialize_mappings();
     void initialize_vc0_mappings();
     void initialize_vc1_mappings();
+    void initialize_vc2_mappings();
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -59,6 +59,7 @@ constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
     NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID");
 constexpr uint32_t vc_1_free_slots_from_downstream_edge_4_stream_id =
     NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID");
+constexpr uint32_t vc2_receiver_free_slots_stream_id = NAMED_CT_ARG("VC2_RECEIVER_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_0_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_0_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_1_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_1_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_2_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_2_FREE_SLOTS_STREAM_ID");
@@ -67,6 +68,8 @@ constexpr uint32_t sender_channel_4_free_slots_stream_id = NAMED_CT_ARG("SENDER_
 constexpr uint32_t sender_channel_5_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_5_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_6_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_7_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_8_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_8_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_9_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_9_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t tensix_relay_local_free_slots_stream_id = NAMED_CT_ARG("TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = NAMED_CT_ARG("MULTI_RISC_TEARDOWN_SYNC_STREAM_ID");
 constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_LINK_SYNC_STREAM_ID");
@@ -77,12 +80,14 @@ constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_L
 constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
 constexpr size_t MAX_NUM_VCS = NAMED_CT_ARG("MAX_NUM_VCS");
-// VC0 and VC1 channel counts depend on router type:
-// Z_ROUTER: 5 VC0 + 4 VC1 = 9 total
-// MESH: 4 VC0 + 4 VC1 = 8 total (with some unused)
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = (MAX_NUM_SENDER_CHANNELS >= 9) ? 5 : 4;
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = MAX_NUM_SENDER_CHANNELS - MAX_NUM_SENDER_CHANNELS_VC0;
-constexpr size_t VC1_SENDER_CHANNEL_START = MAX_NUM_SENDER_CHANNELS_VC0;
+// VC0 and VC1 and VC2 channel counts derived from actual per-VC counts emitted by builder.
+// Z_ROUTER: typically 5 VC0 + 4 VC1 + 1 VC2 = 10 total (when VC2 active)
+// MESH:     typically 4 VC0 + 4 VC1 + 1 VC2 = 9 total (when VC2 active)
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = ACTUAL_VC0_SENDER_CHANNELS;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = ACTUAL_VC1_SENDER_CHANNELS;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC2 = ACTUAL_VC2_SENDER_CHANNELS;
+constexpr size_t VC1_SENDER_CHANNEL_START = ACTUAL_VC0_SENDER_CHANNELS;
+constexpr size_t VC2_SENDER_CHANNEL_START = ACTUAL_VC0_SENDER_CHANNELS + ACTUAL_VC1_SENDER_CHANNELS;
 
 // ============================================================================
 // Downstream tensix connections
@@ -148,6 +153,7 @@ constexpr size_t VC0_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC0_DOWNSTREAM_EDM_SIZE
 constexpr size_t VC1_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC1_DOWNSTREAM_EDM_SIZE");
 constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
 constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
+constexpr size_t ACTUAL_VC2_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC2_SENDER_CHANNELS");
 
 // Remote channel info (always available; 0 when inactive)
 constexpr size_t remote_worker_sender_channel = NAMED_CT_ARG("REMOTE_WORKER_SENDER_CHANNEL");

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -76,6 +76,7 @@ constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_L
 // ============================================================================
 constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
+constexpr size_t MAX_NUM_VCS = NAMED_CT_ARG("MAX_NUM_VCS");
 // VC0 and VC1 channel counts depend on router type:
 // Z_ROUTER: 5 VC0 + 4 VC1 = 9 total
 // MESH: 4 VC0 + 4 VC1 = 8 total (with some unused)
@@ -643,7 +644,7 @@ constexpr size_t RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS =
 using ChannelTrimmingUsagePtr = tt::tt_fabric::FabricDatapathUsageL1Ptr<
     ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE,
     RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS,
-    MAX_NUM_RECEIVER_CHANNELS,
+    MAX_NUM_VCS,
     MAX_NUM_SENDER_CHANNELS>;
 constexpr ChannelTrimmingUsagePtr channel_trimming_usage_recorder{};
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -69,7 +69,6 @@ constexpr uint32_t sender_channel_5_free_slots_stream_id = NAMED_CT_ARG("SENDER_
 constexpr uint32_t sender_channel_6_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_7_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t sender_channel_8_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_8_FREE_SLOTS_STREAM_ID");
-constexpr uint32_t sender_channel_9_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_9_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t tensix_relay_local_free_slots_stream_id = NAMED_CT_ARG("TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID");
 constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = NAMED_CT_ARG("MULTI_RISC_TEARDOWN_SYNC_STREAM_ID");
 constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_LINK_SYNC_STREAM_ID");

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -80,9 +80,11 @@ constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_L
 constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
 constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
 constexpr size_t MAX_NUM_VCS = NAMED_CT_ARG("MAX_NUM_VCS");
-// VC0 and VC1 and VC2 channel counts derived from actual per-VC counts emitted by builder.
-// Z_ROUTER: typically 5 VC0 + 4 VC1 + 1 VC2 = 10 total (when VC2 active)
-// MESH:     typically 4 VC0 + 4 VC1 + 1 VC2 = 9 total (when VC2 active)
+// Actual per-VC sender counts (emitted by builder, must be declared before use)
+constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
+constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
+constexpr size_t ACTUAL_VC2_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC2_SENDER_CHANNELS");
+// VC boundary derivation from actual counts (replaces old >= 9 heuristic)
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = ACTUAL_VC0_SENDER_CHANNELS;
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = ACTUAL_VC1_SENDER_CHANNELS;
 constexpr size_t MAX_NUM_SENDER_CHANNELS_VC2 = ACTUAL_VC2_SENDER_CHANNELS;
@@ -151,10 +153,6 @@ constexpr bool ENABLE_RISC_CPU_DATA_CACHE = NAMED_CT_ARG("ENABLE_RISC_CPU_DATA_C
 constexpr bool z_router_enabled = NAMED_CT_ARG("Z_ROUTER_ENABLED");
 constexpr size_t VC0_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC0_DOWNSTREAM_EDM_SIZE");
 constexpr size_t VC1_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC1_DOWNSTREAM_EDM_SIZE");
-constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
-constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
-constexpr size_t ACTUAL_VC2_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC2_SENDER_CHANNELS");
-
 // Remote channel info (always available; 0 when inactive)
 constexpr size_t remote_worker_sender_channel = NAMED_CT_ARG("REMOTE_WORKER_SENDER_CHANNEL");
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -216,6 +216,7 @@ constexpr size_t local_sender_channel_5_connection_info_addr = NAMED_CT_ARG("LOC
 constexpr size_t local_sender_channel_6_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_6_CONN_INFO_ADDR");
 constexpr size_t local_sender_channel_7_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_7_CONN_INFO_ADDR");
 constexpr size_t local_sender_channel_8_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_8_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_9_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_9_CONN_INFO_ADDR");
 
 // ============================================================================
 // Status pointers
@@ -245,10 +246,12 @@ constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced =
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_6_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_7_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_8_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_9_SERVICED")),
 };
 constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_serviced = {
     static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_0_SERVICED")),
     static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_1_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_2_SERVICED")),
 };
 
 // ============================================================================
@@ -315,6 +318,7 @@ static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_6_LIVE_CHECK_SKIP")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_LIVE_CHECK_SKIP")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_9_LIVE_CHECK_SKIP")),
 };
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_ch_live_check_skip =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(sender_ch_live_check_skip_all_);
@@ -333,6 +337,7 @@ static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_tra
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_6_IS_INJECTION")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_IS_INJECTION")),
     static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_9_IS_INJECTION")),
 };
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(
@@ -349,6 +354,7 @@ static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_6_ACK_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_9_ACK_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(sender_channel_ack_noc_ids_all_);
@@ -363,6 +369,7 @@ static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_6_ACK_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_9_ACK_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint8_t>(sender_channel_ack_cmd_buf_ids_all_);
@@ -373,6 +380,7 @@ constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_id
 static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids_all_ = {
     static_cast<size_t>(NAMED_CT_ARG("RX_CH_0_FWD_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("RX_CH_1_FWD_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_2_FWD_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
@@ -381,6 +389,7 @@ constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids_all_ = {
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_FWD_DATA_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_FWD_DATA_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_2_FWD_DATA_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
@@ -389,6 +398,7 @@ constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids_all_ = {
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_FWD_SYNC_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_FWD_SYNC_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_2_FWD_SYNC_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
@@ -397,6 +407,7 @@ constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding
 static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids_all_ = {
     static_cast<size_t>(NAMED_CT_ARG("RX_CH_0_LOCAL_WRITE_NOC_ID")),
     static_cast<size_t>(NAMED_CT_ARG("RX_CH_1_LOCAL_WRITE_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_2_LOCAL_WRITE_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
@@ -405,6 +416,7 @@ constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids_all_ = {
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_LOCAL_WRITE_CMD_BUF_ID")),
     static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_LOCAL_WRITE_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_2_LOCAL_WRITE_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
@@ -523,22 +535,24 @@ constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS =
 
 constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams =
     take_first_n_elements<MAX_NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint32_t>(
-        std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
+        std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id, 0});
 
 // not in symbol table - because not used
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
     take_first_n_elements<MAX_NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint32_t>(
-        std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{
-            // VC0
-            to_sender_0_pkts_acked_id,
-            to_sender_1_pkts_acked_id,
-            to_sender_2_pkts_acked_id,
-            to_sender_3_pkts_acked_id,
-            // VC1
-            0,  // Padding upto MAX_NUM_SENDER_CHANNELS. VC1 does not use first level acks.
-            0,
-            0,
-            0});
+        std::array<uint32_t, MAX_NUM_SENDER_CHANNELS>{// VC0
+                                                      to_sender_0_pkts_acked_id,
+                                                      to_sender_1_pkts_acked_id,
+                                                      to_sender_2_pkts_acked_id,
+                                                      to_sender_3_pkts_acked_id,
+                                                      // VC1 (no first level acks)
+                                                      0,
+                                                      0,
+                                                      0,
+                                                      0,
+                                                      // Z-router extra + VC2 (no first level acks)
+                                                      0,
+                                                      0});
 
 // data section
 constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
@@ -551,7 +565,9 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_4_pkts_completed_id,
             to_sender_5_pkts_completed_id,
             to_sender_6_pkts_completed_id,
-            to_sender_7_pkts_completed_id});
+            to_sender_7_pkts_completed_id,
+            0,  // Z-router extra / VC2 (worker-only, no router completion)
+            0});
 
 // Miscellaneous configuration
 
@@ -631,8 +647,9 @@ constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> REMOTE_RECEIVER_NUM_BUFFERS_
 // RX channel forwarding disable flags (from imported trimming profile)
 constexpr bool disable_rx_ch0_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH0_FORWARDING") != 0;
 constexpr bool disable_rx_ch1_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH1_FORWARDING") != 0;
+constexpr bool disable_rx_ch2_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH2_FORWARDING") != 0;
 constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_forwarding_disabled = {
-    disable_rx_ch0_forwarding, disable_rx_ch1_forwarding};
+    disable_rx_ch0_forwarding, disable_rx_ch1_forwarding, disable_rx_ch2_forwarding};
 
 constexpr bool ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE =
     get_named_compile_time_arg_val("ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE");

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -314,8 +314,8 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_5_free_slots_stream_id,
     sender_channel_6_free_slots_stream_id,
     sender_channel_7_free_slots_stream_id,
-    0,   // Z-router extra sender (no free-slots stream)
-    0};  // VC2 sender (free-slots managed via vc2_sender_free_slots_stream_id)
+    sender_channel_8_free_slots_stream_id,
+    sender_channel_9_free_slots_stream_id};
 static_assert(sender_channel_free_slots_stream_ids[0] == 22);
 static_assert(sender_channel_free_slots_stream_ids[1] == 23);
 static_assert(sender_channel_free_slots_stream_ids[2] == 24);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -314,8 +314,7 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_5_free_slots_stream_id,
     sender_channel_6_free_slots_stream_id,
     sender_channel_7_free_slots_stream_id,
-    sender_channel_8_free_slots_stream_id,
-    sender_channel_9_free_slots_stream_id};
+    sender_channel_8_free_slots_stream_id};
 static_assert(sender_channel_free_slots_stream_ids[0] == 22);
 static_assert(sender_channel_free_slots_stream_ids[1] == 23);
 static_assert(sender_channel_free_slots_stream_ids[2] == 24);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -314,7 +314,8 @@ static constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> sender_channel_fr
     sender_channel_5_free_slots_stream_id,
     sender_channel_6_free_slots_stream_id,
     sender_channel_7_free_slots_stream_id,
-    0};
+    0,   // Z-router extra sender (no free-slots stream)
+    0};  // VC2 sender (free-slots managed via vc2_sender_free_slots_stream_id)
 static_assert(sender_channel_free_slots_stream_ids[0] == 22);
 static_assert(sender_channel_free_slots_stream_ids[1] == 23);
 static_assert(sender_channel_free_slots_stream_ids[2] == 24);
@@ -3104,7 +3105,8 @@ void kernel_main() {
                 local_sender_channel_5_connection_info_addr,
                 local_sender_channel_6_connection_info_addr,
                 local_sender_channel_7_connection_info_addr,
-                local_sender_channel_8_connection_info_addr});
+                local_sender_channel_8_connection_info_addr,
+                local_sender_channel_9_connection_info_addr});
 
     for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
         auto connection_worker_info_ptr = reinterpret_cast<volatile tt::tt_fabric::EDMChannelWorkerLocationInfo*>(

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -92,6 +92,7 @@ enum class EnvVarID {
     TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,  // Enable channel trimming resource usage capture
     TT_METAL_FABRIC_TRIMMING_PROFILE,          // Path to channel trimming profile YAML for import
     TT_METAL_FABRIC_TRIMMING_OVERRIDE,         // Path to channel trimming global override YAML
+    TT_METAL_ENABLE_FABRIC_VC2,                // Enable fabric VC2 (neighbour exchange)
     TT_METAL_FORCE_REINIT,                     // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,         // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,     // Log kernel compilation commands
@@ -575,6 +576,13 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_FABRIC_TRIMMING_OVERRIDE:
             this->fabric_trimming_override_path = std::string(value);
             break;
+
+        // TT_METAL_ENABLE_FABRIC_VC2
+        // Enables the third virtual channel (VC2) for single-hop neighbour exchange traffic.
+        // Only effective when intermesh VC is also enabled (2D + multi-mesh + Blackhole + no UDM/mux).
+        // Default: false
+        // Usage: export TT_METAL_ENABLE_FABRIC_VC2=1
+        case EnvVarID::TT_METAL_ENABLE_FABRIC_VC2: this->enable_fabric_vc2 = true; break;
 
         // RELIABILITY_MODE
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -285,6 +285,9 @@ class RunTimeOptions {
     // Path to channel trimming global override YAML
     std::string fabric_trimming_override_path;
 
+    // Enable fabric VC2 (neighbour exchange, single-hop)
+    bool enable_fabric_vc2 = false;
+
     // Enable fabric telemetry
     bool enable_fabric_telemetry = false;
     FabricTelemetrySettings fabric_telemetry_settings;
@@ -678,6 +681,10 @@ public:
     bool has_fabric_trimming_override() const { return !fabric_trimming_override_path.empty(); }
     const std::string& get_fabric_trimming_override_path() const { return fabric_trimming_override_path; }
     void set_fabric_trimming_override_path(const std::string& path) { fabric_trimming_override_path = path; }
+
+    // Fabric VC2 enable
+    bool get_enable_fabric_vc2() const { return enable_fabric_vc2; }
+    void set_enable_fabric_vc2(bool enable) { enable_fabric_vc2 = enable; }
 
     // Reliability mode override accessor
     std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }


### PR DESCRIPTION
This cleanup item adds some codepaths to make some parts of the fabric builder and router kernel support up to 3 VCs. It does not add full 3VC support yet. 

This includes:
- Channel mapping setup
- updating fabric_builder_config to have VC2 constants available
- updating channel allocator to support a 3rd VC allocation spec
- new env var `TT_METAL_ENABLE_FABRIC_VC2` to force enable VC2 (though this will currently throw an error if specified)

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/stage-4-checkpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/stage-4-checkpoint)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/stage-4-checkpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/stage-4-checkpoint): https://github.com/tenstorrent/tt-metal/actions/runs/23252919031 (different branch, same commit)
- [x] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/stage-4-checkpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/stage-4-checkpoint): https://github.com/tenstorrent/tt-metal/actions/runs/23252934209 (different branch, same commit)


