### PR TITLE
Fix for interleaved with larger padding width case

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -640,8 +640,8 @@ def test_tilize_with_val_padding_tilize_after_avg_pool2d_sum_input_interleaved_r
     device, hw, kernel, stride, pad
 ):
     """
-    Tests avg_pool2d -> to_layout(TILE) -> multiply
-    This isolates the to_layout(TILE) step on the avg_pool2d output.
+    Tests avg_pool2d followed by to_layout(TILE) on the avg_pool2d output.
+    This isolates and validates the to_layout(TILE) step on the avg_pool2d result against a PyTorch avg_pool2d reference.
 
     The key for this test is that the output from avg_pool2d, which is the input to to_layout, is a row-major interleaved tensor with a larger padded_shape width than logical_shape width.
     This test aims to test such a scenario where there is a mismatch between the padded_shape width and the logical_shape width for interleaved row major tensors.

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -11,7 +11,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, gene
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_equal
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
 from tests.tt_eager.python_api_testing.sweep_tests.pytorch_ops import (
     tilize_with_val_padding as pytorch_tilize_with_val_padding,
 )
@@ -627,3 +627,78 @@ def test_tilize_with_val_padding_fp32_truncation(device, use_multicore):
     tt_output = ttnn.untilize(tt_tiled)
     torch_output = ttnn.to_torch(tt_output)
     assert torch.equal(torch_input, torch_output[..., :50, :50])
+
+
+@pytest.mark.parametrize(
+    "hw, kernel, stride, pad",
+    [
+        ((64, 64), (2, 2), (2, 2), 0),
+        ((32, 32), (3, 3), (2, 2), 1),
+    ],
+)
+def test_tilize_with_val_padding_tilize_after_avg_pool2d_sum_input_interleaved_rm_tensor_has_larger_padded_width_than_logical_width(
+    device, hw, kernel, stride, pad
+):
+    """
+    Tests avg_pool2d -> to_layout(TILE) -> multiply
+    This isolates the to_layout(TILE) step on the avg_pool2d output.
+
+    The key for this test is that the output from avg_pool2d, which is the input to to_layout, is a row-major interleaved tensor with a larger padded_shape width than logical_shape width.
+    This test aims to test such a scenario where there is a mismatch between the padded_shape width and the logical_shape width for interleaved row major tensors.
+    """
+    h, w = hw
+    kh, kw = kernel
+    sh, sw = stride
+
+    torch_input = torch.randn(1, 1, h, w, dtype=torch.bfloat16)
+    ref = torch.nn.functional.avg_pool2d(
+        torch_input, kernel_size=(kh, kw), stride=(sh, sw), padding=pad, count_include_pad=True
+    )
+
+    mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    x_tt = ttnn.from_torch(
+        torch_input.reshape(h, w),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_cfg,
+    )
+    x_flat = ttnn.reshape(x_tt, [1, 1, h * w, 1], memory_config=mem_cfg)
+    x_rm = ttnn.to_layout(x_flat, ttnn.ROW_MAJOR_LAYOUT, None, memory_config=None)
+
+    y = ttnn.avg_pool2d(
+        x_rm,
+        1,
+        h,
+        w,
+        1,
+        [kh, kw],
+        [sh, sw],
+        [pad, pad],
+        False,
+        True,
+        None,
+        memory_config=mem_cfg,
+        applied_shard_scheme=None,
+        compute_kernel_config=None,
+        reallocate_halo_output=False,
+        config_tensor_in_dram=True,
+    )
+
+    # At this point, for the testcase with "(hw, kernel, stride, pad)" == "((64, 64), (2, 2), (2, 2), 0)", y is a row-major interleaved tensor with logical_shape [1, 1, 1024, 1] and padded_shape [1, 1, 1024, 16].
+
+    y_torch_before_tile = ttnn.to_torch(y)
+
+    y_tiled = ttnn.to_layout(
+        y, ttnn.TILE_LAYOUT, None, memory_config=None
+    )  # This should call tilize_with_val_padding internally
+
+    y_torch_after_tile = ttnn.to_torch(y_tiled)
+
+    assert_with_pcc(y_torch_before_tile, y_torch_after_tile, pcc=0.999)
+
+    ref_flat = ref.reshape(-1)
+    result_flat = y_torch_after_tile.reshape(-1)[: ref_flat.numel()]
+
+    assert_with_pcc(ref_flat, result_flat, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -688,7 +688,7 @@ def test_tilize_with_val_padding_tilize_after_avg_pool2d_sum_input_interleaved_r
 
     # At this point, for the testcase with "(hw, kernel, stride, pad)" == "((64, 64), (2, 2), (2, 2), 0)", y is a row-major interleaved tensor with logical_shape [1, 1, 1024, 1] and padded_shape [1, 1, 1024, 16].
     # Make this precondition explicit to ensure the test remains valid if upstream behavior changes.
-    assert y.padded_shape()[-1] > y.logical_shape()[-1]
+    assert y.padded_shape[-1] > y.shape[-1]
 
     y_torch_before_tile = ttnn.to_torch(y)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -687,6 +687,8 @@ def test_tilize_with_val_padding_tilize_after_avg_pool2d_sum_input_interleaved_r
     )
 
     # At this point, for the testcase with "(hw, kernel, stride, pad)" == "((64, 64), (2, 2), (2, 2), 0)", y is a row-major interleaved tensor with logical_shape [1, 1, 1024, 1] and padded_shape [1, 1, 1024, 16].
+    # Make this precondition explicit to ensure the test remains valid if upstream behavior changes.
+    assert y.padded_shape()[-1] > y.logical_shape()[-1]
 
     y_torch_before_tile = ttnn.to_torch(y)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -49,7 +49,13 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
 
     bool has_cliff = !core_range_cliff.empty();
 
-    uint32_t unpadded_row_size_bytes = a.logical_shape()[-1] * a.element_size();    // Assuming bfloat16 dataformat
+    uint32_t unpadded_row_size_bytes =
+        ((!a.is_sharded() || a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED)
+             ? a.padded_shape()[-1]
+             : a.logical_shape()[-1]) *
+        a.element_size();  // For height-sharded and interleaved row-major tensors, the page_size = padded_shape width
+                           // of the tensor.
+    // Assuming bfloat16 dataformat above
     uint32_t padded_row_size_bytes = output.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
     create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_default_program_factory.cpp
@@ -49,13 +49,7 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
 
     bool has_cliff = !core_range_cliff.empty();
 
-    uint32_t unpadded_row_size_bytes =
-        ((!a.is_sharded() || a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED)
-             ? a.padded_shape()[-1]
-             : a.logical_shape()[-1]) *
-        a.element_size();  // For height-sharded and interleaved row-major tensors, the page_size = padded_shape width
-                           // of the tensor.
-    // Assuming bfloat16 dataformat above
+    uint32_t unpadded_row_size_bytes = a.logical_shape()[-1] * a.element_size();    // Assuming bfloat16 dataformat
     uint32_t padded_row_size_bytes = output.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
     create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
@@ -78,10 +72,11 @@ TilizeWithValPaddingMultiCoreDefaultFactory::cached_program_t TilizeWithValPaddi
                         // ex: bf16/uint16 -> log2(2 * 32) = 6, float32/int32/uint32 -> log2(4 * 32) = 7, etc.
     uint32_t elem_size = a.element_size();
     uint32_t num_pages_in_row = 1;
-    uint32_t page_size = a.buffer()->page_size();
+    uint32_t page_size = a.logical_shape()[-1] * a.element_size();
     uint32_t aligned_page_size = a.buffer()->aligned_page_size();
-    uint32_t size_of_valid_data_in_last_page_in_row = a.buffer()->page_size();
-    if (a.is_sharded()) {
+    uint32_t size_of_valid_data_in_last_page_in_row = a.logical_shape()[-1] * a.element_size();
+    if (a.is_sharded() && a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
+        page_size = a.buffer()->page_size();
         uint32_t shard_width =
             a.shard_spec().has_value() ? a.shard_spec().value().shape[1] : a.nd_shard_spec().value().shard_shape[-1];
         num_pages_in_row = tt::div_up(a.logical_shape()[-1], shard_width);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -80,7 +80,12 @@ TilizeWithValPaddingDeviceOperation::program_factory_t TilizeWithValPaddingDevic
 
 void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor) {
-    const auto& input_shape = input_tensor.logical_shape();
+    const auto& memory_layout = input_tensor.memory_config().memory_layout();
+    const bool use_padded =
+        memory_layout == TensorMemoryLayout::INTERLEAVED || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+    // Page size for row-major interleaved and height-sharded tensors is the padded width of the tensor, so we must
+    // ensure that the outpus padded width is larger than this value in those cases.
+    const auto& input_shape = use_padded ? input_tensor.padded_shape() : input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
@@ -122,13 +127,24 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
         TILE_WIDTH,
         TILE_HEIGHT);
 
-    if (input_tensor.memory_config().is_sharded()) {
+    const uint32_t alignment_requirement = hal::get_l1_alignment();
+    if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
+        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED) {
+        uint32_t l1_address_increment_size =
+            operation_attributes.output_padded_shape[-1] *
+            input_tensor.element_size();  // For height-sharded and interleaved tensors, the l1 address in the reader
+                                          // kernel gets incremented by the output padded width size.
+        TT_FATAL(
+            l1_address_increment_size % alignment_requirement == 0,
+            "Output padded width size {} must be aligned to {} bytes for HEIGHT_SHARDED or INTERLEAVED tensors",
+            l1_address_increment_size,
+            alignment_requirement);
+    } else if (input_tensor.memory_config().is_sharded()) {
         uint32_t shard_width = input_tensor.shard_spec().has_value()
                                    ? input_tensor.shard_spec().value().shape[1]
                                    : input_tensor.nd_shard_spec().value().shard_shape[-1];
 
         const uint32_t page_size_bytes = input_tensor.buffer()->page_size();
-        const uint32_t alignment_requirement = hal::get_l1_alignment();
         TT_FATAL(
             page_size_bytes == input_tensor.buffer()->aligned_page_size(),
             "Input row-major shard width {} gives page size {} bytes, which must be aligned to {} bytes L1 SRAM "

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -80,12 +80,7 @@ TilizeWithValPaddingDeviceOperation::program_factory_t TilizeWithValPaddingDevic
 
 void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     const TilizeWithValPaddingParams& operation_attributes, const Tensor& input_tensor) {
-    const auto& memory_layout = input_tensor.memory_config().memory_layout();
-    const bool use_padded =
-        memory_layout == TensorMemoryLayout::INTERLEAVED || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
-    // Page size for row-major interleaved and height-sharded tensors is the padded width of the tensor, so we must
-    // ensure that the output's padded width is larger than this value in those cases.
-    const auto& input_shape = use_padded ? input_tensor.padded_shape() : input_tensor.logical_shape();
+    const auto& input_shape = input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -84,7 +84,7 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
     const bool use_padded =
         memory_layout == TensorMemoryLayout::INTERLEAVED || memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
     // Page size for row-major interleaved and height-sharded tensors is the padded width of the tensor, so we must
-    // ensure that the outpus padded width is larger than this value in those cases.
+    // ensure that the output's padded width is larger than this value in those cases.
     const auto& input_shape = use_padded ? input_tensor.padded_shape() : input_tensor.logical_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands need to be on device!");


### PR DESCRIPTION
### Ticket
[#40179](https://github.com/tenstorrent/tt-metal/issues/40179)
### Problem description
The PR [Adding ND Sharding Support for the tilize_with_val_padding Op](https://github.com/tenstorrent/tt-metal/pull/38415/changes#diff-6aa7fae95f6dff58dbd2e99cb3b38672878d1805789e30051f4826410428cb1c) broke the case where interleaved row-major input tensors had a padded_shape width larger than the logical_shape width, which was the root cause of the issue in the ticket above.
### What's changed
For interleaved and height-sharded tensors, the size of the width of the tensor's padded_shape is the size of the tensor buffer page. Thus, for such cases, the actual size of the row with valid data must be computed as the logical width * element size, rather than simply taking the buffer page_size. Unit tests were also added to test this case.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/patch_for_tilize_with_val_padding_ND_shard_p0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/patch_for_tilize_with_val_padding_ND_shard_p0)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/patch_for_tilize_with_val_padding_ND_shard_p0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/patch_for_tilize_with_val_padding_ND_shard_p0)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/patch_for_tilize_with_val_padding_ND_shard_p0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/patch_for_tilize_with_val_padding_ND_shard_p0) compared to [main results](https://github.com/tenstorrent/tt-metal/actions/runs/23231891054).
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/23268317649) on the PR branch to catch linting errors early