### PR TITLE
Stop Decode Once EOS Token is Reached for Deepseek V3 Model Pipeline

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -113,18 +113,19 @@ class ModelPipeline:
     def run_inference(
         self,
         prompt_token_ids: list[int],
-        max_new_tokens: int,
+        max_new_tokens: int | None = None,
         on_token: Callable[[int], None] | None = None,
         eos_token_id: int | None = None,
         return_generated_tokens: bool = False,
     ) -> list[int] | None:
-        """Run full inference: prefill the prompt then decode until EOS or max_new_tokens.
+        """Run full inference: prefill the prompt then decode until EOS or max_new_tokens (if provided).
         Calls on_token(token_id) for each generated token (including the first
         one sampled after prefill). Optionally returns the list of all generated token IDs.
         """
         if self.pipeline.my_mesh_id != 0:
             raise RuntimeError("run_inference() should only be called on mesh id 0")
-        assert max_new_tokens >= 1, f"max_new_tokens must be >= 1, got {max_new_tokens}"
+        if max_new_tokens is not None and max_new_tokens < 1:
+            raise ValueError(f"max_new_tokens must be >= 1, got {max_new_tokens}")
 
         # Prefill: send prompt tokens; discard outputs for i < S-1; use last output to sample y0.
         next_token_id = self.prefill_forward(prompt_token_ids)
@@ -135,7 +136,8 @@ class ModelPipeline:
 
         # Generation loop: feed y[t], get output, sample y[t+1].
         num_decode_steps = 0
-        for i in range(max_new_tokens - 1):
+        i = 0
+        while max_new_tokens is None or i < max_new_tokens - 1:
             if eos_token_id is not None and next_token_id == eos_token_id:
                 logger.debug("EOS token {} at decode step {}", eos_token_id, i)
                 break
@@ -146,6 +148,7 @@ class ModelPipeline:
             if return_generated_tokens:
                 generated_tokens.append(next_token_id)
             logger.debug("Decode step {} output token: {}", i + 1, next_token_id)
+            i += 1
 
         logger.debug("Generation complete ({} tokens generated)", 1 + num_decode_steps)
         if return_generated_tokens:


### PR DESCRIPTION
### Problem description
We want to make sure that Deepseek model stops decode when `EOS` token is reached.

### What's changed
- Make `max_tokens` parameter optional 
- Iterate decode loop until `max_new_tokens` is generated, or until `EOS` token is reached

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ljovanovic/make_max_tokens_optional)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ljovanovic/make_max_tokens_optional)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ljovanovic/make_max_tokens_optional)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ljovanovic/make_max_tokens_optional)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ljovanovic/make_max_tokens_optional)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ljovanovic/make_max_tokens_optional)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ljovanovic/make_max_tokens_optional)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
