### PR TITLE
#40182: Do not set sfpi objects via get [BUGFIX]

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -60,12 +60,10 @@ sfpi_inline void calculate_div_int32_body(
     // 22 bits, so we can compute qb = (q1<<10 + 0) * (b1<<22 + b0)
     //                               = (q1<<10) * b0
 
-    sfpi::vInt qb;
-
     // Despite the name, SFPMUL24 multiplies two 23-bit integers, giving the
     // low or high 23 bits of the product (last argument: 0=lo, 1=hi).  Inputs
     // do not need to be masked as this is done internally.
-    qb.get() = __builtin_rvtt_sfpmul24(q.get(), b.get(), 0);
+    sfpi::vInt qb = __builtin_rvtt_sfpmul24(q.get(), b.get(), 0);
 
     q <<= 10;
     qb <<= 10;
@@ -80,11 +78,9 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
 
     // Compute tmp = correction * b.
-    sfpi::vInt tmp_hi;
-    sfpi::vInt tmp_lo;
-    b1.get() = __builtin_rvtt_sfpmul24(correction.get(), b1.get(), 0);
-    tmp_hi.get() = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 1);
-    tmp_lo.get() = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 0);
+    b1 = __builtin_rvtt_sfpmul24(correction.get(), b1.get(), 0);
+    sfpi::vInt tmp_hi = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 1);
+    sfpi::vInt tmp_lo = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 0);
     tmp_hi += b1;
     tmp_hi <<= 23;
     sfpi::vInt tmp = tmp_lo + tmp_hi;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -43,8 +43,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vUInt q = sfpi::exman9(q_f);
 
     // Compute q * b using 24-bit multiplication
-    sfpi::vInt qb;
-    qb.get() = __builtin_rvtt_sfpmul24(q.get(), b.get(), 0);
+    sfpi::vInt qb = __builtin_rvtt_sfpmul24(q.get(), b.get(), 0);
     qb <<= 10;
 
     // Compute initial remainder
@@ -55,11 +54,10 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vInt correction = sfpi::float_to_uint16(r_f * inv_b_f, 0);
 
     // Compute correction * b (full 32-bit result from 24-bit multiplies)
-    sfpi::vInt tmp_lo, tmp_hi, b_hi;
-    tmp_lo.get() = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 0);
-    tmp_hi.get() = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 1);
-    b_hi = b >> 23;
-    b_hi.get() = __builtin_rvtt_sfpmul24(correction.get(), b_hi.get(), 0);
+    sfpi::vInt tmp_lo = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 0);
+    sfpi::vInt tmp_hi = __builtin_rvtt_sfpmul24(correction.get(), b.get(), 1);
+    sfpi::vInt b_hi = b >> 23;
+    b_hi = __builtin_rvtt_sfpmul24(correction.get(), b_hi.get(), 0);
     sfpi::vInt tmp = tmp_lo + ((tmp_hi + b_hi) << 23);
 
     // Extract sign mask of r

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -99,15 +99,14 @@ inline void calculate_tangent() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vInt i;
 
-        sfpi::vFloat rounding_bias;
-        sfpi::vFloat j;
         sfpi::vFloat inv_pio2 = sfpi::vConstFloatPrgm2;
 
         // j = round(v / (PI/2))
         // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);
+        sfpi::vFloat j =
+            __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
         // We need the LSB of the integer later, to determine the sign of the result.
         i = sfpi::reinterpret<sfpi::vInt>(j);
@@ -164,14 +163,12 @@ inline void calculate_sine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias;
-        rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
+        sfpi::vFloat rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
         __rvtt_vec_t inv_pi = __builtin_rvtt_sfpreadlreg(sfpi::vConstFloatPrgm2.get());
 
         // Compute j = round(v / PI).
         // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest-even.
-        sfpi::vFloat j;
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pi, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // At this point, the mantissa bits of j contain the integer.
         // Store for later; the LSB determines the sign of the result.
@@ -242,20 +239,18 @@ inline void calculate_cosine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
-        sfpi::vFloat half;
-        half.get() = __builtin_rvtt_sfpxloadi(0x3f00, 0);  // 0.5
+        sfpi::vFloat half = __builtin_rvtt_sfpxloadi(0x3f00, 0);  // 0.5
         __rvtt_vec_t inv_pi = __builtin_rvtt_sfpreadlreg(sfpi::vConstFloatPrgm2.get());
         __rvtt_vec_t one = __builtin_rvtt_sfpreadlreg(sfpi::vConst1.get());
         __rvtt_vec_t neg_one = __builtin_rvtt_sfpreadlreg(sfpi::vConstNeg1.get());
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
         // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest-even.
-        sfpi::vFloat j;
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pi, half.get(), SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi, half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
-        // rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
-        // j.get() = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
+        // rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
+        // j = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         j = j + ROUNDING_BIAS;
 
@@ -265,9 +260,8 @@ inline void calculate_cosine() {
 
         j = j + NEG_ROUNDING_BIAS;
 
-        sfpi::vFloat two;
-        two.get() = __builtin_rvtt_sfpxloadi(0x4000, 0);  // 2.0
-        j.get() = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one, SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat two = __builtin_rvtt_sfpxloadi(0x4000, 0);  // 2.0
+        j = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one, SFPMAD_MOD1_OFFSET_NONE);
 
         // Four-stage Cody-Waite reduction; a = v + j * -PI / 2.
         // P0 representable as bf16; generates a single SFPLOADI, filling NOP slot from previous SFPADDI.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -119,15 +119,14 @@ inline void calculate_tangent() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vInt i;
 
-        sfpi::vFloat rounding_bias;
-        sfpi::vFloat j;
         sfpi::vFloat inv_pio2 = sfpi::vConstFloatPrgm2;
 
         // j = round(v / (PI/2))
         // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);
+        sfpi::vFloat j =
+            __builtin_rvtt_sfpmad(v.get(), inv_pio2.get(), rounding_bias.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
         // We need the LSB of the integer later, to determine the sign of the result.
         i = sfpi::reinterpret<sfpi::vInt>(j);
@@ -184,14 +183,12 @@ inline void calculate_sine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
-        sfpi::vFloat rounding_bias;
-        rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
+        sfpi::vFloat rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
         __rvtt_vec_t inv_pi = __builtin_rvtt_sfpreadlreg(sfpi::vConstFloatPrgm2.get());
 
         // Compute j = round(v / PI).
         // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest-even.
-        sfpi::vFloat j;
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pi, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // At this point, the mantissa bits of j contain the integer.
         // Store for later; the LSB determines the sign of the result.
@@ -262,20 +259,18 @@ inline void calculate_cosine() {
         sfpi::vFloat v = sfpi::dst_reg[0];
 
         // Force v * (1/PI) + 0.5 to compile as a single SFPMAD sequence for consistent instruction scheduling.
-        sfpi::vFloat half;
-        half.get() = __builtin_rvtt_sfpxloadi(0x3f00, 0);  // 0.5
+        sfpi::vFloat half = __builtin_rvtt_sfpxloadi(0x3f00, 0);  // 0.5
         __rvtt_vec_t inv_pi = __builtin_rvtt_sfpreadlreg(sfpi::vConstFloatPrgm2.get());
         __rvtt_vec_t one = __builtin_rvtt_sfpreadlreg(sfpi::vConst1.get());
         __rvtt_vec_t neg_one = __builtin_rvtt_sfpreadlreg(sfpi::vConstNeg1.get());
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
         // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest-even.
-        sfpi::vFloat j;
-        j.get() = __builtin_rvtt_sfpmad(v.get(), inv_pi, half.get(), SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi, half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
-        // rounding_bias.get() = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
-        // j.get() = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
+        // rounding_bias = __builtin_rvtt_sfpxloadi(0x4b40, 0);  // 1.5*2^23
+        // j = __builtin_rvtt_sfpmad(v.get(), one, rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         j = j + ROUNDING_BIAS;
 
@@ -285,9 +280,8 @@ inline void calculate_cosine() {
 
         j = j + NEG_ROUNDING_BIAS;
 
-        sfpi::vFloat two;
-        two.get() = __builtin_rvtt_sfpxloadi(0x4000, 0);  // 2.0
-        j.get() = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one, SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat two = __builtin_rvtt_sfpxloadi(0x4000, 0);  // 2.0
+        j = __builtin_rvtt_sfpmad(j.get(), two.get(), neg_one, SFPMAD_MOD1_OFFSET_NONE);
 
         // Four-stage Cody-Waite reduction; a = v + j * -PI / 2.
         // P0 representable as bf16; generates a single SFPLOADI, filling NOP slot from previous SFPADDI.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40182

### Problem description
sfpi erroneously provides a getter that returns a modifiable lvalue reference.  Besides being just bad form, it circumvents the bookkeeping that needs doing when assigning to value objects.

Some metal code used that :(

### What's changed
Remove all uses of this getter.  Just do assignment.
I tested this with an sfpi that did not provide the bad getter. I'll be removing it in an update soon.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/lvalue-40182)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/lvalue-40182)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/lvalue-40182)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/lvalue-40182)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/lvalue-40182)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/lvalue-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/lvalue-40182)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
