### PR TITLE
[skip ci] Fix heredoc injection vulnerability in codeowners workflow

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -55,12 +55,9 @@ jobs:
     steps:
       - name: Parse comment and get PR info
         id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          # Properly escape comment body to handle quotes
-          COMMENT_BODY=$(cat <<'COMMENT_EOF'
-          ${{ github.event.comment.body }}
-          COMMENT_EOF
-          )
           PR_NUMBER="${{ github.event.issue.number }}"
           COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
 

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -66,7 +66,7 @@ jobs:
           echo "Comment author: $COMMENT_AUTHOR"
 
           # Check if comment contains our trigger commands
-          if echo "$COMMENT_BODY" | grep -E "^/(codeowners?|ping)(\s|$)" > /dev/null; then
+          if printf '%s\n' "$COMMENT_BODY" | grep -E "^/(codeowners?|ping)(\s|$)" > /dev/null; then
             # Add reaction to acknowledge we saw the command
             curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \


### PR DESCRIPTION
## Security Fix: Heredoc Injection Vulnerability

### Issue
The `codeowners-group-analysis.yaml` workflow was vulnerable to command injection through PR comments. An attacker could terminate a heredoc early by including `COMMENT_EOF` on its own line in a comment, causing subsequent lines to execute as arbitrary shell commands.

### Root Cause
GitHub Actions expands `${{ }}` expressions at template time (before the shell runs), not at shell runtime. The heredoc delimiter could be injected before any authorization checks occurred.

### Security Impact
- **Secrets at risk**: `CODEOWNERS_GROUP_ANALYSIS_PAT` and `CODEOWNERS_PING_BOT` tokens
- **Attack vector**: Any user able to comment on pull requests (no special permissions required)
- **Bypass**: Organization membership check occurred after the injection point

### Fix
Replaced the heredoc pattern with environment variable passing:
```yaml
env:
  COMMENT_BODY: ${{ github.event.comment.body }}
run: |
  # Use $COMMENT_BODY variable safely
```

This is secure because the environment variable is set by GitHub Actions and expanded by the shell at runtime, preventing injection.

### Recommendations
1. **Rotate secrets**: Consider rotating `CODEOWNERS_GROUP_ANALYSIS_PAT` and `CODEOWNERS_PING_BOT` as a precaution
2. **Audit logs**: Review GitHub Actions audit logs for suspicious workflow runs triggered by comments
3. **Timeline**: No known exploitation detected

### Credit
**Discovered and reported by**: Aviv Donenfeld (@avivdon)

Thank you for the responsible disclosure and detailed analysis.

---

**Vulnerability Type**: CWE-94 (Code Injection)  
**Severity**: Critical  
**CVSS**: Not applicable (internal CI/CD infrastructure only)