### PR TITLE
Enable more ttnn tests on BH ttsim

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -151,40 +151,17 @@ blackhole:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
 
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
   - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_relational.py
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_activation.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_composite.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_divide.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_math.py
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
 
   # Core tests
   - tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
@@ -193,9 +170,6 @@ blackhole:
   - tests/ttnn/unit_tests/base_functionality/test_cpp_logging.py
   - tests/ttnn/unit_tests/base_functionality/test_concat_issue.py
   - tests/ttnn/unit_tests/base_functionality/test_async.py
-
-  # Eltwise tests (BH-specific failures)
-  - tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
 
   # Conv tests
   - tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -216,11 +190,8 @@ blackhole:
   - tests/ttnn/unit_tests/operations/pool/test_upsample.py
 
   # Matmul tests (same simulator limitations as wormhole)
-  - tests/ttnn/unit_tests/operations/matmul/test_addmm.py
   - tests/ttnn/unit_tests/operations/matmul/test_matmul.py
   - tests/ttnn/unit_tests/operations/matmul/test_linear.py
-  - tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
-  - tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
 
   # Fused tests (same simulator limitations as wormhole + BH-specific)
   - tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -231,11 +202,6 @@ blackhole:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
   - tests/ttnn/unit_tests/operations/fused/parallel_sequential/
-
-  # Transformers tests (same as wormhole + BH-specific)
-  - tests/ttnn/unit_tests/operations/transformers/test_transformer.py
-  - tests/ttnn/unit_tests/operations/transformers/test_paged_fused_update_cache.py
-  - tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
 
   # Reduce tests (same as wormhole + BH-specific)
   - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py


### PR DESCRIPTION
### Ticket
/

### Problem description
ttnn CI test coverage on ttsim is incomplete.

### What's changed
Removed tests from BH skip list that are now passing.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
