### PR TITLE
Fix Shape hash collision for different-rank shapes with identical padding

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -40,6 +40,7 @@ set(UNIT_TESTS_API_SOURCES
     test_runtime_args.cpp
     test_semaphores.cpp
     test_shape_base.cpp
+    test_shape.cpp
     test_sharded_l1_buffer.cpp
     test_simple_dram_buffer.cpp
     test_tensor_accessor_default_page_size.cpp

--- a/tests/tt_metal/tt_metal/api/test_shape.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shape.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/shape.hpp>
+#include <tt_stl/reflection.hpp>
+
+#include "gtest/gtest.h"
+
+namespace tt::tt_metal {
+
+// Regression test: shapes with different ranks but same padded representation
+// must produce different hashes. ShapeBase::init() pads value_ to min-4D with
+// leading 1s, so [128, 128] and [1, 128, 128] both store {1, 1, 128, 128}.
+// The rank must be included in the hash to distinguish them.
+TEST(TensorShapeTests, DifferentRankShapesProduceDifferentHashes) {
+    tt::tt_metal::Shape shape_2d({128, 128});
+    tt::tt_metal::Shape shape_3d({1, 128, 128});
+
+    EXPECT_EQ(shape_2d.rank(), 2);
+    EXPECT_EQ(shape_3d.rank(), 3);
+
+    // Shapes are not equal despite same volume
+    EXPECT_NE(shape_2d, shape_3d);
+
+    // Hashes must differ
+    auto hash_2d = ttsl::hash::detail::hash_object(shape_2d);
+    auto hash_3d = ttsl::hash::detail::hash_object(shape_3d);
+    EXPECT_NE(hash_2d, hash_3d);
+}
+
+TEST(TensorShapeTests, SameRankShapesWithDifferentDimsProduceDifferentHashes) {
+    tt::tt_metal::Shape shape_a({32, 64});
+    tt::tt_metal::Shape shape_b({64, 32});
+
+    auto hash_a = ttsl::hash::detail::hash_object(shape_a);
+    auto hash_b = ttsl::hash::detail::hash_object(shape_b);
+    EXPECT_NE(hash_a, hash_b);
+}
+
+TEST(TensorShapeTests, IdenticalShapesProduceSameHash) {
+    tt::tt_metal::Shape shape_a({1, 128, 128});
+    tt::tt_metal::Shape shape_b({1, 128, 128});
+
+    auto hash_a = ttsl::hash::detail::hash_object(shape_a);
+    auto hash_b = ttsl::hash::detail::hash_object(shape_b);
+    EXPECT_EQ(hash_a, hash_b);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -46,9 +46,13 @@ public:
 
     uint32_t get_normalized_index(std::int64_t index) const;
 
-    // Needed for reflect / fmt
-    static constexpr auto attribute_names = std::forward_as_tuple("value");
-    auto attribute_values() const { return std::forward_as_tuple(this->value_); }
+    // Needed for reflect / fmt.
+    // rank is included because value_ is padded to min-4D with leading 1s (see ShapeBase::init()),
+    // so shapes with different ranks can have identical value_ (e.g., [128,128] and [1,128,128]
+    // both store {1,1,128,128}). Without rank, their hashes collide and cause incorrect program
+    // cache hits, reusing a program compiled for the wrong rank.
+    static constexpr auto attribute_names = std::forward_as_tuple("value", "rank");
+    auto attribute_values() const { return std::tuple<const Container&, size_t>{this->value_, rank()}; }
 
     std::array<uint32_t, 4> to_array_4D() const;
     Shape to_rank(size_t new_rank) const;

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -47,12 +47,9 @@ public:
     uint32_t get_normalized_index(std::int64_t index) const;
 
     // Needed for reflect / fmt.
-    // rank is included because value_ is padded to min-4D with leading 1s (see ShapeBase::init()),
-    // so shapes with different ranks can have identical value_ (e.g., [128,128] and [1,128,128]
-    // both store {1,1,128,128}). Without rank, their hashes collide and cause incorrect program
-    // cache hits, reusing a program compiled for the wrong rank.
-    static constexpr auto attribute_names = std::forward_as_tuple("value", "rank");
-    auto attribute_values() const { return std::tuple<const Container&, size_t>{this->value_, rank()}; }
+    // Uses view() to hash/format the original (unpadded) dimensions.
+    static constexpr auto attribute_names = std::forward_as_tuple("shape");
+    auto attribute_values() const { return std::make_tuple(this->view()); }
 
     std::array<uint32_t, 4> to_array_4D() const;
     Shape to_rank(size_t new_rank) const;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -19,6 +19,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <variant>
+#include <span>
 #include <vector>
 #include <filesystem>
 
@@ -63,6 +64,15 @@ struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
 template <typename Test, template <typename...> class Ref>
 constexpr bool is_specialization_v = detail::is_specialization<Test, Ref>::value;
+
+template <typename T>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t Extent>
+struct is_span<std::span<T, Extent>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_span_v = is_span<T>::value;
 
 // Forward Declare hash_object
 namespace hash {
@@ -1094,6 +1104,15 @@ inline hash_t hash_object(const T& object) noexcept {
     } else if constexpr (is_specialization_v<T, std::vector>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::vector of type {}: {}\n", get_type_name<T>(), object);
+        }
+        hash_t hash = 0;
+        for (const auto& element : object) {
+            hash = hash_objects(hash, element);
+        }
+        return hash;
+    } else if constexpr (is_span_v<T>) {
+        if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
+            fmt::print("Hashing std::span of type {}\n", get_type_name<T>());
         }
         hash_t hash = 0;
         for (const auto& element : object) {


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/39953

### Problem description
ShapeBase::init() pads value_ to a minimum of 4 dimensions by prepending 1s, so shapes with different ranks can end up with identical internal representations — e.g., Shape({128, 128}) and Shape({1, 128, 128}) both store value_ = {1, 1, 128, 128}. Since Shape::attribute_values() only returned value_, the reflection-based hash produced identical results for both, causing program cache collisions. This led to the wrong cached program being reused for tensors with different ranks, producing silently incorrect results.

This was observed with reduce_scatter on a (1,2) mesh where a 2D and 3D input produced the same hash (767182830450032972), and the 3D input reused the 2D program with wrong compile-time args (wrong normalized_dim, slice_Ht, slice_Wt), resulting in PCC ≈ 0.25. The issue is systemic and affects any operation that uses the program cache with tensors of different ranks.

Note that ShapeBase::operator== already uses = default, which compares original_size_, so equality was correct — only hashing was broken.

### What's changed
Include rank() in Shape::attribute_values() so the hash distinguishes shapes with different ranks. The return type uses std::tuple<const Container&, size_t> rather than std::forward_as_tuple because rank() returns a temporary that would otherwise create a dangling reference.

This does not affect fmt formatting, operator<< output, or JSON serialization — Shape has custom implementations for all three that don't use attribute_values(). The only consumer affected is the reflection-based hash system. All program cache hashes involving Shape will change, but this is safe since there is no persistent cache.

Tests are added in a new test_shape.cpp file (separated from test_shape_base.cpp which tests ShapeBase) covering: different-rank shapes produce different hashes, same-rank shapes with different dims produce different hashes, and identical shapes produce the same hash.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sdjordjevic/fix_hash_collision_for_shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sdjordjevic/fix_hash_collision_for_shape)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
