### PR TITLE
[Cleanup]: Guard CoreLocalMem NOC code for TRISC compilation

### DIFF
--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#if !defined(COMPILE_FOR_TRISC)
 #include "experimental/noc.h"
+#endif
 #include "experimental/lock.h"
 #include "tools/profiler/noc_debugging_metadata.hpp"
 #include "tools/profiler/noc_debugging_profiler.hpp"
@@ -166,6 +168,7 @@ private:
     AddressType address_;
 };
 
+#if !defined(COMPILE_FOR_TRISC)
 template <typename T, typename AddressType>
 struct noc_traits_t<CoreLocalMem<T, AddressType>> {
     struct src_args_type {
@@ -192,5 +195,6 @@ struct noc_traits_t<CoreLocalMem<T, AddressType>> {
         static_assert(false, "CoreLocalMem cannot be used as NoC mcast destination");
     }
 };
+#endif  // !defined(COMPILE_FOR_TRISC)
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -168,6 +168,8 @@ private:
     AddressType address_;
 };
 
+// TRISC cores can use CoreLocalMem for L1 pointer access, but noc_traits_t is
+// intentionally omitted since only DM cores have NOC access
 #if !defined(COMPILE_FOR_TRISC)
 template <typename T, typename AddressType>
 struct noc_traits_t<CoreLocalMem<T, AddressType>> {


### PR DESCRIPTION
### Ticket
NA

### Problem description
`CoreLocalMem` in `experimental/core_local_mem.h` unconditionally includes `experimental/noc.h` and defines `noc_traits_t`. This prevents compilation on TRISC cores, which don't have NOC access.

### What's changed
Added `#if !defined(COMPILE_FOR_TRISC)` guards around the NOC include and `noc_traits_t` specialization. TRISC cores can now compile and use `CoreLocalMem` for L1 pointer access along with DMs.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/corelocalmem_guard_triscs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/corelocalmem_guard_triscs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
