### PR TITLE
Fixing Program Selection Logic in ttnn::pad

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -40,9 +40,10 @@ bool can_use_sharded_optimized_factory(const PadParams& operation_attributes, co
     if (operation_attributes.sub_core_grids.has_value()) {
         return false;
     }
-    if (operation_attributes.output_padded_shape[-1] == operation_attributes.output_mem_config.shard_spec()->shape[1]) {
-        return false;
-    }
+    // if (operation_attributes.output_padded_shape[-1] ==
+    // operation_attributes.output_mem_config.shard_spec()->shape[1]) {
+    //     return false;
+    // }
     if (operation_attributes.output_mem_config.shard_spec().value().shape[0] <
         input_tensor.shard_spec().value().shape[0]) {
         // Note this case causes the sharded optimized PadRmShardedWidthOnlyProgramFactory{} to hang.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -40,10 +40,9 @@ bool can_use_sharded_optimized_factory(const PadParams& operation_attributes, co
     if (operation_attributes.sub_core_grids.has_value()) {
         return false;
     }
-    // if (operation_attributes.output_padded_shape[-1] ==
-    // operation_attributes.output_mem_config.shard_spec()->shape[1]) {
-    //     return false;
-    // }
+    if (operation_attributes.output_padded_shape[-1] != operation_attributes.output_mem_config.shard_spec()->shape[1]) {
+        return false;
+    }
     if (operation_attributes.output_mem_config.shard_spec().value().shape[0] <
         input_tensor.shard_spec().value().shape[0]) {
         // Note this case causes the sharded optimized PadRmShardedWidthOnlyProgramFactory{} to hang.


### PR DESCRIPTION
### Ticket
N/A
### Problem description
There was a mistake in the program selection logic in PR [Adding ND sharding support to the ttnn::pad op](https://github.com/tenstorrent/tt-metal/pull/39774). This led to the optimized sharded factories never being called for their appropriate height-sharded tensors. They were instead rerouted to the slower default path, causing the ResNet perf regression noticed in [Single Card Model Perf Tests](https://github.com/tenstorrent/tt-metal/actions/runs/23251550093/job/67596517032).
### What's changed
The program selection logic was corrected for the sharded-optimized program factories.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/pad_ND_sharding_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/pad_ND_sharding_patch)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=awliu/pad_ND_sharding_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:awliu/pad_ND_sharding_patch)
- [x] New/Existing tests provide coverage for changes
- [x] [Single Card Model Perf Tests](https://github.com/tenstorrent/tt-metal/actions/runs/23274069107/job/67673761603)
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/runs/23275251802) on the PR branch to catch linting errors early
