### PR TITLE
Add skips for new fused tests that are failing when LLK asserts are enabled

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -396,7 +396,7 @@ class TestShardedExecution:
         golden = rms_norm_golden(sh_ln_golden(torch_input, weight=torch_w), torch_w)
         check_pcc(golden, fused.output_tensors[0], label=f"sharded {shard_type}")
 
-    @skip_with_llk_assert("Compiler error with LLK asserts enabled")
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue: #40330")
     def test_sharded_three_phase(self, device):
         """3-phase LN->RMS->LN block-sharded on 4x4 grid."""
         from models.experimental.ops.descriptors.fusion import Sequential
@@ -880,6 +880,7 @@ class TestBranchingTopology:
         for i, label in enumerate(["LL", "LR", "RL", "RR"]):
             check_pcc(goldens[i], fused.output_tensors[i], label=label)
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue: #40330")
     def test_asymmetric_deep_left(self, device, multi_tensors):
         """Deep left + shallow right.
 

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -24,7 +24,7 @@ import torch
 import ttnn
 
 
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, skip_with_llk_assert
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +199,7 @@ class TestInfrastructure:
 class TestSequentialExecution:
     """Core sequential chain execution tests."""
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize("num_phases", [2, 3, 4])
     def test_norm_chain(self, device, test_tensors, num_phases):
         """Mixed LN/RMS chain of varying length on single core."""
@@ -340,6 +341,7 @@ class TestSequentialExecution:
 class TestShardedExecution:
     """Sharded (L1) execution tests."""
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize(
         "shard_type",
         [
@@ -394,6 +396,7 @@ class TestShardedExecution:
         golden = rms_norm_golden(sh_ln_golden(torch_input, weight=torch_w), torch_w)
         check_pcc(golden, fused.output_tensors[0], label=f"sharded {shard_type}")
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled")
     def test_sharded_three_phase(self, device):
         """3-phase LN->RMS->LN block-sharded on 4x4 grid."""
         from models.experimental.ops.descriptors.fusion import Sequential
@@ -444,6 +447,7 @@ class TestShardedExecution:
         golden = sh_ln_golden(g, weight=torch_ws[2])
         check_pcc(golden, fused.output_tensors[0], label="sharded 3-phase")
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     def test_sharded_with_bias_residual(self, device):
         """LN(bias+residual)->RMS block-sharded, single-stage."""
         from models.experimental.ops.descriptors.fusion import Sequential
@@ -650,6 +654,7 @@ class TestMatmulFusion:
         golden = torch_rms_norm(torch_rms_norm(torch_input.float(), torch_w.float()) @ torch_b.float(), torch_w.float())
         check_pcc(golden, fused.output_tensors[0], label="multicore RMS->MM->RMS")
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     @pytest.mark.parametrize("num_rms", [2, 3, 4])
     def test_matmul_followed_by_n_rms(self, device, num_rms):
         """MM then N consecutive RMS norms."""
@@ -983,6 +988,7 @@ class TestParallelExecution:
             )
             check_pcc(golden, fused_ops[i].output_tensors[0], label=f"chain {i}")
 
+    @skip_with_llk_assert("Compiler error with LLK asserts enabled. Issue #40330")
     def test_matmul_plus_fused_chain(self, device, test_tensors):
         """Matmul + 3-phase norm chain on disjoint cores."""
         from models.experimental.ops.descriptors.fusion import Sequential

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
@@ -6,10 +6,8 @@ import pytest
 import ttnn
 
 from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_prefill_impl
-from models.common.utility_functions import skip_with_llk_assert
 
 
-@skip_with_llk_assert("Hits LLK assert check for are_unpacker_AB_configured_correctly. Issue: #39199")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
@@ -6,8 +6,10 @@ import pytest
 import ttnn
 
 from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_prefill_impl
+from models.common.utility_functions import skip_with_llk_assert
 
 
+@skip_with_llk_assert("Hits LLK assert check for are_unpacker_AB_configured_correctly. Issue: #39199")
 @pytest.mark.parametrize(
     "batch, seq_len, nh, nkv, kv_lora_rank, d_rope",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope

--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -89,7 +89,7 @@ ALWI void sub_bcast_rows_init_short_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::ROW, MATH_FIDELITY>()));  // TODO(AP)
+    MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1)));
 }
@@ -686,7 +686,7 @@ ALWI void sub_tiles_bcast_rows_to_cb(
 #endif
     // sub_bcast_rows_init_short();
     {
-        MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::ROW, MATH_FIDELITY>()));
+        MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::ROW, MathFidelity::LoFi>()));
         UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(0, 1)));
     }
     sub_tiles_bcast<BroadcastType::ROW>(icb0, icb1, itile0, itile1, dst0);


### PR DESCRIPTION
### Ticket
#40330 

### Problem description
There is a new test test_parallel_sequential.py added which is not running successfully for the case when LLK asserts are enabled.

### What's changed
Added skips for tests which when ran with TT_METAL_LLK_ASSERTS=1 are failing.

After skips are added, we can see that ttnn fused group of tests is green
BHPC:
https://github.com/tenstorrent/tt-metal/actions/runs/23325694285


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_new_fuser_test_when_llk_asserts_are_enabled)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
