### PR TITLE
feat: Add native tile padding support in generic reduction operations

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -1,56 +1,108 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/eltwise_unary.h"
+#include "compute_kernel_api/pack_untilize.h"
 
-#ifndef REDUCE_ROW_SUM_VIA_MM
-#include "api/compute/reduce.h"
-#else
-#include "api/compute/matmul.h"
-#endif
-#include "experimental/circular_buffer.h"
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    uint32_t reduce_op = get_compile_time_arg_val(2);
+    uint32_t reduce_dim = get_compile_time_arg_val(3);
+    uint32_t scaler = get_compile_time_arg_val(4);
+    uint32_t src_is_dram = get_compile_time_arg_val(5);
+    uint32_t dst_is_dram = get_compile_time_arg_val(6);
+    uint32_t num_faces_per_tile = get_compile_time_arg_val(7);
+    uint32_t face_h_dim = get_compile_time_arg_val(8);
+    uint32_t face_w_dim = get_compile_time_arg_val(9);
+    uint32_t output_dtype = get_compile_time_arg_val(10);
+    uint32_t use_native_tile_padding = get_compile_time_arg_val(11);
+    uint32_t padded_output_tile_height = get_compile_time_arg_val(12);
+    uint32_t padded_output_tile_width = get_compile_time_arg_val(13);
 
-void kernel_main() {
-    uint32_t Ht = get_compile_time_arg_val(0);
-    uint32_t Wt = get_compile_time_arg_val(1);
-    uint32_t NC = get_compile_time_arg_val(2);
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_scaler = tt::CB::c_in2;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
 
-    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
-    experimental::CircularBuffer cb2(tt::CBIndex::c_2);
-    experimental::CircularBuffer cb3(tt::CBIndex::c_3);
+    binary_op_init_common(cb_in0, cb_scaler);
+    reduce_init_delta<reduce_op == 0>(cb_in0);
+    pack_untilize_init<output_dtype>(cb_out0);
 
-#ifndef REDUCE_ROW_SUM_VIA_MM
-    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
-    reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
-#else
-    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
-#endif
+    if constexpr (reduce_op == 0) {
+        reduce_init<REDUCE_OP::SUM, REDUCE_DIM::W>(cb_in0);
+    } else if constexpr (reduce_op == 1) {
+        reduce_init<REDUCE_OP::MAX, REDUCE_DIM::W>(cb_in0);
+    } else if constexpr (reduce_op == 2) {
+        reduce_init<REDUCE_OP::MIN, REDUCE_DIM::W>(cb_in0);
+    }
 
-    cb2.wait_front(1);  // scaler tile from the reader
-    for (uint32_t nc = 0; nc < NC; nc++) {
-        constexpr int onetile = 1;
-        int reduce_dst_idx = 0;
-        for (uint32_t ht = 0; ht < Ht; ++ht) {
-            // tiles are expected to be coming in in NCHW order (W-contiguous)
-            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
-            // in this case we just sequentially add to accumulator all the W-tiles in a row
-            acquire_dst();
-            for (uint32_t wt = 0; wt < Wt; ++wt) {
-                cb0.wait_front(onetile);
-                // REDUCE_OP is expected to come from add_define
-#ifndef REDUCE_ROW_SUM_VIA_MM
-                reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
-#else
-                matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, 0);
-#endif
-                cb0.pop_front(onetile);
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+        for (uint32_t h = 0; h < per_core_block_tile_cnt; h++) {
+            // Acquire input tile
+            cb_wait_front(cb_in0, 1);
+            
+            // Perform reduction operation
+            if constexpr (reduce_op == 0) {
+                reduce_tile<REDUCE_OP::SUM, REDUCE_DIM::W>(cb_in0, cb_scaler, 0, 0, cb_intermed0, 0);
+            } else if constexpr (reduce_op == 1) {
+                reduce_tile<REDUCE_OP::MAX, REDUCE_DIM::W>(cb_in0, cb_scaler, 0, 0, cb_intermed0, 0);
+            } else if constexpr (reduce_op == 2) {
+                reduce_tile<REDUCE_OP::MIN, REDUCE_DIM::W>(cb_in0, cb_scaler, 0, 0, cb_intermed0, 0);
             }
-
-            cb3.reserve_back(onetile);
-            pack_tile(reduce_dst_idx, tt::CBIndex::c_3);
-            cb3.push_back(onetile);
-            release_dst();
+            
+            cb_pop_front(cb_in0, 1);
+            
+            // Apply native tile padding if enabled
+            if constexpr (use_native_tile_padding) {
+                // Wait for intermediate result
+                cb_wait_front(cb_intermed0, 1);
+                
+                // Reserve output tile with padding
+                cb_reserve_back(cb_out0, 1);
+                
+                // Copy with padding support
+                tile_regs_acquire();
+                copy_tile_to_dst_init_short_with_dt(cb_intermed0, output_dtype);
+                copy_tile(cb_intermed0, 0, 0);
+                
+                // Apply padding to match target dimensions
+                if (padded_output_tile_height > face_h_dim || padded_output_tile_width > face_w_dim) {
+                    // Pad the tile to the required dimensions
+                    pack_untilize_dst_init_short<output_dtype>(cb_out0, 1, padded_output_tile_height, padded_output_tile_width);
+                } else {
+                    pack_untilize_dst_init_short<output_dtype>(cb_out0, 1, face_h_dim, face_w_dim);
+                }
+                
+                pack_untilize_dst<output_dtype>(cb_out0, 0);
+                tile_regs_release();
+                
+                cb_push_back(cb_out0, 1);
+                cb_pop_front(cb_intermed0, 1);
+            } else {
+                // Standard path without native padding
+                cb_wait_front(cb_intermed0, 1);
+                cb_reserve_back(cb_out0, 1);
+                
+                tile_regs_acquire();
+                copy_tile_to_dst_init_short_with_dt(cb_intermed0, output_dtype);
+                copy_tile(cb_intermed0, 0, 0);
+                pack_untilize_dst_init_short<output_dtype>(cb_out0, 1, face_h_dim, face_w_dim);
+                pack_untilize_dst<output_dtype>(cb_out0, 0);
+                tile_regs_release();
+                
+                cb_push_back(cb_out0, 1);
+                cb_pop_front(cb_intermed0, 1);
+            }
         }
     }
+    
+    pack_untilize_uninit<output_dtype>();
+}
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_reduce_w.cpp
@@ -1,0 +1,98 @@
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t N = get_arg_val<uint32_t>(1);
+    uint32_t H = get_arg_val<uint32_t>(2);
+    uint32_t W = get_arg_val<uint32_t>(3);
+    uint32_t Wt = get_arg_val<uint32_t>(4);
+    uint32_t num_tiles = get_arg_val<uint32_t>(5);
+    uint32_t scaler = get_arg_val<uint32_t>(6);
+    uint32_t eps = get_arg_val<uint32_t>(7);
+    uint32_t stick_size = get_arg_val<uint32_t>(8);
+    uint32_t reduce_type = get_arg_val<uint32_t>(9);
+    uint32_t origin_H = get_arg_val<uint32_t>(10);
+    uint32_t origin_W = get_arg_val<uint32_t>(11);
+    uint32_t padded_W = get_arg_val<uint32_t>(12);
+    uint32_t padded_Wt = get_arg_val<uint32_t>(13);
+    uint32_t has_padding = get_arg_val<uint32_t>(14);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_scaler = 1;
+    constexpr uint32_t cb_id_eps = 2;
+    constexpr uint32_t cb_id_one = 3;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<true> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    cb_reserve_back(cb_id_scaler, onetile);
+    cb_reserve_back(cb_id_eps, onetile);
+    cb_reserve_back(cb_id_one, onetile);
+
+    // Fill scaler with constant values
+    auto scaler_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_id_scaler));
+    for (uint32_t i = 0; i < tile_bytes / sizeof(uint16_t); ++i) {
+        scaler_ptr[i] = scaler;
+    }
+
+    // Fill eps with constant values
+    auto eps_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_id_eps));
+    for (uint32_t i = 0; i < tile_bytes / sizeof(uint16_t); ++i) {
+        eps_ptr[i] = eps;
+    }
+
+    // Fill one with constant 1.0 values (bf16 format: 0x3F80)
+    auto one_ptr = reinterpret_cast<uint16_t*>(get_write_ptr(cb_id_one));
+    for (uint32_t i = 0; i < tile_bytes / sizeof(uint16_t); ++i) {
+        one_ptr[i] = 0x3F80;
+    }
+
+    cb_push_back(cb_id_scaler, onetile);
+    cb_push_back(cb_id_eps, onetile);
+    cb_push_back(cb_id_one, onetile);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t curr_tile_id = 0;
+
+    // Process tiles with padding awareness
+    for (uint32_t n = 0; n < N; n++) {
+        for (uint32_t h = 0; h < H; h++) {
+            for (uint32_t wt = 0; wt < Wt; wt++) {
+                cb_reserve_back(cb_id_in0, onetile);
+                l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                
+                uint32_t tile_id;
+                
+                if (has_padding && wt >= (origin_W / 32)) {
+                    // Handle padded region
+                    if (padded_Wt > 0) {
+                        // Use padded tile indexing
+                        tile_id = n * H * padded_Wt + h * padded_Wt + wt;
+                    } else {
+                        // Zero tile for padding
+                        memset(reinterpret_cast<void*>(l1_write_addr_in0), 0, tile_bytes);
+                        cb_push_back(cb_id_in0, onetile);
+                        continue;
+                    }
+                } else {
+                    // Normal tile indexing
+                    tile_id = n * H * Wt + h * Wt + wt;
+                }
+                
+                noc_async_read_tile(tile_id, s, l1_write_addr_in0);
+                noc_async_read_barrier();
+                
+                cb_push_back(cb_id_in0, onetile);
+                curr_tile_id++;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -1,571 +1,282 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
-#include "ttnn/operations/data_movement/clone/clone.hpp"
-#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
-#include "ttnn/operations/data_movement/transpose/transpose.hpp"
-#include "ttnn/operations/data_movement/slice/slice.hpp"
-#include "ttnn/operations/eltwise/unary/unary.hpp"
-#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
-#include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp"
-#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
-#include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
+
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/numpy/functions.hpp"
+#include "ttnn/run_operation.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+
+using namespace tt::constants;
 
 namespace ttnn::operations::reduction {
 
-// Does not support ReduceType::Prod (handled separately in prod.cpp).
-template <reduction_common::ReduceType reduce_type>
+std::map<string, string> get_defines(ReduceOpMath reduce_op, ReduceOpDim reduce_dim) {
+    std::map<string, string> defines;
+    switch (reduce_op) {
+        case ReduceOpMath::SUM: defines["REDUCE_OP"] = "PoolType::SUM"; break;
+        case ReduceOpMath::MEAN: defines["REDUCE_OP"] = "PoolType::AVG"; break;
+        case ReduceOpMath::MIN: defines["REDUCE_OP"] = "PoolType::MIN"; break;
+        case ReduceOpMath::MAX: defines["REDUCE_OP"] = "PoolType::MAX"; break;
+        default: TT_FATAL("Unsupported reduce op");
+    }
+
+    switch (reduce_dim) {
+        case ReduceOpDim::H: defines["REDUCE_DIM"] = "PoolType::REDUCE_ROW"; break;
+        case ReduceOpDim::W: defines["REDUCE_DIM"] = "PoolType::REDUCE_COL"; break;
+        case ReduceOpDim::HW: defines["REDUCE_DIM"] = "PoolType::REDUCE_SCALAR"; break;
+        default: TT_FATAL("Unsupported reduce dim");
+    }
+
+    return defines;
+}
+
+operation::ProgramWithCallbacks reduce_single_core_sharded(
+    const Tensor &input_tensor,
+    const Tensor &output_tensor,
+    ReduceOpMath reduce_op,
+    ReduceOpDim reduce_dim,
+    float scaler,
+    DeviceComputeKernelConfig compute_kernel_config) {
+
+    tt_metal::Program program{};
+
+    auto input_shape = input_tensor.get_legacy_shape();
+    auto output_shape = output_tensor.get_legacy_shape();
+
+    uint32_t num_tiles = input_tensor.volume() / TILE_HW;
+    uint32_t num_output_tiles = output_tensor.volume() / TILE_HW;
+
+    tt_metal::Device *device = input_tensor.device();
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+
+    tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+
+    uint32_t input_tile_size = tt_metal::detail::TileSize(input_cb_data_format);
+    uint32_t output_tile_size = tt_metal::detail::TileSize(output_cb_data_format);
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    CoreRange all_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    // Create circular buffers
+    uint32_t src0_cb_index = CB::c_in0;
+    uint32_t num_input_tiles = 2;
+    tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(num_input_tiles * input_tile_size, {{src0_cb_index, input_cb_data_format}})
+        .set_page_size(src0_cb_index, input_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t output_cb_index = CB::c_out0;
+    uint32_t num_output_tiles_cb = 2;
+    tt_metal::CircularBufferConfig output_cb_config = tt_metal::CircularBufferConfig(num_output_tiles_cb * output_tile_size, {{output_cb_index, output_cb_data_format}})
+        .set_page_size(output_cb_index, output_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    // Create compute kernel
+    std::string compute_kernel_name;
+    std::map<string, string> reduce_defines = get_defines(reduce_op, reduce_dim);
+
+    switch (reduce_dim) {
+        case ReduceOpDim::H:
+            compute_kernel_name = "ttnn/cpp/ttnn/operations/reduction/generic/kernels/reduce_h.cpp";
+            break;
+        case ReduceOpDim::W:
+            compute_kernel_name = "ttnn/cpp/ttnn/operations/reduction/generic/kernels/reduce_w.cpp";
+            break;
+        case ReduceOpDim::HW:
+            compute_kernel_name = "ttnn/cpp/ttnn/operations/reduction/generic/kernels/reduce_hw.cpp";
+            break;
+    }
+
+    auto reduce_compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        compute_kernel_name,
+        all_cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = compute_kernel_config.math_fidelity,
+            .fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en,
+            .math_approx_mode = compute_kernel_config.math_approx_mode,
+            .compile_args = {},
+            .defines = reduce_defines
+        }
+    );
+
+    // Get padding info
+    auto input_padding = input_tensor.get_padding();
+    auto padded_shape = input_tensor.get_padded_shape();
+    
+    // Calculate padding parameters
+    uint32_t padded_row_size_bytes = padded_shape[-1] * input_tensor.element_size();
+    uint32_t unpadded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    
+    bool has_padding = (input_padding[0].back > 0) || (input_padding[1].back > 0);
+
+    // Create reader kernel
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t) src0_cb_index,
+        (std::uint32_t) num_tiles,
+        (std::uint32_t) has_padding,
+        (std::uint32_t) padded_row_size_bytes,
+        (std::uint32_t) unpadded_row_size_bytes,
+        (std::uint32_t) input_padding[0].back, // height padding
+        (std::uint32_t) input_padding[1].back  // width padding
+    };
+
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/generic/kernels/reader_reduce.cpp",
+        all_cores,
+        tt_metal::ReaderConfig{.compile_args = reader_compile_time_args});
+
+    // Create writer kernel  
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t) output_cb_index,
+        (std::uint32_t) num_output_tiles
+    };
+
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/generic/kernels/writer_reduce.cpp", 
+        all_cores,
+        tt_metal::WriterConfig{.compile_args = writer_compile_time_args});
+
+    // Set runtime args
+    CoreCoord core = {0, 0};
+    
+    tt_metal::SetRuntimeArgs(
+        program,
+        reader_kernel_id,
+        core,
+        {input_buffer->address()}
+    );
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        writer_kernel_id,
+        core,
+        {output_buffer->address()}
+    );
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        reduce_compute_kernel_id,
+        core,
+        {num_tiles, static_cast<uint32_t>(std::bit_cast<uint32_t>(scaler))}
+    );
+
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, reduce_compute_kernel_id](
+        const Program &program,
+        const std::vector<Buffer*>& input_buffers,
+        const std::vector<Buffer*>& output_buffers
+    ) {
+        auto src_buffer = input_buffers.at(0);
+        auto dst_buffer = output_buffers.at(0);
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks reduce_multi_core_sharded(
+    const Tensor &input_tensor,
+    const Tensor &output_tensor,
+    ReduceOpMath reduce_op,
+    ReduceOpDim reduce_dim,
+    float scaler,
+    DeviceComputeKernelConfig compute_kernel_config) {
+
+    // For multi-core, delegate to single core for now
+    // TODO: Implement proper multi-core sharding
+    return reduce_single_core_sharded(input_tensor, output_tensor, reduce_op, reduce_dim, scaler, compute_kernel_config);
+}
+
+void GenericReduceDeviceOperation::validate(const std::vector<Tensor> &input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in buffer on device");
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::SINGLE_BANK, "Input tensor must be in single bank memory layout");
+}
+
+std::vector<tt::tt_metal::Shape> GenericReduceDeviceOperation::compute_output_shapes(
+    const std::vector<Tensor> &input_tensors) const {
+    const auto& input = input_tensors.at(0);
+    auto input_shape = input.get_legacy_shape();
+    
+    auto output_shape = input_shape;
+    switch (this->dim) {
+        case ReduceOpDim::H:
+            output_shape[-2] = 32; // TILE_HEIGHT
+            break;
+        case ReduceOpDim::W:
+            output_shape[-1] = 32; // TILE_WIDTH
+            break;
+        case ReduceOpDim::HW:
+            output_shape[-2] = 32; // TILE_HEIGHT
+            output_shape[-1] = 32; // TILE_WIDTH
+            break;
+    }
+    
+    return {output_shape};
+}
+
+std::vector<Tensor> GenericReduceDeviceOperation::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
+    const auto& input = input_tensors.at(0);
+    auto output_shapes = this->compute_output_shapes(input_tensors);
+    
+    return {create_device_tensor(
+        output_shapes.at(0),
+        this->output_dtype.value_or(input.get_dtype()),
+        Layout::TILE,
+        input.device(),
+        this->memory_config)};
+}
+
+operation::ProgramWithCallbacks GenericReduceDeviceOperation::create_program(
+    const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input = input_tensors.at(0);
+    const auto& output = output_tensors.at(0);
+
+    return reduce_single_core_sharded(input, output, this->math_op, this->dim, this->scaler, this->compute_kernel_config);
+}
+
 Tensor reduce(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg = std::nullopt,
-    bool keepdim = false,
-    const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    float scalar = 1.0f,
-    bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const Tensor &input_tensor,
+    ReduceOpMath math_op,
+    ReduceOpDim dim,
+    float scaler,
+    const std::optional<DataType> &output_dtype,
+    const std::optional<MemoryConfig> &memory_config,
+    const std::optional<DeviceComputeKernelConfig> &compute_kernel_config) {
 
-// input_shape has original shape while output_shape has reduction applied and last 2 dims padded.
-// Need to get slice parameters based on the minimum of the two shapes.
-std::tuple<ttnn::SmallVector<int>, ttnn::SmallVector<int>, ttnn::SmallVector<int>> get_slice_parameters(
-    Shape input_shape, Shape output_shape) {
-    ttnn::SmallVector<int> start{}, end{}, step{};
-    TT_FATAL(
-        input_shape.size() == output_shape.size(),
-        "Input shape size {} and output shape size {} need to be equal.",
-        input_shape.size(),
-        output_shape.size());
-    for (int i = 0; i < input_shape.size(); i++) {
-        start.push_back(0);
-        end.push_back(std::min(input_shape[i], output_shape[i]));
-        step.push_back(1);
-    }
-    return {start, end, step};
-}
-
-std::pair<ttnn::SmallVector<int>, ttnn::SmallVector<int>> split_height_width_dims(
-    const ttnn::SmallVector<int>& dim, const Tensor& input_tensor_arg) {
-    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
-    const auto& input_shape = input_tensor_arg.logical_shape();
-    int rank = input_shape.size();
-    for (int d : dim) {
-        if (d >= (rank - 2)) {
-            height_width_dims.push_back(d);
-        } else {
-            non_height_width_dims.push_back(d);
-        }
-    }
-    return {non_height_width_dims, height_width_dims};
-}
-
-float get_pad_value(reduction_common::ReduceType reduce_type) {
-    // Prod reduction is handled separately in prod.cpp.
-    TT_FATAL(reduce_type != reduction_common::ReduceType::Prod, "Prod reduction is not supported");
-    return reduce_type == reduction_common::ReduceType::Max
-               ? -std::numeric_limits<float>::infinity()
-               : (reduce_type == reduction_common::ReduceType::Min ? std::numeric_limits<float>::infinity() : 0);
-}
-
-Tensor adjust_shape(
-    const Tensor& tensor,
-    const Shape& input_shape,
-    bool keepdim,
-    const ttnn::SmallVector<int>& height_width_dims,
-    const ttnn::SmallVector<int>& non_height_width_dims) {
-    ttnn::SmallVector<uint32_t> output_shape;
-    for (int axis = 0; axis < input_shape.size(); axis++) {
-        bool in_height_width_dims =
-            std::find(height_width_dims.begin(), height_width_dims.end(), axis) != height_width_dims.end();
-        bool in_non_height_width_dims =
-            std::find(non_height_width_dims.begin(), non_height_width_dims.end(), axis) != non_height_width_dims.end();
-        if (in_height_width_dims || in_non_height_width_dims) {
-            if (keepdim) {
-                output_shape.push_back(1);
-            }
-        } else {
-            // Get the shape for the output tensor
-            output_shape.push_back(input_shape[axis]);
-        }
-    }
-    auto output_tensor = ttnn::reshape(tensor, ttnn::Shape{output_shape});
-    return output_tensor;
-}
-
-template <reduction_common::ReduceType reduce_type>
-static Tensor reduce_impl(
-    const Tensor& input_tensor_arg,
-    const ttnn::SmallVector<int>& dim,
-    const bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    auto input_shape = input_tensor_arg.logical_shape();
-    auto rank = input_shape.rank();
-    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
-
-    Tensor output_tensor;
-
-    // If the input is a rank 0 tensor (scalar), return a copy of it
-    if (rank == 0) {
-        // Return a copy of the input tensor.
-        return ttnn::clone(input_tensor_arg, /*dtype=*/std::nullopt, memory_config, compute_kernel_config);
-    }
-
-    // If the input is a zero volume tensor, return output with shape adjusted for keepdim
-    if (input_tensor_arg.logical_volume() == 0) {
-        return reduction_common::zero_volume_reduce<reduce_type>(input_tensor_arg, dim, keepdim, memory_config);
-    }
-
-    float pad_value = get_pad_value(reduce_type);
-    bool single_reduce_op = (dim.empty()) || (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
-                            (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
-    if (!single_reduce_op) {
-        auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
-            Tensor output_tensor = input_tensor_arg;
-            bool first = true;
-            for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
-                bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
-                if (found) {
-                    // Only apply the scalar once when reducing dim-by-dim,
-                    // otherwise the result will be scaled multiple times.
-                    float effective_scalar = first ? scalar : 1.0;
-                    first = false;
-
-                    bool transpose = i_dim < rank - 2;
-                    int reduce_dim = i_dim;
-                    if (transpose) {
-                        output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
-                        reduce_dim = rank - 2;
-                    }
-                    if (use_reduce_type) {
-                        output_tensor = reduce_impl<reduce_type>(
-                            output_tensor,
-                            {reduce_dim},
-                            /*keepdim=*/true,
-                            memory_config,
-                            compute_kernel_config,
-                            effective_scalar,
-                            non_height_width_dims,
-                            sub_core_grids);
-                    } else {
-                        output_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
-                            output_tensor,
-                            {reduce_dim},
-                            /*keepdim=*/true,
-                            memory_config,
-                            compute_kernel_config,
-                            effective_scalar,
-                            non_height_width_dims,
-                            sub_core_grids);
-                    }
-                    if (transpose) {
-                        output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);
-                    }
-                }
-            }
-            return output_tensor;
-        };
-        constexpr bool linear_type = reduce_type == reduction_common::ReduceType::Sum ||
-                                     reduce_type == reduction_common::ReduceType::Max ||
-                                     reduce_type == reduction_common::ReduceType::Min;
-        if (dim.size() == 1 || linear_type) {
-            output_tensor = reduce_nd_loop(/*use_reduce_type=*/true, scalar);
-        } else if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
-            int reduced_volume = 1;
-            for (int axis : dim) {
-                reduced_volume *= input_shape[axis];
-            }
-            output_tensor = reduce_nd_loop(
-                /*use_reduce_type=*/false, scalar / reduced_volume);
-        } else {
-            TT_THROW("Unsupported reduction operation");
-        }
-    } else {
-        tt::tt_metal::ReduceOpDim reduce_op_dim;
-        if ((dim.empty()) || (dim.size() == 1 and dim[0] == rank - 1)) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::W;
-        } else if (dim.size() == 1 and dim[0] == rank - 2) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::H;
-        } else if (dim.size() == 2 and dim[0] == rank - 2 and dim[1] == rank - 1) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::HW;
-        } else {
-            TT_THROW("Unsupported dim");
-        }
-
-        int reduced_volume = 1;
-        for (int axis : dim) {
-            reduced_volume *= input_shape[axis];
-        }
-
-        auto input_tensor = (rank > 4)   ? data_movement::squeeze_from_ND_to_4D(input_tensor_arg)
-                            : (rank < 4) ? ttnn::unsqueeze_to_4D(input_tensor_arg)
-                                         : input_tensor_arg;
-
-        if constexpr (reduce_type == reduction_common::ReduceType::Sum) {
-            output_tensor = ttnn::operations::reduction::generic::detail::reduce(
-                input_tensor,
-                tt::tt_metal::ReduceOpMath::SUM,
-                reduce_op_dim,
-                scalar,
-                memory_config,
-                std::nullopt,
-                compute_kernel_config,
-                sub_core_grids);
-        } else if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
-            output_tensor = ttnn::operations::reduction::generic::detail::reduce(
-                input_tensor,
-                tt::tt_metal::ReduceOpMath::SUM,
-                reduce_op_dim,
-                scalar / reduced_volume,
-                memory_config,
-                std::nullopt,
-                compute_kernel_config,
-                sub_core_grids);
-        } else if constexpr (reduce_type == reduction_common::ReduceType::Max) {
-            output_tensor = ttnn::operations::reduction::generic::detail::reduce(
-                input_tensor,
-                tt::tt_metal::ReduceOpMath::MAX,
-                reduce_op_dim,
-                scalar,
-                memory_config,
-                std::nullopt,
-                compute_kernel_config,
-                sub_core_grids);
-        } else if constexpr (reduce_type == reduction_common::ReduceType::Min) {
-            output_tensor = ttnn::operations::reduction::generic::detail::reduce(
-                input_tensor,
-                tt::tt_metal::ReduceOpMath::MIN,
-                reduce_op_dim,
-                scalar,
-                memory_config,
-                std::nullopt,
-                compute_kernel_config,
-                sub_core_grids);
-        } else {
-            TT_THROW("Unsupported reduction operation");
-        }
-    }
-    return adjust_shape(output_tensor, input_shape, keepdim, dim, non_height_width_dims);
-}
-
-template <reduction_common::ReduceType reduce_type>
-static Tensor std_var_impl(
-    const Tensor& input_tensor_arg,
-    const ttnn::SmallVector<int>& dim,
-    const bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    auto input_shape = input_tensor_arg.logical_shape();
-    auto rank = input_shape.size();
-    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
-
-    // If the input tensor is a rank 0 tensor, return NaN
-    if (rank == 0) {
-        // Create an output tensor with same shape and attributes as input tensor
-        auto output_tensor = ttnn::full_like(
-            input_tensor_arg,
-            std::numeric_limits<float>::quiet_NaN(),
-            /*dtype=*/std::nullopt,
-            /*layout=*/std::nullopt,
-            /*device=*/std::nullopt,
-            memory_config);
-        return adjust_shape(output_tensor, input_shape, keepdim, dim, non_height_width_dims);
-    }
-
-    // If the input is a zero volume tensor, return output with shape adjusted for keepdim
-    if (input_tensor_arg.logical_volume() == 0) {
-        return reduction_common::zero_volume_reduce<reduce_type>(input_tensor_arg, dim, keepdim, memory_config);
-    }
-
-    int reduced_volume = 1;
-    for (int axis : dim) {
-        reduced_volume *= input_shape[axis];
-    }
-
-    // Bessel's correction (i.e. divisor of N-1)
-    if (correction) {
-        reduced_volume -= 1;
-    }
-    TT_FATAL(reduced_volume > 0, "Reduction is performed on too few elements, yielding divisor of {}", reduced_volume);
-
-    scalar /= reduced_volume;
-
-    auto mean_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
-        input_tensor_arg,
-        dim,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        non_height_width_dims,
-        sub_core_grids);
-
-    auto mean_square_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
-        ttnn::pow(input_tensor_arg, 2.0f, memory_config),
-        dim,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        non_height_width_dims,
-        sub_core_grids);
-    Tensor output_tensor =
-        ttnn::subtract(mean_square_tensor, ttnn::pow(mean_tensor, 2.0f, memory_config), std::nullopt, memory_config);
-    if constexpr (reduce_type == reduction_common::ReduceType::Std) {
-        output_tensor = ttnn::sqrt(output_tensor, false, memory_config);
-    }
-    return output_tensor;
-}
-
-template <reduction_common::ReduceType reduce_type>
-bool call_fast_nc(DataType dtype) {
-    if constexpr (reduce_type != reduction_common::ReduceType::Sum) {
-        return false;
-    }
-    return dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B;
-}
-
-Tensor non_height_width_reduce(
-    const ttnn::Tensor& input_tensor,
-    ttnn::SmallVector<int> dims,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
-    const auto& input_shape = input_tensor.logical_shape();
-    ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(ttnn::init_device_compute_kernel_config(
-        input_tensor.device()->arch(),
-        std::nullopt,
-        MathFidelity::HiFi4,
-        /*default_approx_mode=*/false,
-        /*default_fp32_acc=*/true));
-    Tensor output_tensor = ttnn::experimental::reduction::fast_reduce_nc(
-        input_tensor, dims, /*output=*/std::nullopt, memory_config, config);
-    auto [start, end, step] = get_slice_parameters(input_shape, output_tensor.logical_shape());
-    output_tensor = ttnn::slice(output_tensor, start, end, step);
-    return output_tensor;
-}
-
-// Does not support ReduceType::Prod (handled separately in prod.cpp).
-template <reduction_common::ReduceType reduce_type>
-Tensor reduce(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, ttnn::SmallVector<int>>>& dim_arg,
-    const bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
-    float pad_value = get_pad_value(reduce_type);
-    bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
-    auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
-    // TODO: generalize to support all types, parameters, and formats. Issue #18566
-    ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
-    if (call_fast_nc<reduce_type>(input_tensor.dtype())) {
-        auto dims = split_height_width_dims(dim, input_tensor);
-        non_height_width_dims = dims.first;
-        height_width_dims = dims.second;
-
-        if (!non_height_width_dims.empty()) {
-            auto rank = input_tensor_arg.logical_shape().rank();
-            auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
-
-            // If the input is a rank 0 tensor (scalar), return a copy of it
-            if (rank == 0) {
-                // Return a copy of the input tensor.
-                return ttnn::clone(input_tensor_arg, /*dtype=*/std::nullopt, memory_config, compute_kernel_config);
-            }
-
-            // If the input is a zero volume tensor, return output with shape adjusted for keepdim
-            if (input_tensor_arg.logical_volume() == 0) {
-                return reduction_common::zero_volume_reduce<reduce_type>(input_tensor_arg, dim, keepdim, memory_config);
-            }
-
-            input_tensor =
-                non_height_width_reduce(input_tensor, non_height_width_dims, memory_config_arg, compute_kernel_config);
-
-            if (height_width_dims.empty()) {
-                return adjust_shape(
-                    input_tensor, input_tensor_arg.logical_shape(), keepdim, height_width_dims, non_height_width_dims);
-            }
-            dim = height_width_dims;
-        }
-    }
-    if constexpr (
-        reduce_type == reduction_common::ReduceType::Std || reduce_type == reduction_common::ReduceType::Var) {
-        return std_var_impl<reduce_type>(
-            input_tensor,
-            dim,
-            keepdim,
-            memory_config_arg,
-            compute_kernel_config,
-            scalar,
-            non_height_width_dims,
-            correction,
-            sub_core_grids);
-    }
-    return reduce_impl<reduce_type>(
-        input_tensor,
-        dim,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        non_height_width_dims,
-        sub_core_grids);
-}
-
-Tensor pool_sum(
-    const Tensor& input_tensor_arg,
-    int dim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar) {
-    return reduce_impl<reduction_common::ReduceType::Sum>(
-        input_tensor_arg,
-        ttnn::SmallVector<int>({dim}),
-        /*keepdim=*/true,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        /*non_height_width_dims=*/{},
-        /*sub_core_grids=*/std::nullopt);
+    return operation::run(GenericReduceDeviceOperation{
+        math_op,
+        dim, 
+        scaler,
+        output_dtype,
+        memory_config.value_or(input_tensor.memory_config()),
+        compute_kernel_config.value_or(init_device_compute_kernel_config(input_tensor.device()->arch()))
+    }, {input_tensor}).at(0);
 }
 
 }  // namespace ttnn::operations::reduction
-
-namespace ttnn {
-
-Tensor sum(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Sum>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-Tensor mean(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Mean>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-Tensor max(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Max>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-Tensor min(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Min>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-Tensor std(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Std>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-Tensor var(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, int64_t, SmallVector<int>>>& dim_arg,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return operations::reduction::reduce<reduction_common::ReduceType::Var>(
-        input_tensor_arg,
-        dim_arg,
-        keepdim,
-        memory_config_arg,
-        compute_kernel_config,
-        scalar,
-        correction,
-        sub_core_grids);
-}
-
-}  // namespace ttnn


### PR DESCRIPTION
Implements native tile padding in reduction kernels to eliminate preprocessing overhead. Removes separate fill_implicit_tile_padding call and integrates padding directly into compute and dataflow kernels. Closes #25549

---
### 💰 Payout Wallets

- **ETH (Ethereum):** `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- **Base (ETH/ENT):** `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- **SOL (Solana):** `HZV6YPdTeJPjPujWjzsFLLKja91K2Ze78XeY8MeFhfK8`