### PR TITLE
fp8 enablement metal

### DIFF
--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -7,6 +7,7 @@ set(UNIT_TESTS_LLK_SRC
     test_copy_block_matmul_partials.cpp
     test_cumsum.cpp
     test_dropout_sfpu_compute.cpp
+    test_fp8_typecast.cpp
     test_golden_impls.cpp
     test_mul_reduce_scalar.cpp
     test_pack_rows.cpp
@@ -20,5 +21,4 @@ set(UNIT_TESTS_LLK_SRC
     test_transpose.cpp
     test_unary_broadcast.cpp
     test_untilize_tilize.cpp
-    test_fp8_typecast.cpp
 )

--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -20,4 +20,5 @@ set(UNIT_TESTS_LLK_SRC
     test_transpose.cpp
     test_unary_broadcast.cpp
     test_untilize_tilize.cpp
+    test_fp8_typecast.cpp
 )

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -155,7 +155,7 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
         sum_b2 += bi * bi;
         sum_ab += ai * bi;
     }
-    double denom_a = n * sum_a2 - (sum_a * sum_a);
+    double denom_a = (n * sum_a2) - (sum_a * sum_a);
     double denom_b = (n * sum_b2) - (sum_b * sum_b);
     if (denom_a == 0.0 || denom_b == 0.0) {
         return 1.0;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -15,7 +15,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/test_utils/bfloat_utils.hpp"
 
 namespace tt::tt_metal {
 
@@ -132,8 +134,7 @@ static bool check_floats_close(const vector<float>& a, const vector<float>& b, f
     }
     for (size_t i = 0; i < a.size(); i++) {
         if (!is_close(a[i], b[i], rtol, atol)) {
-            std::cerr << "check_floats_close: mismatch at index " << i << " - a[i] = " << a[i] << ", b[i] = " << b[i]
-                      << std::endl;
+            log_info(tt::LogTest, "check_floats_close: mismatch at index {} - a[i] = {}, b[i] = {}", i, a[i], b[i]);
             return false;
         }
     }
@@ -166,7 +167,7 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
 static bool check_pcc(const vector<float>& a, const vector<float>& b, double min_pcc) {
     double pcc = compute_pcc(a, b);
     if (pcc < min_pcc) {
-        std::cerr << "check_pcc: PCC = " << pcc << " < min_pcc = " << min_pcc << std::endl;
+        log_info(tt::LogTest, "check_pcc: PCC = {} < min_pcc = {}", pcc, min_pcc);
         return false;
     }
     return true;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -156,7 +156,7 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
         sum_ab += ai * bi;
     }
     double denom_a = n * sum_a2 - (sum_a * sum_a);
-    double denom_b = n * sum_b2 - (sum_b * sum_b);
+    double denom_b = (n * sum_b2) - (sum_b * sum_b);
     if (denom_a == 0.0 || denom_b == 0.0) {
         return 1.0;
     }

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -144,25 +144,23 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
     if (a.size() != b.size() || a.empty()) {
         return 0.0;
     }
-    double mean_a = 0.0, mean_b = 0.0;
-    for (size_t i = 0; i < a.size(); i++) {
-        mean_a += a[i];
-        mean_b += b[i];
+    const size_t n = a.size();
+    double sum_a = 0.0, sum_b = 0.0;
+    double sum_a2 = 0.0, sum_b2 = 0.0, sum_ab = 0.0;
+    for (size_t i = 0; i < n; i++) {
+        double ai = a[i], bi = b[i];
+        sum_a += ai;
+        sum_b += bi;
+        sum_a2 += ai * ai;
+        sum_b2 += bi * bi;
+        sum_ab += ai * bi;
     }
-    mean_a /= static_cast<double>(a.size());
-    mean_b /= static_cast<double>(b.size());
-    double num = 0.0, denom_a = 0.0, denom_b = 0.0;
-    for (size_t i = 0; i < a.size(); i++) {
-        double da = a[i] - mean_a;
-        double db = b[i] - mean_b;
-        num += da * db;
-        denom_a += da * da;
-        denom_b += db * db;
-    }
+    double denom_a = n * sum_a2 - sum_a * sum_a;
+    double denom_b = n * sum_b2 - sum_b * sum_b;
     if (denom_a == 0.0 || denom_b == 0.0) {
         return 1.0;
     }
-    return num / std::sqrt(denom_a * denom_b);
+    return (n * sum_ab - sum_a * sum_b) / std::sqrt(denom_a * denom_b);
 }
 
 static bool check_pcc(const vector<float>& a, const vector<float>& b, double min_pcc) {

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -62,24 +62,6 @@ static vector<uint32_t> run_fp8_typecast(
                                              .set_page_size(tt::CBIndex::c_16, output_tile_size);
     CreateCircularBuffer(program, core, cb_dst_config);
 
-    std::map<std::string, std::string> defines = {};
-    if (!fp32_dest_acc_en and input_fmt == tt::DataFormat::Fp8_e4m3) {
-        if (output_fmt == tt::DataFormat::Float16_b) {
-            defines["PACK_A_TO_B"] = "DataFormat::Float16";
-        } else if (output_fmt == tt::DataFormat::Bfp8_b) {
-            defines["PACK_A_TO_B"] = "DataFormat::Bfp8";
-        } else {
-            throw std::runtime_error("Invalid output format");
-        }
-    }
-    if (!fp32_dest_acc_en and output_fmt == tt::DataFormat::Fp8_e4m3) {
-        if (input_fmt == tt::DataFormat::Float16_b or input_fmt == tt::DataFormat::Bfp8_b) {
-            defines["PACK_B_TO_A"] = "DataFormat::Float16_b";
-        } else {
-            throw std::runtime_error("Invalid input format");
-        }
-    }
-
     auto reader = CreateKernel(
         program,
         "tt_metal/kernels/dataflow/reader_unary.cpp",
@@ -96,7 +78,7 @@ static vector<uint32_t> run_fp8_typecast(
         program,
         "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp",
         core,
-        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}, .defines = defines});
+        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
 
     detail::WriteToBuffer(src_buffer, src_vec);
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
@@ -330,6 +312,111 @@ TEST_F(BlackholeSingleCardFixture, TensixBfp8bToFp8e4m3Fp32Dest) {
     auto dst_floats = fp8_to_floats(result_vec);
     EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.125f, /*atol=*/0.015625f));
     EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+// ============================================================================
+// Bfp8_b → Bfp8_b (identity)
+// Same format on both sides. The unpack→Dest→repack round-trip through the
+// shared-exponent blocking process may introduce minor rounding, but PCC
+// should remain very high.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixBfp8bToBfp8b) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Bfp8_b, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.3f, /*atol=*/0.3f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixBfp8bToBfp8bFp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Bfp8_b, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.3f, /*atol=*/0.3f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+// ============================================================================
+// fp8_e4m3 → fp8_e4m3 (identity)
+// Same format on both sides. The round-trip should be lossless since every
+// fp8 value survives the unpack→Dest→repack cycle exactly.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3Fp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// ============================================================================
+// Float16_b → Float16_b (identity)
+// Same format on both sides. The round-trip should be lossless since every
+// BF16 value survives the unpack→Dest→repack cycle exactly.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixFloat16bToFloat16b) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -156,7 +156,7 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
         sum_ab += ai * bi;
     }
     double denom_a = n * sum_a2 - sum_a * sum_a;
-    double denom_b = n * sum_b2 - sum_b * sum_b;
+    double denom_b = n * sum_b2 - (sum_b * sum_b);
     if (denom_a == 0.0 || denom_b == 0.0) {
         return 1.0;
     }

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -155,7 +155,7 @@ static double compute_pcc(const vector<float>& a, const vector<float>& b) {
         sum_b2 += bi * bi;
         sum_ab += ai * bi;
     }
-    double denom_a = n * sum_a2 - sum_a * sum_a;
+    double denom_a = n * sum_a2 - (sum_a * sum_a);
     double denom_b = n * sum_b2 - (sum_b * sum_b);
     if (denom_a == 0.0 || denom_b == 0.0) {
         return 1.0;

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/float8.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt_stl/span.hpp>
+#include "device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+using std::vector;
+
+namespace unit_tests::llk::fp8_typecast {
+
+// Run a datacopy kernel with different input/output CB formats.
+// The hardware unpacker reads input_fmt and the packer writes output_fmt,
+// performing the format conversion implicitly. fp32_dest_acc_en controls
+// whether the Dest register operates in 32-bit mode.
+static vector<uint32_t> run_fp8_typecast(
+    IDevice* dev,
+    tt::DataFormat input_fmt,
+    tt::DataFormat output_fmt,
+    const vector<uint32_t>& src_vec,
+    uint32_t num_tiles,
+    bool fp32_dest_acc_en) {
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    uint32_t input_tile_size = tt::tile_size(input_fmt);
+    uint32_t output_tile_size = tt::tile_size(output_fmt);
+
+    InterleavedBufferConfig src_config{
+        .device = dev,
+        .size = num_tiles * input_tile_size,
+        .page_size = num_tiles * input_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto src_buffer = CreateBuffer(src_config);
+
+    InterleavedBufferConfig dst_config{
+        .device = dev,
+        .size = num_tiles * output_tile_size,
+        .page_size = num_tiles * output_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto dst_buffer = CreateBuffer(dst_config);
+
+    CircularBufferConfig cb_src_config = CircularBufferConfig(input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
+                                             .set_page_size(tt::CBIndex::c_0, input_tile_size);
+    CreateCircularBuffer(program, core, cb_src_config);
+
+    CircularBufferConfig cb_dst_config = CircularBufferConfig(output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
+                                             .set_page_size(tt::CBIndex::c_16, output_tile_size);
+    CreateCircularBuffer(program, core, cb_dst_config);
+
+    std::map<std::string, std::string> defines = {};
+    if (!fp32_dest_acc_en and input_fmt == tt::DataFormat::Fp8_e4m3) {
+        if (output_fmt == tt::DataFormat::Float16_b) {
+            defines["PACK_A_TO_B"] = "DataFormat::Float16";
+        } else if (output_fmt == tt::DataFormat::Bfp8_b) {
+            defines["PACK_A_TO_B"] = "DataFormat::Bfp8";
+        } else {
+            throw std::runtime_error("Invalid output format");
+        }
+    }
+    if (!fp32_dest_acc_en and output_fmt == tt::DataFormat::Fp8_e4m3) {
+        if (input_fmt == tt::DataFormat::Float16_b or input_fmt == tt::DataFormat::Bfp8_b) {
+            defines["PACK_B_TO_A"] = "DataFormat::Float16_b";
+        } else {
+            throw std::runtime_error("Invalid input format");
+        }
+    }
+
+    auto reader = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/reader_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp",
+        core,
+        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}, .defines = defines});
+
+    detail::WriteToBuffer(src_buffer, src_vec);
+    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+
+    detail::LaunchProgram(dev, program);
+
+    vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+// Data generators use the existing uniform-distribution helpers:
+//   create_random_vector_of_bfloat16  (bfloat16.hpp)
+//   tt::test_utils::create_random_vector_of_bfp8  (bfloat_utils.hpp)
+// Both generate U(0, rand_max_float) + offset, so passing rand_max_float=20
+// and offset=-10 yields U(-10, 10).
+
+// --- Format-to-float unpackers ---
+
+static vector<float> fp8_to_floats(const vector<uint32_t>& packed) {
+    auto fp8_vec = unpack_uint32_vec_into_float8_e4m3_vec(packed);
+    vector<float> floats;
+    floats.reserve(fp8_vec.size());
+    for (const auto& v : fp8_vec) {
+        floats.push_back(static_cast<float>(v));
+    }
+    return floats;
+}
+
+static vector<float> bf16_to_floats(const vector<uint32_t>& packed) {
+    auto bf16_vec = unpack_uint32_vec_into_bfloat16_vec(packed);
+    vector<float> floats;
+    floats.reserve(bf16_vec.size());
+    for (const auto& v : bf16_vec) {
+        floats.push_back(static_cast<float>(v));
+    }
+    return floats;
+}
+
+static vector<float> bfp8_to_floats(const vector<uint32_t>& packed) {
+    return unpack_bfp8_tiles_into_float_vec(
+        tt::stl::make_const_span(packed), /*row_major_output=*/false, /*is_exp_a=*/false);
+}
+
+// --- Validation ---
+
+static bool check_floats_close(const vector<float>& a, const vector<float>& b, float rtol, float atol) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!is_close(a[i], b[i], rtol, atol)) {
+            std::cerr << "check_floats_close: mismatch at index " << i << " - a[i] = " << a[i] << ", b[i] = " << b[i]
+                      << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+static double compute_pcc(const vector<float>& a, const vector<float>& b) {
+    if (a.size() != b.size() || a.empty()) {
+        return 0.0;
+    }
+    double mean_a = 0.0, mean_b = 0.0;
+    for (size_t i = 0; i < a.size(); i++) {
+        mean_a += a[i];
+        mean_b += b[i];
+    }
+    mean_a /= static_cast<double>(a.size());
+    mean_b /= static_cast<double>(b.size());
+    double num = 0.0, denom_a = 0.0, denom_b = 0.0;
+    for (size_t i = 0; i < a.size(); i++) {
+        double da = a[i] - mean_a;
+        double db = b[i] - mean_b;
+        num += da * db;
+        denom_a += da * da;
+        denom_b += db * db;
+    }
+    if (denom_a == 0.0 || denom_b == 0.0) {
+        return 1.0;
+    }
+    return num / std::sqrt(denom_a * denom_b);
+}
+
+static bool check_pcc(const vector<float>& a, const vector<float>& b, double min_pcc) {
+    double pcc = compute_pcc(a, b);
+    if (pcc < min_pcc) {
+        std::cerr << "check_pcc: PCC = " << pcc << " < min_pcc = " << min_pcc << std::endl;
+        return false;
+    }
+    return true;
+}
+
+}  // namespace unit_tests::llk::fp8_typecast
+
+using namespace unit_tests::llk::fp8_typecast;
+
+// ============================================================================
+// fp8_e4m3 → Float16_b
+// Widening conversion: every fp8 value is exactly representable in BF16.
+// Expected: no precision loss → rtol=0.0, atol=0.0.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToFloat16b) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToFloat16bFp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.0f, /*atol=*/0.0f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// ============================================================================
+// Float16_b → fp8_e4m3
+// Narrowing: BF16 has 7 mantissa bits vs fp8's 3 → precision loss expected.
+// rtol=0.125 covers the max relative quantization error of fp8 (~1/8).
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixFloat16bToFp8e4m3) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.125f, /*atol=*/0.015625f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixFloat16bToFp8e4m3Fp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Float16_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.125f, /*atol=*/0.015625f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+// ============================================================================
+// fp8_e4m3 → Bfp8_b
+// Widening: Bfp8_b has 8 mantissa bits and a shared exponent per 16-element
+// row. For test data within [-10, 10], fp8 values may lose significant
+// precision due to the blocking forming process.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToBfp8b) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.3f, /*atol=*/0.3f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixFp8e4m3ToBfp8bFp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.3f, /*atol=*/0.3f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+// ============================================================================
+// Bfp8_b → fp8_e4m3
+// Narrowing: Bfp8_b has 8 mantissa bits vs fp8's 3 → precision loss expected.
+// ============================================================================
+
+TEST_F(BlackholeSingleCardFixture, TensixBfp8bToFp8e4m3) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Bfp8_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.125f, /*atol=*/0.015625f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixBfp8bToFp8e4m3Fp32Dest) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    constexpr uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        dev, tt::DataFormat::Bfp8_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(check_floats_close(src_floats, dst_floats, /*rtol=*/0.125f, /*atol=*/0.015625f));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
@@ -17,14 +17,6 @@ void kernel_main() {
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_init(tt::CBIndex::c_0);
 
-#ifdef PACK_A_TO_B
-    cfg_reg_rmw_tensix<THCON_SEC0_REG1_In_data_format_RMW>(to_underlying(PACK_A_TO_B));
-#endif
-#ifdef PACK_B_TO_A
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG2_Dstacc_RMW>(to_underlying(PACK_B_TO_A));
-    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Round_10b_mant_RMW>(1);
-#endif
-
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         acquire_dst();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
+    experimental::CircularBuffer cb16(tt::CBIndex::c_16);
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    copy_tile_init(tt::CBIndex::c_0);
+
+#ifdef PACK_A_TO_B
+    cfg_reg_rmw_tensix<THCON_SEC0_REG1_In_data_format_RMW>(to_underlying(PACK_A_TO_B));
+#endif
+#ifdef PACK_B_TO_A
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG2_Dstacc_RMW>(to_underlying(PACK_B_TO_A));
+    cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Round_10b_mant_RMW>(1);
+#endif
+
+    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        acquire_dst();
+
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+        copy_tile(tt::CBIndex::c_0, 0, 0);
+        pack_tile(0, tt::CBIndex::c_16);
+        cb0.pop_front(1);
+        cb16.push_back(1);
+
+        release_dst();
+    }
+}

--- a/tt_metal/api/tt-metalium/float8.hpp
+++ b/tt_metal/api/tt-metalium/float8.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/float8.hpp
+++ b/tt_metal/api/tt-metalium/float8.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/tt_metal/api/tt-metalium/float8.hpp
+++ b/tt_metal/api/tt-metalium/float8.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// FP8 E4M3: 1 sign bit (MSB), 4 exponent bits (bias=7), 3 mantissa bits.
+class float8_e4m3 {
+private:
+    uint8_t uint8_data;
+
+public:
+    constexpr float8_e4m3() = default;
+
+    float8_e4m3(float v) noexcept : uint8_data(from_float(v)) {}
+
+    operator float() const;
+
+    uint8_t to_bits() const { return uint8_data; }
+
+    static float8_e4m3 from_bits(uint8_t bits) {
+        float8_e4m3 f;
+        f.uint8_data = bits;
+        return f;
+    }
+
+private:
+    static uint8_t from_float(float v);
+};
+
+uint32_t pack_four_float8_e4m3_into_uint32(float8_e4m3 a, float8_e4m3 b, float8_e4m3 c, float8_e4m3 d);
+
+// Unpacks a packed uint32 vector (4 fp8 bytes per word) into float8_e4m3 values.
+std::vector<float8_e4m3> unpack_uint32_vec_into_float8_e4m3_vec(const std::vector<uint32_t>& data);
+
+// Generates num_bytes fp8_e4m3 values from a uniform distribution U(0, rand_max_float) + offset, packed 4 per uint32.
+std::vector<uint32_t> create_random_vector_of_float8_e4m3(
+    size_t num_bytes, int rand_max_float, int seed, float offset = 0.0f);

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -61,6 +61,7 @@ constexpr static uint32_t datum_size(const DataFormat& format) {
         case DataFormat::Float16_b: return 2;
         case DataFormat::Float32: return 4;
         case DataFormat::Tf32: throw std::invalid_argument("TF32 unsupported atm");
+        case DataFormat::Fp8_e4m3:
         case DataFormat::Int8:
         case DataFormat::Lf8:
         case DataFormat::UInt8:
@@ -96,6 +97,7 @@ constexpr static uint32_t tile_size(const DataFormat& format) {
         case DataFormat::Float16_b: return (1024 * 2);
         case DataFormat::Float32: return (1024 * 4);
         case DataFormat::Tf32: throw std::invalid_argument("TF32 unsupported atm");
+        case DataFormat::Fp8_e4m3:
         case DataFormat::Int8:
         case DataFormat::Lf8:
         case DataFormat::UInt8:

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -74,6 +74,7 @@ std::ostream& tt::operator<<(std::ostream& os, const DataFormat& format) {
         case DataFormat::Int8: os << "Int8"; break;
         case DataFormat::UInt8: os << "UInt8"; break;
         case DataFormat::Lf8: os << "Lf8"; break;
+        case DataFormat::Fp8_e4m3: os << "Fp8_e4m3"; break;
         case DataFormat::UInt16: os << "UInt16"; break;
         case DataFormat::UInt32: os << "UInt32"; break;
         case DataFormat::Int32: os << "Int32"; break;

--- a/tt_metal/impl/data_format/float8.cpp
+++ b/tt_metal/impl/data_format/float8.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/data_format/float8.cpp
+++ b/tt_metal/impl/data_format/float8.cpp
@@ -89,16 +89,15 @@ float8_e4m3::operator float() const {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    float result;
     if (exp == 0) {
         // HW flushes subnormals (exp=0, mantissa!=0) to zero.
-        result = 0.0f;
-    } else {
-        // Normal: (-1)^sign * 2^(exp-bias) * (1 + man/8)
-        result = std::ldexp(1.0f + static_cast<float>(man) / 8.0f, exp - FP8_BIAS);
+        return sign ? -0.0f : 0.0f;
     }
 
-    return sign ? -result : result;
+    // Reconstruct float32 bit pattern: (-1)^sign * 2^(exp-bias) * (1 + man/8)
+    uint32_t fp32_exp = static_cast<uint32_t>(exp - FP8_BIAS + 127);
+    uint32_t fp32_bits = (static_cast<uint32_t>(sign) << 31) | (fp32_exp << 23) | (static_cast<uint32_t>(man) << 20);
+    return std::bit_cast<float>(fp32_bits);
 }
 
 uint8_t float8_e4m3::from_float(float v) { return fp32_to_fp8_e4m3_bits(v); }
@@ -122,15 +121,16 @@ std::vector<float8_e4m3> unpack_uint32_vec_into_float8_e4m3_vec(const std::vecto
 
 std::vector<uint32_t> create_random_vector_of_float8_e4m3(
     size_t num_bytes, int rand_max_float, int seed, float offset) {
-    auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(0, rand_max_float);
 
     // num_bytes fp8 elements, packed 4 per uint32
     std::vector<uint32_t> result(num_bytes / sizeof(uint32_t), 0);
     for (uint32_t& word : result) {
-        float8_e4m3 a(rand_float() + offset);
-        float8_e4m3 b(rand_float() + offset);
-        float8_e4m3 c(rand_float() + offset);
-        float8_e4m3 d(rand_float() + offset);
+        float8_e4m3 a(dist(rng) + offset);
+        float8_e4m3 b(dist(rng) + offset);
+        float8_e4m3 c(dist(rng) + offset);
+        float8_e4m3 d(dist(rng) + offset);
         word = pack_four_float8_e4m3_into_uint32(a, b, c, d);
     }
     return result;

--- a/tt_metal/impl/data_format/float8.cpp
+++ b/tt_metal/impl/data_format/float8.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/float8.hpp>
+
+#include <bit>
+#include <cmath>
+#include <limits>
+#include <random>
+
+namespace {
+
+// Converts a float32 value to an FP8 E4M3 bit pattern.
+// E4M3: bias=7, exponent range [1,14] normal, [0] subnormal, [15] NaN.
+// Overflow (|val| > max representable ~240) clamps to max finite.
+uint8_t fp32_to_fp8_e4m3_bits(float val) {
+    constexpr int FP8_BIAS = 7;
+    constexpr int FP8_EXP_MAX = 14;  // E=15 is reserved for NaN
+
+    if (std::isnan(val)) {
+        return 0x7F;  // canonical NaN: S=0, E=1111, M=111
+    }
+
+    uint32_t u = std::bit_cast<uint32_t>(val);
+    uint8_t sign = static_cast<uint8_t>((u >> 31) & 1);
+
+    if (std::isinf(val)) {
+        // No infinity in FP8 E4M3 — clamp to max finite: E=1110, M=111
+        return (sign << 7) | 0x77;
+    }
+
+    int32_t fp32_biased_exp = static_cast<int32_t>((u >> 23) & 0xFF);
+    uint32_t fp32_mantissa = u & 0x7FFFFF;
+
+    if (fp32_biased_exp == 0 && fp32_mantissa == 0) {
+        return sign << 7;  // zero
+    }
+
+    if (fp32_biased_exp == 0) {
+        // FP32 subnormal — too small for FP8 normal range, rounds to zero
+        return sign << 7;
+    }
+
+    int32_t exp_unbiased = fp32_biased_exp - 127;
+    int32_t fp8_biased_exp = exp_unbiased + FP8_BIAS;
+
+    if (fp8_biased_exp > FP8_EXP_MAX) {
+        return (sign << 7) | 0x77;  // overflow → max finite
+    }
+
+    uint8_t fp8_exp;
+    uint8_t fp8_man;
+
+    if (fp8_biased_exp <= 0) {
+        // HW does not support FP8 subnormals (exp=0, mantissa!=0) and flushes them to zero.
+        return sign << 7;
+    } else {
+        // Normal FP8: take the top 3 bits of the FP32 mantissa
+        fp8_man = static_cast<uint8_t>((fp32_mantissa >> 20) & 0x7);
+        // Round to nearest even
+        uint32_t round_bit = (fp32_mantissa >> 19) & 1;
+        uint32_t sticky = fp32_mantissa & 0x7FFFF;
+        if (round_bit && (sticky || (fp8_man & 1))) {
+            if (++fp8_man >= 8) {
+                fp8_man = 0;
+                if (++fp8_biased_exp > FP8_EXP_MAX) {
+                    return (sign << 7) | 0x77;  // overflow → max finite
+                }
+            }
+        }
+        fp8_exp = static_cast<uint8_t>(fp8_biased_exp);
+    }
+
+    return (sign << 7) | (fp8_exp << 3) | fp8_man;
+}
+
+}  // namespace
+
+// Widening conversion: FP8 E4M3 → float32
+float8_e4m3::operator float() const {
+    constexpr int FP8_BIAS = 7;
+
+    uint8_t sign = (uint8_data >> 7) & 1;
+    uint8_t exp = (uint8_data >> 3) & 0xF;
+    uint8_t man = uint8_data & 0x7;
+
+    if (exp == 15) {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+
+    float result;
+    if (exp == 0) {
+        // HW flushes subnormals (exp=0, mantissa!=0) to zero.
+        result = 0.0f;
+    } else {
+        // Normal: (-1)^sign * 2^(exp-bias) * (1 + man/8)
+        result = std::ldexp(1.0f + static_cast<float>(man) / 8.0f, exp - FP8_BIAS);
+    }
+
+    return sign ? -result : result;
+}
+
+uint8_t float8_e4m3::from_float(float v) { return fp32_to_fp8_e4m3_bits(v); }
+
+uint32_t pack_four_float8_e4m3_into_uint32(float8_e4m3 a, float8_e4m3 b, float8_e4m3 c, float8_e4m3 d) {
+    return static_cast<uint32_t>(a.to_bits()) | (static_cast<uint32_t>(b.to_bits()) << 8) |
+           (static_cast<uint32_t>(c.to_bits()) << 16) | (static_cast<uint32_t>(d.to_bits()) << 24);
+}
+
+std::vector<float8_e4m3> unpack_uint32_vec_into_float8_e4m3_vec(const std::vector<uint32_t>& data) {
+    std::vector<float8_e4m3> result;
+    result.reserve(data.size() * 4);
+    for (uint32_t word : data) {
+        result.push_back(float8_e4m3::from_bits(word & 0xFF));
+        result.push_back(float8_e4m3::from_bits((word >> 8) & 0xFF));
+        result.push_back(float8_e4m3::from_bits((word >> 16) & 0xFF));
+        result.push_back(float8_e4m3::from_bits((word >> 24) & 0xFF));
+    }
+    return result;
+}
+
+std::vector<uint32_t> create_random_vector_of_float8_e4m3(
+    size_t num_bytes, int rand_max_float, int seed, float offset) {
+    auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
+
+    // num_bytes fp8 elements, packed 4 per uint32
+    std::vector<uint32_t> result(num_bytes / sizeof(uint32_t), 0);
+    for (uint32_t& word : result) {
+        float8_e4m3 a(rand_float() + offset);
+        float8_e4m3 b(rand_float() + offset);
+        float8_e4m3 c(rand_float() + offset);
+        float8_e4m3 d(rand_float() + offset);
+        word = pack_four_float8_e4m3_into_uint32(a, b, c, d);
+    }
+    return result;
+}

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -80,6 +80,7 @@ uint32_t Tile::get_tile_size(const DataFormat& format) const {
         case DataFormat::Float16:
         case DataFormat::Float16_b: return (tile_hw * 2);
         case DataFormat::Float32: return (tile_hw * 4);
+        case DataFormat::Fp8_e4m3:
         case DataFormat::Int8:
         case DataFormat::Lf8:
         case DataFormat::UInt8:

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -31,6 +31,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/float8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -31,8 +31,8 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/float8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/float8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataflow_buffer/dataflow_buffer.cpp

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -218,7 +218,7 @@ DataFormat get_single_pack_src_format(
     } else if (data_format == DataFormat::Invalid) {
         pack_src_format = DataFormat::Invalid;
     } else if (data_format == DataFormat::Fp8_e4m3) {
-        pack_src_format = DataFormat::Float16;  // TODO: fix this???
+        pack_src_format = is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
     } else if (fp32_dest_acc_en) {
         if (is_bfp_format(data_format)) {
             if (bfp8_pack_precise) {

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -61,6 +61,11 @@ DataFormat check_consistent_format_across_buffers(std::span<const DataFormat> da
             continue;
         }
 
+        // Special case where Fp8_e4m3 can be used with any format
+        if (format == DataFormat::Fp8_e4m3) {
+            continue;
+        }
+
         if (format != DataFormat::Invalid) {
             TT_FATAL(ALL_VALID_FORMATS.contains(format), "Format = {} not supported", format);
 
@@ -213,7 +218,7 @@ DataFormat get_single_pack_src_format(
     } else if (data_format == DataFormat::Invalid) {
         pack_src_format = DataFormat::Invalid;
     } else if (data_format == DataFormat::Fp8_e4m3) {
-        pack_src_format = DataFormat::Float16;
+        pack_src_format = DataFormat::Float16;  // TODO: fix this???
     } else if (fp32_dest_acc_en) {
         if (is_bfp_format(data_format)) {
             if (bfp8_pack_precise) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -6,6 +6,7 @@
 
 #include <circular_buffer_constants.h>
 #include "data_format.hpp"
+#include <algorithm>
 #include <cstdint>
 #include <tt_backend_api_types.hpp>
 #include <cstddef>
@@ -201,6 +202,31 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_f
 
     vector<DataFormat> dst_formats = tt::get_pack_dst_formats(
         desc.buf_dataformat_arr);
+
+    // Fp8_e4m3 is always unpacked to Float16 (A-family) in source/dest registers.
+    // Without fp32_dest_acc, the dest register holds Float16 (A-family) data when
+    // the input is Fp8, so non-Fp8 output CBs need A-family pack_src to match.
+    // With fp32_dest_acc, dest holds Float32 and pack_src semantics differ, so skip.
+    // CBs that are themselves Fp8_e4m3 are already handled by get_single_pack_src_format.
+    if (!fp32_dest_acc_en) {
+        bool has_fp8 = std::any_of(desc.buf_dataformat_arr.begin(), desc.buf_dataformat_arr.end(), [](DataFormat f) {
+            return f == DataFormat::Fp8_e4m3;
+        });
+        if (has_fp8) {
+            for (size_t i = 0; i < src_formats.size(); i++) {
+                if (desc.buf_dataformat_arr[i] == DataFormat::Fp8_e4m3) {
+                    continue;
+                }
+                switch (src_formats[i]) {
+                    case DataFormat::Float16_b: src_formats[i] = DataFormat::Float16; break;
+                    case DataFormat::Bfp8_b: src_formats[i] = DataFormat::Bfp8; break;
+                    case DataFormat::Bfp4_b: src_formats[i] = DataFormat::Bfp4; break;
+                    case DataFormat::Bfp2_b: src_formats[i] = DataFormat::Bfp2; break;
+                    default: break;
+                }
+            }
+        }
+    }
 
     TT_ASSERT(src_formats.size() == max_cbs);
     TT_ASSERT(dst_formats.size() == max_cbs);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -208,22 +208,20 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_f
     // the input is Fp8, so non-Fp8 output CBs need A-family pack_src to match.
     // With fp32_dest_acc, dest holds Float32 and pack_src semantics differ, so skip.
     // CBs that are themselves Fp8_e4m3 are already handled by get_single_pack_src_format.
-    if (!fp32_dest_acc_en) {
-        bool has_fp8 = std::any_of(desc.buf_dataformat_arr.begin(), desc.buf_dataformat_arr.end(), [](DataFormat f) {
+    if (!fp32_dest_acc_en &&
+        std::any_of(desc.buf_dataformat_arr.begin(), desc.buf_dataformat_arr.end(), [](DataFormat f) {
             return f == DataFormat::Fp8_e4m3;
-        });
-        if (has_fp8) {
-            for (size_t i = 0; i < src_formats.size(); i++) {
-                if (desc.buf_dataformat_arr[i] == DataFormat::Fp8_e4m3) {
-                    continue;
-                }
-                switch (src_formats[i]) {
-                    case DataFormat::Float16_b: src_formats[i] = DataFormat::Float16; break;
-                    case DataFormat::Bfp8_b: src_formats[i] = DataFormat::Bfp8; break;
-                    case DataFormat::Bfp4_b: src_formats[i] = DataFormat::Bfp4; break;
-                    case DataFormat::Bfp2_b: src_formats[i] = DataFormat::Bfp2; break;
-                    default: break;
-                }
+        })) {
+        for (size_t i = 0; i < src_formats.size(); i++) {
+            if (desc.buf_dataformat_arr[i] == DataFormat::Fp8_e4m3) {
+                continue;
+            }
+            switch (src_formats[i]) {
+                case DataFormat::Float16_b: src_formats[i] = DataFormat::Float16; break;
+                case DataFormat::Bfp8_b: src_formats[i] = DataFormat::Bfp8; break;
+                case DataFormat::Bfp4_b: src_formats[i] = DataFormat::Bfp4; break;
+                case DataFormat::Bfp2_b: src_formats[i] = DataFormat::Bfp2; break;
+                default: break;
             }
         }
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18157

### Problem description
Need to ensure metal is able to propogate proper dataformat information to inits for 
Fp8->Fp8 and Fp8<->Float16_b/bfp8_b

### What's changed
Float16_b/bfp8_b->Fp8: Modify data_format.cpp to set pck_src according to DEST fmt when output CB is fp8
Fp8->Float16_b/bfp8_b: Modify genfiles to check CBs for fp8 input, then modify pck_src to be the corresponding expA type depending on the output CB fmt

Add metal level test for datacopy w relevant dataformat conversions 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pgardner/fp8-enablement-metal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pgardner/fp8-enablement-metal)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/fp8-enablement-metal)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pgardner/fp8-enablement-metal)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pgardner/fp8-enablement-metal)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pgardner/fp8-enablement-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pgardner/fp8-enablement-metal)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
