### PR TITLE
[Fix]: Use UMD's TlbWindow class in Fast Dispatch code

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -25,7 +25,6 @@
 #include "command_queue_common.hpp"
 #include "system_memory_cq_interface.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <umd/device/tt_io.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <tracy/Tracy.hpp>
@@ -115,8 +114,8 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     prefetcher_cores(num_hw_cqs),
     prefetch_q_dev_ptrs(num_hw_cqs),
     prefetch_q_dev_fences(num_hw_cqs) {
-    this->prefetch_q_writers.reserve(num_hw_cqs);
-    this->completion_q_writers.reserve(num_hw_cqs);
+    this->prefetch_q_windows.reserve(num_hw_cqs);
+    this->completion_q_windows.reserve(num_hw_cqs);
 
     if (is_mock_device()) {
         this->cq_size = 65536;
@@ -201,7 +200,8 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         auto prefetcher_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
             prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
-        this->prefetch_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
+        this->prefetch_q_windows.emplace_back(
+            ctx.get_cluster().get_static_tlb_window(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
             ctx.get_dispatch_core_manager().completion_queue_writer_core(this->device_id, channel, cq_id);
@@ -219,8 +219,11 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
 
         this->completion_byte_addrs[cq_id] = completion_q_rd_ptr % completion_tlb_size;
-        this->completion_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(tt_cxy_pair(
-            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
+        this->completion_q_windows.emplace_back(
+            ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
+                completion_queue_writer_core.chip,
+                completion_queue_writer_virtual.x,
+                completion_queue_writer_virtual.y)));
 
         const uint32_t alignment =
             is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
@@ -601,7 +604,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
-    this->completion_q_writers[cq_id].write(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
+    this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
     const uint32_t completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
@@ -805,7 +808,7 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     if (stall_prefetcher) {
         command_size_16B |= (1 << ((sizeof(DispatchSettings::prefetch_q_entry_type) * 8) - 1));
     }
-    this->prefetch_q_writers[cq_id].write(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
+    this->prefetch_q_windows[cq_id]->write16(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
     this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
 }
 

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -6,8 +6,7 @@
 
 // needed for private members
 #include "system_memory_cq_interface.hpp"
-#include <umd/device/chip_helpers/tlb_manager.hpp>  // needed because tt_io.hpp requires needs TLBManager
-#include <umd/device/tt_io.hpp>                     // for umd::Writer
+#include <umd/device/pcie/tlb_window.hpp>            // for tt::umd::TlbWindow
 #include <umd/device/types/xy_pair.hpp>           // for tt_cxy_pair
 #include <atomic>
 #include <cstdint>
@@ -122,8 +121,8 @@ private:
     std::vector<uint32_t> cq_to_last_completed_event;
     mutable std::vector<std::mutex> cq_to_event_locks;
     std::vector<tt_cxy_pair> prefetcher_cores;
-    std::vector<umd::Writer> prefetch_q_writers;
-    std::vector<umd::Writer> completion_q_writers;
+    std::vector<tt::umd::TlbWindow*> prefetch_q_windows;
+    std::vector<tt::umd::TlbWindow*> completion_q_windows;
     std::vector<uint32_t> prefetch_q_dev_ptrs;
     std::vector<uint32_t> prefetch_q_dev_fences;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -205,7 +205,7 @@ public:
 
     tt::umd::TlbWindow* get_static_tlb_window(tt_cxy_pair target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
-        return driver_->get_tlb_manager(target.chip)->get_tlb_window(target_coord);
+        return driver_->get_static_tlb_window(target.chip, target_coord);
     }
 
     std::uint32_t get_numa_node_for_device(uint32_t device_id) const {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -205,9 +205,7 @@ public:
 
     tt::umd::TlbWindow* get_static_tlb_window(tt_cxy_pair target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
-        tt_xy_pair translated_core =
-            driver_->get_soc_descriptor(target.chip).translate_chip_coord_to_translated(target_coord);
-        return driver_->get_tlb_manager(target.chip)->get_tlb_window(translated_core);
+        return driver_->get_tlb_manager(target.chip)->get_tlb_window(target_coord);
     }
 
     std::uint32_t get_numa_node_for_device(uint32_t device_id) const {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -27,7 +27,8 @@
 #include <umd/device/driver_atomics.hpp>
 #include <umd/device/cluster_descriptor.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/tt_io.hpp>
+#include <umd/device/chip_helpers/tlb_manager.hpp>
+#include <umd/device/pcie/tlb_window.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -202,12 +203,11 @@ public:
         return std::tuple((uint32_t)tlb_configuration.tlb_offset, (uint32_t)tlb_configuration.size);
     }
 
-    // Returns a writer object which holds a pointer to a static tlb
-    // Allows for fast writes when targeting same device core by only doing the lookup once and avoiding repeated stack
-    // traversals
-    umd::Writer get_static_tlb_writer(tt_cxy_pair target) const {
+    tt::umd::TlbWindow* get_static_tlb_window(tt_cxy_pair target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
-        return driver_->get_static_tlb_writer(target.chip, target_coord);
+        tt_xy_pair translated_core =
+            driver_->get_soc_descriptor(target.chip).translate_chip_coord_to_translated(target_coord);
+        return driver_->get_tlb_manager(target.chip)->get_tlb_window(translated_core);
     }
 
     std::uint32_t get_numa_node_for_device(uint32_t device_id) const {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -203,6 +203,27 @@ public:
         return std::tuple((uint32_t)tlb_configuration.tlb_offset, (uint32_t)tlb_configuration.size);
     }
 
+    /**
+     * Returns a pointer to the static TLB window associated with the given target.
+     *
+     * Ownership:
+     *   - The returned TlbWindow is owned and managed by the underlying driver.
+     *   - Callers must not delete, free, or otherwise take ownership of the pointer.
+     *
+     * Lifetime:
+     *   - The pointer remains valid for as long as the underlying driver/device
+     *     context for this Cluster instance remains initialized and the static TLB
+     *     configuration is not torn down by the driver.
+     *   - Callers may cache the pointer, but must ensure they do not use it after
+     *     the Cluster/driver has been destroyed or the device has been deinitialized.
+     *
+     * Concurrency:
+     *   - The driver may return the same TlbWindow instance across multiple calls
+     *     (i.e., this is typically a cached/static window).
+     *   - It is safe to share the pointer across threads for read-only operations.
+     *   - If callers perform operations that mutate the TlbWindow or its underlying
+     *     mappings, they must provide appropriate external synchronization.
+     */
     tt::umd::TlbWindow* get_static_tlb_window(tt_cxy_pair target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
         return driver_->get_static_tlb_window(target.chip, target_coord);


### PR DESCRIPTION
### Ticket

Part of the effort to run Fast Dispatch on TTSim.

### Problem description

Runtime code was using UMD's Writer class for communication with dispatch cores. Writer class has a problem that it is implemented only for silicon and the implementation for write function is direct pointer access. This method does not work for simulation use case. We want to introduce the abstraction which is going to work for all platforms we want to run fast dispatch on.

### What's changed

SystemMemoryManager class is now using TlbWindow from UMD. TlbWindow implementes write32 and write16 methods which are going to do direct pointer access for silicon, same as Writer class previously. This also extends the possibiity of running runtime Fast Dispatch code for simulation platforms in the future. 

Since we don't yet have FD tests for TTSim in CI, this changes was tested for TTSim locally, TTSim tests are not segfaulting on TTSim, which they were with Writer class. Silicon tests are in checklist

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjanevski/tlb_window)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjanevski/tlb_window)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjanevski/tlb_window)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

No model related code is changed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjanevski/tlb_window)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjanevski/tlb_window)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjanevski/tlb_window)