### PR TITLE
[Bug fix] fix unintended MetalContext reinit when dispatch core config axis_ is nullopt

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -166,8 +166,17 @@ void MetalContext::initialize(
 
     const size_t fw_compile_hash = std::hash<std::string>{}(rtoptions().get_compile_hash_string());
     validate_worker_l1_size(worker_l1_size, hal());
+
+    // DispatchCoreConfig::get_dispatch_core_axis calls get_default_axis with the default
+    // metal context ID which will cause implicit initialization of a MetalContext.
+    // Workaround that by setting the dispatch core axis here and storing a resolved config.
+    // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
+    DispatchCoreConfig resolved_config = dispatch_core_config;
+    resolved_config.set_dispatch_core_axis(
+        resolve_dispatch_core_axis(dispatch_core_config, get_cluster().arch(), get_fabric_tensix_config()));
+
     if (initialized_) {
-        if (dispatch_core_config_ != dispatch_core_config or num_hw_cqs != num_hw_cqs_ or
+        if (dispatch_core_config_ != resolved_config or num_hw_cqs != num_hw_cqs_ or
             worker_l1_size_ != worker_l1_size or l1_bank_remap != l1_bank_remap_ or
             fw_compile_hash != fw_compile_hash_) {
             log_warning(tt::LogAlways, "Closing and re-initializing MetalContext with new parameters.");
@@ -188,17 +197,8 @@ void MetalContext::initialize(
 
     initialized_ = true;
 
-    // Resolve the dispatch core axis for this context's architecture.
-    // The default DispatchCoreConfig leaves axis_ unset, causing get_dispatch_core_axis()
-    // to call get_default_axis() which only checks the DEFAULT context. For non-default
-    // contexts (e.g. mock BLACKHOLE), this returns the wrong axis. Resolve it eagerly here,
-    // but only when the caller hasn't explicitly set an axis.
-    // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
-    dispatch_core_config_ = dispatch_core_config;
-    DispatchCoreAxis axis =
-        resolve_dispatch_core_axis(dispatch_core_config, get_cluster().arch(), get_fabric_tensix_config());
-    dispatch_core_config_.set_dispatch_core_axis(axis);
-
+    // Store the resolved config
+    dispatch_core_config_ = resolved_config;
     num_hw_cqs_ = num_hw_cqs;
     worker_l1_size_ = worker_l1_size;
     l1_bank_remap_ = l1_bank_remap;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -167,8 +167,8 @@ void MetalContext::initialize(
     const size_t fw_compile_hash = std::hash<std::string>{}(rtoptions().get_compile_hash_string());
     validate_worker_l1_size(worker_l1_size, hal());
 
-    // DispatchCoreConfig::get_dispatch_core_axis calls get_default_axis with the default
-    // metal context ID which will cause implicit initialization of a MetalContext.
+    // DispatchCoreConfig::get_dispatch_core_axis calls get_default_axis with DEFAULT_CONTEXT_ID
+    // which will cause implicit initialization of a MetalContext if one doesn't exist yet.
     // Workaround that by setting the dispatch core axis here and storing a resolved config.
     // TODO: https://github.com/tenstorrent/tt-metal/issues/39974
     DispatchCoreConfig resolved_config = dispatch_core_config;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38445

### Problem description
DispatchCoreConfig::get_dispatch_core_axis() internally calls get_default_axis(), which triggers an implicit initialization of the default MetalContext so we try to not to call this function.

In MetalContext::initialize(), the dispatch core axis was resolved after the re-initialization check that compares the incoming config against the stored config (dispatch_core_config_). The stored one had axis_ set to a default value. The new one didn't have the axis_ set yet. This can cause unintended reinits with axis_ is not set.

### What's changed
Moved the dispatch core axis resolution to before the re-initialization check to make the incoming config fully resolved so we compare new and old configs with axis_ set.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang%2Ffix-101)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Anhuang%2Ffix-101)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang%2Ffix-101)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch%3Anhuang%2Ffix-101)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang%2Ffix-101)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Anhuang%2Ffix-101)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
