### PR TITLE
[Cleanup]: Move dataflow buffer device headers to help differentiate between 1xx and 2xx implementation of dfbs

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -24,7 +24,7 @@
 
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
@@ -140,13 +140,13 @@ void run_single_dfb_program(
             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     }
 
-    uint32_t num_entries_per_consumer = dfb_config.cap == ::experimental::AccessPattern::STRIDED
+    uint32_t num_entries_per_consumer = dfb_config.cap == dfb::AccessPattern::STRIDED
                                             ? dfb_config.num_entries / dfb_config.num_consumers
                                             : dfb_config.num_entries;
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
         num_entries_per_consumer,
-        (uint32_t)dfb_config.cap == ::experimental::AccessPattern::BLOCKED,
+        (uint32_t)dfb_config.cap == dfb::AccessPattern::BLOCKED,
         (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
 
@@ -234,7 +234,7 @@ void run_in_dfb_out_dfb_program(
         experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1, .compile_args = compute_cta});
 
     uint32_t num_entries_per_consumer = tensix2dm_config.num_entries / tensix2dm_config.num_consumers;
-    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address(), num_entries_per_consumer, (uint32_t)tensix2dm_config.cap == ::experimental::AccessPattern::BLOCKED};
+    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address(), num_entries_per_consumer, (uint32_t)tensix2dm_config.cap == dfb::AccessPattern::BLOCKED};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
     auto consumer_kernel = experimental::quasar::CreateKernel(
         program,
@@ -271,9 +271,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -287,9 +287,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
@@ -303,9 +303,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
@@ -319,18 +319,18 @@ TEST_F(MeshDeviceFixture, DMTensixDMTest2xDFB1Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     experimental::dfb::DataflowBufferConfig tensix2dm_config{
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+            .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
@@ -344,18 +344,18 @@ TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB2Sx1S1xDFB1Sx2S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     experimental::dfb::DataflowBufferConfig tensix2dm_config{
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
@@ -369,18 +369,18 @@ TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB4Sx1S1xDFB1Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     experimental::dfb::DataflowBufferConfig tensix2dm_config{
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
@@ -394,9 +394,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -410,9 +410,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -425,9 +425,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -440,9 +440,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -456,9 +456,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -471,9 +471,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -486,9 +486,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -502,9 +502,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
@@ -518,9 +518,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -533,9 +533,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -549,9 +549,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -564,9 +564,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -579,9 +579,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -595,9 +595,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -610,9 +610,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2S) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -627,9 +627,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -643,9 +643,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
@@ -659,9 +659,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -674,9 +674,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1B) { // mismatching
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -690,9 +690,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
@@ -706,9 +706,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx1B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
@@ -722,9 +722,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4B) { // mismatching
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -738,9 +738,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
@@ -754,9 +754,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
@@ -770,9 +770,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx2B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -786,9 +786,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx2B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -801,9 +801,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB4Sx2B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
@@ -816,9 +816,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
 
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
@@ -832,9 +832,9 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX);
 }
@@ -847,9 +847,9 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4B) {
         .entry_size = 1024,
         .num_entries = 16,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = GetParam()};
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -26,7 +26,7 @@
 
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
@@ -88,7 +88,7 @@ void validate_dfb_tile_counters(
             uint8_t expected_tensix_id = (risc_id - 8) % 4;
             for (uint8_t tc = 0; tc < rc->config.num_tcs_to_rr; tc++) {
                 auto ptc = rc->config.packed_tile_counter[tc];
-                uint8_t actual_tensix_id = ::experimental::get_tensix_id(ptc);
+                uint8_t actual_tensix_id = dfb::get_tensix_id(ptc);
                 EXPECT_EQ(actual_tensix_id, expected_tensix_id)
                     << "Tensix producer RISC " << (int)risc_id << " TC[" << (int)tc
                     << "] must use tensix_id=" << (int)expected_tensix_id << " but has " << (int)actual_tensix_id;
@@ -102,7 +102,7 @@ void validate_dfb_tile_counters(
             uint8_t expected_tensix_id = (risc_id - 8) % 4;
             for (uint8_t tc = 0; tc < rc->config.num_tcs_to_rr; tc++) {
                 auto ptc = rc->config.packed_tile_counter[tc];
-                uint8_t actual_tensix_id = ::experimental::get_tensix_id(ptc);
+                uint8_t actual_tensix_id = dfb::get_tensix_id(ptc);
                 EXPECT_EQ(actual_tensix_id, expected_tensix_id)
                     << "Tensix consumer RISC " << (int)risc_id << " TC[" << (int)tc
                     << "] must use tensix_id=" << (int)expected_tensix_id << " but has " << (int)actual_tensix_id;
@@ -111,7 +111,7 @@ void validate_dfb_tile_counters(
     }
 
     // For BLOCKED mode, validate remapper pair indices
-    if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+    if (config.cap == dfb::AccessPattern::BLOCKED) {
         std::set<uint8_t> seen_remapper_indices;
         for (const auto& [risc_id, rc] : producer_configs) {
             uint8_t remapper_idx = rc->config.remapper_pair_index;
@@ -153,11 +153,11 @@ void validate_dfb_tile_counters(
             auto producer_ptc = producer_rc->config.packed_tile_counter[producer_tc_slot];
             auto consumer_ptc = consumer_rc->config.packed_tile_counter[consumer_tc_slot];
 
-            if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            if (config.cap == dfb::AccessPattern::BLOCKED) {
                 // For BLOCKED mode, consumer TCs are different from producer TC (remapper-based)
                 // Accumulate the consumer TC IDs into expected_consumer_tcs
                 if (consumer_idx < 4) {
-                    uint8_t consumer_tc_id = ::experimental::get_counter_id(consumer_ptc);
+                    uint8_t consumer_tc_id = dfb::get_counter_id(consumer_ptc);
                     expected_consumer_tcs |= (consumer_tc_id & 0x1F) << (consumer_idx * 5);
                     consumer_idx++;
                 }
@@ -167,21 +167,21 @@ void validate_dfb_tile_counters(
                     "BLOCKED: Producer {} TC[{}]=(tensix:{}, tc:{}) -> Consumer {} TC[{}]=(tensix:{}, tc:{})",
                     producer_risc_id,
                     producer_tc_slot,
-                    ::experimental::get_tensix_id(producer_ptc),
-                    ::experimental::get_counter_id(producer_ptc),
+                    dfb::get_tensix_id(producer_ptc),
+                    dfb::get_counter_id(producer_ptc),
                     consumer_risc_id,
                     consumer_tc_slot,
-                    ::experimental::get_tensix_id(consumer_ptc),
-                    ::experimental::get_counter_id(consumer_ptc));
+                    dfb::get_tensix_id(consumer_ptc),
+                    dfb::get_counter_id(consumer_ptc));
             } else {
                 // For STRIDED mode, producer and consumer should share the exact same TC
                 EXPECT_EQ(producer_ptc, consumer_ptc)
                     << "STRIDED: Producer " << (int)producer_risc_id << " TC[" << (int)producer_tc_slot
                     << "] should share TC with Consumer " << (int)consumer_risc_id << " TC[" << (int)consumer_tc_slot
-                    << "]. Producer has (tensix:" << (int)::experimental::get_tensix_id(producer_ptc)
-                    << ", tc:" << (int)::experimental::get_counter_id(producer_ptc)
-                    << "), Consumer has (tensix:" << (int)::experimental::get_tensix_id(consumer_ptc)
-                    << ", tc:" << (int)::experimental::get_counter_id(consumer_ptc) << ")";
+                    << "]. Producer has (tensix:" << (int)dfb::get_tensix_id(producer_ptc)
+                    << ", tc:" << (int)dfb::get_counter_id(producer_ptc)
+                    << "), Consumer has (tensix:" << (int)dfb::get_tensix_id(consumer_ptc)
+                    << ", tc:" << (int)dfb::get_counter_id(consumer_ptc) << ")";
 
                 log_info(
                     tt::LogTest,
@@ -190,12 +190,12 @@ void validate_dfb_tile_counters(
                     producer_tc_slot,
                     consumer_risc_id,
                     consumer_tc_slot,
-                    ::experimental::get_tensix_id(producer_ptc),
-                    ::experimental::get_counter_id(producer_ptc));
+                    dfb::get_tensix_id(producer_ptc),
+                    dfb::get_counter_id(producer_ptc));
             }
         }
 
-        if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+        if (config.cap == dfb::AccessPattern::BLOCKED) {
             uint32_t actual_consumer_tcs = producer_rc->config.consumer_tcs;
             ASSERT_EQ(actual_consumer_tcs, expected_consumer_tcs)
                 << "BLOCKED: Producer " << (int)producer_risc_id << " consumer_tcs mismatch. "
@@ -220,10 +220,10 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x1,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -249,10 +249,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x1,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x1E,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -283,10 +283,10 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -315,10 +315,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -347,10 +347,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0xF0,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -379,10 +379,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x3,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x3C,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -417,10 +417,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2SConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x30,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -449,10 +449,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x1,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -478,10 +478,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x1,
         .num_producers = 1,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x1E,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -512,10 +512,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -544,10 +544,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0xF0,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -600,10 +600,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0xF,
         .num_producers = 4,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x30,
         .num_consumers = 2,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();
@@ -651,10 +651,10 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4BConfig) {
         .num_entries = 16,
         .producer_risc_mask = 0x3,
         .num_producers = 2,
-        .pap = ::experimental::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x3C,
         .num_consumers = 4,
-        .cap = ::experimental::AccessPattern::BLOCKED,
+        .cap = dfb::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -6,6 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #ifdef ARCH_QUASAR
+#include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #ifdef ARCH_QUASAR
+#include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
@@ -35,7 +36,7 @@ void kernel_main() {
     }
 
     // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
     for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {
         noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
     }

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/kernel_types.hpp>
 
-#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
 namespace tt {
 enum class DataFormat : uint8_t;
@@ -22,8 +22,7 @@ class Program;
 
 namespace tt::tt_metal::experimental::dfb {
 
-// Alias to avoid ambiguous 'experimental' when used inside tt::tt_metal::experimental
-using AccessPattern = ::experimental::AccessPattern;
+using AccessPattern = ::dfb::AccessPattern;
 
 struct DataflowBufferConfig {
     uint32_t entry_size = 0;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -51,7 +51,7 @@ inline void llk_pack_init(const std::uint32_t pack_output) {
 template <bool out_of_order_output, bool untilize>
 inline std::uint32_t get_output_tile_index(std::uint8_t output_id, std::uint32_t output_tile_index) {
     std::uint32_t l1_tile_index;
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
     if constexpr (out_of_order_output) {
         // Use the write tile index to track position within DFB
         l1_tile_index = local_dfb_interface.wr_entry_idx + output_tile_index;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -8,7 +8,7 @@
 #include "ckernel.h"
 #include "ckernel_trisc_common.h"
 #include "internal/circular_buffer_interface.h"
-#include "internal/dataflow_buffer_init.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
 
 /**
  * @brief  Wait for num_tiles of free space in the dataflow buffer
@@ -16,8 +16,8 @@
  * @param num_tiles: Number of tiles of free space to wait for in dataflow buffer
  */
 inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
     TT_WAIT_FREE(ckernel::p_stall::STALL_PACK, num_tiles, tc_id);
 }
 
@@ -29,8 +29,8 @@ inline void llk_wait_for_free_tiles(const std::int32_t dfb_id, const std::int32_
 // Push N tiles to stream buffer (increment write pointer)
 template <std::uint8_t PACK_SEL = 0x1>
 inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
     // Update the tile counters values
     TT_PUSH_TILES(PACK_SEL, num_tiles, tc_id);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -8,7 +8,7 @@
 #include "ckernel.h"
 #include "ckernel_trisc_common.h"
 #include "internal/circular_buffer_interface.h"
-#include "internal/dataflow_buffer_init.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
 
 /**
  * @brief  Wait for num_tiles available in the incoming dataflow buffer
@@ -16,8 +16,8 @@
  * @param num_tiles: Number of tiles to wait for in dataflow buffer
  */
 inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_tiles) {
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
 
     TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, tc_id);
 }
@@ -29,8 +29,8 @@ inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_ti
  */
 template <std::uint8_t UNPACK_SEL = 0x3>
 inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
-    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
-    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = dfb::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
 
     // Wait until selected unpackers are reading from L1
     TT_POP_TILES(UNPACK_SEL, num_tiles, tc_id);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -10,10 +10,9 @@
 #include "api/debug/waypoint.h"
 #include "api/debug/dprint.h"
 #include "api/debug/device_print.h"
-#include "internal/dataflow_buffer_init.h"
 #include "internal/debug/stack_usage.h"
 #include "internal/debug/sanitize.h"
-#include "internal/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"
 #include "hostdev/dev_msgs.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "api/kernel_thread_globals.h"
@@ -102,10 +101,9 @@ void deassert_trisc() {
     deassert_trisc_reset();
 }
 
-thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
+thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 RemapperAPI g_remapper_configurator __attribute__((used));
-
-volatile experimental::TxnDFBDescriptor experimental::g_txn_dfb_descriptor[32] __attribute__((used));
+volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 
 void device_setup() {
     // instn_buf
@@ -318,7 +316,7 @@ extern "C" uint32_t _start1() {
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
                 if (enables & (1u << index)) {
                     uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
-                    experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+                    setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
                     uint32_t kernel_lma =
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
                     asm("FENCE.i");
@@ -402,7 +400,7 @@ extern "C" uint32_t _start1() {
                                                                 launch_msg->kernel_config.local_cb_offset);
         uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
 
-        experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+        setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -19,7 +19,7 @@
 #include "internal/debug/stack_usage.h"
 #include "api/debug/ring_buffer.h"
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-#include "internal/dataflow_buffer_init.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"
 #endif
 #include "tt-metalium/circular_buffer_constants.h"
 #include "api/kernel_thread_globals.h"
@@ -50,7 +50,7 @@ uint8_t my_relative_x_ __attribute__((used));
 uint8_t my_relative_y_ __attribute__((used));
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
+thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 #endif
 
 namespace ckernel {
@@ -149,7 +149,7 @@ extern "C" uint32_t _start1() {
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);
         uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
-        experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+        setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #endif
 
         // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "internal/dataflow_buffer_interface.h"
-#include "internal/dataflow_buffer_init.h"  // For g_dfb_interface extern declaration
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"  // For g_dfb_interface extern declaration
 #include "api/debug/assert.h"
 
 // TODO: make this the top level api header but then separate out 1xx and 2xx implementations
@@ -40,7 +40,7 @@ public:
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) {
         PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = get_counter_id(packed_tc);
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
         llk_wait_for_free_tiles(logical_dfb_id_, num_entries);
@@ -52,17 +52,17 @@ public:
             while (!ready) {
                 ready = true;
                 for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                    PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                    dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
                     ASSERT(llk_intf_get_capacity(get_tensix_id(ptc), get_counter_id(ptc)) >= num_entries);
                     // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
-                    if (llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc)) < num_entries) {
+                    if (llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
                         ready = false;
                         break;
                     }
                 }
             }
         } else {
-            uint8_t tensix_id = get_tensix_id(packed_tc);
+            uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
             ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
             while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
             // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
@@ -71,7 +71,7 @@ public:
     }
 
     void push_back(uint16_t num_entries) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
@@ -81,10 +81,10 @@ public:
         if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
             // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
             for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
                 ASSERT(llk_intf_get_capacity(get_tensix_id(ptc), get_counter_id(ptc)) >= num_entries);
                 // DPRINT << "push_back: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
-                llk_intf_inc_posted(get_tensix_id(ptc), get_counter_id(ptc), num_entries);
+                llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
             }
             local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
             if (local_dfb_interface_.tc_slots[0].wr_ptr == local_dfb_interface_.tc_slots[0].limit) {
@@ -92,7 +92,7 @@ public:
             }
             // tc_idx deliberately not advanced
         } else {
-            uint8_t tensix_id = get_tensix_id(packed_tc);
+            uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
             ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
             llk_intf_inc_posted(tensix_id, tc_id, num_entries);
             // DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
@@ -110,8 +110,8 @@ public:
     }
 
     void wait_front(uint16_t num_entries) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = get_counter_id(packed_tc);
+        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
         if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
@@ -119,7 +119,7 @@ public:
         }
         llk_wait_tiles(logical_dfb_id_, num_entries);
 #elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = get_tensix_id(packed_tc);
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
         // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id)
         //        << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
         //        << " tc_id: " << static_cast<uint32_t>(tc_id)
@@ -130,8 +130,8 @@ public:
     }
 
     void pop_front(uint16_t num_entries) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = get_counter_id(packed_tc);
+        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
         if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
             return;
@@ -139,7 +139,7 @@ public:
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
         llk_pop_tiles(logical_dfb_id_, num_entries);
 #elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = get_tensix_id(packed_tc);
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
         ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
         llk_intf_inc_acked(tensix_id, tc_id, num_entries);
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
@@ -157,9 +157,9 @@ public:
 #ifndef COMPILE_FOR_TRISC
     template <typename Src>
     void read_in(const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tensix_id = get_tensix_id(packed_tc);
-        uint8_t tc_id = get_counter_id(packed_tc);
+        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 
         // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW doesn't track pending posts
         // When this condition is met, we know previous reads were committed
@@ -188,9 +188,9 @@ public:
 
     template <typename Dst>
     void write_out(const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tensix_id = get_tensix_id(packed_tc);
-        uint8_t tc_id = get_counter_id(packed_tc);
+        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 
 
         // Wait for entries that were previously written across all transaction ids to be acked. Need to do this because HW doesn't track pending acks
@@ -227,15 +227,15 @@ public:
         while (!all_acked) {
             all_acked = true;
             for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                uint8_t tc_id = get_counter_id(packed_tc);
+                dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
                 if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
                     continue;
                 }
                 all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
 #elif !defined(COMPILE_FOR_TRISC)
-                uint8_t tensix_id = get_tensix_id(packed_tc);
+                uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
                 // DPRINT << "read acked: " << static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id)) << " read posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
                 all_acked &=
                     (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -6,9 +6,9 @@
 
 #include <cstdint>
 
-namespace experimental {
+namespace dfb {
 
-enum AccessPattern : uint8_t {  // this should be put into experimental/hostdev or should it be a host file???
+enum AccessPattern : uint8_t {
     STRIDED,
     BLOCKED,
     UNKNOWN,
@@ -46,7 +46,7 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
 }
 // NOLINTEND(readability-redundant-inline-specifier)
 
-// move configs and LocalDFBInterface structs to hw/inc/hostdev
+}  // namespace dfb
 
 /*
     tensix + dm or tensix + tensix via remapper dfb
@@ -64,7 +64,7 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
     (36 + (44 * 12)) * 16 = 8336 bytes
 */
 struct dfb_txn_id_descriptor_t {
-    uint8_t txn_ids[NUM_TXN_IDS];
+    uint8_t txn_ids[dfb::NUM_TXN_IDS];
     uint8_t num_entries_to_process_threshold; // entries each txn ID tracks before posting/acking
     uint8_t num_txn_ids;
     uint8_t num_entries_per_txn_id;
@@ -89,11 +89,11 @@ struct dfb_initializer_t {  // 36 bytes
 } __attribute__((packed));
 
 struct dfb_initializer_per_risc_t {  // 44 bytes
-    uint32_t base_addr[MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t limit[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t base_addr[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t limit[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
     uint32_t consumer_tcs;  // used to program remapper, for a L:R mapping contains all the TCs on the consumer side
                             // (R). TC can be value between 0 and 31 (5 bits, max of 4 TCs)
-    PackedTileCounter packed_tile_counter[MAX_NUM_TILE_COUNTERS_TO_RR];
+    dfb::PackedTileCounter packed_tile_counter[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
     struct {
         uint8_t num_tcs_to_rr : 4;   // 0..8, number of TCs to round-robin (max 4 but keeping space)
         uint8_t tc_init_done : 1;
@@ -118,62 +118,10 @@ struct dfb_initializer_intra_tensix_t {  // 24 bytes
     uint32_t base_addr;
     uint32_t limit;
     uint16_t capacity;
-    PackedTileCounter packed_tile_counter;
+    dfb::PackedTileCounter packed_tile_counter;
     uint8_t tensix_mask;
 } __attribute__((packed));
 
-
-// TODO: Put LocalDFBInterface into device only header so fields can be ifdef for trisc vs dm
-
-// Per–tile-counter slot
-struct DFBTCSlot {
-    uint32_t rd_ptr;
-    uint32_t wr_ptr;
-    uint32_t base_addr;
-    uint32_t limit;
-    PackedTileCounter packed_tile_counter;
-} __attribute__((packed));
-
-// on WH/BH arrays will be sized to 1
-struct LocalDFBInterface {
-    DFBTCSlot tc_slots[MAX_NUM_TILE_COUNTERS_TO_RR];
-
-    uint32_t entry_size;
-    uint32_t stride_size;
-
-    // Entry indices tracking how many entries from DFB base the rd/wr pointers are
-    uint32_t stride_size_tiles; // used by triscs to calculate tile offset from base L1 address
-    uint32_t rd_entry_idx;
-    uint32_t wr_entry_idx;
-    uint32_t wr_entry_ptr;
-
-    uint8_t txn_ids[NUM_TXN_IDS];
-    uint8_t
-        num_entries_per_txn_id;
-    uint8_t num_entries_per_txn_id_per_tc;
-    uint8_t num_tcs_to_rr;
-    uint8_t num_txn_ids;
-    uint8_t tc_idx;
-    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
-    uint8_t broadcast_tc;       // DM-DM BLOCKED producer: post to all TCs instead of round-robin
-
-} __attribute__((packed));
-
-// Holds metadata for transaction ID based ISR handling
-// It is used by the ISR to understand which tile counters need to update which credits (post/ack)
-struct TxnDFBDescriptor {
-    uint8_t num_counters;
-    PackedTileCounter tile_counters[MAX_NUM_TILE_COUNTERS_TO_RR];
-    union {
-        uint8_t tiles_to_post;
-        uint8_t tiles_to_ack;
-    } __attribute__((packed));
-};
-
-static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
 static_assert(sizeof(dfb_initializer_t) == 36, "dfb_initializer_t size is incorrect");
 static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 103, "LocalDFBInterface size is incorrect");
-
-}  // namespace experimental

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -6,26 +6,18 @@
 
 #include <cstdint>
 
-#include "internal/dataflow_buffer_interface.h"
-#include "internal/circular_buffer_interface.h"  // for cb_addr_shift
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h"
 #include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
+#include "internal/circular_buffer_interface.h"  // for cb_addr_shift
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
-#include "internal/tt-2xx/quasar/overlay/dataflow_buffer_isr.h"
 #else
 #include "ckernel_trisc_common.h"
 #endif
 
 #include "api/debug/dprint.h"
-
-// Global DFB interface array - defined in firmware, declared here for use by setup functions
-// For kernels (NCRISC/BRISC/TRISC), provide a definition since they're compiled separately
-extern thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS];
-#ifndef COMPILE_FOR_TRISC
-extern RemapperAPI g_remapper_configurator;
-#endif
-
-namespace experimental {
 
 FORCE_INLINE void setup_isr_csrs() {
 #ifndef COMPILE_FOR_TRISC
@@ -76,7 +68,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
 
             // Populate LocalDFBInterface from combined dfb_initializer_t + dfb_initializer_per_risc_t
-            LocalDFBInterface& dfb_interface = ::g_dfb_interface[logical_dfb_id];
+            LocalDFBInterface& dfb_interface = g_dfb_interface[logical_dfb_id];
 
             // DPRINT << "risc_index: " << static_cast<uint32_t>(risc_index) << ENDL();
             dfb_interface.num_tcs_to_rr = per_risc_ptr->num_tcs_and_init.num_tcs_to_rr;
@@ -129,7 +121,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     }
 
 #ifndef COMPILE_FOR_TRISC
-    // DM0 handles all remapper configuration and DM producer TC initialization
+    // DM0 handles all remapper configuration and transaction id ISR initialization
     if (hartid == 0) {
         // Pass A: configure remapper for all DM producers across all DFBs, then enable
         bool enable_remapper = false;
@@ -144,9 +136,9 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
 
             uint8_t num_producer_tcs = 0;
-            uint8_t producer_tcs[MAX_NUM_TILE_COUNTERS_TO_RR] = {};
+            uint8_t producer_tcs[dfb::MAX_NUM_TILE_COUNTERS_TO_RR] = {};
             uint8_t num_consumer_tcs = 0;
-            uint8_t consumer_tcs[MAX_NUM_TILE_COUNTERS_TO_RR] = {};
+            uint8_t consumer_tcs[dfb::MAX_NUM_TILE_COUNTERS_TO_RR] = {};
             for (uint8_t i = 0; i < num_riscs; i++) {
                 volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
 
@@ -163,7 +155,7 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                         //        << " mask: " << static_cast<uint32_t>(clientR_valid_mask) << ENDL();
                         g_remapper_configurator.configure_clientL_all_fields(
                             producer_client_type,
-                            get_counter_id(per_risc_ptr->packed_tile_counter[0]),
+                            dfb::get_counter_id(per_risc_ptr->packed_tile_counter[0]),
                             clientR_valid_mask,
                             1,  // is_producer
                             1,  // group mode
@@ -266,15 +258,15 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 
                 // Note: resetting tile counters does not reset the buffer capacity to 0
                 for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; tc++) {
-                    PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
-                    uint8_t tc_id = get_counter_id(ptc);
+                    dfb::PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
+                    uint8_t tc_id = dfb::get_counter_id(ptc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
                     // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id)
                     //         << " initializing tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
                     ckernel::trisc::tile_counters[tc_id].f.reset = 1;
                     ckernel::trisc::tile_counters[tc_id].f.buf_capacity = init_ptr->capacity;
 #elif !defined(COMPILE_FOR_TRISC)
-                    uint8_t tensix_id = get_tensix_id(ptc);
+                    uint8_t tensix_id = dfb::get_tensix_id(ptc);
                     // DPRINT << "dfb " << static_cast<uint32_t>(logical_dfb_id)
                     //         << " initializing tc tensix_id: " << static_cast<uint32_t>(tensix_id)
                     //         << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
@@ -319,5 +311,3 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     }
     // DPRINT << "all_tcs_initialized" << ENDL();
 }
-
-}  // namespace experimental

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "dataflow_buffer_config.h"
+#ifndef COMPILE_FOR_TRISC
+#include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
+#endif
+
+// Forward declarations
+struct LocalDFBInterface;
+struct TxnDFBDescriptor;
+
+// Global DFB interface array
+extern thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS];
+#ifndef COMPILE_FOR_TRISC
+// TODO: make this a constant when we clean up number of txn ids
+extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
+extern RemapperAPI g_remapper_configurator;
+#endif
+
+// Per–tile-counter slot
+struct DFBTCSlot {
+    uint32_t rd_ptr;
+    uint32_t wr_ptr;
+    uint32_t base_addr;
+    uint32_t limit;
+    dfb::PackedTileCounter packed_tile_counter;
+} __attribute__((packed));
+
+// on WH/BH arrays will be sized to 1
+struct LocalDFBInterface {
+    DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+
+    uint32_t entry_size;
+    uint32_t stride_size;
+
+    // Entry indices tracking how many entries from DFB base the rd/wr pointers are
+    uint32_t stride_size_tiles; // used by triscs to calculate tile offset from base L1 address
+    uint32_t rd_entry_idx;
+    uint32_t wr_entry_idx;
+    uint32_t wr_entry_ptr;
+
+    uint8_t txn_ids[dfb::NUM_TXN_IDS];
+    uint8_t
+        num_entries_per_txn_id;
+    uint8_t num_entries_per_txn_id_per_tc;
+    uint8_t num_tcs_to_rr;
+    uint8_t num_txn_ids;
+    uint8_t tc_idx;
+    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
+    uint8_t broadcast_tc;       // DM-DM BLOCKED producer: post to all TCs instead of round-robin
+
+} __attribute__((packed));
+
+// Holds metadata for transaction ID based ISR handling
+// It is used by the ISR to understand which tile counters need to update which credits (post/ack)
+struct TxnDFBDescriptor {
+    uint8_t num_counters;
+    dfb::PackedTileCounter tile_counters[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
+    union {
+        uint8_t tiles_to_post;
+        uint8_t tiles_to_ack;
+    } __attribute__((packed));
+};
+
+static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 103, "LocalDFBInterface size is incorrect");

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include "internal/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
 
-namespace experimental {
-
-extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
-
 inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
+#ifndef COMPILE_FOR_TRISC
     uint64_t fired_trids = CMDBUF_RD_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET);
     uint64_t pending = (fired_trids >> 32) & 0xFFFFFFFFULL;
     while (pending) {
@@ -19,9 +16,9 @@ inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
 
         volatile TxnDFBDescriptor& txn_dfb_descriptor = g_txn_dfb_descriptor[trid];
         for (uint8_t i = 0; i < txn_dfb_descriptor.num_counters; i++) {
-            PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
-            uint8_t tensix_id = get_tensix_id(packed_tile_counter);
-            uint8_t tc_id = get_counter_id(packed_tile_counter);
+            dfb::PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
+            uint8_t tensix_id = dfb::get_tensix_id(packed_tile_counter);
+            uint8_t tc_id = dfb::get_counter_id(packed_tile_counter);
             fast_llk_intf_inc_posted(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_post);
         }
 
@@ -35,9 +32,11 @@ inline __attribute__((always_inline)) void dfb_tile_poster_irq_handler() {
         uint64_t clear_val = fired_trids & ~(to_clear << 32);
         CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_1_REG_OFFSET, clear_val);
     }
+#endif
 }
 
 inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
+#ifndef COMPILE_FOR_TRISC
     uint64_t fired_trids = CMDBUF_RD_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET);
     uint64_t pending = fired_trids & 0xFFFFFFFFULL;
     while (pending) {
@@ -45,9 +44,9 @@ inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
 
         volatile TxnDFBDescriptor& txn_dfb_descriptor = g_txn_dfb_descriptor[trid];
         for (uint8_t i = 0; i < txn_dfb_descriptor.num_counters; i++) {
-            PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
-            uint8_t tensix_id = get_tensix_id(packed_tile_counter);
-            uint8_t tc_id = get_counter_id(packed_tile_counter);
+            dfb::PackedTileCounter packed_tile_counter = txn_dfb_descriptor.tile_counters[i];
+            uint8_t tensix_id = dfb::get_tensix_id(packed_tile_counter);
+            uint8_t tc_id = dfb::get_counter_id(packed_tile_counter);
             fast_llk_intf_inc_acked(tensix_id, tc_id, txn_dfb_descriptor.tiles_to_ack);
         }
 
@@ -61,11 +60,12 @@ inline __attribute__((always_inline)) void dfb_tile_acker_irq_handler() {
         uint64_t clear_val = fired_trids & ~to_clear;
         CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IP_2_REG_OFFSET, clear_val);
     }
+#endif
 }
 
 inline __attribute__((interrupt, hot)) void dfb_implicit_sync_handler() {
+#ifndef COMPILE_FOR_TRISC
     dfb_tile_poster_irq_handler();
     dfb_tile_acker_irq_handler();
+#endif
 }
-
-}  // namespace experimental

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -144,8 +144,6 @@ set(HW_JIT_API_HEADERS
     inc/internal/bit_utils.h
     inc/internal/circular_buffer_interface.h
     inc/internal/circular_buffer_init.h
-    inc/internal/dataflow_buffer_interface.h
-    inc/internal/dataflow_buffer_init.h
     inc/internal/firmware_common.h
     inc/internal/mod_div_lib.h
     inc/internal/risc_attribs.h
@@ -184,6 +182,10 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-1xx/blackhole/tdma_xmov.h
     inc/internal/tt-1xx/blackhole/tensix.h
     inc/internal/tt-1xx/blackhole/tensix_types.h
+    inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+    inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+    inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+    inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h
     inc/internal/tt-2xx/quasar/c_tensix_core.h
     inc/internal/tt-2xx/quasar/cfg_defines.h
     inc/internal/tt-2xx/quasar/core_config.h

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -47,7 +47,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             dfb->config.num_producers >= 1 && dfb->config.num_producers <= 4,
             "Tensix producer count must be between 1 and 4, got {}",
             dfb->config.num_producers);
-        dfb->config.producer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::experimental::TENSIX_RISC_OFFSET);
+        dfb->config.producer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
         dfb->tensix_trisc_mask |= (1u << 2);  // Tensix producer uses trisc2
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
         TT_FATAL(
@@ -67,7 +67,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 4,
             "Tensix consumer count must be between 1 and 4, got {}",
             dfb->config.num_consumers);
-        dfb->config.consumer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::experimental::TENSIX_RISC_OFFSET);
+        dfb->config.consumer_risc_mask = static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
         dfb->tensix_trisc_mask |= (1u << 0);  // Default: Tensix consumer uses trisc0; use (1u << 3) for trisc3
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
         TT_FATAL(
@@ -86,21 +86,21 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
 
 namespace detail {
 
-::experimental::PackedTileCounter TileCounterAllocator::allocate(uint8_t tensix_id) {
-    TT_FATAL(tensix_id < ::experimental::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
+::dfb::PackedTileCounter TileCounterAllocator::allocate(uint8_t tensix_id) {
+    TT_FATAL(tensix_id < ::dfb::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
     TT_FATAL(
-        next_tc_id_[tensix_id] < ::experimental::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
+        next_tc_id_[tensix_id] < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
         "Out of tile counters for tensix {}",
         tensix_id);
     uint8_t tc_id = next_tc_id_[tensix_id]++;
-    return static_cast<::experimental::PackedTileCounter>(
-        (tensix_id << ::experimental::PACKED_TC_COUNTER_ID_BITS) | tc_id);
+    return static_cast<::dfb::PackedTileCounter>(
+        (tensix_id << ::dfb::PACKED_TC_COUNTER_ID_BITS) | tc_id);
 }
 
 uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
     uint8_t idx = next_index_[core_coord]++;
     TT_FATAL(
-        idx < ::experimental::NUM_REMAPPER_PAIRINGS,
+        idx < ::dfb::NUM_REMAPPER_PAIRINGS,
         "Out of remapper pairs for core ({}, {})",
         core_coord.x,
         core_coord.y);
@@ -153,7 +153,7 @@ uint8_t ClientTypeAllocator::allocate_for_consumer(uint8_t producer_client_type,
 }
 
 // Computes dfb_txn_id_descriptor_t for either the producer or consumer side of a DFB.
-static ::experimental::dfb_txn_id_descriptor_t compute_txn_descriptor(
+static dfb_txn_id_descriptor_t compute_txn_descriptor(
     uint16_t capacity,
     uint8_t num_producers,
     uint8_t num_consumers,
@@ -191,7 +191,7 @@ static ::experimental::dfb_txn_id_descriptor_t compute_txn_descriptor(
         num_tcs_per_risc);
     uint8_t per_txn_per_tc = per_txn / num_tcs_per_risc;
 
-    ::experimental::dfb_txn_id_descriptor_t desc = {};
+    dfb_txn_id_descriptor_t desc = {};
     desc.num_txn_ids = num_txn_ids;
     desc.num_entries_to_process_threshold = threshold;
     desc.num_entries_per_txn_id = per_txn; // number of transactions each DM producer/consumer contributes
@@ -207,7 +207,7 @@ bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
 bool has_tensix_risc(uint16_t risc_mask) { return (risc_mask & 0x0F00) != 0; }
 
 uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
-    if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+    if (config.cap == ::dfb::AccessPattern::BLOCKED) {
         bool producer_has_dm = has_dm_risc(config.producer_risc_mask);
         bool consumer_has_dm = has_dm_risc(config.consumer_risc_mask);
         bool producer_is_tensix_only = !producer_has_dm && has_tensix_risc(config.producer_risc_mask);
@@ -255,7 +255,7 @@ uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_
 std::vector<uint8_t> extract_tensix_ids(uint16_t risc_mask) {
     std::vector<uint8_t> tensix_ids;
     uint16_t tensix_mask = (risc_mask >> 8) & 0x0F;  // bits 8-11
-    for (uint8_t i = 0; i < ::experimental::NUM_TENSIX; i++) {
+    for (uint8_t i = 0; i < ::dfb::NUM_TENSIX; i++) {
         if (tensix_mask & (1 << i)) {
             tensix_ids.push_back(i);
         }
@@ -269,14 +269,14 @@ uint8_t get_dm_tensix_id_for_pair(uint8_t pair_index) { return pair_index % 4; }
 
 // Holds tile counters allocated together for a producer-consumer group
 struct TileCounterGroup {
-    ::experimental::PackedTileCounter producer_tc{};
-    std::vector<::experimental::PackedTileCounter> consumer_tcs;
+    ::dfb::PackedTileCounter producer_tc{};
+    std::vector<::dfb::PackedTileCounter> consumer_tcs;
 };
 
 uint32_t DataflowBufferImpl::serialized_size() const {
     // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc
-    return sizeof(::experimental::dfb_initializer_t) +
-           (risc_configs.size() * sizeof(::experimental::dfb_initializer_per_risc_t));
+    return sizeof(dfb_initializer_t) +
+           (risc_configs.size() * sizeof(dfb_initializer_per_risc_t));
 }
 
 std::vector<uint8_t> DataflowBufferImpl::serialize() const {
@@ -285,7 +285,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     std::vector<uint8_t> data;
     data.reserve(serialized_size());
 
-    ::experimental::dfb_initializer_t init = {};
+    dfb_initializer_t init = {};
     init.logical_id = this->id;
     init.entry_size = this->entry_size;
     init.stride_in_entries = this->stride_in_entries;
@@ -339,7 +339,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
         TT_FATAL(rc != nullptr, "DFB {}: no risc_config for risc_id {} (bit {})", this->id, bit, bit);
 
         log_info(tt::LogMetal, "New risc config (risc_id={}, is_producer={})", rc->risc_id, rc->is_producer);
-        ::experimental::dfb_initializer_per_risc_t per_risc = {};
+        dfb_initializer_per_risc_t per_risc = {};
 
         per_risc.num_tcs_and_init.num_tcs_to_rr = rc->config.num_tcs_to_rr;
         per_risc.num_tcs_and_init.tc_init_done = 0;  // set by device when this producer finishes TC init
@@ -452,7 +452,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     TT_FATAL(config.entry_size > 0, "Entry size must be > 0");
     TT_FATAL(config.num_entries > 0, "Num entries must be > 0");
 
-    TT_FATAL(config.pap != ::experimental::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
+    TT_FATAL(config.pap != dfb::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
 
     TT_FATAL(
         core_range_set.num_cores() == 1,
@@ -460,7 +460,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         core_range_set.num_cores(),
         core_range_set.str());
     TT_FATAL(
-        config.cap != ::experimental::AccessPattern::BLOCKED || config.num_consumers <= 4,
+        config.cap != dfb::AccessPattern::BLOCKED || config.num_consumers <= 4,
         "Blocked consumer pattern supports at most 4 consumers, but {} were specified",
         config.num_consumers);
 
@@ -481,7 +481,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     uint32_t capacity;
     switch (config.cap) {
-        case ::experimental::AccessPattern::STRIDED:
+        case dfb::AccessPattern::STRIDED:
             TT_FATAL(
                 config.num_entries % std::max(config.num_producers, config.num_consumers) == 0,
                 "Num entries in DFB {} must be divisible by max of num producers and consumers {}",
@@ -490,7 +490,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
             capacity = config.num_entries / std::max(config.num_producers, config.num_consumers);
             dfb->stride_in_entries = std::max(config.num_producers, config.num_consumers);
             break;
-        case ::experimental::AccessPattern::BLOCKED:
+        case dfb::AccessPattern::BLOCKED:
             TT_FATAL(
                 config.num_entries % config.num_producers == 0,
                 "Num entries in DFB {} must be divisible by num producers {}",
@@ -553,7 +553,7 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
     for (auto& [core, core_dfbs] : dfbs_by_core) {
         bool core_needs_remapper = false;
         for (const auto& dfb : core_dfbs) {
-            if (dfb->config.cap == ::experimental::AccessPattern::BLOCKED) {
+            if (dfb->config.cap == dfb::AccessPattern::BLOCKED) {
                 // DM-DM BLOCKED uses software broadcast (no remapper needed)
                 bool dm_dm_blocked = !has_tensix_risc(dfb->config.producer_risc_mask) &&
                                      !has_tensix_risc(dfb->config.consumer_risc_mask);
@@ -602,14 +602,14 @@ void ProgramImpl::finalize_single_dfb_config(
 
     // DM-DM BLOCKED: producer broadcasts to N TCs (one per consumer) instead of using remapper.
     // No Tensix involved on either side.
-    bool dm_dm_blocked = (config.cap == ::experimental::AccessPattern::BLOCKED) &&
+    bool dm_dm_blocked = (config.cap == dfb::AccessPattern::BLOCKED) &&
                          !producer_is_tensix_only && !consumer_is_tensix_only;
 
     // Remapper is needed only for BLOCKED 1-to-many with Tensix
     // Adding a TC to a remapper config entry removes it from the default Tensix<->DM mirror group, even with
     // remapper enabled the default mirroring holds for STRIDED cases
     bool use_remapper = core_has_remapper &&
-                        (config.cap == ::experimental::AccessPattern::BLOCKED) &&
+                        (config.cap == dfb::AccessPattern::BLOCKED) &&
                         !dm_dm_blocked;
 
     uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
@@ -699,7 +699,7 @@ void ProgramImpl::finalize_single_dfb_config(
         for (uint8_t tc_slot = 0; tc_slot < num_producer_tcs; tc_slot++) {
             TileCounterGroup& group = tc_groups[producer_idx][tc_slot];
 
-            if (config.cap == ::experimental::AccessPattern::STRIDED) {
+            if (config.cap == dfb::AccessPattern::STRIDED) {
                 // Determine which consumer(s) this producer TC slot pairs with
                 uint8_t consumer_idx = (producer_idx + tc_slot * producer_risc_ids.size()) % consumer_risc_ids.size();
 
@@ -713,7 +713,7 @@ void ProgramImpl::finalize_single_dfb_config(
                     // With remapper: allocate separate consumer TC
                     uint8_t consumer_tensix_id =
                         ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
-                    ::experimental::PackedTileCounter consumer_tc =
+                    dfb::PackedTileCounter consumer_tc =
                         tile_counter_allocator_.allocate(consumer_tensix_id);
                     group.consumer_tcs.push_back(consumer_tc);
                 } else {
@@ -732,7 +732,7 @@ void ProgramImpl::finalize_single_dfb_config(
                     consumer_idx,
                     consumer_risc_id,
                     use_remapper);
-            } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            } else if (config.cap == dfb::AccessPattern::BLOCKED) {
                 if (dm_dm_blocked) {
                     // DM-DM BLOCKED: allocate one TC per consumer (tc_slot == consumer_idx).
                     // The TC is shared between producer and consumer i -- no remapper needed.
@@ -755,7 +755,7 @@ void ProgramImpl::finalize_single_dfb_config(
                     for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
                         uint8_t consumer_tensix_id =
                             ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
-                        ::experimental::PackedTileCounter consumer_tc =
+                        dfb::PackedTileCounter consumer_tc =
                             tile_counter_allocator_.allocate(consumer_tensix_id);
                         group.consumer_tcs.push_back(consumer_tc);
                     }
@@ -794,8 +794,8 @@ void ProgramImpl::finalize_single_dfb_config(
                 tt::LogMetal,
                 "\tAssigned TC[{}]: (0x{:x}, 0x{:x})",
                 tc,
-                (uint32_t)::experimental::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
-                (uint32_t)::experimental::get_counter_id(risc_config.config.packed_tile_counter[tc]));
+                (uint32_t)dfb::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
+                (uint32_t)dfb::get_counter_id(risc_config.config.packed_tile_counter[tc]));
         }
         risc_config.config.num_tcs_to_rr = num_producer_tcs;
         risc_config.config.broadcast_tc = dm_dm_blocked;
@@ -809,18 +809,18 @@ void ProgramImpl::finalize_single_dfb_config(
             uint32_t packed = 0;
             uint8_t consumer_ids_mask = 0;
 
-            if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            if (config.cap == dfb::AccessPattern::BLOCKED) {
                 // BLOCKED: 1-to-many, all consumers
-                for (size_t i = 0; i < group.consumer_tcs.size() && i < ::experimental::MAX_NUM_TILE_COUNTERS_TO_RR;
+                for (size_t i = 0; i < group.consumer_tcs.size() && i < ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR;
                      i++) {
-                    packed |= (::experimental::get_counter_id(group.consumer_tcs[i]) & 0x1F) << (i * 5);
+                    packed |= (dfb::get_counter_id(group.consumer_tcs[i]) & 0x1F) << (i * 5);
                     consumer_ids_mask |= (1u << consumer_client_types[i]);
                 }
             } else {
                 // STRIDED via remapper: 1-to-1 per tc_slot
                 for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
                     uint8_t consumer_idx = (producer_idx + tc * producer_risc_ids.size()) % consumer_risc_ids.size();
-                    packed |= (::experimental::get_counter_id(tc_groups[producer_idx][tc].consumer_tcs[0]) & 0x1F)
+                    packed |= (dfb::get_counter_id(tc_groups[producer_idx][tc].consumer_tcs[0]) & 0x1F)
                               << (tc * 5);
                     consumer_ids_mask |= (1u << consumer_client_types[consumer_idx]);
                 }
@@ -855,7 +855,7 @@ void ProgramImpl::finalize_single_dfb_config(
             num_consumer_tcs);
 
         for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
-            if (config.cap == ::experimental::AccessPattern::STRIDED) {
+            if (config.cap == dfb::AccessPattern::STRIDED) {
                 uint8_t producer_idx;
                 uint8_t producer_tc_slot;
 
@@ -878,7 +878,7 @@ void ProgramImpl::finalize_single_dfb_config(
                     // Without remapper: shared TC with producer
                     risc_config.config.packed_tile_counter[tc] = tc_groups[producer_idx][producer_tc_slot].producer_tc;
                 }
-            } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            } else if (config.cap == dfb::AccessPattern::BLOCKED) {
                 if (dm_dm_blocked) {
                     // DM-DM BLOCKED: consumer[consumer_idx] TC[tc] = shared TC from producer[tc][consumer_idx].
                     // tc iterates over num_consumer_tcs = num_producers.
@@ -899,8 +899,8 @@ void ProgramImpl::finalize_single_dfb_config(
                 tt::LogMetal,
                 "\tAssigned TC[{}]: (0x{:x}, 0x{:x})",
                 tc,
-                (uint32_t)::experimental::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
-                (uint32_t)::experimental::get_counter_id(risc_config.config.packed_tile_counter[tc]));
+                (uint32_t)dfb::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
+                (uint32_t)dfb::get_counter_id(risc_config.config.packed_tile_counter[tc]));
         }
         risc_config.config.num_tcs_to_rr = num_consumer_tcs;
 
@@ -1048,8 +1048,8 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
                 rc.config.base_addr[tc] = base_addr;
                 rc.config.limit[tc] =
                     rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
-                if ((dfb->config.cap == ::experimental::AccessPattern::STRIDED ||
-                     (dfb->config.cap == ::experimental::AccessPattern::BLOCKED && dfb->config.num_producers > 1)) &&
+                if ((dfb->config.cap == dfb::AccessPattern::STRIDED ||
+                     (dfb->config.cap == dfb::AccessPattern::BLOCKED && dfb->config.num_producers > 1)) &&
                     tc < rc.config.num_tcs_to_rr) {
                     base_addr += entry_size;
                 }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -14,7 +14,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
-#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
 namespace tt::tt_metal {
 struct KernelGroup;
@@ -26,7 +26,7 @@ namespace tt::tt_metal::experimental::dfb::detail {
 struct LocalDFBInterfaceHost {
     std::array<uint32_t, 4> base_addr = {0};
     std::array<uint32_t, 4> limit = {0};
-    std::array<::experimental::PackedTileCounter, 4> packed_tile_counter = {0};
+    std::array<::dfb::PackedTileCounter, 4> packed_tile_counter = {0};
     uint8_t num_tcs_to_rr = 1;
     bool broadcast_tc = false;  // DM-DM BLOCKED producer: post to all TCs instead of round-robin
     uint8_t remapper_pair_index = 0;
@@ -54,8 +54,8 @@ struct DataflowBufferImpl {
     // Shared config fields (written to dfb_initializer_t)
     uint32_t entry_size = 0;
     uint32_t stride_in_entries = 0;
-    ::experimental::dfb_txn_id_descriptor_t producer_txn_descriptor = {};
-    ::experimental::dfb_txn_id_descriptor_t consumer_txn_descriptor = {};
+    dfb_txn_id_descriptor_t producer_txn_descriptor = {};
+    dfb_txn_id_descriptor_t consumer_txn_descriptor = {};
 
     // Flag to track if TC/remapper allocation has been finalized
     bool configs_finalized = false;
@@ -71,7 +71,7 @@ struct DataflowBufferImpl {
 
 class TileCounterAllocator {
 public:
-    ::experimental::PackedTileCounter allocate(uint8_t tensix_id);
+    ::dfb::PackedTileCounter allocate(uint8_t tensix_id);
     void reset() { next_tc_id_.fill(0); }
 
 private:


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/39568 

### What's changed
Reorganize DFB headers to make backporting to WH/BH easier. There will be `tt-1xx` variants of the dfb config and initializer 

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/split-dfbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/split-dfbs)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early