### PR TITLE
[Feature]: Bringup Watcher RTA/CRTA Asserts on QSR

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -132,6 +132,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         std::vector<uint32_t> zero_init(4, 0);  // 2 words for DM + 2 words for TRISC0
         for (const auto& core : core_range) {
             tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, compute_scratch_addr, zero_init);
         }
 
         distributed::MeshWorkload workload;
@@ -147,7 +148,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
                 .compile_args = {l1_unreserved_base}});
 
         CreateKernel(
-            program, rta_crta_kernel_path, core_range_set, ComputeConfig{.compile_args = {l1_unreserved_base}});
+            program, rta_crta_kernel_path, core_range_set, ComputeConfig{.compile_args = {compute_scratch_addr}});
 
         // No SetRuntimeArgs called - all cores have RTA/CRTA offset = 0xFFFF pattern
         workload.add_program(device_range, std::move(program));

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -25,6 +25,11 @@ class RTATestFixture : public MeshWatcherFixture {
 protected:
     const std::string rta_crta_kernel_path =
         "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp";
+    bool is_quasar{false};
+    uint32_t l1_unreserved_base{0};
+    std::shared_ptr<distributed::MeshDevice> mesh_device;
+    IDevice* device{nullptr};
+    uint32_t num_dms_{0};
 
     void SetUp() override {
         bool watcher_assert_disabled = MetalContext::instance().rtoptions().watcher_assert_disabled();
@@ -32,8 +37,12 @@ protected:
             GTEST_SKIP() << "This test requires watcher assert checks (RTA/CRTA) to be enabled";
         }
         MeshWatcherFixture::SetUp();
+        mesh_device = devices_[0];
+        device = mesh_device->get_devices()[0];
+        num_dms_ = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
+        is_quasar = arch_ == tt::ARCH::QUASAR;
+        l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     }
-
     // Common test data
     const std::vector<uint32_t> default_rtas{0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD, 0xEEEEEEEE};
     const std::vector<uint32_t> default_crtas{0x22222222, 0x33333333, 0x44444444, 0x55555555, 0x66666666, 0x77777777};
@@ -43,15 +52,13 @@ protected:
 
     // Helper: Read and validate RTA/CRTA results from L1
     void ValidateArgResults(
-        IDevice* device,
         const CoreCoord& core,
-        uint32_t l1_addr,
         const std::vector<uint32_t>& expected_rtas,
         const std::vector<uint32_t>& expected_crtas) {
         const uint32_t total_size = (2 + expected_rtas.size() + expected_crtas.size()) * sizeof(uint32_t);
         std::vector<uint32_t> read_result;
 
-        tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_addr, total_size, read_result);
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, total_size, read_result);
 
         // Validate counts
         EXPECT_EQ(read_result[0], expected_rtas.size());
@@ -103,21 +110,14 @@ struct RTAAssertTestParams {
 class RTAAssertTest : public RTATestFixture, public ::testing::WithParamInterface<RTAAssertTestParams> {};
 
 // Verifies watcher handles 0xFFFF sentinel pattern (used when no RTAs set):
-// - Device interprets 0xBEEF#### as rta_count = 0 (validated on BRISC/TRISC0)
+// - Device interprets 0xBEEF#### as rta_count = 0 (validated on DM0/TRISC0)
 // - Kernels not accessing args run successfully with sentinel pattern
 // - Kernels accessing args when count = 0 trigger "out of bounds" assert
 // - Catches bug: kernel placed on cores but SetRuntimeArgs() only called for subset
 TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
-    const auto& hal = MetalContext::instance().hal();
-    if (hal.get_arch() == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "Test not yet supported on Quasar";
-    }
-    if (IsSlowDispatch()) {
+    if (IsSlowDispatch() || is_quasar) {
         GTEST_SKIP() << "This test can only be run with fast dispatch mode";
     }
-
-    auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
 
     // Part A: Zero-arg kernels should see rta_count = 0, crta_count = 0
     {
@@ -125,7 +125,6 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         CoreRangeSet core_range_set(std::vector{core_range});
 
         const uint32_t total_read_size = 2 * sizeof(uint32_t);
-        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         // Separate L1 space for TRISC0 writeback (DM writes 2 words, so offset by 8 bytes)
         uint32_t compute_scratch_addr = l1_unreserved_base + total_read_size;
 
@@ -148,7 +147,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
                 .compile_args = {l1_unreserved_base}});
 
         CreateKernel(
-            program, rta_crta_kernel_path, core_range_set, ComputeConfig{.compile_args = {compute_scratch_addr}});
+            program, rta_crta_kernel_path, core_range_set, ComputeConfig{.compile_args = {l1_unreserved_base}});
 
         // No SetRuntimeArgs called - all cores have RTA/CRTA offset = 0xFFFF pattern
         workload.add_program(device_range, std::move(program));
@@ -204,12 +203,6 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
 // cores, and re-dispatching on subsequent runs. Ensures arg counts and payload
 // values match what was set via SetRuntimeArgs/SetCommonRuntimeArgs
 TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
-    const auto& hal = MetalContext::instance().hal();
-    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
-
-    auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
-
     // Quasar: single core; other archs: multi-core with two ranges
     CoreRange core_range1 =
         is_quasar ? CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)) : CoreRange(CoreCoord(0, 0), CoreCoord(1, 1));
@@ -219,7 +212,6 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     // Use l1_unreserved space for RTA/CRTA write back to L1 for verification of correct dispatch payload
     const uint32_t total_word_count = 2 + default_rtas.size() + default_crtas.size();
-    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     // Zero-init the L1 scratch space on all cores before running
     std::vector<uint32_t> zero_init(total_word_count, 0);
@@ -237,15 +229,13 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     KernelHandle kernel;
     if (is_quasar) {
-        auto num_dms = hal.get_processor_types_count(
-            HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
         // Compile args: [dm_id, l1_scratch_addr]
         kernel = experimental::quasar::CreateKernel(
             program,
             rta_crta_kernel_path,
             core_range_set,
             experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = num_dms, .compile_args = {0, l1_unreserved_base}});
+                .num_threads_per_cluster = num_dms_, .compile_args = {0, l1_unreserved_base}});
     } else {
         // Compile args: [l1_scratch_addr]
         kernel = CreateKernel(
@@ -274,11 +264,11 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     // Validate first run
     for (const auto& core : core_range1) {
-        ValidateArgResults(device, core, l1_unreserved_base, default_rtas, default_crtas);
+        ValidateArgResults(core, default_rtas, default_crtas);
     }
     if (!is_quasar) {
         for (const auto& core : core_range2) {
-            ValidateArgResults(device, core, l1_unreserved_base, rtas_range2, default_crtas);
+            ValidateArgResults(core, rtas_range2, default_crtas);
         }
     }
 
@@ -303,11 +293,11 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     // Validate second run for both core ranges
     for (const auto& core : core_range1) {
-        ValidateArgResults(device, core, l1_unreserved_base, default_rtas, default_crtas);
+        ValidateArgResults(core, default_rtas, default_crtas);
     }
     if (!is_quasar) {
         for (const auto& core : core_range2) {
-            ValidateArgResults(device, core, l1_unreserved_base, rtas_range2, default_crtas);
+            ValidateArgResults(core, rtas_range2, default_crtas);
         }
     }
 }
@@ -317,8 +307,6 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 // Tests RTA/CRTA access on DM0 and TRISC0 (single processor per test)
 TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     const auto& params = GetParam();
-    const auto& hal = MetalContext::instance().hal();
-    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
     // Dispatch mode validation:
     // - Quasar: SD only (FD not yet available)
@@ -348,15 +336,13 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     switch (params.processor_class) {
         case HalProcessorClassType::DM:
             if (is_quasar) {
-                auto num_dms = hal.get_processor_types_count(
-                    HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
                 // Compile args: [dm_id]
                 kernel = experimental::quasar::CreateKernel(
                     program,
                     rta_crta_kernel_path,
                     core_range_set,
                     experimental::quasar::QuasarDataMovementConfig{
-                        .num_threads_per_cluster = num_dms, .compile_args = {0}, .defines = defines});
+                        .num_threads_per_cluster = num_dms_, .compile_args = {0}, .defines = defines});
             } else {
                 kernel = CreateKernel(
                     program,
@@ -372,7 +358,8 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
                     program,
                     rta_crta_kernel_path,
                     core_range_set,
-                    experimental::quasar::QuasarComputeConfig{.defines = defines});
+                    experimental::quasar::QuasarComputeConfig{
+                        .num_threads_per_cluster = 1 /*Run only on 1 NEO Cluster*/, .defines = defines});
             } else {
                 kernel = CreateKernel(program, rta_crta_kernel_path, core_range_set, ComputeConfig{.defines = defines});
             }
@@ -395,22 +382,12 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 // Uses a sync barrier so all DMs hit the OOB access together, stress-testing
 // watcher's first-writer-wins assert mechanism. Any DM can report the error.
 TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
-    const auto& hal = MetalContext::instance().hal();
-    if (hal.get_arch() != tt::ARCH::QUASAR) {
+    if (!is_quasar) {
         GTEST_SKIP() << "Test only applicable to Quasar";
     }
 
     CoreRange core_range(CoreCoord(0, 0), CoreCoord(0, 0));
     CoreRangeSet core_range_set(std::vector{core_range});
-
-    auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
-
-    auto num_dms = hal.get_processor_types_count(
-        HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
-
-    // L1 sync counter for barrier (8 bytes for uint64_t)
-    uint32_t l1_sync_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     distributed::MeshWorkload workload;
     Program program;
@@ -424,14 +401,14 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         rta_crta_kernel_path,
         core_range_set,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = num_dms, .compile_args = {num_dms, l1_sync_addr}, .defines = defines});
+            .num_threads_per_cluster = num_dms_, .compile_args = {num_dms_, l1_unreserved_base}, .defines = defines});
 
     SetRuntimeArgs(program, kernel, core_range, default_rtas);
     workload.add_program(device_range, std::move(program));
 
     // Zero out sync counter before launch
     std::vector<uint32_t> zero_sync = {0, 0};
-    tt::tt_metal::detail::WriteToDeviceL1(device, core_range.start_coord, l1_sync_addr, zero_sync);
+    tt::tt_metal::detail::WriteToDeviceL1(device, core_range.start_coord, l1_unreserved_base, zero_sync);
 
     RunProgram(mesh_device, workload);
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -33,6 +33,7 @@ protected:
         }
         MeshWatcherFixture::SetUp();
     }
+
     // Common test data
     const std::vector<uint32_t> default_rtas{0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD, 0xEEEEEEEE};
     const std::vector<uint32_t> default_crtas{0x22222222, 0x33333333, 0x44444444, 0x55555555, 0x66666666, 0x77777777};
@@ -40,73 +41,17 @@ protected:
     distributed::MeshCoordinate zero_coord{0, 0};
     distributed::MeshCoordinateRange device_range{zero_coord, zero_coord};
 
-    // Helper: Create DM kernel (arch-aware)
-    // On Quasar, launches kernel on all DMs with compile_args[0] = dm_select so only
-    // the target DM executes; others exit early via get_my_thread_id() guard.
-    // On BH/WH, launches on RISCV_0 (BRISC) only.
-    // l1_scratch_addr: L1 address for writing RTA/CRTA results (passed as compile-time arg)
-    KernelHandle CreateDMKernel(
-        Program& program,
-        const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-        uint32_t l1_scratch_addr,
-        std::map<std::string, std::string> defines = {},
-        uint32_t dm_select = 0) {
-        const auto& hal = MetalContext::instance().hal();
-        if (hal.get_arch() == tt::ARCH::QUASAR) {
-            auto num_dms = hal.get_processor_types_count(
-                HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
-            return experimental::quasar::CreateKernel(
-                program,
-                rta_crta_kernel_path,
-                core_spec,
-                experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = num_dms,
-                    .compile_args = {dm_select, l1_scratch_addr},
-                    .defines = defines});
-        }
-        return CreateKernel(
-            program,
-            rta_crta_kernel_path,
-            core_spec,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = {l1_scratch_addr},
-                .defines = defines});
-    }
-
-    // Helper: Create compute kernel (arch-aware)
-    KernelHandle CreateComputeKernel(
-        Program& program,
-        const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
-        uint32_t compute_scratch_addr,
-        const std::map<std::string, std::string>& defines = {}) {
-        const auto& hal = MetalContext::instance().hal();
-        if (hal.get_arch() == tt::ARCH::QUASAR) {
-            return experimental::quasar::CreateKernel(
-                program,
-                rta_crta_kernel_path,
-                core_spec,
-                experimental::quasar::QuasarComputeConfig{.compile_args = {compute_scratch_addr}, .defines = defines});
-        }
-        return CreateKernel(
-            program,
-            rta_crta_kernel_path,
-            core_spec,
-            ComputeConfig{.compile_args = {compute_scratch_addr}, .defines = defines});
-    }
-
-    // Helper: Read and validate RTA/CRTA results
+    // Helper: Read and validate RTA/CRTA results from L1
     void ValidateArgResults(
         IDevice* device,
         const CoreCoord& core,
-        uint32_t cb_addr,
+        uint32_t l1_addr,
         const std::vector<uint32_t>& expected_rtas,
         const std::vector<uint32_t>& expected_crtas) {
         const uint32_t total_size = (2 + expected_rtas.size() + expected_crtas.size()) * sizeof(uint32_t);
         std::vector<uint32_t> read_result;
 
-        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, total_size, read_result);
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_addr, total_size, read_result);
 
         // Validate counts
         EXPECT_EQ(read_result[0], expected_rtas.size());
@@ -163,6 +108,10 @@ class RTAAssertTest : public RTATestFixture, public ::testing::WithParamInterfac
 // - Kernels accessing args when count = 0 trigger "out of bounds" assert
 // - Catches bug: kernel placed on cores but SetRuntimeArgs() only called for subset
 TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
+    const auto& hal = MetalContext::instance().hal();
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Test not yet supported on Quasar";
+    }
     if (IsSlowDispatch()) {
         GTEST_SKIP() << "This test can only be run with fast dispatch mode";
     }
@@ -177,9 +126,11 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
 
         const uint32_t total_read_size = 2 * sizeof(uint32_t);
         uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        // Separate L1 space for TRISC0 writeback (DM writes 2 words, so offset by 8 bytes)
+        uint32_t compute_scratch_addr = l1_unreserved_base + total_read_size;
 
-        // Zero-init the L1 scratch space on all cores
-        std::vector<uint32_t> zero_init(2, 0);
+        // Zero-init the L1 scratch space on all cores (both DM and compute regions)
+        std::vector<uint32_t> zero_init(4, 0);  // 2 words for DM + 2 words for TRISC0
         for (const auto& core : core_range) {
             tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
         }
@@ -187,8 +138,17 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         distributed::MeshWorkload workload;
         Program program;
 
-        CreateDMKernel(program, core_range_set, l1_unreserved_base);
-        CreateComputeKernel(program, core_range_set, l1_unreserved_base);
+        CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_range_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = {l1_unreserved_base}});
+
+        CreateKernel(
+            program, rta_crta_kernel_path, core_range_set, ComputeConfig{.compile_args = {compute_scratch_addr}});
 
         // No SetRuntimeArgs called - all cores have RTA/CRTA offset = 0xFFFF pattern
         workload.add_program(device_range, std::move(program));
@@ -204,10 +164,8 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
             EXPECT_EQ(read_result[1], 0);  // crta_count
 
             // TRISC0: verify rta_count = 0, crta_count = 0
-            // Note: Both DM and compute write to the same L1 address, so we're validating
-            // the last writer (compute kernel) here
             read_result.clear();
-            tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, total_read_size, read_result);
+            tt::tt_metal::detail::ReadFromDeviceL1(device, core, compute_scratch_addr, total_read_size, read_result);
             EXPECT_EQ(read_result[0], 0);  // rta_count
             EXPECT_EQ(read_result[1], 0);  // crta_count
         }
@@ -219,12 +177,17 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         CoreRange cores_without_rtas(CoreCoord(2, 2), CoreCoord(3, 3));
         CoreRangeSet core_range_set(std::vector{cores_with_rtas, cores_without_rtas});
 
-        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-
         distributed::MeshWorkload workload;
         Program program;
 
-        auto kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base, {{"MAX_RTA_IDX", "0"}});
+        auto kernel = CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_range_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .defines = {{"MAX_RTA_IDX", "0"}}});  // Kernel will try to read RTA[0]
 
         SetRuntimeArgs(program, kernel, cores_with_rtas, default_rtas);
         // cores_without_rtas has NO RTAs set - 0xBEEF#### pattern -> rta_count = 0 -> assert
@@ -254,7 +217,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     CoreRangeSet core_range_set =
         is_quasar ? CoreRangeSet(std::vector{core_range1}) : CoreRangeSet(std::vector{core_range1, core_range2});
 
-    // Use l1_unreserved space instead of CB for scratch storage
+    // Use l1_unreserved space for RTA/CRTA write back to L1 for verification of correct dispatch payload
     const uint32_t total_word_count = 2 + default_rtas.size() + default_crtas.size();
     uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
@@ -272,18 +235,39 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     distributed::MeshWorkload workload;
     Program program;
 
-    auto kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base);
+    KernelHandle kernel;
+    if (is_quasar) {
+        auto num_dms = hal.get_processor_types_count(
+            HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
+        // Compile args: [dm_id, l1_scratch_addr]
+        kernel = experimental::quasar::CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_range_set,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = num_dms, .compile_args = {0, l1_unreserved_base}});
+    } else {
+        // Compile args: [l1_scratch_addr]
+        kernel = CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_range_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = {l1_unreserved_base}});
+    }
 
-    // Range 1 RTAs
+    // Range 1: 5 RTAs per core
     SetRuntimeArgs(program, kernel, core_range1, default_rtas);
 
-    // Range 2: different RTA size (non-Quasar only)
+    // Range 2: 3 RTAs per core (different size than core_range1)
     std::vector<uint32_t> rtas_range2 = {0x1000, 0x1001, 0x1002};
     if (!is_quasar) {
         SetRuntimeArgs(program, kernel, core_range2, rtas_range2);
     }
 
-    // Common args shared across all cores
+    // Common args
     SetCommonRuntimeArgs(program, kernel, default_crtas);
     workload.add_program(device_range, std::move(program));
     RunProgram(mesh_device, workload);
@@ -308,7 +292,8 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
         }
     }
 
-    // Second run: call SetRuntimeArgs again to test re-dispatch with updated arg counts
+    // Second run: call SetRuntimeArgs again. This tests the case when we're memcpying new data
+    // directly into the command issue queue with the arg count
     auto& program_from_workload = workload.get_programs().at(device_range);
     SetRuntimeArgs(program_from_workload, kernel, core_range1, default_rtas);
     if (!is_quasar) {
@@ -316,7 +301,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     }
     RunProgram(mesh_device, workload);
 
-    // Validate second run
+    // Validate second run for both core ranges
     for (const auto& core : core_range1) {
         ValidateArgResults(device, core, l1_unreserved_base, default_rtas, default_crtas);
     }
@@ -348,9 +333,6 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     CoreRangeSet core_range_set(std::vector{core_range});
 
     auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
-
-    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     distributed::MeshWorkload workload;
     Program program;
@@ -362,14 +344,38 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
         defines["MAX_CRTA_IDX"] = std::to_string(default_crtas.size());  // Out of bounds
     }
 
-    // Create kernel based on processor class (arch-specific creation handled by helpers)
     KernelHandle kernel;
     switch (params.processor_class) {
         case HalProcessorClassType::DM:
-            kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base, defines);
+            if (is_quasar) {
+                auto num_dms = hal.get_processor_types_count(
+                    HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
+                // Compile args: [dm_id]
+                kernel = experimental::quasar::CreateKernel(
+                    program,
+                    rta_crta_kernel_path,
+                    core_range_set,
+                    experimental::quasar::QuasarDataMovementConfig{
+                        .num_threads_per_cluster = num_dms, .compile_args = {0}, .defines = defines});
+            } else {
+                kernel = CreateKernel(
+                    program,
+                    rta_crta_kernel_path,
+                    core_range_set,
+                    DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+            }
             break;
         case HalProcessorClassType::COMPUTE:
-            kernel = CreateComputeKernel(program, core_range_set, l1_unreserved_base, defines);
+            if (is_quasar) {
+                kernel = experimental::quasar::CreateKernel(
+                    program,
+                    rta_crta_kernel_path,
+                    core_range_set,
+                    experimental::quasar::QuasarComputeConfig{.defines = defines});
+            } else {
+                kernel = CreateKernel(program, rta_crta_kernel_path, core_range_set, ComputeConfig{.defines = defines});
+            }
             break;
         default: TT_THROW("Unsupported processor class");
     }
@@ -403,26 +409,22 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
     auto num_dms = hal.get_processor_types_count(
         HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
 
-    // L1 layout: [sync_counter (8 bytes)] [scratch space for RTA/CRTA results]
-    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    uint32_t l1_sync_addr = l1_unreserved_base;
-    uint32_t l1_scratch_addr = l1_unreserved_base + 8;  // After 8-byte sync counter
+    // L1 sync counter for barrier (8 bytes for uint64_t)
+    uint32_t l1_sync_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     distributed::MeshWorkload workload;
     Program program;
 
-    // All DMs sync then attempt OOB RTA access together
     std::map<std::string, std::string> defines = {
         {"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}};
 
+    // Compile args: [num_dms, l1_sync_addr]
     auto kernel = experimental::quasar::CreateKernel(
         program,
         rta_crta_kernel_path,
         core_range_set,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = num_dms,
-            .compile_args = {num_dms, l1_sync_addr, l1_scratch_addr},
-            .defines = defines});
+            .num_threads_per_cluster = num_dms, .compile_args = {num_dms, l1_sync_addr}, .defines = defines});
 
     SetRuntimeArgs(program, kernel, core_range, default_rtas);
     workload.add_program(device_range, std::move(program));
@@ -441,14 +443,14 @@ INSTANTIATE_TEST_SUITE_P(
     WatcherArgAsserts,
     RTAAssertTest,
     ::testing::Values(
-        // RTA out-of-bounds on DM0
+        // RTA tests on DM0
         RTAAssertTestParams{"RTA_DM0", true, "unique runtime arg index out of bounds", HalProcessorClassType::DM},
-        // RTA out-of-bounds on TRISC0
+        // RTA tests on TRISC0
         RTAAssertTestParams{
             "RTA_TRISC0", true, "unique runtime arg index out of bounds", HalProcessorClassType::COMPUTE},
-        // CRTA out-of-bounds on DM0
+        // CRTA tests on DM0
         RTAAssertTestParams{"CRTA_DM0", false, "common runtime arg index out of bounds", HalProcessorClassType::DM},
-        // CRTA out-of-bounds on TRISC0
+        // CRTA tests on TRISC0
         RTAAssertTestParams{
             "CRTA_TRISC0", false, "common runtime arg index out of bounds", HalProcessorClassType::COMPUTE}),
     [](const ::testing::TestParamInfo<RTAAssertTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include <gtest/gtest.h>
 
-#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
@@ -18,8 +17,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/experimental/host_api.hpp>
 #include "debug_tools_fixture.hpp"
-#include "impl/buffers/circular_buffer.hpp"
-#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -43,20 +40,15 @@ protected:
     distributed::MeshCoordinate zero_coord{0, 0};
     distributed::MeshCoordinateRange device_range{zero_coord, zero_coord};
 
-    // Helper: Create CB config for RTA/CRTA tests
-    CircularBufferConfig CreateArgCBConfig(uint32_t word_count) {
-        const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-        uint32_t cb_size = tt::align(word_count * sizeof(uint32_t), l1_alignment);
-        return CircularBufferConfig(cb_size, {{0, tt::DataFormat::Float32}}).set_page_size(0, cb_size);
-    }
-
     // Helper: Create DM kernel (arch-aware)
     // On Quasar, launches kernel on all DMs with compile_args[0] = dm_select so only
     // the target DM executes; others exit early via get_my_thread_id() guard.
     // On BH/WH, launches on RISCV_0 (BRISC) only.
+    // l1_scratch_addr: L1 address for writing RTA/CRTA results (passed as compile-time arg)
     KernelHandle CreateDMKernel(
         Program& program,
         const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+        uint32_t l1_scratch_addr,
         std::map<std::string, std::string> defines = {},
         uint32_t dm_select = 0) {
         const auto& hal = MetalContext::instance().hal();
@@ -68,14 +60,19 @@ protected:
                 rta_crta_kernel_path,
                 core_spec,
                 experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = num_dms, .compile_args = {dm_select}, .defines = defines});
+                    .num_threads_per_cluster = num_dms,
+                    .compile_args = {dm_select, l1_scratch_addr},
+                    .defines = defines});
         }
         return CreateKernel(
             program,
             rta_crta_kernel_path,
             core_spec,
             DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = {l1_scratch_addr},
+                .defines = defines});
     }
 
     // Helper: Create compute kernel (arch-aware)
@@ -179,41 +176,38 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         CoreRangeSet core_range_set(std::vector{core_range});
 
         const uint32_t total_read_size = 2 * sizeof(uint32_t);
-        const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-        uint32_t cb_size = tt::align(total_read_size, l1_alignment);
-        CircularBufferConfig cb0(cb_size, {{tt::CBIndex::c_0, tt::DataFormat::Float32}});
-        cb0.set_page_size(tt::CBIndex::c_0, cb_size);
-        uint32_t compute_scratch_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+        // Zero-init the L1 scratch space on all cores
+        std::vector<uint32_t> zero_init(2, 0);
+        for (const auto& core : core_range) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
+        }
 
         distributed::MeshWorkload workload;
         Program program;
-        CBHandle cb0_handle = CreateCircularBuffer(program, core_range_set, cb0);
 
-        CreateDMKernel(program, core_range_set);
-        CreateComputeKernel(program, core_range_set, compute_scratch_addr);
+        CreateDMKernel(program, core_range_set, l1_unreserved_base);
+        CreateComputeKernel(program, core_range_set, l1_unreserved_base);
 
         // No SetRuntimeArgs called - all cores have RTA/CRTA offset = 0xFFFF pattern
         workload.add_program(device_range, std::move(program));
         RunProgram(mesh_device, workload);
 
-        auto& program_from_workload = workload.get_programs().at(device_range);
         std::vector<uint32_t> read_result;
 
         for (const auto& core : core_range) {
             // DM: verify rta_count = 0, crta_count = 0
             read_result.clear();
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                core,
-                program_from_workload.impl().get_circular_buffer(cb0_handle)->address(),
-                total_read_size,
-                read_result);
+            tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, total_read_size, read_result);
             EXPECT_EQ(read_result[0], 0);  // rta_count
             EXPECT_EQ(read_result[1], 0);  // crta_count
 
             // TRISC0: verify rta_count = 0, crta_count = 0
+            // Note: Both DM and compute write to the same L1 address, so we're validating
+            // the last writer (compute kernel) here
             read_result.clear();
-            tt::tt_metal::detail::ReadFromDeviceL1(device, core, compute_scratch_addr, total_read_size, read_result);
+            tt::tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, total_read_size, read_result);
             EXPECT_EQ(read_result[0], 0);  // rta_count
             EXPECT_EQ(read_result[1], 0);  // crta_count
         }
@@ -225,13 +219,12 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         CoreRange cores_without_rtas(CoreCoord(2, 2), CoreCoord(3, 3));
         CoreRangeSet core_range_set(std::vector{cores_with_rtas, cores_without_rtas});
 
-        CircularBufferConfig cb_config = CreateArgCBConfig(default_rtas.size());
+        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
         distributed::MeshWorkload workload;
         Program program;
-        CreateCircularBuffer(program, core_range_set, cb_config);
 
-        auto kernel = CreateDMKernel(program, core_range_set, {{"MAX_RTA_IDX", "0"}});
+        auto kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base, {{"MAX_RTA_IDX", "0"}});
 
         SetRuntimeArgs(program, kernel, cores_with_rtas, default_rtas);
         // cores_without_rtas has NO RTAs set - 0xBEEF#### pattern -> rta_count = 0 -> assert
@@ -261,16 +254,25 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     CoreRangeSet core_range_set =
         is_quasar ? CoreRangeSet(std::vector{core_range1}) : CoreRangeSet(std::vector{core_range1, core_range2});
 
-    // Configure CB to store read-back args
-    const uint32_t total_read_size = 2 + default_rtas.size() + default_crtas.size();
-    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    CircularBufferConfig cb_config = CreateArgCBConfig(total_read_size);
+    // Use l1_unreserved space instead of CB for scratch storage
+    const uint32_t total_word_count = 2 + default_rtas.size() + default_crtas.size();
+    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    // Zero-init the L1 scratch space on all cores before running
+    std::vector<uint32_t> zero_init(total_word_count, 0);
+    for (const auto& core : core_range1) {
+        tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
+    }
+    if (!is_quasar) {
+        for (const auto& core : core_range2) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
+        }
+    }
 
     distributed::MeshWorkload workload;
     Program program;
-    CreateCircularBuffer(program, core_range_set, cb_config);
 
-    auto kernel = CreateDMKernel(program, core_range_set);
+    auto kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base);
 
     // Range 1 RTAs
     SetRuntimeArgs(program, kernel, core_range1, default_rtas);
@@ -288,11 +290,21 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     // Validate first run
     for (const auto& core : core_range1) {
-        ValidateArgResults(device, core, cb_addr, default_rtas, default_crtas);
+        ValidateArgResults(device, core, l1_unreserved_base, default_rtas, default_crtas);
     }
     if (!is_quasar) {
         for (const auto& core : core_range2) {
-            ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+            ValidateArgResults(device, core, l1_unreserved_base, rtas_range2, default_crtas);
+        }
+    }
+
+    // Zero-init again before second run
+    for (const auto& core : core_range1) {
+        tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
+    }
+    if (!is_quasar) {
+        for (const auto& core : core_range2) {
+            tt::tt_metal::detail::WriteToDeviceL1(device, core, l1_unreserved_base, zero_init);
         }
     }
 
@@ -306,11 +318,11 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     // Validate second run
     for (const auto& core : core_range1) {
-        ValidateArgResults(device, core, cb_addr, default_rtas, default_crtas);
+        ValidateArgResults(device, core, l1_unreserved_base, default_rtas, default_crtas);
     }
     if (!is_quasar) {
         for (const auto& core : core_range2) {
-            ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+            ValidateArgResults(device, core, l1_unreserved_base, rtas_range2, default_crtas);
         }
     }
 }
@@ -338,12 +350,10 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];
 
-    const uint32_t total_read_size = 2 + default_rtas.size() + default_crtas.size();
-    CircularBufferConfig cb_config = CreateArgCBConfig(total_read_size);
+    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     distributed::MeshWorkload workload;
     Program program;
-    CreateCircularBuffer(program, core_range_set, cb_config);
 
     std::map<std::string, std::string> defines;
     if (params.test_rta) {
@@ -355,11 +365,12 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     // Create kernel based on processor class (arch-specific creation handled by helpers)
     KernelHandle kernel;
     switch (params.processor_class) {
-        case HalProcessorClassType::DM: kernel = CreateDMKernel(program, core_range_set, defines); break;
-        case HalProcessorClassType::COMPUTE: {
-            uint32_t compute_scratch_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-            kernel = CreateComputeKernel(program, core_range_set, compute_scratch_addr, defines);
-        } break;
+        case HalProcessorClassType::DM:
+            kernel = CreateDMKernel(program, core_range_set, l1_unreserved_base, defines);
+            break;
+        case HalProcessorClassType::COMPUTE:
+            kernel = CreateComputeKernel(program, core_range_set, l1_unreserved_base, defines);
+            break;
         default: TT_THROW("Unsupported processor class");
     }
 
@@ -389,18 +400,16 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];
 
-    const uint32_t total_read_size = 2 + default_rtas.size() + default_crtas.size();
-    CircularBufferConfig cb_config = CreateArgCBConfig(total_read_size);
-
-    distributed::MeshWorkload workload;
-    Program program;
-    CreateCircularBuffer(program, core_range_set, cb_config);
-
     auto num_dms = hal.get_processor_types_count(
         HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
 
-    // Allocate L1 scratch space for the sync barrier counter (8 bytes for uint64_t)
-    uint32_t l1_sync_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    // L1 layout: [sync_counter (8 bytes)] [scratch space for RTA/CRTA results]
+    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t l1_sync_addr = l1_unreserved_base;
+    uint32_t l1_scratch_addr = l1_unreserved_base + 8;  // After 8-byte sync counter
+
+    distributed::MeshWorkload workload;
+    Program program;
 
     // All DMs sync then attempt OOB RTA access together
     std::map<std::string, std::string> defines = {
@@ -411,7 +420,9 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         rta_crta_kernel_path,
         core_range_set,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = num_dms, .compile_args = {num_dms, l1_sync_addr}, .defines = defines});
+            .num_threads_per_cluster = num_dms,
+            .compile_args = {num_dms, l1_sync_addr, l1_scratch_addr},
+            .defines = defines});
 
     SetRuntimeArgs(program, kernel, core_range, default_rtas);
     workload.add_program(device_range, std::move(program));

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "debug_tools_fixture.hpp"
 #include "impl/buffers/circular_buffer.hpp"
 #include "impl/program/program_impl.hpp"
@@ -25,6 +26,9 @@ namespace tt::tt_metal {
 // Fixture for RTA/CRTA watcher bounds check tests
 class RTATestFixture : public MeshWatcherFixture {
 protected:
+    const std::string rta_crta_kernel_path =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp";
+
     void SetUp() override {
         bool watcher_assert_disabled = MetalContext::instance().rtoptions().watcher_assert_disabled();
         if (watcher_assert_disabled) {
@@ -44,6 +48,55 @@ protected:
         const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
         uint32_t cb_size = tt::align(word_count * sizeof(uint32_t), l1_alignment);
         return CircularBufferConfig(cb_size, {{0, tt::DataFormat::Float32}}).set_page_size(0, cb_size);
+    }
+
+    // Helper: Create DM kernel (arch-aware)
+    // On Quasar, launches kernel on all DMs with compile_args[0] = dm_select so only
+    // the target DM executes; others exit early via get_my_thread_id() guard.
+    // On BH/WH, launches on RISCV_0 (BRISC) only.
+    KernelHandle CreateDMKernel(
+        Program& program,
+        const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+        std::map<std::string, std::string> defines = {},
+        uint32_t dm_select = 0) {
+        const auto& hal = MetalContext::instance().hal();
+        if (hal.get_arch() == tt::ARCH::QUASAR) {
+            auto num_dms = hal.get_processor_types_count(
+                HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
+            return experimental::quasar::CreateKernel(
+                program,
+                rta_crta_kernel_path,
+                core_spec,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = num_dms, .compile_args = {dm_select}, .defines = defines});
+        }
+        return CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_spec,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+    }
+
+    // Helper: Create compute kernel (arch-aware)
+    KernelHandle CreateComputeKernel(
+        Program& program,
+        const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+        uint32_t compute_scratch_addr,
+        const std::map<std::string, std::string>& defines = {}) {
+        const auto& hal = MetalContext::instance().hal();
+        if (hal.get_arch() == tt::ARCH::QUASAR) {
+            return experimental::quasar::CreateKernel(
+                program,
+                rta_crta_kernel_path,
+                core_spec,
+                experimental::quasar::QuasarComputeConfig{.compile_args = {compute_scratch_addr}, .defines = defines});
+        }
+        return CreateKernel(
+            program,
+            rta_crta_kernel_path,
+            core_spec,
+            ComputeConfig{.compile_args = {compute_scratch_addr}, .defines = defines});
     }
 
     // Helper: Read and validate RTA/CRTA results
@@ -101,7 +154,7 @@ struct RTAAssertTestParams {
     std::string test_name;                  // For readable test names
     bool test_rta;                          // true = test RTA, false = test CRTA
     std::string expected_message;           // Expected watcher exception message
-    HalProcessorClassType processor_class;  // DM (BRISC) or COMPUTE (TRISC0)
+    HalProcessorClassType processor_class;  // DM or COMPUTE
 };
 
 // Parameterized test fixture for RTA/CRTA out-of-bounds assertions
@@ -130,24 +183,14 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         uint32_t cb_size = tt::align(total_read_size, l1_alignment);
         CircularBufferConfig cb0(cb_size, {{tt::CBIndex::c_0, tt::DataFormat::Float32}});
         cb0.set_page_size(tt::CBIndex::c_0, cb_size);
-        // For TRISC0 writeback
         uint32_t compute_scratch_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
         distributed::MeshWorkload workload;
         Program program;
         CBHandle cb0_handle = CreateCircularBuffer(program, core_range_set, cb0);
 
-        CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-            core_range_set,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
-        CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-            core_range_set,
-            ComputeConfig{.compile_args = {compute_scratch_addr}});
+        CreateDMKernel(program, core_range_set);
+        CreateComputeKernel(program, core_range_set, compute_scratch_addr);
 
         // No SetRuntimeArgs called - all cores have RTA/CRTA offset = 0xFFFF pattern
         workload.add_program(device_range, std::move(program));
@@ -157,7 +200,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         std::vector<uint32_t> read_result;
 
         for (const auto& core : core_range) {
-            // BRISC: verify rta_count = 0, crta_count = 0
+            // DM: verify rta_count = 0, crta_count = 0
             read_result.clear();
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device,
@@ -188,14 +231,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         Program program;
         CreateCircularBuffer(program, core_range_set, cb_config);
 
-        auto kernel = CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-            core_range_set,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .defines = {{"MAX_RTA_IDX", "0"}}});  // Kernel will try to read RTA[0]
+        auto kernel = CreateDMKernel(program, core_range_set, {{"MAX_RTA_IDX", "0"}});
 
         SetRuntimeArgs(program, kernel, cores_with_rtas, default_rtas);
         // cores_without_rtas has NO RTAs set - 0xBEEF#### pattern -> rta_count = 0 -> assert
@@ -212,13 +248,19 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
 // cores, and re-dispatching on subsequent runs. Ensures arg counts and payload
 // values match what was set via SetRuntimeArgs/SetCommonRuntimeArgs
 TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
-    // First run the program with the initial runtime args
-    CoreRange core_range1(CoreCoord(0, 0), CoreCoord(1, 1));
-    CoreRange core_range2(CoreCoord(2, 2), CoreCoord(3, 3));
-    CoreRangeSet core_range_set(std::vector{core_range1, core_range2});
+    const auto& hal = MetalContext::instance().hal();
+    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];
+
+    // Quasar: single core; other archs: multi-core with two ranges
+    CoreRange core_range1 =
+        is_quasar ? CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)) : CoreRange(CoreCoord(0, 0), CoreCoord(1, 1));
+    CoreRange core_range2(CoreCoord(2, 2), CoreCoord(3, 3));
+    CoreRangeSet core_range_set =
+        is_quasar ? CoreRangeSet(std::vector{core_range1}) : CoreRangeSet(std::vector{core_range1, core_range2});
+
     // Configure CB to store read-back args
     const uint32_t total_read_size = 2 + default_rtas.size() + default_crtas.size();
     uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -228,64 +270,69 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     Program program;
     CreateCircularBuffer(program, core_range_set, cb_config);
 
-    // No out-of-bounds testing here: that's covered by RTAAssertTest
-    // Kernel will read back all RTAs/CRTAs for per-core validation
-    std::map<std::string, std::string> defines = {};
+    auto kernel = CreateDMKernel(program, core_range_set);
 
-    auto kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-        core_range_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
-
-    // Range 1: 5 RTAs per core
+    // Range 1 RTAs
     SetRuntimeArgs(program, kernel, core_range1, default_rtas);
 
-    // Range 2: 3 RTAs per core (different size than core_range1)
+    // Range 2: different RTA size (non-Quasar only)
     std::vector<uint32_t> rtas_range2 = {0x1000, 0x1001, 0x1002};
-    SetRuntimeArgs(program, kernel, core_range2, rtas_range2);
+    if (!is_quasar) {
+        SetRuntimeArgs(program, kernel, core_range2, rtas_range2);
+    }
 
-    // Common args
+    // Common args shared across all cores
     SetCommonRuntimeArgs(program, kernel, default_crtas);
     workload.add_program(device_range, std::move(program));
     RunProgram(mesh_device, workload);
 
-    // Validate first run for both core ranges
+    // Validate first run
     for (const auto& core : core_range1) {
         ValidateArgResults(device, core, cb_addr, default_rtas, default_crtas);
     }
-
-    for (const auto& core : core_range2) {
-        ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+    if (!is_quasar) {
+        for (const auto& core : core_range2) {
+            ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+        }
     }
 
-    // Second run: call SetRuntimeArgs again. This tests the case when we're memcpying new data
-    // directly into the command issue queue with the arg count
+    // Second run: call SetRuntimeArgs again to test re-dispatch with updated arg counts
     auto& program_from_workload = workload.get_programs().at(device_range);
     SetRuntimeArgs(program_from_workload, kernel, core_range1, default_rtas);
-    SetRuntimeArgs(program_from_workload, kernel, core_range2, rtas_range2);
+    if (!is_quasar) {
+        SetRuntimeArgs(program_from_workload, kernel, core_range2, rtas_range2);
+    }
     RunProgram(mesh_device, workload);
 
-    // Validate second run for both core ranges
+    // Validate second run
     for (const auto& core : core_range1) {
         ValidateArgResults(device, core, cb_addr, default_rtas, default_crtas);
     }
-    for (const auto& core : core_range2) {
-        ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+    if (!is_quasar) {
+        for (const auto& core : core_range2) {
+            ValidateArgResults(device, core, cb_addr, rtas_range2, default_crtas);
+        }
     }
 }
 
 // Parameterized test: Out-of-Bounds Arg Access Detection
 // Verifies watcher detects kernels accessing args beyond bounds (index >= count)
-// Tests RTA/CRTA access on both BRISC and TRISC0
+// Tests RTA/CRTA access on DM0 and TRISC0 (single processor per test)
 TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
-    if (IsSlowDispatch()) {
-        GTEST_SKIP() << "This test can only be run with fast dispatch mode";
-    }
     const auto& params = GetParam();
+    const auto& hal = MetalContext::instance().hal();
+    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
-    CoreRange core_range(CoreCoord(0, 0), CoreCoord(4, 4));
+    // Dispatch mode validation:
+    // - Quasar: SD only (FD not yet available)
+    // - Other archs: FD only
+    if (IsSlowDispatch() && !is_quasar) {
+        GTEST_SKIP() << "This test requires fast dispatch mode (except on Quasar)";
+    }
+
+    // Quasar: single core; other archs: 5x5 grid
+    CoreRange core_range =
+        is_quasar ? CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)) : CoreRange(CoreCoord(0, 0), CoreCoord(4, 4));
     CoreRangeSet core_range_set(std::vector{core_range});
 
     auto mesh_device = devices_[0];
@@ -305,25 +352,13 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
         defines["MAX_CRTA_IDX"] = std::to_string(default_crtas.size());  // Out of bounds
     }
 
-    // Create kernel based on processor class
+    // Create kernel based on processor class (arch-specific creation handled by helpers)
     KernelHandle kernel;
     switch (params.processor_class) {
-        case HalProcessorClassType::DM: {
-            kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-                core_range_set,
-                DataMovementConfig{
-                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
-        } break;
+        case HalProcessorClassType::DM: kernel = CreateDMKernel(program, core_range_set, defines); break;
         case HalProcessorClassType::COMPUTE: {
-            // For compute kernel, pass scratch address as compile arg
             uint32_t compute_scratch_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-            kernel = CreateKernel(
-                program,
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp",
-                core_range_set,
-                ComputeConfig{.compile_args = {compute_scratch_addr}, .defines = defines});
+            kernel = CreateComputeKernel(program, core_range_set, compute_scratch_addr, defines);
         } break;
         default: TT_THROW("Unsupported processor class");
     }
@@ -339,18 +374,70 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     ExpectWatcherException(params.expected_message);
 }
 
+// Multi-DM test: verifies all DMs running concurrently can trigger RTA bounds check on Quasar.
+// Uses a sync barrier so all DMs hit the OOB access together, stress-testing
+// watcher's first-writer-wins assert mechanism. Any DM can report the error.
+TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
+    const auto& hal = MetalContext::instance().hal();
+    if (hal.get_arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Test only applicable to Quasar";
+    }
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(0, 0));
+    CoreRangeSet core_range_set(std::vector{core_range});
+
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+
+    const uint32_t total_read_size = 2 + default_rtas.size() + default_crtas.size();
+    CircularBufferConfig cb_config = CreateArgCBConfig(total_read_size);
+
+    distributed::MeshWorkload workload;
+    Program program;
+    CreateCircularBuffer(program, core_range_set, cb_config);
+
+    auto num_dms = hal.get_processor_types_count(
+        HalProgrammableCoreType::TENSIX, static_cast<uint32_t>(HalProcessorClassType::DM));
+
+    // Allocate L1 scratch space for the sync barrier counter (8 bytes for uint64_t)
+    uint32_t l1_sync_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+
+    // All DMs sync then attempt OOB RTA access together
+    std::map<std::string, std::string> defines = {
+        {"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}};
+
+    auto kernel = experimental::quasar::CreateKernel(
+        program,
+        rta_crta_kernel_path,
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = num_dms, .compile_args = {num_dms, l1_sync_addr}, .defines = defines});
+
+    SetRuntimeArgs(program, kernel, core_range, default_rtas);
+    workload.add_program(device_range, std::move(program));
+
+    // Zero out sync counter before launch
+    std::vector<uint32_t> zero_sync = {0, 0};
+    tt::tt_metal::detail::WriteToDeviceL1(device, core_range.start_coord, l1_sync_addr, zero_sync);
+
+    RunProgram(mesh_device, workload);
+
+    // Any DM can report the error; just verify the bounds-check message appears
+    ExpectWatcherException("unique runtime arg index out of bounds");
+}
+
 INSTANTIATE_TEST_SUITE_P(
     WatcherArgAsserts,
     RTAAssertTest,
     ::testing::Values(
-        // RTA tests on BRISC
-        RTAAssertTestParams{"RTA_RISCV0", true, "unique runtime arg index out of bounds", HalProcessorClassType::DM},
-        // RTA tests on TRISC0
+        // RTA out-of-bounds on DM0
+        RTAAssertTestParams{"RTA_DM0", true, "unique runtime arg index out of bounds", HalProcessorClassType::DM},
+        // RTA out-of-bounds on TRISC0
         RTAAssertTestParams{
             "RTA_TRISC0", true, "unique runtime arg index out of bounds", HalProcessorClassType::COMPUTE},
-        // CRTA tests on BRISC
-        RTAAssertTestParams{"CRTA_RISCV0", false, "common runtime arg index out of bounds", HalProcessorClassType::DM},
-        // CRTA tests on TRISC0
+        // CRTA out-of-bounds on DM0
+        RTAAssertTestParams{"CRTA_DM0", false, "common runtime arg index out of bounds", HalProcessorClassType::DM},
+        // CRTA out-of-bounds on TRISC0
         RTAAssertTestParams{
             "CRTA_TRISC0", false, "common runtime arg index out of bounds", HalProcessorClassType::COMPUTE}),
     [](const ::testing::TestParamInfo<RTAAssertTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -8,9 +8,9 @@
 // Supports both DM and compute kernels
 
 #include "experimental/core_local_mem.h"
+#include "api/kernel_thread_globals.h"
 
 #ifndef COMPILE_FOR_TRISC
-#include "api/dataflow/dataflow_api.h"
 #include "internal/firmware_common.h"
 #else
 #include "api/compute/common.h"
@@ -64,7 +64,6 @@ static FORCE_INLINE void trigger_bounds_check_assert() {
 #endif
 }
 
-#ifndef COMPILE_FOR_TRISC
 // Helper: write RTA/CRTA metadata and values to L1 (DM only)
 static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
     experimental::CoreLocalMem<uint32_t> ptr(l1_write_addr);
@@ -82,7 +81,6 @@ static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
     flush_l2_cache_line(reinterpret_cast<uintptr_t>(ptr.get_address()));
 #endif
 }
-#endif
 
 #ifndef COMPILE_FOR_TRISC
 
@@ -138,7 +136,9 @@ void core_agnostic_main() {
 
 void core_agnostic_main() {
     UNPACK({
-#if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
+#if !defined(MAX_RTA_IDX) && !defined(MAX_CRTA_IDX)
+        write_args_to_l1(get_compile_time_arg_val(0));
+#else
         signal_completion_before_assert();
         trigger_bounds_check_assert();
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -14,12 +14,26 @@
 #include "api/compute/common.h"
 #endif
 
+#ifdef ARCH_QUASAR
+// TODO: Remove this once cache invalidation functionality for Quasar is added
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t* addr) {
+    asm volatile("fence" ::: "memory");
+    volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
+    *flush_reg = reinterpret_cast<uint64_t>(addr);
+    asm volatile("fence" ::: "memory");
+}
+
+thread_local extern uint32_t rta_count;
+thread_local extern uint32_t crta_count;
+#else
 extern uint32_t rta_count;
 extern uint32_t crta_count;
+#endif
 
 // Helper to write RTA/CRTA metadata and values to L1
 static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(l1_write_addr);
+    uint32_t* ptr = reinterpret_cast<uint32_t*>(l1_write_addr);
     ptr[0] = rta_count;
     ptr[1] = crta_count;
 
@@ -29,33 +43,45 @@ static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
     for (size_t i = 0; i < crta_count; i++) {
         ptr[i + rta_count + 2] = get_common_arg_val<uint32_t>(i);
     }
+
+#ifdef ARCH_QUASAR
+    flush_l2_cache_line(ptr);
+#endif  // ARCH_QUASAR
 }
 
 #ifndef COMPILE_FOR_TRISC
 
 void core_agnostic_main() {
 #if defined(COMPILE_FOR_DM)
-    uint32_t cpu_index = get_my_thread_id();
+    uint32_t thread_idx = get_my_thread_id();
 
 #if defined(TEST_MULTI_DM_RTA)
     // Multi-DM mode: sync barrier so all DMs hit the OOB access together,
     // stress-testing watcher's first-writer-wins assert mechanism.
+    // Compile args: [num_dms, l1_sync_addr, l1_scratch_addr]
     constexpr uint32_t num_dms = get_compile_time_arg_val(0);
     constexpr uint32_t l1_sync_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(2);
     uint64_t* l1_ptr = reinterpret_cast<uint64_t*>(l1_sync_addr);
     __atomic_add_fetch(l1_ptr, 1, __ATOMIC_RELAXED);
     while (__atomic_load_n(l1_ptr, __ATOMIC_ACQUIRE) != num_dms) {
     }
 #else
     // Single DM test: only specified dm_id executes, others exit early
+    // Compile args: [dm_id, l1_scratch_addr]
     constexpr uint32_t dm_id = get_compile_time_arg_val(0);
-    if (cpu_index != dm_id) {
+    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(1);
+    if (thread_idx != dm_id) {
         return;
     }
-#endif
+#endif  // TEST_MULTI_DM_RTA
+#else   // COMPILE_FOR_DM
+    // Non-Quasar DM: L1 scratch address is the first compile-time arg
+    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(0);
 #endif
 
-    write_args_to_l1(get_write_ptr(tt::CBIndex::c_0));
+    write_args_to_l1(l1_scratch_addr);
+    DPRINT << "done write_args_to_l1" << ENDL();
 
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
     // Signal completion to dispatcher before assert hangs the kernel
@@ -63,30 +89,31 @@ void core_agnostic_main() {
 
     // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
     // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
-#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DM)
     go_message_in->signal = RUN_MSG_DONE;
 #else
     // FD: ACTIVE_ETH, BRISC, NCRISC notify dispatcher via NOC
     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
     notify_dispatch_core_done(dispatch_addr, noc_index);
-#endif
-#endif
+#endif  // COMPILE_FOR_IDLE_ERISC or COMPILE_FOR_DM
+#endif  // MAX_RTA_IDX or MAX_CRTA_IDX
 
 #ifdef MAX_RTA_IDX
     // Access RTA: this should have a watcher assert when MAX_RTA_IDX >= rta_count
     uint32_t rta = get_arg_val<uint32_t>(MAX_RTA_IDX);
-#endif
+#endif  // MAX_RTA_IDX
 #ifdef MAX_CRTA_IDX
     // Access CRTA: this should have a watcher assert when MAX_CRTA_IDX >= crta_count
     uint32_t crta = get_common_arg_val<uint32_t>(MAX_CRTA_IDX);
-#endif
+#endif  // MAX_CRTA_IDX
+    DPRINT << "Completed" << ENDL();
 }
 
 #else  // Compute Kernel
 
 void core_agnostic_main() {
     UNPACK({
-        // Pass the CB base address as a compile time arg
+        // L1 scratch address passed as compile-time arg
         write_args_to_l1(get_compile_time_arg_val(0));
 
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
@@ -101,19 +128,19 @@ void core_agnostic_main() {
         volatile tt_l1_ptr subordinate_map_t* sync =
             reinterpret_cast<volatile tt_l1_ptr subordinate_map_t*>(&mailbox->subordinate_sync);
         sync->trisc0 = RUN_SYNC_MSG_DONE;
-#endif
-#endif
+#endif  // ARCH_QUASAR
+#endif  // MAX_RTA_IDX or //MAX_CRTA_IDX
 
 #ifdef MAX_RTA_IDX
         // Access RTA: this should have a watcher assert when MAX_RTA_IDX >= rta_count
         uint32_t rta = get_arg_val<uint32_t>(MAX_RTA_IDX);
-#endif
+#endif  // MAX_RTA_IDX
 #ifdef MAX_CRTA_IDX
         // Access CRTA: this should have a watcher assert when MAX_CRTA_IDX >= crta_count
         uint32_t crta = get_common_arg_val<uint32_t>(MAX_CRTA_IDX);
-#endif
+#endif  // MAX_CRTA_IDX
     })
 }
-#endif
+#endif  // COMPILE_FOR_TRISC
 
 void kernel_main() { core_agnostic_main(); }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -5,7 +5,9 @@
 // Kernel for testing watcher RTA/CRTA bounds checking:
 // 1. Writes rta_count, crta_count, and all arg values to L1 for validation
 // 2. If MAX_RTA_IDX/MAX_CRTA_IDX defined: accesses that index to test bounds checking
-// Supports both DM (BRISC/NCRISC/DM0-7) and compute (TRISC0-3) kernels
+// Supports both DM and compute kernels
+
+#include "experimental/core_local_mem.h"
 
 #ifndef COMPILE_FOR_TRISC
 #include "api/dataflow/dataflow_api.h"
@@ -15,12 +17,12 @@
 #endif
 
 #ifdef ARCH_QUASAR
-// TODO: Remove this once cache invalidation functionality for Quasar is added
+// TODO: Remove this once PR #38124 is merged
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t* addr) {
+inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
     asm volatile("fence" ::: "memory");
     volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
-    *flush_reg = reinterpret_cast<uint64_t>(addr);
+    *flush_reg = static_cast<uint64_t>(addr);
     asm volatile("fence" ::: "memory");
 }
 
@@ -31,9 +33,41 @@ extern uint32_t rta_count;
 extern uint32_t crta_count;
 #endif
 
-// Helper to write RTA/CRTA metadata and values to L1
+// Helper: Signal completion to dispatcher before assert hangs the kernel
+static FORCE_INLINE void signal_completion_before_assert() {
+#if defined(ARCH_QUASAR)
+    // Quasar SD: signal via go_message
+    volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+    go_message_in->signal = RUN_MSG_DONE;
+#else  // Else WH/BH
+#ifdef COMPILE_FOR_TRISC
+    // signal via subordinate sync
+    volatile tt_l1_ptr subordinate_map_t* sync =
+        reinterpret_cast<volatile tt_l1_ptr subordinate_map_t*>(GET_MAILBOX_ADDRESS_DEV(subordinate_sync));
+    sync->trisc0 = RUN_SYNC_MSG_DONE;
+#else
+    // FD: BRISC, NCRISC notify dispatcher via NOC
+    volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    notify_dispatch_core_done(dispatch_addr, noc_index);
+#endif  // COMPILE_FOR_TRISC
+#endif  // ARCH_QUASAR
+}
+
+// Helper: trigger bounds-check assert by accessing arg beyond bounds
+static FORCE_INLINE void trigger_bounds_check_assert() {
+#ifdef MAX_RTA_IDX
+    volatile uint32_t rta = get_arg_val<uint32_t>(MAX_RTA_IDX);
+#endif
+#ifdef MAX_CRTA_IDX
+    volatile uint32_t crta = get_common_arg_val<uint32_t>(MAX_CRTA_IDX);
+#endif
+}
+
+#ifndef COMPILE_FOR_TRISC
+// Helper: write RTA/CRTA metadata and values to L1 (DM only)
 static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
-    uint32_t* ptr = reinterpret_cast<uint32_t*>(l1_write_addr);
+    experimental::CoreLocalMem<uint32_t> ptr(l1_write_addr);
     ptr[0] = rta_count;
     ptr[1] = crta_count;
 
@@ -45,102 +79,71 @@ static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
     }
 
 #ifdef ARCH_QUASAR
-    flush_l2_cache_line(ptr);
-#endif  // ARCH_QUASAR
+    flush_l2_cache_line(reinterpret_cast<uintptr_t>(ptr.get_address()));
+#endif
 }
+#endif
 
 #ifndef COMPILE_FOR_TRISC
 
 void core_agnostic_main() {
 #if defined(COMPILE_FOR_DM)
+    // Quasar DM kernel
     uint32_t thread_idx = get_my_thread_id();
 
 #if defined(TEST_MULTI_DM_RTA)
-    // Multi-DM mode: sync barrier so all DMs hit the OOB access together,
-    // stress-testing watcher's first-writer-wins assert mechanism.
-    // Compile args: [num_dms, l1_sync_addr, l1_scratch_addr]
+    // Multi-DM mode: sync barrier so all DMs hit the bounds-check access together
+    // Compile args: [num_dms, l1_sync_addr]
     constexpr uint32_t num_dms = get_compile_time_arg_val(0);
     constexpr uint32_t l1_sync_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(2);
-    uint64_t* l1_ptr = reinterpret_cast<uint64_t*>(l1_sync_addr);
-    __atomic_add_fetch(l1_ptr, 1, __ATOMIC_RELAXED);
-    while (__atomic_load_n(l1_ptr, __ATOMIC_ACQUIRE) != num_dms) {
+    experimental::CoreLocalMem<uint32_t> l1_sync_ptr(l1_sync_addr);
+    __atomic_add_fetch(l1_sync_ptr.get_unsafe_ptr(), 1, __ATOMIC_RELAXED);
+    while (__atomic_load_n(l1_sync_ptr.get_unsafe_ptr(), __ATOMIC_ACQUIRE) != num_dms) {
+    }
+#elif defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
+    // Assert test: only specified dm_id executes, others exit early
+    // Compile args: [dm_id]
+    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
+    if (thread_idx != dm_id) {
+        return;
     }
 #else
-    // Single DM test: only specified dm_id executes, others exit early
+    // Validation test: write args to L1 for host readback
     // Compile args: [dm_id, l1_scratch_addr]
     constexpr uint32_t dm_id = get_compile_time_arg_val(0);
     constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(1);
     if (thread_idx != dm_id) {
         return;
     }
-#endif  // TEST_MULTI_DM_RTA
-#else   // COMPILE_FOR_DM
-    // Non-Quasar DM: L1 scratch address is the first compile-time arg
-    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(0);
+    write_args_to_l1(l1_scratch_addr);
 #endif
 
+#else  // Non-Quasar DM (BRISC/NCRISC)
+
+#if !defined(MAX_RTA_IDX) && !defined(MAX_CRTA_IDX)
+    // Validation test: L1 scratch address is the first compile-time arg
+    constexpr uint32_t l1_scratch_addr = get_compile_time_arg_val(0);
     write_args_to_l1(l1_scratch_addr);
-    DPRINT << "done write_args_to_l1" << ENDL();
+#endif
+
+#endif
 
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
-    // Signal completion to dispatcher before assert hangs the kernel
-    volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-
-    // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
-    // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
-#if defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DM)
-    go_message_in->signal = RUN_MSG_DONE;
-#else
-    // FD: ACTIVE_ETH, BRISC, NCRISC notify dispatcher via NOC
-    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
-    notify_dispatch_core_done(dispatch_addr, noc_index);
-#endif  // COMPILE_FOR_IDLE_ERISC or COMPILE_FOR_DM
-#endif  // MAX_RTA_IDX or MAX_CRTA_IDX
-
-#ifdef MAX_RTA_IDX
-    // Access RTA: this should have a watcher assert when MAX_RTA_IDX >= rta_count
-    uint32_t rta = get_arg_val<uint32_t>(MAX_RTA_IDX);
-#endif  // MAX_RTA_IDX
-#ifdef MAX_CRTA_IDX
-    // Access CRTA: this should have a watcher assert when MAX_CRTA_IDX >= crta_count
-    uint32_t crta = get_common_arg_val<uint32_t>(MAX_CRTA_IDX);
-#endif  // MAX_CRTA_IDX
-    DPRINT << "Completed" << ENDL();
+    signal_completion_before_assert();
+    trigger_bounds_check_assert();
+#endif
 }
 
 #else  // Compute Kernel
 
 void core_agnostic_main() {
     UNPACK({
-        // L1 scratch address passed as compile-time arg
-        write_args_to_l1(get_compile_time_arg_val(0));
-
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
-        // Signal completion before triggering assert
-#if defined(ARCH_QUASAR)
-        // Quasar SD: signal via go_message
-        volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-        go_message_in->signal = RUN_MSG_DONE;
-#else
-        // BH/WH: signal via subordinate sync
-        volatile tt_l1_ptr mailboxes_t* mailbox = reinterpret_cast<volatile tt_l1_ptr mailboxes_t*>(MEM_MAILBOX_BASE);
-        volatile tt_l1_ptr subordinate_map_t* sync =
-            reinterpret_cast<volatile tt_l1_ptr subordinate_map_t*>(&mailbox->subordinate_sync);
-        sync->trisc0 = RUN_SYNC_MSG_DONE;
-#endif  // ARCH_QUASAR
-#endif  // MAX_RTA_IDX or //MAX_CRTA_IDX
-
-#ifdef MAX_RTA_IDX
-        // Access RTA: this should have a watcher assert when MAX_RTA_IDX >= rta_count
-        uint32_t rta = get_arg_val<uint32_t>(MAX_RTA_IDX);
-#endif  // MAX_RTA_IDX
-#ifdef MAX_CRTA_IDX
-        // Access CRTA: this should have a watcher assert when MAX_CRTA_IDX >= crta_count
-        uint32_t crta = get_common_arg_val<uint32_t>(MAX_CRTA_IDX);
-#endif  // MAX_CRTA_IDX
+        signal_completion_before_assert();
+        trigger_bounds_check_assert();
+#endif
     })
 }
-#endif  // COMPILE_FOR_TRISC
+#endif
 
 void kernel_main() { core_agnostic_main(); }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -64,7 +64,7 @@ static FORCE_INLINE void trigger_bounds_check_assert() {
 #endif
 }
 
-// Helper: write RTA/CRTA metadata and values to L1 (DM only)
+// Helper: write RTA/CRTA metadata and values to L1
 static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
     experimental::CoreLocalMem<uint32_t> ptr(l1_write_addr);
     ptr[0] = rta_count;
@@ -90,7 +90,7 @@ void core_agnostic_main() {
     uint32_t thread_idx = get_my_thread_id();
 
 #if defined(TEST_MULTI_DM_RTA)
-    // Multi-DM mode: sync barrier so all DMs hit the bounds-check access together
+    // Multi-DM mode: Spin-wait for all DMs to reach barrier so all hit the bounds-check access together
     // Compile args: [num_dms, l1_sync_addr]
     constexpr uint32_t num_dms = get_compile_time_arg_val(0);
     constexpr uint32_t l1_sync_addr = get_compile_time_arg_val(1);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_rta_crta_asserts.cpp
@@ -5,10 +5,11 @@
 // Kernel for testing watcher RTA/CRTA bounds checking:
 // 1. Writes rta_count, crta_count, and all arg values to L1 for validation
 // 2. If MAX_RTA_IDX/MAX_CRTA_IDX defined: accesses that index to test bounds checking
-// Supports both DM (BRISC/NCRISC) and compute (TRISC0) kernels
+// Supports both DM (BRISC/NCRISC/DM0-7) and compute (TRISC0-3) kernels
 
 #ifndef COMPILE_FOR_TRISC
 #include "api/dataflow/dataflow_api.h"
+#include "internal/firmware_common.h"
 #else
 #include "api/compute/common.h"
 #endif
@@ -31,31 +32,44 @@ static FORCE_INLINE void write_args_to_l1(uint32_t l1_write_addr) {
 }
 
 #ifndef COMPILE_FOR_TRISC
-// Signal dispatcher completion before triggering assert (prevents Finish() hang)
-static FORCE_INLINE void signal_dispatcher_completion() {
-    tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
-    uint64_t dispatch_addr = NOC_XY_ADDR(
-        NOC_X(mailboxes->go_messages[mailboxes->go_message_index].master_x),
-        NOC_Y(mailboxes->go_messages[mailboxes->go_message_index].master_y),
-        DISPATCH_MESSAGE_ADDR +
-            NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_messages[mailboxes->go_message_index].dispatch_message_offset);
-    noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
-        noc_index,
-        NCRISC_AT_CMD_BUF,
-        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
-        dispatch_addr,
-        0xF,
-        NOC_UNICAST_WRITE_VC,
-        false,
-        true);
-}
 
 void core_agnostic_main() {
+#if defined(COMPILE_FOR_DM)
+    uint32_t cpu_index = get_my_thread_id();
+
+#if defined(TEST_MULTI_DM_RTA)
+    // Multi-DM mode: sync barrier so all DMs hit the OOB access together,
+    // stress-testing watcher's first-writer-wins assert mechanism.
+    constexpr uint32_t num_dms = get_compile_time_arg_val(0);
+    constexpr uint32_t l1_sync_addr = get_compile_time_arg_val(1);
+    uint64_t* l1_ptr = reinterpret_cast<uint64_t*>(l1_sync_addr);
+    __atomic_add_fetch(l1_ptr, 1, __ATOMIC_RELAXED);
+    while (__atomic_load_n(l1_ptr, __ATOMIC_ACQUIRE) != num_dms) {
+    }
+#else
+    // Single DM test: only specified dm_id executes, others exit early
+    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
+    if (cpu_index != dm_id) {
+        return;
+    }
+#endif
+#endif
+
     write_args_to_l1(get_write_ptr(tt::CBIndex::c_0));
 
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
-    // Signal completion to BRISC before triggering assert
-    signal_dispatcher_completion();
+    // Signal completion to dispatcher before assert hangs the kernel
+    volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+
+    // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
+    // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
+#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+    go_message_in->signal = RUN_MSG_DONE;
+#else
+    // FD: ACTIVE_ETH, BRISC, NCRISC notify dispatcher via NOC
+    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    notify_dispatch_core_done(dispatch_addr, noc_index);
+#endif
 #endif
 
 #ifdef MAX_RTA_IDX
@@ -76,11 +90,18 @@ void core_agnostic_main() {
         write_args_to_l1(get_compile_time_arg_val(0));
 
 #if defined(MAX_RTA_IDX) || defined(MAX_CRTA_IDX)
-        // Signal completion to TRISC before triggering assert
+        // Signal completion before triggering assert
+#if defined(ARCH_QUASAR)
+        // Quasar SD: signal via go_message
+        volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+        go_message_in->signal = RUN_MSG_DONE;
+#else
+        // BH/WH: signal via subordinate sync
         volatile tt_l1_ptr mailboxes_t* mailbox = reinterpret_cast<volatile tt_l1_ptr mailboxes_t*>(MEM_MAILBOX_BASE);
         volatile tt_l1_ptr subordinate_map_t* sync =
             reinterpret_cast<volatile tt_l1_ptr subordinate_map_t*>(&mailbox->subordinate_sync);
         sync->trisc0 = RUN_SYNC_MSG_DONE;
+#endif
 #endif
 
 #ifdef MAX_RTA_IDX

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -107,7 +107,7 @@ void init_sync_registers() {
 extern "C" uint32_t _start1() {
     configure_csr();
     uint32_t hartid = internal_::get_hw_thread_idx();
-    // DPRINT << "hartid: " << hartid << ENDL();
+    DPRINT << "hartid: " << hartid << ENDL();
     volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
                                                        ->subordinate_sync.map[hartid];  // first entry is for NCRISC
     WAYPOINT("I");
@@ -126,7 +126,7 @@ extern "C" uint32_t _start1() {
     *trisc_run = RUN_SYNC_MSG_DONE;
 
     DeviceProfilerInit();
-    // DPRINT << "TRISC-FW: initialized" << ENDL();
+    DPRINT << "TRISC-FW: initialized" << ENDL();
     while (1) {
         WAYPOINT("W");
         while (*trisc_run != RUN_SYNC_MSG_GO) {
@@ -152,8 +152,7 @@ extern "C" uint32_t _start1() {
         experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #endif
 
-        // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when cache invalidating
-        // functionality is ready for Quasar
+        // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged
         rta_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset +
                                   MEM_L1_UNCACHED_BASE);
@@ -201,9 +200,9 @@ extern "C" uint32_t _start1() {
         DEVICE_PRINT_KERNEL_FINISHED();
 
         // Signal completion
-        // DPRINT << "SIGNALING COMPLETION " << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
+        DPRINT << "SIGNALING COMPLETION " << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
         tensix_sync();
         *trisc_run = RUN_SYNC_MSG_DONE;
-        // DPRINT << "COMPLETION SIGNED OFF" << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
+        DPRINT << "COMPLETION SIGNED OFF" << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
     }
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -39,6 +39,11 @@ thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
+thread_local uint32_t rta_count __attribute__((used));
+thread_local uint32_t crta_count __attribute__((used));
+#endif
+
 uint8_t my_logical_x_ __attribute__((used));
 uint8_t my_logical_y_ __attribute__((used));
 uint8_t my_relative_x_ __attribute__((used));
@@ -102,7 +107,7 @@ void init_sync_registers() {
 extern "C" uint32_t _start1() {
     configure_csr();
     uint32_t hartid = internal_::get_hw_thread_idx();
-    DPRINT << "hartid: " << hartid << ENDL();
+    // DPRINT << "hartid: " << hartid << ENDL();
     volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
                                                        ->subordinate_sync.map[hartid];  // first entry is for NCRISC
     WAYPOINT("I");
@@ -121,7 +126,7 @@ extern "C" uint32_t _start1() {
     *trisc_run = RUN_SYNC_MSG_DONE;
 
     DeviceProfilerInit();
-    DPRINT << "TRISC-FW: initialized" << ENDL();
+    // DPRINT << "TRISC-FW: initialized" << ENDL();
     while (1) {
         WAYPOINT("W");
         while (*trisc_run != RUN_SYNC_MSG_GO) {
@@ -147,13 +152,40 @@ extern "C" uint32_t _start1() {
         experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #endif
 
+        // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when cache invalidating
+        // functionality is ready for Quasar
         rta_l1_base =
-            (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset);
+            (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset +
+                                  MEM_L1_UNCACHED_BASE);
         crta_l1_base =
-            (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset);
+            (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset +
+                                  MEM_L1_UNCACHED_BASE);
         sem_l1_base[ProgrammableCoreType::TENSIX] =
             (uint32_t tt_l1_ptr*)(kernel_config_base +
                                   launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
+        // Initialize RTA count from L1 memory
+        // Set to 0 if: 1. offset is sentinel (no args set)
+        //              2. memory contains known garbage pattern 0xBEEF#### (uninitialized slot)
+        if (launch_msg->kernel_config.rta_offset[hartid].rta_offset == RTA_CRTA_NO_ARGS_SENTINEL ||
+            ((rta_l1_base[0] & 0xFFFF0000) == WATCHER_RTA_UNSET_PATTERN)) {
+            rta_count = 0;
+        } else {
+            rta_count = rta_l1_base[0];
+            rta_l1_base += 1;  // Skip count word
+        }
+
+        // Initialize CRTA count from L1 memory
+        // Set to 0 if: 1. offset is sentinel (no common args set)
+        //              2. memory contains known garbage pattern 0xBEEF#### (unicast mode, kernel has no CRTAs)
+        if (launch_msg->kernel_config.rta_offset[hartid].crta_offset == RTA_CRTA_NO_ARGS_SENTINEL ||
+            ((crta_l1_base[0] & 0xFFFF0000) == WATCHER_RTA_UNSET_PATTERN)) {
+            crta_count = 0;
+        } else {
+            crta_count = crta_l1_base[0];
+            crta_l1_base += 1;  // Skip count word
+        }
+#endif
 
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
@@ -169,9 +201,9 @@ extern "C" uint32_t _start1() {
         DEVICE_PRINT_KERNEL_FINISHED();
 
         // Signal completion
-        DPRINT << "SIGNALING COMPLETION " << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
+        // DPRINT << "SIGNALING COMPLETION " << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
         tensix_sync();
         *trisc_run = RUN_SYNC_MSG_DONE;
-        DPRINT << "COMPLETION SIGNED OFF" << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
+        // DPRINT << "COMPLETION SIGNED OFF" << HEX() << (uint32_t)*trisc_run << DEC() << ENDL();
     }
 }

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2109,6 +2109,7 @@ FORCE_INLINE void noc_inline_mcast_dw_write(
     }
 #endif
 
+#if !defined(ARCH_QUASAR)
     noc_fast_write_dw_inline_multicast<noc_mode, dst_type, flush>(
         noc,
         write_at_cmd_buf,
@@ -2120,6 +2121,7 @@ FORCE_INLINE void noc_inline_mcast_dw_write(
         posted,  // posted
         customized_src_addr,
         num_dest);
+#endif
 
     WAYPOINT("NWID");
 }

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2109,7 +2109,6 @@ FORCE_INLINE void noc_inline_mcast_dw_write(
     }
 #endif
 
-#if !defined(ARCH_QUASAR)
     noc_fast_write_dw_inline_multicast<noc_mode, dst_type, flush>(
         noc,
         write_at_cmd_buf,
@@ -2121,7 +2120,6 @@ FORCE_INLINE void noc_inline_mcast_dw_write(
         posted,  // posted
         customized_src_addr,
         num_dest);
-#endif
 
     WAYPOINT("NWID");
 }

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -10,6 +10,7 @@
 #include "experimental/lock.h"
 #include "tools/profiler/noc_debugging_metadata.hpp"
 #include "tools/profiler/noc_debugging_profiler.hpp"
+#include "internal/debug/sanitize.h"
 
 namespace experimental {
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
RTA/CRTA watcher bounds checking was not entirely supported on Quasar. Also, bringup the existing test infrastructure for  Quasar's threaded model.

### What's changed
Added Quasar support for RTA/CRTA watcher assert tests:                                                                                                                                     
- In the test kernel test_rta_crta_asserts.cpp: Added `COMPILE_FOR_DM` path for Quasar multi-threaded DMs, thread_local `rta/crta_count` declarations, L2 cache flush for validation path write-back.
- In test_runtime_args_known_garbage.cpp: Architecture-aware kernel creation for Quasar, direct L1 scratch space instead of CBs, and new Quasar only `QuasarMultiDMOutOfBoundsArgDetection` test for concurrent DM bounds checking. Also Quasar tests run with slow dispatch; WH/BH use fast dispatch.                                                                          
- TRISC firmware (`trisc.cc`): Added thread_local `rta_count/crta_count` initialization from L1 when watcher is enabled
- `core_local_mem.h`: Added `sanitize.h` include for `DEBUG_SANITIZE_L1_ADDR` (was missed from adding here: https://github.com/tenstorrent/tt-metal/pull/40240)

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_rta_assert)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_rta_assert)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_rta_assert)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Quasar emulator runs: https://gist.github.com/sidnadTT/a1d9772605d98ef1354d81a39ae62a7f

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_rta_assert)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_rta_assert)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_rta_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_rta_assert)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
