### PR TITLE
Force sparse checkout in merge gate

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -216,6 +216,13 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      fetch-depth:
+        required: false
+        type: number
+        default: 500
+        description: >-
+          Git fetch depth for the checkout step. Must be large enough to
+          include all tags and history needed for `git describe`.
 
 jobs:
   # =============================================================================

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -49,6 +49,11 @@ on:
         type: string
         default: ""
         description: "Git ref to checkout (defaults to github.sha if not provided)"
+      fetch-depth:
+        required: false
+        type: number
+        default: 500
+        description: "Git fetch depth passed through to build-artifact"
   workflow_dispatch:
     inputs:
       platform:
@@ -104,6 +109,7 @@ jobs:
       skip-tt-train: false
       tracy: true
       ref: ${{ inputs.ref }}
+      fetch-depth: ${{ inputs.fetch-depth }}
 
   # build job runs the matrix - either when called from merge-gate with pre-built tags,
   # or when called via workflow_call without the platform dropdown
@@ -144,6 +150,7 @@ jobs:
       skip-tt-train: false
       tracy: true
       ref: ${{ inputs.ref }}
+      fetch-depth: ${{ inputs.fetch-depth }}
       # Pass pre-built docker image tags based on platform
       ci-build-docker-image: ${{
         (matrix.config.platform == 'Ubuntu 24.04' && inputs.ubuntu-2404-ci-build-tag) ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -80,6 +80,7 @@ jobs:
       ci-build-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
       dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
 
+
   fail-fast:
     if: failure()
     runs-on: ubuntu-latest
@@ -128,6 +129,7 @@ jobs:
       basic-dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-dev-tag }}
       basic-ttnn-runtime-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
       manylinux-docker-image: ${{ needs.docker-images.outputs.manylinux-tag }}
+      fetch-depth: 1
 
   build-tsan:
     if: ${{ github.ref_name == 'main' ||
@@ -152,6 +154,7 @@ jobs:
       basic-dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-basic-dev-tag }}
       basic-ttnn-runtime-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-basic-ttnn-runtime-tag }}
       manylinux-docker-image: ${{ needs.docker-images.outputs.manylinux-tag }}
+      fetch-depth: 1
 
   build-sweeps:
     if: ${{ github.ref_name == 'main' ||
@@ -170,6 +173,7 @@ jobs:
       ubuntu-2404-ci-build-tag: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
       ubuntu-2404-dev-tag: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
       ubuntu-2404-manylinux-tag: ${{ needs.docker-images.outputs.manylinux-tag }}
+      fetch-depth: 1
 
   metalium-smoke-tests:
     needs: [find-changes, build-tsan]
@@ -239,6 +243,7 @@ jobs:
       basic-dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-dev-tag }}
       basic-ttnn-runtime-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
       manylinux-docker-image: ${{ needs.docker-images.outputs.manylinux-tag }}
+      fetch-depth: 1
 
   metalium-basic-tests:
     if: ${{


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Merge gate sweeps/builds were doing full repo checkouts

### What's changed
* Updated merge gate to only clone the HEAD commit for build jobs.
* Propagated fetch-depth option for consistency
