### PR TITLE
[Bug fix] Fix data race in watcher poll

### DIFF
--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -544,13 +544,13 @@ void WatcherServer::Impl::poll_watcher_data() {
 
             try {
                 dump();
-            } catch (std::runtime_error& e) {
+            } catch (const std::runtime_error& e) {
                 // Depending on whether test mode is enabled, catch and stop server, or re-throw.
                 if (rtoptions.get_test_mode_enabled()) {
                     server_killed_due_to_error_ = true;
                     break;
                 }
-                throw e;
+                throw;
             }
 
             fprintf(logfile_, "Dump #%d completed at %.3lfs\n", dump_count_.load(), get_elapsed_secs());

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -531,27 +531,32 @@ void WatcherServer::Impl::poll_watcher_data() {
     log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
 
     while (true) {
-        fprintf(logfile_, "-----\n");
-        fprintf(logfile_, "Dump #%d at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
+        // Need to hold the lock here as well to prevent kernel_names_ being modified from the main thread while being
+        // read out to a file in the dump function
+        {
+            const std::lock_guard<std::mutex> lock(watch_mutex_);
+            fprintf(logfile_, "-----\n");
+            fprintf(logfile_, "Dump #%d at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
 
-        if (device_id_to_reader_.empty()) {
-            fprintf(logfile_, "No active devices\n");
-        }
-
-        try {
-            dump();
-        } catch (std::runtime_error& e) {
-            // Depending on whether test mode is enabled, catch and stop server, or re-throw.
-            if (rtoptions.get_test_mode_enabled()) {
-                server_killed_due_to_error_ = true;
-                break;
+            if (device_id_to_reader_.empty()) {
+                fprintf(logfile_, "No active devices\n");
             }
-            throw e;
-        }
 
-        fprintf(logfile_, "Dump #%d completed at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
-        fflush(logfile_);
-        dump_count_++;
+            try {
+                dump();
+            } catch (std::runtime_error& e) {
+                // Depending on whether test mode is enabled, catch and stop server, or re-throw.
+                if (rtoptions.get_test_mode_enabled()) {
+                    server_killed_due_to_error_ = true;
+                    break;
+                }
+                throw e;
+            }
+
+            fprintf(logfile_, "Dump #%d completed at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
+            fflush(logfile_);
+            dump_count_++;
+        }
 
         // Wait for the interval, but check stop flag frequently to exit early
         constexpr auto poll_interval = std::chrono::milliseconds(100);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This was seen [rarely] in merge gate. I could not reproduce locally, but I suspect it's because Watcher poll thread is accessing some shared state like kernel_names_ while the main thread is writing to the vector. If the vector needs to be resized to push back another kernel name then references to the old data will become invalidated.

```
==310==ERROR: AddressSanitizer: SEGV on unknown address 0x00000006af5f (pc 0x556dcca6b910 bp 0x7ba235bc6f00 sp 0x7ba235bc6678 T472)
==310==The signal is caused by a READ memory access.
    #0 0x556dcca6b910 in __sanitizer::internal_strlen(char const*) crtstuff.c
    #1 0x556dcc9d65a6 in printf_common(void*, char const*, __va_list_tag*) crtstuff.c
    #2 0x556dcc9d83c3 in fprintf (/usr/bin/tt-nn-validation-basic+0x8373c3) (BuildId: 2ae26661b7e5e9ad74712b4e4e5a3b91d663ce8c)
    #3 0x7faa9c84a510 in tt::tt_metal::WatcherDeviceReader::Dump(_IO_FILE*) /work/tt_metal/impl/debug/watcher_device_reader.cpp:403:9
    #4 0x7faa9c849830 in tt::tt_metal::WatcherServer::Impl::dump(_IO_FILE*) /work/tt_metal/impl/debug/watcher_server.cpp:195:37
    #5 0x7faa9c847b21 in tt::tt_metal::WatcherServer::Impl::dump() /work/tt_metal/impl/debug/watcher_server.cpp:55:19
    #6 0x7faa9c847b21 in tt::tt_metal::WatcherServer::Impl::poll_watcher_data() /work/tt_metal/impl/debug/watcher_server.cpp:542:13
    #7 0x7faa9983a252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: eb0991e99bf8c31e942757ab71a6266bffb30e1f)
    #8 0x556dcca4f696 in asan_thread_start(void*) crtstuff.c
    #9 0x7faa994aeac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
    #10 0x7faa9953fa83 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x125a83) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)

```

### What's changed
- Add a mutex around the dump function to serialize the watcher thread and main thread in this section

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nhuang/fix-watcher-race)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/fix-watcher-race)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/fix-watcher-race)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/fix-watcher-race)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/fix-watcher-race)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/fix-watcher-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/fix-watcher-race)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
