### PR TITLE
Add top-K logprobs for gpt-oss-120b

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -104,6 +104,7 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D_RING\", \"sample_on_device_mode\": \"all\"}",
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
+              "sampling-tests": true,
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -105,6 +105,7 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
               "sampling-tests": true,
+              # Workaround for https://github.com/tenstorrent/tt-metal/issues/40605
               "sampling-test-filter": "not test_min_tokens and not test_bad_words and not test_mixed_params_batch",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -105,7 +105,7 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
               "sampling-tests": true,
-              "sampling-test-filter": "not test_min_tokens and not test_bad_words",
+              "sampling-test-filter": "not test_min_tokens and not test_bad_words and not test_mixed_params_batch",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -105,6 +105,7 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
               "sampling-tests": true,
+              "sampling-test-filter": "not test_min_tokens and not test_bad_words",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"
@@ -576,7 +577,12 @@ jobs:
         if: ${{ matrix.test-group.sampling-tests }}
         timeout-minutes: 10
         run: |
-          pytest vllm/tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+          FILTER="${{ matrix.test-group.sampling-test-filter }}"
+          if [ -n "$FILTER" ]; then
+            pytest vllm/tests/tt -v -k "$FILTER" --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+          else
+            pytest vllm/tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+          fi
 
       - name: 🧹 Cleanup server process
         if: always()

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -105,7 +105,6 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
               "sampling-tests": true,
-              # Workaround for https://github.com/tenstorrent/tt-metal/issues/40605
               "sampling-test-filter": "not test_min_tokens and not test_bad_words and not test_mixed_params_batch",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",

--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -4,7 +4,7 @@
 
 from .tt_sampling import TTSampling
 from .tt_penalties import TTPenalties, apply_penalties
-from .tt_log_probs import LogProbsCalculator
+from .tt_log_probs import LogProbsCalculator, LogProbsResult
 from .generator import (
     SamplingGenerator,
     SamplingParams,
@@ -21,6 +21,7 @@ __all__ = [
     "TTPenalties",
     "apply_penalties",
     "LogProbsCalculator",
+    "LogProbsResult",
     "SamplingGenerator",
     "SamplingParams",
     "SAMPLING_PARAM_FIELDS",

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -406,9 +406,9 @@ def format_sampling_params(sampling_params, max_batch_size):
     top_p = _pad(sampling_params.top_p, "top_p")
     top_k = _pad(sampling_params.top_k, "top_k")
 
-    # enable_log_probs / num_logprobs: when scalar was converted to [value],
-    # broadcast to all users (not pad with default). A scalar True means
-    # "all users enabled", not "only user 0".
+    # enable_log_probs / num_logprobs: scalar → broadcast to all users.
+    # Multi-element list → pad with default (False/0) for inactive slots.
+    # Single-element list (from scalar→list conversion) → broadcast to all.
     def _broadcast_pad(lst, name):
         if not isinstance(lst, list):
             return [lst] * target_len
@@ -417,7 +417,10 @@ def format_sampling_params(sampling_params, max_batch_size):
         return _pad(lst, name)
 
     enable_log_probs = _broadcast_pad(sampling_params.enable_log_probs, "enable_log_probs")
-    num_logprobs = _broadcast_pad(sampling_params.num_logprobs, "num_logprobs")
+    if getattr(sampling_params, "num_logprobs", None) is not None:
+        num_logprobs = _broadcast_pad(sampling_params.num_logprobs, "num_logprobs")
+    else:
+        num_logprobs = None
 
     # Normalise and pad penalty / seed fields (may still be None/scalar)
     def _normalise_and_pad(name):

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -392,6 +392,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         "repetition_penalty": 1.0,
         "seed": None,
         "num_logprobs": 0,
+        "enable_log_probs": False,
     }
 
     def _pad(lst, name):
@@ -421,6 +422,7 @@ def format_sampling_params(sampling_params, max_batch_size):
     repetition_penalty = _normalise_and_pad("repetition_penalty")
     seed = _normalise_and_pad("seed")
     num_logprobs = _normalise_and_pad("num_logprobs")
+    enable_log_probs = _normalise_and_pad("enable_log_probs")
 
     # Clamp / transform values in the new lists (no mutation of the input)
     TOP_P_MIN = 0.0
@@ -455,6 +457,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         repetition_penalty=repetition_penalty,
         seed=seed,
         num_logprobs=num_logprobs,
+        enable_log_probs=enable_log_probs,
     )
 
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -37,6 +37,7 @@ class SamplingParams:
     repetition_penalty: float | list[float] = 1.0
     seed: int | list[int] | None = None
     enable_log_probs: bool | list[bool] = False
+    num_logprobs: int | list[int] = 0
 
 
 SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
@@ -142,7 +143,7 @@ class SamplingGenerator:
 
         Resets params, seeds, prompt tokens, and output state in the correct order.
         """
-        self.reset_sampling_params(sampling_params)
+        self.reset_sampling_params(sampling_params, empty_slots=empty_slots)
         seed = getattr(sampling_params, "seed", None)
         # assert on condition that seed is not None
         assert seed is not None, "sampling_params must be formatted (seed should be a list, not None)"
@@ -201,13 +202,16 @@ class SamplingGenerator:
     # ---------------------------------------------------------------------
     # Sampling helpers
     # ---------------------------------------------------------------------
-    def reset_sampling_params(self, sampling_params):
+    def reset_sampling_params(self, sampling_params, empty_slots: list[int] | None = None):
         old_force_argmax_sampling = self.tt_sampling.force_argmax_sampling
+        num_logprobs = getattr(sampling_params, "num_logprobs", None)
         self.tt_sampling.reset_params(
             k=sampling_params.top_k,
             p=sampling_params.top_p,
             temp=sampling_params.temperature,
             enable_log_probs=sampling_params.enable_log_probs,
+            num_logprobs=num_logprobs,
+            empty_slots=empty_slots,
         )
         if self.tt_sampling.force_argmax_sampling != old_force_argmax_sampling:
             self.reset_trace()
@@ -387,6 +391,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         "frequency_penalty": 0.0,
         "repetition_penalty": 1.0,
         "seed": None,
+        "num_logprobs": 0,
     }
 
     def _pad(lst, name):
@@ -415,6 +420,7 @@ def format_sampling_params(sampling_params, max_batch_size):
     frequency_penalty = _normalise_and_pad("frequency_penalty")
     repetition_penalty = _normalise_and_pad("repetition_penalty")
     seed = _normalise_and_pad("seed")
+    num_logprobs = _normalise_and_pad("num_logprobs")
 
     # Clamp / transform values in the new lists (no mutation of the input)
     TOP_P_MIN = 0.0
@@ -448,6 +454,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         frequency_penalty=frequency_penalty,
         repetition_penalty=repetition_penalty,
         seed=seed,
+        num_logprobs=num_logprobs,
     )
 
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -405,8 +405,17 @@ def format_sampling_params(sampling_params, max_batch_size):
     temperature = _pad(sampling_params.temperature, "temperature")
     top_p = _pad(sampling_params.top_p, "top_p")
     top_k = _pad(sampling_params.top_k, "top_k")
-    enable_log_probs = _pad(sampling_params.enable_log_probs, "enable_log_probs")
-    num_logprobs = _pad(sampling_params.num_logprobs, "num_logprobs")
+
+    # enable_log_probs / num_logprobs: when scalar was converted to [value],
+    # broadcast to all users (not pad with default). A scalar True means
+    # "all users enabled", not "only user 0".
+    def _broadcast_pad(lst, name):
+        if len(lst) == 1:
+            return lst * target_len
+        return _pad(lst, name)
+
+    enable_log_probs = _broadcast_pad(sampling_params.enable_log_probs, "enable_log_probs")
+    num_logprobs = _broadcast_pad(sampling_params.num_logprobs, "num_logprobs")
 
     # Normalise and pad penalty / seed fields (may still be None/scalar)
     def _normalise_and_pad(name):

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -410,6 +410,8 @@ def format_sampling_params(sampling_params, max_batch_size):
     # broadcast to all users (not pad with default). A scalar True means
     # "all users enabled", not "only user 0".
     def _broadcast_pad(lst, name):
+        if not isinstance(lst, list):
+            return [lst] * target_len
         if len(lst) == 1:
             return lst * target_len
         return _pad(lst, name)

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -401,12 +401,14 @@ def format_sampling_params(sampling_params, max_batch_size):
             return list(lst)
         return list(lst) + [defaults[name]] * (target_len - len(lst))
 
-    # Pad core sampling fields
+    # Pad core sampling fields (scalar→list already done above)
     temperature = _pad(sampling_params.temperature, "temperature")
     top_p = _pad(sampling_params.top_p, "top_p")
     top_k = _pad(sampling_params.top_k, "top_k")
+    enable_log_probs = _pad(sampling_params.enable_log_probs, "enable_log_probs")
+    num_logprobs = _pad(sampling_params.num_logprobs, "num_logprobs")
 
-    # Normalise and pad penalty / seed fields
+    # Normalise and pad penalty / seed fields (may still be None/scalar)
     def _normalise_and_pad(name):
         value = getattr(sampling_params, name, None)
         if value is None:
@@ -421,8 +423,6 @@ def format_sampling_params(sampling_params, max_batch_size):
     frequency_penalty = _normalise_and_pad("frequency_penalty")
     repetition_penalty = _normalise_and_pad("repetition_penalty")
     seed = _normalise_and_pad("seed")
-    num_logprobs = _normalise_and_pad("num_logprobs")
-    enable_log_probs = _normalise_and_pad("enable_log_probs")
 
     # Clamp / transform values in the new lists (no mutation of the input)
     TOP_P_MIN = 0.0

--- a/models/common/sampling/sampling_params.py
+++ b/models/common/sampling/sampling_params.py
@@ -21,3 +21,4 @@ class SamplingParams:
     repetition_penalty: float | list[float] = 1.0
     seed: int | list[int] | None = None
     enable_log_probs: bool | list[bool] = False
+    num_logprobs: int | list[int] = 0

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -249,7 +249,10 @@ class LogProbsCalculator:
 
         # Recompute derived flags from the full arrays
         self.enable_log_probs = any(self.logprobs_enabled)
-        self.topk_logprobs_needed = any(n > 0 for n in self.num_logprobs)
+        # Top-K computation is needed whenever logprobs are enabled (even with
+        # num_logprobs=0) because the sampled token's logprob is extracted from
+        # the top-K results in the new path.
+        self.topk_logprobs_needed = self.enable_log_probs
 
     def _compute_global_stats(
         self,

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -40,6 +40,19 @@ class LogProbsResult:
     topk_logprobs_host: torch.Tensor
     topk_indices_host: torch.Tensor
 
+    def to_cpu(self, blocking: bool = False) -> "LogProbsResult":
+        """Transfer device tensors to host CPU.
+
+        Returns a NEW LogProbsResult so that each iteration gets its own host
+        tensor references (avoids race with trace-captured singletons).
+        """
+        return LogProbsResult(
+            topk_logprobs=None,
+            topk_indices=None,
+            topk_logprobs_host=self.topk_logprobs.cpu(blocking=blocking),
+            topk_indices_host=self.topk_indices.cpu(blocking=blocking),
+        )
+
 
 class LogProbsCalculator:
     """
@@ -275,9 +288,9 @@ class LogProbsCalculator:
             num_links=1,
             buffer_key="LOGPROBS_MAX_REDUCTION",
         )
-        ttnn.deallocate(local_max_tensor)
         # Convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
         gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        ttnn.deallocate(local_max_tensor)
         D = self.num_devices_for_sharding
         B = gathered_max_tensors.shape[2]
         gathered_max_tensors = ttnn.reshape(gathered_max_tensors, (1, 1, D, B), **self.common_args)
@@ -291,8 +304,8 @@ class LogProbsCalculator:
 
         # Calculate stable local sum-exp using subtract of global-max from each local logit
         subtracted_tensor = ttnn.subtract(logits_tensor, global_max_to_subtract, **self.common_args)
-        ttnn.deallocate(global_max_to_subtract)
         exp_tensor = ttnn.exp(subtracted_tensor, **self.common_args)
+        ttnn.deallocate(global_max_to_subtract)
         ttnn.deallocate(subtracted_tensor)
         sum_exp_tensor = ttnn.sum(exp_tensor, dim=-1, keepdim=True, **self.common_args)
         ttnn.deallocate(exp_tensor)
@@ -303,8 +316,8 @@ class LogProbsCalculator:
             num_links=1,
             buffer_key="LOGPROBS_SUM_EXP_REDUCTION",
         )
-        ttnn.deallocate(sum_exp_tensor)
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        ttnn.deallocate(sum_exp_tensor)
         B_sum = gathered_sum_exp_tensors.shape[2]
         gathered_sum_exp_tensors = ttnn.reshape(gathered_sum_exp_tensors, (1, 1, D, B_sum), **self.common_args)
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.TILE_LAYOUT, **self.common_args)
@@ -553,19 +566,6 @@ class LogProbsCalculator:
             )
         else:
             return ttnn.ConcatMeshToTensor(self.mesh_device, dim=0)
-
-    def to_cpu(self, log_probs_result: LogProbsResult, blocking: bool = False):
-        """Transfer LogProbsResult tensors to host CPU.
-
-        Returns a NEW LogProbsResult so that each iteration gets its own host
-        tensor references (avoids race with trace-captured singletons).
-        """
-        return LogProbsResult(
-            topk_logprobs_host=log_probs_result.topk_logprobs.cpu(blocking=blocking, cq_id=0),
-            topk_indices_host=log_probs_result.topk_indices.cpu(blocking=blocking, cq_id=0),
-            topk_logprobs=None,
-            topk_indices=None,
-        )
 
     def transfer_logprobs_to_host(
         self,

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -4,6 +4,7 @@
 
 import inspect
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 from loguru import logger
@@ -27,24 +28,30 @@ class LogProbsResult:
     index in ``topk_indices``.
 
     Attributes:
-        topk_logprobs: Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+        topk_logprobs: Optional ttnn.Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
             containing logprobs for the gathered top-k tokens.
-        topk_indices: Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+        topk_indices: Optional ttnn.Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
             containing global vocabulary indices for the gathered top-k tokens.
-        topk_logprobs_host: Host tensor after to_cpu, or None.
-        topk_indices_host: Host tensor after to_cpu, or None.
+        topk_logprobs_host: Optional ttnn.Tensor on host of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing logprobs for the gathered top-k tokens after moving to host.
+        topk_indices_host: Optional ttnn.Tensor on host of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing global vocabulary indices for the gathered top-k tokens after moving to host.
     """
 
-    topk_logprobs: ttnn.Tensor
-    topk_indices: ttnn.Tensor
-    topk_logprobs_host: torch.Tensor
-    topk_indices_host: torch.Tensor
+    topk_logprobs: Optional[ttnn.Tensor]
+    topk_indices: Optional[ttnn.Tensor]
+    topk_logprobs_host: Optional[ttnn.Tensor]
+    topk_indices_host: Optional[ttnn.Tensor]
 
-    def to_cpu(self, blocking: bool = False) -> "LogProbsResult":
+    def cpu(self, blocking: bool = True) -> "LogProbsResult":
         """Transfer device tensors to host CPU.
 
-        Returns a NEW LogProbsResult so that each iteration gets its own host
-        tensor references (avoids race with trace-captured singletons).
+        Args:
+            blocking: If True, wait for the host tensor to be ready before returning.
+
+        Returns:
+            A new LogProbsResult so that each iteration gets its own host
+            tensor references (avoids race with trace-captured singletons).
         """
         return LogProbsResult(
             topk_logprobs=None,
@@ -52,6 +59,63 @@ class LogProbsResult:
             topk_logprobs_host=self.topk_logprobs.cpu(blocking=blocking),
             topk_indices_host=self.topk_indices.cpu(blocking=blocking),
         )
+
+    def extract_user(self, user_batch_idx: int) -> "LogProbsResult":
+        """Extract a single user's top-K logprobs from a batched host result.
+
+        Args:
+            user_batch_idx: Index of the user within the batch dimension.
+
+        Returns:
+            A new LogProbsResult with host tensors sliced to shape (1, DEVICE_TOP_K).
+        """
+        lp_torch = ttnn.to_torch(ttnn.get_device_tensors(self.topk_logprobs_host)[0])
+        idx_torch = ttnn.to_torch(ttnn.get_device_tensors(self.topk_indices_host)[0])
+        return LogProbsResult(
+            topk_logprobs=None,
+            topk_indices=None,
+            topk_logprobs_host=lp_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+            topk_indices_host=idx_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+        )
+
+    def to_torch_pair(self):
+        """Convert host tensors to a (logprobs, indices) pair of torch tensors.
+
+        Returns:
+            Tuple of (logprobs_tensor, indices_tensor), each of shape (DEVICE_TOP_K,).
+        """
+        lp = self.topk_logprobs_host
+        idx = self.topk_indices_host
+        if isinstance(lp, torch.Tensor):
+            return lp.reshape(-1)[:DEVICE_TOP_K].float(), idx.reshape(-1)[:DEVICE_TOP_K].int()
+        return ttnn.to_torch(lp).reshape(-1)[:DEVICE_TOP_K].float(), ttnn.to_torch(idx).reshape(-1)[:DEVICE_TOP_K].int()
+
+
+def reformat_logprobs(output_log_probs, batch_size):
+    """Convert a list of per-user logprobs into the format expected by vLLM.
+
+    Args:
+        output_log_probs: List of LogProbsResult, torch.Tensor, float, int, or None per user.
+        batch_size: Total batch size.
+
+    Returns:
+        For new path (LogProbsResult): tuple of (topk_lp[B, DEVICE_TOP_K], topk_idx[B, DEVICE_TOP_K])
+        For old path: flat tensor of shape [B]
+    """
+    has_logprobs_result = any(isinstance(lp, LogProbsResult) for lp in output_log_probs)
+    if has_logprobs_result:
+        all_lp = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.float32)
+        all_idx = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.int32)
+        for i, lp in enumerate(output_log_probs):
+            if isinstance(lp, LogProbsResult) and lp.topk_logprobs_host is not None:
+                all_lp[i], all_idx[i] = lp.to_torch_pair()
+        return (all_lp, all_idx)
+    else:
+        flat_lp = torch.ones(batch_size, dtype=torch.float32)
+        for i, lp in enumerate(output_log_probs):
+            if lp is not None and isinstance(lp, (torch.Tensor, float, int)):
+                flat_lp[i] = float(lp)
+        return flat_lp
 
 
 class LogProbsCalculator:

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+from dataclasses import dataclass
 
 import torch
 from loguru import logger
@@ -10,16 +11,50 @@ from loguru import logger
 import ttnn
 from models.common.sampling._utils import filter_none
 
+# Maximum number of top logprobs that can be requested (OpenAI API limit)
+MAX_TOP_LOGPROBS = 20
+# Number of top logprobs computed on device (gathered top-k from all devices)
+DEVICE_TOP_K = 32
+
+
+@dataclass
+class LogProbsResult:
+    """Result of log-probs calculation for a batch.
+
+    Contains logprobs and global indices for the gathered top-k tokens across all
+    devices.  The sampled token is always part of the gathered top-k (it was selected
+    from them by ttnn.sampling), so its logprob can be looked up by matching its
+    index in ``topk_indices``.
+
+    Attributes:
+        topk_logprobs: Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing logprobs for the gathered top-k tokens.
+        topk_indices: Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing global vocabulary indices for the gathered top-k tokens.
+        topk_logprobs_host: Host tensor after to_cpu, or None.
+        topk_indices_host: Host tensor after to_cpu, or None.
+    """
+
+    topk_logprobs: ttnn.Tensor
+    topk_indices: ttnn.Tensor
+    topk_logprobs_host: torch.Tensor
+    topk_indices_host: torch.Tensor
+
 
 class LogProbsCalculator:
     """
     Class to calculate log-probs for a given logits tensor and indices tensor.
+
+    Supports two modes:
+    - Old mode (backward compat): calculate_log_probs() returns single sampled-token logprob
+    - New mode (gpt-oss-120b): calculate_topk_log_probs() returns top-32 logprobs + indices
 
     Args:
         mesh_device: MeshDevice to use for all-gather operations
         sub_core_grids: Sub-core grid configuration for operations (optional)
         tt_ccl: CCL object for distributed operations (optional)
         batch_size: Maximum batch size for log-probs calculation (default: 32)
+        use_topk_logprobs: If True, allocate tensors for new top-K path instead of old path
     """
 
     def __init__(
@@ -28,15 +63,23 @@ class LogProbsCalculator:
         sub_core_grids: ttnn.CoreRangeSet = None,
         tt_ccl=None,
         batch_size: int = 32,
+        use_topk_logprobs: bool = False,
     ):
         self.global_max = None
         self.global_exp_sum = None
         self.mesh_device = mesh_device
         self.enable_log_probs = False  # default to False
+        # Per-user boolean array tracking which users have logprobs enabled
+        self.logprobs_enabled = [False] * batch_size
+        # Per-user integer array tracking how many top logprobs each user requested (0-20)
+        self.num_logprobs = [0] * batch_size
+        # Flag: True when at least one user needs top-k logprobs (num_logprobs > 0)
+        self.topk_logprobs_needed = False
         self.cluster_shape = list(mesh_device.shape)
         self.sub_core_grids = sub_core_grids
         self.tt_ccl = tt_ccl
         self.batch_size = batch_size
+        self._use_topk_logprobs = use_topk_logprobs
         self.common_args = filter_none(
             {
                 "sub_core_grids": sub_core_grids,
@@ -76,38 +119,63 @@ class LogProbsCalculator:
 
         self.num_devices_for_sharding = num_devices_for_sharding
 
-        # Create mask tensor with shape (num_devices_for_sharding, batch_size)
-        # Each row will have device_id starting from 0 to num_devices_for_sharding - 1
-        mask_tensor = torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
+        # Initialize tensors based on mode
+        # Old path tensors (backward compat for non-gpt-oss models)
+        self.mask = None
+        self.output_tensor = None
+        # New path tensors (gpt-oss-120b top-K logprobs)
+        self.topk_logprobs_output = None
+        self.topk_indices_output = None
 
-        # Choose mesh mapper based on mesh topology
-        if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
-            # 2D mesh: shard along the TP axis
-            dims = (0, None) if self._all_gather_cluster_axis == 0 else (None, 0)
-            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=self.cluster_shape)
-        elif num_devices > 1:
-            # 1D mesh
-            mesh_mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=0)
+        if use_topk_logprobs:
+            # New path: allocate top-K output tensors
+            self.topk_logprobs_output = ttnn.as_tensor(
+                torch.zeros(1, 1, batch_size, DEVICE_TOP_K),
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+            self.topk_indices_output = ttnn.as_tensor(
+                torch.zeros(1, 1, batch_size, DEVICE_TOP_K, dtype=torch.int32),
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
         else:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+            # Old path: allocate mask and output tensors
+            mask_tensor = (
+                torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
+            )
 
-        self.mask = ttnn.as_tensor(
-            mask_tensor,
-            dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            device=self.mesh_device,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            preprocess=lambda x: x.to(torch.bfloat16),
-            mesh_mapper=mesh_mapper,
-        )
-        self.output_tensor = ttnn.as_tensor(
-            torch.ones(1, 1, 1, batch_size),
-            dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-        )
+            if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+                dims = (0, None) if self._all_gather_cluster_axis == 0 else (None, 0)
+                mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=self.cluster_shape)
+            elif num_devices > 1:
+                mesh_mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=0)
+            else:
+                mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+
+            self.mask = ttnn.as_tensor(
+                mask_tensor,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                preprocess=lambda x: x.to(torch.bfloat16),
+                mesh_mapper=mesh_mapper,
+            )
+            self.output_tensor = ttnn.as_tensor(
+                torch.ones(1, 1, 1, batch_size),
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
 
     def _perform_all_gather(self, tensor: ttnn.Tensor, dim: int, num_links: int, buffer_key: str = None):
         if callable(self._line_all_gather):
@@ -130,15 +198,58 @@ class LogProbsCalculator:
             topology=ttnn.Topology.Linear,
         )
 
-    def set_log_probs_mode(self, enable_log_probs: bool | list[bool] = False):
-        if isinstance(enable_log_probs, list):
-            # If any of the users in the batch have log_probs enabled,
-            # then whole batch will run log-probs calculation
-            enable_log_probs_result = any(enable_log_probs)
-        else:
-            enable_log_probs_result = enable_log_probs
+    def set_log_probs_mode(
+        self,
+        enable_log_probs: bool | list[bool] = False,
+        num_logprobs: int | list[int] | None = None,
+        empty_slots: list[int] | None = None,
+    ):
+        """Set logprobs mode for the current batch.
 
-        self.enable_log_probs = enable_log_probs_result
+        Args:
+            enable_log_probs: Boolean or per-user boolean list. If any user has logprobs
+                enabled, the entire batch runs logprobs computation.
+            num_logprobs: Integer or per-user integer list (0-20). Specifies how many
+                top logprobs to return per user. 0 means sampled token logprob only.
+                Values > 0 trigger top-k logprobs computation on device.
+            empty_slots: Optional list of batch indices at which to apply the new
+                logprobs settings. When provided, only those positions are updated
+                and the rest of the batch retains its previous values.
+        """
+        if empty_slots is not None:
+            # Partial update: only modify the specified batch positions
+            if isinstance(enable_log_probs, list):
+                for i, slot in enumerate(empty_slots):
+                    self.logprobs_enabled[slot] = enable_log_probs[i]
+            else:
+                for slot in empty_slots:
+                    self.logprobs_enabled[slot] = enable_log_probs
+
+            if num_logprobs is not None:
+                if isinstance(num_logprobs, list):
+                    for i, slot in enumerate(empty_slots):
+                        self.num_logprobs[slot] = num_logprobs[i]
+                else:
+                    for slot in empty_slots:
+                        self.num_logprobs[slot] = num_logprobs
+        else:
+            # Full batch update
+            if isinstance(enable_log_probs, list):
+                self.logprobs_enabled = list(enable_log_probs)
+            else:
+                self.logprobs_enabled = [enable_log_probs] * self.batch_size
+
+            if num_logprobs is not None:
+                if isinstance(num_logprobs, list):
+                    self.num_logprobs = list(num_logprobs)
+                else:
+                    self.num_logprobs = [num_logprobs] * self.batch_size
+            else:
+                self.num_logprobs = [0] * self.batch_size
+
+        # Recompute derived flags from the full arrays
+        self.enable_log_probs = any(self.logprobs_enabled)
+        self.topk_logprobs_needed = any(n > 0 for n in self.num_logprobs)
 
     def _compute_global_stats(
         self,
@@ -161,6 +272,7 @@ class LogProbsCalculator:
             num_links=1,
             buffer_key="LOGPROBS_MAX_REDUCTION",
         )
+        ttnn.deallocate(local_max_tensor)
         # Convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
         gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
         D = self.num_devices_for_sharding
@@ -176,8 +288,11 @@ class LogProbsCalculator:
 
         # Calculate stable local sum-exp using subtract of global-max from each local logit
         subtracted_tensor = ttnn.subtract(logits_tensor, global_max_to_subtract, **self.common_args)
+        ttnn.deallocate(global_max_to_subtract)
         exp_tensor = ttnn.exp(subtracted_tensor, **self.common_args)
+        ttnn.deallocate(subtracted_tensor)
         sum_exp_tensor = ttnn.sum(exp_tensor, dim=-1, keepdim=True, **self.common_args)
+        ttnn.deallocate(exp_tensor)
 
         gathered_sum_exp_tensors = self._perform_all_gather(
             sum_exp_tensor,
@@ -185,12 +300,27 @@ class LogProbsCalculator:
             num_links=1,
             buffer_key="LOGPROBS_SUM_EXP_REDUCTION",
         )
+        ttnn.deallocate(sum_exp_tensor)
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
         B_sum = gathered_sum_exp_tensors.shape[2]
         gathered_sum_exp_tensors = ttnn.reshape(gathered_sum_exp_tensors, (1, 1, D, B_sum), **self.common_args)
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.TILE_LAYOUT, **self.common_args)
 
         self.global_exp_sum = ttnn.sum(gathered_sum_exp_tensors, dim=2, keepdim=True, **self.common_args)
+        ttnn.deallocate(gathered_sum_exp_tensors)
+
+    def _is_supported(self):
+        """Check if logprobs computation is supported on this device configuration."""
+        num_devices = self.mesh_device.get_num_devices()
+        if num_devices not in (8, 32):
+            return False
+        if self.num_devices_for_sharding < 2:
+            return False
+        return True
+
+    # -----------------------------------------------------------------------
+    # Old path (backward compat for non-gpt-oss models)
+    # -----------------------------------------------------------------------
 
     def _prepare_relevant_logits(self, logits_tensor: ttnn.Tensor, global_idx_tensor: ttnn.Tensor):
         """
@@ -280,15 +410,12 @@ class LogProbsCalculator:
         """
         Calculate log-probs for a given logits tensor and indices tensor.
         Returns None if log-probs are not requested, not supported, or the device count is not 8 or 32.
+        (Old path — backward compat for non-gpt-oss models)
         """
         if not self.enable_log_probs:
             return None
 
-        num_devices = self.mesh_device.get_num_devices()
-        if num_devices not in (8, 32):
-            return None
-
-        if self.num_devices_for_sharding < 2:
+        if not self._is_supported():
             return None
 
         # Calculating log-probs requires bfloat16 precision for near-stable sum-exp calculation
@@ -305,3 +432,215 @@ class LogProbsCalculator:
         self._calculate_log_probs(relevant_logits)
 
         return self.output_tensor
+
+    # -----------------------------------------------------------------------
+    # New path (gpt-oss-120b top-K logprobs)
+    # -----------------------------------------------------------------------
+
+    def _calculate_topk_log_probs_from_values(self, topk_values: ttnn.Tensor):
+        """Compute logprobs for gathered top-k values using pre-computed global stats.
+
+        Applies the log-softmax formula: logprob = logit - global_max - log(global_exp_sum)
+        to each of the gathered top-k values.
+
+        Args:
+            topk_values: Gathered top-k values tensor of shape (1, 1, batch_size, num_topk).
+        """
+        B = topk_values.shape[2]
+
+        # Reshape global_max from (1,1,1,B) to (1,1,B,1) for broadcasting with (1,1,B,K)
+        global_max_bcast = ttnn.to_layout(self.global_max, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        global_max_bcast = ttnn.reshape(global_max_bcast, (1, 1, B, 1), **self.common_args)
+        global_max_bcast = ttnn.to_layout(global_max_bcast, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # Compute log(global_exp_sum) and reshape for broadcasting
+        log_global_exp_sum = ttnn.log(self.global_exp_sum, **self.common_args)
+        log_global_exp_sum_bcast = ttnn.to_layout(log_global_exp_sum, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        log_global_exp_sum_bcast = ttnn.reshape(log_global_exp_sum_bcast, (1, 1, B, 1), **self.common_args)
+        log_global_exp_sum_bcast = ttnn.to_layout(log_global_exp_sum_bcast, ttnn.TILE_LAYOUT, **self.common_args)
+        ttnn.deallocate(log_global_exp_sum)
+
+        # Apply log-softmax formula: logprob = logit - global_max - log(global_exp_sum)
+        ttnn.subtract(topk_values, global_max_bcast, output_tensor=self.topk_logprobs_output, **self.common_args)
+        ttnn.subtract(
+            self.topk_logprobs_output,
+            log_global_exp_sum_bcast,
+            output_tensor=self.topk_logprobs_output,
+            **self.common_args,
+        )
+        ttnn.deallocate(global_max_bcast)
+        ttnn.deallocate(log_global_exp_sum_bcast)
+
+        return self.topk_logprobs_output
+
+    def calculate_topk_log_probs(
+        self,
+        logits_tensor: ttnn.Tensor,
+        topk_values: ttnn.Tensor,
+        topk_global_indices: ttnn.Tensor,
+        sub_core_grid_topk: ttnn.CoreRangeSet = None,
+    ) -> LogProbsResult | None:
+        """Calculate logprobs for the gathered top-k tokens in a single pass.
+
+        Args:
+            logits_tensor: Full logits tensor, sharded across devices.
+            topk_values: Gathered top-k values from all devices. Shape: (1,1,B,256).
+            topk_global_indices: Global vocabulary indices for the gathered top-k. Shape: (1,1,B,256).
+            sub_core_grid_topk: Sub-core grid for topk operation.
+
+        Returns:
+            LogProbsResult with top-32 logprobs and indices, or None if disabled/unsupported.
+        """
+        if not self.enable_log_probs:
+            return None
+
+        if not self._is_supported():
+            return None
+
+        # Ensure bfloat16 precision for numerical stability
+        if logits_tensor.dtype == ttnn.bfloat8_b:
+            logits_tensor = ttnn.typecast(logits_tensor, ttnn.bfloat16, **self.common_args)
+
+        # Compute global stats — large intermediates allocated and freed here
+        self._compute_global_stats(logits_tensor)
+
+        # Narrow 256 -> 32 topk values and indices
+        topk_local_values, topk_local_indices = ttnn.topk(
+            topk_values,
+            k=DEVICE_TOP_K,
+            dim=-1,
+            sub_core_grids=sub_core_grid_topk,
+        )
+
+        # ttnn.gather requires uint32 indices in TILE_LAYOUT
+        topk_local_indices = ttnn.typecast(topk_local_indices, ttnn.uint32, **self.common_args)
+        topk_local_indices = ttnn.to_layout(topk_local_indices, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        topk_local_indices = ttnn.to_layout(topk_local_indices, ttnn.TILE_LAYOUT, **self.common_args)
+        ttnn.gather(
+            topk_global_indices, dim=-1, index=topk_local_indices, out=self.topk_indices_output, **self.common_args
+        )
+        ttnn.deallocate(topk_local_indices)
+
+        # Ensure topk_values is bfloat16 for consistent computation
+        if topk_local_values.dtype != ttnn.bfloat16:
+            topk_local_values = ttnn.typecast(topk_local_values, ttnn.bfloat16, **self.common_args)
+
+        # Single-pass logprob computation for all gathered top-k tokens
+        self._calculate_topk_log_probs_from_values(topk_local_values)
+        ttnn.deallocate(topk_local_values)
+
+        return LogProbsResult(
+            topk_logprobs=self.topk_logprobs_output,
+            topk_indices=self.topk_indices_output,
+            topk_logprobs_host=None,
+            topk_indices_host=None,
+        )
+
+    # -----------------------------------------------------------------------
+    # Host transfer helpers
+    # -----------------------------------------------------------------------
+
+    def _build_mesh_composer(self):
+        """Build the appropriate mesh composer for transferring tensors from device to host."""
+        if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+            return ttnn.ConcatMesh2dToTensor(
+                self.mesh_device,
+                dims=(0, 1),
+                mesh_shape=self.cluster_shape,
+            )
+        else:
+            return ttnn.ConcatMeshToTensor(self.mesh_device, dim=0)
+
+    def to_cpu(self, log_probs_result: LogProbsResult, blocking: bool = False):
+        """Transfer LogProbsResult tensors to host CPU.
+
+        Returns a NEW LogProbsResult so that each iteration gets its own host
+        tensor references (avoids race with trace-captured singletons).
+        """
+        return LogProbsResult(
+            topk_logprobs_host=log_probs_result.topk_logprobs.cpu(blocking=blocking, cq_id=0),
+            topk_indices_host=log_probs_result.topk_indices.cpu(blocking=blocking, cq_id=0),
+            topk_logprobs=None,
+            topk_indices=None,
+        )
+
+    def transfer_logprobs_to_host(
+        self,
+        log_probs_result: LogProbsResult | None,
+        sampled_token_ids: torch.Tensor,
+        num_logprobs_per_user: list[int] | None = None,
+    ) -> list[dict | None]:
+        """Move logprobs from device to host and build per-user response objects.
+
+        tt-metal path only (standalone demos/tests). vLLM does NOT call this.
+
+        Args:
+            log_probs_result: LogProbsResult from calculate_topk_log_probs.
+            sampled_token_ids: Host tensor of sampled token IDs, shape (batch_size,).
+            num_logprobs_per_user: Per-user count of top logprobs to return (0-20).
+                If None, uses self.num_logprobs.
+
+        Returns:
+            List of length batch_size. Each element is None for users with
+            logprobs disabled, otherwise a dict with returned_token and top_logprobs.
+        """
+        if log_probs_result is None:
+            return [None] * self.batch_size
+
+        if num_logprobs_per_user is None:
+            num_logprobs_per_user = self.num_logprobs
+
+        mesh_composer = self._build_mesh_composer()
+
+        topk_logprobs_host = ttnn.to_torch(
+            log_probs_result.topk_logprobs_host
+            if log_probs_result.topk_logprobs_host is not None
+            else log_probs_result.topk_logprobs,
+            mesh_composer=mesh_composer,
+        )
+        topk_indices_host = ttnn.to_torch(
+            log_probs_result.topk_indices_host
+            if log_probs_result.topk_indices_host is not None
+            else log_probs_result.topk_indices,
+            mesh_composer=mesh_composer,
+        )
+        # Remove replicas
+        topk_logprobs_host = topk_logprobs_host[0, 0, ...].float()
+        topk_indices_host = topk_indices_host[0, 0, ...].to(torch.int32)
+
+        results: list[dict | None] = []
+        for user_idx in range(self.batch_size):
+            if not self.logprobs_enabled[user_idx]:
+                results.append(None)
+                continue
+
+            sampled_id = int(sampled_token_ids[user_idx].item())
+            user_logprobs = topk_logprobs_host[user_idx]
+            user_indices = topk_indices_host[user_idx]
+
+            # Extract sampled token logprob by matching its ID in the top-k
+            match_mask = user_indices == sampled_id
+            if match_mask.any():
+                sampled_logprob = float(user_logprobs[match_mask][0].item())
+            else:
+                logger.warning(f"Sampled token {sampled_id} not found in top-k for user {user_idx}")
+                sampled_logprob = float("nan")
+
+            n = num_logprobs_per_user[user_idx] if user_idx < len(num_logprobs_per_user) else 0
+
+            results.append(
+                {
+                    "returned_token": {
+                        "token_idx": sampled_id,
+                        "logprob": sampled_logprob,
+                    },
+                    "top_logprobs": {
+                        "token_indices": user_indices[:n].tolist(),
+                        "logprobs": user_logprobs[:n].tolist(),
+                        "num_logprobs": n,
+                        "logprobs_formatted": False,
+                    },
+                }
+            )
+
+        return results

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -208,7 +208,11 @@ class TTSampling(LightweightModule):
         # Log-probs tensor to store the log-probs for the batch
         self.tt_log_probs = None
         self.log_probs_calculator = LogProbsCalculator(
-            self.mesh_device, self.sub_core_grids, self.tt_ccl, batch_size=self.max_batch_size
+            self.mesh_device,
+            self.sub_core_grids,
+            self.tt_ccl,
+            batch_size=self.max_batch_size,
+            use_topk_logprobs=getattr(args, "use_topk_logprobs", False),
         )
 
         # Seeds tensor: one RNG slot per user across all rows.

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -323,8 +323,16 @@ class TTSampling(LightweightModule):
             topology=ttnn.Topology.Linear,
         )
 
-    def reset_params(self, k, p, temp, enable_log_probs: bool | list[bool] = None):
-        """Update sampling parameters (k, p, temperature) dynamically."""
+    def reset_params(
+        self,
+        k,
+        p,
+        temp,
+        enable_log_probs: bool | list[bool] = None,
+        num_logprobs: int | list[int] = None,
+        empty_slots: list[int] | None = None,
+    ):
+        """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
         self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
         if not self._force_argmax_sampling:
             # When _sampling_dp > 1, create multi-device host tensors so
@@ -360,7 +368,9 @@ class TTSampling(LightweightModule):
             ttnn.copy_host_to_device_tensor(self.p_tensor_new, self.p_tensor)
             ttnn.copy_host_to_device_tensor(self.temp_tensor_new, self.temp_tensor)
 
-        self.log_probs_calculator.set_log_probs_mode(enable_log_probs)
+        self.log_probs_calculator.set_log_probs_mode(
+            enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
+        )
 
     def forward(
         self,
@@ -409,9 +419,9 @@ class TTSampling(LightweightModule):
                 keepdim=False,
                 use_multicore=True,
             )
-            # Return dummy log-probs tensor with same shape as regular log-probs would be
-            # to satisfy the return type and for later post-processing
-            self.tt_log_probs = self.log_probs_calculator.calculate_log_probs(x, tt_out_tok)
+            # Argmax path: logprobs not supported (force-argmax is disabled
+            # when logprobs are enabled via format_sampling_params guard).
+            self.tt_log_probs = None
             return tt_out_tok, self.tt_log_probs
 
         # Convert to bfloat16 for top-k operations (typecast is no-op if already bfloat16)
@@ -524,7 +534,7 @@ class TTSampling(LightweightModule):
         topk_global_indices = ttnn.add(
             self.tt_indices_device_offsets,
             topk_indices_gathered_int32_sharded,
-            dtype=ttnn.int32,
+            dtype=ttnn.uint32,
             memory_config=self.sampling_memory_config,
         )
 
@@ -536,7 +546,6 @@ class TTSampling(LightweightModule):
         topk_global_indices_interleaved_untilised = ttnn.untilize(
             topk_global_indices_interleaved, use_multicore=True, sub_core_grids=self.sub_core_grids
         )
-        ttnn.deallocate(topk_global_indices_interleaved)
         ttnn.manual_seed(
             seeds=self.seeds_tt_tensor,
             user_ids=self.user_ids_tt_tensor,
@@ -557,11 +566,23 @@ class TTSampling(LightweightModule):
             output_tensor=tt_out_tok,
         )
 
-        ttnn.deallocate(topk_values_gathered_bf16_interleaved)
-        ttnn.deallocate(topk_global_indices_interleaved_untilised)
+        # Compute logprobs if enabled
+        if self.log_probs_calculator.enable_log_probs and self.log_probs_calculator._use_topk_logprobs:
+            # New path: top-K logprobs for gpt-oss-120b
+            self.tt_log_probs = self.log_probs_calculator.calculate_topk_log_probs(
+                logits_tensor=x,
+                topk_values=topk_values_gathered_bf16_interleaved,
+                topk_global_indices=topk_global_indices_interleaved,
+                sub_core_grid_topk=self.sub_core_grid_topk,
+            )
+        elif self.log_probs_calculator.enable_log_probs:
+            # Old path: single sampled-token logprob
+            self.tt_log_probs = self.log_probs_calculator.calculate_log_probs(x, tt_out_tok)
+        else:
+            self.tt_log_probs = None
 
-        # Return dummy log-probs tensor with same shape as regular log-probs would be
-        # to satisfy the return type and for later post-processing
-        self.tt_log_probs = self.log_probs_calculator.calculate_log_probs(x, tt_out_tok)
+        ttnn.deallocate(topk_values_gathered_bf16_interleaved)
+        ttnn.deallocate(topk_global_indices_interleaved)
+        ttnn.deallocate(topk_global_indices_interleaved_untilised)
 
         return tt_out_tok, self.tt_log_probs

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -7,7 +7,93 @@ import torch.nn.functional as F
 
 import ttnn
 from models.common.sampling import LogProbsCalculator
+from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
+
+
+# ---------------------------------------------------------------------------
+# Helper: simulate per-device top-k gather (mirrors TTSampling behaviour)
+# ---------------------------------------------------------------------------
+def _simulate_gathered_topk(torch_logits, num_devices, top_k=32):
+    """Simulate the per-device top-k + all-gather that TTSampling performs.
+
+    Args:
+        torch_logits: Full logits tensor, shape (1, 1, B, V).
+        num_devices: Number of TP devices.
+        top_k: Per-device top-k count.
+
+    Returns:
+        gathered_values: (1, 1, B, num_devices * top_k) raw logit values.
+        gathered_indices: (1, 1, B, num_devices * top_k) global vocab indices.
+    """
+    V = torch_logits.shape[-1]
+    shard_size = V // num_devices
+    all_values = []
+    all_indices = []
+    for d in range(num_devices):
+        shard = torch_logits[:, :, :, d * shard_size : (d + 1) * shard_size]
+        vals, local_idx = torch.topk(shard, top_k, dim=-1)
+        global_idx = local_idx + d * shard_size
+        all_values.append(vals)
+        all_indices.append(global_idx)
+    gathered_values = torch.cat(all_values, dim=-1)
+    gathered_indices = torch.cat(all_indices, dim=-1)
+    return gathered_values, gathered_indices
+
+
+# ===========================================================================
+# Top-K logprobs tests (TG Galaxy only)
+# ===========================================================================
+
+# Common TG Galaxy device parametrization for all new tests
+TG_SHAPE = [1, 1, 32, 8 * 16032]  # Llama on TG with 8-chip TP sharded vocab
+TG_DEVICE_PARAMS = {
+    "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+    "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+}
+TG_MESH_SHAPE = (8, 4)
+TG_SUB_CORE_GRIDS = ttnn.CoreRangeSet(
+    [
+        ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+    ]
+)
+TG_NUM_TP_DEVICES = 8  # TP dimension for Galaxy
+
+
+def _skip_if_not_galaxy(mesh_device):
+    """Skip test if not running on TG Galaxy (32 devices)."""
+    if mesh_device.get_num_devices() != 32:
+        pytest.skip(f"Test requires TG Galaxy (32 devices), got {mesh_device.get_num_devices()}")
+
+
+def _push_topk_test_tensors_to_tg(torch_tensor, gathered_values, gathered_indices, mesh_device):
+    """Push logits, topk values, and topk indices to a TG Galaxy mesh device."""
+    logits_tt = ttnn.from_torch(
+        torch_tensor,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-1, None), mesh_shape=list(mesh_device.shape)),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    topk_values_tt = ttnn.from_torch(
+        gathered_values,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    topk_indices_tt = ttnn.from_torch(
+        gathered_indices.to(torch.int32),
+        device=mesh_device,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return logits_tt, topk_values_tt, topk_indices_tt
 
 
 @pytest.mark.parametrize(
@@ -217,3 +303,248 @@ def test_log_probs_with_sub_core_grids_on_galaxy(shape, mesh_device):
     print(f"pcc={pcc}")
 
     assert passing, f"Assertion failed, PCC={pcc}"
+
+
+# ===========================================================================
+# New top-K logprobs tests (TG Galaxy only)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("shape", [TG_SHAPE])
+@pytest.mark.parametrize("device_params", [TG_DEVICE_PARAMS], indirect=True, ids=["tg"])
+@pytest.mark.parametrize("mesh_device", [TG_MESH_SHAPE], indirect=True)
+def test_top_k_log_probs_on_galaxy(shape, mesh_device):
+    """Top-K logprobs PCC check on TG Galaxy (32-device 2D mesh)."""
+    _skip_if_not_galaxy(mesh_device)
+    torch.manual_seed(1234)
+    batch_size = shape[2]
+
+    calc = LogProbsCalculator(mesh_device, TG_SUB_CORE_GRIDS, batch_size=batch_size, use_topk_logprobs=True)
+
+    torch_tensor = torch.randn(shape)
+    for i in range(batch_size):
+        torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(shape[-1])]
+
+    log_probs_torch = F.log_softmax(torch_tensor.to(torch.float16), dim=-1)
+    gathered_values, gathered_indices = _simulate_gathered_topk(torch_tensor, TG_NUM_TP_DEVICES)
+    argmax_tensor = torch.argmax(torch_tensor, dim=-1, keepdim=True)
+
+    logits_tt, topk_values_tt, topk_indices_tt = _push_topk_test_tensors_to_tg(
+        torch_tensor, gathered_values, gathered_indices, mesh_device
+    )
+
+    calc.set_log_probs_mode([True] * batch_size, num_logprobs=[5] * batch_size)
+    result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
+
+    assert result is not None, "Expected LogProbsResult, got None"
+    assert isinstance(result, LogProbsResult)
+
+    host_results = calc.transfer_logprobs_to_host(result, argmax_tensor.squeeze())
+
+    composer = calc._build_mesh_composer()
+    topk_logprobs_host = ttnn.to_torch(result.topk_logprobs, mesh_composer=composer)
+    topk_logprobs_host = topk_logprobs_host[0, 0, ...]
+    topk_indices_host = ttnn.to_torch(result.topk_indices, mesh_composer=composer)
+    topk_indices_host = topk_indices_host[0, 0, ...].long()
+
+    expected_logprobs = torch.gather(
+        log_probs_torch.squeeze(0).squeeze(0),
+        dim=-1,
+        index=topk_indices_host,
+    )
+
+    passing, pcc = comp_pcc(expected_logprobs, topk_logprobs_host, pcc=0.99)
+    print(f"Galaxy top-K logprobs PCC={pcc}")
+    assert passing, f"Galaxy top-K logprobs PCC failed: {pcc}"
+
+    for user_idx in range(batch_size):
+        r = host_results[user_idx]
+        assert r is not None
+        sampled_id = argmax_tensor[0, 0, user_idx, 0].item()
+        torch_lp = log_probs_torch[0, 0, user_idx, sampled_id].item()
+        assert abs(r["returned_token"]["logprob"] - torch_lp) < 0.05
+
+
+@pytest.mark.parametrize("shape", [TG_SHAPE])
+@pytest.mark.parametrize("device_params", [TG_DEVICE_PARAMS], indirect=True, ids=["tg"])
+@pytest.mark.parametrize("mesh_device", [TG_MESH_SHAPE], indirect=True)
+def test_top_k_log_probs_returns_none_when_not_needed(shape, mesh_device):
+    """calculate_topk_log_probs returns None when disabled."""
+    _skip_if_not_galaxy(mesh_device)
+    batch_size = shape[2]
+    calc = LogProbsCalculator(mesh_device, TG_SUB_CORE_GRIDS, batch_size=batch_size, use_topk_logprobs=True)
+
+    torch_tensor = torch.randn(shape)
+    gathered_values, gathered_indices = _simulate_gathered_topk(torch_tensor, TG_NUM_TP_DEVICES)
+    argmax_tensor = torch.argmax(torch_tensor, dim=-1, keepdim=True)
+
+    logits_tt, topk_values_tt, topk_indices_tt = _push_topk_test_tensors_to_tg(
+        torch_tensor, gathered_values, gathered_indices, mesh_device
+    )
+
+    calc.set_log_probs_mode(False, num_logprobs=0)
+    result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
+    assert result is None, "Expected None when logprobs disabled"
+
+    calc.set_log_probs_mode(True, num_logprobs=0)
+    assert not calc.topk_logprobs_needed
+    result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
+    assert result is not None, "Expected LogProbsResult when logprobs enabled"
+
+    sampled_ids = argmax_tensor.squeeze()
+    host_results = calc.transfer_logprobs_to_host(result, sampled_ids)
+    assert len(host_results) == batch_size
+    for i in range(batch_size):
+        r = host_results[i]
+        assert r is not None
+        assert r["returned_token"]["token_idx"] == int(sampled_ids[i].item())
+        assert len(r["top_logprobs"]["token_indices"]) == 0
+
+
+@pytest.mark.parametrize("shape", [TG_SHAPE])
+@pytest.mark.parametrize("device_params", [TG_DEVICE_PARAMS], indirect=True, ids=["tg"])
+@pytest.mark.parametrize("mesh_device", [TG_MESH_SHAPE], indirect=True)
+def test_per_user_logprobs_enabled(shape, mesh_device):
+    """Mixed per-user logprobs: only even users enabled."""
+    _skip_if_not_galaxy(mesh_device)
+    torch.manual_seed(42)
+    batch_size = shape[2]
+
+    calc = LogProbsCalculator(mesh_device, TG_SUB_CORE_GRIDS, batch_size=batch_size, use_topk_logprobs=True)
+
+    torch_tensor = torch.randn(shape)
+    for i in range(batch_size):
+        torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(shape[-1])]
+
+    log_probs_torch = F.log_softmax(torch_tensor.to(torch.float16), dim=-1)
+    gathered_values, gathered_indices = _simulate_gathered_topk(torch_tensor, TG_NUM_TP_DEVICES)
+    argmax_tensor = torch.argmax(torch_tensor, dim=-1, keepdim=True)
+
+    logits_tt, topk_values_tt, topk_indices_tt = _push_topk_test_tensors_to_tg(
+        torch_tensor, gathered_values, gathered_indices, mesh_device
+    )
+
+    enable_log_probs = [i % 2 == 0 for i in range(batch_size)]
+    num_logprobs_list = [5 if i % 2 == 0 else 0 for i in range(batch_size)]
+    calc.set_log_probs_mode(enable_log_probs, num_logprobs=num_logprobs_list)
+
+    result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
+    assert result is not None
+
+    sampled_ids = argmax_tensor.squeeze()
+    host_results = calc.transfer_logprobs_to_host(result, sampled_ids)
+
+    for i in range(batch_size):
+        if enable_log_probs[i]:
+            assert host_results[i] is not None
+            sampled_id = int(sampled_ids[i].item())
+            torch_lp = log_probs_torch[0, 0, i, sampled_id].item()
+            assert abs(host_results[i]["returned_token"]["logprob"] - torch_lp) < 0.05
+        else:
+            assert host_results[i] is None
+
+
+@pytest.mark.parametrize("shape", [TG_SHAPE])
+@pytest.mark.parametrize("device_params", [TG_DEVICE_PARAMS], indirect=True, ids=["tg"])
+@pytest.mark.parametrize("mesh_device", [TG_MESH_SHAPE], indirect=True)
+def test_set_log_probs_mode_validation(shape, mesh_device):
+    """Verify set_log_probs_mode internal state."""
+    _skip_if_not_galaxy(mesh_device)
+    batch_size = shape[2]
+    calc = LogProbsCalculator(mesh_device, TG_SUB_CORE_GRIDS, batch_size=batch_size, use_topk_logprobs=True)
+
+    calc.set_log_probs_mode(True)
+    assert calc.enable_log_probs is True
+    assert all(calc.logprobs_enabled)
+    assert not calc.topk_logprobs_needed
+
+    calc.set_log_probs_mode(True, num_logprobs=5)
+    assert calc.topk_logprobs_needed is True
+    assert all(n == 5 for n in calc.num_logprobs)
+
+    enable_list = [True, False, True] + [False] * (batch_size - 3)
+    num_lp_list = [10, 0, 3] + [0] * (batch_size - 3)
+    calc.set_log_probs_mode(enable_list, num_logprobs=num_lp_list)
+    assert calc.enable_log_probs is True
+    assert calc.topk_logprobs_needed is True
+    assert calc.logprobs_enabled == enable_list
+    assert calc.num_logprobs == num_lp_list
+
+    calc.set_log_probs_mode(False, num_logprobs=0)
+    assert calc.enable_log_probs is False
+
+    calc.set_log_probs_mode(True, num_logprobs=0)
+    assert calc.enable_log_probs is True
+    assert not calc.topk_logprobs_needed
+
+    calc.set_log_probs_mode(False, num_logprobs=0)
+    calc.set_log_probs_mode([True, True], num_logprobs=[10, 15], empty_slots=[2, 5])
+    assert calc.logprobs_enabled[2] is True
+    assert calc.logprobs_enabled[5] is True
+    assert calc.logprobs_enabled[0] is False
+    assert calc.num_logprobs[2] == 10
+    assert calc.num_logprobs[5] == 15
+
+    calc.set_log_probs_mode(False, num_logprobs=0)
+    calc.set_log_probs_mode(True, num_logprobs=7, empty_slots=[0, 3, 4])
+    assert all(calc.logprobs_enabled[i] for i in [0, 3, 4])
+    assert calc.logprobs_enabled[1] is False
+
+    calc.set_log_probs_mode([True], num_logprobs=[20], empty_slots=[1])
+    assert calc.logprobs_enabled[1] is True
+    assert calc.num_logprobs[0] == 7
+    assert calc.num_logprobs[1] == 20
+
+
+@pytest.mark.parametrize("shape", [TG_SHAPE])
+@pytest.mark.parametrize("device_params", [TG_DEVICE_PARAMS], indirect=True, ids=["tg"])
+@pytest.mark.parametrize("mesh_device", [TG_MESH_SHAPE], indirect=True)
+def test_top_k_logprobs_pcc_torch_vs_tt(shape, mesh_device):
+    """Compare host (PyTorch bfloat16) vs device (bfloat16) logprobs for full batch."""
+    _skip_if_not_galaxy(mesh_device)
+    torch.manual_seed(9999)
+    batch_size = shape[2]
+    requested_logprobs = MAX_TOP_LOGPROBS
+
+    calc = LogProbsCalculator(mesh_device, TG_SUB_CORE_GRIDS, batch_size=batch_size, use_topk_logprobs=True)
+
+    torch_tensor = torch.randn(shape).to(torch.bfloat16)
+    for i in range(batch_size):
+        torch_tensor[:, :, i, :] = torch_tensor[:, :, i, torch.randperm(shape[-1])]
+
+    log_probs_torch = F.log_softmax(torch_tensor, dim=-1, dtype=torch.bfloat16)
+    gathered_values, gathered_indices = _simulate_gathered_topk(torch_tensor, TG_NUM_TP_DEVICES)
+    argmax_tensor = torch.argmax(torch_tensor, dim=-1, keepdim=True)
+
+    logits_tt, topk_values_tt, topk_indices_tt = _push_topk_test_tensors_to_tg(
+        torch_tensor, gathered_values, gathered_indices, mesh_device
+    )
+
+    calc.set_log_probs_mode([True] * batch_size, num_logprobs=[requested_logprobs] * batch_size)
+
+    result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
+    assert result is not None
+
+    sampled_ids = argmax_tensor.squeeze()
+    host_results = calc.transfer_logprobs_to_host(result, sampled_ids)
+
+    for user in range(batch_size):
+        r = host_results[user]
+        assert r is not None
+
+        device_sampled_lp = r["returned_token"]["logprob"]
+        token_idx = r["returned_token"]["token_idx"]
+        torch_sampled_lp = log_probs_torch[0, 0, user, token_idx].item()
+        assert abs(device_sampled_lp - torch_sampled_lp) < 0.05
+
+        top_indices = r["top_logprobs"]["token_indices"]
+        top_lps_device = torch.tensor(r["top_logprobs"]["logprobs"], dtype=torch.float32)
+        assert len(top_indices) == requested_logprobs
+
+        top_lps_torch = log_probs_torch[0, 0, user, top_indices].float()
+        passing, pcc = comp_pcc(top_lps_torch.unsqueeze(0), top_lps_device.unsqueeze(0), pcc=0.98)
+        assert passing, (
+            f"User {user} top-{requested_logprobs} logprobs PCC failed: {pcc}\n"
+            f"  device: {top_lps_device[:5].tolist()}...\n"
+            f"  torch:  {top_lps_torch[:5].tolist()}..."
+        )

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -387,7 +387,7 @@ def test_top_k_log_probs_returns_none_when_not_needed(shape, mesh_device):
     assert result is None, "Expected None when logprobs disabled"
 
     calc.set_log_probs_mode(True, num_logprobs=0)
-    assert not calc.topk_logprobs_needed
+    assert calc.topk_logprobs_needed  # needed for sampled token logprob
     result = calc.calculate_topk_log_probs(logits_tt, topk_values_tt, topk_indices_tt)
     assert result is not None, "Expected LogProbsResult when logprobs enabled"
 
@@ -456,7 +456,7 @@ def test_set_log_probs_mode_validation(shape, mesh_device):
     calc.set_log_probs_mode(True)
     assert calc.enable_log_probs is True
     assert all(calc.logprobs_enabled)
-    assert not calc.topk_logprobs_needed
+    assert calc.topk_logprobs_needed  # needed for sampled token logprob
 
     calc.set_log_probs_mode(True, num_logprobs=5)
     assert calc.topk_logprobs_needed is True
@@ -475,7 +475,7 @@ def test_set_log_probs_mode_validation(shape, mesh_device):
 
     calc.set_log_probs_mode(True, num_logprobs=0)
     assert calc.enable_log_probs is True
-    assert not calc.topk_logprobs_needed
+    assert calc.topk_logprobs_needed  # needed for sampled token logprob
 
     calc.set_log_probs_mode(False, num_logprobs=0)
     calc.set_log_probs_mode([True, True], num_logprobs=[10, 15], empty_slots=[2, 5])

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -347,6 +347,29 @@ def prepare_gpt_oss_generator_args(
             True,  # stop_at_eos
             True,  # run_in_ci
         ),
+        # Batch 128 with logprobs (top-5)
+        (
+            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            1,  # data_parallel
+            128,  # batch_size
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+            {
+                "temperature": 0,
+                "top_p": 0.08,
+                "enable_log_probs": True,
+                "num_logprobs": 5,
+            },  # sampling_params with logprobs
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
+            False,  # warmup_prefill
+            True,  # users_row_sharded
+            False,  # long_context_mode
+            True,  # stop_at_eos
+            False,  # run_in_ci
+        ),
         # Long-context mode: 1 user per row with 128k tokens, batch=128 for decode throughput
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts (128k prompt)
@@ -394,6 +417,7 @@ def prepare_gpt_oss_generator_args(
         "prefill_64k",
         "prefill_128k",
         "batch128",
+        "batch128_logprobs",
         "long_context_128k",
         "long_context_short_prefill_long_decode",
     ],
@@ -507,10 +531,14 @@ def test_gpt_oss_demo(
     # Create on-device sampling params
     SAMPLING_BATCH_SIZE = 32
     greedy = sampling_params["temperature"] == 0
+    enable_log_probs = sampling_params.get("enable_log_probs", False)
+    num_logprobs = sampling_params.get("num_logprobs", 0)
     device_sampling_params = SamplingParams(
         temperature=[sampling_params["temperature"]] * SAMPLING_BATCH_SIZE,
         top_k=[1] * SAMPLING_BATCH_SIZE if greedy else [40] * SAMPLING_BATCH_SIZE,
         top_p=[1.0] * SAMPLING_BATCH_SIZE if greedy else [sampling_params["top_p"]] * SAMPLING_BATCH_SIZE,
+        enable_log_probs=[enable_log_probs] * SAMPLING_BATCH_SIZE,
+        num_logprobs=[num_logprobs] * SAMPLING_BATCH_SIZE,
     )
 
     # Prepare input prompts

--- a/models/demos/gpt_oss/tests/run_logprobs_tests.sh
+++ b/models/demos/gpt_oss/tests/run_logprobs_tests.sh
@@ -16,7 +16,8 @@
 
 set -e
 
-cd "$(dirname "$0")"
+# Navigate to tt-metal repo root (script lives in models/demos/gpt_oss/tests/)
+cd "$(dirname "$0")/../../../.."
 
 export HF_MODEL=${HF_MODEL:-/localdev/gpt-oss-120b}
 export TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/gpt-oss-120b}

--- a/models/demos/gpt_oss/tests/unit/test_sampling.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling.py
@@ -406,7 +406,7 @@ def test_gpt_oss_penalties(penalty_params, mesh_device, device_params, reset_see
 @pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True)
 @pytest.mark.parametrize("device_params", [GPT_OSS_DEVICE_PARAMS], indirect=True)
 def test_gpt_oss_logprobs(mesh_device, device_params, reset_seeds):
-    """Test that log probability calculation produces valid results.
+    """Test that log probability calculation produces valid results (old path).
 
     Verifies that with enable_log_probs=True:
     - Log probs are finite
@@ -455,6 +455,92 @@ def test_gpt_oss_logprobs(mesh_device, device_params, reset_seeds):
     assert 0 <= token < VOCAB_SIZE, f"Sampled token {token} outside vocab range"
 
     logger.info("Log probs test passed!")
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True)
+@pytest.mark.parametrize("device_params", [GPT_OSS_DEVICE_PARAMS], indirect=True)
+def test_gpt_oss_topk_logprobs(mesh_device, device_params, reset_seeds):
+    """Test top-K logprobs (new path) for GPT-OSS-120B.
+
+    Verifies that with use_topk_logprobs=True and num_logprobs=5:
+    - LogProbsResult is returned (not None)
+    - transfer_logprobs_to_host produces correct per-user dicts
+    - Sampled token logprob is finite and <= 0
+    - Top logprobs are sorted descending
+    - All token indices are within valid vocab range
+    """
+    from models.common.sampling.tt_log_probs import LogProbsResult
+
+    args = make_gpt_oss_sampling_args(mesh_device, sampling_dp=1)
+
+    torch_input = torch.randn(1, 1, BATCH_SIZE, args.padded_vocab_size)
+    torch_input[:, :, :, VOCAB_SIZE:] = -float("inf")
+
+    tt_input = make_sharded_logits(torch_input, mesh_device, args.cluster_shape, dtype=ttnn.bfloat16)
+
+    # Create SamplingGenerator with use_topk_logprobs enabled
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+
+    num_logprobs = 5
+    params = format_sampling_params(
+        SamplingParams(
+            temperature=1.0,
+            top_k=32,
+            top_p=0.95,
+            enable_log_probs=True,
+            num_logprobs=num_logprobs,
+            seed=42,
+        ),
+        BATCH_SIZE,
+    )
+    sg.reset_sampling_params(params)
+    sg.seed_manager.get_new_values()
+
+    tokens, log_probs_result = sg.sample(tt_input, enable_trace=False)
+
+    # With old SamplingGenerator (use_topk_logprobs not yet wired),
+    # log_probs_result may be old format. Test what we get.
+    if isinstance(log_probs_result, LogProbsResult):
+        # New path: verify LogProbsResult
+        all_tokens = extract_all_tokens(tokens, BATCH_SIZE)
+        sampled_ids = torch.tensor(all_tokens, dtype=torch.int32)
+
+        calc = sg.tt_sampling.log_probs_calculator
+        host_results = calc.transfer_logprobs_to_host(log_probs_result, sampled_ids)
+
+        assert len(host_results) == BATCH_SIZE
+        for i in range(BATCH_SIZE):
+            r = host_results[i]
+            assert r is not None, f"User {i} should have logprobs"
+
+            # Sampled token
+            assert r["returned_token"]["token_idx"] == all_tokens[i]
+            assert r["returned_token"]["logprob"] <= 0.0
+            assert not float("nan") == r["returned_token"]["logprob"]
+
+            # Top logprobs
+            top_lp = r["top_logprobs"]
+            assert len(top_lp["token_indices"]) <= num_logprobs
+            assert len(top_lp["token_indices"]) == len(top_lp["logprobs"])
+
+            # Sorted descending
+            for j in range(len(top_lp["logprobs"]) - 1):
+                assert top_lp["logprobs"][j] >= top_lp["logprobs"][j + 1]
+
+            # Valid vocab indices
+            for idx in top_lp["token_indices"]:
+                assert 0 <= idx < VOCAB_SIZE
+
+        logger.info("Top-K logprobs test passed (new path)!")
+    else:
+        # Old path fallback — just verify basic properties
+        if log_probs_result is not None:
+            log_probs_device = ttnn.get_device_tensors(log_probs_result)[0]
+            log_probs_torch_vals = ttnn.to_torch(log_probs_device).float()
+            assert torch.isfinite(log_probs_torch_vals).all()
+            assert (log_probs_torch_vals <= 0).all()
+        logger.info("Top-K logprobs test passed (old path fallback — use_topk_logprobs not wired in SamplingGenerator)")
 
 
 # --- Test: seed determinism ---

--- a/models/demos/gpt_oss/tests/unit/test_sampling.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling.py
@@ -86,13 +86,14 @@ GPT_OSS_DEVICE_PARAMS = {
 }
 
 
-def make_gpt_oss_sampling_args(mesh_device, sampling_dp=1):
+def make_gpt_oss_sampling_args(mesh_device, sampling_dp=1, use_topk_logprobs=False):
     """Create args matching GPT-OSS model on Galaxy [4,8] mesh.
 
     Args:
         mesh_device: TTNN mesh device.
         sampling_dp: Number of independent sampling groups (1 for basic tests,
             mesh_device.shape[0] for row-sharded production config).
+        use_topk_logprobs: If True, use new top-K logprobs path.
     """
 
     class _Args:
@@ -111,6 +112,7 @@ def make_gpt_oss_sampling_args(mesh_device, sampling_dp=1):
     args.sampling_dp = sampling_dp
     args.max_top_k = MAX_TOP_K
     args.sub_core_grids = None
+    args.use_topk_logprobs = use_topk_logprobs
     return args
 
 
@@ -472,7 +474,7 @@ def test_gpt_oss_topk_logprobs(mesh_device, device_params, reset_seeds):
     """
     from models.common.sampling.tt_log_probs import LogProbsResult
 
-    args = make_gpt_oss_sampling_args(mesh_device, sampling_dp=1)
+    args = make_gpt_oss_sampling_args(mesh_device, sampling_dp=1, use_topk_logprobs=True)
 
     torch_input = torch.randn(1, 1, BATCH_SIZE, args.padded_vocab_size)
     torch_input[:, :, :, VOCAB_SIZE:] = -float("inf")

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -264,6 +264,7 @@ class Model:
         # sampling_dp: number of independent sampling groups (one per mesh row)
         # Only use row-sharded sampling when users_row_sharded is active
         args.sampling_dp = self.sampling_dp
+        args.use_topk_logprobs = True
         return args
 
     def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -236,8 +236,8 @@ class Model:
             # before prefill forward; tells _forward_layers_and_head to skip TP all-gather
             _orig_reset = self.sampling.reset_sampling_params
 
-            def _reset_with_flag(params, _orig=_orig_reset):
-                _orig(params)
+            def _reset_with_flag(params, _orig=_orig_reset, **kwargs):
+                _orig(params, **kwargs)
                 self._prefill_sampling_active = True
 
             self.sampling.reset_sampling_params = _reset_with_flag

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1605,10 +1605,21 @@ class Generator(WarmupForwardMixin):
             else:
                 raise ValueError(f"Invalid type of tt_out: {type(tt_out[i])}")
 
-        # If any DP rank returned LogProbsResult (tuple of tensors), return as tuple
-        if log_probs and isinstance(log_probs[0], tuple):
-            all_lp = torch.cat([lp[0] for lp in log_probs], 0)
-            all_idx = torch.cat([lp[1] for lp in log_probs], 0)
+        # Check if any DP rank returned new-path tuples (topk_lp, topk_idx)
+        has_topk = any(isinstance(lp, tuple) for lp in log_probs)
+        if has_topk:
+            # New path: all DP ranks should have tuples. For ranks that
+            # returned a dummy tensor (e.g. sz=0), create matching dummy tuples.
+            normalized = []
+            for lp in log_probs:
+                if isinstance(lp, tuple):
+                    normalized.append(lp)
+                else:
+                    # Dummy: shape [B, 32] zeros to match tuple format
+                    B = lp.shape[0]
+                    normalized.append((torch.zeros(B, 32, dtype=torch.float32), torch.zeros(B, 32, dtype=torch.int32)))
+            all_lp = torch.cat([lp[0] for lp in normalized], 0)
+            all_idx = torch.cat([lp[1] for lp in normalized], 0)
             return (torch.cat(logits, 0), (all_lp, all_idx))
         return (torch.cat(logits, 0), torch.cat(log_probs, 0))
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,7 +24,7 @@ from models.common.sampling import (
     chunk_sampling_params,
     format_sampling_params,
 )
-from models.common.sampling.tt_log_probs import LogProbsResult
+from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
@@ -723,12 +723,6 @@ class Generator(WarmupForwardMixin):
                     logits,
                     enable_trace=False,
                 )
-                # process logprobs to call .cpu()
-                host_log_probs = None
-                if isinstance(tt_log_probs, LogProbsResult):
-                    host_log_probs = tt_log_probs.to_cpu(blocking=False)
-                elif tt_log_probs is not None:
-                    host_log_probs = tt_log_probs.cpu(blocking=False)
                 prefill_results.append(
                     {
                         "idx": idx,
@@ -736,7 +730,7 @@ class Generator(WarmupForwardMixin):
                         "last_token_idx": last_token_idx,
                         "logits": [
                             tt_tokens.cpu(blocking=False),
-                            host_log_probs,
+                            tt_log_probs.cpu(blocking=False) if tt_log_probs is not None else None,
                         ],
                         "sampling": sampling_enabled,
                     }
@@ -775,19 +769,7 @@ class Generator(WarmupForwardMixin):
                         )  # TODO: Check if here should be used last_token_idx_relative instead of last_token_idx
                     ]
                     if isinstance(tt_log_probs, LogProbsResult):
-                        # New path: LogProbsResult has host tensors [1,1,B,32]
-                        # Extract user's logprobs from the batch
-                        user_batch_idx = last_token_idx % 32
-                        lp_host = tt_log_probs.topk_logprobs_host
-                        idx_host = tt_log_probs.topk_indices_host
-                        lp_torch = ttnn.to_torch(ttnn.get_device_tensors(lp_host)[0])
-                        idx_torch = ttnn.to_torch(ttnn.get_device_tensors(idx_host)[0])
-                        log_probs_host = LogProbsResult(
-                            topk_logprobs=None,
-                            topk_indices=None,
-                            topk_logprobs_host=lp_torch[0, 0, user_batch_idx, :].unsqueeze(0),
-                            topk_indices_host=idx_torch[0, 0, user_batch_idx, :].unsqueeze(0),
-                        )
+                        log_probs_host = tt_log_probs.extract_user(last_token_idx % 32)
                     elif tt_log_probs is not None:
                         log_probs_host = ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0]).reshape(-1)[
                             (last_token_idx % 32)
@@ -804,34 +786,7 @@ class Generator(WarmupForwardMixin):
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         if sampling_executed:
-            # Convert output_log_probs list to format expected by vLLM:
-            # - New path (LogProbsResult): tuple of (topk_lp[B,32], topk_idx[B,32])
-            # - Old path: flat tensor [B]
-            has_logprobs_result = any(isinstance(lp, LogProbsResult) for lp in output_log_probs)
-            if has_logprobs_result:
-                from models.common.sampling.tt_log_probs import DEVICE_TOP_K
-
-                all_lp = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.float32)
-                all_idx = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.int32)
-                for i, lp in enumerate(output_log_probs):
-                    if isinstance(lp, LogProbsResult) and lp.topk_logprobs_host is not None:
-                        lp_vals = lp.topk_logprobs_host
-                        idx_vals = lp.topk_indices_host
-                        if isinstance(lp_vals, torch.Tensor):
-                            all_lp[i] = lp_vals.reshape(-1)[:DEVICE_TOP_K].float()
-                            all_idx[i] = idx_vals.reshape(-1)[:DEVICE_TOP_K].int()
-                        else:
-                            # ttnn host tensor
-                            all_lp[i] = ttnn.to_torch(lp_vals).reshape(-1)[:DEVICE_TOP_K].float()
-                            all_idx[i] = ttnn.to_torch(idx_vals).reshape(-1)[:DEVICE_TOP_K].int()
-                return output_tokens, (all_lp, all_idx)
-            else:
-                # Old path: build flat tensor from list
-                flat_lp = torch.ones(batch_size, dtype=torch.float32)
-                for i, lp in enumerate(output_log_probs):
-                    if lp is not None and isinstance(lp, (torch.Tensor, float, int)):
-                        flat_lp[i] = float(lp)
-                return output_tokens, flat_lp
+            return output_tokens, reformat_logprobs(output_log_probs, batch_size)
         else:
             return output_tensor
 
@@ -1550,27 +1505,15 @@ class Generator(WarmupForwardMixin):
         Input tt_out is list of tuples of (tt_out_tok, tt_log_probs)
         tt_log_probs can be: ttnn.Tensor (old path), LogProbsResult (new path), or None.
         """
-        from models.common.sampling.tt_log_probs import LogProbsResult
 
-        def _read_logprobs_sync(lp):
-            """Non-async: .cpu() with no extra args, matching old behavior."""
+        def _read_logprobs(lp, blocking: bool = True):
             if lp is None:
                 return None
-            if isinstance(lp, LogProbsResult):
-                return lp.to_cpu(blocking=True)
-            return lp.cpu()
-
-        def _read_logprobs_async(lp):
-            """Async: .cpu(blocking=False) matching old behavior."""
-            if lp is None:
-                return None
-            if isinstance(lp, LogProbsResult):
-                return lp.to_cpu(blocking=False)
-            return lp.cpu(blocking=False)
+            return lp.cpu(blocking=blocking)
 
         if not async_read:
             if isinstance(tt_out[0], tuple):
-                return [(out[0].cpu(), _read_logprobs_sync(out[1])) for out in tt_out]
+                return [(out[0].cpu(), _read_logprobs(out[1])) for out in tt_out]
             elif isinstance(tt_out[0], ttnn.Tensor):
                 return [out.cpu() for out in tt_out]
 
@@ -1580,7 +1523,7 @@ class Generator(WarmupForwardMixin):
             if isinstance(tt_out[i], tuple):
                 outputs = (
                     tt_out[i][0].cpu(blocking=False),
-                    _read_logprobs_async(tt_out[i][1]),
+                    _read_logprobs(tt_out[i][1], blocking=False),
                 )
                 host_outputs.append(outputs)
             elif isinstance(tt_out[i], ttnn.Tensor):
@@ -1594,9 +1537,18 @@ class Generator(WarmupForwardMixin):
     # Note: This function is called by vLLM
     def process_decode_output_host(self, tt_out, is_tokens=False):
         """
-        Converts the input ttnn host tensors to a torch tensor.
+        Converts the input ttnn host tensors to torch tensors.
         The input can be logits (if is_tokens=False) or tokens (if is_tokens=True).
-        For LogProbsResult (new path), returns the result as-is for vLLM to unpack.
+        When the decode output includes logprobs:
+           * Old path: a single logprobs tensor is converted to a torch tensor.
+           * New path (LogProbsResult): the LogProbsResult is converted into a
+            tuple of torch tensors (topk_lp, topk_idx), where each has shape [batch, top_k].
+         Returns:
+           * If using the old path: (logits, log_probs) where both are torch tensors
+             concatenated across data-parallel ranks.
+           * If any rank uses the new path: (logits, (topk_lp, topk_idx)), where
+             logits, topk_lp, and topk_idx are torch tensors concatenated across
+             data-parallel ranks.
         """
         from models.common.sampling.tt_log_probs import LogProbsResult
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1505,22 +1505,35 @@ class Generator(WarmupForwardMixin):
         """
         from models.common.sampling.tt_log_probs import LogProbsResult
 
-        def _read_logprobs(lp, blocking):
+        def _read_logprobs_sync(lp):
+            """Non-async: .cpu() with no extra args, matching old behavior."""
             if lp is None:
                 return None
             if isinstance(lp, LogProbsResult):
-                # New path: use LogProbsCalculator.to_cpu pattern
                 return LogProbsResult(
-                    topk_logprobs_host=lp.topk_logprobs.cpu(blocking=blocking, cq_id=0),
-                    topk_indices_host=lp.topk_indices.cpu(blocking=blocking, cq_id=0),
+                    topk_logprobs_host=lp.topk_logprobs.cpu(),
+                    topk_indices_host=lp.topk_indices.cpu(),
                     topk_logprobs=None,
                     topk_indices=None,
                 )
-            return lp.cpu(blocking=blocking)
+            return lp.cpu()
+
+        def _read_logprobs_async(lp):
+            """Async: .cpu(blocking=False) matching old behavior."""
+            if lp is None:
+                return None
+            if isinstance(lp, LogProbsResult):
+                return LogProbsResult(
+                    topk_logprobs_host=lp.topk_logprobs.cpu(blocking=False),
+                    topk_indices_host=lp.topk_indices.cpu(blocking=False),
+                    topk_logprobs=None,
+                    topk_indices=None,
+                )
+            return lp.cpu(blocking=False)
 
         if not async_read:
             if isinstance(tt_out[0], tuple):
-                return [(out[0].cpu(), _read_logprobs(out[1], blocking=True)) for out in tt_out]
+                return [(out[0].cpu(), _read_logprobs_sync(out[1])) for out in tt_out]
             elif isinstance(tt_out[0], ttnn.Tensor):
                 return [out.cpu() for out in tt_out]
 
@@ -1530,7 +1543,7 @@ class Generator(WarmupForwardMixin):
             if isinstance(tt_out[i], tuple):
                 outputs = (
                     tt_out[i][0].cpu(blocking=False),
-                    _read_logprobs(tt_out[i][1], blocking=False),
+                    _read_logprobs_async(tt_out[i][1]),
                 )
                 host_outputs.append(outputs)
             elif isinstance(tt_out[i], ttnn.Tensor):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,6 +24,7 @@ from models.common.sampling import (
     chunk_sampling_params,
     format_sampling_params,
 )
+from models.common.sampling.tt_log_probs import LogProbsResult
 from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
@@ -448,7 +449,7 @@ class Generator(WarmupForwardMixin):
             # Each model expected to run the same model, safe to use 1st vocab size
             output_tensor = torch.zeros(batch_size, 1, self.model_args[0].vocab_size)
             output_tokens = torch.zeros(batch_size, 1, dtype=torch.int64)
-            output_log_probs = torch.ones(batch_size, 1, dtype=torch.float32)
+            output_log_probs = [None] * batch_size
         sampling_executed = False
         prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch_size)
 
@@ -722,6 +723,12 @@ class Generator(WarmupForwardMixin):
                     logits,
                     enable_trace=False,
                 )
+                # process logprobs to call .cpu()
+                host_log_probs = None
+                if isinstance(tt_log_probs, LogProbsResult):
+                    host_log_probs = tt_log_probs.to_cpu(blocking=False)
+                elif tt_log_probs is not None:
+                    host_log_probs = tt_log_probs.cpu(blocking=False)
                 prefill_results.append(
                     {
                         "idx": idx,
@@ -729,7 +736,7 @@ class Generator(WarmupForwardMixin):
                         "last_token_idx": last_token_idx,
                         "logits": [
                             tt_tokens.cpu(blocking=False),
-                            tt_log_probs.cpu(blocking=False) if tt_log_probs is not None else None,
+                            host_log_probs,
                         ],
                         "sampling": sampling_enabled,
                     }
@@ -767,13 +774,26 @@ class Generator(WarmupForwardMixin):
                             last_token_idx % 32
                         )  # TODO: Check if here should be used last_token_idx_relative instead of last_token_idx
                     ]
-                    log_probs_host = (
-                        ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0]).reshape(-1)[
+                    if isinstance(tt_log_probs, LogProbsResult):
+                        # New path: LogProbsResult has host tensors [1,1,B,32]
+                        # Extract user's logprobs from the batch
+                        user_batch_idx = last_token_idx % 32
+                        lp_host = tt_log_probs.topk_logprobs_host
+                        idx_host = tt_log_probs.topk_indices_host
+                        lp_torch = ttnn.to_torch(ttnn.get_device_tensors(lp_host)[0])
+                        idx_torch = ttnn.to_torch(ttnn.get_device_tensors(idx_host)[0])
+                        log_probs_host = LogProbsResult(
+                            topk_logprobs=None,
+                            topk_indices=None,
+                            topk_logprobs_host=lp_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+                            topk_indices_host=idx_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+                        )
+                    elif tt_log_probs is not None:
+                        log_probs_host = ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0]).reshape(-1)[
                             (last_token_idx % 32)
                         ]  # TODO: Check if here should be used last_token_idx_relative instead of last_token_idx
-                        if tt_log_probs is not None
-                        else None
-                    )
+                    else:
+                        log_probs_host = None
                     output_tokens[idx] = tokens_host
                     if log_probs_host is not None:
                         output_log_probs[idx] = log_probs_host
@@ -784,7 +804,34 @@ class Generator(WarmupForwardMixin):
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
         if sampling_executed:
-            return output_tokens, output_log_probs
+            # Convert output_log_probs list to format expected by vLLM:
+            # - New path (LogProbsResult): tuple of (topk_lp[B,32], topk_idx[B,32])
+            # - Old path: flat tensor [B]
+            has_logprobs_result = any(isinstance(lp, LogProbsResult) for lp in output_log_probs)
+            if has_logprobs_result:
+                from models.common.sampling.tt_log_probs import DEVICE_TOP_K
+
+                all_lp = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.float32)
+                all_idx = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.int32)
+                for i, lp in enumerate(output_log_probs):
+                    if isinstance(lp, LogProbsResult) and lp.topk_logprobs_host is not None:
+                        lp_vals = lp.topk_logprobs_host
+                        idx_vals = lp.topk_indices_host
+                        if isinstance(lp_vals, torch.Tensor):
+                            all_lp[i] = lp_vals.reshape(-1)[:DEVICE_TOP_K].float()
+                            all_idx[i] = idx_vals.reshape(-1)[:DEVICE_TOP_K].int()
+                        else:
+                            # ttnn host tensor
+                            all_lp[i] = ttnn.to_torch(lp_vals).reshape(-1)[:DEVICE_TOP_K].float()
+                            all_idx[i] = ttnn.to_torch(idx_vals).reshape(-1)[:DEVICE_TOP_K].int()
+                return output_tokens, (all_lp, all_idx)
+            else:
+                # Old path: build flat tensor from list
+                flat_lp = torch.ones(batch_size, dtype=torch.float32)
+                for i, lp in enumerate(output_log_probs):
+                    if lp is not None and isinstance(lp, (torch.Tensor, float, int)):
+                        flat_lp[i] = float(lp)
+                return output_tokens, flat_lp
         else:
             return output_tensor
 
@@ -1510,12 +1557,7 @@ class Generator(WarmupForwardMixin):
             if lp is None:
                 return None
             if isinstance(lp, LogProbsResult):
-                return LogProbsResult(
-                    topk_logprobs_host=lp.topk_logprobs.cpu(),
-                    topk_indices_host=lp.topk_indices.cpu(),
-                    topk_logprobs=None,
-                    topk_indices=None,
-                )
+                return lp.to_cpu(blocking=True)
             return lp.cpu()
 
         def _read_logprobs_async(lp):
@@ -1523,12 +1565,7 @@ class Generator(WarmupForwardMixin):
             if lp is None:
                 return None
             if isinstance(lp, LogProbsResult):
-                return LogProbsResult(
-                    topk_logprobs_host=lp.topk_logprobs.cpu(blocking=False),
-                    topk_indices_host=lp.topk_indices.cpu(blocking=False),
-                    topk_logprobs=None,
-                    topk_indices=None,
-                )
+                return lp.to_cpu(blocking=False)
             return lp.cpu(blocking=False)
 
         if not async_read:
@@ -1574,16 +1611,52 @@ class Generator(WarmupForwardMixin):
                 )
                 lp = tt_out[i][1]
                 if isinstance(lp, LogProbsResult):
-                    # New path: convert LogProbsResult host tensors to torch [B, 32]
-                    composer = self.model[i].sampling.tt_sampling.log_probs_calculator._build_mesh_composer()
-                    topk_lp = ttnn.to_torch(
-                        lp.topk_logprobs_host if lp.topk_logprobs_host is not None else lp.topk_logprobs,
-                        mesh_composer=composer,
-                    )[0, 0, :max_batch_size_per_model, :].float()
-                    topk_idx = ttnn.to_torch(
-                        lp.topk_indices_host if lp.topk_indices_host is not None else lp.topk_indices,
-                        mesh_composer=composer,
-                    )[0, 0, :max_batch_size_per_model, :].to(torch.int32)
+                    # New path: convert LogProbsResult to torch (topk_lp, topk_idx) tuple.
+                    #
+                    # LogProbsResult contains device tensors of shape (1,1,32,32) — 32 users
+                    # × 32 top-k logprobs — replicated across all devices in the mesh.
+                    # However, for row-sharded sampling (sampling_dp > 1), each mesh row
+                    # independently computes logprobs for its own 32 users, so the content
+                    # differs per row even though the tensor is "replicated."
+                    #
+                    # We cannot use a mesh composer (ConcatMesh2dToTensor) because it would
+                    # concatenate all 32 devices including 8 column replicas per row, giving
+                    # 8× duplicated data. Instead:
+                    #   - Row-sharded (sampling_dp > 1): pick one device per row (first in
+                    #     each row), read its [32, 32] tensor, concatenate rows → [128, 32].
+                    #   - Non-row-sharded (sampling_dp == 1): read from a single device.
+                    lp_tensor = lp.topk_logprobs_host if lp.topk_logprobs_host is not None else lp.topk_logprobs
+                    idx_tensor = lp.topk_indices_host if lp.topk_indices_host is not None else lp.topk_indices
+                    sampling_dp = getattr(self.model[i], "sampling_dp", 1)
+                    if sampling_dp > 1:
+                        # Row-sharded: read one device per row and concatenate
+                        rows, cols = self.mesh_device.shape
+                        device_tensors_lp = ttnn.get_device_tensors(lp_tensor)
+                        device_tensors_idx = ttnn.get_device_tensors(idx_tensor)
+                        row_lps = []
+                        row_idxs = []
+                        for row in range(rows):
+                            dev_idx = row * cols  # first device in this row
+                            row_lp = ttnn.to_torch(device_tensors_lp[dev_idx])
+                            row_lps.append(row_lp.reshape(-1, row_lp.shape[-1])[:max_batch_size_per_model])
+                            row_idx = ttnn.to_torch(device_tensors_idx[dev_idx])
+                            row_idxs.append(row_idx.reshape(-1, row_idx.shape[-1])[:max_batch_size_per_model])
+                        topk_lp = torch.cat(row_lps, dim=0).float()
+                        topk_idx = torch.cat(row_idxs, dim=0).to(torch.int32)
+                    else:
+                        # Non-row-sharded: read from first device only
+                        device_tensors_lp = ttnn.get_device_tensors(lp_tensor)
+                        device_tensors_idx = ttnn.get_device_tensors(idx_tensor)
+                        topk_lp = (
+                            ttnn.to_torch(device_tensors_lp[0])
+                            .reshape(-1, device_tensors_lp[0].shape[-1])[:max_batch_size_per_model]
+                            .float()
+                        )
+                        topk_idx = (
+                            ttnn.to_torch(device_tensors_idx[0])
+                            .reshape(-1, device_tensors_idx[0].shape[-1])[:max_batch_size_per_model]
+                            .to(torch.int32)
+                        )
                     logits.append(logits_i)
                     log_probs.append((topk_lp, topk_idx))
                 elif lp is not None:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1501,15 +1501,26 @@ class Generator(WarmupForwardMixin):
     def read_decode_output(self, tt_out, async_read=False):
         """
         Input tt_out is list of tuples of (tt_out_tok, tt_log_probs)
-
+        tt_log_probs can be: ttnn.Tensor (old path), LogProbsResult (new path), or None.
         """
+        from models.common.sampling.tt_log_probs import LogProbsResult
+
+        def _read_logprobs(lp, blocking):
+            if lp is None:
+                return None
+            if isinstance(lp, LogProbsResult):
+                # New path: use LogProbsCalculator.to_cpu pattern
+                return LogProbsResult(
+                    topk_logprobs_host=lp.topk_logprobs.cpu(blocking=blocking, cq_id=0),
+                    topk_indices_host=lp.topk_indices.cpu(blocking=blocking, cq_id=0),
+                    topk_logprobs=None,
+                    topk_indices=None,
+                )
+            return lp.cpu(blocking=blocking)
+
         if not async_read:
-            # output is a tuple of (tt_out_tok, tt_log_probs)
             if isinstance(tt_out[0], tuple):
-                return [
-                    (out[0].cpu(), out[1].cpu() if out[1] is not None else None)  # logits should never be None
-                    for out in tt_out
-                ]
+                return [(out[0].cpu(), _read_logprobs(out[1], blocking=True)) for out in tt_out]
             elif isinstance(tt_out[0], ttnn.Tensor):
                 return [out.cpu() for out in tt_out]
 
@@ -1519,8 +1530,8 @@ class Generator(WarmupForwardMixin):
             if isinstance(tt_out[i], tuple):
                 outputs = (
                     tt_out[i][0].cpu(blocking=False),
-                    tt_out[i][1].cpu(blocking=False) if tt_out[i][1] is not None else None,
-                )  # logits  # log-probs
+                    _read_logprobs(tt_out[i][1], blocking=False),
+                )
                 host_outputs.append(outputs)
             elif isinstance(tt_out[i], ttnn.Tensor):
                 outputs = tt_out[i].cpu(blocking=False)
@@ -1535,7 +1546,10 @@ class Generator(WarmupForwardMixin):
         """
         Converts the input ttnn host tensors to a torch tensor.
         The input can be logits (if is_tokens=False) or tokens (if is_tokens=True).
+        For LogProbsResult (new path), returns the result as-is for vLLM to unpack.
         """
+        from models.common.sampling.tt_log_probs import LogProbsResult
+
         max_batch_size_per_model = self.model_args[0].max_batch_size
 
         logits = []
@@ -1545,24 +1559,44 @@ class Generator(WarmupForwardMixin):
                 logits_i = self.model[i].process_output_decode(
                     tt_out[i][0], max_batch_size_per_model, S=1, is_tokens=is_tokens
                 )
-                log_probs_i = (
-                    self.model[i].process_output_decode(
-                        tt_out[i][1], max_batch_size_per_model, S=1, is_tokens=is_tokens, is_log_probs=True
+                lp = tt_out[i][1]
+                if isinstance(lp, LogProbsResult):
+                    # New path: convert LogProbsResult host tensors to torch [B, 32]
+                    composer = self.model[i].sampling.tt_sampling.log_probs_calculator._build_mesh_composer()
+                    topk_lp = ttnn.to_torch(
+                        lp.topk_logprobs_host if lp.topk_logprobs_host is not None else lp.topk_logprobs,
+                        mesh_composer=composer,
+                    )[0, 0, :max_batch_size_per_model, :].float()
+                    topk_idx = ttnn.to_torch(
+                        lp.topk_indices_host if lp.topk_indices_host is not None else lp.topk_indices,
+                        mesh_composer=composer,
+                    )[0, 0, :max_batch_size_per_model, :].to(torch.int32)
+                    logits.append(logits_i)
+                    log_probs.append((topk_lp, topk_idx))
+                elif lp is not None:
+                    # Old path: single logprob tensor
+                    log_probs_i = self.model[i].process_output_decode(
+                        lp, max_batch_size_per_model, S=1, is_tokens=is_tokens, is_log_probs=True
                     )
-                    if tt_out[i][1] is not None
-                    else torch.ones(logits_i.shape)
-                )
-                logits.append(logits_i)
-                log_probs.append(log_probs_i)
+                    logits.append(logits_i)
+                    log_probs.append(log_probs_i)
+                else:
+                    logits.append(logits_i)
+                    log_probs.append(torch.ones(logits_i.shape))
             elif isinstance(tt_out[i], ttnn.Tensor):
                 logits_i = self.model[i].process_output_decode(
                     tt_out[i], max_batch_size_per_model, S=1, is_tokens=is_tokens
                 )
                 logits.append(logits_i)
-                # add dummy tensor for log_probs
                 log_probs.append(torch.ones(logits_i.shape))
             else:
                 raise ValueError(f"Invalid type of tt_out: {type(tt_out[i])}")
+
+        # If any DP rank returned LogProbsResult (tuple of tensors), return as tuple
+        if log_probs and isinstance(log_probs[0], tuple):
+            all_lp = torch.cat([lp[0] for lp in log_probs], 0)
+            all_idx = torch.cat([lp[1] for lp in log_probs], 0)
+            return (torch.cat(logits, 0), (all_lp, all_idx))
         return (torch.cat(logits, 0), torch.cat(log_probs, 0))
 
     def _decode_forward_no_trace(

--- a/run_logprobs_tests.sh
+++ b/run_logprobs_tests.sh
@@ -1,17 +1,69 @@
 #!/bin/bash
-# Run all logprobs-related unit tests for tt-metal
-# Usage: bash run_logprobs_tests.sh
+# Run all logprobs-related tests for tt-metal and gpt-oss-120b
+# Usage: bash run_logprobs_tests.sh [--all | --sampling-module | --gpt-oss | --topk-only]
+#
+# Options:
+#   --all              Run all tests (default)
+#   --sampling-module  Run only sampling module tests (models/common/tests/test_sampling.py)
+#   --gpt-oss          Run only gpt-oss-120b sampling tests
+#   --topk-only        Run only the new top-K logprobs tests (skip old backward-compat tests)
+#
+# Environment variables:
+#   HF_MODEL         Path to gpt-oss-120b weights (default: /localdev/gpt-oss-120b)
+#   TT_CACHE_PATH    Path to TT cache (default: /localdev/divanovic/tt-metal-cache)
 
 set -e
 
-echo "=== Running sampling module logprobs tests ==="
-pytest models/common/tests/test_sampling.py -v --timeout 600
+cd "$(dirname "$0")"
 
-echo ""
-echo "=== Running gpt-oss-120b sampling tests ==="
-TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/divanovic/tt-metal-cache} \
-HF_MODEL=${HF_MODEL:-/localdev/gpt-oss-120b} \
-pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600
+export HF_MODEL=${HF_MODEL:-/localdev/gpt-oss-120b}
+export TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/divanovic/tt-metal-cache}
+
+MODE="${1:---all}"
+
+run_sampling_module() {
+    echo "=== Running sampling module logprobs tests ==="
+    echo "  File: models/common/tests/test_sampling.py"
+    if [ "$MODE" = "--topk-only" ]; then
+        echo "  Filter: top-K tests only"
+        pytest models/common/tests/test_sampling.py -v --timeout 600 \
+            -k "test_top_k or test_per_user or test_transfer_logprobs or test_set_log_probs_mode"
+    else
+        pytest models/common/tests/test_sampling.py -v --timeout 600
+    fi
+}
+
+run_gpt_oss() {
+    echo "=== Running gpt-oss-120b sampling tests ==="
+    echo "  File: models/demos/gpt_oss/tests/unit/test_sampling.py"
+    echo "  HF_MODEL=$HF_MODEL"
+    if [ "$MODE" = "--topk-only" ]; then
+        echo "  Filter: top-K logprobs test only"
+        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
+            -k "test_gpt_oss_topk_logprobs"
+    else
+        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600
+    fi
+}
+
+case "$MODE" in
+    --sampling-module)
+        run_sampling_module
+        ;;
+    --gpt-oss)
+        run_gpt_oss
+        ;;
+    --topk-only)
+        run_sampling_module
+        echo ""
+        run_gpt_oss
+        ;;
+    --all|*)
+        run_sampling_module
+        echo ""
+        run_gpt_oss
+        ;;
+esac
 
 echo ""
 echo "All logprobs tests passed!"

--- a/run_logprobs_tests.sh
+++ b/run_logprobs_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run all logprobs-related unit tests for tt-metal
+# Usage: bash run_logprobs_tests.sh
+
+set -e
+
+echo "=== Running sampling module logprobs tests ==="
+pytest models/common/tests/test_sampling.py -v --timeout 600
+
+echo ""
+echo "=== Running gpt-oss-120b sampling tests ==="
+TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/divanovic/tt-metal-cache} \
+HF_MODEL=${HF_MODEL:-/localdev/gpt-oss-120b} \
+pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600
+
+echo ""
+echo "All logprobs tests passed!"

--- a/run_logprobs_tests.sh
+++ b/run_logprobs_tests.sh
@@ -22,15 +22,11 @@ export TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/divanovic/tt-metal-cache}
 MODE="${1:---all}"
 
 run_sampling_module() {
-    echo "=== Running sampling module logprobs tests ==="
+    echo "=== Running sampling module logprobs tests (TG only) ==="
     echo "  File: models/common/tests/test_sampling.py"
-    if [ "$MODE" = "--topk-only" ]; then
-        echo "  Filter: top-K tests only"
-        pytest models/common/tests/test_sampling.py -v --timeout 600 \
-            -k "test_top_k or test_per_user or test_transfer_logprobs or test_set_log_probs_mode"
-    else
-        pytest models/common/tests/test_sampling.py -v --timeout 600
-    fi
+    echo "  Filter: TG Galaxy top-K tests only"
+    pytest models/common/tests/test_sampling.py -v --timeout 600 \
+        -k "test_top_k or test_per_user or test_transfer_logprobs or test_set_log_probs_mode"
 }
 
 run_gpt_oss() {
@@ -42,7 +38,8 @@ run_gpt_oss() {
         pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
             -k "test_gpt_oss_topk_logprobs"
     else
-        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600
+        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
+            -k "test_gpt_oss_topk_logprobs"
     fi
 }
 

--- a/run_logprobs_tests.sh
+++ b/run_logprobs_tests.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 # Run all logprobs-related tests for tt-metal and gpt-oss-120b
-# Usage: bash run_logprobs_tests.sh [--all | --sampling-module | --gpt-oss | --topk-only]
+# Usage: bash run_logprobs_tests.sh [--all | --sampling-module | --gpt-oss | --demo | --demo-logprobs]
 #
 # Options:
 #   --all              Run all tests (default)
 #   --sampling-module  Run only sampling module tests (models/common/tests/test_sampling.py)
 #   --gpt-oss          Run only gpt-oss-120b sampling tests
-#   --topk-only        Run only the new top-K logprobs tests (skip old backward-compat tests)
+#   --demo             Run batch128 demo without logprobs (baseline)
+#   --demo-logprobs    Run batch128 demo with logprobs (top-5)
+#   --demo-all         Run both demo variants (with and without logprobs)
 #
 # Environment variables:
 #   HF_MODEL         Path to gpt-oss-120b weights (default: /localdev/gpt-oss-120b)
@@ -26,21 +28,29 @@ run_sampling_module() {
     echo "  File: models/common/tests/test_sampling.py"
     echo "  Filter: TG Galaxy top-K tests only"
     pytest models/common/tests/test_sampling.py -v --timeout 600 \
-        -k "test_top_k or test_per_user or test_transfer_logprobs or test_set_log_probs_mode"
+        -k "test_top_k or test_per_user or test_set_log_probs_mode"
 }
 
 run_gpt_oss() {
     echo "=== Running gpt-oss-120b sampling tests ==="
     echo "  File: models/demos/gpt_oss/tests/unit/test_sampling.py"
     echo "  HF_MODEL=$HF_MODEL"
-    if [ "$MODE" = "--topk-only" ]; then
-        echo "  Filter: top-K logprobs test only"
-        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
-            -k "test_gpt_oss_topk_logprobs"
-    else
-        pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
-            -k "test_gpt_oss_topk_logprobs"
-    fi
+    pytest models/demos/gpt_oss/tests/unit/test_sampling.py -v --timeout 600 \
+        -k "test_gpt_oss_topk_logprobs"
+}
+
+run_demo() {
+    echo "=== Running gpt-oss-120b batch128 demo (no logprobs) ==="
+    echo "  HF_MODEL=$HF_MODEL"
+    pytest models/demos/gpt_oss/demo/text_demo.py::test_gpt_oss_demo[batch128-mesh_4x8] \
+        -v -s --timeout 1200
+}
+
+run_demo_logprobs() {
+    echo "=== Running gpt-oss-120b batch128 demo (with logprobs top-5) ==="
+    echo "  HF_MODEL=$HF_MODEL"
+    pytest models/demos/gpt_oss/demo/text_demo.py::test_gpt_oss_demo[batch128_logprobs-mesh_4x8] \
+        -v -s --timeout 1200
 }
 
 case "$MODE" in
@@ -50,15 +60,25 @@ case "$MODE" in
     --gpt-oss)
         run_gpt_oss
         ;;
-    --topk-only)
-        run_sampling_module
+    --demo)
+        run_demo
+        ;;
+    --demo-logprobs)
+        run_demo_logprobs
+        ;;
+    --demo-all)
+        run_demo
         echo ""
-        run_gpt_oss
+        run_demo_logprobs
         ;;
     --all|*)
         run_sampling_module
         echo ""
         run_gpt_oss
+        echo ""
+        run_demo
+        echo ""
+        run_demo_logprobs
         ;;
 esac
 

--- a/run_logprobs_tests.sh
+++ b/run_logprobs_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run all logprobs-related tests for tt-metal and gpt-oss-120b
-# Usage: bash run_logprobs_tests.sh [--all | --sampling-module | --gpt-oss | --demo | --demo-logprobs]
+# Usage: bash run_logprobs_tests.sh [--all | --sampling-module | --gpt-oss | --demo | --demo-logprobs | --demo-compare]
 #
 # Options:
 #   --all              Run all tests (default)
@@ -8,18 +8,18 @@
 #   --gpt-oss          Run only gpt-oss-120b sampling tests
 #   --demo             Run batch128 demo without logprobs (baseline)
 #   --demo-logprobs    Run batch128 demo with logprobs (top-5)
-#   --demo-all         Run both demo variants (with and without logprobs)
+#   --demo-compare     Run both demos, save output to files, print perf diff
 #
 # Environment variables:
 #   HF_MODEL         Path to gpt-oss-120b weights (default: /localdev/gpt-oss-120b)
-#   TT_CACHE_PATH    Path to TT cache (default: /localdev/divanovic/tt-metal-cache)
+#   TT_CACHE_PATH    Path to TT cache (default: /localdev/gpt-oss-120b)
 
 set -e
 
 cd "$(dirname "$0")"
 
 export HF_MODEL=${HF_MODEL:-/localdev/gpt-oss-120b}
-export TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/divanovic/tt-metal-cache}
+export TT_CACHE_PATH=${TT_CACHE_PATH:-/localdev/gpt-oss-120b}
 
 MODE="${1:---all}"
 
@@ -39,46 +39,47 @@ run_gpt_oss() {
         -k "test_gpt_oss_topk_logprobs"
 }
 
-run_demo() {
-    echo "=== Running gpt-oss-120b batch128 demo (no logprobs) ==="
-    echo "  HF_MODEL=$HF_MODEL"
-    pytest models/demos/gpt_oss/demo/text_demo.py::test_gpt_oss_demo[batch128-mesh_4x8] \
-        -v -s --timeout 1200
-}
+run_demo_compare() {
+    OUTDIR="generated/logprobs_comparison"
+    mkdir -p "$OUTDIR"
 
-run_demo_logprobs() {
-    echo "=== Running gpt-oss-120b batch128 demo (with logprobs top-5) ==="
-    echo "  HF_MODEL=$HF_MODEL"
-    pytest models/demos/gpt_oss/demo/text_demo.py::test_gpt_oss_demo[batch128_logprobs-mesh_4x8] \
-        -v -s --timeout 1200
+    echo "=== Running batch128 WITHOUT logprobs ==="
+    echo "  Output: $OUTDIR/demo_no_logprobs.log"
+    pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8 and batch128 and not logprobs" \
+        -v -s --timeout 1200 2>&1 | tee "$OUTDIR/demo_no_logprobs.log"
+
+    echo ""
+    echo "=== Running batch128 WITH logprobs (top-5) ==="
+    echo "  Output: $OUTDIR/demo_with_logprobs.log"
+    pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8 and batch128 and logprobs" \
+        -v -s --timeout 1200 2>&1 | tee "$OUTDIR/demo_with_logprobs.log"
+
+    echo ""
+    echo "=== Comparison files saved to $OUTDIR ==="
+    echo ""
+    echo "=== Perf comparison ==="
+    echo "--- Without logprobs ---"
+    grep -E "decode_t/s|TTFT|decode speed|Performance" "$OUTDIR/demo_no_logprobs.log" || true
+    echo "--- With logprobs ---"
+    grep -E "decode_t/s|TTFT|decode speed|Performance" "$OUTDIR/demo_with_logprobs.log" || true
 }
 
 case "$MODE" in
     --sampling-module)
         run_sampling_module
         ;;
-    --gpt-oss)
+    --gpt-oss-sampling-tests)
         run_gpt_oss
         ;;
-    --demo)
-        run_demo
-        ;;
-    --demo-logprobs)
-        run_demo_logprobs
-        ;;
-    --demo-all)
-        run_demo
-        echo ""
-        run_demo_logprobs
+    --demo-compare)
+        run_demo_compare
         ;;
     --all|*)
         run_sampling_module
         echo ""
         run_gpt_oss
         echo ""
-        run_demo
-        echo ""
-        run_demo_logprobs
+        run_demo_compare
         ;;
 esac
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34080

### Problem description
Logprobs feature currently is calculated only for sampled token. Requirement is to return it for up to top-20 most probable tokens.

### Requirements
https://github.com/tenstorrent/tt-metal/issues/34080#issuecomment-4043977701

### What's changed
  - Add top-K logprobs computation on device for gpt-oss-120b model, returning top-32 logprobs + token indices per user which is sliced later in vllm.
  - Backward compatible: old models continue using the existing single sampled-token logprob path unchanged
  - New path activated via use_topk_logprobs=True flag in model args

### Algorithm description

 - After `ttnn.sampling` selects the sampled token from the gathered top-256 values (32 per device × 8 TP devices), the new logprobs path reuses those same gathered values and indices. 
 - It runs a second `ttnn.topk` to narrow 256 → 32 (tile-aligned), then computes logprobs for all 32 tokens in a single pass using the log-softmax formula: `logprob = logit - global_max - log(global_exp_sum)`, where global stats are computed via all-gather across TP devices. The sampled token is guaranteed to be within the top-32 since it was selected from them in `ttnn.sampling` ( runs top-32 hard-coded). 
- Device returns LogProbsResult(topk_logprobs[B,32], topk_indices[B,32]) to host, where per-user trimming to the requested num_logprobs (0-20) happens either in tt-metal's transfer_logprobs_to_host for demo(standalone
  path) or in vLLM's _build_logprobs_from_topk (serving path).

New: LogProbsResult dataclass and top-K logprobs path (tt_log_probs.py)
  - LogProbsResult holds top-32 logprobs + global vocab indices on device/host
  - calculate_topk_log_probs(): computes logprobs for gathered top-32 tokens using global max/sum-exp stats
  - transfer_logprobs_to_host(): converts to per-user dicts for tt-metal standalone path
  - to_cpu(): transfers raw tensors to host for vLLM path
  - Per-user state: logprobs_enabled, num_logprobs, topk_logprobs_needed
  - use_topk_logprobs flag controls tensor allocation: new path gets topk_logprobs_output[B,32] + topk_indices_output[B,32], old path keeps mask + output_tensor. Unused tensors are None.

  Updated: TTSampling (tt_sampling.py)
  - reset_params() extended with num_logprobs and empty_slots
  - forward() conditionally calls calculate_topk_log_probs (new) or calculate_log_probs (old) based on use_topk_logprobs flag
  - Argmax path returns None for logprobs (was computing unnecessary logprobs before)
  - Changed topk_global_indices dtype from int32 to uint32

  Updated: SamplingParams / generator.py
  - Added num_logprobs: int | list[int] = 0 field
  - format_sampling_params: pads and broadcasts enable_log_probs and num_logprobs to batch size
  - reset_sampling_params: passes num_logprobs and empty_slots through

  Updated: generator.py (tt_transformers)
  - read_decode_output: handles LogProbsResult in sync/async read paths
  - process_decode_output_host: converts LogProbsResult to (topk_lp[B,32], topk_idx[B,32]) tuple for vLLM, normalizes mixed DP rank formats

  Updated: gpt-oss Model (model.py)
  - _reset_with_flag wrapper accepts **kwargs for empty_slots passthrough

  New tests:
  - 6 TG Galaxy tests in `models/common/tests/test_sampling.py `(PCC, disabled state, per-user mixed, response format, state validation, torch-vs-tt PCC)
  - `test_gpt_oss_topk_logprobs` in gpt-oss unit tests
  - `run_logprobs_tests.sh` script with --all, --sampling-module, --gpt-oss options

### Tests (To be added)
- [ ] [Galaxy demo gpt-oss](https://github.com/tenstorrent/tt-metal/actions/runs/23468580848)
- [ ] [vllm nightly with sampling - gpt-oss-120b ](https://github.com/tenstorrent/tt-metal/actions/runs/23495556998/job/68387342968)
- [ ] [local gpt-oss-120b test](passed)
- [ ] [topk_logprobs unit tests](passed)