### PR TITLE
#36669: Add mixed-precision support to batch_norm

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -40,8 +40,20 @@ pytestmark = pytest.mark.use_module_device
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
 @pytest.mark.parametrize("testing_dtype", ["float32", "bfloat16"])
 @pytest.mark.parametrize("testing_dtype2", ["float32", "bfloat16"])
+@pytest.mark.parametrize("use_output_tensor", [True, False])
 def test_batch_norm_tests(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype, testing_dtype2
+    input_shapes,
+    check_mean,
+    check_var,
+    weight,
+    bias,
+    eps,
+    device,
+    momentum,
+    training,
+    testing_dtype,
+    testing_dtype2,
+    use_output_tensor,
 ):
     # Skip certain configurations that we don't want to test or support
     if (not training) and ((not check_mean) or (not check_var)):
@@ -71,17 +83,34 @@ def test_batch_norm_tests(
         else (None, None)
     )
 
-    tt_output_tensor_on_device = ttnn.batch_norm(
-        input_tensor,
-        running_mean=mean_tensor,
-        running_var=var_tensor,
-        training=training,
-        eps=eps,
-        weight=weight_tensor,
-        bias=bias_tensor,
-        momentum=momentum,
-    )
+    if use_output_tensor:
+        _, tt_output_tensor_on_device = data_gen_with_range_batch_norm(
+            input_shapes, 0, 1, device, is_input=True, testing_dtype=testing_dtype
+        )
+        ttnn.batch_norm(
+            input_tensor,
+            running_mean=mean_tensor,
+            running_var=var_tensor,
+            training=training,
+            eps=eps,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            momentum=momentum,
+            output=tt_output_tensor_on_device,
+        )
+    else:
+        tt_output_tensor_on_device = ttnn.batch_norm(
+            input_tensor,
+            running_mean=mean_tensor,
+            running_var=var_tensor,
+            training=training,
+            eps=eps,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            momentum=momentum,
+        )
     tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+
     tt_updated_mean = None
     tt_updated_var = None
     if training:

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -39,35 +39,37 @@ pytestmark = pytest.mark.use_module_device
 @pytest.mark.parametrize("eps", [1.0, 1e-05])
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
 @pytest.mark.parametrize("testing_dtype", ["float32", "bfloat16"])
+@pytest.mark.parametrize("testing_dtype2", ["float32", "bfloat16"])
 def test_batch_norm_tests(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype
+    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype, testing_dtype2
 ):
+    # Skip certain configurations that we don't want to test or support
+    if (not training) and ((not check_mean) or (not check_var)):
+        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
+
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
     )
     mean_data, mean_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
         if (check_mean)
         else (None, None)
     )
     var_data, var_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=testing_dtype)
+        data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=testing_dtype2)
         if (check_var)
         else (None, None)
     )
     weight_data, weight_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
         if weight
         else (None, None)
     )
     bias_data, bias_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
         if bias
         else (None, None)
     )
-
-    if (not training) and ((not check_mean) or (not check_var)):
-        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
 
     tt_output_tensor_on_device = ttnn.batch_norm(
         input_tensor,

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -447,7 +447,7 @@ def test_batch_norm_output_Default(input_shapes, device):
 )
 def test_batch_norm_compute_config(input_shapes, training, weight, bias, device):
     N, H, W, C = input_shapes
-    d_type = "float32"
+    d_type = "bfloat16"
     torch.manual_seed(0)
 
     # Generate the inputs

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -39,78 +39,47 @@ pytestmark = pytest.mark.use_module_device
 @pytest.mark.parametrize("eps", [1.0, 1e-05])
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
 @pytest.mark.parametrize("testing_dtype", ["float32", "bfloat16"])
-@pytest.mark.parametrize("testing_dtype2", ["float32", "bfloat16"])
-@pytest.mark.parametrize("use_output_tensor", [True, False])
 def test_batch_norm_tests(
-    input_shapes,
-    check_mean,
-    check_var,
-    weight,
-    bias,
-    eps,
-    device,
-    momentum,
-    training,
-    testing_dtype,
-    testing_dtype2,
-    use_output_tensor,
+    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype
 ):
-    # Skip certain configurations that we don't want to test or support
-    if (not training) and ((not check_mean) or (not check_var)):
-        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
-
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
     )
     mean_data, mean_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
         if (check_mean)
         else (None, None)
     )
     var_data, var_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=testing_dtype2)
+        data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=testing_dtype)
         if (check_var)
         else (None, None)
     )
     weight_data, weight_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
         if weight
         else (None, None)
     )
     bias_data, bias_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype)
         if bias
         else (None, None)
     )
 
-    if use_output_tensor:
-        _, tt_output_tensor_on_device = data_gen_with_range_batch_norm(
-            input_shapes, 0, 1, device, is_input=True, testing_dtype=testing_dtype
-        )
-        ttnn.batch_norm(
-            input_tensor,
-            running_mean=mean_tensor,
-            running_var=var_tensor,
-            training=training,
-            eps=eps,
-            weight=weight_tensor,
-            bias=bias_tensor,
-            momentum=momentum,
-            output=tt_output_tensor_on_device,
-        )
-    else:
-        tt_output_tensor_on_device = ttnn.batch_norm(
-            input_tensor,
-            running_mean=mean_tensor,
-            running_var=var_tensor,
-            training=training,
-            eps=eps,
-            weight=weight_tensor,
-            bias=bias_tensor,
-            momentum=momentum,
-        )
-    tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+    if (not training) and ((not check_mean) or (not check_var)):
+        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
 
+    tt_output_tensor_on_device = ttnn.batch_norm(
+        input_tensor,
+        running_mean=mean_tensor,
+        running_var=var_tensor,
+        training=training,
+        eps=eps,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        momentum=momentum,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor_on_device)
     tt_updated_mean = None
     tt_updated_var = None
     if training:
@@ -119,40 +88,37 @@ def test_batch_norm_tests(
         if check_var:
             tt_updated_var = ttnn.to_torch(var_tensor)
 
-    # PyTorch batch_norm does not support mixed dtypes; use float32 reference then cast back
-    in_ref = in_data.float()
-    mean_ref = mean_data.float() if mean_data is not None else None
-    var_ref = var_data.float() if var_data is not None else None
-    weight_ref = weight_data.float() if weight_data is not None else None
-    bias_ref = bias_data.float() if bias_data is not None else None
     torch_result = torch.nn.functional.batch_norm(
-        input=in_ref,
-        running_mean=mean_ref,
-        running_var=var_ref,
-        weight=weight_ref,
-        bias=bias_ref,
+        input=in_data,
+        running_mean=mean_data,
+        running_var=var_data,
+        weight=weight_data,
+        bias=bias_data,
         training=training,
         eps=eps,
         momentum=momentum,
     )
-    torch_result = torch_result.to(tt_output.dtype)
     comp_BN_Output = compare_results_batch_norm([tt_output], [torch_result])
     if training:
         channels = input_shapes[1]
         if check_mean:
-            mean_compare = mean_ref.view(1, channels, 1, 1).to(mean_data.dtype)
             comp_BN_running_mean = compare_results_batch_norm(
-                [tt_updated_mean], [mean_compare], stats=True
+                [tt_updated_mean], [mean_data.view(1, channels, 1, 1)], stats=True
             )  # Check Updated running mean
         else:
-            comp_BN_running_mean = tt_updated_mean is None
+            if tt_updated_mean is None:
+                comp_BN_running_mean = True
+            else:
+                comp_BN_running_mean = False
         if check_var:
-            var_compare = var_ref.view(1, channels, 1, 1).to(var_data.dtype)
             comp_BN_running_var = compare_results_batch_norm(
-                [tt_updated_var], [var_compare], stats=True
+                [tt_updated_var], [var_data.view(1, channels, 1, 1)], stats=True
             )  # Check Updated running var
         else:
-            comp_BN_running_var = tt_updated_var is None
+            if tt_updated_var is None:
+                comp_BN_running_var = True
+            else:
+                comp_BN_running_var = False
         comp_BN_Output = comp_BN_Output and comp_BN_running_mean and comp_BN_running_var
     assert comp_BN_Output
 
@@ -559,3 +525,145 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
     assert all(
         high > low for high, low in zip(pccs_high, pccs_low)
     ), "High-accuracy config should have higher PCC than low-accuracy config"
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([3, 5, 64, 120]),
+    ],
+)
+@pytest.mark.parametrize("use_output_tensor", [False, True])
+@pytest.mark.parametrize(
+    "training, check_mean, check_var",
+    [
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        # (False, False, False),  # xfail case
+        # (False, True, False),  # xfail case
+        # (False, False, True),  # xfail case
+        (False, True, True),
+    ],
+)
+@pytest.mark.parametrize("weight", [False, True])
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("eps", [1e-05])
+@pytest.mark.parametrize("momentum", [0.1])
+@pytest.mark.parametrize("testing_dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("testing_dtype2", ["bfloat16", "float32"])
+def test_batch_norm_mixed_precision(
+    input_shapes,
+    use_output_tensor,
+    training,
+    check_mean,
+    check_var,
+    weight,
+    bias,
+    eps,
+    device,
+    momentum,
+    testing_dtype,
+    testing_dtype2,
+):
+    # Skip certain configurations that we don't want to test or support
+    if (not training) and ((not check_mean) or (not check_var)):
+        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
+
+    in_data, input_tensor = data_gen_with_range_batch_norm(
+        input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
+    )
+    mean_data, mean_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        if (check_mean)
+        else (None, None)
+    )
+    var_data, var_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=testing_dtype2)
+        if (check_var)
+        else (None, None)
+    )
+    weight_data, weight_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        if weight
+        else (None, None)
+    )
+    bias_data, bias_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=testing_dtype2)
+        if bias
+        else (None, None)
+    )
+
+    if use_output_tensor:
+        _, tt_output_tensor_on_device = data_gen_with_range_batch_norm(
+            input_shapes, 0, 1, device, is_input=True, testing_dtype=testing_dtype
+        )
+        ttnn.batch_norm(
+            input_tensor,
+            running_mean=mean_tensor,
+            running_var=var_tensor,
+            training=training,
+            eps=eps,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            momentum=momentum,
+            output=tt_output_tensor_on_device,
+        )
+    else:
+        tt_output_tensor_on_device = ttnn.batch_norm(
+            input_tensor,
+            running_mean=mean_tensor,
+            running_var=var_tensor,
+            training=training,
+            eps=eps,
+            weight=weight_tensor,
+            bias=bias_tensor,
+            momentum=momentum,
+        )
+    tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+
+    tt_updated_mean = None
+    tt_updated_var = None
+    if training:
+        if check_mean:
+            tt_updated_mean = ttnn.to_torch(mean_tensor)
+        if check_var:
+            tt_updated_var = ttnn.to_torch(var_tensor)
+
+    # PyTorch batch_norm does not support float32 input, bfloat16 output; use float32 reference then cast back
+    in_ref = in_data.float()
+    mean_ref = mean_data.float() if mean_data is not None else None
+    var_ref = var_data.float() if var_data is not None else None
+    weight_ref = weight_data.float() if weight_data is not None else None
+    bias_ref = bias_data.float() if bias_data is not None else None
+    torch_result = torch.nn.functional.batch_norm(
+        input=in_ref,
+        running_mean=mean_ref,
+        running_var=var_ref,
+        weight=weight_ref,
+        bias=bias_ref,
+        training=training,
+        eps=eps,
+        momentum=momentum,
+    )
+    torch_result = torch_result.to(tt_output.dtype)
+    comp_BN_Output = compare_results_batch_norm([tt_output], [torch_result])
+    if training:
+        channels = input_shapes[1]
+        if check_mean:
+            mean_compare = mean_ref.view(1, channels, 1, 1).to(mean_data.dtype)
+            comp_BN_running_mean = compare_results_batch_norm(
+                [tt_updated_mean], [mean_compare], stats=True
+            )  # Check Updated running mean
+        else:
+            comp_BN_running_mean = tt_updated_mean is None
+        if check_var:
+            var_compare = var_ref.view(1, channels, 1, 1).to(var_data.dtype)
+            comp_BN_running_var = compare_results_batch_norm(
+                [tt_updated_var], [var_compare], stats=True
+            )  # Check Updated running var
+        else:
+            comp_BN_running_var = tt_updated_var is None
+        comp_BN_Output = comp_BN_Output and comp_BN_running_mean and comp_BN_running_var
+    assert comp_BN_Output

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -428,7 +428,7 @@ def test_batch_norm_output_Default(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        torch.Size([2, 3, 64, 64]),
+        torch.Size([3, 17, 47, 32]),
     ],
 )
 @pytest.mark.parametrize(
@@ -440,34 +440,36 @@ def test_batch_norm_output_Default(input_shapes, device):
         (False, False, False),
     ],
 )
-def test_batch_norm_compute_config(input_shapes, training, weight, bias, device):
+@pytest.mark.parametrize(
+    "input_dtype, param_dtype", [("bfloat16", "bfloat16"), ("bfloat16", "float32"), ("float32", "float32")]
+)
+def test_batch_norm_compute_config(input_shapes, training, weight, bias, input_dtype, param_dtype, device):
     N, H, W, C = input_shapes
-    d_type = "bfloat16"
+    if (
+        training and input_shapes[1] < 14
+    ):  # experimentally determined as PCC unreliable for small tensors ([1, C, 1, 1] in this case)
+        pytest.fail(
+            "Training mode PCC ordering is unreliable. Keep `input_shapes[1] >= 14` to avoid this test failure. Also see training modeTODO in batch_norm.cpp"
+        )
     torch.manual_seed(0)
 
     # Generate the inputs
     torch_input_tensor, tt_input_tensor = data_gen_with_range_batch_norm(
-        input_shapes, 5, 10, device, is_input=True, testing_dtype=d_type
+        input_shapes, 5, 10, device, is_input=True, testing_dtype=input_dtype
     )
     torch_mean_tensor, tt_mean_tensor = data_gen_with_range_batch_norm(
-        input_shapes, 4, 10, device, testing_dtype=d_type
+        input_shapes, 4, 10, device, testing_dtype=param_dtype
     )
-    torch_var_tensor, tt_var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device, testing_dtype=d_type)
+    torch_var_tensor, tt_var_tensor = data_gen_with_range_batch_norm(
+        input_shapes, 4, 20, device, testing_dtype=param_dtype
+    )
     torch_weight_tensor, tt_weight_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=d_type) if weight else (None, None)
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=param_dtype)
+        if weight
+        else (None, None)
     )
     torch_bias_tensor, tt_bias_tensor = (
-        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=d_type) if bias else (None, None)
-    )
-
-    # Compute the torch result
-    torch_output_tensor = torch.nn.functional.batch_norm(
-        input=torch_input_tensor,
-        running_mean=torch_mean_tensor,
-        running_var=torch_var_tensor,
-        weight=torch_weight_tensor,
-        bias=torch_bias_tensor,
-        training=training,
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device, testing_dtype=param_dtype) if bias else (None, None)
     )
 
     # Helper function to execute batch_norm for a given compute config
@@ -480,18 +482,34 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
             input=tt_input_tensor,
             running_mean=tt_mean,
             running_var=tt_var,
-            training=training,
             weight=tt_weight_tensor,
             bias=tt_bias_tensor,
+            training=training,
             compute_kernel_config=compute_config,
         )
 
+        torch_mean_ref = torch_mean_tensor.clone()
+        torch_var_ref = torch_var_tensor.clone()
+        torch_output_ref = torch.nn.functional.batch_norm(
+            input=torch_input_tensor,
+            running_mean=torch_mean_ref,
+            running_var=torch_var_ref,
+            weight=torch_weight_tensor,
+            bias=torch_bias_tensor,
+            training=training,
+        )
+
         if training:
-            tt_tensors = [ttnn.to_torch(tt_mean), ttnn.to_torch(tt_var)]
-            torch_tensors = [torch_mean_tensor, torch_var_tensor]
+            channels = input_shapes[1]
+            tt_tensors = [ttnn.to_torch(tt_output_tensor), ttnn.to_torch(tt_mean), ttnn.to_torch(tt_var)]
+            torch_tensors = [
+                torch_output_ref.to(tt_tensors[0].dtype),
+                torch_mean_ref.view(1, channels, 1, 1).to(tt_tensors[1].dtype),
+                torch_var_ref.view(1, channels, 1, 1).to(tt_tensors[2].dtype),
+            ]
         else:
             tt_tensors = [ttnn.to_torch(tt_output_tensor)]
-            torch_tensors = [torch_output_tensor]
+            torch_tensors = [torch_output_ref.to(tt_tensors[0].dtype)]
 
         return torch_tensors, tt_tensors
 
@@ -509,8 +527,8 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
         math_approx_mode=False,
         fp32_dest_acc_en=False,
     )
-    torch_tensors, tt_tensors = do_batch_norm_for_config(config_low)
-    pccs_low = compute_pccs_for_tensors(torch_tensors, tt_tensors)
+    torch_tensors_low, tt_tensors_low = do_batch_norm_for_config(config_low)
+    pccs_low = compute_pccs_for_tensors(torch_tensors_low, tt_tensors_low)
 
     # Execute high-accuracy groupnorm
     config_high = ttnn.init_device_compute_kernel_config(
@@ -519,12 +537,14 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, device)
         math_approx_mode=False,
         fp32_dest_acc_en=True,
     )
-    torch_tensors, tt_tensors = do_batch_norm_for_config(config_high)
-    pccs_high = compute_pccs_for_tensors(torch_tensors, tt_tensors)
+    torch_tensors_high, tt_tensors_high = do_batch_norm_for_config(config_high)
+    pccs_high = compute_pccs_for_tensors(torch_tensors_high, tt_tensors_high)
 
-    assert all(
-        high > low for high, low in zip(pccs_high, pccs_low)
-    ), "High-accuracy config should have higher PCC than low-accuracy config"
+    print(f"pccs_low={pccs_low}, pccs_high={pccs_high}")
+    assert all(high > low for high, low in zip(pccs_high, pccs_low)), (
+        f"High-accuracy config should have higher PCC than low-accuracy config: "
+        f"pccs_high={pccs_high}, pccs_low={pccs_low}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -428,6 +428,7 @@ def test_batch_norm_output_Default(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     [
+        # Training mode PCC ordering is unreliable. Keep `input_shapes[1] >= 14` to avoid this test failure.
         torch.Size([3, 17, 47, 32]),
     ],
 )
@@ -445,12 +446,6 @@ def test_batch_norm_output_Default(input_shapes, device):
 )
 def test_batch_norm_compute_config(input_shapes, training, weight, bias, input_dtype, param_dtype, device):
     N, H, W, C = input_shapes
-    if (
-        training and input_shapes[1] < 14
-    ):  # experimentally determined as PCC unreliable for small tensors ([1, C, 1, 1] in this case)
-        pytest.fail(
-            "Training mode PCC ordering is unreliable. Keep `input_shapes[1] >= 14` to avoid this test failure. Also see training modeTODO in batch_norm.cpp"
-        )
     torch.manual_seed(0)
 
     # Generate the inputs
@@ -561,9 +556,10 @@ def test_batch_norm_compute_config(input_shapes, training, weight, bias, input_d
         (True, True, False),
         (True, False, True),
         (True, False, False),
-        # (False, False, False),  # xfail case
-        # (False, True, False),  # xfail case
-        # (False, False, True),  # xfail case
+        # running_mean and running_var must be defined in evaluation mode:
+        # (False, False, False),
+        # (False, True, False),
+        # (False, False, True),
         (False, True, True),
     ],
 )
@@ -587,10 +583,6 @@ def test_batch_norm_mixed_precision(
     testing_dtype,
     testing_dtype2,
 ):
-    # Skip certain configurations that we don't want to test or support
-    if (not training) and ((not check_mean) or (not check_var)):
-        pytest.xfail("running_mean and running_var must be defined in evaluation mode")
-
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
     )

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -90,37 +90,40 @@ def test_batch_norm_tests(
         if check_var:
             tt_updated_var = ttnn.to_torch(var_tensor)
 
+    # PyTorch batch_norm does not support mixed dtypes; use float32 reference then cast back
+    in_ref = in_data.float()
+    mean_ref = mean_data.float() if mean_data is not None else None
+    var_ref = var_data.float() if var_data is not None else None
+    weight_ref = weight_data.float() if weight_data is not None else None
+    bias_ref = bias_data.float() if bias_data is not None else None
     torch_result = torch.nn.functional.batch_norm(
-        input=in_data,
-        running_mean=mean_data,
-        running_var=var_data,
-        weight=weight_data,
-        bias=bias_data,
+        input=in_ref,
+        running_mean=mean_ref,
+        running_var=var_ref,
+        weight=weight_ref,
+        bias=bias_ref,
         training=training,
         eps=eps,
         momentum=momentum,
     )
+    torch_result = torch_result.to(tt_output.dtype)
     comp_BN_Output = compare_results_batch_norm([tt_output], [torch_result])
     if training:
         channels = input_shapes[1]
         if check_mean:
+            mean_compare = mean_ref.view(1, channels, 1, 1).to(mean_data.dtype)
             comp_BN_running_mean = compare_results_batch_norm(
-                [tt_updated_mean], [mean_data.view(1, channels, 1, 1)], stats=True
+                [tt_updated_mean], [mean_compare], stats=True
             )  # Check Updated running mean
         else:
-            if tt_updated_mean is None:
-                comp_BN_running_mean = True
-            else:
-                comp_BN_running_mean = False
+            comp_BN_running_mean = tt_updated_mean is None
         if check_var:
+            var_compare = var_ref.view(1, channels, 1, 1).to(var_data.dtype)
             comp_BN_running_var = compare_results_batch_norm(
-                [tt_updated_var], [var_data.view(1, channels, 1, 1)], stats=True
+                [tt_updated_var], [var_compare], stats=True
             )  # Check Updated running var
         else:
-            if tt_updated_var is None:
-                comp_BN_running_var = True
-            else:
-                comp_BN_running_var = False
+            comp_BN_running_var = tt_updated_var is None
         comp_BN_Output = comp_BN_Output and comp_BN_running_mean and comp_BN_running_var
     assert comp_BN_Output
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -101,6 +101,11 @@ Tensor batch_norm(
 
     Tensor batch_mean, batch_var;
     if (training) {
+        // TODO: These generic TTNN ops use the compute_kernel_config as-is. In mixed precision,
+        // the highest-precision accumulation is only enforced inside the batch_norm and
+        // running_statistics prims (via any_float32). If required in the future, we may need to
+        // propagate the precision requirement here so these reductions also accumulate in fp32
+        // when params are fp32.
         batch_mean = operations::normalization::mean_NHW(input, memory_config, compute_kernel_config);
         auto mean_sq = operations::normalization::mean_NHW(
             ttnn::square(input, memory_config), memory_config, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -47,6 +47,49 @@ Tensor batch_norm(
         input.logical_shape().rank(),
         input.logical_shape().rank());
 
+    // output must have the same dtype as input
+    if (output.has_value()) {
+        TT_FATAL(
+            output->dtype() == input.dtype(),
+            "batch_norm: output dtype ({}) must match input dtype ({})",
+            output->dtype(),
+            input.dtype());
+    }
+
+    // All user-provided parameters (running_mean, running_var, weight, bias) must share the same dtype
+    auto get_param_dtype = [&]() -> std::optional<DataType> {
+        if (running_mean.has_value()) {
+            return running_mean->dtype();
+        }
+        if (running_var.has_value()) {
+            return running_var->dtype();
+        }
+        if (weight.has_value()) {
+            return weight->dtype();
+        }
+        if (bias.has_value()) {
+            return bias->dtype();
+        }
+        return std::nullopt;
+    };
+    auto param_dtype = get_param_dtype();
+    if (param_dtype.has_value()) {
+        auto check_param = [&](const std::optional<Tensor>& t, std::string_view name) {
+            if (t.has_value()) {
+                TT_FATAL(
+                    t->dtype() == param_dtype.value(),
+                    "batch_norm: {} dtype ({}) must match other parameter tensors dtype ({})",
+                    name,
+                    t->dtype(),
+                    param_dtype.value());
+            }
+        };
+        check_param(running_mean, "running_mean");
+        check_param(running_var, "running_var");
+        check_param(weight, "weight");
+        check_param(bias, "bias");
+    }
+
     // For 0V tensors
     if (input.logical_volume() == 0) [[unlikely]] {
         return ttnn::clone(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -104,8 +104,8 @@ Tensor batch_norm(
         // TODO: These generic TTNN ops use the compute_kernel_config as-is. In mixed precision,
         // the highest-precision accumulation is only enforced inside the batch_norm and
         // running_statistics prims (via any_float32). If required in the future, we may need to
-        // propagate the precision requirement here so these reductions also accumulate in fp32
-        // when params are fp32.
+        // propagate the precision requirement here so that the output `batch_mean`/`batch_var` are in
+        // higher precision rather than inheriting the `dtype` of input.
         batch_mean = operations::normalization::mean_NHW(input, memory_config, compute_kernel_config);
         auto mean_sq = operations::normalization::mean_NHW(
             ttnn::square(input, memory_config), memory_config, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -101,7 +101,7 @@ Tensor batch_norm(
 
     Tensor batch_mean, batch_var;
     if (training) {
-        // TODO: These generic TTNN ops use the compute_kernel_config as-is. In mixed precision,
+        // Note: These generic TTNN ops use the compute_kernel_config as-is. In mixed precision,
         // the highest-precision accumulation is only enforced inside the batch_norm and
         // running_statistics prims (via any_float32). If required in the future, we may need to
         // propagate the precision requirement here so that the output `batch_mean`/`batch_var` are in

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_nanobind.cpp
@@ -63,7 +63,9 @@ void bind_batch_norm_operation(nb::module_& mod) {
 
             These apply for all the tensor inputs to this operation, including the optional :attr:`output` tensor.
 
-            The output tensor will be in TILE layout and have the same dtype as the :attr:`input_tensor`
+            Mixed precision is supported: input tensors may have different dtypes (e.g. BFLOAT16 input with FLOAT32 parameters).
+            The output tensor will be in TILE layout with dtype equal to the highest precision among all provided input tensors.
+            When a preallocated :attr:`output` tensor is provided, its dtype is used instead.
 
         Memory Support:
             - Interleaved: DRAM and L1

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_nanobind.cpp
@@ -41,7 +41,7 @@ void bind_batch_norm_operation(nb::module_& mod) {
             weight (ttnn.Tensor, optional): the weight or gamma value of shape `[1, C, 1, 1]`. Defaults to `None`.
             bias (ttnn.Tensor, optional): the bias or beta value of shape `[1, C, 1, 1]`. Defaults to `None`.
             training (bool, optional): Selection between training mode and inference (evaluation) mode. Defaults to `False` (Inference mode).
-            output (ttnn.Tensor, optional): Preallocated output tensor to store batch norm result of shape `[N, C, H, W]`. Defaults to `None`.
+            output (ttnn.Tensor, optional): Preallocated output tensor to store batch norm result of shape `[N, C, H, W]`. Must have the same dtype as :attr:`input_tensor`. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): device compute kernel configuration for the operation. Defaults to `None`.
 
@@ -63,9 +63,9 @@ void bind_batch_norm_operation(nb::module_& mod) {
 
             These apply for all the tensor inputs to this operation, including the optional :attr:`output` tensor.
 
-            Mixed precision is supported: input tensors may have different dtypes (e.g. BFLOAT16 input with FLOAT32 parameters).
-            The output tensor will be in TILE layout with dtype equal to the highest precision among all provided input tensors.
-            When a preallocated :attr:`output` tensor is provided, its dtype is used instead.
+            Mixed precision is supported: ``input`` (and ``output``, if provided) may use a different dtype from the
+            parameter tensors (``running_mean``, ``running_var``, ``weight``, ``bias``). The output dtype always
+            matches the input dtype. All parameter tensors must share the same dtype with each other.
 
         Memory Support:
             - Interleaved: DRAM and L1

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -177,15 +177,11 @@ ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::normalization::BatchNormOperation;
 
-    // Output always has the same dtype as input; params (mean/var/weight/bias) may differ.
-    DataType output_dtype = input.dtype();
-
     OperationType::operation_attributes_t operation_attributes{
         eps,
         memory_config.value_or(input.memory_config()),
         ttnn::operations::normalization::batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, input),
-        input.dtype(),
-        output_dtype};
+        input.dtype()};
     OperationType::tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -41,14 +41,9 @@ void BatchNormOperation::validate_tensors(
     check_tensor_BN(batch_mean, "batch_mean_shape", C);
     check_tensor_BN(batch_var, "batch_mean_shape", C);
 
-    // output (N, C, H, W) — must have the same dtype as input
+    // output (N, C, H, W)
     if (output.has_value()) {
         check_tensor_BN(output.value(), "output_shape", C);
-        TT_FATAL(
-            output->dtype() == input.dtype(),
-            "batch_norm: output dtype ({}) must match input dtype ({})",
-            output->dtype(),
-            input.dtype());
     }
 
     // weight (1, C, 1, 1)
@@ -176,7 +171,6 @@ ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::normalization::BatchNormOperation;
-
     OperationType::operation_attributes_t operation_attributes{
         eps,
         memory_config.value_or(input.memory_config()),

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -41,9 +41,14 @@ void BatchNormOperation::validate_tensors(
     check_tensor_BN(batch_mean, "batch_mean_shape", C);
     check_tensor_BN(batch_var, "batch_mean_shape", C);
 
-    // output (N, C, H, W)
+    // output (N, C, H, W) — must have the same dtype as input
     if (output.has_value()) {
         check_tensor_BN(output.value(), "output_shape", C);
+        TT_FATAL(
+            output->dtype() == input.dtype(),
+            "batch_norm: output dtype ({}) must match input dtype ({})",
+            output->dtype(),
+            input.dtype());
     }
 
     // weight (1, C, 1, 1)
@@ -172,24 +177,8 @@ ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::normalization::BatchNormOperation;
 
+    // Output always has the same dtype as input; params (mean/var/weight/bias) may differ.
     DataType output_dtype = input.dtype();
-    if (output.has_value()) {
-        output_dtype = output->dtype();
-    } else {
-        auto promote = [&output_dtype](DataType dt) {
-            if (dt == DataType::FLOAT32) {
-                output_dtype = DataType::FLOAT32;
-            }
-        };
-        promote(batch_mean.dtype());
-        promote(batch_var.dtype());
-        if (weight.has_value()) {
-            promote(weight->dtype());
-        }
-        if (bias.has_value()) {
-            promote(bias->dtype());
-        }
-    }
 
     OperationType::operation_attributes_t operation_attributes{
         eps,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -171,11 +171,32 @@ ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::normalization::BatchNormOperation;
+
+    DataType output_dtype = input.dtype();
+    if (output.has_value()) {
+        output_dtype = output->dtype();
+    } else {
+        auto promote = [&output_dtype](DataType dt) {
+            if (dt == DataType::FLOAT32) {
+                output_dtype = DataType::FLOAT32;
+            }
+        };
+        promote(batch_mean.dtype());
+        promote(batch_var.dtype());
+        if (weight.has_value()) {
+            promote(weight->dtype());
+        }
+        if (bias.has_value()) {
+            promote(bias->dtype());
+        }
+    }
+
     OperationType::operation_attributes_t operation_attributes{
         eps,
         memory_config.value_or(input.memory_config()),
         ttnn::operations::normalization::batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, input),
-        input.dtype()};
+        input.dtype(),
+        output_dtype};
     OperationType::tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -39,6 +39,7 @@ struct BatchNormOperation {
             tt::tt_metal::KernelHandle writer_kernel_id{};
             tt::tt_metal::KernelHandle compute_kernel_id{};
             CoreCoord compute_with_storage_grid_size;
+            bool any_float32{};
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -54,6 +54,25 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
+    const bool any_float32 =
+        (tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()) == tt::DataFormat::Float32 ||
+         tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
+         tt::tt_metal::datatype_to_dataformat_converter(batch_var_tensor.dtype()) == tt::DataFormat::Float32 ||
+         tt::tt_metal::datatype_to_dataformat_converter(c.dtype()) == tt::DataFormat::Float32 ||
+         (weight_has_value &&
+          tt::tt_metal::datatype_to_dataformat_converter(weight_tensor->dtype()) == tt::DataFormat::Float32) ||
+         (bias_has_value &&
+          tt::tt_metal::datatype_to_dataformat_converter(bias_tensor->dtype()) == tt::DataFormat::Float32));
+    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
+
+    const uint32_t cHtWt = cHt * cWt;
+    const auto scalar = eps;
+    const auto packed_scalar_eps =
+        use_fp32_acc ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
+
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 14;
     constexpr size_t num_kernel_args = 3;
@@ -71,12 +90,6 @@ void set_or_update_runtime_arguments(
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, num_kernel_args>{0});
             continue;
         }
-
-        uint32_t cHtWt = cHt * cWt;
-        const auto scalar = eps;
-        const auto packed_scalar_eps = input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32
-                                           ? std::bit_cast<uint32_t>(scalar)
-                                           : pack_two_bfloat16_into_uint32({scalar, scalar});
 
         std::array reader_runtime_args = {
             packed_scalar_eps,
@@ -150,12 +163,23 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     auto f_data_format =
         bias_has_value ? datatype_to_dataformat_converter(bias_tensor->dtype()) : DataFormat::Float16_b;
 
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
+    const bool any_float32 =
+        (a_data_format == DataFormat::Float32 || b_data_format == DataFormat::Float32 ||
+         c_data_format == DataFormat::Float32 || d_data_format == DataFormat::Float32 ||
+         e_data_format == DataFormat::Float32 || f_data_format == DataFormat::Float32);
+    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
+    auto interm_data_format = any_float32 ? DataFormat::Float32 : a_data_format;
+
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
     uint32_t b_single_tile_size = tt::tile_size(b_data_format);
     uint32_t c_single_tile_size = tt::tile_size(c_data_format);
     uint32_t d_single_tile_size = tt::tile_size(d_data_format);
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
     uint32_t f_single_tile_size = tt::tile_size(f_data_format);
+    uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
 
     // we parallelize the computation across the output tiles
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -187,7 +211,12 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_num_tiles_per_cb,
         d_data_format);  // batch_var
     auto [eps_cb, eps_cb_handle] = create_cb(
-        tt::CBIndex::c_4, program, all_device_cores, d_single_tile_size, b_num_tiles_per_cb, d_data_format);  // eps
+        tt::CBIndex::c_4,
+        program,
+        all_device_cores,
+        interm_single_tile_size,
+        b_num_tiles_per_cb,
+        interm_data_format);  // eps
     auto [weight_tensor_cb, weight_tensor_cb_handle] = create_cb(
         tt::CBIndex::c_5, program, all_device_cores, e_single_tile_size, b_num_tiles_per_cb, e_data_format);  // weight
     auto [bias_tensor_cb, bias_tensor_cb_handle] = create_cb(
@@ -198,11 +227,11 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         tt::CBIndex::c_7,
         program,
         all_device_cores,
-        a_single_tile_size,
+        interm_single_tile_size,
         num_tiles_per_cb,
-        a_data_format);  // to store 1/(sqrt(batch_var + eps))
-    auto [temp_1_cb, temp_1_cb_handle] =
-        create_cb(tt::CBIndex::c_8, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
+        interm_data_format);  // to store 1/(sqrt(batch_var + eps))
+    auto [temp_1_cb, temp_1_cb_handle] = create_cb(
+        tt::CBIndex::c_8, program, all_device_cores, interm_single_tile_size, num_tiles_per_cb, interm_data_format);
 
     std::vector<uint32_t> reader_compile_time_args = {
         input_tensor_cb,
@@ -226,17 +255,12 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         .append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(bias_tensor ? bias_tensor->buffer() : nullptr).append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> dataflow_defines;  // Currently support only for fp32, bf16
-    if (input_tensor.dtype() == DataType::FLOAT32) {
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
-        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
-    } else {
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
-        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
+    // READER KERNEL
+    std::map<std::string, std::string> reader_defines;
+    if (use_fp32_acc) {
+        reader_defines["FILL_EPS_FP32"] = "1";
     }
 
-    // READER KERNEL
-    auto reader_defines = dataflow_defines;
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp",
@@ -244,7 +268,20 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
 
     // WRITER KERNEL
-    auto writer_defines = dataflow_defines;
+    std::map<std::string, std::string> writer_defines;
+    if (b_data_format == DataFormat::Float32) {
+        writer_defines["MEAN_IS_FP32"] = "1";
+    }
+    if (d_data_format == DataFormat::Float32) {
+        writer_defines["VAR_IS_FP32"] = "1";
+    }
+    if (e_data_format == DataFormat::Float32) {
+        writer_defines["WEIGHT_IS_FP32"] = "1";
+    }
+    if (f_data_format == DataFormat::Float32) {
+        writer_defines["BIAS_IS_FP32"] = "1";
+    }
+
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp",
@@ -252,11 +289,8 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
 
     // COMPUTE KERNEL
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
+    if (use_fp32_acc) {
         for (const auto cb_index :
              {input_tensor_cb,
               batch_mean_tensor_cb,
@@ -286,11 +320,14 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_{}.cpp",
-            fp32_dest_acc_en ? "sfpu_kernel" : "kernel"),
+            use_fp32_acc ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = use_fp32_acc,
+            .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .math_approx_mode = math_approx_mode,
             .compile_args = compute_kernel_args});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -151,14 +151,10 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     auto f_data_format =
         bias_has_value ? datatype_to_dataformat_converter(bias_tensor->dtype()) : DataFormat::Float16_b;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-
     const bool any_float32 =
         (a_data_format == DataFormat::Float32 || b_data_format == DataFormat::Float32 ||
          c_data_format == DataFormat::Float32 || d_data_format == DataFormat::Float32 ||
          e_data_format == DataFormat::Float32 || f_data_format == DataFormat::Float32);
-    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
     auto interm_data_format = any_float32 ? DataFormat::Float32 : a_data_format;
 
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
@@ -285,8 +281,11 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     // COMPUTE KERNEL
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (use_fp32_acc) {
+    if (fp32_dest_acc_en) {
         for (const auto cb_index :
              {input_tensor_cb,
               batch_mean_tensor_cb,
@@ -321,11 +320,11 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_{}.cpp",
-            any_float32 ? "sfpu_kernel" : "kernel"),
+            (fp32_dest_acc_en || any_float32) ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = use_fp32_acc,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -172,7 +172,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
 
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
     uint32_t b_single_tile_size = tt::tile_size(b_data_format);
-    uint32_t c_single_tile_size = tt::tile_size(c_data_format);
     uint32_t d_single_tile_size = tt::tile_size(d_data_format);
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
     uint32_t f_single_tile_size = tt::tile_size(f_data_format);
@@ -198,8 +197,15 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_single_tile_size,
         b_num_tiles_per_cb,
         b_data_format);  // batch_mean
+    // Output CB uses interm_data_format so the compute kernel can pack without packer format
+    // switching. The writer handles the final conversion to the tensor's native dtype.
     auto [output_tensor_cb, output_tensor_cb_handle] = create_cb(
-        tt::CBIndex::c_2, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);  // output
+        tt::CBIndex::c_2,
+        program,
+        all_device_cores,
+        interm_single_tile_size,
+        num_tiles_per_cb,
+        interm_data_format);  // output
     auto [batch_var_tensor_cb, batch_var_tensor_cb_handle] = create_cb(
         tt::CBIndex::c_3,
         program,
@@ -277,6 +283,9 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     }
     if (f_data_format == DataFormat::Float32) {
         writer_defines["BIAS_IS_FP32"] = "1";
+    }
+    if (interm_data_format == DataFormat::Float32 && c_data_format != DataFormat::Float32) {
+        writer_defines["CONVERT_OUTPUT_TO_BF16"] = "1";
     }
 
     auto writer_kernel_id = tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -255,6 +255,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         eps_cb,
     };
     tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_time_args);
+    reader_compile_time_args.push_back(static_cast<uint32_t>(any_float32));
 
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(weight_has_value),
@@ -271,39 +272,24 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     tt::tt_metal::TensorAccessorArgs(weight_tensor ? weight_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(bias_tensor ? bias_tensor->buffer() : nullptr).append_to(writer_compile_time_args);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(b_data_format == DataFormat::Float32));
+    auto param_data_format =
+        weight_has_value ? e_data_format : (bias_has_value ? f_data_format : DataFormat::Float16_b);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(param_data_format == DataFormat::Float32));
 
     // READER KERNEL
-    std::map<std::string, std::string> reader_defines;
-    if (any_float32) {
-        reader_defines["FILL_EPS_FP32"] = "1";
-    }
-
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
     // WRITER KERNEL
-    std::map<std::string, std::string> writer_defines;
-    if (b_data_format == DataFormat::Float32) {
-        writer_defines["MEAN_IS_FP32"] = "1";
-    }
-    if (d_data_format == DataFormat::Float32) {
-        writer_defines["VAR_IS_FP32"] = "1";
-    }
-    if (e_data_format == DataFormat::Float32) {
-        writer_defines["WEIGHT_IS_FP32"] = "1";
-    }
-    if (f_data_format == DataFormat::Float32) {
-        writer_defines["BIAS_IS_FP32"] = "1";
-    }
-
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp",
         all_device_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     // COMPUTE KERNEL
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
@@ -333,15 +319,10 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         weight_tensor_cb,
         temp_1_cb,
         bias_tensor_cb,
-        writer_output_cb};
-
-    std::map<std::string, std::string> compute_defines;
-    if (needs_output_typecast) {
-        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
-        auto out_fmt = static_cast<uint32_t>(c_data_format);
-        compute_defines["TYPECAST_OUTPUT_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
-        compute_defines["TYPECAST_OUTPUT"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
-    }
+        writer_output_cb,
+        static_cast<uint32_t>(needs_output_typecast),
+        static_cast<uint32_t>(DataFormat::Float32),
+        needs_output_typecast ? static_cast<uint32_t>(c_data_format) : static_cast<uint32_t>(DataFormat::Float32)};
 
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
@@ -355,8 +336,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args,
-            .defines = std::move(compute_defines)});
+            .compile_args = compute_kernel_args});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -27,6 +27,7 @@ void set_or_update_runtime_arguments(
     tt::tt_metal::KernelHandle writer_kernel_id,
     tt::tt_metal::KernelHandle compute_kernel_id,
     CoreCoord compute_with_storage_grid_size,
+    bool any_float32,
     const BatchNormOperation::operation_attributes_t& operation_attributes,
     const BatchNormOperation::tensor_args_t& tensor_args,
     BatchNormOperation::tensor_return_value_t& c,
@@ -54,16 +55,6 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-
-    const bool any_float32 =
-        (tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()) == tt::DataFormat::Float32 ||
-         tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
-         tt::tt_metal::datatype_to_dataformat_converter(batch_var_tensor.dtype()) == tt::DataFormat::Float32 ||
-         tt::tt_metal::datatype_to_dataformat_converter(c.dtype()) == tt::DataFormat::Float32 ||
-         (weight_has_value &&
-          tt::tt_metal::datatype_to_dataformat_converter(weight_tensor->dtype()) == tt::DataFormat::Float32) ||
-         (bias_has_value &&
-          tt::tt_metal::datatype_to_dataformat_converter(bias_tensor->dtype()) == tt::DataFormat::Float32));
 
     const uint32_t cHtWt = cHt * cWt;
     const auto scalar = eps;
@@ -178,6 +169,8 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     uint32_t f_single_tile_size = tt::tile_size(f_data_format);
     uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
 
+    // If accumulation occurs in float32 but output dtype is different, the compute kernel must typecast from
+    // float32 to output dtype
     const bool needs_output_typecast =
         (interm_data_format == DataFormat::Float32 && c_data_format != DataFormat::Float32);
 
@@ -348,13 +341,15 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         writer_kernel_id,
         compute_kernel_id,
         compute_with_storage_grid_size,
+        any_float32,
         operation_attributes,
         tensor_args,
         output,
         set_runtime_args);
 
     return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+        std::move(program),
+        {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size, any_float32}};
 }
 
 void BatchNormOperation::BatchNormFactory::override_runtime_arguments(
@@ -375,6 +370,7 @@ void BatchNormOperation::BatchNormFactory::override_runtime_arguments(
         cached_program.shared_variables.writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
         cached_program.shared_variables.compute_with_storage_grid_size,
+        cached_program.shared_variables.any_float32,
         operation_attributes,
         tensor_args,
         output,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -172,10 +172,14 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
 
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
     uint32_t b_single_tile_size = tt::tile_size(b_data_format);
+    uint32_t c_single_tile_size = tt::tile_size(c_data_format);
     uint32_t d_single_tile_size = tt::tile_size(d_data_format);
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
     uint32_t f_single_tile_size = tt::tile_size(f_data_format);
     uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
+
+    const bool needs_output_typecast =
+        (interm_data_format == DataFormat::Float32 && c_data_format != DataFormat::Float32);
 
     // we parallelize the computation across the output tiles
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -197,15 +201,25 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         b_single_tile_size,
         b_num_tiles_per_cb,
         b_data_format);  // batch_mean
-    // Output CB uses interm_data_format so the compute kernel can pack without packer format
-    // switching. The writer handles the final conversion to the tensor's native dtype.
     auto [output_tensor_cb, output_tensor_cb_handle] = create_cb(
         tt::CBIndex::c_2,
         program,
         all_device_cores,
-        interm_single_tile_size,
+        needs_output_typecast ? interm_single_tile_size : c_single_tile_size,
         num_tiles_per_cb,
-        interm_data_format);  // output
+        needs_output_typecast ? interm_data_format : c_data_format);  // compute output (staging when typecast)
+
+    uint32_t writer_output_cb = output_tensor_cb;
+    if (needs_output_typecast) {
+        auto [writer_cb, writer_cb_handle] = create_cb(
+            tt::CBIndex::c_9,
+            program,
+            all_device_cores,
+            c_single_tile_size,
+            num_tiles_per_cb,
+            c_data_format);  // writer-facing output (BF16)
+        writer_output_cb = writer_cb;
+    }
     auto [batch_var_tensor_cb, batch_var_tensor_cb_handle] = create_cb(
         tt::CBIndex::c_3,
         program,
@@ -246,7 +260,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         static_cast<uint32_t>(weight_has_value),
         static_cast<uint32_t>(bias_has_value),
         batch_mean_tensor_cb,
-        output_tensor_cb,
+        writer_output_cb,
         batch_var_tensor_cb,
         weight_tensor_cb,
         bias_tensor_cb,
@@ -284,9 +298,6 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
     if (f_data_format == DataFormat::Float32) {
         writer_defines["BIAS_IS_FP32"] = "1";
     }
-    if (interm_data_format == DataFormat::Float32 && c_data_format != DataFormat::Float32) {
-        writer_defines["CONVERT_OUTPUT_TO_BF16"] = "1";
-    }
 
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
@@ -321,7 +332,17 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         den_cb,
         weight_tensor_cb,
         temp_1_cb,
-        bias_tensor_cb};
+        bias_tensor_cb,
+        writer_output_cb};
+
+    std::map<std::string, std::string> compute_defines;
+    if (needs_output_typecast) {
+        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
+        auto out_fmt = static_cast<uint32_t>(c_data_format);
+        compute_defines["TYPECAST_OUTPUT_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
+        compute_defines["TYPECAST_OUTPUT"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
+    }
+
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
         fmt::format(
@@ -334,7 +355,8 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args});
+            .compile_args = compute_kernel_args,
+            .defines = std::move(compute_defines)});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -55,8 +55,6 @@ void set_or_update_runtime_arguments(
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
     const bool any_float32 =
         (tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()) == tt::DataFormat::Float32 ||
          tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
@@ -66,12 +64,11 @@ void set_or_update_runtime_arguments(
           tt::tt_metal::datatype_to_dataformat_converter(weight_tensor->dtype()) == tt::DataFormat::Float32) ||
          (bias_has_value &&
           tt::tt_metal::datatype_to_dataformat_converter(bias_tensor->dtype()) == tt::DataFormat::Float32));
-    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
 
     const uint32_t cHtWt = cHt * cWt;
     const auto scalar = eps;
     const auto packed_scalar_eps =
-        use_fp32_acc ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
+        any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
 
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 14;
@@ -257,7 +254,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
 
     // READER KERNEL
     std::map<std::string, std::string> reader_defines;
-    if (use_fp32_acc) {
+    if (any_float32) {
         reader_defines["FILL_EPS_FP32"] = "1";
     }
 
@@ -320,7 +317,7 @@ BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::Batch
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_{}.cpp",
-            use_fp32_acc ? "sfpu_kernel" : "kernel"),
+            any_float32 ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -56,11 +56,6 @@ void set_or_update_runtime_arguments(
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
-    const uint32_t cHtWt = cHt * cWt;
-    const auto scalar = eps;
-    const auto packed_scalar_eps =
-        any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
-
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 14;
     constexpr size_t num_kernel_args = 3;
@@ -78,6 +73,11 @@ void set_or_update_runtime_arguments(
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, num_kernel_args>{0});
             continue;
         }
+
+        uint32_t cHtWt = cHt * cWt;
+        const auto scalar = eps;
+        const auto packed_scalar_eps =
+            any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
 
         std::array reader_runtime_args = {
             packed_scalar_eps,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -7,14 +7,13 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rsqrt.h"
-#ifdef TYPECAST_OUTPUT
 #include "api/compute/eltwise_unary/typecast.h"
-#endif
 
 #include <cstdint>
 
 #include "experimental/circular_buffer.h"
 
+template <bool NeedsOutputTypecast, uint32_t TcInFmt, uint32_t TcOutFmt>
 ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t cb_bcast,
     uint32_t cb_other,
@@ -27,7 +26,7 @@ ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t cb_bias,
     uint32_t cb_tmp_1,
     uint32_t cb_output_0,
-    [[maybe_unused]] uint32_t cb_output_final,
+    uint32_t cb_output_final,
     uint32_t weight_has,
     uint32_t bias_has,
     uint32_t last_srca_cb) {
@@ -185,35 +184,35 @@ ALWI uint32_t batchnorm_bcast_tiles(
             cb_tmp_1_obj.pop_front(onetile);
         }
 
-#ifdef TYPECAST_OUTPUT
-        cb_output_0_obj.wait_front(onetile);
-        experimental::CircularBuffer cb_output_final_obj(cb_output_final);
-        cb_output_final_obj.reserve_back(onetile);
+        if constexpr (NeedsOutputTypecast) {
+            cb_output_0_obj.wait_front(onetile);
+            experimental::CircularBuffer cb_output_final_obj(cb_output_final);
+            cb_output_final_obj.reserve_back(onetile);
 
-        tile_regs_acquire();
-        copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_output_0);
-        last_srca_cb = cb_output_0;
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_output_0, i, i * 2);
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_output_0);
+            last_srca_cb = cb_output_0;
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_output_0, i, i * 2);
+            }
+            typecast_tile_init<TcInFmt, TcOutFmt>();
+            for (uint32_t i = 0; i < onetile; ++i) {
+                typecast_tile<TcInFmt, TcOutFmt>(i * 2);
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_reconfig_data_format(cb_output_final);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                pack_tile(i * 2, cb_output_final);
+            }
+            tile_regs_release();
+
+            pack_reconfig_data_format(cb_output_final, cb_output_0);
+
+            cb_output_0_obj.pop_front(onetile);
+            cb_output_final_obj.push_back(onetile);
         }
-        TYPECAST_OUTPUT_INIT();
-        for (uint32_t i = 0; i < onetile; ++i) {
-            TYPECAST_OUTPUT(i * 2);
-        }
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_reconfig_data_format(cb_output_final);
-        for (uint32_t i = 0; i < onetile; ++i) {
-            pack_tile(i * 2, cb_output_final);
-        }
-        tile_regs_release();
-
-        pack_reconfig_data_format(cb_output_final, cb_output_0);
-
-        cb_output_0_obj.pop_front(onetile);
-        cb_output_final_obj.push_back(onetile);
-#endif
     }
     cb_bcast_obj.pop_front(onetile);
     cb_den_obj.pop_front(onetile);
@@ -248,6 +247,9 @@ void kernel_main() {
     constexpr auto cb_tmp_1 = get_compile_time_arg_val(9);      // (input - batch_mean)/(sqrt(batch_var + eps))
     constexpr auto cb_bias = get_compile_time_arg_val(10);      // bias tensor
     constexpr auto cb_output_final = get_compile_time_arg_val(11);  // writer-facing output CB (BF16 when typecast)
+    constexpr bool needs_output_typecast = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t tc_in_fmt = get_compile_time_arg_val(13);
+    constexpr uint32_t tc_out_fmt = get_compile_time_arg_val(14);
 
     auto cb_bcast = cb_batch_mean;
     auto cb_other = cb_input;
@@ -263,7 +265,7 @@ void kernel_main() {
     cb_eps_obj.wait_front(onetile);
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
-        last_srca_cb = batchnorm_bcast_tiles(
+        last_srca_cb = batchnorm_bcast_tiles<needs_output_typecast, tc_in_fmt, tc_out_fmt>(
             cb_bcast,
             cb_other,
             tile_freq,
@@ -281,7 +283,7 @@ void kernel_main() {
             last_srca_cb);
     }
     if (remaining_iterations > 0) {
-        last_srca_cb = batchnorm_bcast_tiles(
+        last_srca_cb = batchnorm_bcast_tiles<needs_output_typecast, tc_in_fmt, tc_out_fmt>(
             cb_bcast,
             cb_other,
             remaining_iterations,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -12,7 +12,7 @@
 
 #include "experimental/circular_buffer.h"
 
-ALWI void batchnorm_bcast_tiles(
+ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t cb_bcast,
     uint32_t cb_other,
     uint32_t freq,
@@ -25,7 +25,8 @@ ALWI void batchnorm_bcast_tiles(
     uint32_t cb_tmp_1,
     uint32_t cb_output_0,
     uint32_t weight_has,
-    uint32_t bias_has) {
+    uint32_t bias_has,
+    uint32_t last_srca_cb) {
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;
     uint32_t weight_has_value = weight_has;
@@ -49,26 +50,22 @@ ALWI void batchnorm_bcast_tiles(
     cb_batch_var_obj.wait_front(onetile);
 
     tile_regs_acquire();
-    tile_regs_wait();
-    copy_tile_to_dst_init_short_with_dt(cb_eps, cb_batch_var);
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_batch_var, i, i * 2);
-    }
+    copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_batch_var);
+    last_srca_cb = cb_batch_var;
+    copy_tile(cb_batch_var, 0, 0);
     add_binary_tile_init();
-    copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_eps);
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_eps, i, i * 2 + 1);
-
-        add_binary_tile(i * 2, i * 2 + 1, i * 2);
-    }
+    copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_eps);
+    last_srca_cb = cb_eps;
+    copy_tile(cb_eps, 0, 1);
+    add_binary_tile(0, 1, 0);
     rsqrt_tile_init();
-    for (uint32_t i = 0; i < onetile; ++i) {
-        rsqrt_tile(i * 2);
-
-        pack_tile(i * 2, cb_den);
-    }
+    rsqrt_tile(0);
     tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile(0, cb_den);
     tile_regs_release();
+
     cb_den_obj.push_back(onetile);
     cb_batch_var_obj.pop_front(onetile);
 
@@ -81,55 +78,53 @@ ALWI void batchnorm_bcast_tiles(
         cb_bias_obj.wait_front(onetile);
     }
     for (uint32_t j = tile_start; j < freq; ++j) {
-        // input - batch_mean
         cb_other_obj.wait_front(onetile);
-        tile_regs_acquire();
-        tile_regs_wait();
-        copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_other);
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_other, i, i * 2);
-        }
-        sub_binary_tile_init();
-        copy_tile_to_dst_init_short_with_dt(cb_other, cb_bcast);
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_bcast, i, i * 2 + 1);
-            sub_binary_tile(i * 2, i * 2 + 1, i * 2);
-        }
-        cb_other_obj.pop_front(onetile);
-
-        //(input - batch_mean)/(sqrt(batch_var + eps))
         cb_affine_or_out_obj.reserve_back(onetile);
-        mul_binary_tile_init();
-        copy_tile_to_dst_init_short_with_dt(cb_bcast, cb_den);
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_den, i, i * 2 + 1);
-            mul_binary_tile(i * 2, i * 2 + 1, i * 2);
 
-            pack_tile(i * 2, cb_affine_or_out);
-        }
+        // (input - batch_mean) * den
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_other);
+        last_srca_cb = cb_other;
+        copy_tile(cb_other, 0, 0);
+        sub_binary_tile_init();
+        copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bcast);
+        last_srca_cb = cb_bcast;
+        copy_tile(cb_bcast, 0, 1);
+        sub_binary_tile(0, 1, 0);
+
+        mul_binary_tile_init();
+        copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_den);
+        last_srca_cb = cb_den;
+        copy_tile(cb_den, 0, 1);
+        mul_binary_tile(0, 1, 0);
         tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_affine_or_out);
         tile_regs_release();
+
+        cb_other_obj.pop_front(onetile);
         cb_affine_or_out_obj.push_back(onetile);
 
         if (weight_has_value) {  // result = result * weight
             cb_affine_or_out_obj.wait_front(onetile);
             cb_scaled_output_obj.reserve_back(onetile);
-            tile_regs_acquire();
-            tile_regs_wait();
-            copy_tile_to_dst_init_short_with_dt(cb_weight, cb_affine_or_out);
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_affine_or_out, i, i * 2);
-            }
-            mul_binary_tile_init();
-            copy_tile_to_dst_init_short_with_dt(cb_affine_or_out, cb_weight);
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_weight, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
 
-                pack_tile(i * 2, cb_scaled_output);
-            }
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_affine_or_out);
+            last_srca_cb = cb_affine_or_out;
+            copy_tile(cb_affine_or_out, 0, 0);
+            mul_binary_tile_init();
+            copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_weight);
+            last_srca_cb = cb_weight;
+            copy_tile(cb_weight, 0, 1);
+            mul_binary_tile(0, 1, 0);
             tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, cb_scaled_output);
             tile_regs_release();
+
             cb_scaled_output_obj.push_back(onetile);
             cb_affine_or_out_obj.pop_front(onetile);
         }
@@ -137,22 +132,22 @@ ALWI void batchnorm_bcast_tiles(
         if (bias_has_value) {  // result = result + bias
             cb_tmp_1_obj.wait_front(onetile);
             cb_output_0_obj.reserve_back(onetile);
-            tile_regs_acquire();
-            tile_regs_wait();
-            copy_tile_to_dst_init_short_with_dt(cb_bias, cb_tmp_1);
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_tmp_1, i, i * 2);
-            }
-            add_binary_tile_init();
-            copy_tile_to_dst_init_short_with_dt(cb_tmp_1, cb_bias);
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_bias, i, i * 2 + 1);
-                add_binary_tile(i * 2, i * 2 + 1, i * 2);
 
-                pack_tile(i * 2, cb_output_0);
-            }
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_tmp_1);
+            last_srca_cb = cb_tmp_1;
+            copy_tile(cb_tmp_1, 0, 0);
+            add_binary_tile_init();
+            copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bias);
+            last_srca_cb = cb_bias;
+            copy_tile(cb_bias, 0, 1);
+            add_binary_tile(0, 1, 0);
             tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, cb_output_0);
             tile_regs_release();
+
             cb_output_0_obj.push_back(onetile);
             cb_tmp_1_obj.pop_front(onetile);
         }
@@ -165,6 +160,7 @@ ALWI void batchnorm_bcast_tiles(
     if (bias_has_value) {
         cb_bias_obj.pop_front(onetile);
     }
+    return last_srca_cb;
 }
 
 void kernel_main() {
@@ -193,6 +189,7 @@ void kernel_main() {
     auto cb_other = cb_input;
 
     unary_op_init_common(cb_other, cb_output_0);
+    uint32_t last_srca_cb = cb_other;
 
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
@@ -202,7 +199,7 @@ void kernel_main() {
     cb_eps_obj.wait_front(onetile);
 
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
-        batchnorm_bcast_tiles(
+        last_srca_cb = batchnorm_bcast_tiles(
             cb_bcast,
             cb_other,
             tile_freq,
@@ -215,10 +212,11 @@ void kernel_main() {
             cb_tmp_1,
             cb_output_0,
             weight_has_value,
-            bias_has_value);
+            bias_has_value,
+            last_srca_cb);
     }
     if (remaining_iterations > 0) {
-        batchnorm_bcast_tiles(
+        last_srca_cb = batchnorm_bcast_tiles(
             cb_bcast,
             cb_other,
             remaining_iterations,
@@ -231,7 +229,8 @@ void kernel_main() {
             cb_tmp_1,
             cb_output_0,
             weight_has_value,
-            bias_has_value);
+            bias_has_value,
+            last_srca_cb);
     }
 
     cb_eps_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -56,18 +56,27 @@ ALWI uint32_t batchnorm_bcast_tiles(
     tile_regs_acquire();
     copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_batch_var);
     last_srca_cb = cb_batch_var;
-    copy_tile(cb_batch_var, 0, 0);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_batch_var, i, i * 2);
+    }
     add_binary_tile_init();
     copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_eps);
     last_srca_cb = cb_eps;
-    copy_tile(cb_eps, 0, 1);
-    add_binary_tile(0, 1, 0);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        copy_tile(cb_eps, i, i * 2 + 1);
+
+        add_binary_tile(i * 2, i * 2 + 1, i * 2);
+    }
     rsqrt_tile_init();
-    rsqrt_tile(0);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        rsqrt_tile(i * 2);
+    }
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile(0, cb_den);
+    for (uint32_t i = 0; i < onetile; ++i) {
+        pack_tile(i * 2, cb_den);
+    }
     tile_regs_release();
 
     cb_den_obj.push_back(onetile);
@@ -89,22 +98,30 @@ ALWI uint32_t batchnorm_bcast_tiles(
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_other);
         last_srca_cb = cb_other;
-        copy_tile(cb_other, 0, 0);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_other, i, i * 2);
+        }
         sub_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bcast);
         last_srca_cb = cb_bcast;
-        copy_tile(cb_bcast, 0, 1);
-        sub_binary_tile(0, 1, 0);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_bcast, i, i * 2 + 1);
+            sub_binary_tile(i * 2, i * 2 + 1, i * 2);
+        }
 
         mul_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_den);
         last_srca_cb = cb_den;
-        copy_tile(cb_den, 0, 1);
-        mul_binary_tile(0, 1, 0);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_den, i, i * 2 + 1);
+            mul_binary_tile(i * 2, i * 2 + 1, i * 2);
+        }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile(0, cb_affine_or_out);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i * 2, cb_affine_or_out);
+        }
         tile_regs_release();
 
         cb_other_obj.pop_front(onetile);
@@ -117,16 +134,22 @@ ALWI uint32_t batchnorm_bcast_tiles(
             tile_regs_acquire();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_affine_or_out);
             last_srca_cb = cb_affine_or_out;
-            copy_tile(cb_affine_or_out, 0, 0);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_affine_or_out, i, i * 2);
+            }
             mul_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_weight);
             last_srca_cb = cb_weight;
-            copy_tile(cb_weight, 0, 1);
-            mul_binary_tile(0, 1, 0);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_weight, i, i * 2 + 1);
+                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
+            }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(0, cb_scaled_output);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                pack_tile(i * 2, cb_scaled_output);
+            }
             tile_regs_release();
 
             cb_scaled_output_obj.push_back(onetile);
@@ -140,16 +163,22 @@ ALWI uint32_t batchnorm_bcast_tiles(
             tile_regs_acquire();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_tmp_1);
             last_srca_cb = cb_tmp_1;
-            copy_tile(cb_tmp_1, 0, 0);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_tmp_1, i, i * 2);
+            }
             add_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bias);
             last_srca_cb = cb_bias;
-            copy_tile(cb_bias, 0, 1);
-            add_binary_tile(0, 1, 0);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                copy_tile(cb_bias, i, i * 2 + 1);
+                add_binary_tile(i * 2, i * 2 + 1, i * 2);
+            }
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(0, cb_output_0);
+            for (uint32_t i = 0; i < onetile; ++i) {
+                pack_tile(i * 2, cb_output_0);
+            }
             tile_regs_release();
 
             cb_output_0_obj.push_back(onetile);
@@ -164,14 +193,20 @@ ALWI uint32_t batchnorm_bcast_tiles(
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_output_0);
         last_srca_cb = cb_output_0;
-        copy_tile(cb_output_0, 0, 0);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_output_0, i, i * 2);
+        }
         TYPECAST_OUTPUT_INIT();
-        TYPECAST_OUTPUT(0);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            TYPECAST_OUTPUT(i * 2);
+        }
         tile_regs_commit();
 
         tile_regs_wait();
         pack_reconfig_data_format(cb_output_final);
-        pack_tile(0, cb_output_final);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            pack_tile(i * 2, cb_output_final);
+        }
         tile_regs_release();
 
         pack_reconfig_data_format(cb_output_final, cb_output_0);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -13,6 +13,11 @@
 
 #include "experimental/circular_buffer.h"
 
+// batchnorm_bcast_tiles: For each output tile in [tile_start, freq), computes batch-norm on tiles from cb_other
+// (input) broadcast against cb_bcast (batch mean). First builds 1/sqrt(batch_var + eps) in cb_den, then per tile:
+// (input - mean) * den, optional multiply by weight, optional add bias. When NeedsOutputTypecast, SFPU typecasts
+// from FP32 staging (cb_output_0) to writer-facing cb_output_final. Tracks last_srca_cb in/out so
+// copy_tile_to_dst_init_short_with_dt can reconfigure the SrcA unpacker correctly across mixed dtypes.
 template <bool NeedsOutputTypecast, uint32_t TcInFmt, uint32_t TcOutFmt>
 ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t cb_bcast,
@@ -31,7 +36,7 @@ ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t bias_has,
     uint32_t last_srca_cb) {
     constexpr uint32_t onetile = 1;
-    constexpr int dst0 = 0;
+    constexpr uint32_t index = 0;
     uint32_t weight_has_value = weight_has;
     uint32_t bias_has_value = bias_has;
     auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
@@ -55,27 +60,18 @@ ALWI uint32_t batchnorm_bcast_tiles(
     tile_regs_acquire();
     copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_batch_var);
     last_srca_cb = cb_batch_var;
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_batch_var, i, i * 2);
-    }
+    copy_tile(cb_batch_var, index, index * 2);
     add_binary_tile_init();
     copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_eps);
     last_srca_cb = cb_eps;
-    for (uint32_t i = 0; i < onetile; ++i) {
-        copy_tile(cb_eps, i, i * 2 + 1);
-
-        add_binary_tile(i * 2, i * 2 + 1, i * 2);
-    }
+    copy_tile(cb_eps, index, index * 2 + 1);
+    add_binary_tile(index * 2, index * 2 + 1, index * 2);
     rsqrt_tile_init();
-    for (uint32_t i = 0; i < onetile; ++i) {
-        rsqrt_tile(i * 2);
-    }
+    rsqrt_tile(index * 2);
     tile_regs_commit();
 
     tile_regs_wait();
-    for (uint32_t i = 0; i < onetile; ++i) {
-        pack_tile(i * 2, cb_den);
-    }
+    pack_tile(index * 2, cb_den);
     tile_regs_release();
 
     cb_den_obj.push_back(onetile);
@@ -97,30 +93,22 @@ ALWI uint32_t batchnorm_bcast_tiles(
         tile_regs_acquire();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_other);
         last_srca_cb = cb_other;
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_other, i, i * 2);
-        }
+        copy_tile(cb_other, index, index * 2);
         sub_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bcast);
         last_srca_cb = cb_bcast;
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_bcast, i, i * 2 + 1);
-            sub_binary_tile(i * 2, i * 2 + 1, i * 2);
-        }
+        copy_tile(cb_bcast, index, index * 2 + 1);
+        sub_binary_tile(index * 2, index * 2 + 1, index * 2);
 
         mul_binary_tile_init();
         copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_den);
         last_srca_cb = cb_den;
-        for (uint32_t i = 0; i < onetile; ++i) {
-            copy_tile(cb_den, i, i * 2 + 1);
-            mul_binary_tile(i * 2, i * 2 + 1, i * 2);
-        }
+        copy_tile(cb_den, index, index * 2 + 1);
+        mul_binary_tile(index * 2, index * 2 + 1, index * 2);
         tile_regs_commit();
 
         tile_regs_wait();
-        for (uint32_t i = 0; i < onetile; ++i) {
-            pack_tile(i * 2, cb_affine_or_out);
-        }
+        pack_tile(index * 2, cb_affine_or_out);
         tile_regs_release();
 
         cb_other_obj.pop_front(onetile);
@@ -133,22 +121,16 @@ ALWI uint32_t batchnorm_bcast_tiles(
             tile_regs_acquire();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_affine_or_out);
             last_srca_cb = cb_affine_or_out;
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_affine_or_out, i, i * 2);
-            }
+            copy_tile(cb_affine_or_out, index, index * 2);
             mul_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_weight);
             last_srca_cb = cb_weight;
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_weight, i, i * 2 + 1);
-                mul_binary_tile(i * 2, i * 2 + 1, i * 2);
-            }
+            copy_tile(cb_weight, index, index * 2 + 1);
+            mul_binary_tile(index * 2, index * 2 + 1, index * 2);
             tile_regs_commit();
 
             tile_regs_wait();
-            for (uint32_t i = 0; i < onetile; ++i) {
-                pack_tile(i * 2, cb_scaled_output);
-            }
+            pack_tile(index * 2, cb_scaled_output);
             tile_regs_release();
 
             cb_scaled_output_obj.push_back(onetile);
@@ -162,22 +144,16 @@ ALWI uint32_t batchnorm_bcast_tiles(
             tile_regs_acquire();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_tmp_1);
             last_srca_cb = cb_tmp_1;
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_tmp_1, i, i * 2);
-            }
+            copy_tile(cb_tmp_1, index, index * 2);
             add_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_bias);
             last_srca_cb = cb_bias;
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_bias, i, i * 2 + 1);
-                add_binary_tile(i * 2, i * 2 + 1, i * 2);
-            }
+            copy_tile(cb_bias, index, index * 2 + 1);
+            add_binary_tile(index * 2, index * 2 + 1, index * 2);
             tile_regs_commit();
 
             tile_regs_wait();
-            for (uint32_t i = 0; i < onetile; ++i) {
-                pack_tile(i * 2, cb_output_0);
-            }
+            pack_tile(index * 2, cb_output_0);
             tile_regs_release();
 
             cb_output_0_obj.push_back(onetile);
@@ -192,20 +168,14 @@ ALWI uint32_t batchnorm_bcast_tiles(
             tile_regs_acquire();
             copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_output_0);
             last_srca_cb = cb_output_0;
-            for (uint32_t i = 0; i < onetile; ++i) {
-                copy_tile(cb_output_0, i, i * 2);
-            }
+            copy_tile(cb_output_0, index, index * 2);
             typecast_tile_init<TcInFmt, TcOutFmt>();
-            for (uint32_t i = 0; i < onetile; ++i) {
-                typecast_tile<TcInFmt, TcOutFmt>(i * 2);
-            }
+            typecast_tile<TcInFmt, TcOutFmt>(index * 2);
             tile_regs_commit();
 
             tile_regs_wait();
             pack_reconfig_data_format(cb_output_final);
-            for (uint32_t i = 0; i < onetile; ++i) {
-                pack_tile(i * 2, cb_output_final);
-            }
+            pack_tile(index * 2, cb_output_final);
             tile_regs_release();
 
             pack_reconfig_data_format(cb_output_final, cb_output_0);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -7,6 +7,9 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rsqrt.h"
+#ifdef TYPECAST_OUTPUT
+#include "api/compute/eltwise_unary/typecast.h"
+#endif
 
 #include <cstdint>
 
@@ -24,6 +27,7 @@ ALWI uint32_t batchnorm_bcast_tiles(
     uint32_t cb_bias,
     uint32_t cb_tmp_1,
     uint32_t cb_output_0,
+    [[maybe_unused]] uint32_t cb_output_final,
     uint32_t weight_has,
     uint32_t bias_has,
     uint32_t last_srca_cb) {
@@ -151,6 +155,30 @@ ALWI uint32_t batchnorm_bcast_tiles(
             cb_output_0_obj.push_back(onetile);
             cb_tmp_1_obj.pop_front(onetile);
         }
+
+#ifdef TYPECAST_OUTPUT
+        cb_output_0_obj.wait_front(onetile);
+        experimental::CircularBuffer cb_output_final_obj(cb_output_final);
+        cb_output_final_obj.reserve_back(onetile);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(last_srca_cb, cb_output_0);
+        last_srca_cb = cb_output_0;
+        copy_tile(cb_output_0, 0, 0);
+        TYPECAST_OUTPUT_INIT();
+        TYPECAST_OUTPUT(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_output_final);
+        pack_tile(0, cb_output_final);
+        tile_regs_release();
+
+        pack_reconfig_data_format(cb_output_final, cb_output_0);
+
+        cb_output_0_obj.pop_front(onetile);
+        cb_output_final_obj.push_back(onetile);
+#endif
     }
     cb_bcast_obj.pop_front(onetile);
     cb_den_obj.pop_front(onetile);
@@ -184,6 +212,7 @@ void kernel_main() {
     constexpr auto cb_weight = get_compile_time_arg_val(8);     // weight tensor
     constexpr auto cb_tmp_1 = get_compile_time_arg_val(9);      // (input - batch_mean)/(sqrt(batch_var + eps))
     constexpr auto cb_bias = get_compile_time_arg_val(10);      // bias tensor
+    constexpr auto cb_output_final = get_compile_time_arg_val(11);  // writer-facing output CB (BF16 when typecast)
 
     auto cb_bcast = cb_batch_mean;
     auto cb_other = cb_input;
@@ -211,6 +240,7 @@ void kernel_main() {
             cb_bias,
             cb_tmp_1,
             cb_output_0,
+            cb_output_final,
             weight_has_value,
             bias_has_value,
             last_srca_cb);
@@ -228,6 +258,7 @@ void kernel_main() {
             cb_bias,
             cb_tmp_1,
             cb_output_0,
+            cb_output_final,
             weight_has_value,
             bias_has_value,
             last_srca_cb);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -9,10 +9,36 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#if defined(TYPECAST_MEAN) || defined(TYPECAST_VAR)
 #include "api/compute/eltwise_unary/typecast.h"
-#endif
 #include "experimental/circular_buffer.h"
+
+template <bool NeedsTypecast, uint32_t TcInFmt, uint32_t TcOutFmt>
+ALWI void maybe_typecast_stat(
+    experimental::CircularBuffer& src_obj, uint32_t src_cb, uint32_t dst_cb, uint32_t prev_cb, uint32_t tile_index) {
+    if constexpr (NeedsTypecast) {
+        constexpr uint32_t onetile = 1;
+        src_obj.wait_front(onetile);
+        experimental::CircularBuffer dst_obj(dst_cb);
+        dst_obj.reserve_back(onetile);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short_with_dt(prev_cb, src_cb);
+        copy_tile(src_cb, tile_index, tile_index * 2);
+        typecast_tile_init<TcInFmt, TcOutFmt>();
+        typecast_tile<TcInFmt, TcOutFmt>(tile_index * 2);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_reconfig_data_format(dst_cb);
+        pack_tile(tile_index * 2, dst_cb);
+        tile_regs_release();
+
+        pack_reconfig_data_format(dst_cb, src_cb);
+
+        src_obj.pop_front(onetile);
+        dst_obj.push_back(onetile);
+    }
+}
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -32,7 +58,12 @@ void kernel_main() {
     constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
     constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
     constexpr auto cb_writer_updated_mean = get_compile_time_arg_val(14);  // writer-facing updated mean
-    [[maybe_unused]] constexpr auto cb_writer_updated_var = get_compile_time_arg_val(15);  // writer-facing updated var
+    constexpr auto cb_writer_updated_var = get_compile_time_arg_val(15);   // writer-facing updated var
+    constexpr bool stat_needs_typecast = get_compile_time_arg_val(16) == 1;
+    constexpr uint32_t tc_in_fmt = get_compile_time_arg_val(17);
+    constexpr uint32_t tc_out_fmt = get_compile_time_arg_val(18);
+    constexpr bool needs_mean_typecast = old_running_mean_has_value && stat_needs_typecast;
+    constexpr bool needs_var_typecast = old_running_var_has_value && stat_needs_typecast;
 
     experimental::CircularBuffer cb_batch_mean_obj(cb_batch_mean);
     experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
@@ -135,30 +166,8 @@ void kernel_main() {
             tile_regs_release();
             cb_updated_running_mean_obj.push_back(onetile);
 
-#ifdef TYPECAST_MEAN
-            {
-                cb_updated_running_mean_obj.wait_front(onetile);
-                experimental::CircularBuffer cb_writer_mean_obj(cb_writer_updated_mean);
-                cb_writer_mean_obj.reserve_back(onetile);
-
-                tile_regs_acquire();
-                copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_updated_running_mean);
-                copy_tile(cb_updated_running_mean, tile_index, tile_index * 2);
-                TYPECAST_MEAN_INIT();
-                TYPECAST_MEAN(tile_index * 2);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_reconfig_data_format(cb_writer_updated_mean);
-                pack_tile(tile_index * 2, cb_writer_updated_mean);
-                tile_regs_release();
-
-                pack_reconfig_data_format(cb_writer_updated_mean, cb_updated_running_mean);
-
-                cb_updated_running_mean_obj.pop_front(onetile);
-                cb_writer_mean_obj.push_back(onetile);
-            }
-#endif
+            maybe_typecast_stat<needs_mean_typecast, tc_in_fmt, tc_out_fmt>(
+                cb_updated_running_mean_obj, cb_updated_running_mean, cb_writer_updated_mean, cb_tmp2, tile_index);
 
             cb_tmp3_obj.pop_front(onetile);
             cb_tmp2_obj.pop_front(onetile);
@@ -241,30 +250,8 @@ void kernel_main() {
             tile_regs_release();
             cb_updated_running_var_obj.push_back(onetile);
 
-#ifdef TYPECAST_VAR
-            {
-                cb_updated_running_var_obj.wait_front(onetile);
-                experimental::CircularBuffer cb_writer_var_obj(cb_writer_updated_var);
-                cb_writer_var_obj.reserve_back(onetile);
-
-                tile_regs_acquire();
-                copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_updated_running_var);
-                copy_tile(cb_updated_running_var, tile_index, tile_index * 2);
-                TYPECAST_VAR_INIT();
-                TYPECAST_VAR(tile_index * 2);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_reconfig_data_format(cb_writer_updated_var);
-                pack_tile(tile_index * 2, cb_writer_updated_var);
-                tile_regs_release();
-
-                pack_reconfig_data_format(cb_writer_updated_var, cb_updated_running_var);
-
-                cb_updated_running_var_obj.pop_front(onetile);
-                cb_writer_var_obj.push_back(onetile);
-            }
-#endif
+            maybe_typecast_stat<needs_var_typecast, tc_in_fmt, tc_out_fmt>(
+                cb_updated_running_var_obj, cb_updated_running_var, cb_writer_updated_var, cb_tmp2, tile_index);
 
             cb_tmp3_obj.pop_front(onetile);
             cb_tmp2_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -9,6 +9,9 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#if defined(TYPECAST_MEAN) || defined(TYPECAST_VAR)
+#include "api/compute/eltwise_unary/typecast.h"
+#endif
 #include "experimental/circular_buffer.h"
 
 void kernel_main() {
@@ -28,6 +31,8 @@ void kernel_main() {
     constexpr auto cb_tmp1 = get_compile_time_arg_val(11);                 // tmp 1
     constexpr auto cb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
     constexpr auto cb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
+    constexpr auto cb_writer_updated_mean = get_compile_time_arg_val(14);  // writer-facing updated mean
+    [[maybe_unused]] constexpr auto cb_writer_updated_var = get_compile_time_arg_val(15);  // writer-facing updated var
 
     experimental::CircularBuffer cb_batch_mean_obj(cb_batch_mean);
     experimental::CircularBuffer cb_batch_var_obj(cb_batch_var);
@@ -130,6 +135,31 @@ void kernel_main() {
             tile_regs_release();
             cb_updated_running_mean_obj.push_back(onetile);
 
+#ifdef TYPECAST_MEAN
+            {
+                cb_updated_running_mean_obj.wait_front(onetile);
+                experimental::CircularBuffer cb_writer_mean_obj(cb_writer_updated_mean);
+                cb_writer_mean_obj.reserve_back(onetile);
+
+                tile_regs_acquire();
+                copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_updated_running_mean);
+                copy_tile(cb_updated_running_mean, tile_index, tile_index * 2);
+                TYPECAST_MEAN_INIT();
+                TYPECAST_MEAN(tile_index * 2);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_reconfig_data_format(cb_writer_updated_mean);
+                pack_tile(tile_index * 2, cb_writer_updated_mean);
+                tile_regs_release();
+
+                pack_reconfig_data_format(cb_writer_updated_mean, cb_updated_running_mean);
+
+                cb_updated_running_mean_obj.pop_front(onetile);
+                cb_writer_mean_obj.push_back(onetile);
+            }
+#endif
+
             cb_tmp3_obj.pop_front(onetile);
             cb_tmp2_obj.pop_front(onetile);
         }
@@ -210,6 +240,31 @@ void kernel_main() {
             pack_tile_with_dt(tile_index * 2, cb_out0);
             tile_regs_release();
             cb_updated_running_var_obj.push_back(onetile);
+
+#ifdef TYPECAST_VAR
+            {
+                cb_updated_running_var_obj.wait_front(onetile);
+                experimental::CircularBuffer cb_writer_var_obj(cb_writer_updated_var);
+                cb_writer_var_obj.reserve_back(onetile);
+
+                tile_regs_acquire();
+                copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_updated_running_var);
+                copy_tile(cb_updated_running_var, tile_index, tile_index * 2);
+                TYPECAST_VAR_INIT();
+                TYPECAST_VAR(tile_index * 2);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_reconfig_data_format(cb_writer_updated_var);
+                pack_tile(tile_index * 2, cb_writer_updated_var);
+                tile_regs_release();
+
+                pack_reconfig_data_format(cb_writer_updated_var, cb_updated_running_var);
+
+                cb_updated_running_var_obj.pop_front(onetile);
+                cb_writer_var_obj.push_back(onetile);
+            }
+#endif
 
             cb_tmp3_obj.pop_front(onetile);
             cb_tmp2_obj.pop_front(onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -50,7 +50,6 @@ void kernel_main() {
 
     // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        // cb tile index
         constexpr uint32_t tile_index = 0;
 
         cb_batch_mean_obj.wait_front(onetile);
@@ -59,35 +58,34 @@ void kernel_main() {
         if constexpr (old_running_mean_has_value) {
             // 1 - momentum
             cb_tmp1_obj.reserve_back(onetile);
-            sub_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
-            copy_tile_to_dst_init_short_with_dt(cb_momentum, cb_one);
+            sub_binary_tile_init();
+            // Use cb_batch_mean as old_cbid since unary_op_init_common configured the unpacker for it
+            copy_tile_to_dst_init_short_with_dt(cb_batch_mean, cb_one);
             copy_tile(cb_one, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_one, cb_momentum);
             copy_tile(cb_momentum, tile_index, tile_index * 2 + 1);
-
             sub_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp1);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp1);
             tile_regs_release();
             cb_tmp1_obj.push_back(onetile);
 
             // momentum * batch stat
             cb_tmp2_obj.reserve_back(onetile);
-            mul_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
+            mul_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_momentum, cb_batch_mean);
             copy_tile(cb_batch_mean, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_batch_mean, cb_momentum);
             copy_tile(cb_momentum, tile_index, tile_index * 2 + 1);
-
             mul_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp2);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp2);
             tile_regs_release();
             cb_tmp2_obj.push_back(onetile);
 
@@ -96,16 +94,15 @@ void kernel_main() {
             cb_old_running_mean_obj.wait_front(onetile);
             cb_tmp3_obj.reserve_back(onetile);
             tile_regs_acquire();
-            tile_regs_wait();
-
             copy_tile_to_dst_init_short_with_dt(cb_tmp1, cb_old_running_mean);
             copy_tile(cb_old_running_mean, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_old_running_mean, cb_tmp1);
             copy_tile(cb_tmp1, tile_index, tile_index * 2 + 1);
-
             mul_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp3);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp3);
             tile_regs_release();
             cb_tmp3_obj.push_back(onetile);
 
@@ -116,21 +113,19 @@ void kernel_main() {
             cb_tmp2_obj.wait_front(onetile);
             cb_tmp3_obj.wait_front(onetile);
             cb_updated_running_mean_obj.reserve_back(onetile);
-            add_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
+            add_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_tmp3);
             copy_tile(cb_tmp3, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_tmp3, cb_tmp2);
             copy_tile(cb_tmp2, tile_index, tile_index * 2 + 1);
-
             add_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_updated_running_mean);
-            // For the output tensor, return the same values as either of the stats.
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_updated_running_mean);
             if constexpr (!old_running_var_has_value) {
-                pack_tile(tile_index * 2, cb_out0);
+                pack_tile_with_dt(tile_index * 2, cb_out0);
             }
             tile_regs_release();
             cb_updated_running_mean_obj.push_back(onetile);
@@ -144,36 +139,34 @@ void kernel_main() {
         if constexpr (old_running_var_has_value) {
             // 1 - momentum
             cb_tmp1_obj.reserve_back(onetile);
-            sub_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
+            sub_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_momentum, cb_one);
             copy_tile(cb_one, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_one, cb_momentum);
             copy_tile(cb_momentum, tile_index, tile_index * 2 + 1);
-
             sub_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp1);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp1);
             tile_regs_release();
             cb_tmp1_obj.push_back(onetile);
 
             // momentum * batch stat
             cb_batch_var_obj.wait_front(onetile);
             cb_tmp2_obj.reserve_back(onetile);
-            mul_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
+            mul_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_momentum, cb_batch_var);
             copy_tile(cb_batch_var, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_batch_var, cb_momentum);
             copy_tile(cb_momentum, tile_index, tile_index * 2 + 1);
-
             mul_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp2);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp2);
             tile_regs_release();
             cb_tmp2_obj.push_back(onetile);
 
@@ -184,16 +177,15 @@ void kernel_main() {
             cb_old_running_var_obj.wait_front(onetile);
             cb_tmp3_obj.reserve_back(onetile);
             tile_regs_acquire();
-            tile_regs_wait();
-
             copy_tile_to_dst_init_short_with_dt(cb_tmp1, cb_old_running_var);
             copy_tile(cb_old_running_var, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_old_running_var, cb_tmp1);
             copy_tile(cb_tmp1, tile_index, tile_index * 2 + 1);
-
             mul_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_tmp3);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_tmp3);
             tile_regs_release();
             cb_tmp3_obj.push_back(onetile);
 
@@ -204,19 +196,18 @@ void kernel_main() {
             cb_tmp2_obj.wait_front(onetile);
             cb_tmp3_obj.wait_front(onetile);
             cb_updated_running_var_obj.reserve_back(onetile);
-            add_binary_tile_init();
             tile_regs_acquire();
-            tile_regs_wait();
-
+            add_binary_tile_init();
             copy_tile_to_dst_init_short_with_dt(cb_tmp2, cb_tmp3);
             copy_tile(cb_tmp3, tile_index, tile_index * 2);
             copy_tile_to_dst_init_short_with_dt(cb_tmp3, cb_tmp2);
             copy_tile(cb_tmp2, tile_index, tile_index * 2 + 1);
-
             add_binary_tile(tile_index * 2, tile_index * 2 + 1, tile_index * 2);
             tile_regs_commit();
-            pack_tile(tile_index * 2, cb_updated_running_var);
-            pack_tile(tile_index * 2, cb_out0);
+
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, cb_updated_running_var);
+            pack_tile_with_dt(tile_index * 2, cb_out0);
             tile_regs_release();
             cb_updated_running_var_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -86,6 +86,7 @@ void kernel_main() {
 
     // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        // cb tile index
         constexpr uint32_t tile_index = 0;
 
         cb_batch_mean_obj.wait_front(onetile);
@@ -160,6 +161,7 @@ void kernel_main() {
 
             tile_regs_wait();
             pack_tile_with_dt(tile_index * 2, cb_updated_running_mean);
+            // For the output tensor, return the same values as either of the stats.
             if constexpr (!old_running_var_has_value) {
                 pack_tile_with_dt(tile_index * 2, cb_out0);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -42,10 +42,10 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    float eps_f = 0;
-    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
     cb_id_eps_obj.reserve_back(onetile);
 #ifdef FILL_EPS_FP32
+    float eps_f = 0;
+    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
     fill_with_val<1024, float>(cb_id_eps, eps_f);
 #else
     fill_with_val_bfloat16(cb_id_eps, eps);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -26,6 +26,7 @@ void kernel_main() {
     constexpr auto cb_id_src = get_compile_time_arg_val(0);
     constexpr auto cb_id_eps = get_compile_time_arg_val(1);
     constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr bool fill_eps_fp32 = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
 
     constexpr uint32_t onetile = 1;
 
@@ -43,13 +44,13 @@ void kernel_main() {
     uint32_t start_t = start_remaining % HtWt;
 
     cb_id_eps_obj.reserve_back(onetile);
-#ifdef FILL_EPS_FP32
-    float eps_f = 0;
-    std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
-    fill_with_val<1024, float>(cb_id_eps, eps_f);
-#else
-    fill_with_val_bfloat16(cb_id_eps, eps);
-#endif
+    if constexpr (fill_eps_fp32) {
+        float eps_f = 0;
+        std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
+        fill_with_val<1024, float>(cb_id_eps, eps_f);
+    } else {
+        fill_with_val_bfloat16(cb_id_eps, eps);
+    }
     cb_id_eps_obj.push_back(onetile);
 
     // Input tile offset

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -42,14 +42,13 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    cb_id_eps_obj.reserve_back(onetile);
-#ifdef FILL_WITH_VALUE_FLOAT
     float eps_f = 0;
     std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
-    FILL_WITH_VALUE_FLOAT(cb_id_eps, eps_f);
-#endif
-#ifdef FILL_WITH_VALUE
-    FILL_WITH_VALUE(cb_id_eps, eps);
+    cb_id_eps_obj.reserve_back(onetile);
+#ifdef FILL_EPS_FP32
+    fill_with_val<1024, float>(cb_id_eps, eps_f);
+#else
+    fill_with_val_bfloat16(cb_id_eps, eps);
 #endif
     cb_id_eps_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -29,6 +29,7 @@ void kernel_main() {
     constexpr bool fill_eps_fp32 = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
 
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t k_tile_face_elems = 1024;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
@@ -47,7 +48,7 @@ void kernel_main() {
     if constexpr (fill_eps_fp32) {
         float eps_f = 0;
         std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<1024, float>(cb_id_eps, eps_f);
+        fill_with_val<k_tile_face_elems, float>(cb_id_eps, eps_f);
     } else {
         fill_with_val_bfloat16(cb_id_eps, eps);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -54,10 +54,10 @@ void kernel_main() {
     fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
-    float momentum_f = 0;
-    std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
     cb_id_momentum_obj.reserve_back(onetile);
 #ifdef FILL_MOMENTUM_FP32
+    float momentum_f = 0;
+    std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
     fill_with_val<1024, float>(cb_id_momentum, momentum_f);
 #else
     fill_with_val_bfloat16(cb_id_momentum, momentum);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -54,14 +54,13 @@ void kernel_main() {
     fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
-    cb_id_momentum_obj.reserve_back(onetile);
-#ifdef FILL_WITH_VALUE_FLOAT
     float momentum_f = 0;
     std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
-    FILL_WITH_VALUE_FLOAT(cb_id_momentum, momentum_f);
-#endif
-#ifdef FILL_WITH_VALUE
-    FILL_WITH_VALUE(cb_id_momentum, momentum);
+    cb_id_momentum_obj.reserve_back(onetile);
+#ifdef FILL_MOMENTUM_FP32
+    fill_with_val<1024, float>(cb_id_momentum, momentum_f);
+#else
+    fill_with_val_bfloat16(cb_id_momentum, momentum);
 #endif
     cb_id_momentum_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -27,6 +27,7 @@ void kernel_main() {
     constexpr auto cb_id_momentum = get_compile_time_arg_val(1);
     constexpr auto cb_id_one = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr bool fill_momentum_fp32 = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
     constexpr uint32_t onetile = 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
@@ -55,13 +56,13 @@ void kernel_main() {
 
     // momentum
     cb_id_momentum_obj.reserve_back(onetile);
-#ifdef FILL_MOMENTUM_FP32
-    float momentum_f = 0;
-    std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
-    fill_with_val<1024, float>(cb_id_momentum, momentum_f);
-#else
-    fill_with_val_bfloat16(cb_id_momentum, momentum);
-#endif
+    if constexpr (fill_momentum_fp32) {
+        float momentum_f = 0;
+        std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
+        fill_with_val<1024, float>(cb_id_momentum, momentum_f);
+    } else {
+        fill_with_val_bfloat16(cb_id_momentum, momentum);
+    }
     cb_id_momentum_obj.push_back(onetile);
 
     uint32_t num_tiles_read = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -29,6 +29,7 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<3>();
     constexpr bool fill_momentum_fp32 = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t k_tile_face_elems = 1024;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
@@ -59,7 +60,7 @@ void kernel_main() {
     if constexpr (fill_momentum_fp32) {
         float momentum_f = 0;
         std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<1024, float>(cb_id_momentum, momentum_f);
+        fill_with_val<k_tile_face_elems, float>(cb_id_momentum, momentum_f);
     } else {
         fill_with_val_bfloat16(cb_id_momentum, momentum);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -45,6 +45,7 @@ void kernel_main() {
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
+    // output
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -39,6 +39,8 @@ void kernel_main() {
     constexpr auto batch_var_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
     constexpr auto weight_args = TensorAccessorArgs<batch_var_args.next_compile_time_args_offset()>();
     constexpr auto bias_args = TensorAccessorArgs<weight_args.next_compile_time_args_offset()>();
+    constexpr bool batch_stat_is_fp32 = get_compile_time_arg_val(bias_args.next_compile_time_args_offset()) == 1;
+    constexpr bool param_is_fp32 = get_compile_time_arg_val(bias_args.next_compile_time_args_offset() + 1) == 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
@@ -82,11 +84,11 @@ void kernel_main() {
             cb_id_src_obj.reserve_back(onetile);
             noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
-#ifdef MEAN_IS_FP32
-            fill_tile_with_first_element<float>(cb_id_src);
-#else
-            fill_tile_with_first_element_bfloat16(cb_id_src);
-#endif
+            if constexpr (batch_stat_is_fp32) {
+                fill_tile_with_first_element<float>(cb_id_src);
+            } else {
+                fill_tile_with_first_element_bfloat16(cb_id_src);
+            }
             cb_id_src_obj.push_back(onetile);
 
             // read a tile from batch variance
@@ -94,11 +96,11 @@ void kernel_main() {
             noc.async_read(
                 batch_var, cb_id_batch_var_obj, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
-#ifdef VAR_IS_FP32
-            fill_tile_with_first_element<float>(cb_id_batch_var);
-#else
-            fill_tile_with_first_element_bfloat16(cb_id_batch_var);
-#endif
+            if constexpr (batch_stat_is_fp32) {
+                fill_tile_with_first_element<float>(cb_id_batch_var);
+            } else {
+                fill_tile_with_first_element_bfloat16(cb_id_batch_var);
+            }
             cb_id_batch_var_obj.push_back(onetile);
 
             if constexpr (weight_has_value) {  // read a tile from weight tensor
@@ -106,11 +108,11 @@ void kernel_main() {
                 noc.async_read(
                     weight, cb_id_weight_obj, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-#ifdef WEIGHT_IS_FP32
-                fill_tile_with_first_element<float>(cb_id_weight);
-#else
-                fill_tile_with_first_element_bfloat16(cb_id_weight);
-#endif
+                if constexpr (param_is_fp32) {
+                    fill_tile_with_first_element<float>(cb_id_weight);
+                } else {
+                    fill_tile_with_first_element_bfloat16(cb_id_weight);
+                }
                 cb_id_weight_obj.push_back(onetile);
             }
 
@@ -118,11 +120,11 @@ void kernel_main() {
                 cb_id_bias_obj.reserve_back(onetile);
                 noc.async_read(bias, cb_id_bias_obj, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-#ifdef BIAS_IS_FP32
-                fill_tile_with_first_element<float>(cb_id_bias);
-#else
-                fill_tile_with_first_element_bfloat16(cb_id_bias);
-#endif
+                if constexpr (param_is_fp32) {
+                    fill_tile_with_first_element<float>(cb_id_bias);
+                } else {
+                    fill_tile_with_first_element_bfloat16(cb_id_bias);
+                }
                 cb_id_bias_obj.push_back(onetile);
             }
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -83,7 +83,11 @@ void kernel_main() {
             cb_id_src_obj.reserve_back(onetile);
             noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
+#ifdef MEAN_IS_FP32
+            fill_tile_with_first_element<float>(cb_id_src);
+#else
+            fill_tile_with_first_element_bfloat16(cb_id_src);
+#endif
             cb_id_src_obj.push_back(onetile);
 
             // read a tile from batch variance
@@ -91,7 +95,11 @@ void kernel_main() {
             noc.async_read(
                 batch_var, cb_id_batch_var_obj, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
-            FILL_TILE_WITH_FIRST_ELEMENT(cb_id_batch_var);
+#ifdef VAR_IS_FP32
+            fill_tile_with_first_element<float>(cb_id_batch_var);
+#else
+            fill_tile_with_first_element_bfloat16(cb_id_batch_var);
+#endif
             cb_id_batch_var_obj.push_back(onetile);
 
             if constexpr (weight_has_value) {  // read a tile from weight tensor
@@ -99,7 +107,11 @@ void kernel_main() {
                 noc.async_read(
                     weight, cb_id_weight_obj, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_weight);
+#ifdef WEIGHT_IS_FP32
+                fill_tile_with_first_element<float>(cb_id_weight);
+#else
+                fill_tile_with_first_element_bfloat16(cb_id_weight);
+#endif
                 cb_id_weight_obj.push_back(onetile);
             }
 
@@ -107,7 +119,11 @@ void kernel_main() {
                 cb_id_bias_obj.reserve_back(onetile);
                 noc.async_read(bias, cb_id_bias_obj, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                FILL_TILE_WITH_FIRST_ELEMENT(cb_id_bias);
+#ifdef BIAS_IS_FP32
+                fill_tile_with_first_element<float>(cb_id_bias);
+#else
+                fill_tile_with_first_element_bfloat16(cb_id_bias);
+#endif
                 cb_id_bias_obj.push_back(onetile);
             }
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -43,8 +43,13 @@ void kernel_main() {
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
-    // output
+    // output — when the compute CB is float32 but the tensor stores bfloat16, the tile size
+    // for address calculation and DRAM writes must match the tensor's native format (bfloat16).
+#ifdef CONVERT_OUTPUT_TO_BF16
+    constexpr uint32_t dst_tile_bytes = 2048;  // bfloat16: 1024 elements * 2 bytes
+#else
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+#endif
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     // batch_var
@@ -130,6 +135,15 @@ void kernel_main() {
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst
                 cb_id_dst_obj.wait_front(onetile);
+#ifdef CONVERT_OUTPUT_TO_BF16
+                {
+                    auto* fp32_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_dst));
+                    auto* bf16_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_dst));
+                    for (uint32_t i = 0; i < 1024; ++i) {
+                        bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
+                    }
+                }
+#endif
                 noc.async_write(
                     cb_id_dst_obj,
                     dst,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -43,13 +43,7 @@ void kernel_main() {
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
 
-    // output — when the compute CB is float32 but the tensor stores bfloat16, the tile size
-    // for address calculation and DRAM writes must match the tensor's native format (bfloat16).
-#ifdef CONVERT_OUTPUT_TO_BF16
-    constexpr uint32_t dst_tile_bytes = 2048;  // bfloat16: 1024 elements * 2 bytes
-#else
     const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-#endif
     const auto dst = TensorAccessor(dst_args, dst_addr, dst_tile_bytes);
 
     // batch_var
@@ -135,15 +129,6 @@ void kernel_main() {
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst
                 cb_id_dst_obj.wait_front(onetile);
-#ifdef CONVERT_OUTPUT_TO_BF16
-                {
-                    auto* fp32_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_dst));
-                    auto* bf16_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_dst));
-                    for (uint32_t i = 0; i < 1024; ++i) {
-                        bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
-                    }
-                }
-#endif
                 noc.async_write(
                     cb_id_dst_obj,
                     dst,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -99,17 +99,6 @@ void kernel_main() {
 
                     // write data
                     cb_id_updated_running_mean_obj.wait_front(onetile);
-#ifdef CONVERT_UPDATED_MEAN_TO_BF16
-                    {
-                        auto* fp32_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_updated_running_mean));
-                        auto* bf16_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_updated_running_mean));
-                        for (uint32_t i = 0; i < 1024; ++i) {
-                            bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
-                        }
-                    }
-#endif
                     noc.async_write(
                         cb_id_updated_running_mean_obj,
                         old_running_mean,
@@ -139,17 +128,6 @@ void kernel_main() {
 
                     // write data
                     cb_id_updated_running_var_obj.wait_front(onetile);
-#ifdef CONVERT_UPDATED_VAR_TO_BF16
-                    {
-                        auto* fp32_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_updated_running_var));
-                        auto* bf16_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_updated_running_var));
-                        for (uint32_t i = 0; i < 1024; ++i) {
-                            bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
-                        }
-                    }
-#endif
                     noc.async_write(
                         cb_id_updated_running_var_obj,
                         old_running_var,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -99,6 +99,17 @@ void kernel_main() {
 
                     // write data
                     cb_id_updated_running_mean_obj.wait_front(onetile);
+#ifdef CONVERT_UPDATED_MEAN_TO_BF16
+                    {
+                        auto* fp32_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_updated_running_mean));
+                        auto* bf16_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_updated_running_mean));
+                        for (uint32_t i = 0; i < 1024; ++i) {
+                            bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
+                        }
+                    }
+#endif
                     noc.async_write(
                         cb_id_updated_running_mean_obj,
                         old_running_mean,
@@ -128,6 +139,17 @@ void kernel_main() {
 
                     // write data
                     cb_id_updated_running_var_obj.wait_front(onetile);
+#ifdef CONVERT_UPDATED_VAR_TO_BF16
+                    {
+                        auto* fp32_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id_updated_running_var));
+                        auto* bf16_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_id_updated_running_var));
+                        for (uint32_t i = 0; i < 1024; ++i) {
+                            bf16_ptr[i] = static_cast<uint16_t>(fp32_ptr[i] >> 16);
+                        }
+                    }
+#endif
                     noc.async_write(
                         cb_id_updated_running_var_obj,
                         old_running_var,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -90,7 +90,11 @@ void kernel_main() {
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
-                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_old_running_mean);
+#ifdef OLD_MEAN_IS_FP32
+                    fill_tile_with_first_element<float>(cb_id_old_running_mean);
+#else
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
+#endif
                     cb_id_old_running_mean_obj.push_back(onetile);
 
                     // write data
@@ -115,7 +119,11 @@ void kernel_main() {
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
-                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_old_running_var);
+#ifdef OLD_VAR_IS_FP32
+                    fill_tile_with_first_element<float>(cb_id_old_running_var);
+#else
+                    fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
+#endif
                     cb_id_old_running_var_obj.push_back(onetile);
 
                     // write data

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -37,6 +37,8 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
     constexpr auto old_running_mean_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
     constexpr auto old_running_var_args = TensorAccessorArgs<old_running_mean_args.next_compile_time_args_offset()>();
+    constexpr bool old_stat_is_fp32 =
+        get_compile_time_arg_val(old_running_var_args.next_compile_time_args_offset()) == 1;
 
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const auto src = TensorAccessor(src_args, src_addr, src_tile_bytes);
@@ -90,11 +92,11 @@ void kernel_main() {
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
-#ifdef OLD_MEAN_IS_FP32
-                    fill_tile_with_first_element<float>(cb_id_old_running_mean);
-#else
-                    fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
-#endif
+                    if constexpr (old_stat_is_fp32) {
+                        fill_tile_with_first_element<float>(cb_id_old_running_mean);
+                    } else {
+                        fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
+                    }
                     cb_id_old_running_mean_obj.push_back(onetile);
 
                     // write data
@@ -119,11 +121,11 @@ void kernel_main() {
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
-#ifdef OLD_VAR_IS_FP32
-                    fill_tile_with_first_element<float>(cb_id_old_running_var);
-#else
-                    fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
-#endif
+                    if constexpr (old_stat_is_fp32) {
+                        fill_tile_with_first_element<float>(cb_id_old_running_var);
+                    } else {
+                        fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
+                    }
                     cb_id_old_running_var_obj.push_back(onetile);
 
                     // write data

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -36,6 +36,7 @@ struct RunningStatistics {
             tt::tt_metal::KernelHandle writer_kernel_id{};
             tt::tt_metal::KernelHandle compute_kernel_id{};
             CoreCoord compute_with_storage_grid_size;
+            bool any_float32{};
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -27,6 +27,7 @@ void set_or_update_runtime_arguments(
     tt::tt_metal::KernelHandle writer_kernel_id,
     tt::tt_metal::KernelHandle compute_kernel_id,
     CoreCoord compute_with_storage_grid_size,
+    bool any_float32,
     const RunningStatistics::operation_attributes_t& operation_attributes,
     const RunningStatistics::tensor_args_t& tensor_args,
     RunningStatistics::tensor_return_value_t& c,
@@ -54,15 +55,6 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-
-    const bool any_float32 =
-        (tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
-         tt::tt_metal::datatype_to_dataformat_converter(batch_var_tensor.dtype()) == tt::DataFormat::Float32 ||
-         tt::tt_metal::datatype_to_dataformat_converter(c.dtype()) == tt::DataFormat::Float32 ||
-         (running_mean_has_value &&
-          tt::tt_metal::datatype_to_dataformat_converter(running_mean_tensor->dtype()) == tt::DataFormat::Float32) ||
-         (running_var_has_value &&
-          tt::tt_metal::datatype_to_dataformat_converter(running_var_tensor->dtype()) == tt::DataFormat::Float32));
 
     const uint32_t cHtWt = cHt * cWt;
     const auto scalar = momentum;
@@ -382,13 +374,15 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         writer_kernel_id,
         compute_kernel_id,
         compute_with_storage_grid_size,
+        any_float32,
         operation_attributes,
         tensor_args,
         output,
         set_runtime_args);
 
     return {
-        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+        std::move(program),
+        {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size, any_float32}};
 }
 
 void RunningStatistics::RunningStatisticsProgramFactory::override_runtime_arguments(
@@ -409,6 +403,7 @@ void RunningStatistics::RunningStatisticsProgramFactory::override_runtime_argume
         cached_program.shared_variables.writer_kernel_id,
         cached_program.shared_variables.compute_kernel_id,
         cached_program.shared_variables.compute_with_storage_grid_size,
+        cached_program.shared_variables.any_float32,
         operation_attributes,
         tensor_args,
         output,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -174,10 +174,12 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
     uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
 
-    const bool needs_mean_typecast =
-        running_mean_has_value && (interm_data_format == DataFormat::Float32 && d_data_format != DataFormat::Float32);
-    const bool needs_var_typecast =
-        running_var_has_value && (interm_data_format == DataFormat::Float32 && e_data_format != DataFormat::Float32);
+    auto running_stat_data_format =
+        running_mean_has_value ? d_data_format : (running_var_has_value ? e_data_format : DataFormat::Float16_b);
+    const bool stat_format_needs_typecast =
+        (interm_data_format == DataFormat::Float32 && running_stat_data_format != DataFormat::Float32);
+    const bool needs_mean_typecast = running_mean_has_value && stat_format_needs_typecast;
+    const bool needs_var_typecast = running_var_has_value && stat_format_needs_typecast;
 
     // we parallelize the computation across the output tiles
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -278,6 +280,7 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         one_cb,
     };
     tt::tt_metal::TensorAccessorArgs(batch_mean_tensor.buffer()).append_to(reader_compile_time_args);
+    reader_compile_time_args.push_back(static_cast<uint32_t>(any_float32));
 
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(running_mean_has_value),
@@ -295,31 +298,21 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         .append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(running_var_tensor ? running_var_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
+    writer_compile_time_args.push_back(static_cast<uint32_t>(running_stat_data_format == DataFormat::Float32));
 
     // READER KERNEL
-    std::map<std::string, std::string> reader_defines;
-    if (any_float32) {
-        reader_defines["FILL_MOMENTUM_FP32"] = "1";
-    }
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp",
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
     // WRITER KERNEL
-    std::map<std::string, std::string> writer_defines;
-    if (d_data_format == DataFormat::Float32) {
-        writer_defines["OLD_MEAN_IS_FP32"] = "1";
-    }
-    if (e_data_format == DataFormat::Float32) {
-        writer_defines["OLD_VAR_IS_FP32"] = "1";
-    }
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp",
         all_device_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     // COMPUTE KERNEL
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
@@ -341,6 +334,9 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         }
     }
 
+    auto tc_out_fmt = stat_format_needs_typecast ? static_cast<uint32_t>(running_stat_data_format)
+                                                 : static_cast<uint32_t>(DataFormat::Float32);
+
     std::vector<uint32_t> compute_kernel_args = {
         static_cast<uint32_t>(running_mean_has_value),
         static_cast<uint32_t>(running_var_has_value),
@@ -357,21 +353,10 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         tmp2_cb,
         tmp3_cb,
         writer_updated_m_cb,
-        writer_updated_v_cb};
-
-    std::map<std::string, std::string> compute_defines;
-    if (needs_mean_typecast) {
-        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
-        auto out_fmt = static_cast<uint32_t>(d_data_format);
-        compute_defines["TYPECAST_MEAN_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
-        compute_defines["TYPECAST_MEAN"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
-    }
-    if (needs_var_typecast) {
-        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
-        auto out_fmt = static_cast<uint32_t>(e_data_format);
-        compute_defines["TYPECAST_VAR_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
-        compute_defines["TYPECAST_VAR"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
-    }
+        writer_updated_v_cb,
+        static_cast<uint32_t>(stat_format_needs_typecast),
+        static_cast<uint32_t>(DataFormat::Float32),
+        tc_out_fmt};
 
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
@@ -385,8 +370,7 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args,
-            .defines = std::move(compute_defines)});
+            .compile_args = compute_kernel_args});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -54,6 +54,24 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(batch_mean_tensor.device()->arch(), operation_attributes.compute_kernel_config);
+    const bool any_float32 =
+        (tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
+         tt::tt_metal::datatype_to_dataformat_converter(batch_var_tensor.dtype()) == tt::DataFormat::Float32 ||
+         tt::tt_metal::datatype_to_dataformat_converter(c.dtype()) == tt::DataFormat::Float32 ||
+         (running_mean_has_value &&
+          tt::tt_metal::datatype_to_dataformat_converter(running_mean_tensor->dtype()) == tt::DataFormat::Float32) ||
+         (running_var_has_value &&
+          tt::tt_metal::datatype_to_dataformat_converter(running_var_tensor->dtype()) == tt::DataFormat::Float32));
+    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
+
+    const uint32_t cHtWt = cHt * cWt;
+    const auto scalar = momentum;
+    const auto packed_scalar_momentum =
+        use_fp32_acc ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
+
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 13;
     constexpr size_t num_kernel_args = 3;
@@ -71,12 +89,6 @@ void set_or_update_runtime_arguments(
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, num_kernel_args>{0});
             continue;
         }
-
-        uint32_t cHtWt = cHt * cWt;
-        const auto scalar = momentum;
-        const auto packed_scalar_momentum = batch_mean_tensor.dtype() == tt::tt_metal::DataType::FLOAT32
-                                                ? std::bit_cast<uint32_t>(scalar)
-                                                : pack_two_bfloat16_into_uint32({scalar, scalar});
         std::array reader_runtime_args = {
             packed_scalar_momentum,
             batch_mean_tensor.buffer()->address(),
@@ -148,11 +160,22 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     auto e_data_format =
         running_var_has_value ? datatype_to_dataformat_converter(running_var_tensor->dtype()) : DataFormat::Float16_b;
 
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
+    const bool any_float32 =
+        (a_data_format == DataFormat::Float32 || b_data_format == DataFormat::Float32 ||
+         c_data_format == DataFormat::Float32 || d_data_format == DataFormat::Float32 ||
+         e_data_format == DataFormat::Float32);
+    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
+    auto interm_data_format = any_float32 ? DataFormat::Float32 : a_data_format;
+
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
     uint32_t b_single_tile_size = tt::tile_size(b_data_format);
     uint32_t c_single_tile_size = tt::tile_size(c_data_format);
     uint32_t d_single_tile_size = tt::tile_size(d_data_format);
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
+    uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
 
     // we parallelize the computation across the output tiles
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -199,16 +222,16 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         tt::CBIndex::c_5,
         program,
         all_device_cores,
-        b_single_tile_size,
+        interm_single_tile_size,
         b_num_tiles_per_cb,
-        b_data_format);  // momentum
+        interm_data_format);  // momentum
     auto [one_cb, one_cb_handle] = create_cb(
         tt::CBIndex::c_6,
         program,
         all_device_cores,
-        b_single_tile_size,
+        interm_single_tile_size,
         b_num_tiles_per_cb,
-        b_data_format);  // to store 1
+        interm_data_format);  // to store 1
     auto [updated_m_cb, updated_m_cb_handle] = create_cb(
         tt::CBIndex::c_7,
         program,
@@ -225,14 +248,14 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         e_data_format);  // updated running var
 
     // Intermediate buffers required for updation of running stats
-    auto [tmp1_cb, tmp1_cb_handle] =
-        create_cb(tt::CBIndex::c_9, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+    auto [tmp1_cb, tmp1_cb_handle] = create_cb(
+        tt::CBIndex::c_9, program, all_device_cores, interm_single_tile_size, b_num_tiles_per_cb, interm_data_format);
 
-    auto [tmp2_cb, tmp2_cb_handle] =
-        create_cb(tt::CBIndex::c_10, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+    auto [tmp2_cb, tmp2_cb_handle] = create_cb(
+        tt::CBIndex::c_10, program, all_device_cores, interm_single_tile_size, b_num_tiles_per_cb, interm_data_format);
 
-    auto [tmp3_cb, tmp3_cb_handle] =
-        create_cb(tt::CBIndex::c_11, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+    auto [tmp3_cb, tmp3_cb_handle] = create_cb(
+        tt::CBIndex::c_11, program, all_device_cores, interm_single_tile_size, b_num_tiles_per_cb, interm_data_format);
 
     std::vector<uint32_t> reader_compile_time_args = {
         batch_mean_tensor_cb,
@@ -258,17 +281,11 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     tt::tt_metal::TensorAccessorArgs(running_var_tensor ? running_var_tensor->buffer() : nullptr)
         .append_to(writer_compile_time_args);
 
-    std::map<std::string, std::string> dataflow_defines;  // Currently support only for fp32, bf16
-    if (batch_mean_tensor.dtype() == DataType::FLOAT32) {
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element<float>";
-        dataflow_defines["FILL_WITH_VALUE_FLOAT"] = "fill_with_val<1024, float>";
-    } else {
-        dataflow_defines["FILL_TILE_WITH_FIRST_ELEMENT"] = "fill_tile_with_first_element_bfloat16";
-        dataflow_defines["FILL_WITH_VALUE"] = "fill_with_val_bfloat16";
-    }
-
     // READER KERNEL
-    auto reader_defines = dataflow_defines;
+    std::map<std::string, std::string> reader_defines;
+    if (use_fp32_acc) {
+        reader_defines["FILL_MOMENTUM_FP32"] = "1";
+    }
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp",
@@ -276,7 +293,13 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, std::move(reader_defines)));
 
     // WRITER KERNEL
-    auto writer_defines = dataflow_defines;
+    std::map<std::string, std::string> writer_defines;
+    if (d_data_format == DataFormat::Float32) {
+        writer_defines["OLD_MEAN_IS_FP32"] = "1";
+    }
+    if (e_data_format == DataFormat::Float32) {
+        writer_defines["OLD_VAR_IS_FP32"] = "1";
+    }
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp",
@@ -284,11 +307,8 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, std::move(writer_defines)));
 
     // COMPUTE KERNEL
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
+    if (use_fp32_acc) {
         for (const auto cb_index :
              {batch_mean_tensor_cb,
               batch_var_tensor_cb,
@@ -325,11 +345,14 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_{}.cpp",
-            fp32_dest_acc_en ? "sfpu_kernel" : "kernel"),
+            use_fp32_acc ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = use_fp32_acc,
+            .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+            .math_approx_mode = math_approx_mode,
             .compile_args = compute_kernel_args});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -149,14 +149,10 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     auto e_data_format =
         running_var_has_value ? datatype_to_dataformat_converter(running_var_tensor->dtype()) : DataFormat::Float16_b;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
-
     const bool any_float32 =
         (a_data_format == DataFormat::Float32 || b_data_format == DataFormat::Float32 ||
          c_data_format == DataFormat::Float32 || d_data_format == DataFormat::Float32 ||
          e_data_format == DataFormat::Float32);
-    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
     auto interm_data_format = any_float32 ? DataFormat::Float32 : a_data_format;
 
     uint32_t a_single_tile_size = tt::tile_size(a_data_format);
@@ -307,8 +303,11 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     // COMPUTE KERNEL
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (use_fp32_acc) {
+    if (fp32_dest_acc_en) {
         for (const auto cb_index :
              {batch_mean_tensor_cb,
               batch_var_tensor_cb,
@@ -354,11 +353,11 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_{}.cpp",
-            any_float32 ? "sfpu_kernel" : "kernel"),
+            (fp32_dest_acc_en || any_float32) ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = use_fp32_acc,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -174,6 +174,11 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     uint32_t e_single_tile_size = tt::tile_size(e_data_format);
     uint32_t interm_single_tile_size = tt::tile_size(interm_data_format);
 
+    const bool needs_mean_typecast =
+        running_mean_has_value && (interm_data_format == DataFormat::Float32 && d_data_format != DataFormat::Float32);
+    const bool needs_var_typecast =
+        running_var_has_value && (interm_data_format == DataFormat::Float32 && e_data_format != DataFormat::Float32);
+
     // we parallelize the computation across the output tiles
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -229,23 +234,33 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         interm_single_tile_size,
         b_num_tiles_per_cb,
         interm_data_format);  // to store 1
-    // Updated running mean/var CBs use intermediate format so the compute kernel
-    // can pack without switching the packer's data format mid-computation.
-    // The writer kernel handles the final conversion to the tensor's native format.
     auto [updated_m_cb, updated_m_cb_handle] = create_cb(
         tt::CBIndex::c_7,
         program,
         all_device_cores,
-        interm_single_tile_size,
+        needs_mean_typecast ? interm_single_tile_size : d_single_tile_size,
         b_num_tiles_per_cb,
-        interm_data_format);  // updated running mean
+        needs_mean_typecast ? interm_data_format : d_data_format);  // updated running mean (staging when typecast)
     auto [updated_v_cb, updated_v_cb_handle] = create_cb(
         tt::CBIndex::c_8,
         program,
         all_device_cores,
-        interm_single_tile_size,
+        needs_var_typecast ? interm_single_tile_size : e_single_tile_size,
         b_num_tiles_per_cb,
-        interm_data_format);  // updated running var
+        needs_var_typecast ? interm_data_format : e_data_format);  // updated running var (staging when typecast)
+
+    uint32_t writer_updated_m_cb = updated_m_cb;
+    uint32_t writer_updated_v_cb = updated_v_cb;
+    if (needs_mean_typecast) {
+        auto [wm_cb, wm_cb_handle] = create_cb(
+            tt::CBIndex::c_12, program, all_device_cores, d_single_tile_size, b_num_tiles_per_cb, d_data_format);
+        writer_updated_m_cb = wm_cb;
+    }
+    if (needs_var_typecast) {
+        auto [wv_cb, wv_cb_handle] = create_cb(
+            tt::CBIndex::c_13, program, all_device_cores, e_single_tile_size, b_num_tiles_per_cb, e_data_format);
+        writer_updated_v_cb = wv_cb;
+    }
 
     // Intermediate buffers required for updation of running stats
     auto [tmp1_cb, tmp1_cb_handle] = create_cb(
@@ -271,8 +286,8 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         output_tensor_cb,
         old_running_mean_tensor_cb,
         old_running_var_tensor_cb,
-        updated_m_cb,
-        updated_v_cb,
+        writer_updated_m_cb,
+        writer_updated_v_cb,
     };
     tt::tt_metal::TensorAccessorArgs(batch_var_tensor.buffer()).append_to(writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
@@ -299,12 +314,6 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     }
     if (e_data_format == DataFormat::Float32) {
         writer_defines["OLD_VAR_IS_FP32"] = "1";
-    }
-    if (interm_data_format == DataFormat::Float32 && d_data_format != DataFormat::Float32) {
-        writer_defines["CONVERT_UPDATED_MEAN_TO_BF16"] = "1";
-    }
-    if (interm_data_format == DataFormat::Float32 && e_data_format != DataFormat::Float32) {
-        writer_defines["CONVERT_UPDATED_VAR_TO_BF16"] = "1";
     }
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
@@ -346,7 +355,24 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         one_cb,
         tmp1_cb,
         tmp2_cb,
-        tmp3_cb};
+        tmp3_cb,
+        writer_updated_m_cb,
+        writer_updated_v_cb};
+
+    std::map<std::string, std::string> compute_defines;
+    if (needs_mean_typecast) {
+        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
+        auto out_fmt = static_cast<uint32_t>(d_data_format);
+        compute_defines["TYPECAST_MEAN_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
+        compute_defines["TYPECAST_MEAN"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
+    }
+    if (needs_var_typecast) {
+        auto in_fmt = static_cast<uint32_t>(DataFormat::Float32);
+        auto out_fmt = static_cast<uint32_t>(e_data_format);
+        compute_defines["TYPECAST_VAR_INIT"] = fmt::format("typecast_tile_init<{}u, {}u>", in_fmt, out_fmt);
+        compute_defines["TYPECAST_VAR"] = fmt::format("typecast_tile<{}u, {}u>", in_fmt, out_fmt);
+    }
+
     auto compute_kernel_id = tt_metal::CreateKernel(
         program,
         fmt::format(
@@ -359,7 +385,8 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
             .math_approx_mode = math_approx_mode,
-            .compile_args = compute_kernel_args});
+            .compile_args = compute_kernel_args,
+            .defines = std::move(compute_defines)});
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -55,8 +55,6 @@ void set_or_update_runtime_arguments(
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(batch_mean_tensor.device()->arch(), operation_attributes.compute_kernel_config);
     const bool any_float32 =
         (tt::tt_metal::datatype_to_dataformat_converter(batch_mean_tensor.dtype()) == tt::DataFormat::Float32 ||
          tt::tt_metal::datatype_to_dataformat_converter(batch_var_tensor.dtype()) == tt::DataFormat::Float32 ||
@@ -65,12 +63,11 @@ void set_or_update_runtime_arguments(
           tt::tt_metal::datatype_to_dataformat_converter(running_mean_tensor->dtype()) == tt::DataFormat::Float32) ||
          (running_var_has_value &&
           tt::tt_metal::datatype_to_dataformat_converter(running_var_tensor->dtype()) == tt::DataFormat::Float32));
-    const bool use_fp32_acc = fp32_dest_acc_en || any_float32;
 
     const uint32_t cHtWt = cHt * cWt;
     const auto scalar = momentum;
     const auto packed_scalar_momentum =
-        use_fp32_acc ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
+        any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
 
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 13;
@@ -232,20 +229,23 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         interm_single_tile_size,
         b_num_tiles_per_cb,
         interm_data_format);  // to store 1
+    // Updated running mean/var CBs use intermediate format so the compute kernel
+    // can pack without switching the packer's data format mid-computation.
+    // The writer kernel handles the final conversion to the tensor's native format.
     auto [updated_m_cb, updated_m_cb_handle] = create_cb(
         tt::CBIndex::c_7,
         program,
         all_device_cores,
-        d_single_tile_size,
+        interm_single_tile_size,
         b_num_tiles_per_cb,
-        d_data_format);  // updated running mean
+        interm_data_format);  // updated running mean
     auto [updated_v_cb, updated_v_cb_handle] = create_cb(
         tt::CBIndex::c_8,
         program,
         all_device_cores,
-        e_single_tile_size,
+        interm_single_tile_size,
         b_num_tiles_per_cb,
-        e_data_format);  // updated running var
+        interm_data_format);  // updated running var
 
     // Intermediate buffers required for updation of running stats
     auto [tmp1_cb, tmp1_cb_handle] = create_cb(
@@ -283,7 +283,7 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
 
     // READER KERNEL
     std::map<std::string, std::string> reader_defines;
-    if (use_fp32_acc) {
+    if (any_float32) {
         reader_defines["FILL_MOMENTUM_FP32"] = "1";
     }
     auto reader_kernel_id = tt_metal::CreateKernel(
@@ -299,6 +299,12 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
     }
     if (e_data_format == DataFormat::Float32) {
         writer_defines["OLD_VAR_IS_FP32"] = "1";
+    }
+    if (interm_data_format == DataFormat::Float32 && d_data_format != DataFormat::Float32) {
+        writer_defines["CONVERT_UPDATED_MEAN_TO_BF16"] = "1";
+    }
+    if (interm_data_format == DataFormat::Float32 && e_data_format != DataFormat::Float32) {
+        writer_defines["CONVERT_UPDATED_VAR_TO_BF16"] = "1";
     }
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
@@ -345,7 +351,7 @@ RunningStatistics::RunningStatisticsProgramFactory::create(
         program,
         fmt::format(
             "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_{}.cpp",
-            use_fp32_acc ? "sfpu_kernel" : "kernel"),
+            any_float32 ? "sfpu_kernel" : "kernel"),
         all_device_cores,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -55,12 +55,6 @@ void set_or_update_runtime_arguments(
         tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
 
     auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-
-    const uint32_t cHtWt = cHt * cWt;
-    const auto scalar = momentum;
-    const auto packed_scalar_momentum =
-        any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
-
     constexpr size_t num_reader_args = 11;
     constexpr size_t num_writer_args = 13;
     constexpr size_t num_kernel_args = 3;
@@ -78,6 +72,11 @@ void set_or_update_runtime_arguments(
             handle_args(program, compute_kernel_id, core, std::array<uint32_t, num_kernel_args>{0});
             continue;
         }
+
+        uint32_t cHtWt = cHt * cWt;
+        const auto scalar = momentum;
+        const auto packed_scalar_momentum =
+            any_float32 ? std::bit_cast<uint32_t>(scalar) : pack_two_bfloat16_into_uint32({scalar, scalar});
         std::array reader_runtime_args = {
             packed_scalar_momentum,
             batch_mean_tensor.buffer()->address(),


### PR DESCRIPTION
### Ticket
Closes #36669.

### Problem description
`ttnn.batch_norm` required all tensors (input, parameters, output) to share the same dtype. This prevented common mixed-precision workflows where the input/output are one `dtype` but parameters (running_mean, running_var, weight, bias) are another `dtype`. This matches with PyTorch requirements, except PyTorch does not support inputs in higher precision and parameters in lower precision.

### What's changed

**Implementation:**
- Added `dtype` validation: `output` must match `input` dtype; all parameter tensors must share the same dtype with each other (but may differ from input/output).
- Intermediate circular buffers and scalar fills use FP32 when any tensor is FP32, keeping full precision throughout computation. Format conversion happens at the last moment via SFPU `typecast_tile` in the compute kernels, with staging CBs bridging the FP32 compute path to BF16 writer-facing CBs.
- SFPU kernel dispatch broadened from `fp32_dest_acc_en` to `(fp32_dest_acc_en || any_float32)` so mixed-precision inputs use the SFPU kernels.
- `batch_norm_sfpu_kernel.cpp` tracks the last-configured SrcA circular buffer (`last_srca_cb`) across runtime-conditional weight/bias branches to ensure correct unpacker reconfiguration via `copy_tile_to_dst_init_short_with_dt`.
- Tile register pattern changed from `acquire → wait → compute+pack → commit → release` to `acquire → compute → commit → wait → pack → release`; `pack_tile` replaced with `pack_tile_with_dt` in running statistics — both required for correctness when the packer format differs from the compute format.
- All `#define`-based dataflow macros (`FILL_TILE_WITH_FIRST_ELEMENT`, `FILL_WITH_VALUE`, etc.) replaced with compile-time args and `if constexpr`, enabling per-tensor format dispatch without preprocessor guards.
- Future work: training-mode batch stat reductions (`mean_NHW`, `square`, `subtract`) are not in mixed precision end-to-end; this is because the API creates `batch_mean`, `batch_var` with same `dtype` as `input`, and then those are used for further calculations in higher precision.
 
**Tests:**
- New `test_batch_norm_mixed_precision` test covering all BF16/FP32 input×parameter combinations with preallocated output tensors.
- Extended `test_batch_norm_compute_config` with `input_dtype`/`param_dtype` parametrizations covering `(bfloat16, bfloat16)`, `(bfloat16, float32)`, and `(float32, float32)` to ensure mixed precision works in user-provided `fp32_dest_acc_en` scenarios

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/36669-add-mixed-precision-support-to-batch-norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/36669-add-mixed-precision-support-to-batch-norm)
- [x] [![PR Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml/badge.svg?branch=gchoudhary/36669-add-mixed-precision-support-to-batch-norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml?query=branch:gchoudhary/36669-add-mixed-precision-support-to-batch-norm)
- [x] [![Merge Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml/badge.svg?branch=gchoudhary/36669-add-mixed-precision-support-to-batch-norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml?query=branch:gchoudhary/36669-add-mixed-precision-support-to-batch-norm)
- [x] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/36669-add-mixed-precision-support-to-batch-norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/36669-add-mixed-precision-support-to-batch-norm)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/36669-add-mixed-precision-support-to-batch-norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/36669-add-mixed-precision-support-to-batch-norm)
- [x] New/Existing tests provide coverage for changes