### PR TITLE
sanity with watcher fix

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/cb_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/cb_helpers.hpp
@@ -55,25 +55,6 @@ ALWI uint32_t get_full_tile_size(DataFormat format);
  */
 ALWI uint32_t get_cb_num_pages(uint32_t cb_id);
 
-/**
- * @brief Validate that a CB's page size equals the tile size for its data format (compile-time version)
- *
- * On compute kernels (TRISC), fifo_page_size is stored in 16-byte units, so we shift left
- * by CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT to convert back to bytes.
- *
- * @tparam format Data format (compile-time constant)
- * @param cb_id Circular buffer ID
- */
-template <DataFormat format>
-ALWI bool is_valid_cb_tile_page_size(uint32_t cb_id);
-
-/**
- * @brief Validate that a CB's page size equals the tile size for its data format (runtime version)
- *
- * Same shift logic as the compile-time version.
- */
-ALWI bool is_valid_cb_tile_page_size(uint32_t cb_id, DataFormat format);
-
 // =============================================================================
 // Data Format Classification Helpers
 // =============================================================================

--- a/ttnn/cpp/ttnn/kernel_lib/cb_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/cb_helpers.inl
@@ -5,7 +5,6 @@
 // Do not include directly - include cb_helpers.hpp instead
 
 #include "api/compute/cb_api.h"
-#include "tt-metalium/circular_buffer_constants.h"
 
 namespace compute_kernel_lib {
 
@@ -64,21 +63,6 @@ ALWI uint32_t get_full_tile_size(DataFormat format) {
 ALWI uint32_t get_cb_num_pages(uint32_t cb_id) {
     auto& cb = get_local_cb_interface(cb_id);
     return cb.fifo_size / cb.fifo_page_size;
-}
-
-template <DataFormat format>
-ALWI bool is_valid_cb_tile_page_size(uint32_t cb_id) {
-    uint32_t tile_size = get_full_tile_size<format>();
-    uint32_t page_size_bytes = get_local_cb_interface(cb_id).fifo_page_size
-                               << CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT;
-    return page_size_bytes == tile_size;
-}
-
-ALWI bool is_valid_cb_tile_page_size(uint32_t cb_id, DataFormat format) {
-    uint32_t tile_size = get_full_tile_size(format);
-    uint32_t page_size_bytes = get_local_cb_interface(cb_id).fifo_page_size
-                               << CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT;
-    return page_size_bytes == tile_size;
 }
 
 // =============================================================================

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -80,10 +80,11 @@ constexpr bool can_use_fast_tilize() {
 
 template <uint32_t input_cb, uint32_t output_cb>
 ALWI void assert_tilize_cb_page_sizes(bool asymmetric_cb_pages) {
-    // When output is a block float format (e.g. Bfp8_b), the op converts from a
-    // non-block input format (e.g. Float16_b), so page sizes legitimately differ.
+    // Page sizes only need to match when input and output have the same data format.
+    // Format-converting tilize (e.g. Float32 -> BFloat16) legitimately produces
+    // different page sizes since tile sizes differ between formats.
 #if defined(UCK_CHLKC_PACK)
-    if constexpr (!is_block_float_format(pack_dst_format[output_cb])) {
+    if constexpr (pack_dst_format[input_cb] == pack_dst_format[output_cb]) {
         const uint32_t in_page_size = get_local_cb_interface(input_cb).fifo_page_size;
         const uint32_t out_page_size = get_local_cb_interface(output_cb).fifo_page_size;
         if (asymmetric_cb_pages) {

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -75,28 +75,6 @@ constexpr bool can_use_fast_tilize() {
 }
 
 // =============================================================================
-// CB Validation Helpers (must be called from PACK guard)
-// =============================================================================
-
-template <uint32_t input_cb, uint32_t output_cb>
-ALWI void assert_tilize_cb_page_sizes(bool asymmetric_cb_pages) {
-    // Page sizes only need to match when input and output have the same data format.
-    // Format-converting tilize (e.g. Float32 -> BFloat16) legitimately produces
-    // different page sizes since tile sizes differ between formats.
-#if defined(UCK_CHLKC_PACK)
-    if constexpr (pack_dst_format[input_cb] == pack_dst_format[output_cb]) {
-        const uint32_t in_page_size = get_local_cb_interface(input_cb).fifo_page_size;
-        const uint32_t out_page_size = get_local_cb_interface(output_cb).fifo_page_size;
-        if (asymmetric_cb_pages) {
-            ASSERT(in_page_size != out_page_size);
-        } else {
-            ASSERT(in_page_size == out_page_size);
-        }
-    }
-#endif
-}
-
-// =============================================================================
 // Main Function Implementation
 // =============================================================================
 
@@ -147,15 +125,6 @@ ALWI void tilize(
         ASSERT(*total_input_pages > (num_blocks - 1) * 32);  // at least one row in the last block
         ASSERT(*total_input_pages <= num_blocks * 32);        // rows fit within num_blocks tile-rows
     }
-
-    // Sanity checks: verify CB page sizes match the usage pattern.
-    // Guarded because get_local_cb_interface() references cb_interface, which is
-    // not defined for the MATH TRISC (trisc.cc excludes it via #if !defined(UCK_CHLKC_MATH)).
-    PACK((assert_tilize_cb_page_sizes<input_cb, output_cb>(asymmetric_cb_pages)));
-    PACK(ASSERT(is_valid_cb_tile_page_size(output_cb, (DataFormat)pack_dst_format[output_cb])));
-    UNPACK(if (!asymmetric_cb_pages) {
-        ASSERT(is_valid_cb_tile_page_size(input_cb, (DataFormat)unpack_src_format[input_cb]));
-    })
 
     // Tilize input must not be a block float format (Bfp8/4/2 and _b variants).
     // Block floats have shared exponents that break row-major-to-tile reinterpretation.

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -75,18 +75,24 @@ constexpr bool can_use_fast_tilize() {
 }
 
 // =============================================================================
-// CB Validation Helpers (must be called from PACK/UNPACK guards)
+// CB Validation Helpers (must be called from PACK guard)
 // =============================================================================
 
 template <uint32_t input_cb, uint32_t output_cb>
 ALWI void assert_tilize_cb_page_sizes(bool asymmetric_cb_pages) {
-    const uint32_t in_page_size = get_local_cb_interface(input_cb).fifo_page_size;
-    const uint32_t out_page_size = get_local_cb_interface(output_cb).fifo_page_size;
-    if (asymmetric_cb_pages) {
-        ASSERT(in_page_size != out_page_size);
-    } else {
-        ASSERT(in_page_size == out_page_size);
+    // When output is a block float format (e.g. Bfp8_b), the op converts from a
+    // non-block input format (e.g. Float16_b), so page sizes legitimately differ.
+#if defined(UCK_CHLKC_PACK)
+    if constexpr (!is_block_float_format(pack_dst_format[output_cb])) {
+        const uint32_t in_page_size = get_local_cb_interface(input_cb).fifo_page_size;
+        const uint32_t out_page_size = get_local_cb_interface(output_cb).fifo_page_size;
+        if (asymmetric_cb_pages) {
+            ASSERT(in_page_size != out_page_size);
+        } else {
+            ASSERT(in_page_size == out_page_size);
+        }
     }
+#endif
 }
 
 // =============================================================================

--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
@@ -40,23 +40,6 @@ constexpr uint32_t compute_num_blocks(uint32_t total_width, uint32_t max_block_w
 }
 
 // =============================================================================
-// CB Validation Helpers (must be called from PACK/UNPACK guards)
-// =============================================================================
-
-template <uint32_t input_cb, uint32_t output_cb>
-ALWI void assert_untilize_cb_page_sizes() {
-    // When input is a block float format (e.g. Bfp8_b), the op converts to a
-    // non-block output format (e.g. Float16_b), so page sizes legitimately differ.
-#if defined(UCK_CHLKC_PACK)
-    if constexpr (!is_block_float_format(pack_dst_format[input_cb])) {
-        const uint32_t in_page_size = get_local_cb_interface(input_cb).fifo_page_size;
-        const uint32_t out_page_size = get_local_cb_interface(output_cb).fifo_page_size;
-        ASSERT(in_page_size == out_page_size);
-    }
-#endif
-}
-
-// =============================================================================
 // Standalone Init/Uninit Wrapper Functions Implementations
 // =============================================================================
 
@@ -104,13 +87,6 @@ ALWI void untilize(uint32_t num_blocks) {
 
     // Runtime parameter validation
     ASSERT(num_blocks > 0);
-
-    // Sanity checks: verify CB page sizes match the usage pattern.
-    // Guarded because get_local_cb_interface() references cb_interface, which is
-    // not defined for the MATH TRISC (trisc.cc excludes it via #if !defined(UCK_CHLKC_MATH)).
-    PACK((assert_untilize_cb_page_sizes<input_cb, output_cb>()));
-    UNPACK(ASSERT(is_valid_cb_tile_page_size(input_cb, (DataFormat)unpack_src_format[input_cb])));
-    PACK(ASSERT(is_valid_cb_tile_page_size(output_cb, (DataFormat)pack_dst_format[output_cb])));
 
     // Untilize output must not be a block float format (Bfp8/4/2 and _b variants).
     // Block floats have shared exponents that break tile-to-row-major reinterpretation.


### PR DESCRIPTION
### Description

Sanity nightly tests with watcher enabled were failing in the conv, reduce, and models test groups (e.g. https://github.com/tenstorrent/tt-metal/actions/runs/23275449802).

The watcher was stopping the device due to asserts in `tilize_helpers.inl` and `untilize_helpers.inl` that checked CB page sizes. The assert conditions weren't correct (introduced in 751f7ae0ed671586ed000ad4f829fd87565f04ff), so they are removed along with the now-unused helper functions.

Removed `assert_tilize_cb_page_sizes` because input and output cbs can have differing page sizes (eg. Float16_b -> bfp8)
Removed `is_valid_cb_tile_page_size` check because it isn't correct in cases where the cb page size  = tile_size + offset (eg. like in `ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp`)

### Checklist

- [x] [Sanity tests nightly debug run with watcher](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-debug.yaml) CI - [said groups pass](https://github.com/tenstorrent/tt-metal/actions/runs/23290455923)