### PR TITLE
[skip ci] Make BHPC obey inputs for nightly debug runs

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -83,6 +83,11 @@ on:
         type: boolean
         default: false
         description: "Enable LLK asserts"
+      schedule-runs-all-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "When true (default), a scheduled run uses the Blackhole schedule suite (not gated on run-* alone). When false, only run-* inputs enable jobs—set false when calling from another workflow."
   workflow_dispatch:
     inputs:
       runner-label:
@@ -284,7 +289,7 @@ jobs:
 
   run-profiler-regression:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-profiler-regression == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-profiler-regression == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
     strategy:
@@ -302,7 +307,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   umd-unit-tests:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-umd-unit-tests == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-umd-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     secrets: inherit
     uses: ./.github/workflows/umd-unit-tests.yaml
     strategy:
@@ -318,7 +323,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   models-unit-tests:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-models-unit-tests == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-models-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     secrets: inherit
     uses: ./.github/workflows/models-post-commit.yaml
     strategy:
@@ -335,7 +340,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   ttnn-unit-tests:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-ttnn-unit-tests == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-ttnn-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
     strategy:
@@ -351,7 +356,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   ops-unit-tests:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-ops-unit-tests == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-ops-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -370,7 +375,7 @@ jobs:
   # TT-CNN Unit Tests
   tt-cnn-unit-tests:
     needs: [resolve-artifacts, generate-matrix]
-    if: ${{ always() && !cancelled() && (inputs.run-tt-cnn-unit-tests == true || github.event_name == 'schedule') }}
+    if: ${{ always() && !cancelled() && (inputs.run-tt-cnn-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule')) }}
     secrets: inherit
     uses: ./.github/workflows/tt-cnn-post-commit.yaml
     strategy:
@@ -388,7 +393,7 @@ jobs:
   # Multi-card post-commit tests
   blackhole-multi-card-fast-unit-tests:
     # Don't run on daily P100-only schedule
-    if: ${{ always() && !cancelled() && (inputs.run-blackhole-multi-card-fast-unit-tests == true || (github.event_name == 'schedule' && github.event.schedule != '0 7 * * *')) }}
+    if: ${{ always() && !cancelled() && (inputs.run-blackhole-multi-card-fast-unit-tests == true || (inputs.schedule-runs-all-tests != false && github.event_name == 'schedule' && github.event.schedule != '0 7 * * *')) }}
     needs: [resolve-artifacts, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -387,7 +387,8 @@ jobs:
 
   # Multi-card post-commit tests
   blackhole-multi-card-fast-unit-tests:
-    if: ${{ always() && !cancelled() && (!contains(fromJson(needs.generate-matrix.outputs.matrix), 'P100') || github.event_name == 'schedule' || inputs.run-blackhole-multi-card-fast-unit-tests == true) }}
+    # Don't run on daily P100-only schedule
+    if: ${{ always() && !cancelled() && (inputs.run-blackhole-multi-card-fast-unit-tests == true || (github.event_name == 'schedule' && github.event.schedule != '0 7 * * *')) }}
     needs: [resolve-artifacts, generate-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -73,6 +73,8 @@ on:
 
 jobs:
   define-ops-tests:
+    # Test suite is not supported on P100a runners (Blackhole P100 CIv2 label).
+    if: ${{ inputs.runner-label != 'P100a' }}
     runs-on: ubuntu-latest
     outputs:
       ops-tests: ${{ steps.compute-tests.outputs.ops-tests }}

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -131,6 +131,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
+      schedule-runs-all-tests: false
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
@@ -167,6 +168,7 @@ jobs:
       platform: "Ubuntu 24.04"
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      schedule-runs-all-tests: false
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Since each test workflow runs on schedule with `github.event_name == 'schedule'`, scheduled nightly debug BHPC runs also run all tests despite requesting some tests to be skipped.

### What's changed
Add `inputs.schedule-runs-all-tests` which is true by default but set to false for nightly debug BHPC runs. This will ignore the `github.event_name == 'schedule'` setting and defer back to the test input to determine what tests need to run.

Also: skip ops-post-commit on P100a

### Checklist

- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/make-bhpc-obey-inputs-and-schedules)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/make-bhpc-obey-inputs-and-schedules)
- [x] BHPC p100a: https://github.com/tenstorrent/tt-metal/actions/runs/23310697511
Confirm ops-post-commit is skipped
- [x] Nightly debug BH https://github.com/tenstorrent/tt-metal/actions/runs/23309480453
Confirm profiler tests are run
- [x] Nightly debug BH watcher https://github.com/tenstorrent/tt-metal/actions/runs/23309495110
Confirm profiler tests are skipped

