### PR TITLE
Fix galaxy unit tests and add batching capability to fast dispatch

### DIFF
--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -183,7 +183,7 @@ jobs:
             echo "::group::${name}"
             if GTEST_OUTPUT="xml:/work/generated/test_reports/${xml_name}" "$@"; then
               echo "::endgroup::"
-              echo "::notice title=PASS::${name}"
+              echo "::notice title=PASS::${name} passed."
             else
               local status=$?
               failed=1

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -197,7 +197,7 @@ jobs:
             "unit_tests_dispatch_command_queue_single_card.xml" \
             env TT_METAL_ENABLE_REMOTE_CHIP=1 \
             ./build/test/tt_metal/unit_tests_dispatch \
-            --gtest_filter="CommandQueueSingleCard*Fixture.*"
+            --gtest_filter="UnitMeshCQSingleCard*Fixture.*"
 
           run_gtest \
             "Galaxy/TG device tests slow dispatch" \

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -182,14 +182,15 @@ jobs:
 
             echo "::group::${name}"
             if GTEST_OUTPUT="xml:/work/generated/test_reports/${xml_name}" "$@"; then
-              echo "PASS: ${name}"
+              echo "::endgroup::"
+              echo "::notice title=PASS::${name}"
             else
               local status=$?
               failed=1
               failed_names+=("${name} (exit ${status})")
-              echo "::error title=${name}::Command failed with exit code ${status}"
+              echo "::endgroup::"
+              echo "::error title=FAIL::${name} (exit ${status})"
             fi
-            echo "::endgroup::"
           }
 
           run_gtest \
@@ -342,6 +343,8 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+        with:
+          test-report-path: generated/test_reports/
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -172,11 +172,70 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           mkdir -p generated/test_reports
-          TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCard*Fixture.*"
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
-          ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
-          TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshMultiCQMultiDevice*Fixture.*"
-          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*DispatchContext*"
+          failed=0
+          failed_names=()
+
+          run_gtest() {
+            local name="$1"
+            local xml_name="$2"
+            shift 2
+
+            echo "::group::${name}"
+            if GTEST_OUTPUT="xml:/work/generated/test_reports/${xml_name}" "$@"; then
+              echo "PASS: ${name}"
+            else
+              local status=$?
+              failed=1
+              failed_names+=("${name} (exit ${status})")
+              echo "::error title=${name}::Command failed with exit code ${status}"
+            fi
+            echo "::endgroup::"
+          }
+
+          run_gtest \
+            "Dispatch single-card fixtures" \
+            "unit_tests_dispatch_command_queue_single_card.xml" \
+            env TT_METAL_ENABLE_REMOTE_CHIP=1 \
+            ./build/test/tt_metal/unit_tests_dispatch \
+            --gtest_filter="CommandQueueSingleCard*Fixture.*"
+
+          run_gtest \
+            "Galaxy/TG device tests slow dispatch" \
+            "unit_tests_device_galaxy_slow_dispatch.xml" \
+            env TT_METAL_SLOW_DISPATCH_MODE=1 \
+            ./build/test/tt_metal/unit_tests_device \
+            --gtest_filter="GalaxyFixture.*:TGFixture.*"
+
+          run_gtest \
+            "Galaxy/TG device tests fast dispatch" \
+            "unit_tests_device_galaxy_fast_dispatch.xml" \
+            ./build/test/tt_metal/unit_tests_device \
+            --gtest_filter="GalaxyFixture.*:TGFixture.*"
+
+          run_gtest \
+            "Multi-CQ Galaxy dispatch tests" \
+            "unit_tests_dispatch_multicq_galaxy.xml" \
+            env TT_METAL_GTEST_NUM_HW_CQS=2 \
+            ./build/test/tt_metal/unit_tests_dispatch \
+            --gtest_filter="UnitMeshMultiCQMultiDevice*Fixture.*"
+
+          run_gtest \
+            "Distributed DispatchContext tests slow dispatch" \
+            "distributed_unit_tests_dispatch_context_slow_dispatch.xml" \
+            env TT_METAL_SLOW_DISPATCH_MODE=1 \
+            ./build/test/tt_metal/distributed/distributed_unit_tests \
+            --gtest_filter="*DispatchContext*"
+
+          if [[ ${#failed_names[@]} -gt 0 ]]; then
+            {
+              echo "## Galaxy unit test command failures"
+              echo
+              for failed_name in "${failed_names[@]}"; do
+                echo "- ${failed_name}"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
       - name: Run fabric tests
         if: ${{ matrix.test-group.model == 'fabric' }}

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -96,8 +96,55 @@ TEST_F(DispatchContextFixture, TestWritesAndWorkloads) {
             EXPECT_EQ(dst_vec, src_vec);
         }
     }
+}
 
-    // Initializing again should throw
+TEST(DispatchContext, DoubleInitWithoutTerminateShouldThrow) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
+    }
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP()
+            << "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.";
+    }
+
+    // Initialize fast dispatch
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+
+    // Double init without terminate should throw
+    EXPECT_THROW(experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get()), std::runtime_error);
+
+    // Clean up
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+}
+
+// Note: Multiple init/terminate cycles within a single test (or on the same MeshDevice) are not
+// supported. The hardware state cannot be properly reset between cycles. The DispatchContext
+// singleton allows sequential tests (each with their own MeshDevice) to each do one init/terminate
+// cycle, but not multiple cycles per test.
+TEST(DispatchContext, DISABLED_ReInitAfterTerminateShouldFail) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
+    }
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP()
+            << "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.";
+    }
+
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+
+    // Unsupported path: re-initializing after terminate on the same MeshDevice currently fails and
+    // can leave the device in an unrecoverable state during teardown, so keep this test disabled.
     EXPECT_THROW(experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get()), std::runtime_error);
 }
 
@@ -160,7 +207,9 @@ TEST_F(DispatchContextFixture, SdEnableFdDisableFdThenL1Buffer) {
         EXPECT_EQ(fd_buf_readback_in_sd, fd_src_vec) << "Sharded buffer data mismatch after FD->SD transition";
     }
 
-    // Write and verify interleaved L1 buffer in SD mode
+    // Write and verify interleaved L1 buffer in SD mode. This remains a replicated MeshBuffer across the mesh, so
+    // validate it shard-by-shard rather than through EnqueueReadMeshBuffer(), which is only defined for sharded global
+    // layouts on multi-device meshes.
     DeviceLocalBufferConfig sd_buffer_config{
         .page_size = single_tile_size, .buffer_type = BufferType::L1, .bottom_up = false};
     ReplicatedBufferConfig sd_global_config{.size = num_tiles * single_tile_size};
@@ -174,7 +223,7 @@ TEST_F(DispatchContextFixture, SdEnableFdDisableFdThenL1Buffer) {
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
         std::vector<uint32_t> sd_dst_vec = {};
         ReadShard(mesh_device_->mesh_command_queue(), sd_dst_vec, sd_buf, coord);
-        EXPECT_EQ(sd_dst_vec, sd_src_vec) << "SD interleaved buffer verification failed";
+        EXPECT_EQ(sd_dst_vec, sd_src_vec) << "SD interleaved buffer verification failed after FD->SD transition";
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -126,7 +126,7 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
 
 namespace tt::tt_metal {
 
-TEST_F(UnitMeshCQSingleCardProgramFixture, TestSimpleL1Read) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TestSimpleL1Read) {
     for (auto& mesh_device : devices_) {
         RunTest(mesh_device.get());
     }

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -163,6 +163,15 @@ protected:
                 }
                 break;
             }
+            // In multi-rank Galaxy the MMIO chip's tunnel peers are on remote hosts,
+            // so the loop above produces no local devices. Fall back to the always-local
+            // MMIO device so tests continue to run on this rank.
+            if (devices_.empty() && reserved_devices_.contains(mmio_device_id)) {
+                auto& mmio_device = reserved_devices_.at(mmio_device_id);
+                if (!mmio_device->is_remote_only()) {
+                    devices_.push_back(mmio_device);
+                }
+            }
         } else {
             devices_.push_back(reserved_devices_.at(mmio_device_id));
         }

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -173,7 +173,10 @@ protected:
                 }
             }
         } else {
-            devices_.push_back(reserved_devices_.at(mmio_device_id));
+            auto& mmio_device = reserved_devices_.at(mmio_device_id);
+            if (!mmio_device->is_remote_only()) {
+                devices_.push_back(mmio_device);
+            }
         }
     }
 
@@ -296,7 +299,10 @@ private:
                 }
             }
         } else {
-            shared_devices_.push_back(shared_reserved_devices_.at(mmio_device_id));
+            auto& mmio_device = shared_reserved_devices_.at(mmio_device_id);
+            if (!mmio_device->is_remote_only()) {
+                shared_devices_.push_back(mmio_device);
+            }
         }
 
         shared_max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -199,6 +199,120 @@ protected:
 
 using UnitMeshCQSingleCardBufferFixture = UnitMeshCQSingleCardFixture;
 
+// Suite-level shared fixture: creates devices once per test suite instead of per test.
+// Tests using this fixture must NOT modify persistent device state (sub-device managers, etc.).
+// On test failure, devices are automatically torn down and re-created before the next test.
+class UnitMeshCQSingleCardSharedFixture : virtual public MeshDispatchFixture {
+protected:
+    inline static std::vector<std::shared_ptr<distributed::MeshDevice>> shared_devices_;
+    inline static std::map<int, std::shared_ptr<distributed::MeshDevice>> shared_reserved_devices_;
+    inline static bool devices_valid_ = false;
+    inline static bool needs_recovery_ = false;
+    inline static uint32_t shared_max_cbs_ = 0;
+
+    static void SetUpTestSuite() {
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            return;
+        }
+        create_shared_devices();
+    }
+
+    static void TearDownTestSuite() { destroy_shared_devices(); }
+
+    void SetUp() override {
+        if (!validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+
+        if (needs_recovery_ || !devices_valid_) {
+            destroy_shared_devices();
+            create_shared_devices();
+        }
+        if (shared_devices_.empty()) {
+            GTEST_SKIP() << "No local devices available for testing (all devices are remote-only)";
+        }
+        devices_ = shared_devices_;
+        max_cbs_ = shared_max_cbs_;
+    }
+
+    void TearDown() override {
+        if (HasFailure()) {
+            needs_recovery_ = true;
+        }
+    }
+
+    std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
+    distributed::MeshCoordinate zero_coord_ = distributed::MeshCoordinate::zero_coordinate(2);
+    distributed::MeshCoordinateRange device_range_ = distributed::MeshCoordinateRange(zero_coord_, zero_coord_);
+
+private:
+    bool validate_dispatch_mode() {
+        slow_dispatch_ = false;
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            return false;
+        }
+        return true;
+    }
+
+    static void create_shared_devices() {
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
+        std::vector<ChipId> chip_ids;
+        auto* enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
+        if (enable_remote_chip or
+            tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
+            for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
+                chip_ids.push_back(id);
+            }
+        } else {
+            chip_ids.push_back(mmio_device_id);
+        }
+        shared_reserved_devices_ = distributed::MeshDevice::create_unit_meshes(
+            chip_ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, dispatch_core_config);
+
+        if (enable_remote_chip) {
+            const auto tunnels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+            for (const auto& tunnel : tunnels) {
+                for (const auto chip_id : tunnel) {
+                    if (shared_reserved_devices_.contains(chip_id)) {
+                        auto& device = shared_reserved_devices_.at(chip_id);
+                        if (!device->is_remote_only()) {
+                            shared_devices_.push_back(device);
+                        }
+                    }
+                }
+                break;
+            }
+            if (shared_devices_.empty() && shared_reserved_devices_.contains(mmio_device_id)) {
+                auto& mmio_device = shared_reserved_devices_.at(mmio_device_id);
+                if (!mmio_device->is_remote_only()) {
+                    shared_devices_.push_back(mmio_device);
+                }
+            }
+        } else {
+            shared_devices_.push_back(shared_reserved_devices_.at(mmio_device_id));
+        }
+
+        shared_max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
+        devices_valid_ = true;
+        needs_recovery_ = false;
+    }
+
+    static void destroy_shared_devices() {
+        shared_devices_.clear();
+        shared_reserved_devices_.clear();
+        devices_valid_ = false;
+    }
+};
+
+using UnitMeshCQSingleCardSharedBufferFixture = UnitMeshCQSingleCardSharedFixture;
+
 class UnitMeshCQMultiDeviceFixture : public MeshDispatchFixture {
 protected:
     void SetUp() override {

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -108,6 +108,9 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
+        if (devices_.empty()) {
+            GTEST_SKIP() << "No local devices available for testing (all devices are remote-only)";
+        }
         init_max_cbs();
     }
 
@@ -151,7 +154,11 @@ protected:
             for (const auto& tunnel : tunnels) {
                 for (const auto chip_id : tunnel) {
                     if (reserved_devices_.contains(chip_id)) {
-                        devices_.push_back(reserved_devices_.at(chip_id));
+                        auto& device = reserved_devices_.at(chip_id);
+                        // Only add devices that have local resources (skip remote-only devices)
+                        if (!device->is_remote_only()) {
+                            devices_.push_back(device);
+                        }
                     }
                 }
                 break;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -699,7 +699,7 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer
 namespace basic_tests {
 namespace dram_tests {
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToDramBank0) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -708,7 +708,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToDramBank0) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllDramBanks) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToAllDramBanks) {
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {
             .num_pages = uint32_t(mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
@@ -720,7 +720,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllDramBanks) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {
@@ -732,7 +732,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRou
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, Sending131072Pages) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, Sending131072Pages) {
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -741,7 +741,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, Sending131072Pages) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestPageLargerThanAndUnalignedToTransferPage) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestPageLargerThanAndUnalignedToTransferPage) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {
@@ -753,7 +753,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestPageLargerThanAndUnalignedToTransf
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -764,7 +764,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestSinglePageLargerThanMaxPrefetchCom
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -775,7 +775,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSizeShardedBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -798,7 +798,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestSinglePageLargerThanMaxPrefetchCom
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
@@ -821,7 +821,8 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
+TEST_F(
+    UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -844,7 +845,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMa
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
@@ -870,7 +871,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -881,7 +882,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestSingleUnalignedPageLargerThanMaxPr
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -892,7 +893,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMa
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
@@ -918,7 +919,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMa
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedSubBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     const uint32_t buffer_size = 20 * page_size;
     const uint32_t region_size = 5 * page_size;
@@ -961,7 +962,9 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeShardedSubBuffer) {
+TEST_F(
+    UnitMeshCQSingleCardSharedBufferFixture,
+    TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeShardedSubBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     const uint32_t buffer_size = 20 * page_size;
     const uint32_t region_size = 5 * page_size;
@@ -1002,7 +1005,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMa
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForDram) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForDram) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
     for (const auto& mesh_device : devices_) {
@@ -1011,7 +1014,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForDram) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForDram2) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -1022,7 +1025,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForDram2) {
 }
 
 // Requires enqueue write buffer
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
@@ -1042,7 +1045,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffe
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -1058,7 +1061,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestIssueMultipleReadWriteCommandsForO
 }
 
 // Test that command queue wraps when buffer available space in completion region is less than a page
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpace) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficientSpace) {
     uint32_t large_page_size = 8192;  // page size for first and third read
     uint32_t small_page_size = 2048;  // page size for second read
 
@@ -1118,7 +1121,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpace
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBuffer) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
@@ -1157,7 +1160,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
@@ -1183,7 +1186,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBuffer) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffset) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
@@ -1207,7 +1210,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadBufferWriteSubBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadBufferWriteSubBuffer) {
     const uint32_t page_size = 128;
     const uint32_t buffer_size = 100 * page_size;
     const uint32_t buffer_region_offset = 50 * page_size;
@@ -1239,7 +1242,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadBufferWriteSubBuffer) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadSubBufferWriteBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferWriteBuffer) {
     const uint32_t page_size = 128;
     const uint32_t buffer_size = 100 * page_size;
     const uint32_t buffer_region_offset = 50 * page_size;
@@ -1268,7 +1271,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadSubBufferWriteBuffer) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadSubBufferInvalidRegion) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferInvalidRegion) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = 100 * page_size;
     const uint32_t buffer_region_offset = 25 * page_size;
@@ -1287,7 +1290,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadSubBufferInvalidRegion) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWriteSubBufferInvalidRegion) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = 100 * page_size;
     const uint32_t buffer_region_offset = 25 * page_size;
@@ -1308,7 +1311,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
 
 // Test that command queue wraps when buffer read needs to be split into multiple enqueue_read_buffer commands and
 // available space in completion region is less than a page
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpace2) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficientSpace2) {
     // Using default 75-25 issue and completion queue split
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
@@ -1684,7 +1687,7 @@ TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanM
 
 namespace l1_tests {
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferForL1) {
     const uint32_t max_buffer_size = 152;
     const std::vector<ShardedSubBufferStressTestConfig>& configs =
         local_test_functions::generate_sharded_sub_buffer_test_configs(max_buffer_size);
@@ -1737,7 +1740,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBufferForL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleNonOverlappingWritesShardedSubBufferForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingWritesShardedSubBufferForL1) {
     const uint32_t page_size = 64;
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = 4 * page_size;
@@ -1798,7 +1801,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleNonOverlappingWritesSharde
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1809,7 +1812,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -1832,7 +1835,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetch
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSingleUnalignedPageLargerThanMaxPrefetchCommandSizeForL1) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1843,7 +1846,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestSingleUnalignedPageLargerThanMaxPr
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1) {
     for (const auto& mesh_device : devices_) {
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -1855,7 +1858,8 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMa
 }
 
 TEST_F(
-    UnitMeshCQSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
+    UnitMeshCQSingleCardSharedBufferFixture,
+    TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     for (const auto& mesh_device : devices_) {
         log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
@@ -1879,7 +1883,7 @@ TEST_F(
 }
 
 TEST_F(
-    UnitMeshCQSingleCardBufferFixture,
+    UnitMeshCQSingleCardSharedBufferFixture,
     TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1ShardedSubBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     const uint32_t buffer_size = 32 * page_size;
@@ -1919,7 +1923,7 @@ TEST_F(
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleNonOverlappingReadsShardedSubBufferForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingReadsShardedSubBufferForL1) {
     const uint32_t page_size = 64;
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = buffer_size / 4;
@@ -1982,7 +1986,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestMultipleNonOverlappingReadsSharded
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBufferMultiplePagesPerShardForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferMultiplePagesPerShardForL1) {
     const uint32_t page_size = 64;
     const uint32_t buffer_size = page_size * 16;
     const uint32_t buffer_region_offset = page_size * 3;
@@ -2017,7 +2021,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteShardedSubBufferMultipleP
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 128 * page_size;
     const BufferRegion region(2 * page_size, 2048);
@@ -2037,7 +2041,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffsetForL1) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 512 * page_size;
     const BufferRegion region(400 * page_size, 2048);
@@ -2057,7 +2061,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetForL1
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToL1Bank0) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
     for (const auto& mesh_device : devices_) {
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
@@ -2065,7 +2069,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToL1Bank0) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllL1Banks) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToAllL1Banks) {
     for (const auto& mesh_device : devices_) {
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
@@ -2078,7 +2082,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllL1Banks) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (const auto& mesh_device : devices_) {
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
@@ -2091,7 +2095,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobi
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForL1) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForL1) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
     for (const auto& mesh_device : devices_) {
@@ -2104,7 +2108,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestNon32BAlignedPageSizeForL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestBackToBackNon32BAlignedPageSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestBackToBackNon32BAlignedPageSize) {
     constexpr BufferType buff_type = BufferType::L1;
 
     for (const auto& mesh_device : devices_) {
@@ -2136,7 +2140,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, TestBackToBackNon32BAlignedPageSize) {
 }
 
 // This case was failing for FD v1.3 design
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestLargeBuffer4096BPageSize) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestLargeBuffer4096BPageSize) {
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {.num_pages = 512, .page_size = 4096, .buftype = BufferType::L1};
 
@@ -2262,7 +2266,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) 
 
 }  // end namespace l1_tests
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, TestNonblockingReads) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNonblockingReads) {
     constexpr BufferType buff_type = BufferType::L1;
 
     for (const auto& mesh_device : devices_) {
@@ -2334,7 +2338,7 @@ namespace stress_tests {
 
 // TODO: Add stress test that vary page size
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
@@ -2345,7 +2349,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsBl
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
@@ -2359,7 +2363,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReadsNo
 }
 
 // TODO: Split this into separate tests
-TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferL1ReadWrites) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, ShardedBufferL1ReadWrites) {
     std::map<std::string, std::vector<std::array<uint32_t, 2>>> test_params;
 
     for (const auto& mesh_device : devices_) {
@@ -2426,7 +2430,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferL1ReadWrites) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferDRAMReadWrites) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, ShardedBufferDRAMReadWrites) {
     for (const auto& mesh_device : devices_) {
         for (const std::array<uint32_t, 2> cores :
              {std::array<uint32_t, 2>{1, 1},
@@ -2486,7 +2490,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferDRAMReadWrites) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferLargeL1ReadWrites) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, ShardedBufferLargeL1ReadWrites) {
     for (const auto& mesh_device : devices_) {
         for (const std::array<uint32_t, 2> cores : {std::array<uint32_t, 2>{1, 1}, std::array<uint32_t, 2>{2, 3}}) {
             for (const std::array<uint32_t, 2> num_pages : {
@@ -2538,7 +2542,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferLargeL1ReadWrites) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferLargeDRAMReadWrites) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, ShardedBufferLargeDRAMReadWrites) {
     for (const auto& mesh_device : devices_) {
         for (const std::array<uint32_t, 2> cores : {std::array<uint32_t, 2>{1, 1}, std::array<uint32_t, 2>{6, 1}}) {
             for (const std::array<uint32_t, 2> num_pages : {
@@ -2590,7 +2594,7 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, ShardedBufferLargeDRAMReadWrites) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardBufferFixture, StressWrapTest) {
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, StressWrapTest) {
     if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
         log_info(tt::LogTest, "cannot run this test on WH B0");
         GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -647,17 +647,17 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_sub_buffer(
 
     for (const uint32_t region_start_page : region_start_pages) {
         const BufferRegion region(region_start_page * page_size, region_num_pages * page_size);
-        for (uint i = 0; i < cqs.size(); i++) {
+        for (auto cq : cqs) {
             distributed::DeviceLocalBufferConfig local_config{
                 .page_size = page_size, .buffer_type = buffer_type, .bottom_up = false};
             auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
 
-            clear_buffer(cqs[i], buffer);
+            clear_buffer(cq, buffer);
             auto src = generate_arange_vector(region.size);
-            EnqueueWriteMeshSubBuffer(cqs[i], buffer, src, region, false);
+            EnqueueWriteMeshSubBuffer(cq, buffer, src, region, false);
 
             vector<uint32_t> result(region.size / sizeof(uint32_t));
-            EnqueueReadMeshSubBuffer(cqs[i], result, buffer, region, true);
+            EnqueueReadMeshSubBuffer(cq, result, buffer, region, true);
             pass &= (src == result);
         }
     }
@@ -677,17 +677,17 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer
     const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_num_pages * page_size};
     const BufferRegion region(region_start_page * page_size, region_num_pages * page_size);
 
-    for (uint i = 0; i < cqs.size(); i++) {
+    for (auto cq : cqs) {
         distributed::DeviceLocalBufferConfig local_config{
             .page_size = page_size, .buffer_type = buffer_type, .bottom_up = false};
         auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
 
-        clear_buffer(cqs[i], buffer);
+        clear_buffer(cq, buffer);
         auto src = generate_arange_vector(region.size);
-        EnqueueWriteMeshSubBuffer(cqs[i], buffer, src, region, false);
+        EnqueueWriteMeshSubBuffer(cq, buffer, src, region, false);
 
         vector<uint32_t> result(region.size / sizeof(uint32_t));
-        EnqueueReadMeshSubBuffer(cqs[i], result, buffer, region, true);
+        EnqueueReadMeshSubBuffer(cq, result, buffer, region, true);
         pass &= (src == result);
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -634,6 +634,66 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(
     return pass;
 }
 
+bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_sub_buffer(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>>& cqs,
+    uint32_t page_size,
+    uint32_t buffer_num_pages,
+    const std::array<uint32_t, 3>& region_start_pages,
+    uint32_t region_num_pages,
+    BufferType buffer_type) {
+    bool pass = true;
+    const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_num_pages * page_size};
+
+    for (const uint32_t region_start_page : region_start_pages) {
+        const BufferRegion region(region_start_page * page_size, region_num_pages * page_size);
+        for (uint i = 0; i < cqs.size(); i++) {
+            distributed::DeviceLocalBufferConfig local_config{
+                .page_size = page_size, .buffer_type = buffer_type, .bottom_up = false};
+            auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
+
+            clear_buffer(cqs[i], buffer);
+            auto src = generate_arange_vector(region.size);
+            EnqueueWriteMeshSubBuffer(cqs[i], buffer, src, region, false);
+
+            vector<uint32_t> result(region.size / sizeof(uint32_t));
+            EnqueueReadMeshSubBuffer(cqs[i], result, buffer, region, true);
+            pass &= (src == result);
+        }
+    }
+
+    return pass;
+}
+
+bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>>& cqs,
+    uint32_t page_size,
+    uint32_t buffer_num_pages,
+    uint32_t region_start_page,
+    uint32_t region_num_pages,
+    BufferType buffer_type) {
+    bool pass = true;
+    const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_num_pages * page_size};
+    const BufferRegion region(region_start_page * page_size, region_num_pages * page_size);
+
+    for (uint i = 0; i < cqs.size(); i++) {
+        distributed::DeviceLocalBufferConfig local_config{
+            .page_size = page_size, .buffer_type = buffer_type, .bottom_up = false};
+        auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
+
+        clear_buffer(cqs[i], buffer);
+        auto src = generate_arange_vector(region.size);
+        EnqueueWriteMeshSubBuffer(cqs[i], buffer, src, region, false);
+
+        vector<uint32_t> result(region.size / sizeof(uint32_t));
+        EnqueueReadMeshSubBuffer(cqs[i], result, buffer, region, true);
+        pass &= (src == result);
+    }
+
+    return pass;
+}
+
 }  // end namespace local_test_functions
 
 namespace basic_tests {
@@ -1319,7 +1379,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
@@ -1337,13 +1398,12 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTw
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
-    // Was a failing case where we used to accidentally program cb num pages to be total
-    // pages instead of cb num pages.
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
@@ -1352,7 +1412,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
@@ -1366,7 +1427,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
@@ -1374,14 +1436,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running On Device {}", device->id());
-        // From stable diffusion read buffer
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
@@ -1399,7 +1461,64 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteComman
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDramWrapsAcrossBanksAndTransactions) {
+    constexpr uint32_t page_size = 200;
+    const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const uint32_t num_banks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
+        const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
+        TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
+
+        distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+        distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+        EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestSubBufferReadCrossesRelayPageBoundary) {
+    constexpr uint32_t relay_page_boundary = 0xFF;
+    constexpr uint32_t page_size = 200;
+    constexpr uint32_t buffer_num_pages = relay_page_boundary + 8;
+    constexpr uint32_t region_num_pages = 4;
+    constexpr std::array<uint32_t, 3> region_start_pages = {
+        relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
+
+    for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
+        distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+        distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+        EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_sub_buffer(
+            mesh_device, cqs, page_size, buffer_num_pages, region_start_pages, region_num_pages, BufferType::DRAM));
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestLargeSubBufferReadPastRebaseBoundary) {
+    constexpr uint32_t relay_page_boundary = 0xFF;
+    constexpr uint32_t page_size = 2048;
+    constexpr uint32_t buffer_num_pages = relay_page_boundary + 128;
+    constexpr uint32_t region_start_page = relay_page_boundary + 1;
+    constexpr uint32_t region_num_pages = 64;
+
+    for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+        distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+        bool pass = local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
+            mesh_device, cqs, page_size, buffer_num_pages, region_start_page, region_num_pages, BufferType::DRAM);
+        EXPECT_TRUE(pass) << "Large sub-buffer read past rebase boundary failed on device " << device->id();
     }
 }
 
@@ -1496,6 +1615,53 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestIssueMultipleReadWriteComma
     vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
     EXPECT_TRUE(
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+}
+
+TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDramWrapsAcrossBanksAndTransactions) {
+    auto mesh_device = this->device_;
+    auto* device = mesh_device->get_devices()[0];
+    constexpr uint32_t page_size = 200;
+    const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    const uint32_t num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
+    const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
+    TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
+
+    distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+    distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+    EXPECT_TRUE(
+        local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+}
+
+TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestSubBufferReadCrossesRelayPageBoundary) {
+    auto mesh_device = this->device_;
+    constexpr uint32_t relay_page_boundary = 0xFF;
+    constexpr uint32_t page_size = 200;
+    constexpr uint32_t buffer_num_pages = relay_page_boundary + 8;
+    constexpr uint32_t region_num_pages = 4;
+    constexpr std::array<uint32_t, 3> region_start_pages = {
+        relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
+
+    distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+    distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_sub_buffer(
+        mesh_device, cqs, page_size, buffer_num_pages, region_start_pages, region_num_pages, BufferType::DRAM));
+}
+
+TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestLargeSubBufferReadPastRebaseBoundary) {
+    auto mesh_device = this->device_;
+    constexpr uint32_t relay_page_boundary = 0xFF;
+    constexpr uint32_t page_size = 2048;
+    constexpr uint32_t buffer_num_pages = relay_page_boundary + 128;
+    constexpr uint32_t region_start_page = relay_page_boundary + 1;
+    constexpr uint32_t region_num_pages = 64;
+
+    distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
+    distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
+        mesh_device, cqs, page_size, buffer_num_pages, region_start_page, region_num_pages, BufferType::DRAM));
 }
 
 TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -298,6 +298,8 @@ TEST_F(UnitMeshCQSingleCardFixture, ActiveEthTestReadWriteMultipleCoresL1) {
     }
 }
 
+// Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
+// forced-active channels 0,1,2,3,15), leaving no idle cores available.
 TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteEntireL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -331,6 +333,8 @@ TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteEntireL1) {
     }
 }
 
+// Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
+// forced-active channels 0,1,2,3,15), leaving no idle cores available.
 TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
     const uint32_t num_elements = 1010;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
@@ -368,6 +372,8 @@ TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
     }
 }
 
+// Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
+// forced-active channels 0,1,2,3,15), leaving no idle cores available.
 TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteMultipleCoresL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -13,7 +13,7 @@
 
 using namespace tt::tt_metal;
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicReadWriteL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadWriteL1) {
     const uint32_t num_elements = 1000;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -42,7 +42,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicReadWriteL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicReadL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadL1) {
     const uint32_t num_elements = 1000;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -69,7 +69,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicReadL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicWriteL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicWriteL1) {
     const uint32_t num_elements = 1000;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -96,7 +96,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestBasicWriteL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestInvalidReadWriteAddressL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestInvalidReadWriteAddressL1) {
     const uint32_t num_elements = 1010;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -127,7 +127,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestInvalidReadWriteAddressL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteMultipleCoresL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteMultipleCoresL1) {
     const DeviceAddr address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     const uint32_t num_elements = 1000;
@@ -171,7 +171,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteMultipleCoresL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteZeroElementsL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteZeroElementsL1) {
     const CoreCoord logical_core = {0, 0};
     const DeviceAddr address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -195,7 +195,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteZeroElementsL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteEntireL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteEntireL1) {
     const CoreCoord logical_core = {0, 0};
     const DeviceAddr address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -222,7 +222,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestReadWriteEntireL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, ActiveEthTestReadWriteEntireL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, ActiveEthTestReadWriteEntireL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     const uint32_t size =
@@ -254,7 +254,7 @@ TEST_F(UnitMeshCQSingleCardFixture, ActiveEthTestReadWriteEntireL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, ActiveEthTestReadWriteMultipleCoresL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, ActiveEthTestReadWriteMultipleCoresL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     const uint32_t num_elements = 1000;
@@ -300,7 +300,7 @@ TEST_F(UnitMeshCQSingleCardFixture, ActiveEthTestReadWriteMultipleCoresL1) {
 
 // Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
 // forced-active channels 0,1,2,3,15), leaving no idle cores available.
-TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteEntireL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestReadWriteEntireL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     const uint32_t size =
@@ -335,7 +335,7 @@ TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteEntireL1) {
 
 // Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
 // forced-active channels 0,1,2,3,15), leaving no idle cores available.
-TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestInvalidReadWriteAddressL1) {
     const uint32_t num_elements = 1010;
     const std::vector<uint32_t> src_data = generate_arange_vector(num_elements * sizeof(uint32_t));
 
@@ -374,7 +374,7 @@ TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestInvalidReadWriteAddressL1) {
 
 // Skips on Galaxy MMIO: all 16 ethernet cores are active (used for tunnel routing and
 // forced-active channels 0,1,2,3,15), leaving no idle cores available.
-TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteMultipleCoresL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, IdleEthTestReadWriteMultipleCoresL1) {
     const DeviceAddr address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     const uint32_t num_elements = 1000;
@@ -428,7 +428,7 @@ TEST_F(UnitMeshCQSingleCardFixture, IdleEthTestReadWriteMultipleCoresL1) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TestInvalidReadWriteAddressDRAM) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TestInvalidReadWriteAddressDRAM) {
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
         auto* device = mesh_device->get_devices()[0];
@@ -460,7 +460,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TestInvalidReadWriteAddressDRAM) {
     }
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, TestReadWriteMultipleCoresDRAM) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TestReadWriteMultipleCoresDRAM) {
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -89,7 +89,7 @@ bool RunCrossCqReadWriteWithWaitForEvent(
 bool RunBurstWritesThenSingleCrossCqEvent(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const distributed::MeshCoordinate& zero_coord,
-    TestBufferConfig config,
+    const TestBufferConfig& config,
     size_t num_buffers) {
     vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
         mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
@@ -129,7 +129,7 @@ bool RunBurstWritesThenSingleCrossCqEvent(
 bool RunDeviceOnlyEventChainWithPerIterationValidation(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const distributed::MeshCoordinate& zero_coord,
-    TestBufferConfig config,
+    const TestBufferConfig& config,
     size_t num_iterations) {
     vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
         mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -38,6 +38,182 @@ void FinishAllCqs(vector<std::reference_wrapper<distributed::MeshCommandQueue>>&
         distributed::Finish(cq);
     }
 }
+
+bool RunCrossCqReadWriteWithWaitForEvent(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const distributed::MeshCoordinate& zero_coord,
+    TestBufferConfig config,
+    size_t num_buffers_per_cq,
+    bool vary_buffer_sizes,
+    bool notify_host) {
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+        mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+    bool pass = true;
+
+    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+        if (vary_buffer_sizes && buf_idx > 0 && ((buf_idx % 10) == 0)) {
+            config.page_size *= 2;
+            config.num_pages *= 2;
+        }
+
+        vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
+        vector<vector<uint32_t>> srcs;
+        const size_t buf_size = config.num_pages * config.page_size;
+
+        for (uint i = 0; i < cqs.size(); i++) {
+            const uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+            auto& cq_write = cqs[i];
+            auto& cq_read = cqs[(i + 1) % cqs.size()];
+            vector<uint32_t> result;
+
+            distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+            distributed::DeviceLocalBufferConfig device_local_config{
+                .page_size = config.page_size, .buffer_type = config.buftype};
+            buffers.push_back(
+                distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
+            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+
+            distributed::WriteShard(cq_write, buffers[i], srcs[i], zero_coord, false);
+            auto event =
+                notify_host ? cq_write.get().enqueue_record_event_to_host() : cq_write.get().enqueue_record_event();
+            cq_read.get().enqueue_wait_for_event(event);
+            distributed::ReadShard(cq_read, result, buffers[i], zero_coord, true);
+            pass &= (srcs[i] == result);
+        }
+    }
+
+    FinishAllCqs(cqs);
+    return pass;
+}
+
+bool RunBurstWritesThenSingleCrossCqEvent(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const distributed::MeshCoordinate& zero_coord,
+    TestBufferConfig config,
+    size_t num_buffers) {
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+        mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+    auto& cq_write = cqs[0];
+    auto& cq_read = cqs[1];
+    bool pass = true;
+    const size_t buf_size = config.num_pages * config.page_size;
+
+    vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
+    vector<vector<uint32_t>> srcs;
+    buffers.reserve(num_buffers);
+    srcs.reserve(num_buffers);
+
+    for (size_t buf_idx = 0; buf_idx < num_buffers; buf_idx++) {
+        distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+        distributed::DeviceLocalBufferConfig device_local_config{
+            .page_size = config.page_size, .buffer_type = config.buftype};
+        buffers.push_back(
+            distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
+        srcs.push_back(generate_arange_vector(buffers.back()->size(), buf_idx * 100));
+        distributed::WriteShard(cq_write, buffers.back(), srcs.back(), zero_coord, false);
+    }
+
+    auto event = cq_write.get().enqueue_record_event();
+    cq_read.get().enqueue_wait_for_event(event);
+
+    for (size_t buf_idx = 0; buf_idx < num_buffers; buf_idx++) {
+        vector<uint32_t> result;
+        distributed::ReadShard(cq_read, result, buffers[buf_idx], zero_coord, true);
+        pass &= (srcs[buf_idx] == result);
+    }
+
+    FinishAllCqs(cqs);
+    return pass;
+}
+
+bool RunDeviceOnlyEventChainWithPerIterationValidation(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const distributed::MeshCoordinate& zero_coord,
+    TestBufferConfig config,
+    size_t num_iterations) {
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+        mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+    bool pass = true;
+    const size_t buf_size = config.num_pages * config.page_size;
+
+    distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig device_local_config{
+        .page_size = config.page_size, .buffer_type = config.buftype};
+    auto buffer = distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get());
+
+    for (size_t iter = 0; iter < num_iterations; iter++) {
+        auto& cq_write = cqs[iter % 2];
+        auto& cq_read = cqs[(iter + 1) % 2];
+
+        auto src = generate_arange_vector(buf_size, iter * 1000);
+        distributed::WriteShard(cq_write, buffer, src, zero_coord, false);
+        auto event = cq_write.get().enqueue_record_event();
+        cq_read.get().enqueue_wait_for_event(event);
+
+        vector<uint32_t> result;
+        distributed::ReadShard(cq_read, result, buffer, zero_coord, true);
+        bool iter_pass = (src == result);
+        if (!iter_pass) {
+            log_warning(
+                tt::LogTest,
+                "Device-only event chain iteration {} FAILED (write CQ={}, read CQ={})",
+                iter,
+                cq_write.get().id(),
+                cq_read.get().id());
+        }
+        pass &= iter_pass;
+    }
+
+    FinishAllCqs(cqs);
+    return pass;
+}
+
+bool RunHeavyBurstWritesThenDeviceOnlyEvent(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const distributed::MeshCoordinate& zero_coord,
+    size_t num_buffers) {
+    vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
+        mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
+    auto& cq_write = cqs[0];
+    auto& cq_read = cqs[1];
+    bool pass = true;
+
+    vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
+    vector<vector<uint32_t>> srcs;
+    buffers.reserve(num_buffers);
+    srcs.reserve(num_buffers);
+
+    constexpr uint32_t page_size = 2048;
+    constexpr uint32_t num_pages = 64;
+    const size_t buf_size = num_pages * page_size;
+
+    for (size_t buf_idx = 0; buf_idx < num_buffers; buf_idx++) {
+        distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
+        distributed::DeviceLocalBufferConfig device_local_config{
+            .page_size = page_size, .buffer_type = BufferType::DRAM};
+        buffers.push_back(
+            distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
+        srcs.push_back(generate_arange_vector(buffers.back()->size(), buf_idx * 10000));
+        distributed::WriteShard(cq_write, buffers.back(), srcs.back(), zero_coord, false);
+    }
+
+    auto event = cq_write.get().enqueue_record_event();
+    cq_read.get().enqueue_wait_for_event(event);
+
+    for (size_t buf_idx = 0; buf_idx < num_buffers; buf_idx++) {
+        vector<uint32_t> result;
+        distributed::ReadShard(cq_read, result, buffers[buf_idx], zero_coord, true);
+        bool buf_pass = (srcs[buf_idx] == result);
+        if (!buf_pass) {
+            log_warning(tt::LogTest, "Heavy burst buffer {} mismatch after device-only event", buf_idx);
+        }
+        pass &= buf_pass;
+    }
+
+    FinishAllCqs(cqs);
+    return pass;
+}
+
 }  // namespace local_test_functions
 
 namespace basic_tests {
@@ -265,73 +441,86 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // Ensure read back data is correct, data is different for each write.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
-        vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
-            mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
-        vector<uint32_t> cmds_issued_per_cq = {0, 0};
-
-        size_t num_buffers_per_cq = 50;
-        bool pass = true;
-
         auto start = std::chrono::system_clock::now();
-
-        for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
-            // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
-            if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
-                config.page_size *= 2;
-                config.num_pages *= 2;
-            }
-
-            vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
-            vector<vector<uint32_t>> srcs;
-            size_t buf_size = config.num_pages * config.page_size;
-
-            for (uint i = 0; i < cqs.size(); i++) {
-                uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-                auto& cq_write = cqs[i];
-                auto& cq_read = cqs[(i + 1) % cqs.size()];
-                vector<uint32_t> result;
-
-                // Create MeshBuffer with proper config
-                distributed::ReplicatedBufferConfig global_buffer_config{.size = buf_size};
-                distributed::DeviceLocalBufferConfig device_local_config{
-                    .page_size = config.page_size, .buffer_type = config.buftype};
-                buffers.push_back(
-                    distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
-                srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
-
-                // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
-                log_debug(
-                    tt::LogTest,
-                    "buf_idx: {} Doing Write (page_size: {} num_pages: {}) to cq_id: {}",
-                    buf_idx,
-                    config.page_size,
-                    config.num_pages,
-                    cq_write.get().id());
-
-                distributed::WriteShard(cq_write, buffers[i], srcs[i], zero_coord_, false);
-                auto event = cq_write.get().enqueue_record_event();
-                cq_read.get().enqueue_wait_for_event(event);
-                distributed::ReadShard(cq_read, result, buffers[i], zero_coord_, true);
-                bool local_pass = (srcs[i] == result);
-                log_debug(
-                    tt::LogTest,
-                    "Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}",
-                    buf_idx,
-                    i,
-                    local_pass,
-                    srcs[i],
-                    result);
-                pass &= local_pass;
-            }
-        }
-
-        local_test_functions::FinishAllCqs(cqs);
+        bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
+            mesh_device,
+            zero_coord_,
+            config,
+            /*num_buffers_per_cq=*/50,
+            /*vary_buffer_sizes=*/true,
+            /*notify_host=*/false);
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
-        EXPECT_TRUE(pass);
+        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass) << "Cross-CQ event read/write failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsDeterministic) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
+        bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
+            mesh_device,
+            zero_coord_,
+            config,
+            /*num_buffers_per_cq=*/8,
+            /*vary_buffer_sizes=*/false,
+            /*notify_host=*/false);
+        EXPECT_TRUE(pass) << "Deterministic cross-CQ event failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsHostVisibleControl) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
+        bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
+            mesh_device,
+            zero_coord_,
+            config,
+            /*num_buffers_per_cq=*/50,
+            /*vary_buffer_sizes=*/true,
+            /*notify_host=*/true);
+        EXPECT_TRUE(pass) << "Host-visible cross-CQ event failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCrossCqEvent) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
+        bool pass = local_test_functions::RunBurstWritesThenSingleCrossCqEvent(
+            mesh_device, zero_coord_, config, /*num_buffers=*/6);
+        EXPECT_TRUE(pass) << "Burst writes + event ordering failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWithPerIterationValidation) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
+        bool pass = local_test_functions::RunDeviceOnlyEventChainWithPerIterationValidation(
+            mesh_device, zero_coord_, config, /*num_iterations=*/16);
+        EXPECT_TRUE(pass) << "Device-only event chain failed on device " << device->id();
+    }
+}
+
+TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDeviceOnlyEvent) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
+        bool pass =
+            local_test_functions::RunHeavyBurstWritesThenDeviceOnlyEvent(mesh_device, zero_coord_, /*num_buffers=*/12);
+        EXPECT_TRUE(pass) << "Heavy burst event ordering failed on device " << device->id();
     }
 }
 
@@ -340,6 +529,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // write and write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
@@ -454,9 +645,9 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
 
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "PingPong event chain failed on device " << device->id();
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -154,14 +154,14 @@ void run_eltwise_binary_test(
 
 }  // namespace
 
-TEST_F(UnitMeshCQSingleCardFixture, EltwiseBinaryAdd) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, EltwiseBinaryAdd) {
     run_eltwise_binary_test(devices_[0], devices_[0]->mesh_command_queue(), static_cast<int>(EltwiseOp::ADD));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, EltwiseBinarySub) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, EltwiseBinarySub) {
     run_eltwise_binary_test(devices_[0], devices_[0]->mesh_command_queue(), static_cast<int>(EltwiseOp::SUB));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, EltwiseBinaryMul) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, EltwiseBinaryMul) {
     run_eltwise_binary_test(devices_[0], devices_[0]->mesh_command_queue(), static_cast<int>(EltwiseOp::MUL));
 }

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -498,37 +498,37 @@ bool test_interleaved_l1_datacopy(
 
 }  // namespace
 
-TEST_F(UnitMeshCQSingleCardFixture, WriteInterleavedSticksAndReadBack) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, WriteInterleavedSticksAndReadBack) {
     ASSERT_TRUE(test_write_interleaved_sticks_and_then_read_interleaved_sticks(
         devices_[0], devices_[0]->mesh_command_queue()));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedStickReaderSingleBankTilizedWriter) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedStickReaderSingleBankTilizedWriter) {
     ASSERT_TRUE(interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(
         devices_[0], devices_[0]->mesh_command_queue()));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedTilizedReaderInterleavedStickWriter) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedTilizedReaderInterleavedStickWriter) {
     ASSERT_TRUE(interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(
         devices_[0], devices_[0]->mesh_command_queue()));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedL1DatacopyL1ToL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedL1DatacopyL1ToL1) {
     ASSERT_TRUE(
         (test_interleaved_l1_datacopy<true, true>(devices_[0], devices_[0]->mesh_command_queue())));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedL1DatacopyDramToL1) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedL1DatacopyDramToL1) {
     ASSERT_TRUE(
         (test_interleaved_l1_datacopy<false, true>(devices_[0], devices_[0]->mesh_command_queue())));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedL1DatacopyL1ToDram) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedL1DatacopyL1ToDram) {
     ASSERT_TRUE(
         (test_interleaved_l1_datacopy<true, false>(devices_[0], devices_[0]->mesh_command_queue())));
 }
 
-TEST_F(UnitMeshCQSingleCardFixture, InterleavedL1DatacopyDramToDram) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, InterleavedL1DatacopyDramToDram) {
     ASSERT_TRUE(
         (test_interleaved_l1_datacopy<false, false>(devices_[0], devices_[0]->mesh_command_queue())));
 }

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -282,7 +282,7 @@ static bool test_sdpa_reduce_c(
 }
 
 // NIGHTLY_ prefix ensures this test only runs in nightly CI pipelines
-TEST_F(UnitMeshCQSingleCardFixture, NIGHTLY_SdpaReduceC) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, NIGHTLY_SdpaReduceC) {
     bool pass = true;
 
     /**

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -202,6 +202,10 @@ public:
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
     bool is_mmio_capable() const override;
+    // Returns true if this MeshDevice contains only remote devices (no local devices on this host).
+    // Remote-only MeshDevices cannot perform operations requiring local device access like
+    // allocator(), create_sub_device_manager(), etc. Use this to check before calling such methods.
+    bool is_remote_only() const;
     std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
 
     // A MeshDevice is a collection of devices arranged in a 2D grid.

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -44,7 +44,10 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     TT_FATAL(
         !fast_dispatch_enabled_,
         "Fast Dispatch can only be manually enabled when running the workload with Slow Dispatch mode.");
-    TT_FATAL(num_fd_inits_ == 0, "Fast Dispatch can only be manually initialized and torn down once.");
+    TT_FATAL(
+        num_fd_inits_ == 0,
+        "Fast Dispatch is already manually initialized. Terminate the current manual Fast Dispatch session before "
+        "initializing another one.");
     TT_FATAL(
         cluster.is_ubb_galaxy() || cluster.arch() == tt::ARCH::BLACKHOLE,
         "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.");
@@ -92,7 +95,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     }
 
     TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
-    TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch can only be manually terminated and torn down once.");
+    TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch termination requires exactly one active manual Fast Dispatch session.");
 
     ContextId context_id = extract_context_id(mesh_device);
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
@@ -124,7 +127,8 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     fast_dispatch_enabled_ = false;
 
     // Disable Fast Dispatch and reinitialize dispatch managers to pick up SD core descriptor
-    MetalContext::instance(context_id).set_fast_dispatch_mode(false);
+    MetalContext::instance().set_fast_dispatch_mode(false);
+    num_fd_inits_--;
 }
 
 void DispatchContext::enable_asynchronous_slow_dispatch(distributed::MeshDevice* mesh_device) {

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -127,7 +127,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     fast_dispatch_enabled_ = false;
 
     // Disable Fast Dispatch and reinitialize dispatch managers to pick up SD core descriptor
-    MetalContext::instance().set_fast_dispatch_mode(false);
+    MetalContext::instance(context_id).set_fast_dispatch_mode(false);
     num_fd_inits_--;
 }
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -836,11 +836,9 @@ void FDMeshCommandQueue::read_completion_queue() {
             if (num_outstanding_reads_ == 0) {
                 reads_processed_cv_.notify_one();
             }
-        } catch (const std::runtime_error& e) {
-            // Just to clarify, this is a weird case and it is an unrecoverable error.
-            // If we are here, its likely the device is hung, meaning that the whole program is stuck.
-            // We don't have a recovery mechanism for this, so we just need to clean up the state and let the main
-            // thread handle it.
+        } catch (const std::exception&) {
+            // Unrecoverable error (device hung, timeout, or other exception). Clean up state and let the main
+            // thread handle it via the stored exception pointer.
             {
                 std::lock_guard<std::mutex> exception_lock(exception_mutex_);
                 thread_exception_ptr_ = std::current_exception();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1011,6 +1011,7 @@ void MeshDeviceImpl::load_sub_device_manager(SubDeviceManagerId sub_device_manag
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }
 void MeshDeviceImpl::clear_loaded_sub_device_manager() {
+    auto lock = lock_api();
     validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->clear_loaded_sub_device_manager();
 }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -237,6 +237,12 @@ bool MeshDeviceImpl::is_initialized() const {
         this->get_devices(), [](const auto* device) { return device->is_initialized(); });
 }
 
+bool MeshDeviceImpl::is_remote_only() const {
+    // A MeshDevice is remote-only if it has been initialized but has no local devices.
+    // This happens when the mesh contains only devices on remote hosts in a multi-host setup.
+    return is_internal_state_initialized && view_->get_devices().empty();
+}
+
 uint32_t MeshDeviceImpl::l1_size_per_core() const {
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->l1_size_per_core(); });
@@ -968,26 +974,42 @@ void MeshDeviceImpl::disable_and_clear_program_cache() {
 
 size_t MeshDeviceImpl::num_program_cache_entries() { return program_cache_->num_entries(); }
 
+void MeshDeviceImpl::validate_sub_device_manager_tracker() const {
+    if (!sub_device_manager_tracker_) {
+        TT_THROW(
+            "SubDeviceManagerTracker is not initialized on MeshDevice {}. "
+            "This MeshDevice contains only remote devices (no local devices on this host). "
+            "Operations requiring local device access cannot be performed on remote-only MeshDevices. "
+            "Use is_remote_only() to check before calling this method.",
+            id());
+    }
+}
+
 SubDeviceManagerId MeshDeviceImpl::create_sub_device_manager(
     std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) {
     auto lock = lock_api();
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 
 SubDeviceManagerId MeshDeviceImpl::create_sub_device_manager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
     auto lock = lock_api();
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
 }
 void MeshDeviceImpl::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     auto lock = lock_api();
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->remove_sub_device_manager(sub_device_manager_id);
 }
 void MeshDeviceImpl::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     auto lock = lock_api();
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
 }
 void MeshDeviceImpl::clear_loaded_sub_device_manager() {
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->clear_loaded_sub_device_manager();
 }
 
@@ -1079,10 +1101,12 @@ uint32_t MeshDeviceImpl::num_virtual_eth_cores(SubDeviceId sub_device_id) {
 
 // Core and worker management methods (These are OK)
 CoreRangeSet MeshDeviceImpl::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).cores(core_type);
 }
 
 uint32_t MeshDeviceImpl::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()
         ->sub_device(sub_device_id)
         .impl()
@@ -1140,6 +1164,7 @@ SystemMemoryManager& MeshDeviceImpl::sysmem_manager() {
 void MeshDeviceImpl::release_mesh_trace(const MeshTraceId& trace_id) {
     TracyTTMetalReleaseMeshTrace(this->get_device_ids(), *trace_id);
 
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->get_active_sub_device_manager()->release_trace(trace_id);
 
     // Only enable allocations once all captured traces are released
@@ -1149,6 +1174,7 @@ void MeshDeviceImpl::release_mesh_trace(const MeshTraceId& trace_id) {
 }
 
 std::shared_ptr<MeshTraceBuffer> MeshDeviceImpl::get_mesh_trace(const MeshTraceId& trace_id) {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_trace(trace_id);
 }
 
@@ -1339,12 +1365,15 @@ HalMemType MeshDeviceImpl::get_mem_type_of_core(CoreCoord virtual_core) const {
 
 // Methods for SubDevice Management
 bool MeshDeviceImpl::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->has_noc_mcast_txns(sub_device_id);
 }
 uint8_t MeshDeviceImpl::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
 }
 uint8_t MeshDeviceImpl::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+    validate_sub_device_manager_tracker();
     if (unicast_data) {
         return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
             sub_device_id);
@@ -1352,9 +1381,11 @@ uint8_t MeshDeviceImpl::noc_data_start_index(SubDeviceId sub_device_id, bool uni
     return 0;
 }
 SubDeviceManagerId MeshDeviceImpl::get_active_sub_device_manager_id() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->id();
 }
 SubDeviceManagerId MeshDeviceImpl::get_default_sub_device_manager_id() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_default_sub_device_manager()->id();
 }
 CoreCoord MeshDeviceImpl::virtual_program_dispatch_core(uint8_t cq_id) const {
@@ -1362,19 +1393,24 @@ CoreCoord MeshDeviceImpl::virtual_program_dispatch_core(uint8_t cq_id) const {
         this->get_devices(), [cq_id](const auto* device) { return device->virtual_program_dispatch_core(cq_id); });
 }
 const std::vector<SubDeviceId>& MeshDeviceImpl::get_sub_device_ids() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_ids();
 }
 const std::vector<SubDeviceId>& MeshDeviceImpl::get_sub_device_stall_group() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_stall_group();
 }
 void MeshDeviceImpl::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->get_active_sub_device_manager()->set_sub_device_stall_group(sub_device_ids);
 }
 void MeshDeviceImpl::reset_sub_device_stall_group() {
+    validate_sub_device_manager_tracker();
     sub_device_manager_tracker_->get_active_sub_device_manager()->reset_sub_device_stall_group();
 }
 
 uint32_t MeshDeviceImpl::num_sub_devices() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices();
 }
 
@@ -1416,21 +1452,25 @@ void MeshDeviceImpl::quiesce_devices() {
 
 // Allocator methods
 std::optional<DeviceAddr> MeshDeviceImpl::lowest_occupied_compute_l1_address() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address();
 }
 
 std::optional<DeviceAddr> MeshDeviceImpl::lowest_occupied_compute_l1_address(
     tt::stl::Span<const SubDeviceId> sub_device_ids) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->lowest_occupied_compute_l1_address(sub_device_ids);
 }
 
 const std::unique_ptr<AllocatorImpl>& MeshDeviceImpl::allocator_impl() const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_default_sub_device_manager()->allocator(SubDeviceId{0});
 }
 
 const std::unique_ptr<Allocator>& MeshDeviceImpl::allocator() const { return this->allocator_impl()->view(); }
 
 const std::unique_ptr<AllocatorImpl>& MeshDeviceImpl::allocator_impl(SubDeviceId sub_device_id) const {
+    validate_sub_device_manager_tracker();
     return sub_device_manager_tracker_->get_active_sub_device_manager()->allocator(sub_device_id);
 }
 
@@ -1457,6 +1497,7 @@ int MeshDevice::id() const { return pimpl_->id(); }
 ChipId MeshDevice::build_id() const { return pimpl_->build_id(); }
 uint8_t MeshDevice::num_hw_cqs() const { return pimpl_->num_hw_cqs(); }
 bool MeshDevice::is_initialized() const { return pimpl_->is_initialized(); }
+bool MeshDevice::is_remote_only() const { return pimpl_->is_remote_only(); }
 int MeshDevice::num_dram_channels() const { return pimpl_->num_dram_channels(); }
 uint32_t MeshDevice::l1_size_per_core() const { return pimpl_->l1_size_per_core(); }
 uint32_t MeshDevice::dram_size_per_channel() const { return pimpl_->dram_size_per_channel(); }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -240,6 +240,8 @@ bool MeshDeviceImpl::is_initialized() const {
 bool MeshDeviceImpl::is_remote_only() const {
     // A MeshDevice is remote-only if it has been initialized but has no local devices.
     // This happens when the mesh contains only devices on remote hosts in a multi-host setup.
+    // view_ is guaranteed non-null after construction (all ctors require a MeshDeviceView).
+    TT_FATAL(view_ != nullptr, "MeshDeviceImpl::is_remote_only() called before view_ is initialized");
     return is_internal_state_initialized && view_->get_devices().empty();
 }
 

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -177,9 +177,6 @@ private:
     // Active distributed context used by mesh command queues (split from distributed_context_).
     std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
 
-    // Throws TT_THROW if sub_device_manager_tracker_ is null (remote-only device)
-    void validate_sub_device_manager_tracker() const;
-
     friend class ::tt::tt_metal::experimental::DispatchContext;
 
 public:

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -168,10 +168,17 @@ private:
 
     std::lock_guard<std::mutex> lock_api() { return std::lock_guard<std::mutex>(api_mutex_); }
 
+    // Validates that the sub_device_manager_tracker_ is initialized before accessing it.
+    // Throws if the tracker is null (e.g., on remote-only MeshDevices).
+    void validate_sub_device_manager_tracker() const;
+
     // Distributed context used to synchronize operations done by all ranks on the given mesh device.
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
     // Active distributed context used by mesh command queues (split from distributed_context_).
     std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
+
+    // Throws TT_THROW if sub_device_manager_tracker_ is null (remote-only device)
+    void validate_sub_device_manager_tracker() const;
 
     friend class ::tt::tt_metal::experimental::DispatchContext;
 
@@ -307,6 +314,10 @@ public:
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
     bool is_mmio_capable() const override;
+    // Returns true if this MeshDevice contains only remote devices (no local devices on this host).
+    // Remote-only MeshDevices cannot perform operations requiring local device access like
+    // allocator(), create_sub_device_manager(), etc. Use this to check before calling such methods.
+    bool is_remote_only() const;
     std::shared_ptr<distributed::MeshDevice> get_mesh_device() override;
 
     // A MeshDevice is a collection of devices arranged in a 2D grid.

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -701,8 +701,9 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         initializers_[ProfilerInitializer::key]->teardown(init_done_);
     }
 
-    TT_ASSERT(init_done_.contains(CommandQueueInitializer::key));
-    initializers_[CommandQueueInitializer::key]->teardown(init_done_);
+    if (init_done_.contains(CommandQueueInitializer::key)) {
+        initializers_[CommandQueueInitializer::key]->teardown(init_done_);
+    }
 
     TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
 

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -684,24 +684,40 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         mmio_devices_to_close.insert(mmio_device_id);
     }
 
-    // Order matters
-    TT_ASSERT(init_done_.contains(DispatchKernelInitializer::key));
-    initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
+    // Teardown in reverse initialization order.  Dispatch/Fabric/Profiler are
+    // conditional because ScopedDevices is created with
+    // initialize_fabric_and_dispatch_fw=false and the actual init happens later
+    // in create_unit_meshes.  If an exception interrupts that second phase,
+    // cleanup must still succeed for the components that *were* initialized.
+    if (init_done_.contains(DispatchKernelInitializer::key)) {
+        initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
+    }
 
-    TT_ASSERT(init_done_.contains(FabricFirmwareInitializer::key));
-    initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
+    if (init_done_.contains(FabricFirmwareInitializer::key)) {
+        initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
+    }
 
-    TT_ASSERT(init_done_.contains(ProfilerInitializer::key));
-    initializers_[ProfilerInitializer::key]->teardown(init_done_);
+    if (init_done_.contains(ProfilerInitializer::key)) {
+        initializers_[ProfilerInitializer::key]->teardown(init_done_);
+    }
 
     TT_ASSERT(init_done_.contains(CommandQueueInitializer::key));
     initializers_[CommandQueueInitializer::key]->teardown(init_done_);
 
     TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
-    initializers_[DispatchKernelInitializer::key]->post_teardown();
-    initializers_[FabricFirmwareInitializer::key]->post_teardown();
-    initializers_[ProfilerInitializer::key]->post_teardown();
-    initializers_[CommandQueueInitializer::key]->post_teardown();
+
+    if (initializers_.contains(DispatchKernelInitializer::key)) {
+        initializers_[DispatchKernelInitializer::key]->post_teardown();
+    }
+    if (initializers_.contains(FabricFirmwareInitializer::key)) {
+        initializers_[FabricFirmwareInitializer::key]->post_teardown();
+    }
+    if (initializers_.contains(ProfilerInitializer::key)) {
+        initializers_[ProfilerInitializer::key]->post_teardown();
+    }
+    if (initializers_.contains(CommandQueueInitializer::key)) {
+        initializers_[CommandQueueInitializer::key]->post_teardown();
+    }
 
     bool pass = true;
     for (const auto& dev_id : devices_to_close) {

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -60,7 +60,7 @@ void FabricFirmwareInitializer::configure() {
     if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
         wait_for_fabric_router_sync(get_fabric_router_sync_timeout_ms());
     }
-    initialized_ = true;
+    initialized_.test_and_set();
 }
 
 void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& init_done) {
@@ -74,7 +74,7 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
     }
     if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
         devices_.clear();
-        initialized_ = false;
+        initialized_.clear();
         init_done.erase(key);
         return;
     }
@@ -82,7 +82,7 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
     tt_fabric::FabricConfig fabric_config = descriptor_->fabric_config();
     if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
         devices_.clear();
-        initialized_ = false;
+        initialized_.clear();
         init_done.erase(key);
         return;
     }
@@ -133,7 +133,7 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
     }
 
     devices_.clear();
-    initialized_ = false;
+    initialized_.clear();
     init_done.erase(key);
 }
 
@@ -142,7 +142,7 @@ void FabricFirmwareInitializer::post_teardown() {
     descriptor_->metal_context().set_fabric_config(tt::tt_fabric::FabricConfig::DISABLED);
 }
 
-bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }
+bool FabricFirmwareInitializer::is_initialized() const { return initialized_.test(); }
 
 void FabricFirmwareInitializer::compile_and_configure_fabric() {
     std::vector<std::shared_future<Device*>> events;
@@ -162,12 +162,15 @@ void FabricFirmwareInitializer::compile_and_configure_fabric() {
         return;
     }
 
+    size_t configured_count = 0;
     for (const auto& event : events) {
         auto* dev = event.get();
         if (dev) {
             dev->configure_fabric();
+            configured_count++;
         }
     }
+    log_info(tt::LogMetal, "Fabric initialized on {} devices", configured_count);
 }
 
 void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms) const {

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -42,7 +42,7 @@ private:
 
     tt::tt_fabric::ControlPlane& control_plane_;
     std::vector<Device*> devices_;
-    std::atomic_flag initialized_ = ATOMIC_FLAG_INIT;
+    std::atomic_flag initialized_ = {};
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "device/device_impl.hpp"
 #include "firmware_initializer.hpp"
 
@@ -40,7 +42,7 @@ private:
 
     tt::tt_fabric::ControlPlane& control_plane_;
     std::vector<Device*> devices_;
-    bool initialized_ = false;
+    std::atomic_flag initialized_ = ATOMIC_FLAG_INIT;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -42,7 +42,7 @@ private:
 
     tt::tt_fabric::ControlPlane& control_plane_;
     std::vector<Device*> devices_;
-    std::atomic_flag initialized_ = {};
+    std::atomic_flag initialized_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -67,8 +67,11 @@ void issue_record_event_commands(
 
     // Calculate the actual command size
     tt::tt_metal::DeviceCommandCalculator calculator;
-    for (int i = 0; i < num_worker_counters; ++i) {
+    for (uint32_t i = 0; i + 1 < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
+    }
+    if (num_worker_counters > 0) {
+        calculator.add_dispatch_wait_with_prefetch_stall();
     }
 
     calculator.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
@@ -91,15 +94,24 @@ void issue_record_event_commands(
         // recording an event does not have any side-effects on the dispatch completion count
         // hence clear_count is set to false, i.e. the number of workers on the dispatcher is
         // not reset
-        // We only need the write barrier for the last wait cmd.
-        /* write_barrier ensures that all writes initiated by the dispatcher are
-                                        flushed before the event is recorded */
-        command_sequence.add_dispatch_wait(
-            CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | (clear_count ? CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM : 0) |
-                ((i == num_worker_counters - 1) ? CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER : 0),
-            0,
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
-            expected_num_workers_completed[offset_index]);
+        // The final wait must also stall prefetch so mesh-local events cannot be published before prior relay traffic
+        // has drained through the dispatcher.
+        const uint32_t wait_flags = CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM |
+                                    (clear_count ? CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM : 0) |
+                                    ((i == num_worker_counters - 1) ? CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER : 0);
+        if (i == num_worker_counters - 1) {
+            command_sequence.add_dispatch_wait_with_prefetch_stall(
+                wait_flags,
+                0,
+                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                expected_num_workers_completed[offset_index]);
+        } else {
+            command_sequence.add_dispatch_wait(
+                wait_flags,
+                0,
+                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                expected_num_workers_completed[offset_index]);
+        }
     }
 
     std::vector<CQDispatchWritePackedUnicastSubCmd> unicast_sub_cmds(num_command_queues);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Galaxy unit tests pipeline was failing. 

> The GTest filter CommandQueueSingleCard*Fixture.* has matched zero tests since commit dc02138a594 (Sept 17, 2025), which renamed all CommandQueueSingleCard*Fixture classes to UnitMeshCQSingleCard*Fixture as part of a full migration from the legacy DispatchFixture API to the Mesh API. The workflow was never updated to match.

> The filter should be UnitMeshCQSingleCard*Fixture.*, which matches the three current fixture classes:

> UnitMeshCQSingleCardFixture
UnitMeshCQSingleCardProgramFixture
UnitMeshCQSingleCardTraceFixture
This affects both origin/main (which also has the stale filter) and this branch. I've updated the filter in this branch's workflow file.

### What's changed
* Galaxy unit tests actually runs tests again. The stale test filter was replaced with the current filter name. Failing test cases were made to not fail.
* Grouped unit tests into batches that don't require full setup and teardown. This saves several minutes of runtime and keeps the unit tests under the 10 minute timeout (7.5min)
* Added a test grouping helper that posts test group pass/fail and provides a dropdown to show/hide test output.
* Added new tests Opus identified as behavioral contracts from the tech report docs that were not exercised in the code.
* Dispatch potential bug fix: The final wait must also stall prefetch so mesh-local events cannot be published before prior relay traffic has drained through the dispatcher.
* Fast dispatch one-shot restriction relaxed 
* Device manager could have incomplete teardown if setup was incomplete tt_metal/impl/device/device_manager.cpp. Made the teardown more thorough.
* tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp now shows total number of initialized devices and uses an atomic flag.

AI Summary:
This PR addresses unit test regressions on Galaxy hardware by introducing support for "remote-only" MeshDevices in multi-host configurations, improving test infrastructure, fixing exception safety issues, and enhancing CI reporting. Key changes include:

Remote-only MeshDevice Support: Adds is_remote_only() API to identify MeshDevices with no local devices, preventing invalid operations on remote-only meshes.

Test Fixture Improvements: Introduces UnitMeshCQSingleCardSharedFixture for suite-level device sharing, significantly improving test performance while maintaining isolation.

Exception-Safe Teardown: Replaces assertions with conditional checks in device cleanup paths, ensuring partial cleanup succeeds even when initialization was interrupted.

Thread-Safety Enhancements: Converts fabric firmware initializer state to std::atomic_flag and fixes race conditions in exception handling.

CI Workflow Improvements: Adds structured test reporting with failure aggregation and proper exit codes.

Extended Test Coverage: Adds 5 new event synchronization tests and sub-buffer tests crossing relay page boundaries.


### Checklist

- [x] galaxy unit tests https://github.com/tenstorrent/tt-metal/actions/runs/23281054870/job/67695169588

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-galaxy-unit)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-galaxy-unit)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-galaxy-unit)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-galaxy-unit)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-galaxy-unit)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-galaxy-unit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-galaxy-unit)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
