### PR TITLE
Fix composite CCL hang with trace by using caller-provided semaphores in all_broadcast

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_composite_ccl_hang.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_composite_ccl_hang.py
@@ -1,0 +1,412 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+def _setup_device(mesh_device):
+    # Set up sub-devices for async operation
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+    return ccl_sub_device_crs, worker_sub_device_id
+
+
+def _setup_l1_overwrite(mesh_device):
+    tile_height = 32
+    tile_width = 32
+    element_size = 4  # int32
+
+    mv = ttnn.get_memory_view(mesh_device, ttnn.BufferType.L1)
+    nbytes = mv.largest_contiguous_bytes_free_per_bank
+    nbanks = mv.num_banks
+    ntiles = nbytes // (tile_height * tile_width * element_size)
+
+    def run_l1_overwrite():
+        t = ttnn.allocate_tensor_on_device(
+            shape=ttnn.Shape((tile_height, tile_width * ntiles * nbanks)),
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_device=mesh_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        ttnn.mul_(t, 0)
+        ttnn.add_(t, 1000)
+
+    while True:
+        try:
+            run_l1_overwrite()
+            ttnn.synchronize_device(mesh_device)
+            break
+        except RuntimeError:
+            ntiles -= 1
+            if ntiles <= 0:
+                pytest.fail("Cannot allocate any L1 tiles for overwrite op")
+
+    return run_l1_overwrite
+
+
+def _trace_corruption_and_rerun(mesh_device, run_ccl_op, run_l1_overwrite):
+    run_l1_overwrite()
+    ttnn.synchronize_device(mesh_device)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device)
+    run_l1_overwrite()
+    ttnn.end_trace_capture(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    run_ccl_op()
+    ttnn.synchronize_device(mesh_device)
+
+    ttnn.execute_trace(mesh_device, trace_id)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    out = run_ccl_op()
+    ttnn.synchronize_device(mesh_device)
+    return out
+
+
+def _make_sem(mesh_device, cores, buffer_type, initial_value=0):
+    return ttnn.create_global_semaphore(mesh_device, cores, initial_value, buffer_type)
+
+
+def _cluster_axis_with_more_than_one_device(mesh_device):
+    shape = mesh_device.shape
+    if hasattr(shape, "dims") and shape.dims() >= 2:
+        if shape[0] == 1 and shape[1] > 1:
+            return 1
+        return 0
+    try:
+        return 1 if len(shape) >= 2 and shape[0] == 1 and shape[1] > 1 else 0
+    except TypeError:
+        return 0
+
+
+# External semaphores are intentionally allocated in L1.
+# This test reproduces the real L1 trace-overwrite scenario while verifying that
+# explicitly passed semaphores are correctly forwarded in composite paths.
+SEM_BUFFER_TYPE = ttnn.BufferType.L1
+
+
+def _check_mesh_output(result, golden, opname):
+    for i, t in enumerate(ttnn.get_device_tensors(result)):
+        tt_out = ttnn.to_torch(t)
+        eq, msg = comp_pcc(tt_out, golden)
+        assert eq, f"{opname} correctness failed on device {i}: {msg}"
+
+
+# Covers every composite all_gather_async forwarding path:
+#   - subcore                : wrapper_sub_core_grids (FABRIC_1D, (1,8))
+#   - tiled_padded           : use_composite_all_gather TILE+padding (FABRIC_1D, (1,8))
+#   - persistent_2d / mesh_2d: wrapper_persistent_buffer / wrapper_mesh_device on FABRIC_2D (2,4)
+#   - persistent_1d_* / mesh_1d_*: same two wrappers on FABRIC_1D (1,8), with row_major and tile_padded triggers
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "device_params, mesh_device, case",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "subcore"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "tiled_padded"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D}, (2, 4), "persistent_2d"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D}, (2, 4), "mesh_2d"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "persistent_1d_rm"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "mesh_1d_rm"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "persistent_1d_tp"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "mesh_1d_tp"),
+    ],
+    ids=[
+        "subcore",
+        "tiled_padded",
+        "persistent_2d",
+        "mesh_2d",
+        "persistent_1d_rm",
+        "mesh_1d_rm",
+        "persistent_1d_tp",
+        "mesh_1d_tp",
+    ],
+    indirect=["device_params", "mesh_device"],
+)
+def test_composite_all_gather_hang(mesh_device, case):
+    logger.info(f"all_gather[{case}]: a hang during execution means this test failed")
+    torch.manual_seed(42)
+    ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
+    run_l1_overwrite = _setup_l1_overwrite(mesh_device)
+
+    semaphores = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
+    barrier_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
+
+    use_persistent = case.startswith("persistent_")
+    use_mesh_overload = case.startswith("mesh_")
+    use_cluster_axis = use_persistent or use_mesh_overload
+
+    if case == "subcore":
+        num_gather_devices = mesh_device.get_num_devices()
+        per_device_width = 64
+        golden = torch.randn(32, per_device_width * num_gather_devices).bfloat16()
+        ag_input = ttnn.from_torch(
+            golden,
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
+        )
+        dim = 1
+    elif case == "tiled_padded":
+        num_gather_devices = mesh_device.get_num_devices()
+        per_device_rows = 33  # not tile-aligned on gather dim 0
+        golden = torch.randn(per_device_rows * num_gather_devices, 64).bfloat16()
+        ag_input = ttnn.from_torch(
+            golden,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+        )
+        dim = 0
+    elif case in ("persistent_2d", "mesh_2d"):
+        num_gather_devices = mesh_device.shape[0]
+        per_device_width = 128
+        golden = torch.randn(32, per_device_width * num_gather_devices).bfloat16()
+        ag_input = ttnn.from_torch(
+            golden,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(2, 4), dims=(1, None)),
+        )
+        dim = 1
+    else:  # persistent_1d_rm, mesh_1d_rm, persistent_1d_tp, mesh_1d_tp
+        num_gather_devices = mesh_device.get_num_devices()
+        if case.endswith("_rm"):
+            per_device_extent = 64
+            dim = 1
+            layout = ttnn.ROW_MAJOR_LAYOUT
+            golden = torch.randn(32, per_device_extent * num_gather_devices).bfloat16()
+            mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=1)
+        else:  # _tp
+            per_device_extent = 33
+            dim = 0
+            layout = ttnn.TILE_LAYOUT
+            golden = torch.randn(per_device_extent * num_gather_devices, 64).bfloat16()
+            mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+        ag_input = ttnn.from_torch(
+            golden,
+            device=mesh_device,
+            layout=layout,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    cluster_axis = _cluster_axis_with_more_than_one_device(mesh_device) if use_cluster_axis else None
+
+    def run_op():
+        if use_persistent:
+            return ttnn.experimental.all_gather_async(
+                input_tensor=ag_input,
+                persistent_output_buffer=None,
+                dim=dim,
+                multi_device_global_semaphore=semaphores,
+                num_links=1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+                subdevice_id=worker_sub_device_id,
+                cluster_axis=cluster_axis,
+                barrier_semaphore=barrier_sem,
+            )
+        if use_mesh_overload:
+            return ttnn.experimental.all_gather_async(
+                input_tensor=ag_input,
+                dim=dim,
+                cluster_axis=cluster_axis,
+                mesh_device=mesh_device,
+                topology=ttnn.Topology.Linear,
+                multi_device_global_semaphore=semaphores,
+                persistent_output_tensor=None,
+                num_links=1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                subdevice_id=worker_sub_device_id,
+                barrier_semaphore=barrier_sem,
+            )
+        return ttnn.experimental.all_gather_async(
+            input_tensor=ag_input,
+            dim=dim,
+            multi_device_global_semaphore=semaphores,
+            num_links=1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+            subdevice_id=worker_sub_device_id,
+            barrier_semaphore=barrier_sem,
+        )
+
+    result = _trace_corruption_and_rerun(mesh_device, run_op, run_l1_overwrite)
+    _check_mesh_output(result, golden, f"all_gather_{case}")
+
+
+# Covers both all_reduce_async composite overloads:
+#   - 2D: mesh_device + cluster_axis path on FABRIC_2D (2,4)
+#   - 1D: num_devices path on FABRIC_1D (1,8)
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize(
+    "device_params, mesh_device, case",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_2D}, (2, 4), "2D"),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}, (1, 8), "1D"),
+    ],
+    ids=["2D", "1D"],
+    indirect=["device_params", "mesh_device"],
+)
+def test_composite_all_reduce_hang(mesh_device, case):
+    logger.info(f"all_reduce[{case}]: a hang during execution means this test failed")
+    torch.manual_seed(42)
+    ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
+    run_l1_overwrite = _setup_l1_overwrite(mesh_device)
+
+    rs_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(3)]
+    ag_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
+    barrier_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
+
+    if case == "2D":
+        per_chip_shape = [32, 256]
+        num_reduce_devices = mesh_device.shape[0]
+        inputs = [torch.randn(per_chip_shape).bfloat16() for _ in range(num_reduce_devices)]
+        golden = sum(inputs)
+        full_input = torch.cat(inputs, dim=0)
+        input_mesh = ttnn.from_torch(
+            full_input,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(2, 4), dims=(0, None)),
+        )
+
+        def run_op():
+            return ttnn.experimental.all_reduce_async(
+                input_mesh,
+                cluster_axis=0,
+                mesh_device=mesh_device,
+                barrier_semaphores=barrier_sems,
+                rs_global_semaphores=rs_sems,
+                ag_global_semaphores=ag_sems,
+                math_op=ttnn.ReduceType.Sum,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+                subdevice_id=worker_sub_device_id,
+            )
+
+    else:  # 1D
+        num_devices = mesh_device.get_num_devices()
+        input_single = torch.randn(32, 256).bfloat16()
+        golden = input_single * num_devices
+        input_mesh = ttnn.from_torch(
+            input_single,
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+        def run_op():
+            return ttnn.experimental.all_reduce_async(
+                input_tensor=input_mesh,
+                num_devices=num_devices,
+                barrier_semaphores=barrier_sems,
+                rs_global_semaphores=rs_sems,
+                ag_global_semaphores=ag_sems,
+                math_op=ttnn.ReduceType.Sum,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+                num_links=1,
+                subdevice_id=None,
+            )
+
+    result = _trace_corruption_and_rerun(mesh_device, run_op, run_l1_overwrite)
+    _check_mesh_output(result, golden, f"all_reduce_{case}")
+
+
+# Covers all_to_all_async composite path forwarding (barrier path when branch supports it).
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=["mesh_device"])
+def test_composite_all_to_all_hang(mesh_device):
+    logger.info("all_to_all: a hang during execution means this test failed")
+    torch.manual_seed(42)
+    ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
+    run_l1_overwrite = _setup_l1_overwrite(mesh_device)
+
+    ccl_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
+    barrier_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
+
+    num_devices = mesh_device.get_num_devices()
+    in_dim = 0
+    out_dim = 1
+    logical_shape = [256, 256]
+
+    golden_full = torch.randn(logical_shape).bfloat16()
+    golden = list(torch.chunk(golden_full, num_devices, dim=out_dim))
+
+    input_mesh = ttnn.from_torch(
+        golden_full,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=in_dim),
+    )
+
+    output_shape = list(logical_shape)
+    output_shape[out_dim] //= num_devices
+    persistent_intermediate = ttnn.from_torch(
+        torch.zeros(output_shape),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    persistent_output = ttnn.from_torch(
+        torch.zeros(output_shape),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    def run_op():
+        return ttnn.experimental.all_to_all_async(
+            input_tensor=input_mesh,
+            persistent_intermediate_buffer=persistent_intermediate,
+            persistent_output_buffer=persistent_output,
+            in_dim=in_dim,
+            out_dim=out_dim,
+            multi_device_global_semaphore=ccl_sem,
+            barrier_semaphore=barrier_sem,
+            num_links=1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Ring,
+            subdevice_id=worker_sub_device_id,
+        )
+
+    result = _trace_corruption_and_rerun(mesh_device, run_op, run_l1_overwrite)
+    for i, t in enumerate(ttnn.get_device_tensors(result)):
+        tt_out = ttnn.to_torch(t)
+        eq, msg = comp_pcc(tt_out, golden[i])
+        assert eq, f"all_to_all correctness failed on device {i}: {msg}"

--- a/tests/ttnn/unit_tests/operations/ccl/test_composite_ccl_hang.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_composite_ccl_hang.py
@@ -79,10 +79,6 @@ def _trace_corruption_and_rerun(mesh_device, run_ccl_op, run_l1_overwrite):
     return out
 
 
-def _make_sem(mesh_device, cores, buffer_type, initial_value=0):
-    return ttnn.create_global_semaphore(mesh_device, cores, initial_value, buffer_type)
-
-
 def _cluster_axis_with_more_than_one_device(mesh_device):
     shape = mesh_device.shape
     if hasattr(shape, "dims") and shape.dims() >= 2:
@@ -93,12 +89,6 @@ def _cluster_axis_with_more_than_one_device(mesh_device):
         return 1 if len(shape) >= 2 and shape[0] == 1 and shape[1] > 1 else 0
     except TypeError:
         return 0
-
-
-# External semaphores are intentionally allocated in L1.
-# This test reproduces the real L1 trace-overwrite scenario while verifying that
-# explicitly passed semaphores are correctly forwarded in composite paths.
-SEM_BUFFER_TYPE = ttnn.BufferType.L1
 
 
 def _check_mesh_output(result, golden, opname):
@@ -139,13 +129,16 @@ def _check_mesh_output(result, golden, opname):
     indirect=["device_params", "mesh_device"],
 )
 def test_composite_all_gather_hang(mesh_device, case):
-    logger.info(f"all_gather[{case}]: a hang during execution means this test failed")
     torch.manual_seed(42)
     ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
     run_l1_overwrite = _setup_l1_overwrite(mesh_device)
 
-    semaphores = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
-    barrier_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
+    logger.info(f"all_gather[{case}]: expected pass; hang means failure")
+
+    semaphores = [
+        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1) for _ in range(2)
+    ]
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1)
 
     use_persistent = case.startswith("persistent_")
     use_mesh_overload = case.startswith("mesh_")
@@ -179,7 +172,7 @@ def test_composite_all_gather_hang(mesh_device, case):
         dim = 0
     elif case in ("persistent_2d", "mesh_2d"):
         num_gather_devices = mesh_device.shape[0]
-        per_device_width = 128
+        per_device_width = 33
         golden = torch.randn(32, per_device_width * num_gather_devices).bfloat16()
         ag_input = ttnn.from_torch(
             golden,
@@ -258,7 +251,7 @@ def test_composite_all_gather_hang(mesh_device, case):
     _check_mesh_output(result, golden, f"all_gather_{case}")
 
 
-# Covers both all_reduce_async composite overloads:
+# Covers both all_reduce_async overloads used by this hang regression test:
 #   - 2D: mesh_device + cluster_axis path on FABRIC_2D (2,4)
 #   - 1D: num_devices path on FABRIC_1D (1,8)
 @pytest.mark.timeout(60)
@@ -272,17 +265,20 @@ def test_composite_all_gather_hang(mesh_device, case):
     indirect=["device_params", "mesh_device"],
 )
 def test_composite_all_reduce_hang(mesh_device, case):
-    logger.info(f"all_reduce[{case}]: a hang during execution means this test failed")
     torch.manual_seed(42)
     ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
     run_l1_overwrite = _setup_l1_overwrite(mesh_device)
 
-    rs_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(3)]
-    ag_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
-    barrier_sems = [_make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE) for _ in range(2)]
+    logger.info(f"all_reduce[{case}]: expected pass; hang means failure")
+
+    rs_sems = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1) for _ in range(3)]
+    ag_sems = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1) for _ in range(2)]
+    barrier_sems = [
+        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1) for _ in range(2)
+    ]
 
     if case == "2D":
-        per_chip_shape = [32, 256]
+        per_chip_shape = [1, 1, 32, 96]
         num_reduce_devices = mesh_device.shape[0]
         inputs = [torch.randn(per_chip_shape).bfloat16() for _ in range(num_reduce_devices)]
         golden = sum(inputs)
@@ -346,13 +342,14 @@ def test_composite_all_reduce_hang(mesh_device, case):
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=["mesh_device"])
 def test_composite_all_to_all_hang(mesh_device):
-    logger.info("all_to_all: a hang during execution means this test failed")
     torch.manual_seed(42)
     ccl_sub_device_crs, worker_sub_device_id = _setup_device(mesh_device)
     run_l1_overwrite = _setup_l1_overwrite(mesh_device)
 
-    ccl_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
-    barrier_sem = _make_sem(mesh_device, ccl_sub_device_crs, SEM_BUFFER_TYPE)
+    logger.info("all_to_all: expected pass; hang means failure")
+
+    ccl_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0, ttnn.BufferType.L1)
 
     num_devices = mesh_device.get_num_devices()
     in_dim = 0

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
@@ -121,7 +121,9 @@ std::vector<ttnn::Tensor> all_broadcast(
     const ttnn::MemoryConfig& output_mem_config,
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore) {
     const auto& tensor_topology = input_tensor.tensor_topology();
     const auto& tensor_topology_shape = tensor_topology.distribution_shape();
 
@@ -149,6 +151,8 @@ std::vector<ttnn::Tensor> all_broadcast(
             .output_mem_config = output_mem_config,
             .cluster_axis = cluster_axis,
             .sub_device_id = sub_device_id,
+            .semaphore = semaphore,
+            .barrier_semaphore = barrier_semaphore,
             .topology = topology,
             .use_l1_small_for_semaphores = use_l1_small_for_semaphores},
         input_tensor);

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
@@ -40,5 +40,7 @@ std::vector<ttnn::Tensor> all_broadcast(
     const ttnn::MemoryConfig& output_mem_config,
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 namespace ttnn::prim {
@@ -16,6 +17,8 @@ struct AllBroadcastParams {
     MemoryConfig output_mem_config;
     std::optional<uint32_t> cluster_axis;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+    std::optional<tt::tt_metal::GlobalSemaphore> semaphore;
+    std::optional<tt::tt_metal::GlobalSemaphore> barrier_semaphore;
     tt::tt_fabric::Topology topology{};
     bool use_l1_small_for_semaphores = false;
 };

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -348,19 +348,25 @@ tt::tt_metal::WorkloadDescriptor AllBroadcastProgramFactory::create_workload_des
     const auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
     ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevices = {subdevice_id};
 
-    // Allocate the two workload-scoped GlobalSemaphores.  Park them on the
-    // descriptor's `semaphores` vector so their device-side allocations stay
+    // Use caller-provided GlobalSemaphores when available; otherwise allocate workload-scoped ones.
+    // Park them on the descriptor's `semaphores` vector so their device-side allocations stay
     // alive for the lifetime of the cached workload — both are referenced by
     // writer runtime args as absolute addresses.  The init barrier is stored
     // at index 0 and the out-ready drain semaphore at index 1; subscript
-    // access below mirrors the original argument ordering at the create_at
+    // access below mirrors the argument ordering at the build_program_descriptor_at
     // call site (semaphore = final drain, barrier_semaphore = init barrier).
     auto sem_buffer_type = operation_attributes.use_l1_small_for_semaphores ? tt::tt_metal::BufferType::L1_SMALL
                                                                             : tt::tt_metal::BufferType::L1;
-    workload_descriptor.semaphores.push_back(
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
-    workload_descriptor.semaphores.push_back(
-        ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type));
+    auto get_or_create_semaphore =
+        [&](const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore) -> tt::tt_metal::GlobalSemaphore {
+        if (semaphore.has_value()) {
+            return semaphore.value();
+        }
+        return ttnn::global_semaphore::create_global_semaphore(mesh_device, available_cores, 0, sem_buffer_type);
+    };
+
+    workload_descriptor.semaphores.push_back(get_or_create_semaphore(operation_attributes.barrier_semaphore));
+    workload_descriptor.semaphores.push_back(get_or_create_semaphore(operation_attributes.semaphore));
     const auto& init_barrier_semaphore = workload_descriptor.semaphores[0];
     const auto& final_barrier_semaphore = workload_descriptor.semaphores[1];
     log_debug(tt::LogOp, "Semaphores allocated and waiting for all devices to be ready");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -46,7 +46,10 @@ ttnn::Tensor all_gather_async(
             resolved_num_links,
             memory_config,
             subdevice_id,
-            /*cluster_axis*/ std::nullopt);
+            /*cluster_axis*/ std::nullopt,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(
@@ -103,7 +106,15 @@ ttnn::Tensor all_gather_async(
         log_debug(tt::LogOp, "Using composite_all_gather");
         TT_FATAL(!sub_core_grid.has_value(), "Composite All Gather OP does not currently support sub core grid");
         return composite_common::composite_all_gather(
-            input_tensor, dim, resolved_num_links, memory_config, subdevice_id, cluster_axis);
+            input_tensor,
+            dim,
+            resolved_num_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(
@@ -157,8 +168,22 @@ std::vector<ttnn::Tensor> all_gather_async(
     if (composite_all_gather_case && !all_gather_async_llama_sharded_case) {
         log_debug(tt::LogOp, "Using composite_all_gather");
         TT_FATAL(!sub_core_grid.has_value(), "Composite All Gather OP does not currently support sub core grid");
-        return composite_common::composite_all_gather(
-            input_tensors, dim, resolved_num_links, memory_config, subdevice_id, cluster_axis);
+        std::vector<Tensor> output_tensors;
+        output_tensors.reserve(input_tensors.size());
+        for (size_t i = 0; i < input_tensors.size(); ++i) {
+            output_tensors.push_back(composite_common::composite_all_gather(
+                input_tensors[i],
+                dim,
+                resolved_num_links,
+                memory_config,
+                subdevice_id,
+                cluster_axis,
+                /*use_l1_small_for_semaphores*/ false,
+                multi_device_global_semaphore[0].global_semaphores[i],
+                barrier_semaphore.has_value() ? std::optional<GlobalSemaphore>(barrier_semaphore.value()[i])
+                                              : std::nullopt));
+        }
+        return output_tensors;
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     std::vector<Tensor> output_tensors;
@@ -222,7 +247,15 @@ ttnn::Tensor all_gather_async(
         log_debug(tt::LogOp, "Using composite_all_gather");
         TT_FATAL(!sub_core_grid.has_value(), "Composite All Gather OP does not currently support sub core grid");
         return composite_common::composite_all_gather(
-            input_tensor, dim, resolved_links, memory_config, subdevice_id, cluster_axis);
+            input_tensor,
+            dim,
+            resolved_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -313,7 +313,10 @@ ttnn::Tensor all_gather_async_reversed(
             resolved_num_links,
             memory_config,
             subdevice_id,
-            /*cluster_axis*/ std::nullopt);
+            /*cluster_axis*/ std::nullopt,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(
@@ -369,7 +372,15 @@ ttnn::Tensor all_gather_async_reversed(
         log_debug(tt::LogOp, "Using composite_all_gather");
         TT_FATAL(!sub_core_grid.has_value(), "Composite All Gather OP does not currently support sub core grid");
         return composite_common::composite_all_gather(
-            input_tensor, dim, resolved_num_links, memory_config, subdevice_id, cluster_axis);
+            input_tensor,
+            dim,
+            resolved_num_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(
@@ -423,7 +434,15 @@ ttnn::Tensor all_gather_async_reversed(
         log_debug(tt::LogOp, "Using composite_all_gather");
         TT_FATAL(!sub_core_grid.has_value(), "Composite All Gather OP does not currently support sub core grid");
         return composite_common::composite_all_gather(
-            input_tensor, dim, resolved_links, memory_config, subdevice_id, cluster_axis);
+            input_tensor,
+            dim,
+            resolved_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore[0],
+            barrier_semaphore);
     }
     log_debug(tt::LogOp, "Using minimal_all_gather_async");
     return ttnn::prim::all_gather_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -207,7 +207,10 @@ ttnn::Tensor all_reduce_async(
             resolved_num_links,
             out_memory_config,
             worker_subdevice_id_opt,
-            std::nullopt);
+            std::nullopt,
+            /*use_l1_small_for_semaphores*/ false,
+            ag_global_semaphores[0],
+            barrier_semaphores[1]);
         reshaped_tensor.deallocate();
 
         // Reduce (num_devices, B, C, H, W) -> (1, B, C, H, W)
@@ -330,7 +333,12 @@ ttnn::Tensor all_reduce_async(
             resolved_num_links,
             change_mem_config ? std::nullopt : std::optional<ttnn::MemoryConfig>(out_memory_config),
             worker_subdevice_id_opt,
-            cluster_axis);
+            cluster_axis,
+            /*use_l1_small_for_semaphores*/ false,
+            ag_global_semaphores.has_value() ? std::optional<GlobalSemaphore>(ag_global_semaphores.value()[0])
+                                             : std::nullopt,
+            barrier_semaphores.has_value() ? std::optional<GlobalSemaphore>(barrier_semaphores.value()[1])
+                                           : std::nullopt);
         reshaped_tensor.deallocate();
 
         // Reduce (num_devices, B, C, H, W) -> (1, B, C, H, W)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.cpp
@@ -19,6 +19,7 @@ ttnn::Tensor all_to_all_async(
     const int32_t in_dim,
     const int32_t out_dim,
     const GlobalSemaphore& multi_device_global_semaphore,
+    const std::optional<GlobalSemaphore>& barrier_semaphore,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
@@ -30,7 +31,15 @@ ttnn::Tensor all_to_all_async(
         // but the composite implementation is unable to reuse it. So overwrite persistent_output_buffer
         // to point to the real output buffer internally created by the composite implementation.
         persistent_output_buffer = composite_common::composite_all_to_all(
-            input_tensor, in_dim, out_dim, num_links, memory_config, subdevice_id);
+            input_tensor,
+            in_dim,
+            out_dim,
+            num_links,
+            memory_config,
+            subdevice_id,
+            /*use_l1_small_for_semaphores*/ false,
+            multi_device_global_semaphore,
+            barrier_semaphore);
         return persistent_output_buffer;
     }
     auto input_shape = input_tensor.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async.hpp
@@ -18,6 +18,7 @@ ttnn::Tensor all_to_all_async(
     int32_t in_dim,
     int32_t out_dim,
     const GlobalSemaphore& multi_device_global_semaphore,
+    const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
     uint32_t num_links = 1,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/all_to_all_async_nanobind.cpp
@@ -75,6 +75,7 @@ void bind_all_to_all_async(nb::module_& mod) {
         nb::arg("in_dim"),
         nb::arg("out_dim"),
         nb::arg("multi_device_global_semaphore"),
+        nb::arg("barrier_semaphore") = nb::none(),
         nb::kw_only(),
         nb::arg("num_links") = 1,
         nb::arg("memory_config") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -348,7 +348,9 @@ ttnn::Tensor composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore) {
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
@@ -394,7 +396,9 @@ ttnn::Tensor composite_all_gather(
         input_tensor.memory_config(),
         num_links,
         ttnn::ccl::Topology::Linear,
-        use_l1_small_for_semaphores);
+        use_l1_small_for_semaphores,
+        semaphore,
+        barrier_semaphore);
 
     // Do the gather itself
     ttnn::Tensor all_gather_output_tensor = ttnn::concat(broadcasted_tensors, gather_dim);
@@ -418,12 +422,22 @@ std::vector<ttnn::Tensor> composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore) {
     std::vector<ttnn::Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
     for (const auto& input_tensor : input_tensors) {
         output_tensors.push_back(composite_all_gather(
-            input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis, use_l1_small_for_semaphores));
+            input_tensor,
+            dim,
+            num_links,
+            memory_config,
+            subdevice_id,
+            cluster_axis,
+            use_l1_small_for_semaphores,
+            semaphore,
+            barrier_semaphore));
     }
     return output_tensors;
 }
@@ -435,7 +449,9 @@ ttnn::Tensor composite_all_to_all(
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-    bool use_l1_small_for_semaphores) {
+    bool use_l1_small_for_semaphores,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore) {
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
@@ -491,7 +507,9 @@ ttnn::Tensor composite_all_to_all(
         interim_memory_config,
         num_links,
         ttnn::ccl::Topology::Linear,
-        use_l1_small_for_semaphores);
+        use_l1_small_for_semaphores,
+        semaphore,
+        barrier_semaphore);
     input_tensor.deallocate();
 
     // Step 2: Slice out the index range each device cares about, along out_dim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -55,7 +55,9 @@ ttnn::Tensor composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore = std::nullopt);
 // same as above but for vector of mesh
 std::vector<ttnn::Tensor> composite_all_gather(
     const std::vector<ttnn::Tensor>& input_tensors,
@@ -64,7 +66,9 @@ std::vector<ttnn::Tensor> composite_all_gather(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
 ttnn::Tensor composite_all_to_all(
     ttnn::Tensor input_tensor,
@@ -73,6 +77,8 @@ ttnn::Tensor composite_all_to_all(
     uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-    bool use_l1_small_for_semaphores = false);
+    bool use_l1_small_for_semaphores = false,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& barrier_semaphore = std::nullopt);
 
 }  // namespace composite_common


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40382

### Problem description
As described in Ticket(#40382), composite CCL ops (`all_gather_async, all_reduce_async, all_to_all_async`) all go through `all_broadcast`, which allocates two L1 semaphores (init_barrier, final_barrier) internally at runtime. Trace replay can overwrite these L1 regions. On the next invocation, the program cache hits, so all_broadcast skips reallocation and reuses the now-corrupted semaphore addresses, causing a hang at `noc_semaphore_wait`.
The fix is to let callers pass semaphores in from outside (allocated before trace capture) so `all_broadcast` never relies on its own L1 allocations surviving across trace replays.

With this patch applied, running 
```
APPLY_HANG_PATCH=1 pytest hang.py 
```
against the reproduction script in #40382 completes all three tests without hanging.

### What's changed
- `all_broadcast`: Accept optional `semaphore` and `barrier_semaphore` params, falling back to internal allocation via `value_or` when not provided.
- `composite_all_gather`, `composite_all_to_all`: Pipe the two semaphore params through to `all_broadcast`.
- `all_gather_async` and `all_gather_async_reversed`: Pass `multi_device_global_semaphore[0]` and `barrier_semaphore` into `composite_all_gather` for all overloads.
- `all_reduce_async`: Pass `ag_global_semaphores[0]` and `barrier_semaphores[1]` into `composite_all_gather` on both composite overloads.
- `all_to_all_async`: Add optional `barrier_semaphore` parameter to the public API (C++ signature + Python nanobind), and forward both `multi_device_global_semaphore` and `barrier_semaphore` to `composite_all_to_all`. Previously the composite path did not forward the caller-provided semaphores to `all_broadcast`, so `all_broadcast` allocated its own L1 semaphores.
- Add `tests/ttnn/unit_tests/operations/ccl/test_composite_ccl_hang.py`: hang-detection unit test covering every experimental composite CCL path that routes through all_broadcast. 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moreh/ccl-hang)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moreh/ccl-hang)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moreh/ccl-hang)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moreh/ccl-hang)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moreh/ccl-hang)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moreh/ccl-hang)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moreh/ccl-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moreh/ccl-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moreh/ccl-hang)