### PR TITLE
Remove default dim_stride_target in unpack_reconfig_data_format

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_compressed.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_compressed.h
@@ -103,7 +103,7 @@ FORCE_INLINE void reconfig_unpack_srcb(uint32_t fmt_idx) {
     UNPACK(({
         uint32_t src_format = DATA_FORMATS[fmt_idx];
         uint32_t tile_size_shifted = TILE_SIZES[fmt_idx] >> 4;
-        _llk_unpack_reconfig_data_format_srcb_impl_<DST_ACCUM_MODE>(
+        _llk_unpack_reconfig_data_format_srcb_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(
             src_format, src_format, tile_size_shifted, FACE_R_DIM, 4);
     }));
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_compressed.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_compressed.h
@@ -91,7 +91,7 @@ FORCE_INLINE void reconfig_unpack_srca(uint32_t fmt_idx) {
     UNPACK(({
         uint32_t src_format = DATA_FORMATS[fmt_idx];
         uint32_t tile_size_shifted = TILE_SIZES[fmt_idx] >> 4;
-        _llk_unpack_reconfig_data_format_srca_impl_<DST_ACCUM_MODE>(
+        _llk_unpack_reconfig_data_format_srca_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(
             src_format, src_format, tile_size_shifted, FACE_R_DIM, 4);
     }));
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -96,10 +96,7 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
@@ -108,15 +105,12 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
@@ -125,80 +119,68 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     } else if (
         get_operand_face_r_dim(old_srca_operand_id) != get_operand_face_r_dim(new_srca_operand_id) ||
         get_operand_num_faces(old_srca_operand_id) != get_operand_num_faces(new_srca_operand_id)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, p_dim_stride_target::FACE_ROW_MAJOR>(
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
             srca_new_operand);
     }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     } else if (
         get_operand_face_r_dim(old_srcb_operand_id) != get_operand_face_r_dim(new_srcb_operand_id) ||
         get_operand_num_faces(old_srcb_operand_id) != get_operand_num_faces(new_srcb_operand_id)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, p_dim_stride_target::FACE_ROW_MAJOR>(
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
             srcb_new_operand);
     }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     _llk_unpack_reconfig_zero_src_flag_(
         unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srcb_old_operand, srcb_new_operand);
     _llk_unpack_reconfig_zero_src_flag_(
         unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -107,10 +107,7 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     const std::uint32_t srca_operand_id = get_operand_id(srca_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
@@ -119,15 +116,12 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t srcb_operand_id = get_operand_id(srcb_new_operand);
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
@@ -136,80 +130,68 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     // Currently, there is a constraint that tile size is equal to the fifo page size
     // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
     const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
     if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
     } else if (
         get_operand_face_r_dim(old_srca_operand_id) != get_operand_face_r_dim(new_srca_operand_id) ||
         get_operand_num_faces(old_srca_operand_id) != get_operand_num_faces(new_srca_operand_id)) {
-        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, p_dim_stride_target::FACE_ROW_MAJOR>(
+        llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
             srca_new_operand);
     }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
     if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     } else if constexpr (dim_stride_target != p_dim_stride_target::IGNORE) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     } else if (
         get_operand_face_r_dim(old_srcb_operand_id) != get_operand_face_r_dim(new_srcb_operand_id) ||
         get_operand_num_faces(old_srcb_operand_id) != get_operand_num_faces(new_srcb_operand_id)) {
-        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, p_dim_stride_target::FACE_ROW_MAJOR>(
+        llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, to_from_int8>(
             srcb_new_operand);
     }
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(srcb_new_operand);
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srca_new_operand);
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(srcb_new_operand);
     _llk_unpack_reconfig_zero_src_flag_(
         unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <
-    bool is_fp32_dest_acc_en,
-    bool to_from_int8 = false,
-    p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,
     const std::uint32_t srca_new_operand,
     const std::uint32_t srcb_old_operand,
     const std::uint32_t srcb_new_operand) {
-    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    llk_unpack_reconfig_data_format_srca<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srca_old_operand, srca_new_operand);
-    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, to_from_int8, dim_stride_target>(
+    llk_unpack_reconfig_data_format_srcb<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
         srcb_old_operand, srcb_new_operand);
     _llk_unpack_reconfig_zero_src_flag_(
         unpack_dst_format[get_operand_id(srca_new_operand)], unpack_dst_format[get_operand_id(srcb_new_operand)]);

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -421,7 +421,8 @@ ALWI void mm_block_init_short_with_both_dt(
     uint32_t rt_dim = 1,
     uint32_t kt_dim = 1) {
 #ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id)));
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(
+        old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id, old_in0_cb_id, in0_cb_id)));
     mm_block_init_short(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim);
 #endif  // TODO: AM; add Quasar implementation

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -207,7 +207,8 @@ ALWI void mm_init_short(
 ALWI void mm_init_short_with_dt(
     uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t c_in_old_srca, const uint32_t transpose = 0) {
 #ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_cb_id)));
+    UNPACK(
+        (llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(c_in_old_srca, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_cb_id)));
     mm_init_short(in0_cb_id, in1_cb_id, transpose);
 #endif  // TODO: AM; add Quasar implementation
@@ -385,7 +386,8 @@ ALWI void mm_block_init_short_with_dt(
     uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
     state_configure(in1_cb_id, in0_cb_id, call_line);
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id)));
+    UNPACK(
+        (llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_in1_cb_id, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_in1_cb_id, in1_cb_id)));
     mm_block_init_short(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim);
 #endif  // TODO: AM; add Quasar implementation

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -54,9 +54,8 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_new_operand) {
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srca<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srca_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srca_new_operand)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_new_operand)));
 #endif  // TODO: AM; add Quasar implementation
 }
@@ -70,9 +69,8 @@ ALWI void reconfig_data_format_srca(const uint32_t srca_old_operand, const uint3
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srca<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srca_old_operand, srca_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srca_old_operand, srca_new_operand)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE, to_from_int8>(srca_old_operand, srca_new_operand)));
 #endif  // TODO: AM; add Quasar implementation
 }
@@ -86,9 +84,8 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_new_operand) {
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srcb<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srcb_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srcb_new_operand)));
     MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_new_operand)));
 #endif  // TODO: AM; add Quasar implementation
 }
@@ -102,9 +99,8 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint3
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format_srcb<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srcb_old_operand, srcb_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srcb_old_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format_srcb<DST_ACCUM_MODE, to_from_int8>(srcb_old_operand, srcb_new_operand)));
 #endif  // TODO: AM; add Quasar implementation
 }

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -17,9 +17,8 @@ ALWI void reconfig_data_format(const uint32_t srca_new_operand, const uint32_t s
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srca_new_operand, srcb_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srca_new_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(srca_new_operand, srcb_new_operand)));
 #endif  // TODO: AM; add Quasar implementation
 }
@@ -37,9 +36,8 @@ ALWI void reconfig_data_format(
     // If is_tile_dim_reconfig_en is enabled, modify the dimension and stride according to enum; else, ignore them
     UNPACK((llk_unpack_reconfig_data_format<
             DST_ACCUM_MODE,
-            to_from_int8,
-            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE>(
-        srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
+            is_tile_dim_reconfig_en ? p_dim_stride_target::FACE_ROW_MAJOR : p_dim_stride_target::IGNORE,
+            to_from_int8>(srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
     MATH((llk_math_reconfig_data_format<DST_ACCUM_MODE, to_from_int8>(
         srca_old_operand, srca_new_operand, srcb_old_operand, srcb_new_operand)));
 #endif  // TODO: AM; add Quasar implementation

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -69,7 +69,7 @@ ALWI void copy_tile_to_dst_init_short_with_dt(uint32_t old_cbid, uint32_t new_cb
     // This reconfig call checks if old operand has different data format to
     // new operand idx, otherwise no reconfig call occurs
 #ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cbid, new_cbid)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_cbid, new_cbid)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cbid, new_cbid)));
     copy_tile_to_dst_init_short(new_cbid, transpose);
 #endif  // TODO: AM; add Quasar implementation

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -123,7 +123,7 @@ ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t
           true /*tilize en*/>(new_icb)));
     // This reconfig call checks if old operand has different data format to
     // new operand idx, otherwise no reconfig call occurs
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
     UNPACK((llk_unpack_tilize_init(new_icb, block)));
 
@@ -250,7 +250,7 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
 // clang-format on
 ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -270,7 +270,7 @@ ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32
 }
 
 ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
-    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE>(icb, icb)));
+    UNPACK((llk_unpack_reconfig_data_format<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(icb, icb)));
     MATH((llk_math_reconfig_data_format<true, true>(icb, icb)));
 
     fast_tilize_init(icb, full_dim, ocb);

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -235,7 +235,7 @@ class FuserSentinel:
 
         if srca_changed:
             code += (
-                f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, false>(\n"
+                f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
                 f"    {self._fmt(new_fmt.unpack_A_src)}, {self._fmt(new_fmt.unpack_A_dst)}, {compute_node.src_a.tile_size}\n"
                 f");\n"
             )
@@ -248,7 +248,7 @@ class FuserSentinel:
             )
             if srcb_tile_size is not None:
                 code += (
-                    f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, false>(\n"
+                    f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
                     f"    {self._fmt(new_fmt.unpack_B_src)}, {self._fmt(new_fmt.unpack_B_dst)}, {srcb_tile_size}\n"
                     f");\n"
                 )

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -50,7 +50,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Start of second unpack kernel to perform unpack matmul on now tilized input data
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, false>(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, TILE_SIZE_PACK);
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, TILE_SIZE_PACK);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         0, 0, FACE_R_DIM, 4, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -68,11 +68,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Start of second unpack kernel to perform unpack matmul on now tilized input data
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
-    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, false>(
+    _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         formats_array[run].unpack_A_src,
         formats_array[run].unpack_A_dst,
         tile_size); // have to reconfigure unpack kernel data formats_array if they change in this run
-    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, false>(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
+    _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+        formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
 #ifdef ARCH_BLACKHOLE
     _llk_unpack_tilize_uninit_(formats_array[run].unpack_A_dst, 4, FACE_R_DIM);
 #else

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -56,8 +56,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, false>(unpack_a_src_format1, unpack_a_dst_format1, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, false>(unpack_b_src_format1, unpack_b_dst_format1, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format1, unpack_a_dst_format1, 128);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format1, unpack_b_dst_format1, 128);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -76,8 +76,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, false>(unpack_a_src_format2, unpack_a_dst_format2, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, false>(unpack_b_src_format2, unpack_b_dst_format2, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format2, unpack_a_dst_format2, 128);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format2, unpack_b_dst_format2, 128);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -92,8 +92,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, false>(unpack_a_src_format3, unpack_a_dst_format3, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, false>(unpack_b_src_format3, unpack_b_dst_format3, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format3, unpack_a_dst_format3, 128);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format3, unpack_b_dst_format3, 128);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -173,7 +173,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     {
                         // We need to use reconfigure API to avoid race condition between hardware configuration in the second stage and unpacking in the first
                         // stage.
-                        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, false /* to_from_int8 */>(
+                        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false /* to_from_int8 */>(
                             unpack_src_format, unpack_dst_format, 16 * 16 * 4 /* tile_size */);
                     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -76,7 +76,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -128,7 +128,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -77,7 +77,7 @@ inline void _llk_unpack_configure_stoch_rnd_()
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
@@ -126,7 +126,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 }
 
 // TODO NC: Clean up as the part of tt-metal#34499
-template <bool is_fp32_dest_acc_en, bool to_from_int8 = false, p_dim_stride_target dim_stride_target = p_dim_stride_target::IGNORE>
+template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -29,7 +29,7 @@ ALWI void reduce_with_matmul_init(uint32_t in0_cb_id, uint32_t in1_cb_id) {
 }
 
 ALWI void reduce_with_matmul_init_with_dt(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t c_in_old_srca) {
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_cb_id)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(c_in_old_srca, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(c_in_old_srca, in1_cb_id)));
     reduce_with_matmul_init(in0_cb_id, in1_cb_id);
 }
@@ -75,7 +75,7 @@ constexpr bool manages_cb(ReduceInputPolicy p) {
 template <PoolType reduce_type, ReduceDim reduce_dim>
 ALWI void reduce_init_short_with_dt(uint32_t old_cb_id, uint32_t input_cb_id, uint32_t scaler_cb_id) {
     // Reconfigure SRCA data format from old_cb_id to input_cb_id (similar to copy_tile_to_dst_init_short_with_dt)
-    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cb_id, input_cb_id)));
+    UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_cb_id, input_cb_id)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_cb_id, input_cb_id)));
 
     // Reconfigure unpacker for reduce operation (SRCA and SRCB)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37622)

### Problem description
Want to avoid users accidentally not reconfiguring things that they might need to when calling functions like `unpack_reconfig_data_format_src*`

### What's changed
Removed the default value for the dim_stride_target enum argument, which was previously set to IGNORE, and for any instances where the unpack reconfig was called before using a default value now explicitly calls with IGNORE

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ryanzhu/unp-recfg-templ)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ryanzhu/unp-recfg-templ)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ryanzhu/unp-recfg-templ)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ryanzhu/unp-recfg-templ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ryanzhu/unp-recfg-templ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ryanzhu/unp-recfg-templ)