### PR TITLE
[Bug fix] Pass in context_id to MeshDeviceImpl create_submesh

### DIFF
--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -25,6 +25,7 @@
 #include <umd/device/types/arch.hpp>
 
 // Internal access
+#include "dispatch/system_memory_manager.hpp"
 #include "impl/context/context_types.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include "context/metal_env_accessor.hpp"
@@ -454,6 +455,27 @@ TEST(MetalContextIntegrationTest, ForkWithDisjointDevices) {
 
     wait_for_child(pid1, "Child 1");
     wait_for_child(pid2, "Child 2");
+}
+
+TEST(MetalContextIntegrationTest, MeshDevicePropagatesContextId) {
+    MetalEnvDescriptor desc(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 8));
+    MetalEnv env(desc);
+    auto mesh_shape = env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    auto mesh_device = env.create_mesh_device(mesh_device_config);
+
+    ContextId context_id = mesh_device->impl().get_context_id();
+
+    EXPECT_NE(mesh_device->impl().get_context_id(), DEFAULT_CONTEXT_ID);
+
+    auto submesh_0 = mesh_device->create_submesh(distributed::MeshShape(1, 1));
+    EXPECT_EQ(submesh_0->impl().get_context_id(), context_id);
+
+    auto submesh_1 = mesh_device->create_submesh(distributed::MeshShape(1, 2));
+    EXPECT_EQ(submesh_1->impl().get_context_id(), context_id);
+
+    SystemMemoryManager& sysmem_manager = mesh_device->impl().get_devices()[0]->sysmem_manager();
+    EXPECT_EQ(sysmem_manager.get_context_id(), context_id);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -633,6 +633,12 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
         parent_mesh,
         context_id_);
 
+    TT_FATAL(
+        submesh->impl().get_context_id() == context_id_,
+        "Submesh context id {} does not match parent mesh context id {}.",
+        submesh->impl().get_context_id(),
+        context_id_);
+
     const auto& allocator_config = reference_device()->allocator_impl()->get_config();
     submesh->initialize(
         num_hw_cqs(),

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -630,7 +630,8 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
     submesh->pimpl_ = std::make_unique<MeshDeviceImpl>(
         scoped_devices_,
         std::make_unique<MeshDeviceView>(submesh_shape, submesh_devices, submesh_fabric_node_ids),
-        parent_mesh);
+        parent_mesh,
+        context_id_);
 
     const auto& allocator_config = reference_device()->allocator_impl()->get_config();
     submesh->initialize(

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -94,7 +94,7 @@ private:
             size_t worker_l1_size,
             const DispatchCoreConfig& dispatch_core_config,
             const MeshDeviceConfig& config,
-            ContextId context_id = DEFAULT_CONTEXT_ID);
+            ContextId context_id);
         ScopedDevices(
             const std::vector<MaybeRemote<int>>& all_device_ids,
             const std::vector<MaybeRemote<int>>& active_device_ids,
@@ -103,7 +103,7 @@ private:
             size_t num_command_queues,
             size_t worker_l1_size,
             const DispatchCoreConfig& dispatch_core_config,
-            ContextId context_id = DEFAULT_CONTEXT_ID);
+            ContextId context_id);
 
         // Destructor releases physical resources
         ~ScopedDevices();
@@ -179,8 +179,8 @@ public:
     MeshDeviceImpl(
         std::shared_ptr<ScopedDevices> mesh_handle,
         std::unique_ptr<MeshDeviceView> mesh_device_view,
-        std::shared_ptr<MeshDevice> parent_mesh = {},
-        ContextId context_id = DEFAULT_CONTEXT_ID);
+        std::shared_ptr<MeshDevice> parent_mesh,
+        ContextId context_id);
     ~MeshDeviceImpl() override;
 
     MeshDeviceImpl(const MeshDeviceImpl&) = delete;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38445

### Problem description
- Missing context id parameter when creating a MeshDeviceImpl in create_submesh

### What's changed
- Add missing context_id param
- Remove the default argument in the 'context_id' parameter to prevent this from happening
- Add a unit test to check the context_id is passed down to the sub mesh and also sysmem manager since that's accessible as well.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nhuang/metal-object-7)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/metal-object-7)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/metal-object-7)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/metal-object-7)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/metal-object-7)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/metal-object-7)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/metal-object-7)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
