### PR TITLE
Adjust perf numbers when llk asserts are enabled.

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -115,7 +115,7 @@ def test_conv2d_auto_sliced_vae(device):
     )
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_dram_group_norm_vae_welford_reciprocal_performance():
     # Create a command that runs the specific test
@@ -152,7 +152,7 @@ def test_dram_group_norm_vae_welford_reciprocal_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_block_sharded_group_norm_sdxl_performance():
     # Create a command that runs the specific test
@@ -189,7 +189,7 @@ def test_block_sharded_group_norm_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_block_sharded_group_norm_negative_mask_sdxl_performance():
     # Create a command that runs the specific test
@@ -226,7 +226,7 @@ def test_block_sharded_group_norm_negative_mask_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_ff_matmul_with_gelu_sdxl_performance():
     # Create a command that runs the specific test
@@ -263,7 +263,7 @@ def test_ff_matmul_with_gelu_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_conv2d_block_sharded_sdxl_performance():
     # Create a command that runs the specific test
@@ -300,7 +300,7 @@ def test_conv2d_block_sharded_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
-@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_conv2d_auto_sliced_vae_performance():
     # Create a command that runs the specific test

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.common.utility_functions import skip_with_llk_assert
 from models.perf.device_perf_utils import run_device_perf_detailed
 
 MARGIN = 0.015
@@ -114,6 +115,7 @@ def test_conv2d_auto_sliced_vae(device):
     )
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_dram_group_norm_vae_welford_reciprocal_performance():
     # Create a command that runs the specific test
@@ -150,6 +152,7 @@ def test_dram_group_norm_vae_welford_reciprocal_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_block_sharded_group_norm_sdxl_performance():
     # Create a command that runs the specific test
@@ -186,6 +189,7 @@ def test_block_sharded_group_norm_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_block_sharded_group_norm_negative_mask_sdxl_performance():
     # Create a command that runs the specific test
@@ -222,6 +226,7 @@ def test_block_sharded_group_norm_negative_mask_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_ff_matmul_with_gelu_sdxl_performance():
     # Create a command that runs the specific test
@@ -258,6 +263,7 @@ def test_ff_matmul_with_gelu_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_conv2d_block_sharded_sdxl_performance():
     # Create a command that runs the specific test
@@ -294,6 +300,7 @@ def test_conv2d_block_sharded_sdxl_performance():
     ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
 
 
+@skip_with_llk_assert(reason="No need to verify LLK asserts for performance tests.")
 @pytest.mark.models_device_performance_bare_metal
 def test_conv2d_auto_sliced_vae_performance():
     # Create a command that runs the specific test


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40151

### Problem description
When LLK asserts are enabled, perf test expected numbers are changed - expected but still requires code change.

### What's changed
Adjusted perf numbers for the tests when LLK asserts are enabled.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/sanity_perf_test_llk_assert_compliance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/sanity_perf_test_llk_assert_compliance)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
