### PR TITLE
Remove --rerun-on-retrain from run_validation.sh

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1298,10 +1298,9 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         host->set_motherboard(deployment_host.motherboard);
     }
 
-    // Only include board types and connections for hosts that are in deployment_hosts.
+    // Only include board types and connections for hosts present in the deployment.
     const size_t num_deployment_hosts = deployment_hosts.size();
 
-    // Add board types that are present in the deployment descriptor only
     for (const auto& [host_id, node] : host_id_to_node) {
         if (*host_id >= num_deployment_hosts) {
             continue;
@@ -1314,7 +1313,6 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         }
     }
 
-    // Add ASIC connections (only between hosts present in deployment)
     for (const auto& [start, end] : chip_connections) {
         if (*start.host_id >= num_deployment_hosts || *end.host_id >= num_deployment_hosts) {
             continue;

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1298,8 +1298,14 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         host->set_motherboard(deployment_host.motherboard);
     }
 
-    // Add board types
+    // Only include board types and connections for hosts that are in deployment_hosts.
+    const size_t num_deployment_hosts = deployment_hosts.size();
+
+    // Add board types that are present in the deployment descriptor only
     for (const auto& [host_id, node] : host_id_to_node) {
+        if (*host_id >= num_deployment_hosts) {
+            continue;
+        }
         for (const auto& [tray_id, board] : node->boards) {
             auto* board_location = fsd.mutable_board_types()->add_board_locations();
             board_location->set_host_id(*host_id);
@@ -1308,8 +1314,11 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
         }
     }
 
-    // Add ASIC connections from chip_connections
+    // Add ASIC connections (only between hosts present in deployment)
     for (const auto& [start, end] : chip_connections) {
+        if (*start.host_id >= num_deployment_hosts || *end.host_id >= num_deployment_hosts) {
+            continue;
+        }
         auto* connection = fsd.mutable_eth_connections()->add_connection();
 
         auto* endpoint_a = connection->mutable_endpoint_a();

--- a/tools/scaleout/exabox/analyze_validation_results.py
+++ b/tools/scaleout/exabox/analyze_validation_results.py
@@ -107,7 +107,7 @@ CATEGORIES = {
     ),
     "recovered_connections": (
         r"Ethernet Links were Retrained",
-        "BLUE",
+        "GREEN",
         "Recovered connections",
     ),
     "missing_global_connection": (

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -22,7 +22,6 @@ Optional:
     --factory-descriptor-path <path>        Path to pregenerated factory system descriptor (FSD) file (.textproto)
                                             (if provided, cabling and deployment descriptors are ignored)
     --output <directory>                    Output directory for log files (default: validation_output)
-    --rerun-on-retrain                      Rerun validation when Ethernet links are retrained
     --help                                  Display this help message and exit
 
 Example:
@@ -41,7 +40,6 @@ ITERATIONS=50
 
 FACTORY_DESCRIPTOR_PATH=""
 OUTPUT_DIR="validation_output"
-RERUN_ON_RETRAIN=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -104,14 +102,6 @@ while [[ $# -gt 0 ]]; do
             fi
             OUTPUT_DIR="$2"
             shift 2
-            ;;
-        --rerun-on-retrain)
-            if [[ -n "$2" ]] && [[ "$2" != --* ]]; then
-                echo "Error: --rerun-on-retrain does not accept a value"
-                exit 1
-            fi
-            RERUN_ON_RETRAIN=true
-            shift
             ;;
         --help)
             show_help
@@ -206,27 +196,6 @@ for ((i=1; i<=ITERATIONS; i++)); do
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"
-
-    if [[ "$RERUN_ON_RETRAIN" == true ]] && grep -q "Ethernet Links were Retrained" "$LOG_FILE"; then
-        OUTPUT_DIR_RETRY="${OUTPUT_DIR}_retry"
-
-        mkdir -p "$OUTPUT_DIR_RETRY"
-
-        LOG_FILE_RETRY="$OUTPUT_DIR_RETRY/cluster_validation_iteration_${i}_retry.log"
-
-        {
-            echo "=========================================="
-            echo "Iteration: $i - retry due to retrained links"
-            echo "Timestamp: $(date)"
-            echo "=========================================="
-            echo ""
-
-            echo "Re-running cluster validation..."
-            run_cluster_validation
-            echo "Iteration $i retry completed at $(date)"
-            echo "=========================================="
-        } 2>&1 | tee "$LOG_FILE_RETRY"
-    fi
 
     echo "Iteration $i logged to $LOG_FILE"
     echo ""

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -406,6 +406,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     if (links_reset) {
+        log_output_rank0("Ethernet Links were Retrained. Updating topology and continuing to traffic.");
         cluster.rediscover_ethernet_links();
     }
 

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -406,9 +406,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     if (links_reset) {
-        // Return and ask user to run again, otherwise some incorrect HW states might persist and cause hangs
-        log_output_rank0("Ethernet Links were Retrained. Please run the validation tool again to issue traffic.");
-        return 0;
+        cluster.rediscover_ethernet_links();
     }
 
     ConnectivityValidationConfig validation_config{

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1629,7 +1629,7 @@ void perform_link_reset(
 
     reset_ethernet_links(physical_system_descriptor, reset_topology);
 
-    log_output_rank0("Link reset completed. Please run the validation tool again to verify the link.");
+    log_output_rank0("Link reset completed.");
 }
 
 fsd::proto::FactorySystemDescriptor get_factory_system_descriptor(

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -31,6 +31,7 @@
 #include <yaml-cpp/yaml.h>
 #include "protobuf/factory_system_descriptor.pb.h"
 #include <llrt/tt_cluster.hpp>
+#include "umd/device/utils/semver.hpp"
 
 namespace tt::scaleout_tools {
 
@@ -1350,6 +1351,22 @@ void reset_local_ethernet_links(
         }
     }
 
+    // DEBUG: Log how many links will be reset and which ones. If this is 0 for a directed reset,
+    // the link was skipped (likely because it is cross-node and dst host != my host).
+    log_warning(
+        tt::LogDistributed,
+        "[DEBUG reset_local_ethernet_links] {} link(s) queued for local reset (my_host={})",
+        links_to_reset.size(),
+        physical_system_descriptor.my_host_name());
+    for (const auto& link : links_to_reset) {
+        log_warning(
+            tt::LogDistributed,
+            "[DEBUG reset_local_ethernet_links]   chip_id={} chan={} | {}",
+            link.chip_id,
+            link.channel,
+            link.log_message);
+    }
+
     // Perform resets on all links in vector
     send_reset_msg_to_links(links_to_reset);
 }
@@ -1610,8 +1627,18 @@ void perform_link_reset(
     uint32_t reset_asic_location,
     uint32_t reset_channel,
     PhysicalSystemDescriptor& physical_system_descriptor) {
-    bool link_retrain_supported = tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::WORMHOLE_B0;
-    TT_FATAL(link_retrain_supported, "Link reset is only supported on WORMHOLE_B0 architecture");
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const bool link_retrain_supported =
+        (cluster.arch() == tt::ARCH::WORMHOLE_B0 ||
+         (cluster.arch() == tt::ARCH::BLACKHOLE &&
+          cluster.get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0)));
+    TT_FATAL(
+        link_retrain_supported,
+        "Link reset is only supported on WORMHOLE_B0 or BLACKHOLE with ETH FW >= 1.9.0 (detected arch: {}, FW: {})",
+        cluster.arch(),
+        cluster.get_ethernet_firmware_version().has_value()
+            ? cluster.get_ethernet_firmware_version()->to_string()
+            : "unknown");
 
     tt::tt_metal::AsicTopology reset_topology =
         build_reset_topology(reset_host, reset_tray_id, reset_asic_location, reset_channel, physical_system_descriptor);

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1351,22 +1351,6 @@ void reset_local_ethernet_links(
         }
     }
 
-    // DEBUG: Log how many links will be reset and which ones. If this is 0 for a directed reset,
-    // the link was skipped (likely because it is cross-node and dst host != my host).
-    log_warning(
-        tt::LogDistributed,
-        "[DEBUG reset_local_ethernet_links] {} link(s) queued for local reset (my_host={})",
-        links_to_reset.size(),
-        physical_system_descriptor.my_host_name());
-    for (const auto& link : links_to_reset) {
-        log_warning(
-            tt::LogDistributed,
-            "[DEBUG reset_local_ethernet_links]   chip_id={} chan={} | {}",
-            link.chip_id,
-            link.channel,
-            link.log_message);
-    }
-
     // Perform resets on all links in vector
     send_reset_msg_to_links(links_to_reset);
 }

--- a/tools/scaleout/validation/utils/ethernet_link_api.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.cpp
@@ -47,6 +47,20 @@ void reset_links_wh(const std::vector<ResetLink>& links_to_reset) {
         do {
             cluster.read_core(reset_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), eth_retrain_addr);
         } while (reset_status[0]);
+
+        // DEBUG: Read ETH_TRAIN_STATUS_ADDR (0x1104) immediately after RETRAIN_FORCE clears to check
+        // whether the FW has updated the training status. Expected: 1 (SUCCESS). If 0 (IN_PROGRESS),
+        // the FW either hasn't finished writing yet or doesn't update this register during forced retrains.
+        constexpr tt::tt_metal::DeviceAddr ETH_TRAIN_STATUS_ADDR = 0x1104;
+        std::vector<uint32_t> train_status = {0};
+        cluster.read_core(train_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), ETH_TRAIN_STATUS_ADDR);
+        log_warning(
+            tt::LogDistributed,
+            "[DEBUG reset_links_wh] chip_id={} chan={} ETH_TRAIN_STATUS (0x1104)={} after RETRAIN_FORCE cleared "
+            "(0=IN_PROGRESS, 1=SUCCESS, 2=FAIL)",
+            link.chip_id,
+            link.channel,
+            train_status[0]);
     }
 }
 

--- a/tools/scaleout/validation/utils/ethernet_link_api.cpp
+++ b/tools/scaleout/validation/utils/ethernet_link_api.cpp
@@ -47,20 +47,6 @@ void reset_links_wh(const std::vector<ResetLink>& links_to_reset) {
         do {
             cluster.read_core(reset_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), eth_retrain_addr);
         } while (reset_status[0]);
-
-        // DEBUG: Read ETH_TRAIN_STATUS_ADDR (0x1104) immediately after RETRAIN_FORCE clears to check
-        // whether the FW has updated the training status. Expected: 1 (SUCCESS). If 0 (IN_PROGRESS),
-        // the FW either hasn't finished writing yet or doesn't update this register during forced retrains.
-        constexpr tt::tt_metal::DeviceAddr ETH_TRAIN_STATUS_ADDR = 0x1104;
-        std::vector<uint32_t> train_status = {0};
-        cluster.read_core(train_status, sizeof(uint32_t), tt_cxy_pair(link.chip_id, coord), ETH_TRAIN_STATUS_ADDR);
-        log_warning(
-            tt::LogDistributed,
-            "[DEBUG reset_links_wh] chip_id={} chan={} ETH_TRAIN_STATUS (0x1104)={} after RETRAIN_FORCE cleared "
-            "(0=IN_PROGRESS, 1=SUCCESS, 2=FAIL)",
-            link.chip_id,
-            link.channel,
-            train_status[0]);
     }
 }
 

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -17,17 +17,15 @@
 
 namespace tt::scaleout_tools {
 
-// WH: ETH_TRAIN_STATUS_ADDR (0x1104) in the node_info FW layout.
-//     Values: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
-// BH: port_status field inside eth_status_t in boot_results_t, at BOOT_RESULTS_ADDR + 4 = 0x7CC04.
-//     Values: 0 = PORT_UNKNOWN (in-progress), 1 = PORT_UP (success), 2 = PORT_DOWN (fail).
-// Both architectures use the same 0/1/2 encoding, matching EthTrainingStatus::IN_PROGRESS/SUCCESS/FAIL.
+// Returns the L1 address of the ETH training status register for the given arch.
+// WH: ETH_TRAIN_STATUS_ADDR (0x1104)
+// BH: port_status in boot_results_t (BOOT_RESULTS_ADDR + 4).
+// Both use the same encoding: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
 [[nodiscard]] uint32_t get_eth_train_status_addr(const tt::Cluster& cluster) {
     if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
-        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;  // 0x1104
+        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;
     }
     if (cluster.arch() == tt::ARCH::BLACKHOLE) {
-        // port_status is the second uint32_t in eth_status_t, located at BOOT_RESULTS_ADDR + 4.
         return tt::umd::blackhole::BOOT_RESULTS_ADDR +
                static_cast<uint32_t>(offsetof(tt::umd::blackhole::eth_status_t, port_status));
     }

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <umd/device/types/xy_pair.hpp>
+#include <umd/device/types/wormhole_eth.hpp>
+#include <umd/device/types/blackhole_eth.hpp>
 #include <factory_system_descriptor/utils.hpp>
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
@@ -15,7 +17,22 @@
 
 namespace tt::scaleout_tools {
 
-constexpr uint32_t ETH_TRAINING_STATUS_REG = 0x1104;
+// WH: ETH_TRAIN_STATUS_ADDR (0x1104) in the node_info FW layout.
+//     Values: 0 = IN_PROGRESS, 1 = SUCCESS, 2 = FAIL.
+// BH: port_status field inside eth_status_t in boot_results_t, at BOOT_RESULTS_ADDR + 4 = 0x7CC04.
+//     Values: 0 = PORT_UNKNOWN (in-progress), 1 = PORT_UP (success), 2 = PORT_DOWN (fail).
+// Both architectures use the same 0/1/2 encoding, matching EthTrainingStatus::IN_PROGRESS/SUCCESS/FAIL.
+[[nodiscard]] uint32_t get_eth_train_status_addr(const tt::Cluster& cluster) {
+    if (cluster.arch() == tt::ARCH::WORMHOLE_B0) {
+        return tt::umd::wormhole::ETH_TRAIN_STATUS_ADDR;  // 0x1104
+    }
+    if (cluster.arch() == tt::ARCH::BLACKHOLE) {
+        // port_status is the second uint32_t in eth_status_t, located at BOOT_RESULTS_ADDR + 4.
+        return tt::umd::blackhole::BOOT_RESULTS_ADDR +
+               static_cast<uint32_t>(offsetof(tt::umd::blackhole::eth_status_t, port_status));
+    }
+    TT_THROW("Unsupported architecture for ETH training status check: {}", cluster.arch());
+}
 
 struct LinkDescriptors {
     std::string host;
@@ -34,7 +51,7 @@ struct LinkDescriptors {
 
 void set_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord, uint32_t status) {
     const std::vector<uint32_t> status_data{status};
-    cluster.write_core(chip_id, coord, status_data, ETH_TRAINING_STATUS_REG);
+    cluster.write_core(chip_id, coord, status_data, get_eth_train_status_addr(cluster));
     cluster.l1_barrier(chip_id);
 }
 
@@ -53,13 +70,12 @@ protected:
         driver_ = &cluster_->get_driver();
         distributed_context_ = context_->get_distributed_context_ptr();
 
-        // Check if running on T3K (8 WH devices)
-        auto* const cluster_desc = (*driver_)->get_cluster_description();
-        const size_t num_devices = cluster_->get_unique_chip_ids().size();
-        const auto board_type = cluster_desc->get_board_type(0);
-
-        if (num_devices != 8 || board_type != BoardType::N300) {
-            GTEST_SKIP() << "This test requires a T3K system";
+        const bool link_retrain_supported =
+            cluster_->arch() == tt::ARCH::WORMHOLE_B0 ||
+            (cluster_->arch() == tt::ARCH::BLACKHOLE &&
+             cluster_->get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0));
+        if (!link_retrain_supported) {
+            GTEST_SKIP() << "Link retraining not supported on this system (requires WH or BH with ETH FW >= 1.9.0)";
         }
 
         // Initialize physical system descriptor
@@ -82,12 +98,14 @@ public:
         return *physical_system_descriptor_;
     }
     const std::unordered_map<uint64_t, ChipId>& get_asic_id_to_chip_id() const { return asic_id_to_chip_id_; }
-    std::string get_cabling_descriptor_path() const { return "tools/tests/scaleout/cabling_descriptors/t3k.textproto"; }
+    std::string get_cabling_descriptor_path() const {
+        return "/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto";
+    }
 };
 
 [[nodiscard]] uint32_t get_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord) {
     std::vector<uint32_t> status(1, 0);
-    cluster.read_core(status, sizeof(uint32_t), tt_cxy_pair(chip_id, coord), ETH_TRAINING_STATUS_REG);
+    cluster.read_core(status, sizeof(uint32_t), tt_cxy_pair(chip_id, coord), get_eth_train_status_addr(cluster));
     return status[0];
 }
 
@@ -178,7 +196,6 @@ TEST_F(DirectedRetrainingFixture, TestActiveEthRetraining) {
         driver_ref, distributed_context_, context_->rtoptions().get_target_device(), true, true);
     get_physical_system_descriptor().merge(std::move(new_psd));
 
-    // Validate connectivity after link reset
     validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
 }
 
@@ -321,7 +338,6 @@ TEST_F(DirectedRetrainingFixture, TestOnDemandCableRestart) {
         EXPECT_EQ(get_link_training_status(get_cluster(), link.chip_id, link.coord), 1);
     }
 
-    // Validate connectivity after link resets using T3K cabling descriptor
     validate_connectivity(get_physical_system_descriptor(), get_cabling_descriptor_path());
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1109,6 +1109,20 @@ void Cluster::disable_ethernet_cores_with_retrain() {
     }
 }
 
+void Cluster::rediscover_ethernet_links() {
+    // Update the UMD descriptor's ethernet fields in-place; cluster_desc_ raw pointer remains valid.
+    this->driver_->rediscover_ethernet_links();
+
+    // Add any newly active eth cores to routing info as IDLE (existing entries are left untouched).
+    this->initialize_ethernet_cores_router_mode();
+
+    // Rebuild from fresh descriptor state.
+    this->ethernet_sockets_.clear();
+    this->frequent_retrain_cores_.clear();
+    this->disable_ethernet_cores_with_retrain();
+    this->initialize_ethernet_sockets();
+}
+
 void Cluster::initialize_ethernet_cores_router_mode() {
     for (const auto& [assoc_mmio_device, devices] : this->cluster_desc_->get_chips_grouped_by_closest_mmio()) {
         for (const auto& chip_id : devices) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -368,6 +368,10 @@ public:
         return this->frequent_retrain_cores_.at(chip_id);
     }
 
+    // Re-runs UMD topology discovery and rebuilds ethernet_sockets_ and frequent_retrain_cores_.
+    // Call after link retraining to allow continued operation without restarting the process.
+    void rediscover_ethernet_links();
+
     const std::unordered_map<CoreCoord, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
         return this->device_eth_routing_info_.at(chip_id);
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

`run_validation.sh` has a `--rerun-on-retrain` flag that works around the fact that `run_cluster_validation` exits early after retraining Ethernet links (due to a stale `ClusterDescriptor`). When enabled, the script greps the log for `"Ethernet Links were Retrained"` and automatically re-invokes `run_cluster_validation` a second time to actually send traffic. This is no longer necessary once `rediscover_ethernet_links()` lands, since the tool can update its topology in-place and continue to traffic in a single invocation.

### What's changed

- **`run_validation.sh`**: Removed `--rerun-on-retrain` flag, its variable, arg-parser case, help text, and the entire retry block that conditionally re-ran validation after retrain.
- **`run_cluster_validation.cpp`**: Replaced the early `return 0` after retrain with a log message and `cluster.rediscover_ethernet_links()`, allowing execution to fall through to `generate_link_metrics()`.
- **`cluster_validation_utils.cpp`**: Removed the "please run the validation tool again" message from the `link_reset` subcommand since it no longer applies.
- **`analyze_validation_results.py`**: Changed the `recovered_connections` color from `BLUE` to `GREEN` since recovery is now a success path, not a manual-intervention case. The regex still matches the updated log message.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/validation_retun_on_retrain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/validation_retun_on_retrain)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
