### PR TITLE
Refactor out HostTensor ops

### DIFF
--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -9,6 +9,7 @@
 namespace tt::tt_metal::host_buffer {
 
 HostBuffer get_host_buffer(const Tensor& tensor);
+HostBuffer get_host_buffer(const HostTensor& tensor);
 
 template <typename T>
 ttsl::Span<const T> get_as(const HostBuffer& buffer);
@@ -18,6 +19,9 @@ ttsl::Span<T> get_as(HostBuffer& buffer);
 
 template <typename T>
 ttsl::Span<const T> get_as(const Tensor& tensor);
+
+template <typename T>
+ttsl::Span<const T> get_as(const HostTensor& tensor);
 
 template <typename T>
 ttsl::Span<T> get_as(Tensor& tensor);

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -4,61 +4,22 @@
 
 #pragma once
 
-#include <tt_stl/overloaded.hpp>
-#include <type_traits>
-
 #include "ttnn/tensor/tensor.hpp"
 
 namespace tt::tt_metal::host_buffer {
 
-template <typename T>
-void validate_datatype(const Tensor& tensor) {
-    using BaseType = std::remove_cvref_t<T>;
-    if constexpr (std::is_same_v<BaseType, uint32_t>) {
-        TT_FATAL(
-            tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::BFLOAT8_B or
-                tensor.dtype() == DataType::BFLOAT4_B,
-            "Incorrect data type {}",
-            tensor.dtype());
-    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
-        TT_FATAL(tensor.dtype() == DataType::INT32, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<BaseType, float>) {
-        TT_FATAL(tensor.dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
-        TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
-        TT_FATAL(tensor.dtype() == DataType::UINT16, "Incorrect data type {}", tensor.dtype());
-    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
-        TT_FATAL(tensor.dtype() == DataType::UINT8, "Incorrect data type {}", tensor.dtype());
-    } else {
-        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
-    }
-}
-
 HostBuffer get_host_buffer(const Tensor& tensor);
 
 template <typename T>
-ttsl::Span<const T> get_as(const HostBuffer& buffer) {
-    return buffer.view_as<T>();
-}
+ttsl::Span<const T> get_as(const HostBuffer& buffer);
 
 template <typename T>
-ttsl::Span<T> get_as(HostBuffer& buffer) {
-    return buffer.view_as<T>();
-}
+ttsl::Span<T> get_as(HostBuffer& buffer);
 
 template <typename T>
-ttsl::Span<const T> get_as(const Tensor& tensor) {
-    validate_datatype<T>(tensor);
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
+ttsl::Span<const T> get_as(const Tensor& tensor);
 
 template <typename T>
-ttsl::Span<T> get_as(Tensor& tensor) {
-    validate_datatype<T>(tensor);
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
+ttsl::Span<T> get_as(Tensor& tensor);
 
 }  // namespace tt::tt_metal::host_buffer

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -124,7 +124,7 @@ void copy_to_device(
 //                                  .to_layout()
 // ======================================================================================
 
-Tensor to_layout(const Tensor& tensor, Layout target_layout);
+HostTensor to_layout(const HostTensor& tensor, Layout target_layout);
 
 // ======================================================================================
 //                                  .pad() and .unpad()
@@ -183,7 +183,7 @@ std::string to_string(const Tensor& tensor);
 
 Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id);
 
-Tensor to_dtype(const Tensor& input_tensor, DataType dtype);
+HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype);
 
 // Utility to convert runtime DataType to compile-time constant and dispatch the function call
 template <typename Func, typename... Args>

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -135,10 +135,14 @@ HostTensor pad(
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value);
 
+HostTensor pad_to_tile(const HostTensor& tensor, float pad_value);
+
 HostTensor unpad(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end);
+
+HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape);
 
 // ======================================================================================
 //                                         Print

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -145,6 +145,15 @@ HostTensor unpad(
 HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape);
 
 // ======================================================================================
+//                                  .view()
+// ======================================================================================
+
+HostTensor view(
+    const HostTensor& tensor,
+    const tt::tt_metal::Shape& new_logical_shape,
+    const tt::tt_metal::Shape& new_padded_shape);
+
+// ======================================================================================
 //                                         Print
 // ======================================================================================
 

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -135,8 +135,10 @@ HostTensor pad(
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value);
 
-Tensor unpad(
-    const Tensor& tensor, const tt::tt_metal::Shape& output_tensor_start, const tt::tt_metal::Shape& output_tensor_end);
+HostTensor unpad(
+    const HostTensor& tensor,
+    const tt::tt_metal::Shape& output_tensor_start,
+    const tt::tt_metal::Shape& output_tensor_end);
 
 // ======================================================================================
 //                                         Print

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -129,8 +129,8 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout);
 // ======================================================================================
 //                                  .pad() and .unpad()
 // ======================================================================================
-Tensor pad(
-    const Tensor& tensor,
+HostTensor pad(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value);

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include <ttnn/tensor/host_buffer/functions.hpp>
 #include <ttnn/tensor/tensor.hpp>
 #include <ttnn/tensor/tensor_utils.hpp>
@@ -16,24 +17,23 @@ namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
 template <typename T>
-void validate_datatype(const Tensor& tensor) {
+void validate_datatype(DataType dtype) {
     using BaseType = std::remove_cvref_t<T>;
     if constexpr (std::is_same_v<BaseType, uint32_t>) {
         TT_FATAL(
-            tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::BFLOAT8_B or
-                tensor.dtype() == DataType::BFLOAT4_B,
+            dtype == DataType::UINT32 or dtype == DataType::BFLOAT8_B or dtype == DataType::BFLOAT4_B,
             "Incorrect data type {}",
-            tensor.dtype());
+            dtype);
     } else if constexpr (std::is_same_v<BaseType, int32_t>) {
-        TT_FATAL(tensor.dtype() == DataType::INT32, "Incorrect data type {}", tensor.dtype());
+        TT_FATAL(dtype == DataType::INT32, "Incorrect data type {}", dtype);
     } else if constexpr (std::is_same_v<BaseType, float>) {
-        TT_FATAL(tensor.dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.dtype());
+        TT_FATAL(dtype == DataType::FLOAT32, "Incorrect data type {}", dtype);
     } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
-        TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.dtype());
+        TT_FATAL(dtype == DataType::BFLOAT16, "Incorrect data type {}", dtype);
     } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
-        TT_FATAL(tensor.dtype() == DataType::UINT16, "Incorrect data type {}", tensor.dtype());
+        TT_FATAL(dtype == DataType::UINT16, "Incorrect data type {}", dtype);
     } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
-        TT_FATAL(tensor.dtype() == DataType::UINT8, "Incorrect data type {}", tensor.dtype());
+        TT_FATAL(dtype == DataType::UINT8, "Incorrect data type {}", dtype);
     } else {
         static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
     }
@@ -42,16 +42,19 @@ void validate_datatype(const Tensor& tensor) {
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-HostBuffer get_host_buffer(const Tensor& tensor) {
-    TT_FATAL(is_cpu_tensor(tensor), "Tensor must have HostStorage");
-    const auto& storage = tensor.host_storage();
+HostBuffer get_host_buffer(const HostTensor& tensor) {
     std::vector<HostBuffer> buffers;
-    storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    tensor.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
     TT_FATAL(
         buffers.size() == 1,
         "Can't get a single buffer from host storage distributed over mesh shape {}",
-        storage.buffer().shape());
+        tensor.buffer().shape());
     return buffers.front();
+}
+
+HostBuffer get_host_buffer(const Tensor& tensor) {
+    TT_FATAL(is_cpu_tensor(tensor), "Tensor must have on host");
+    return get_host_buffer(tensor.host_tensor());
 }
 
 template <typename T>
@@ -65,15 +68,22 @@ ttsl::Span<T> get_as(HostBuffer& buffer) {
 }
 
 template <typename T>
+ttsl::Span<const T> get_as(const HostTensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+template <typename T>
 ttsl::Span<const T> get_as(const Tensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor);
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
     HostBuffer buffer = get_host_buffer(tensor);
     return buffer.template view_as<T>();
 }
 
 template <typename T>
 ttsl::Span<T> get_as(Tensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor);
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
     HostBuffer buffer = get_host_buffer(tensor);
     return buffer.template view_as<T>();
 }
@@ -84,6 +94,8 @@ ttsl::Span<T> get_as(Tensor& tensor) {
     template ttsl::Span<const T> get_as<const T>(const HostBuffer&); \
     template ttsl::Span<T> get_as<T>(HostBuffer&);                   \
     template ttsl::Span<const T> get_as<const T>(HostBuffer&);       \
+    template ttsl::Span<const T> get_as<T>(const HostTensor&);       \
+    template ttsl::Span<const T> get_as<const T>(const HostTensor&); \
     template ttsl::Span<const T> get_as<T>(const Tensor&);           \
     template ttsl::Span<const T> get_as<const T>(const Tensor&);     \
     template ttsl::Span<T> get_as<T>(Tensor&);                       \

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 #include <vector>
 
 #include <ttnn/tensor/host_buffer/functions.hpp>
@@ -10,6 +11,36 @@
 #include <ttnn/tensor/tensor_utils.hpp>
 
 namespace tt::tt_metal::host_buffer {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+template <typename T>
+void validate_datatype(const Tensor& tensor) {
+    using BaseType = std::remove_cvref_t<T>;
+    if constexpr (std::is_same_v<BaseType, uint32_t>) {
+        TT_FATAL(
+            tensor.dtype() == DataType::UINT32 or tensor.dtype() == DataType::BFLOAT8_B or
+                tensor.dtype() == DataType::BFLOAT4_B,
+            "Incorrect data type {}",
+            tensor.dtype());
+    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
+        TT_FATAL(tensor.dtype() == DataType::INT32, "Incorrect data type {}", tensor.dtype());
+    } else if constexpr (std::is_same_v<BaseType, float>) {
+        TT_FATAL(tensor.dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.dtype());
+    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
+        TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.dtype());
+    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
+        TT_FATAL(tensor.dtype() == DataType::UINT16, "Incorrect data type {}", tensor.dtype());
+    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
+        TT_FATAL(tensor.dtype() == DataType::UINT8, "Incorrect data type {}", tensor.dtype());
+    } else {
+        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
 
 HostBuffer get_host_buffer(const Tensor& tensor) {
     TT_FATAL(is_cpu_tensor(tensor), "Tensor must have HostStorage");
@@ -22,4 +53,49 @@ HostBuffer get_host_buffer(const Tensor& tensor) {
         storage.buffer().shape());
     return buffers.front();
 }
+
+template <typename T>
+ttsl::Span<const T> get_as(const HostBuffer& buffer) {
+    return buffer.view_as<T>();
+}
+
+template <typename T>
+ttsl::Span<T> get_as(HostBuffer& buffer) {
+    return buffer.view_as<T>();
+}
+
+template <typename T>
+ttsl::Span<const T> get_as(const Tensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor);
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+template <typename T>
+ttsl::Span<T> get_as(Tensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor);
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+// Explicit template instantiations
+#define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                         \
+    template ttsl::Span<const T> get_as<T>(const HostBuffer&);       \
+    template ttsl::Span<const T> get_as<const T>(const HostBuffer&); \
+    template ttsl::Span<T> get_as<T>(HostBuffer&);                   \
+    template ttsl::Span<const T> get_as<const T>(HostBuffer&);       \
+    template ttsl::Span<const T> get_as<T>(const Tensor&);           \
+    template ttsl::Span<const T> get_as<const T>(const Tensor&);     \
+    template ttsl::Span<T> get_as<T>(Tensor&);                       \
+    template ttsl::Span<const T> get_as<const T>(Tensor&);
+
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(float)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(bfloat16)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint16_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint8_t)
+
+#undef INSTANTIATE_HOST_BUFFER_FUNCTIONS
+
 }  // namespace tt::tt_metal::host_buffer

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1343,21 +1343,24 @@ HostTensor unpad(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
+    // TODO(#40993): This should be a FATAL
+    TT_ASSERT(tensor.layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
     return dispatch(
         tensor.dtype(), [&]<typename T>() { return unpad_impl<T>(tensor, output_tensor_start, output_tensor_end); });
 }
 
 HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape) {
+    // TODO(#40993): These asserts should be FATAL
     for (auto index = -3; index >= -static_cast<int>(tensor.padded_shape().rank()); index--) {
-        TT_FATAL(
+        TT_ASSERT(
             tensor.logical_shape()[index] == output_tensor_shape[index],
             "Input shape must match output shape apart from last 2 dims");
     }
-    TT_FATAL(
+    TT_ASSERT(
         tensor.padded_shape()[-2] % constants::TILE_HEIGHT == 0 &&
             tensor.padded_shape()[-1] % constants::TILE_WIDTH == 0,
         "Last 2 dims of input shape must be multiples of 32");
-    TT_FATAL(
+    TT_ASSERT(
         tensor.padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
             tensor.padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
         "Last 2 dims of output must be within range to have been padded to input");

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -203,7 +203,7 @@ HostTensor pad_bfloat4_b(
 }
 
 HostTensor unpad_bfloat4_b(
-    const Tensor& tensor,
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     auto tile = tensor.tensor_spec().tile();
@@ -1234,6 +1234,7 @@ HostTensor pad(
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
+    TT_FATAL(tensor.layout() != Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
     return dispatch(tensor.dtype(), [&]<typename T>() {
         return pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });
@@ -1270,8 +1271,6 @@ HostTensor unpad_impl(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
-    TT_FATAL(!is_device_tensor(tensor), "unpad only supports host tensors");
-
     const auto& input_shape = tensor.padded_shape();
     const auto input_strides = compute_strides(input_shape);
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1368,6 +1368,55 @@ HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& 
 }
 
 // ======================================================================================
+//                                  .view()
+// ======================================================================================
+
+HostTensor view(
+    const HostTensor& tensor,
+    const tt::tt_metal::Shape& new_logical_shape,
+    const tt::tt_metal::Shape& new_padded_shape) {
+    // Just edit shape if shape has a 0 dimension
+    if (tensor.logical_volume() == 0) {
+        TT_FATAL(new_logical_shape.volume() == 0, "Tensor volume is 0, but shape's volume is not");
+    }
+    bool is_row_major = tensor.layout() == Layout::ROW_MAJOR;
+    bool changing_last_dim = new_padded_shape[-1] != tensor.padded_shape()[-1];
+    const auto& input_memory_config = tensor.memory_config();
+    TT_FATAL(
+        !input_memory_config.is_sharded() || !changing_last_dim ||
+            input_memory_config.shard_spec()->shape[1] == tensor.padded_shape()[-1],
+        "Changing the last dimension of a sharded tensor is not supported unless the shard width matches the input "
+        "last dimension. "
+        "Input shape: {}, New shape: {}, Shard width: {}",
+        tensor.padded_shape(),
+        new_padded_shape,
+        input_memory_config.shard_spec()->shape[1]);
+
+    auto output_memory_config = input_memory_config;
+    if (is_row_major && input_memory_config.is_sharded() && changing_last_dim) {
+        auto shard_spec = input_memory_config.shard_spec().value();
+        auto shard_volume = shard_spec.numel();
+        shard_spec.shape[1] = new_padded_shape[-1];  // update output shard to match new shard width
+        shard_spec.shape[0] = shard_volume / shard_spec.shape[1];
+        output_memory_config =
+            MemoryConfig{input_memory_config.memory_layout(), input_memory_config.buffer_type(), shard_spec};
+    }
+
+    auto new_spec = tt::tt_metal::TensorSpec(
+        new_logical_shape,
+        TensorLayout::fromPaddedShape(
+            tensor.dtype(),
+            tensor.tensor_spec().page_config(),
+            output_memory_config,
+            new_logical_shape,
+            new_padded_shape));
+
+    // TODO (#25340): Review tensor topology logic for reshape
+    const auto& buffer = tensor.buffer();
+    return HostTensor(buffer, new_spec, tensor.tensor_topology());
+}
+
+// ======================================================================================
 //                                  .extract_shard()
 // ======================================================================================
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1239,6 +1239,32 @@ HostTensor pad(
     });
 }
 
+HostTensor pad_to_tile(const HostTensor& tensor, float pad_value) {
+    uint32_t height = tensor.padded_shape()[-2];
+    uint32_t width = tensor.padded_shape()[-1];
+    uint32_t padded_height = round_up(height, constants::TILE_HEIGHT);
+    uint32_t padded_width = round_up(width, constants::TILE_WIDTH);
+
+    ttsl::SmallVector<uint32_t> padded_shape;
+    ttsl::SmallVector<uint32_t> input_tensor_start;
+
+    for (auto index = 0; index < static_cast<int>(tensor.padded_shape().rank()) - 2; index++) {
+        padded_shape.push_back(tensor.padded_shape()[index]);
+        input_tensor_start.push_back(0);
+    }
+
+    padded_shape.push_back(padded_height);
+    padded_shape.push_back(padded_width);
+    input_tensor_start.push_back(0);
+    input_tensor_start.push_back(0);
+
+    return pad(
+        tensor,
+        tt::tt_metal::Shape(std::move(padded_shape)),
+        tt::tt_metal::Shape{std::move(input_tensor_start)},
+        pad_value);
+}
+
 template <typename T>
 HostTensor unpad_impl(
     const HostTensor& tensor,
@@ -1318,6 +1344,28 @@ HostTensor unpad(
     const tt::tt_metal::Shape& output_tensor_end) {
     return dispatch(
         tensor.dtype(), [&]<typename T>() { return unpad_impl<T>(tensor, output_tensor_start, output_tensor_end); });
+}
+
+HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape) {
+    for (auto index = -3; index >= -static_cast<int>(tensor.padded_shape().rank()); index--) {
+        TT_ASSERT(
+            tensor.logical_shape()[index] == output_tensor_shape[index],
+            "Input shape must match output shape apart from last 2 dims");
+    }
+    TT_ASSERT(
+        tensor.padded_shape()[-2] % constants::TILE_HEIGHT == 0 &&
+            tensor.padded_shape()[-1] % constants::TILE_WIDTH == 0,
+        "Last 2 dims of input shape must be multiples of 32");
+    TT_ASSERT(
+        tensor.padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
+            tensor.padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
+        "Last 2 dims of output must be within range to have been padded to input");
+    Shape output_tensor_start(ttsl::SmallVector<uint32_t>(tensor.padded_shape().rank(), 0));
+    Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.padded_shape().rank(), 1));
+    for (int index = -1; index >= -static_cast<int>(output_tensor_shape.rank()); index--) {
+        output_tensor_end[index] = output_tensor_shape[index];
+    }
+    return unpad(tensor, output_tensor_start, output_tensor_end);
 }
 
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -429,9 +429,6 @@ void to_string(
 }  // namespace detail
 
 template <typename T>
-Tensor to_layout_impl(const Tensor& tensor, Layout target_layout);
-
-template <typename T>
 std::string to_string_impl(const Tensor& tensor) {
     const auto& shape = tensor.logical_shape();
 
@@ -449,9 +446,9 @@ std::string to_string_impl(const Tensor& tensor) {
             return tensor;
         }
         if (tensor.dtype() == DataType::BFLOAT8_B || tensor.dtype() == DataType::BFLOAT4_B) {
-            return to_layout_impl<T>(tt::tt_metal::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
+            return to_layout(tt::tt_metal::to_dtype(tensor, DataType::FLOAT32), Layout::ROW_MAJOR);
         }
-        return to_layout_impl<T>(tensor, Layout::ROW_MAJOR);
+        return to_layout(tensor, Layout::ROW_MAJOR);
     };
 
     auto get_host_buffers = [&](const HostStorage& storage) {
@@ -1053,7 +1050,7 @@ template std::vector<uint8_t> decode_tensor_data<uint8_t>(
 // ======================================================================================
 
 template <typename T>
-Tensor to_layout_impl(const Tensor& tensor, Layout target_layout) {
+HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
     if (tensor.layout() == target_layout) {
         return tensor;
     }
@@ -1076,8 +1073,8 @@ Tensor to_layout_impl(const Tensor& tensor, Layout target_layout) {
         TT_THROW("Unreachable");
     };
 
-    return Tensor(
-        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); }),
+    return HostTensor(
+        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); }),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -1090,7 +1087,7 @@ Tensor to_layout_impl(const Tensor& tensor, Layout target_layout) {
 }
 
 template <typename T>
-Tensor to_layout_bfloat_impl(const Tensor& tensor, Layout target_layout) {
+HostTensor to_layout_bfloat_impl(const HostTensor& tensor, Layout target_layout) {
     static_assert(std::is_same_v<T, bfloat8_b> || std::is_same_v<T, bfloat4_b>, "Invalid type T");
     // TODO: Flip to assert when we remove use cases in python and c++
     if (tensor.layout() != target_layout or tensor.layout() != Layout::TILE) {
@@ -1104,16 +1101,16 @@ Tensor to_layout_bfloat_impl(const Tensor& tensor, Layout target_layout) {
 }
 
 template <>
-Tensor to_layout_impl<bfloat8_b>(const Tensor& tensor, Layout target_layout) {
+HostTensor to_layout_impl<bfloat8_b>(const HostTensor& tensor, Layout target_layout) {
     return to_layout_bfloat_impl<bfloat8_b>(tensor, target_layout);
 }
 
 template <>
-Tensor to_layout_impl<bfloat4_b>(const Tensor& tensor, Layout target_layout) {
+HostTensor to_layout_impl<bfloat4_b>(const HostTensor& tensor, Layout target_layout) {
     return to_layout_bfloat_impl<bfloat4_b>(tensor, target_layout);
 }
 
-Tensor to_layout(const Tensor& tensor, Layout target_layout) {
+HostTensor to_layout(const HostTensor& tensor, Layout target_layout) {
     return dispatch(tensor.dtype(), [&]<typename T>() { return to_layout_impl<T>(tensor, target_layout); });
 }
 
@@ -1529,14 +1526,13 @@ tt::tt_metal::DistributedHostBuffer transform_buffers(
 
 }  // namespace detail
 
-Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
+HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
     const auto src_type = input_tensor.dtype();
     if (src_type == dtype) {
         return input_tensor;
     }
-    TT_FATAL(is_cpu_tensor(input_tensor), "to_dtype(...) function only supports host tensors!");
 
-    auto input_buffer = detail::preprocess_buffers(input_tensor.host_tensor().buffer(), src_type);
+    auto input_buffer = detail::preprocess_buffers(input_tensor.buffer(), src_type);
 
     auto output_storage = [src_type, dst_type = dtype, &input_tensor, &input_buffer]() {
         auto with_src_and_dst = [&]<typename SrcType, typename DstType>() {
@@ -1584,7 +1580,7 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
             input_tensor.logical_shape(),
             input_tensor.padded_shape()));
 
-    return Tensor(HostTensor(std::move(output_storage), output_spec, input_tensor.tensor_topology()));
+    return HostTensor(std::move(output_storage), output_spec, input_tensor.tensor_topology());
 }
 
 }  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1231,7 +1231,12 @@ HostTensor pad(
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
-    TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
+    // TODO(#40993): Flip to assert when we remove use cases in python and c++
+    if (tensor.layout() != Layout::ROW_MAJOR) {
+        log_warning(
+            tt::LogOp, "Tensor layout {} must be ROW_MAJOR for padding! Returning original tensor!", tensor.layout());
+        return tensor;
+    }
     return dispatch(tensor.dtype(), [&]<typename T>() {
         return pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -117,8 +117,8 @@ HostTensor pad_bfloat8_b(
     return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
-Tensor unpad_bfloat8_b(
-    const Tensor& tensor,
+HostTensor unpad_bfloat8_b(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     auto tile = tensor.tensor_spec().tile();
@@ -129,17 +129,19 @@ Tensor unpad_bfloat8_b(
     auto input_float_data =
         unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = HostBuffer(std::move(input_float_data));
-    auto float_tensor = Tensor(
-                            std::move(input_float_buffer),
-                            TensorSpec(
-                                tensor.logical_shape(),
-                                TensorLayout::fromPaddedShape(
-                                    DataType::FLOAT32,
-                                    PageConfig(tensor.layout(), tile),
-                                    MemoryConfig{},
-                                    tensor.logical_shape(),
-                                    tensor.padded_shape())))
-                            .unpad(output_tensor_start, output_tensor_end);
+
+    HostTensor intermediate(
+        std::move(input_float_buffer),
+        TensorSpec(
+            tensor.logical_shape(),
+            TensorLayout::fromPaddedShape(
+                DataType::FLOAT32,
+                PageConfig(tensor.layout(), tile),
+                MemoryConfig{},
+                tensor.logical_shape(),
+                tensor.padded_shape())),
+        tensor.tensor_topology());
+    auto float_tensor = unpad(intermediate, output_tensor_start, output_tensor_end);
 
     // Convert back to BFLOAT8_B
     auto output_float_data = host_buffer::get_as<const float>(float_tensor);
@@ -200,7 +202,7 @@ HostTensor pad_bfloat4_b(
     return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
-Tensor unpad_bfloat4_b(
+HostTensor unpad_bfloat4_b(
     const Tensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
@@ -1238,8 +1240,8 @@ HostTensor pad(
 }
 
 template <typename T>
-Tensor unpad_impl(
-    const Tensor& tensor,
+HostTensor unpad_impl(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     TT_FATAL(!is_device_tensor(tensor), "unpad only supports host tensors");
@@ -1283,8 +1285,8 @@ Tensor unpad_impl(
         return output_buffer;
     };
 
-    return Tensor(
-        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); }),
+    return HostTensor(
+        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); }),
         TensorSpec(
             tt::tt_metal::Shape(output_shape),
             tt::tt_metal::TensorLayout(
@@ -1295,23 +1297,23 @@ Tensor unpad_impl(
 }
 
 template <>
-Tensor unpad_impl<bfloat8_b>(
-    const Tensor& tensor,
+HostTensor unpad_impl<bfloat8_b>(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     return unpad_bfloat8_b(tensor, output_tensor_start, output_tensor_end);
 }
 
 template <>
-Tensor unpad_impl<bfloat4_b>(
-    const Tensor& tensor,
+HostTensor unpad_impl<bfloat4_b>(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     return unpad_bfloat4_b(tensor, output_tensor_start, output_tensor_end);
 }
 
-Tensor unpad(
-    const Tensor& tensor,
+HostTensor unpad(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     return dispatch(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1348,15 +1348,15 @@ HostTensor unpad(
 
 HostTensor unpad_from_tile(const HostTensor& tensor, const tt::tt_metal::Shape& output_tensor_shape) {
     for (auto index = -3; index >= -static_cast<int>(tensor.padded_shape().rank()); index--) {
-        TT_ASSERT(
+        TT_FATAL(
             tensor.logical_shape()[index] == output_tensor_shape[index],
             "Input shape must match output shape apart from last 2 dims");
     }
-    TT_ASSERT(
+    TT_FATAL(
         tensor.padded_shape()[-2] % constants::TILE_HEIGHT == 0 &&
             tensor.padded_shape()[-1] % constants::TILE_WIDTH == 0,
         "Last 2 dims of input shape must be multiples of 32");
-    TT_ASSERT(
+    TT_FATAL(
         tensor.padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
             tensor.padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
         "Last 2 dims of output must be within range to have been padded to input");

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1234,7 +1234,7 @@ HostTensor pad(
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
-    TT_FATAL(tensor.layout() != Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
+    TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
     return dispatch(tensor.dtype(), [&]<typename T>() {
         return pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -75,8 +75,8 @@ std::shared_ptr<distributed::MeshBuffer> allocate_device_buffer(
     return distributed::MeshBuffer::create(replicated_buffer_config, device_local_buffer_config, mesh_device);
 }
 
-Tensor pad_bfloat8_b(
-    const Tensor& tensor,
+HostTensor pad_bfloat8_b(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
@@ -114,7 +114,7 @@ Tensor pad_bfloat8_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(std::move(output_uint32_buffer), output_spec);
+    return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
 Tensor unpad_bfloat8_b(
@@ -146,7 +146,7 @@ Tensor unpad_bfloat8_b(
     auto output_packed_data =
         pack_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
-    return Tensor(
+    return HostTensor(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
@@ -155,11 +155,12 @@ Tensor unpad_bfloat8_b(
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
                 float_tensor.logical_shape(),
-                float_tensor.padded_shape())));
+                float_tensor.padded_shape())),
+        tensor.tensor_topology());
 }
 
-Tensor pad_bfloat4_b(
-    const Tensor& tensor,
+HostTensor pad_bfloat4_b(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
@@ -196,7 +197,7 @@ Tensor pad_bfloat4_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(std::move(output_uint32_buffer), output_spec);
+    return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
 Tensor unpad_bfloat4_b(
@@ -228,7 +229,7 @@ Tensor unpad_bfloat4_b(
     auto output_packed_data =
         pack_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
-    return Tensor(
+    return HostTensor(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
@@ -237,7 +238,8 @@ Tensor unpad_bfloat4_b(
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
                 float_tensor.logical_shape(),
-                float_tensor.padded_shape())));
+                float_tensor.padded_shape())),
+        tensor.tensor_topology());
 }
 
 // ======================================================================================
@@ -1118,13 +1120,11 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
 // ======================================================================================
 
 template <typename T>
-Tensor pad_impl(
-    const Tensor& tensor,
+HostTensor pad_impl(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
-    TT_FATAL(!is_device_tensor(tensor), "pad only supports host tensors");
-
     auto pad_value_ = static_cast<T>(pad_value);
     auto input_padded_shape = tensor.padded_shape();
     if (input_padded_shape.rank() < 2) {
@@ -1196,8 +1196,8 @@ Tensor pad_impl(
         return output_buffer;
     };
 
-    return Tensor(
-        tensor.host_storage().transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); }),
+    return HostTensor(
+        tensor.transform([&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); }),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -1210,8 +1210,8 @@ Tensor pad_impl(
 }
 
 template <>
-Tensor pad_impl<bfloat8_b>(
-    const Tensor& tensor,
+HostTensor pad_impl<bfloat8_b>(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
@@ -1219,16 +1219,16 @@ Tensor pad_impl<bfloat8_b>(
 }
 
 template <>
-Tensor pad_impl<bfloat4_b>(
-    const Tensor& tensor,
+HostTensor pad_impl<bfloat4_b>(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
     return pad_bfloat4_b(tensor, output_padded_shape, input_tensor_start, pad_value);
 }
 
-Tensor pad(
-    const Tensor& tensor,
+HostTensor pad(
+    const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -177,7 +177,8 @@ Tensor pad(
         return input_tensor;
     }
 
-    auto output = tensor_impl::pad(input_tensor, output_padded_shape, input_tensor_start, pad_value);
+    auto output =
+        Tensor(tensor_impl::pad(input_tensor.host_tensor(), output_padded_shape, input_tensor_start, pad_value));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -189,7 +189,7 @@ Tensor unpad(
     const tt::tt_metal::Shape& output_tensor_end) {
     GraphTracker::instance().track_function_start(
         "Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
-    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for unpadding");
+    TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for unpadding");
     auto output = Tensor(tensor_impl::unpad(input_tensor.host_tensor(), output_tensor_start, output_tensor_end));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -198,7 +198,7 @@ Tensor unpad(
 
 Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
-    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
+    TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
     auto output = Tensor(tensor_impl::pad_to_tile(input_tensor.host_tensor(), pad_value));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -207,7 +207,7 @@ Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
 Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape) {
     GraphTracker::instance().track_function_start("Tensor::unpad_from_tile", input_tensor, output_tensor_shape);
-    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for unpad_from_tile conversion");
+    TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for unpad_from_tile conversion");
     auto output = Tensor(tensor_impl::unpad_from_tile(input_tensor.host_tensor(), output_tensor_shape));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -268,41 +268,39 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
         return Tensor(std::move(device_storage), new_spec, input_tensor.tensor_topology());
     }
 
-                tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();
-                std::array<uint32_t, 2> shard_page_shape = {1, new_shard_spec.shape[1]};
-                std::array<uint32_t, 2> tensor2d_shape_in_pages = {
-                    new_spec.physical_shape().height() / shard_page_shape[0],
-                    new_spec.physical_shape().width() / shard_page_shape[1]};
-                tt::tt_metal::ShardSpecBuffer new_shard_spec_buffer =
-                    tt::tt_metal::ShardSpecBuffer(new_shard_spec, shard_page_shape, tensor2d_shape_in_pages);
+    tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();
+    std::array<uint32_t, 2> shard_page_shape = {1, new_shard_spec.shape[1]};
+    std::array<uint32_t, 2> tensor2d_shape_in_pages = {
+        new_spec.physical_shape().height() / shard_page_shape[0],
+        new_spec.physical_shape().width() / shard_page_shape[1]};
+    tt::tt_metal::ShardSpecBuffer new_shard_spec_buffer =
+        tt::tt_metal::ShardSpecBuffer(new_shard_spec, shard_page_shape, tensor2d_shape_in_pages);
 
-                tt::tt_metal::Shape tensor_shape_pages(tensor2d_shape_in_pages);
-                tt::tt_metal::Shape shard_shape_pages(new_shard_spec_buffer.shape_in_pages());
-                tt::tt_metal::BufferDistributionSpec new_buffer_dist_spec = tt::tt_metal::BufferDistributionSpec(
-                    tensor_shape_pages, shard_shape_pages, new_shard_spec.grid, new_shard_spec.orientation);
+    tt::tt_metal::Shape tensor_shape_pages(tensor2d_shape_in_pages);
+    tt::tt_metal::Shape shard_shape_pages(new_shard_spec_buffer.shape_in_pages());
+    tt::tt_metal::BufferDistributionSpec new_buffer_dist_spec = tt::tt_metal::BufferDistributionSpec(
+        tensor_shape_pages, shard_shape_pages, new_shard_spec.grid, new_shard_spec.orientation);
 
-                auto device_local_config = input_tensor.mesh_buffer().device_local_config();
-                auto& sharding_args = device_local_config.sharding_args;
-                tt::tt_metal::BufferShardingArgs new_sharding_args(
-                    new_buffer_dist_spec, new_shard_spec_buffer, sharding_args.buffer_layout());
+    auto device_local_config = input_tensor.mesh_buffer().device_local_config();
+    auto& sharding_args = device_local_config.sharding_args;
+    tt::tt_metal::BufferShardingArgs new_sharding_args(
+        new_buffer_dist_spec, new_shard_spec_buffer, sharding_args.buffer_layout());
 
-                tt::tt_metal::distributed::DeviceLocalBufferConfig new_device_config = {
-                    .page_size = new_spec.compute_page_size_bytes(),
-                    .buffer_type = device_local_config.buffer_type,
-                    .sharding_args = new_sharding_args,
-                    .bottom_up = device_local_config.bottom_up};
+    tt::tt_metal::distributed::DeviceLocalBufferConfig new_device_config = {
+        .page_size = new_spec.compute_page_size_bytes(),
+        .buffer_type = device_local_config.buffer_type,
+        .sharding_args = new_sharding_args,
+        .bottom_up = device_local_config.bottom_up};
 
-                auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-                    input_tensor.mesh_buffer().global_config(),
-                    new_device_config,
-                    input_tensor.device(),
-                    input_tensor.mesh_buffer().address());
-                tt::tt_metal::DeviceStorage view_storage(
-                    view_mesh_buffer,
-                    input_tensor.device_storage().coords,
-                    input_tensor.device_storage().get_root_mesh_buffer());
+    auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        input_tensor.mesh_buffer().global_config(),
+        new_device_config,
+        input_tensor.device(),
+        input_tensor.mesh_buffer().address());
+    tt::tt_metal::DeviceStorage view_storage(
+        view_mesh_buffer, input_tensor.device_storage().coords, input_tensor.device_storage().get_root_mesh_buffer());
 
-                return Tensor(view_storage, new_spec, input_tensor.tensor_topology());
+    return Tensor(view_storage, new_spec, input_tensor.tensor_topology());
 }
 
 Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -199,26 +199,7 @@ Tensor unpad(
 
 Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
-    uint32_t height = input_tensor.padded_shape()[-2];
-    uint32_t width = input_tensor.padded_shape()[-1];
-    uint32_t padded_height = round_up(height, constants::TILE_HEIGHT);
-    uint32_t padded_width = round_up(width, constants::TILE_WIDTH);
-
-    ttsl::SmallVector<uint32_t> padded_shape;
-    ttsl::SmallVector<uint32_t> input_tensor_start;
-
-    for (auto index = 0; index < static_cast<int>(input_tensor.padded_shape().rank()) - 2; index++) {
-        padded_shape.push_back(input_tensor.padded_shape()[index]);
-        input_tensor_start.push_back(0);
-    }
-
-    padded_shape.push_back(padded_height);
-    padded_shape.push_back(padded_width);
-    input_tensor_start.push_back(0);
-    input_tensor_start.push_back(0);
-
-    auto output = input_tensor.pad(
-        tt::tt_metal::Shape(std::move(padded_shape)), tt::tt_metal::Shape{std::move(input_tensor_start)}, pad_value);
+    auto output = Tensor(tensor_impl::pad_to_tile(input_tensor.host_tensor(), pad_value));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
@@ -226,26 +207,7 @@ Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
 Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape) {
     GraphTracker::instance().track_function_start("Tensor::unpad_from_tile", input_tensor, output_tensor_shape);
-
-    for (auto index = -3; index >= -static_cast<int>(input_tensor.padded_shape().rank()); index--) {
-        TT_ASSERT(
-            input_tensor.logical_shape()[index] == output_tensor_shape[index],
-            "Input shape must match output shape apart from last 2 dims");
-    }
-    TT_ASSERT(
-        input_tensor.padded_shape()[-2] % constants::TILE_HEIGHT == 0 &&
-            input_tensor.padded_shape()[-1] % constants::TILE_WIDTH == 0,
-        "Last 2 dims of input shape must be multiples of 32");
-    TT_ASSERT(
-        input_tensor.padded_shape()[-2] < output_tensor_shape[-2] + constants::TILE_HEIGHT &&
-            input_tensor.padded_shape()[-1] < output_tensor_shape[-1] + constants::TILE_WIDTH,
-        "Last 2 dims of output must be within range to have been padded to input");
-    Shape output_tensor_start(ttsl::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 0));
-    Shape output_tensor_end(ttsl::SmallVector<uint32_t>(input_tensor.padded_shape().rank(), 1));
-    for (int index = -1; index >= -static_cast<int>(output_tensor_shape.rank()); index--) {
-        output_tensor_end[index] = output_tensor_shape[index];
-    }
-    auto output = input_tensor.unpad(output_tensor_start, output_tensor_end);
+    auto output = Tensor(tensor_impl::unpad_from_tile(input_tensor.host_tensor(), output_tensor_shape));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -152,8 +152,7 @@ Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_
 
 Tensor to_layout(const Tensor& input_tensor, Layout target_layout) {
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout);
-    TT_FATAL(
-        input_tensor.storage_type() != StorageType::DEVICE, "Bring tensor to host before converting to target layout");
+    TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for to_layout conversion");
     Tensor output = tensor_impl::to_layout(input_tensor, target_layout);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -167,7 +166,7 @@ Tensor pad(
     float pad_value) {
     GraphTracker::instance().track_function_start(
         "Tensor::pad", input_tensor, output_padded_shape, input_tensor_start, pad_value);
-    TT_ASSERT(is_cpu_tensor(input_tensor), "Tensor must be on host for padding");
+    TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for padding");
     // TODO: Flip to assert when we remove use cases in python and c++
     if (input_tensor.layout() != Layout::ROW_MAJOR) {
         log_warning(
@@ -190,7 +189,7 @@ Tensor unpad(
     const tt::tt_metal::Shape& output_tensor_end) {
     GraphTracker::instance().track_function_start(
         "Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
-    TT_ASSERT(input_tensor.layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
+    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for unpadding");
     auto output = Tensor(tensor_impl::unpad(input_tensor.host_tensor(), output_tensor_start, output_tensor_end));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -218,7 +218,6 @@ Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& ou
 //                                  .tensor_view()
 // ======================================================================================
 
-// TODO(river): This will be moved to runtime after MeshTensor is in.
 Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
     // Just edit shape if shape has a 0 dimension
     if (input_tensor.logical_volume() == 0) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -197,6 +197,15 @@ Tensor unpad(
 }
 
 Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
+    // TODO: Flip to assert when we remove use cases in python and c++
+    if (input_tensor.layout() != Layout::ROW_MAJOR) {
+        log_warning(
+            tt::LogOp,
+            "Tensor layout {} must be ROW_MAJOR for padding! Returning original tensor!",
+            input_tensor.layout());
+        return input_tensor;
+    }
+
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
     auto output = Tensor(tensor_impl::pad_to_tile(input_tensor.host_tensor(), pad_value));

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -153,7 +153,7 @@ Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_
 Tensor to_layout(const Tensor& input_tensor, Layout target_layout) {
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for to_layout conversion");
-    Tensor output = tensor_impl::to_layout(input_tensor, target_layout);
+    Tensor output = Tensor(tensor_impl::to_layout(input_tensor.host_tensor(), target_layout));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
@@ -337,7 +337,7 @@ Tensor reshape(const Tensor& input_tensor, const tt::tt_metal::Shape& new_shape)
 
 Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
     GraphTracker::instance().track_function_start("tt::tt_metal::to_dtype", input_tensor, dtype);
-    auto output_tensor = tensor_impl::to_dtype(input_tensor, dtype);
+    auto output_tensor = Tensor(tensor_impl::to_dtype(input_tensor.host_tensor(), dtype));
     GraphTracker::instance().track_function_end(output_tensor);
     return output_tensor;
 }

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -198,6 +198,7 @@ Tensor unpad(
 
 Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
+    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
     auto output = Tensor(tensor_impl::pad_to_tile(input_tensor.host_tensor(), pad_value));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -206,6 +207,7 @@ Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
 Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& output_tensor_shape) {
     GraphTracker::instance().track_function_start("Tensor::unpad_from_tile", input_tensor, output_tensor_shape);
+    TT_FATAL(is_device_tensor(input_tensor), "Tensor must be on host for unpad_from_tile conversion");
     auto output = Tensor(tensor_impl::unpad_from_tile(input_tensor.host_tensor(), output_tensor_shape));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -216,10 +218,8 @@ Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& ou
 //                                  .tensor_view()
 // ======================================================================================
 
-Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
-    tt::tt_metal::GraphTracker::instance().track_function_start(
-        "Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
-
+// TODO(river): This will be moved to runtime after MeshTensor is in.
+Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
     // Just edit shape if shape has a 0 dimension
     if (input_tensor.logical_volume() == 0) {
         TT_FATAL(new_logical_shape.volume() == 0, "Tensor volume is 0, but shape's volume is not");
@@ -255,22 +255,18 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
             output_memory_config,
             new_logical_shape,
             new_padded_shape));
-    // TODO (#25340): Review tensor topology logic for reshape
-    auto output = std::invoke(
-        [&input_tensor, &new_spec, &new_logical_shape, &output_memory_config, &changing_last_dim]() -> Tensor {
-            const auto& tensor = input_tensor;
 
-            if (is_device_tensor(tensor)) {
-                auto device_storage = tensor.device_storage();
-                if (tensor.layout() != Layout::ROW_MAJOR || !changing_last_dim) {
-                    return Tensor(std::move(device_storage), new_spec, tensor.tensor_topology());
-                }
-                if (!tensor.memory_config().is_sharded()) {
-                    auto* device_buffer = device_storage.get_buffer();
-                    auto page_size_bytes = new_spec.compute_page_size_bytes();
-                    device_buffer->set_page_size(page_size_bytes);
-                    return Tensor(std::move(device_storage), new_spec, tensor.tensor_topology());
-                }
+    // TODO (#25340): Review tensor topology logic for reshape
+    if (input_tensor.layout() != Layout::ROW_MAJOR || !changing_last_dim) {
+        return Tensor(input_tensor.device_storage(), new_spec, input_tensor.tensor_topology());
+    }
+    if (!input_tensor.memory_config().is_sharded()) {
+        auto device_storage = input_tensor.device_storage();
+        auto* device_buffer = device_storage.get_buffer();
+        auto page_size_bytes = new_spec.compute_page_size_bytes();
+        device_buffer->set_page_size(page_size_bytes);
+        return Tensor(std::move(device_storage), new_spec, input_tensor.tensor_topology());
+    }
 
                 tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();
                 std::array<uint32_t, 2> shard_page_shape = {1, new_shard_spec.shape[1]};
@@ -285,7 +281,7 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                 tt::tt_metal::BufferDistributionSpec new_buffer_dist_spec = tt::tt_metal::BufferDistributionSpec(
                     tensor_shape_pages, shard_shape_pages, new_shard_spec.grid, new_shard_spec.orientation);
 
-                auto device_local_config = device_storage.get_mesh_buffer().device_local_config();
+                auto device_local_config = input_tensor.mesh_buffer().device_local_config();
                 auto& sharding_args = device_local_config.sharding_args;
                 tt::tt_metal::BufferShardingArgs new_sharding_args(
                     new_buffer_dist_spec, new_shard_spec_buffer, sharding_args.buffer_layout());
@@ -297,19 +293,29 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                     .bottom_up = device_local_config.bottom_up};
 
                 auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-                    device_storage.get_mesh_buffer().global_config(),
+                    input_tensor.mesh_buffer().global_config(),
                     new_device_config,
-                    device_storage.get_device(),
-                    device_storage.get_mesh_buffer().address());
+                    input_tensor.device(),
+                    input_tensor.mesh_buffer().address());
                 tt::tt_metal::DeviceStorage view_storage(
-                    view_mesh_buffer, device_storage.coords, device_storage.get_root_mesh_buffer());
+                    view_mesh_buffer,
+                    input_tensor.device_storage().coords,
+                    input_tensor.device_storage().get_root_mesh_buffer());
 
-                return Tensor(view_storage, new_spec, tensor.tensor_topology());
-            }
+                return Tensor(view_storage, new_spec, input_tensor.tensor_topology());
+}
 
-            const auto& buffer = tensor.host_storage().buffer();
-            return Tensor(HostTensor(buffer, new_spec, tensor.tensor_topology()));
-        });
+Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
+    tt::tt_metal::GraphTracker::instance().track_function_start(
+        "Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
+
+    Tensor output;
+    if (is_cpu_tensor(input_tensor)) {
+        output = Tensor(tensor_impl::view(input_tensor.host_tensor(), new_logical_shape, new_padded_shape));
+    } else {
+        output = view_device(input_tensor, new_logical_shape, new_padded_shape);
+    }
+
     output = tt::tt_metal::set_tensor_id(output);
     tt::tt_metal::GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -191,7 +191,7 @@ Tensor unpad(
     GraphTracker::instance().track_function_start(
         "Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
     TT_ASSERT(input_tensor.layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
-    auto output = tensor_impl::unpad(input_tensor, output_tensor_start, output_tensor_end);
+    auto output = Tensor(tensor_impl::unpad(input_tensor.host_tensor(), output_tensor_start, output_tensor_end));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36877

### PR Type
Refactor

### Problem description
Runtime is lowering ttnn::Tensor to tt_metal as HostTensor and MeshTensor.
HostTensor has a certain set of host side ops that needs lowering.

### What's changed
This PR separates out the ops on the ttnn side so ttnn::Tensor ops calls HostTensor ops when possible.
Note all functions are still in ttnn land to ease review burden,
and will be lowered in a subsequent PR.

Functions migrated:
- to_layout
- to_dtype
- pad
- pad_to_tile
- unpad
- unpad_to_tile

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-tensor-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-tensor-ops)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/host-tensor-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/host-tensor-ops)
  - Error present in main 
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-tensor-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-tensor-ops)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

