### PR TITLE
Fix ttnn.pad crash when padding small width to large width

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -57,6 +57,70 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
     assert torch.equal(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize(
+    "shape,padding,torch_padding",
+    [
+        ((8, 1, 1, 1), ((0, 0), (0, 0), (0, 0), (0, 191)), (0, 191, 0, 0, 0, 0, 0, 0)),
+        ((1, 1, 1, 2), ((0, 0), (0, 0), (0, 0), (0, 254)), (0, 254, 0, 0, 0, 0, 0, 0)),
+        ((4, 1, 1, 4), ((0, 0), (0, 0), (0, 0), (0, 60)), (0, 60, 0, 0, 0, 0, 0, 0)),
+    ],
+)
+@pytest.mark.parametrize("value", [0])
+def test_pad_rm_small_to_large_width(device, shape, padding, torch_padding, value):
+    """Regression test for issue #39875: padding from very small width to large width
+    caused CB allocation to exceed L1 size due to using input width for stick batching."""
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(shape).bfloat16().float()
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+def run_pad_rm_small_to_large_width_with_program_cache(device, shape, padding, torch_padding, value):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(shape).bfloat16().float()
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    with device.cache_entries_counter.measure():
+        output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape,padding,torch_padding",
+    [
+        ((8, 1, 1, 1), ((0, 0), (0, 0), (0, 0), (0, 191)), (0, 191, 0, 0, 0, 0, 0, 0)),
+    ],
+)
+@pytest.mark.parametrize("value", [0])
+def test_pad_rm_small_to_large_width_with_program_cache(device, shape, padding, torch_padding, value):
+    """Regression test for issue #39875 with program cache: ensure override_runtime_arguments
+    also uses output stick size for CB batching."""
+    for _ in range(2):
+        run_pad_rm_small_to_large_width_with_program_cache(device, shape, padding, torch_padding, value)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttnn.from_torch(
+            py_dummy_tensor,
+            dtype=ttnn.DataType.BFLOAT16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+    assert device.cache_entries_counter.total == 1
+
+
 def run_pad_with_program_cache(device, n, c, h, w, padding, torch_padding, value, dtype, layout):
     torch.manual_seed(0)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -111,7 +111,7 @@ def test_pad_rm_small_to_large_width_with_program_cache(device, shape, padding, 
         run_pad_rm_small_to_large_width_with_program_cache(device, shape, padding, torch_padding, value)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.from_torch(
+        ttnn.from_torch(
             py_dummy_tensor,
             dtype=ttnn.DataType.BFLOAT16,
             layout=ttnn.TILE_LAYOUT,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "pad_rm_reader_writer_multi_core_default_program_factory.hpp"
 
+#include <algorithm>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -20,14 +20,12 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
 
-uint32_t get_num_stick_per_barrier(const Tensor& input_tensor) {
-    uint32_t W = input_tensor.padded_shape()[3];
-    uint32_t W_bytes = W * input_tensor.element_size();
+uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
     uint32_t num_stick_per_barrier = 0;
-    for (uint32_t cur_bytes = 0; cur_bytes < max_read_size; cur_bytes += W_bytes) {
+    for (uint32_t cur_bytes = 0; cur_bytes < max_read_size; cur_bytes += stick_size_padded_aligned) {
         num_stick_per_barrier++;
     }
-    return num_stick_per_barrier;
+    return std::max(num_stick_per_barrier, uint32_t{1});
 }
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_rm(
@@ -40,7 +38,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     const CoreRangeSet& core_group_2,
     uint32_t num_w_sticks_per_core_group_2,
     uint32_t num_input_pages_in_row,
-    uint32_t num_output_pages_in_row) {
+    uint32_t num_output_pages_in_row,
+    uint32_t stick_size_padded_aligned) {
     auto* input_buffer = input_tensor.buffer();
     auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
@@ -70,7 +69,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
             num_sticks_per_core = 0;
         }
 
-        uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(input_tensor);
+        uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
         // reader
         std::vector<uint32_t> reader_runtime_args = {
             input_buffer->address(),
@@ -275,14 +274,15 @@ PadRmReaderWriterMultiCoreDefaultProgramFactory::create(
         core_group_2,
         num_sticks_padded_per_core_group_2,
         num_input_pages_in_row,
-        num_output_pages_in_row);
+        num_output_pages_in_row,
+        stick_size_padded_aligned);
 
     for (uint32_t i = 0; i < cores_in_order.size(); i++) {
         CoreCoord core = cores_in_order[i];
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
     }
-    uint32_t cb_npages = get_num_stick_per_barrier(a);
+    uint32_t cb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
     const uint32_t buffer_reader_writer_async_factor = 16;
     tt::tt_metal::CircularBufferConfig cb_src0_config =
         tt::tt_metal::CircularBufferConfig(
@@ -344,6 +344,10 @@ void PadRmReaderWriterMultiCoreDefaultProgramFactory::override_runtime_arguments
         num_output_pages_in_row = tt::div_up(operation_attributes.output_padded_shape[-1], output_shard_width);
     }
 
+    uint32_t W_padded = operation_attributes.output_padded_shape[3];
+    auto stick_size_padded = W_padded * src_tensor.element_size();
+    uint32_t stick_size_padded_aligned = tt::align(stick_size_padded, hal::get_l1_alignment());
+
     auto all_runtime_args = get_runtime_args_rm(
         src_tensor,
         dst_tensor,
@@ -354,7 +358,8 @@ void PadRmReaderWriterMultiCoreDefaultProgramFactory::override_runtime_arguments
         core_group_2,
         num_sticks_padded_per_core_group_2,
         num_input_pages_in_row,
-        num_output_pages_in_row);
+        num_output_pages_in_row,
+        stick_size_padded_aligned);
 
     for (uint32_t i = 0; i < cores_in_order.size(); i++) {
         CoreCoord core = cores_in_order[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -22,11 +22,7 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 namespace {
 
 uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
-    uint32_t num_stick_per_barrier = 0;
-    for (uint32_t cur_bytes = 0; cur_bytes < max_read_size; cur_bytes += stick_size_padded_aligned) {
-        num_stick_per_barrier++;
-    }
-    return std::max(num_stick_per_barrier, uint32_t{1});
+    return std::max(tt::div_up(max_read_size, stick_size_padded_aligned), 1u);
 }
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_rm(


### PR DESCRIPTION
## Summary
- Fixes #39875 — `ttnn.pad` crashed with L1 overflow (6.4MB vs 1.5MB limit) when padding from shape `[8,1,1,1]` to `[8,1,1,192]`
- Root cause: `get_num_stick_per_barrier()` in the multi-core RM pad factory used the **input** tensor width (1) to compute how many sticks to batch, but the circular buffer stores **output**-sized sticks (192 wide). This made `num_stick_per_barrier` = 1024, and with the 16x async factor the CB allocation exploded.
- Fix: use the output padded stick size (`stick_size_padded_aligned`) in `get_num_stick_per_barrier()` so CB allocation scales correctly with the actual data stored in the buffer.

## Test plan
- [x] Added `test_pad_rm_small_to_large_width` — 3 parametrized cases including the exact shape from the issue `[8,1,1,1]→[8,1,1,192]`
- [x] Added `test_pad_rm_small_to_large_width_with_program_cache` — verifies the program cache path (`override_runtime_arguments`) also works
- [x] Existing `test_pad_rm` tests pass (no regressions)