### PR TITLE
Add nanobind bindings for tensor utilities and work distribution

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_grid_to_cores.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_grid_to_cores.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "num_cores, grid_x, grid_y, row_wise, expected_count",
+    [
+        (4, 8, 8, False, 4),
+        (4, 8, 8, True, 4),
+        (16, 4, 4, False, 16),
+        (1, 1, 1, False, 1),
+    ],
+)
+def test_grid_to_cores_grid_overload(num_cores, grid_x, grid_y, row_wise, expected_count):
+    cores = ttnn.grid_to_cores(num_cores, grid_x, grid_y, row_wise=row_wise)
+    assert len(cores) == expected_count
+    assert cores[0] == ttnn.CoreCoord(0, 0)
+
+
+@pytest.mark.parametrize(
+    "start, end, row_wise, expected_count",
+    [
+        (ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1), False, 4),
+        (ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0), False, 1),
+        (ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3), True, 16),
+    ],
+)
+def test_grid_to_cores_corecoord_overload(start, end, row_wise, expected_count):
+    cores = ttnn.grid_to_cores(start, end, row_wise=row_wise)
+    assert len(cores) == expected_count

--- a/tests/ttnn/unit_tests/base_functionality/test_grid_to_cores.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_grid_to_cores.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from models.common.utility_functions import is_wormhole_b0, is_blackhole
+
+
+@pytest.mark.parametrize(
+    "dtype, expected_tile_size",
+    [
+        (ttnn.bfloat16, 2048),
+        (ttnn.float32, 4096),
+        (ttnn.bfloat8_b, 1088),  # (256 * 4) data + (16 * 4) exponents
+        (ttnn.bfloat4_b, 576),  # (128 * 4) data + (16 * 4) exponents
+        (ttnn.uint16, 2048),
+        (ttnn.uint32, 4096),
+    ],
+)
+def test_tile_size(dtype, expected_tile_size):
+    assert ttnn.tile_size(dtype) == expected_tile_size
+
+
+@pytest.mark.parametrize(
+    "dtype, expected_element_size",
+    [
+        (ttnn.bfloat16, 2),
+        (ttnn.float32, 4),
+        (ttnn.uint16, 2),
+        (ttnn.uint32, 4),
+    ],
+)
+def test_element_size(dtype, expected_element_size):
+    assert ttnn.element_size(dtype) == expected_element_size
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+def test_element_size_throws_for_block_floats(dtype):
+    """Block float formats have shared exponents, so per-element size is undefined."""
+    with pytest.raises(Exception):
+        ttnn.element_size(dtype)
+
+
+def test_dram_alignment(device):
+    alignment = ttnn.get_dram_alignment()
+    assert (alignment & (alignment - 1)) == 0, "DRAM alignment must be a power of 2"
+    if is_wormhole_b0():
+        assert alignment == 32
+    elif is_blackhole():
+        assert alignment == 64
+
+
+def test_l1_alignment(device):
+    alignment = ttnn.get_l1_alignment()
+    assert (alignment & (alignment - 1)) == 0, "L1 alignment must be a power of 2"
+    assert alignment == 16
+
+
+@pytest.mark.parametrize(
+    "shape, dtype, layout, memory_config",
+    [
+        ((1, 1, 32, 64), ttnn.bfloat16, ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ((1, 1, 32, 64), ttnn.float32, ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ((1, 1, 32, 64), ttnn.bfloat8_b, ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ((1, 1, 32, 64), ttnn.bfloat4_b, ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+        ((1, 1, 16, 64), ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, ttnn.DRAM_MEMORY_CONFIG),
+    ],
+)
+def test_buffer_page_size(shape, dtype, layout, memory_config, device):
+    torch_tensor = torch.randn(shape, dtype=torch.float32)
+    t = ttnn.to_device(
+        ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout), device=device, memory_config=memory_config
+    )
+    page_size = t.buffer_page_size()
+    assert page_size > 0
+
+    if layout == ttnn.TILE_LAYOUT:
+        assert page_size == ttnn.tile_size(dtype)
+    else:
+        # Row-major: stick size = width * element_size
+        assert page_size == shape[-1] * ttnn.element_size(dtype)
+
+
+@pytest.mark.parametrize(
+    "shape, dtype, layout, expected_pages",
+    [
+        ((1, 1, 64, 64), ttnn.bfloat16, ttnn.TILE_LAYOUT, 4),  # 2x2 tiles
+        ((1, 1, 64, 64), ttnn.float32, ttnn.TILE_LAYOUT, 4),
+        ((1, 1, 64, 64), ttnn.bfloat8_b, ttnn.TILE_LAYOUT, 4),
+        ((1, 1, 16, 64), ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, 16),  # 16 sticks
+    ],
+)
+def test_buffer_num_pages(shape, dtype, layout, expected_pages, device):
+    torch_tensor = torch.randn(shape, dtype=torch.float32)
+    t = ttnn.to_device(
+        ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout), device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    assert t.buffer_num_pages() == expected_pages
+
+
+@pytest.mark.parametrize(
+    "memory_config, alignment_fn",
+    [
+        (ttnn.DRAM_MEMORY_CONFIG, ttnn.get_dram_alignment),
+        (ttnn.L1_MEMORY_CONFIG, ttnn.get_l1_alignment),
+    ],
+)
+def test_buffer_aligned_page_size(memory_config, alignment_fn, device):
+    torch_tensor = torch.randn((1, 1, 32, 32), dtype=torch.float32)
+    t = ttnn.to_device(
+        ttnn.from_torch(torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT),
+        device=device,
+        memory_config=memory_config,
+    )
+    aligned_size = t.buffer_aligned_page_size()
+    page_size = t.buffer_page_size()
+    assert aligned_size >= page_size
+    assert aligned_size % alignment_fn() == 0
+
+
+@pytest.mark.parametrize(
+    "dtype, expected",
+    [
+        (ttnn.bfloat16, 2),
+        (ttnn.float32, 4),
+    ],
+)
+def test_tensor_element_size_instance_method(dtype, expected, device):
+    torch_tensor = torch.randn((1, 1, 32, 32), dtype=torch.float32)
+    t = ttnn.to_device(
+        ttnn.from_torch(torch_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT),
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    assert t.element_size() == expected

--- a/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_utilities.py
@@ -106,6 +106,7 @@ def test_buffer_num_pages(shape, dtype, layout, expected_pages, device):
         (ttnn.DRAM_MEMORY_CONFIG, ttnn.get_dram_alignment),
         (ttnn.L1_MEMORY_CONFIG, ttnn.get_l1_alignment),
     ],
+    ids=["dram", "l1"],
 )
 def test_buffer_aligned_page_size(memory_config, alignment_fn, device):
     torch_tensor = torch.randn((1, 1, 32, 32), dtype=torch.float32)

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -510,6 +510,16 @@ void device_module(nb::module_& m_device) {
         "Return the maximum size of the worker L1 unreserved memory.");
 
     m_device.def(
+        "get_dram_alignment",
+        &tt::tt_metal::hal::get_dram_alignment,
+        "Return the DRAM alignment requirement in bytes for the current architecture.");
+
+    m_device.def(
+        "get_l1_alignment",
+        &tt::tt_metal::hal::get_l1_alignment,
+        "Return the L1 alignment requirement in bytes for the current architecture.");
+
+    m_device.def(
         "get_optimal_dram_bank_to_logical_worker_assignment",
         [](MeshDevice* device, tt::tt_metal::NOC noc) {
             return device->get_optimal_dram_bank_to_logical_worker_assignment(noc);

--- a/ttnn/cpp/ttnn-nanobind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/core.cpp
@@ -22,6 +22,8 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 
+#include <nanobind/stl/vector.h>
+
 // NOLINTBEGIN(bugprone-unused-raii)
 
 namespace ttnn::operations::core {
@@ -528,6 +530,47 @@ void py_module(nb::module_& mod) {
         >>> num_cores, all_cores, core_group_1, core_group_2, units_1, units_2 = \\
         ...     ttnn.split_work_to_cores(core_rangeset, 100)
         >>> print(f"Using {num_cores} cores, {units_1} units per core in group 1, {units_2} in group 2")
+        )doc");
+
+    mod.def(
+        "grid_to_cores",
+        nb::overload_cast<uint32_t, uint32_t, uint32_t, bool>(&tt::tt_metal::grid_to_cores),
+        nb::arg("num_cores"),
+        nb::arg("grid_size_x"),
+        nb::arg("grid_size_y"),
+        nb::arg("row_wise") = false,
+        R"doc(
+            Convert a grid specification to a list of CoreCoord objects.
+
+            Args:
+                num_cores (int): Number of cores to generate coordinates for.
+                grid_size_x (int): Width of the core grid.
+                grid_size_y (int): Height of the core grid.
+                row_wise (bool, optional): Iterate row-wise. Defaults to False.
+
+            Returns:
+                list[CoreCoord]: List of core coordinates.
+
+            Example:
+            >>> cores = ttnn.grid_to_cores(4, 8, 8)
+        )doc");
+
+    mod.def(
+        "grid_to_cores",
+        nb::overload_cast<CoreCoord, CoreCoord, bool>(&tt::tt_metal::grid_to_cores),
+        nb::arg("start"),
+        nb::arg("end"),
+        nb::arg("row_wise") = false,
+        R"doc(
+            Convert a core range to a list of CoreCoord objects.
+
+            Args:
+                start (CoreCoord): Start coordinate of the range.
+                end (CoreCoord): End coordinate of the range (inclusive).
+                row_wise (bool, optional): Iterate row-wise. Defaults to False.
+
+            Returns:
+                list[CoreCoord]: List of core coordinates.
         )doc");
 }
 

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1375,6 +1375,61 @@ void pytensor_module(nb::module_& mod) {
 
         )doc")
         .def(
+            "buffer_page_size",
+            [](const Tensor& self) -> uint32_t {
+                TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
+                return self.mesh_buffer().page_size();
+            },
+            R"doc(
+            Get the page size of the underlying buffer in bytes.
+
+            For tiled tensors, this is the tile size. For row-major tensors,
+            this is the stick size (width * element_size).
+
+            The tensor must be on device.
+        )doc")
+        .def(
+            "buffer_num_pages",
+            [](const Tensor& self) -> uint32_t {
+                TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
+                return self.mesh_buffer().num_pages();
+            },
+            R"doc(
+            Get the number of pages in the underlying buffer.
+
+            For tiled tensors, this is the number of tiles.
+            For row-major tensors, this is the number of sticks (rows).
+
+            The tensor must be on device.
+        )doc")
+        .def(
+            "buffer_aligned_page_size",
+            [](const Tensor& self) -> uint32_t {
+                TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
+                auto* ref_buffer = self.mesh_buffer().get_reference_buffer();
+                TT_FATAL(ref_buffer != nullptr, "Could not get reference buffer.");
+                return ref_buffer->aligned_page_size();
+            },
+            R"doc(
+            Get the aligned page size of the underlying buffer in bytes.
+
+            This is the page size rounded up to the buffer's alignment requirement
+            (e.g., DRAM alignment). Used for efficient DMA transfers.
+
+            The tensor must be on device.
+        )doc")
+        .def(
+            "element_size",
+            [](const Tensor& self) -> uint32_t {
+                return tt::datum_size(datatype_to_dataformat_converter(self.dtype()));
+            },
+            R"doc(
+            Get the size of a single element in bytes for this tensor's data type.
+
+            Returns:
+                int: Element size in bytes (e.g., 2 for bfloat16, 4 for float32).
+        )doc")
+        .def(
             "get_layout", [](const Tensor& self) { return self.layout(); }, R"doc(
             Get memory layout of TT Tensor.
 

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -38,6 +38,8 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include "ttnn/tensor/types.hpp"
 
 using namespace tt::tt_metal;
 
@@ -236,6 +238,44 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::arg("dtype"),
             "Get tile size in bytes for the given data type")
         .def(nb::self == nb::self);
+
+    // Standalone tile/element size utilities — equivalent to Tile.get_tile_size but
+    // usable without a Tile object (e.g., for intermediate CB sizing).
+    m_tensor.def(
+        "tile_size",
+        [](DataType dtype) -> uint32_t { return tt::tile_size(datatype_to_dataformat_converter(dtype)); },
+        nb::arg("dtype"),
+        R"doc(
+            Get tile size in bytes for the given data type (standard 32x32 tile).
+
+            Args:
+                dtype: TTNN data type (e.g., ttnn.bfloat16, ttnn.float32).
+
+            Returns:
+                int: Tile size in bytes (e.g., 2048 for bfloat16, 4096 for float32).
+
+            Example:
+            >>> ttnn.tile_size(ttnn.bfloat16)  # Returns 2048
+            >>> ttnn.tile_size(ttnn.float32)   # Returns 4096
+        )doc");
+
+    m_tensor.def(
+        "element_size",
+        [](DataType dtype) -> uint32_t { return tt::datum_size(datatype_to_dataformat_converter(dtype)); },
+        nb::arg("dtype"),
+        R"doc(
+            Get element size in bytes for the given data type.
+
+            Args:
+                dtype: TTNN data type (e.g., ttnn.bfloat16, ttnn.float32).
+
+            Returns:
+                int: Element size in bytes (e.g., 2 for bfloat16, 4 for float32).
+
+            Example:
+            >>> ttnn.element_size(ttnn.bfloat16)  # Returns 2
+            >>> ttnn.element_size(ttnn.float32)   # Returns 4
+        )doc");
 
     auto pyTensorSpec = static_cast<nb::class_<TensorSpec>>(m_tensor.attr("TensorSpec"));
     pyTensorSpec

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -291,6 +291,8 @@ from ttnn.device import (
     dump_device_memory_state,
     get_memory_view,
     get_max_worker_l1_unreserved_size,
+    get_dram_alignment,
+    get_l1_alignment,
     get_optimal_dram_bank_to_logical_worker_assignment,
     enable_asynchronous_slow_dispatch,
     disable_asynchronous_slow_dispatch,
@@ -340,8 +342,12 @@ from ttnn.core import (
     num_cores_to_corerangeset,
     num_cores_to_corerangeset_in_subcoregrids,
     split_work_to_cores,
+    grid_to_cores,
     get_current_command_queue_id_for_thread,
 )
+
+tile_size = ttnn._ttnn.tensor.tile_size
+element_size = ttnn._ttnn.tensor.element_size
 
 import ttnn.reflection
 import ttnn.database

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -17,6 +17,7 @@ from ttnn.types import (
 )
 
 split_work_to_cores = ttnn._ttnn.operations.core.split_work_to_cores
+grid_to_cores = ttnn._ttnn.operations.core.grid_to_cores
 
 set_printoptions = ttnn._ttnn.core.set_printoptions
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -18,6 +18,8 @@ Arch = ttnn._ttnn.device.Arch
 DEFAULT_L1_SMALL_SIZE = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE
 DEFAULT_TRACE_REGION_SIZE = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE
 get_max_worker_l1_unreserved_size = ttnn._ttnn.device.get_max_worker_l1_unreserved_size
+get_dram_alignment = ttnn._ttnn.device.get_dram_alignment
+get_l1_alignment = ttnn._ttnn.device.get_l1_alignment
 get_optimal_dram_bank_to_logical_worker_assignment = (
     ttnn._ttnn.device.get_optimal_dram_bank_to_logical_worker_assignment
 )


### PR DESCRIPTION
Expose C++ utility functions to Python via nanobind for use in program descriptors, removing the need to hardcode architecture-specific constants.

Often times, our python code (be it tests, be it ops implemented via program descriptor) hardcode some of these constants, which is a brittle approach.

This change allows for cleaner test writing. Also it makes the usage of program descriptors in python easier, which are a great way for prototyping ops, running quick kernels, and also reproducing bugs. 

New bindings:
- Tile/element size: ttnn.tile_size(dtype), ttnn.element_size(dtype)
- HAL queries: ttnn.get_dram_alignment(), ttnn.get_l1_alignment()
- Buffer queries: tensor.buffer_page_size(), buffer_num_pages(), buffer_aligned_page_size(), tensor.element_size()
- Work distribution: ttnn.grid_to_cores()


- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/23304075674)
- [x] [Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/23304077813)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/nanobind_additions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/nanobind_additions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/nanobind_additions)