### PR TITLE
Fix DeepSeek decode norm dispatch regression

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -47,7 +47,6 @@ from models.demos.deepseek_v3.utils.run_config import (
     RunPrefillConfig,
     WeightConfig,
 )
-from models.experimental.ops.descriptors.fusion import Parallel
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
 
@@ -173,6 +172,22 @@ def build_prefill_matmul_program_config(seq_len, k, n, batch=1, tile_h=32, tile_
 
 def _deepseek_kvdbg_enabled() -> bool:
     return os.getenv("DEEPSEEK_KVDBG", "").lower() in ("1", "true", "yes", "y")
+
+
+def _launch_merged_descriptors(op_descriptors):
+    if not op_descriptors:
+        raise ValueError("op_descriptors cannot be empty")
+
+    merged_descriptor = op_descriptors[0].descriptor
+    if len(op_descriptors) > 1:
+        merged_descriptor = ttnn.merge_program_descriptors([op.descriptor for op in op_descriptors])
+
+    io_tensors = [tensor for op in op_descriptors for tensor in op.input_tensors] + [
+        tensor for op in op_descriptors for tensor in op.output_tensors
+    ]
+    ttnn.generic_op(io_tensors, merged_descriptor)
+
+    return [op.output_tensors for op in op_descriptors]
 
 
 class MLA1D(AbstractModule):
@@ -1062,7 +1077,7 @@ class MLA1D(AbstractModule):
 
         # Slice configs for fused wq_kv_a output: [q_lora_rank | kv_lora_rank | qk_rope_head_dim]
         # Q and KV nope use non-overlapping core grids so they can run parallel norms
-        # via Parallel (which requires non-overlapping core ranges).
+        # via merged descriptor dispatch on non-overlapping core ranges.
         num_q_cores = 16
         num_kv_nope_cores = 16
         shard_height = ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE)
@@ -1868,9 +1883,9 @@ class MLA1D(AbstractModule):
         kv_norm_desc = descriptors.rms_norm(
             tt_kv_nope, program_config=RMSNorm._get_pc(tt_kv_nope.memory_config()), **cfg["kv_norm"]
         )
-        Parallel(q_norm_desc, kv_norm_desc).build(tt_q.device()).launch()
-        tt_q = q_norm_desc.output_tensors[0]
-        tt_kv_nope = kv_norm_desc.output_tensors[0]
+        results = _launch_merged_descriptors([q_norm_desc, kv_norm_desc])
+        tt_q = results[0][0]
+        tt_kv_nope = results[1][0]
         # Q: 1,1,32,1536, width sharded 8x2 [32,96]
 
         # KV RoPE

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -175,6 +175,9 @@ def _deepseek_kvdbg_enabled() -> bool:
 
 
 def _launch_merged_descriptors(op_descriptors):
+    # Temporary workaround for https://github.com/tenstorrent/tt-metal/issues/40275.
+    # Keep the DeepSeek decode Q/KV norm path on the old merged generic_op
+    # dispatch until the Parallel(...).build().launch() cache/rebind logic is fixed.
     if not op_descriptors:
         raise ValueError("op_descriptors cannot be empty")
 
@@ -1076,8 +1079,8 @@ class MLA1D(AbstractModule):
         )  # 1,4,128,576, height sharded 8x8 [32,576]
 
         # Slice configs for fused wq_kv_a output: [q_lora_rank | kv_lora_rank | qk_rope_head_dim]
-        # Q and KV nope use non-overlapping core grids so they can run parallel norms
-        # via merged descriptor dispatch on non-overlapping core ranges.
+        # Q and KV nope use non-overlapping core grids, but keep this decode path
+        # on the pre-40275 merged-descriptor dispatch as a temporary workaround.
         num_q_cores = 16
         num_kv_nope_cores = 16
         shard_height = ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE)
@@ -1883,6 +1886,9 @@ class MLA1D(AbstractModule):
         kv_norm_desc = descriptors.rms_norm(
             tt_kv_nope, program_config=RMSNorm._get_pc(tt_kv_nope.memory_config()), **cfg["kv_norm"]
         )
+        # Temporary workaround for https://github.com/tenstorrent/tt-metal/issues/40275:
+        # avoid the fusion cache/rebind path here until
+        # Parallel(...).build().launch() is fixed for this decode flow.
         results = _launch_merged_descriptors([q_norm_desc, kv_norm_desc])
         tt_q = results[0][0]
         tt_kv_nope = results[1][0]


### PR DESCRIPTION
[![DeepSeek V3 Multi-Host Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=yieldthought/deepseek-fix-40275-mla-parallel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ayieldthought%2Fdeepseek-fix-40275-mla-parallel-cache)
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought/deepseek-fix-40275-mla-parallel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-fix-40275-mla-parallel-cache)

## CI
- DeepSeek V3 Multi-Host Tests (`setup=dual`, `deepseekv3_module_tests=true`, `demo=true`): [run 23292735344](https://github.com/tenstorrent/tt-metal/actions/runs/23292735344)
- (Galaxy) DeepSeek tests (`test-type=module`): [run 23292735359](https://github.com/tenstorrent/tt-metal/actions/runs/23292735359)

## Summary
- restore the DeepSeek decode Q/KV norm launch in `models/demos/deepseek_v3/tt/mla/mla1d.py` to a direct merged-descriptor dispatch path
- avoid the new `Parallel(...).build(...).launch()` fusion cache/rebind path at this call site
- keep the broader fusion infrastructure from `#39157` intact

## Why
Bisect for `#40275` landed on `0445a2b6a6` (`Implement Parallel and Sequential fusion infrastructure (#39157)`).

The only live DeepSeek codepath touched there was `MLA1D._fwd_decode_norm_and_rope()`, where the old merged-dispatch path was replaced with `Parallel(...).build(...).launch()`. The likely regression mechanism is the new fusion build-cache rebind logic mutating the cached fused descriptor across decode steps for the two sibling RMSNorm ops in this path.

This PR applies the narrow mitigation: use the old merged dispatch semantics only for the affected DeepSeek decode norm call site.

## Validation
Local B5 dual multihost regression check passed on this branch:
- rebuilt current `origin/main` plus this patch with `tests/scripts/bisect_deepseek_demo_corruption.sh`
- waited for full `tt-reset` completion
- reran the single-prompt DeepSeek demo regression case from `#40275`
- `check_deepseek_demo_prefix.py` passed: `DeepSeek demo matches the reference for the first 1 rows using 32 normalized characters per row.`

Fixes #40275
