### PR TITLE
Add skip_with_llk_assert for est_ccl_all_reduce.py due to LLK_ASSERT hit

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import skip_with_llk_assert
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -30,6 +31,9 @@ def create_fabric_router_config(max_payload_size):
     return config
 
 
+@skip_with_llk_assert(
+    "Hit LLK assert in llk_math_eltwise_unary_datacopy, dest index out of bounds. TODO: add issue number."
+)
 @pytest.mark.parametrize(
     "num_devices, output_shape, input_shard_shape, tensor_mem_layout",
     [


### PR DESCRIPTION
### Ticket
#40335 

### Problem description
There is a test which hit LLK_ASSERT on dest_index being out of range. In the test dest_index gets value 4 which means that DestSync::SyncHalf and DST_ACCUM_MODE = true (32b data) were used. Only in that case, the limit on number of tiles in dest register is 4, meaning that allowed indexes for dest register are 0, 1, 2 and 3. Value 4 for dest_index would lead up to MATH accessing the other half of dest register which might be owned by PACK thread which is considered as invalid access.

Affected tests:
models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py

### What's changed
Added skip_with_llk_assert for mentioned test in order to get green Blackhole post commit run when LLK_ASSERTS are enabled.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_bh_multi_card_when_llk_asserts_enabled)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
