### PR TITLE
[GRIDSAMPLE] [ROTATE] Invalid noc transactions bugfixes

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -65,6 +65,23 @@ ALWI void clear_out_tiles(uint64_t write_addr, uint64_t clear_value_addr) {
     noc_async_read_barrier();
 }
 
+// Zero out all tiles for a given circular buffer.
+template <uint32_t cb_id>
+ALWI void zero_out_tiles() {
+    constexpr uint32_t tile_size = get_tile_size(cb_id);
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
+    const uint32_t num_zeros_reads = (tile_size / MEM_ZEROS_SIZE) * num_tiles;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id);
+
+    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read_one_packet_with_state<true>(zeros_noc_addr, write_addr);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+}
+
 template <uint32_t config_dram_addr, uint32_t config_page_size, uint32_t tensor_args_index, uint32_t cb_reader_index>
 ALWI void load_config_tensor_if_in_dram(uint32_t core_index) {
     // TODO: Instead of all cores reading from dram, only the first column reads, and does an MCAST to all the other

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -57,7 +57,7 @@ GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFact
         grid_nsticks_per_core = grid_shard_spec.shape[0];
         output_nsticks_per_core = output_tensor.shard_spec().value().shape[0];
 
-        num_cores = (total_grid_nsticks + grid_nsticks_per_core - 1) / grid_nsticks_per_core;
+        num_cores = grid_shard_spec.num_cores();
         all_cores = grid_shard_spec.grid;
         logical_cores = corerange_to_cores(
             all_cores, num_cores, grid_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
@@ -139,10 +139,11 @@ GridSampleNearestProgramFactory::cached_program_t GridSampleNearestProgramFactor
         0U,                                          // ct_arg[12]: reader_id (will be set per core)
         grid_nsticks_per_core,                       // ct_arg[13]: grid_nsticks_per_core
         is_sharded ? 1U : 0U,                        // ct_arg[14]: is_sharded
-        fill_cb_index                                // ct_arg[15]: fill_cb_index
+        fill_cb_index,                               // ct_arg[15]: fill_cb_index
+        input_shape[0]                               // ct_arg[16]: batch_size
     };
 
-    // Add tensor accessor args for input tensor (16 compile time args offset)
+    // Add tensor accessor args for input tensor (17 compile time args offset)
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(writer_compile_time_args);
     if (!is_sharded) {
         tt::tt_metal::TensorAccessorArgs(*grid_tensor.buffer()).append_to(writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include "api/compile_time_args.h"
 #include "api/dataflow/dataflow_api.h"
-#include "ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp"
+#include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
 #include "../grid_sample_reader_common.hpp"
 
 #define PRINT_AND_PROFILE 0

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -76,6 +76,14 @@ void kernel_main() {
     // Get local grid data base address (already in L1)
     const uint32_t l1_grid_base_addr = get_read_ptr(grid_cb_index);
 
+    // Compute how many sticks on this core contain valid grid data.
+    // Padding sticks (from height-sharding) may contain garbage L1 data that,
+    // if interpreted as grid coordinates, can cause NOC reads to invalid addresses.
+    constexpr uint32_t total_valid_sticks = input_batch * grid_hw;
+    const uint32_t remaining =
+        (global_grid_stick_start < total_valid_sticks) ? (total_valid_sticks - global_grid_stick_start) : 0;
+    const uint32_t valid_sticks_this_core = (remaining < grid_nsticks_per_core) ? remaining : grid_nsticks_per_core;
+
     // Process each grid stick assigned to this core
     uint32_t grid_stick_idx = 0;
     uint32_t l1_grid_addr = l1_grid_base_addr;
@@ -103,18 +111,30 @@ void kernel_main() {
     }
 
     while (grid_stick_idx < grid_nsticks_per_core) {
-        volatile tt_l1_ptr uint16_t* const grid_stick_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_grid_addr);
+        if (grid_stick_idx < valid_sticks_this_core) {
+            volatile tt_l1_ptr uint16_t* const grid_stick_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_grid_addr);
 
-        uint32_t batch_offset = curr_batch * input_height * input_width;
-        process_grid_point<
-            grid_dtype,
-            use_precomputed_grid,
-            input_height,
-            input_width,
-            input_stick_nbytes,
-            input_cb_index,
-            scalar_cb_index>(grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+            uint32_t batch_offset = curr_batch * input_height * input_width;
+            process_grid_point<
+                grid_dtype,
+                use_precomputed_grid,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                input_cb_index,
+                scalar_cb_index>(grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+        } else {
+            // Padding stick from height-sharding — push zero-weight data to CBs
+            // so the compute kernel receives the expected number of items.
+            // Input CB content doesn't matter since all weights are zero.
+            cb_reserve_back(input_cb_index, 1);
+            cb_push_back(input_cb_index, 1);
+
+            cb_reserve_back(scalar_cb_index, 1);
+            fill_four_val(get_write_ptr(scalar_cb_index), 0, 0, 0, 0);
+            cb_push_back(scalar_cb_index, 1);
+        }
 
         // Always advance once after processing
         advance_grid_index_bounded(

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp"
+#include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
 #include "../grid_sample_reader_common.hpp"
 
 #define PRINT_AND_PROFILE 0
@@ -132,7 +133,8 @@ void kernel_main() {
             cb_push_back(input_cb_index, 1);
 
             cb_reserve_back(scalar_cb_index, 1);
-            fill_four_val(get_write_ptr(scalar_cb_index), 0, 0, 0, 0);
+            zero_out_page<scalar_cb_index>(get_write_ptr(scalar_cb_index));
+            noc_async_read_barrier();
             cb_push_back(scalar_cb_index, 1);
         }
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -14,6 +14,17 @@
 #include "api/debug/dprint.h"
 #endif
 
+template <uint32_t input_cb_index, uint32_t scalar_cb_index>
+ALWI void push_padding_sticks() {
+    cb_reserve_back(input_cb_index, 1);
+    cb_push_back(input_cb_index, 1);
+
+    cb_reserve_back(scalar_cb_index, 1);
+    zero_out_page<scalar_cb_index>(get_write_ptr(scalar_cb_index));
+    noc_async_read_barrier();
+    cb_push_back(scalar_cb_index, 1);
+}
+
 ALWI void advance_grid_index_bounded(
     uint32_t& in_grid_row_idx,
     uint32_t& grid_stick_idx,
@@ -127,14 +138,7 @@ void kernel_main() {
         } else {
             // Padding stick from height-sharding — push zero-weight data to CBs
             // so the compute kernel receives the expected number of items.
-            // Input CB content doesn't matter since all weights are zero.
-            cb_reserve_back(input_cb_index, 1);
-            cb_push_back(input_cb_index, 1);
-
-            cb_reserve_back(scalar_cb_index, 1);
-            zero_out_page<scalar_cb_index>(get_write_ptr(scalar_cb_index));
-            noc_async_read_barrier();
-            cb_push_back(scalar_cb_index, 1);
+            push_padding_sticks<input_cb_index, scalar_cb_index>();
         }
 
         // Always advance once after processing

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -87,13 +87,13 @@ void kernel_main() {
     // Get local grid data base address (already in L1)
     const uint32_t l1_grid_base_addr = get_read_ptr(grid_cb_index);
 
-    // Compute how many sticks on this core contain valid grid data.
-    // Padding sticks (from height-sharding) may contain garbage L1 data that,
-    // if interpreted as grid coordinates, can cause NOC reads to invalid addresses.
-    constexpr uint32_t total_valid_sticks = input_batch * grid_hw;
-    const uint32_t remaining =
+    // Clamp this core's stick count to exclude height-sharding padding.
+    // Padding sticks contain garbage that would produce invalid NOC addresses.
+    constexpr uint32_t total_valid_sticks = input_batch * grid_hw;  // logical grid sticks across all batches
+    const uint32_t remaining =  // valid sticks from this core's start to end of grid
         (global_grid_stick_start < total_valid_sticks) ? (total_valid_sticks - global_grid_stick_start) : 0;
-    const uint32_t valid_sticks_this_core = (remaining < grid_nsticks_per_core) ? remaining : grid_nsticks_per_core;
+    const uint32_t valid_sticks_this_core =  // min(assigned, remaining) — actual work for this core
+        (remaining < grid_nsticks_per_core) ? remaining : grid_nsticks_per_core;
 
     // Process each grid stick assigned to this core
     uint32_t grid_stick_idx = 0;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -14,8 +14,14 @@
 #include "api/debug/dprint.h"
 #endif
 
+// Push one dummy input stick and one zeroed scalar stick into their CBs.
+// Used for height-sharding padding sticks that have no real grid data:
+// the compute kernel always consumes a fixed number of CB entries per core,
+// so we must push placeholder pages to keep reader and compute in sync.
+// The scalar page is zeroed so the interpolation weight is 0, making the
+// padded output harmless (written to the shard but masked by valid_sticks).
 template <uint32_t input_cb_index, uint32_t scalar_cb_index>
-ALWI void push_padding_sticks() {
+ALWI void push_noop_sticks() {
     cb_reserve_back(input_cb_index, 1);
     cb_push_back(input_cb_index, 1);
 
@@ -138,7 +144,7 @@ void kernel_main() {
         } else {
             // Padding stick from height-sharding — push zero-weight data to CBs
             // so the compute kernel receives the expected number of items.
-            push_padding_sticks<input_cb_index, scalar_cb_index>();
+            push_noop_sticks<input_cb_index, scalar_cb_index>();
         }
 
         // Always advance once after processing

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -5,7 +5,6 @@
 #include <cmath>
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp"
 #include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
 #include "../grid_sample_reader_common.hpp"
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -82,17 +82,11 @@ ALWI void process_grid_point_nearest(
         }
     }
 
-    // Boundary checks - optimized for precomputed grid with sentinel values
-    bool h_valid, w_valid;
-    if constexpr (use_precomputed_grid) {
-        // For precomputed grid, check sentinel value (-1) for invalid coordinates
-        h_valid = (nearest_h != -1);
-        w_valid = (nearest_w != -1);
-    } else {
-        // For regular grid, do full coordinate validation
-        h_valid = is_coordinate_valid(nearest_h, input_height);
-        w_valid = is_coordinate_valid(nearest_w, input_width);
-    }
+    // Full coordinate validation for both precomputed and regular grids.
+    // This catches out-of-bounds coordinates from padded shard data in addition
+    // to the precomputed grid sentinel value (-1), which fails the >= 0 check.
+    bool h_valid = is_coordinate_valid(nearest_h, input_height);
+    bool w_valid = is_coordinate_valid(nearest_w, input_width);
 
     if (h_valid && w_valid) {
         // Read the nearest neighbor pixel
@@ -149,6 +143,7 @@ void kernel_main() {
     constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(13);
     constexpr uint32_t is_sharded = get_compile_time_arg_val(14);
     constexpr uint32_t fill_cb_index = get_compile_time_arg_val(15);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(16);
 
     uint32_t input_addr = 0;
     uint32_t global_grid_stick_start = 0;
@@ -168,7 +163,7 @@ void kernel_main() {
     }
 
     // Input tensor accessor for remote NOC reads - same as sharded reader
-    constexpr auto input_tensor_args = TensorAccessorArgs<16>();
+    constexpr auto input_tensor_args = TensorAccessorArgs<17>();
     const auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_addr, input_stick_nbytes);
 
     constexpr auto grid_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
@@ -222,22 +217,28 @@ void kernel_main() {
         uint32_t l1_write_output_addr =
             l1_write_output_base_addr +
             (grid_stick_idx * grid_batching_factor * input_stick_nbytes + in_grid_row_idx * input_stick_nbytes);
-        // Process nearest neighbor sampling and write directly to output
-        process_grid_point_nearest<
-            grid_dtype,
-            is_sharded,
-            use_precomputed_grid,
-            align_corners,
-            input_height,
-            input_width,
-            input_stick_nbytes,
-            output_cb_index>(
-            grid_stick_ptr,
-            in_grid_row_idx,
-            input_tensor_accessor,
-            batch_offset,
-            l1_write_output_addr,
-            fill_stick_addr);
+
+        if (curr_batch < batch_size) {
+            // Process nearest neighbor sampling and write directly to output
+            process_grid_point_nearest<
+                grid_dtype,
+                is_sharded,
+                use_precomputed_grid,
+                align_corners,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                output_cb_index>(
+                grid_stick_ptr,
+                in_grid_row_idx,
+                input_tensor_accessor,
+                batch_offset,
+                l1_write_output_addr,
+                fill_stick_addr);
+        } else {
+            // Padding stick beyond valid batches - write zeros
+            noc_async_read(get_noc_addr(fill_stick_addr), l1_write_output_addr, input_stick_nbytes);
+        }
 
         // Always advance once after processing
         advance_grid_index<is_sharded>(

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/reader_rotate_nearest_interleaved.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
     constexpr uint32_t fill_cb_index = get_compile_time_arg_val(7);
     constexpr uint32_t input_stick_nbytes_unaligned = get_compile_time_arg_val(8);
     constexpr bool fill_is_zero = get_compile_time_arg_val(9) != 0;
-    constexpr uint32_t batch_size = get_compile_time_arg_val(10);
+    constexpr uint32_t burst_size = get_compile_time_arg_val(10);
 
     constexpr auto src_args = TensorAccessorArgs<11>();
     const auto input_tensor_accessor = TensorAccessor(src_args, input_addr, input_stick_nbytes_unaligned);
@@ -50,12 +50,12 @@ void kernel_main() {
     }
 
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
-        uint32_t sticks_this_batch =
-            (num_sticks - local_stick_idx) < batch_size ? (num_sticks - local_stick_idx) : batch_size;
-        cb_reserve_back(output_cb_index, sticks_this_batch);
+        uint32_t sticks_this_burst =
+            (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
+        cb_reserve_back(output_cb_index, sticks_this_burst);
         uint32_t l1_write_addr = get_write_ptr(output_cb_index);
 
-        for (uint32_t i = 0; i < sticks_this_batch; i++, local_stick_idx++) {
+        for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
             const uint32_t global_stick_idx = start_stick_id + local_stick_idx;
 
             const uint32_t batch_idx = global_stick_idx / (input_height * input_width);
@@ -91,6 +91,6 @@ void kernel_main() {
         }
 
         noc_async_read_barrier();
-        cb_push_back(output_cb_index, sticks_this_batch);
+        cb_push_back(output_cb_index, sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/kernels/dataflow/writer_rotate_nearest_interleaved.cpp
@@ -15,23 +15,23 @@ void kernel_main() {
     constexpr uint32_t output_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t output_stick_nbytes = get_compile_time_arg_val(1);
     constexpr uint32_t num_cb_pages = get_compile_time_arg_val(2);
-    constexpr uint32_t batch_size = get_compile_time_arg_val(3);
+    constexpr uint32_t burst_size = get_compile_time_arg_val(3);
     constexpr auto dst_args = TensorAccessorArgs<4>();
     const auto output_tensor_accessor = TensorAccessor(dst_args, output_addr, output_stick_nbytes);
 
     for (uint32_t local_stick_idx = 0; local_stick_idx < num_sticks;) {
-        uint32_t sticks_this_batch =
-            (num_sticks - local_stick_idx) < batch_size ? (num_sticks - local_stick_idx) : batch_size;
-        cb_wait_front(output_cb_index, sticks_this_batch);
+        uint32_t sticks_this_burst =
+            (num_sticks - local_stick_idx) < burst_size ? (num_sticks - local_stick_idx) : burst_size;
+        cb_wait_front(output_cb_index, sticks_this_burst);
         uint32_t l1_read_addr = get_read_ptr(output_cb_index);
 
-        for (uint32_t i = 0; i < sticks_this_batch; i++, local_stick_idx++) {
+        for (uint32_t i = 0; i < sticks_this_burst; i++, local_stick_idx++) {
             const uint32_t global_stick_idx = start_stick_id + local_stick_idx;
             const uint64_t output_noc_addr = output_tensor_accessor.get_noc_addr(global_stick_idx);
             noc_async_write(l1_read_addr, output_noc_addr, output_stick_nbytes);
             l1_read_addr += output_stick_nbytes;
         }
         noc_async_write_barrier();
-        cb_pop_front(output_cb_index, sticks_this_batch);
+        cb_pop_front(output_cb_index, sticks_this_burst);
     }
 }

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -24,7 +24,7 @@ using namespace tt::tt_metal;
 
 constexpr uint32_t NEAREST_BUFFERING_FACTOR = 2;
 constexpr uint32_t NUM_TILES_DEST = 8;
-constexpr uint32_t MAX_BATCH_SIZE = 5;
+constexpr uint32_t MAX_BURST_SIZE = 5;
 
 // Helper to convert float to bfloat16 representation using tie-to-even rounding (matches PyTorch)
 static uint16_t nearest_float_to_bfloat16(float value) {
@@ -137,9 +137,14 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
     const uint32_t max_sticks_per_core =
         any_sharded ? input_nsticks_per_core : std::max(num_sticks_per_core_group_1, num_sticks_per_core_group_2);
     uint32_t num_cb_pages = std::min(max_sticks_per_core, max_cb_pages_from_l1);
-    const uint32_t batch_size = num_cb_pages < MAX_BATCH_SIZE ? num_cb_pages : MAX_BATCH_SIZE;
-    // CB total size must be an even multiple of batch_size (required by cb_push_back/cb_pop_front API)
-    num_cb_pages = round_down(num_cb_pages, batch_size);
+    TT_FATAL(
+        num_cb_pages > 0,
+        "Not enough L1 for even a single CB page: aligned_input_stick_nbytes={} exceeds l1_for_cb={}",
+        aligned_input_stick_nbytes,
+        l1_for_cb);
+    const uint32_t burst_size = num_cb_pages < MAX_BURST_SIZE ? num_cb_pages : MAX_BURST_SIZE;
+    // CB total size must be an even multiple of burst_size (required by cb_push_back/cb_pop_front API)
+    num_cb_pages = round_down(num_cb_pages, burst_size);
 
     uint32_t next_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_page_size = aligned_input_stick_nbytes;
@@ -184,7 +189,7 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
         fill_cb_index,
         effective_stick_nbytes,
         static_cast<uint32_t>(fill_is_zero),
-        batch_size,
+        burst_size,
     };
 
     auto* input_buffer = input_tensor.buffer();
@@ -195,7 +200,7 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
         output_cb_index,
         aligned_output_stick_nbytes,
         num_cb_pages,
-        batch_size,
+        burst_size,
     };
 
     auto* output_buffer = output_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -137,6 +137,9 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
     const uint32_t max_sticks_per_core =
         any_sharded ? input_nsticks_per_core : std::max(num_sticks_per_core_group_1, num_sticks_per_core_group_2);
     uint32_t num_cb_pages = std::min(max_sticks_per_core, max_cb_pages_from_l1);
+    const uint32_t batch_size = num_cb_pages < MAX_BATCH_SIZE ? num_cb_pages : MAX_BATCH_SIZE;
+    // CB total size must be an even multiple of batch_size (required by cb_push_back/cb_pop_front API)
+    num_cb_pages = (num_cb_pages / batch_size) * batch_size;
 
     uint32_t next_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_page_size = aligned_input_stick_nbytes;
@@ -167,7 +170,6 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
         any_sharded ? output_tensor.buffer() : nullptr);
 
     const bool fill_is_zero = (fill_value_bf16 == 0);
-    const uint32_t batch_size = num_cb_pages < MAX_BATCH_SIZE ? num_cb_pages : MAX_BATCH_SIZE;
 
     const uint32_t effective_stick_nbytes = any_sharded ? effective_channels * element_size : input_stick_nbytes;
 

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_nearest_program_factory.cpp
@@ -139,7 +139,7 @@ RotateDeviceOperation::NearestProgramFactory::cached_program_t RotateDeviceOpera
     uint32_t num_cb_pages = std::min(max_sticks_per_core, max_cb_pages_from_l1);
     const uint32_t batch_size = num_cb_pages < MAX_BATCH_SIZE ? num_cb_pages : MAX_BATCH_SIZE;
     // CB total size must be an even multiple of batch_size (required by cb_push_back/cb_pop_front API)
-    num_cb_pages = (num_cb_pages / batch_size) * batch_size;
+    num_cb_pages = round_down(num_cb_pages, batch_size);
 
     uint32_t next_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_page_size = aligned_input_stick_nbytes;


### PR DESCRIPTION
### Problem description
When L2 Nightly is run with watcher enabled there are certain watcher flagged issues, such as invalid NOC transactions, invalid memory accesses etc. This PR fixes all the flagged issues within pool group. 

### What's changed
Changing the kernels to read only the chunks that are actually in L1 to omit the invalid mmeory accesses. 
Changing the out of bound stick detection and reading from zero mem base when index is invalid.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/pool_watcher_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/pool_watcher_fixes)
- [x] [![L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/pool_watcher_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/pool_watcher_fixes)
- [x] [![Single card Device perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=dstoiljkovic/pool_watcher_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:dstoiljkovic/pool_watcher_fixes)

