### PR TITLE
Adding UMD unique ids to PSD Info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ METALIUM_GUIDE.md @davorchap @tenstorrent/codeowner-bypass
 .github/workflows/vllm-nightly-tests.yaml @ppetrovicTT @skhorasganiTT @rdraskicTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/vllm-nightly-tests-impl.yaml @ppetrovicTT @skhorasganiTT @rdraskicTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/multi-host-physical.yaml @sjameelTT @aliuTT @cfjchu @tenstorrent/codeowner-bypass @tenstorrent/metalium-developers-infra
-.github/workflows/fabric-cpu-only-tests-impl.yaml @Riddy21 @tt-asaigal @aliuTT @cfjchu @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+.github/workflows/fabric-cpu-only-tests-impl.yaml @Riddy21 @tt-asaigal @aliuTT @cfjchu @p1-0tr @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 
 /infra/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 scripts/build_scripts/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
@@ -143,8 +143,9 @@ tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema @aagarwalTT @Sean
 tests/tt_metal/tt_metal/sfpi/ @nathan-TT @kstevensTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT @kstevensTT @tenstorrent/codeowner-bypass
 tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
-tests/tt_metal/tt_fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @tenstorrent/codeowner-bypass
-tests/tt_metal/tt_fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @tenstorrent/metalium-developers-infra
+tests/tt_metal/tt_fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @p1-0tr @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_fabric/physical_discovery/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @p1-0tr @tenstorrent/codeowner-bypass
+tests/tt_metal/tt_fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @Riddy21 @p1-0tr @tenstorrent/metalium-developers-infra
 tests/tt_metal/multihost/ @tenstorrent/metalium-developers-metal-distributed @tenstorrent/codeowner-bypass
 tests/tt_metal/multihost/**/CMakeLists.txt @tenstorrent/metalium-developers-metal-distributed @tenstorrent/metalium-developers-infra
 tests/tt_metal/tools/profiler/ @mo-tenstorrent @nhuang-tt @tenstorrent/codeowner-bypass

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/physical_system_discovery.hpp"
+#include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include "distributed_context.hpp"
 #include "impl/context/metal_context.hpp"
@@ -84,6 +85,13 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
         asic_id_to_chip_id[AsicID{asic_id}] = chip_id;
     }
 
+    // Validate UMD unique ID mapping (AsicID -> ChipId)
+    for (auto asic : physical_system_desc.get_asics_connected_to_host(my_host)) {
+        auto expected_chip_id = asic_id_to_chip_id.at(asic);
+        EXPECT_EQ(physical_system_desc.get_umd_unique_id(asic), expected_chip_id)
+            << "get_umd_unique_id(asic_id) should match cluster's ChipId for asic " << *asic;
+    }
+
     // Local Connectivity
     for (auto asic : physical_system_desc.get_asics_connected_to_host(my_host)) {
         auto chip_id = asic_id_to_chip_id.at(asic);
@@ -145,6 +153,34 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
         physical_system_desc.dump_to_yaml();
         log_info(tt::LogTest, "Dumping Physical System Descriptor to Text Proto");
         physical_system_desc.emit_to_text_proto();
+    }
+}
+
+TEST(PhysicalDiscovery, TestUmdUniqueIdSerializationRoundtrip) {
+    using namespace tt::tt_metal::distributed::multihost;
+    auto distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    auto& driver_ref = const_cast<tt::umd::Cluster&>(*cluster.get_driver());
+    auto physical_system_desc =
+        tt::tt_metal::run_physical_system_discovery(driver_ref, distributed_context, rtoptions.get_target_device());
+
+    auto unique_chip_ids = cluster.get_unique_chip_ids();
+    std::unordered_map<AsicID, ChipId> asic_id_to_chip_id;
+    for (const auto& [chip_id, asic_id] : unique_chip_ids) {
+        asic_id_to_chip_id[AsicID{asic_id}] = chip_id;
+    }
+
+    // Serialize and deserialize
+    auto bytes = tt::tt_metal::serialize_physical_system_descriptor_to_bytes(physical_system_desc);
+    auto deserialized = tt::tt_metal::deserialize_physical_system_descriptor_from_bytes(bytes);
+
+    // Verify umd_unique_id is preserved for each local asic
+    auto my_host = physical_system_desc.my_host_name();
+    for (auto asic : physical_system_desc.get_asics_connected_to_host(my_host)) {
+        auto expected_chip_id = asic_id_to_chip_id.at(asic);
+        EXPECT_EQ(deserialized.get_umd_unique_id(asic), expected_chip_id)
+            << "umd_unique_id should be preserved after serialize/deserialize for asic " << *asic;
     }
 }
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -51,6 +51,7 @@ struct ASICDescriptor {
     ASICLocation asic_location;
     BoardType board_type = BoardType::UNKNOWN;
     AsicID unique_id;
+    ChipId umd_unique_id;
     std::string host_name;
 };
 
@@ -178,6 +179,7 @@ public:
     const AsicTopology& get_asic_topology(const std::string& hostname) const;
     TrayID get_tray_id(AsicID asic_id) const;
     ASICLocation get_asic_location(AsicID asic_id) const;
+    ChipId get_umd_unique_id(AsicID asic_id) const;
     std::vector<AsicID> get_asics_connected_to_host(const std::string& hostname) const;
     std::pair<AsicID, uint8_t> get_connected_asic_and_channel(AsicID asic_id, uint8_t chan_id) const;
     AsicID get_asic_id(const std::string& hostname, TrayID tray_id, ASICLocation asic_location) const;

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -296,8 +296,9 @@ ASICLocation PhysicalSystemDescriptor::get_asic_location(AsicID asic_id) const {
 }
 
 ChipId PhysicalSystemDescriptor::get_umd_unique_id(AsicID asic_id) const {
-    TT_FATAL(asic_descriptors_.contains(asic_id), "No ASIC descriptor found for asic_id {}", asic_id);
-    return asic_descriptors_.at(asic_id).umd_unique_id;
+    auto it = asic_descriptors_.find(asic_id);
+    TT_FATAL(it != asic_descriptors_.end(), "No ASIC descriptor found for asic_id {}", asic_id);
+    return it->second.umd_unique_id;
 }
 
 std::vector<AsicID> PhysicalSystemDescriptor::get_asics_connected_to_host(const std::string& hostname) const {

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -295,6 +295,11 @@ ASICLocation PhysicalSystemDescriptor::get_asic_location(AsicID asic_id) const {
     return asic_descriptors_.at(asic_id).asic_location;
 }
 
+ChipId PhysicalSystemDescriptor::get_umd_unique_id(AsicID asic_id) const {
+    TT_FATAL(asic_descriptors_.contains(asic_id), "No ASIC descriptor found for asic_id {}", asic_id);
+    return asic_descriptors_.at(asic_id).umd_unique_id;
+}
+
 std::vector<AsicID> PhysicalSystemDescriptor::get_asics_connected_to_host(const std::string& hostname) const {
     std::vector<AsicID> asics;
     if (system_graph_.asic_connectivity_graph.contains(hostname)) {

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -452,7 +452,12 @@ PhysicalSystemDescriptor run_local_discovery(
             psd.get_pcie_devices_per_tray()[hostname_key],
             psd.get_pcie_id_to_asic_location()[hostname_key]);
         psd.get_asic_descriptors()[src_unique_id] = ASICDescriptor{
-            TrayID{tray_id}, asic_location, cluster_desc->get_board_type(src_chip_id), src_unique_id, hostname_key};
+            TrayID{tray_id},
+            asic_location,
+            cluster_desc->get_board_type(src_chip_id),
+            src_unique_id,
+            src_chip_id,
+            hostname_key};
     };
 
     for (const auto& [chip_id, unique_id] : chip_unique_ids) {

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -63,7 +63,7 @@ message AsicDescriptor {
     uint32 asic_location = 2;
     uint32 board_type = 3;  // Enum value for BoardType
     uint64 unique_id = 4;
-    int32 umd_unique_id = 6;
+    optional int32 umd_unique_id = 6;
     string host_name = 5;
 }
 

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -63,6 +63,7 @@ message AsicDescriptor {
     uint32 asic_location = 2;
     uint32 board_type = 3;  // Enum value for BoardType
     uint64 unique_id = 4;
+    int32 umd_unique_id = 6;
     string host_name = 5;
 }
 

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -263,8 +263,9 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
         asic_desc.unique_id = AsicID{proto_asic_desc.unique_id()};
         // For backward compatibility: if umd_unique_id is not set (defaults to 0 in proto3),
         // we need to find the ChipId from the cluster descriptor. However, since we don't have
-        // access to cluster_desc_ here, we'll use 0 as a sentinel and handle it elsewhere if needed.
-        asic_desc.umd_unique_id = proto_asic_desc.umd_unique_id();
+        // access to cluster_desc_ here, we use -1 as a sentinel (0 is a valid ChipId).
+        asic_desc.umd_unique_id =
+            proto_asic_desc.has_umd_unique_id() ? proto_asic_desc.umd_unique_id() : static_cast<ChipId>(-1);
         asic_desc.host_name = proto_asic_desc.host_name();
 
         asic_descriptors[asic_id] = asic_desc;

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -166,6 +166,7 @@ void physical_system_descriptor_to_proto(
         proto_asic_desc->set_asic_location(*asic_desc.asic_location);
         proto_asic_desc->set_board_type(board_type_to_proto(asic_desc.board_type));
         proto_asic_desc->set_unique_id(*asic_desc.unique_id);
+        proto_asic_desc->set_umd_unique_id(asic_desc.umd_unique_id);
         proto_asic_desc->set_host_name(asic_desc.host_name);
     }
 
@@ -260,6 +261,10 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
         asic_desc.asic_location = ASICLocation{proto_asic_desc.asic_location()};
         asic_desc.board_type = proto_to_board_type(proto_asic_desc.board_type());
         asic_desc.unique_id = AsicID{proto_asic_desc.unique_id()};
+        // For backward compatibility: if umd_unique_id is not set (defaults to 0 in proto3),
+        // we need to find the ChipId from the cluster descriptor. However, since we don't have
+        // access to cluster_desc_ here, we'll use 0 as a sentinel and handle it elsewhere if needed.
+        asic_desc.umd_unique_id = proto_asic_desc.umd_unique_id();
         asic_desc.host_name = proto_asic_desc.host_name();
 
         asic_descriptors[asic_id] = asic_desc;


### PR DESCRIPTION
## Summary

Adds UMD chip IDs (`ChipId`) to the Physical System Descriptor, enabling direct lookup from PSD's `AsicID` to the UMD layer's `ChipId` used for device enumeration and hardware access.

## Changes

- **ASICDescriptor**: Added `umd_unique_id` (ChipId) field and `get_umd_unique_id(AsicID)` method
- **Discovery**: Populates `umd_unique_id` from cluster descriptor's chip ID during local discovery
- **Proto/Serialization**: Added field to protobuf schema and serialization; older PSDs deserialize with default 0
