### PR TITLE
Fix multi host CI pipeline for MTP demo tests

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -356,10 +356,8 @@ jobs:
             generated/artifacts/dual_demo_full_results.json
           if-no-files-found: warn
 
-      # Temporary skip while https://github.com/tenstorrent/tt-metal/pull/40317
-      # attempts a proper fix; dual MTP smoke currently times out in CI.
       - name: Run dual MTP demo parity smoke test
-        if: ${{ false && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -383,7 +381,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
 
       - name: Upload dual MTP demo output artifacts
-        if: ${{ false && always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-mtp-output-${{ github.run_id }}

--- a/models/demos/deepseek_v3/demo/test_mtp_demo.py
+++ b/models/demos/deepseek_v3/demo/test_mtp_demo.py
@@ -97,10 +97,13 @@ def test_mtp_demp_compare_outputs(
         repeat_batches=1,
         force_recalculate=force_recalculate_weight_config,
         signpost=True,
+        sampling_temperature=0.0,
+        sampling_top_k=1,
+        sampling_top_p=1.0,
     )
 
     baseline = run_demo(enable_mtp=False, **common_kwargs)
-    mtp = run_demo(enable_mtp=True, **common_kwargs)
+    mtp = run_demo(enable_mtp=True, sample_on_device=False, **common_kwargs)
 
     _assert_demo_outputs_match(baseline, mtp)
 

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -241,10 +241,15 @@ run_dual_demo_test() {
 }
 
 run_dual_demo_mtp_test() {
+    fail=0
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 2400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_full_demo_mtp]' 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log" ; fail+=$?
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 run_quad_demo_test() {
@@ -260,10 +265,15 @@ run_quad_demo_test() {
 }
 
 run_quad_demo_mtp_test() {
+    fail=0
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_full_demo_mtp]' 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log" ; fail+=$?
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
 }
 
 ###############################################################################

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -229,51 +229,32 @@ run_quad_teacher_forced_test() {
 ###############################################################################
 
 run_dual_demo_test() {
-    fail=0
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 2400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_full_demo]' 2>&1 | tee generated/artifacts/dual_demo_output.log" ; fail+=$?
-
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_full_demo]' 2>&1 | tee generated/artifacts/dual_demo_output.log"
 }
 
 run_dual_demo_mtp_test() {
-    fail=0
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 2400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log" ; fail+=$?
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
 
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
 }
 
 run_quad_demo_test() {
-    fail=0
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_full_demo]' 2>&1 | tee generated/artifacts/quad_demo_output.log" ; fail+=$?
-
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_full_demo]' 2>&1 | tee generated/artifacts/quad_demo_output.log"
 }
 
 run_quad_demo_mtp_test() {
-    fail=0
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log" ; fail+=$?
-
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout models/demos/deepseek_v3/demo/test_mtp_demo.py 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
 }
 
 ###############################################################################
@@ -281,27 +262,17 @@ run_quad_demo_mtp_test() {
 ###############################################################################
 
 run_dual_demo_stress_test() {
-    fail=0
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 5400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_stress_demo]' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log" ; fail+=$?
-
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_stress_demo]' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log"
 }
 
 run_quad_demo_stress_test() {
-    fail=0
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 5400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_stress_demo]' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log" ; fail+=$?
-
-    if [[ $fail -ne 0 ]]; then
-        exit 1
-    fi
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_stress_demo]' 2>&1 | tee generated/artifacts/quad_demo_stress_output.log"
 }
 
 ###############################################################################


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently the multi host CI pipeline fails due to missing mtp demo signature

### What's changed
Updated pipeline (dual/quad) to use test_mtp_demo.py instead of demo.py directly.

### Checklist

[![DeepSeek V3 Multi-Host Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch%3Ajrock%2Fds-fix-mtp-ci-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ajrock%2Fds-fix-mtp-ci-pipeline)
