### PR TITLE
Split out creation and serialization API for Tensor

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -161,6 +161,7 @@ target_sources(
         core/tensor/tensor.cpp
         core/tensor/tensor_attributes.cpp
         core/tensor/tensor_impl.cpp
+        core/tensor/host_tensor_factory.cpp
         core/tensor/tensor_ops.cpp
         core/tensor/tensor_utils.cpp
         core/tensor/unit_mesh/unit_mesh_utils.cpp

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -209,4 +209,30 @@ auto dispatch(DataType dtype, Func&& func, Args&&... args) {
     }
 }
 
+// ======================================================================================
+//                                  HostTensor Factory Functions
+// ======================================================================================
+// These functions create HostTensor objects without device involvement.
+// They are the underlying implementation for Tensor::from_xxx methods.
+
+namespace host_tensor {
+
+template <typename T>
+HostTensor from_span(ttsl::Span<const T> buffer, const TensorSpec& spec, T pad_value = 0);
+
+template <typename T>
+HostTensor from_borrowed_data(
+    ttsl::Span<T> buffer, const Shape& shape, MemoryPin pin, const std::optional<Tile>& tile = std::nullopt);
+
+template <typename T>
+HostTensor from_vector(const std::vector<T>& buffer, const TensorSpec& spec, T pad_value = 0);
+
+template <typename T>
+HostTensor from_vector(std::vector<T>&& buffer, const TensorSpec& spec, T pad_value = 0);
+
+template <typename T>
+std::vector<T> to_vector(const HostTensor& tensor);
+
+}  // namespace host_tensor
+
 }  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/tensor/tensor_impl.hpp"
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/bfloat4.hpp>
+#include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <ttnn/tensor/layout/tensor_layout.hpp>
+#include <ttnn/tensor/tensor_spec.hpp>
+#include <ttnn/tensor/types.hpp>
+#include <ttnn/distributed/tensor_topology.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/memory_pin.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+
+#include <tt_stl/span.hpp>
+
+#include <algorithm>
+
+// ============================================================================
+// Forward declarations of helper functions to be lowered to tt_metal later
+// ============================================================================
+
+namespace tt::tt_metal {
+bool logical_matches_physical(const TensorSpec& tensor_spec);
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::tensor_impl {
+template <typename T>
+std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value);
+
+template <typename T>
+std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec);
+}  // namespace tt::tt_metal::tensor_impl
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+namespace tt::tt_metal::tensor_impl::host_tensor {
+
+namespace {
+// TODO(#40348):
+// Will be host_buffer::get_host_buffer
+HostBuffer get_single_host_buffer(const HostTensor& tensor) {
+    const auto& distributed_buffer = tensor.buffer();
+    std::vector<HostBuffer> buffers;
+    distributed_buffer.apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    TT_FATAL(
+        buffers.size() == 1,
+        "Can't get a single buffer from HostTensor distributed over mesh shape {}",
+        distributed_buffer.shape());
+    return buffers.front();
+}
+}  // namespace
+
+template <typename T>
+HostTensor from_span(ttsl::Span<const T> buffer, const TensorSpec& spec, T pad_value) {
+    return from_vector(std::vector<T>(buffer.begin(), buffer.end()), spec, pad_value);
+}
+
+template <typename T>
+HostTensor from_borrowed_data(
+    ttsl::Span<T> buffer, const Shape& shape, MemoryPin pin, const std::optional<Tile>& tile) {
+    size_t volume = shape.volume();
+    TT_FATAL(buffer.size() == volume, "Buffer size {} differs from shape volume {}", buffer.size(), volume);
+
+    auto host_buffer = HostBuffer(buffer, std::move(pin));
+    auto buffer_dtype = convert_to_data_type<T>();
+    TensorSpec tensor_spec(shape, TensorLayout(buffer_dtype, PageConfig(Layout::ROW_MAJOR, tile), MemoryConfig{}));
+
+    return HostTensor(std::move(host_buffer), std::move(tensor_spec), TensorTopology{});
+}
+
+template <typename T>
+HostTensor from_vector(const std::vector<T>& buffer, const TensorSpec& spec, T pad_value) {
+    return from_span(ttsl::make_const_span(buffer), spec, pad_value);
+}
+
+template <typename T>
+HostTensor from_vector(std::vector<T>&& buffer, const TensorSpec& spec, T pad_value) {
+    size_t volume = spec.logical_shape().volume();
+    TT_FATAL(buffer.size() == volume, "Buffer size {} differs from shape volume {}", buffer.size(), volume);
+
+    if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
+        TT_FATAL(spec.layout() == Layout::TILE, "Block float types only supported in TILE layout");
+    }
+
+    auto buffer_dtype = convert_to_data_type<T>();
+    auto buffer_spec =
+        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
+
+    auto host_buffer = logical_matches_physical(buffer_spec)
+                           ? HostBuffer(std::move(buffer))
+                           : HostBuffer(encode_tensor_data(ttsl::make_const_span(buffer), spec, pad_value));
+
+    return HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+}
+
+template <typename T>
+std::vector<T> to_vector(const HostTensor& tensor) {
+    TT_FATAL(
+        tensor.dtype() == convert_to_data_type<T>(),
+        "Unsupported data type for to_vector: got {}, expected: {}",
+        tensor.dtype(),
+        convert_to_data_type<T>());
+
+    HostBuffer host_buffer = get_single_host_buffer(tensor);
+
+    auto data = host_buffer.view_as<const T>();
+    if (logical_matches_physical(tensor.tensor_spec())) {
+        return std::vector<T>(data.begin(), data.end());
+    }
+    return decode_tensor_data(data, tensor.tensor_spec());
+}
+
+template <>
+std::vector<float> to_vector<float>(const HostTensor& tensor) {
+    HostBuffer host_buffer = get_single_host_buffer(tensor);
+
+    switch (tensor.dtype()) {
+        case DataType::BFLOAT16: {
+            auto buffer = host_buffer.view_as<const bfloat16>();
+            std::vector<float> physical_data;
+            physical_data.reserve(buffer.size());
+            std::transform(buffer.begin(), buffer.end(), std::back_inserter(physical_data), [](bfloat16 val) {
+                return static_cast<float>(val);
+            });
+            if (logical_matches_physical(tensor.tensor_spec())) {
+                return physical_data;
+            }
+            return decode_tensor_data(ttsl::make_const_span(physical_data), tensor.tensor_spec());
+        }
+        case DataType::FLOAT32: {
+            auto buffer = host_buffer.view_as<const float>();
+            if (logical_matches_physical(tensor.tensor_spec())) {
+                return std::vector<float>(buffer.begin(), buffer.end());
+            }
+            return decode_tensor_data(buffer, tensor.tensor_spec());
+        }
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B: {
+            const auto& tile = tensor.tensor_spec().tile();
+            auto buffer = host_buffer.view_as<const uint32_t>();
+            std::vector<float> unpacked_data =
+                tensor.dtype() == DataType::BFLOAT8_B
+                    ? unpack_bfp8_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
+                    : unpack_bfp4_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+            return decode_tensor_data(ttsl::make_const_span(unpacked_data), tensor.tensor_spec());
+        }
+        default: {
+            TT_THROW("Cannot convert HostTensor to vector<float> for data type: {}", tensor.dtype());
+        }
+    }
+}
+
+// ============================================================================
+// Explicit template instantiations
+// ============================================================================
+
+template HostTensor from_span<bfloat16>(ttsl::Span<const bfloat16>, const TensorSpec&, bfloat16);
+template HostTensor from_span<float>(ttsl::Span<const float>, const TensorSpec&, float);
+template HostTensor from_span<int32_t>(ttsl::Span<const int32_t>, const TensorSpec&, int32_t);
+template HostTensor from_span<uint32_t>(ttsl::Span<const uint32_t>, const TensorSpec&, uint32_t);
+template HostTensor from_span<uint16_t>(ttsl::Span<const uint16_t>, const TensorSpec&, uint16_t);
+template HostTensor from_span<uint8_t>(ttsl::Span<const uint8_t>, const TensorSpec&, uint8_t);
+
+template HostTensor from_borrowed_data<bfloat16>(
+    ttsl::Span<bfloat16>, const Shape&, MemoryPin, const std::optional<Tile>&);
+template HostTensor from_borrowed_data<float>(ttsl::Span<float>, const Shape&, MemoryPin, const std::optional<Tile>&);
+template HostTensor from_borrowed_data<int32_t>(
+    ttsl::Span<int32_t>, const Shape&, MemoryPin, const std::optional<Tile>&);
+template HostTensor from_borrowed_data<uint32_t>(
+    ttsl::Span<uint32_t>, const Shape&, MemoryPin, const std::optional<Tile>&);
+template HostTensor from_borrowed_data<uint16_t>(
+    ttsl::Span<uint16_t>, const Shape&, MemoryPin, const std::optional<Tile>&);
+template HostTensor from_borrowed_data<uint8_t>(
+    ttsl::Span<uint8_t>, const Shape&, MemoryPin, const std::optional<Tile>&);
+
+template HostTensor from_vector<bfloat16>(const std::vector<bfloat16>&, const TensorSpec&, bfloat16);
+template HostTensor from_vector<float>(const std::vector<float>&, const TensorSpec&, float);
+template HostTensor from_vector<int32_t>(const std::vector<int32_t>&, const TensorSpec&, int32_t);
+template HostTensor from_vector<uint32_t>(const std::vector<uint32_t>&, const TensorSpec&, uint32_t);
+template HostTensor from_vector<uint16_t>(const std::vector<uint16_t>&, const TensorSpec&, uint16_t);
+template HostTensor from_vector<uint8_t>(const std::vector<uint8_t>&, const TensorSpec&, uint8_t);
+
+template HostTensor from_vector<bfloat16>(std::vector<bfloat16>&&, const TensorSpec&, bfloat16);
+template HostTensor from_vector<float>(std::vector<float>&&, const TensorSpec&, float);
+template HostTensor from_vector<int32_t>(std::vector<int32_t>&&, const TensorSpec&, int32_t);
+template HostTensor from_vector<uint32_t>(std::vector<uint32_t>&&, const TensorSpec&, uint32_t);
+template HostTensor from_vector<uint16_t>(std::vector<uint16_t>&&, const TensorSpec&, uint16_t);
+template HostTensor from_vector<uint8_t>(std::vector<uint8_t>&&, const TensorSpec&, uint8_t);
+
+template std::vector<bfloat16> to_vector<bfloat16>(const HostTensor&);
+template std::vector<int32_t> to_vector<int32_t>(const HostTensor&);
+template std::vector<uint32_t> to_vector<uint32_t>(const HostTensor&);
+template std::vector<uint16_t> to_vector<uint16_t>(const HostTensor&);
+template std::vector<uint8_t> to_vector<uint8_t>(const HostTensor&);
+
+}  // namespace tt::tt_metal::tensor_impl::host_tensor

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -26,15 +26,20 @@
 // ============================================================================
 
 namespace tt::tt_metal {
-bool logical_matches_physical(const TensorSpec& tensor_spec);
+bool logical_matches_physical(const TensorSpec& tensor_spec);  // NOLINT(readability-redundant-declaration)
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::tensor_impl {
 template <typename T>
-std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value);
+std::vector<T> encode_tensor_data(  // NOLINT(readability-redundant-declaration)
+    ttsl::Span<const T> logical_data,
+    const TensorSpec& tensor_spec,
+    T pad_value);
 
 template <typename T>
-std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec);
+std::vector<T> decode_tensor_data(  // NOLINT(readability-redundant-declaration)
+    ttsl::Span<const T> physical_data,
+    const TensorSpec& tensor_spec);
 }  // namespace tt::tt_metal::tensor_impl
 
 // ============================================================================

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 
 #include <tt_stl/span.hpp>
+#include <tt_stl/fmt.hpp>
 
 #include <algorithm>
 

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -107,7 +107,7 @@ HostTensor from_vector(std::vector<T>&& buffer, const TensorSpec& spec, T pad_va
 }
 
 template <typename T>
-std::vector<T> to_vector(const HostTensor& tensor) {
+std::vector<T> to_vector_generic(const HostTensor& tensor) {
     TT_FATAL(
         tensor.dtype() == convert_to_data_type<T>(),
         "Unsupported data type for to_vector: got {}, expected: {}",
@@ -123,8 +123,7 @@ std::vector<T> to_vector(const HostTensor& tensor) {
     return decode_tensor_data(data, tensor.tensor_spec());
 }
 
-template <>
-std::vector<float> to_vector<float>(const HostTensor& tensor) {
+std::vector<float> to_vector_float(const HostTensor& tensor) {
     HostBuffer host_buffer = get_single_host_buffer(tensor);
 
     switch (tensor.dtype()) {
@@ -161,6 +160,14 @@ std::vector<float> to_vector<float>(const HostTensor& tensor) {
             TT_THROW("Cannot convert HostTensor to vector<float> for data type: {}", tensor.dtype());
         }
     }
+}
+
+template <typename T>
+std::vector<T> to_vector(const HostTensor& tensor) {
+    if constexpr (std::is_same_v<T, float>) {
+        return to_vector_float(tensor);
+    }
+    return to_vector_generic<T>(tensor);
 }
 
 // ============================================================================
@@ -200,6 +207,7 @@ template HostTensor from_vector<uint32_t>(std::vector<uint32_t>&&, const TensorS
 template HostTensor from_vector<uint16_t>(std::vector<uint16_t>&&, const TensorSpec&, uint16_t);
 template HostTensor from_vector<uint8_t>(std::vector<uint8_t>&&, const TensorSpec&, uint8_t);
 
+template std::vector<float> to_vector<float>(const HostTensor&);
 template std::vector<bfloat16> to_vector<bfloat16>(const HostTensor&);
 template std::vector<int32_t> to_vector<int32_t>(const HostTensor&);
 template std::vector<uint32_t> to_vector<uint32_t>(const HostTensor&);

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/bfloat4.hpp>
@@ -48,21 +49,6 @@ std::vector<T> decode_tensor_data(  // NOLINT(readability-redundant-declaration)
 // ============================================================================
 
 namespace tt::tt_metal::tensor_impl::host_tensor {
-
-namespace {
-// TODO(#40348):
-// Will be host_buffer::get_host_buffer
-HostBuffer get_single_host_buffer(const HostTensor& tensor) {
-    const auto& distributed_buffer = tensor.buffer();
-    std::vector<HostBuffer> buffers;
-    distributed_buffer.apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-    TT_FATAL(
-        buffers.size() == 1,
-        "Can't get a single buffer from HostTensor distributed over mesh shape {}",
-        distributed_buffer.shape());
-    return buffers.front();
-}
-}  // namespace
 
 template <typename T>
 HostTensor from_span(ttsl::Span<const T> buffer, const TensorSpec& spec, T pad_value) {
@@ -115,7 +101,7 @@ std::vector<T> to_vector_generic(const HostTensor& tensor) {
         tensor.dtype(),
         convert_to_data_type<T>());
 
-    HostBuffer host_buffer = get_single_host_buffer(tensor);
+    HostBuffer host_buffer = host_buffer::get_host_buffer(tensor);
 
     auto data = host_buffer.view_as<const T>();
     if (logical_matches_physical(tensor.tensor_spec())) {
@@ -125,7 +111,7 @@ std::vector<T> to_vector_generic(const HostTensor& tensor) {
 }
 
 std::vector<float> to_vector_float(const HostTensor& tensor) {
-    HostBuffer host_buffer = get_single_host_buffer(tensor);
+    HostBuffer host_buffer = host_buffer::get_host_buffer(tensor);
 
     switch (tensor.dtype()) {
         case DataType::BFLOAT16: {

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -50,8 +50,44 @@ std::vector<T> decode_tensor_data(  // NOLINT(readability-redundant-declaration)
 
 namespace tt::tt_metal::tensor_impl::host_tensor {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+template <typename T>
+HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T pad_value) {
+    auto buffer_dtype = convert_to_data_type<T>();
+    auto buffer_spec =
+        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
+
+    size_t volume = spec.logical_shape().volume();
+
+    TT_FATAL(
+        !logical_matches_physical(spec),
+        "Logical matches physical, don't support that case, use Tensor::from_span instead!");
+
+    TT_FATAL(
+        buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
+    if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
+        TT_FATAL(spec.layout() == Layout::TILE, "Block float types are only supported in TILE layout");
+    }
+
+    auto host_buffer = HostBuffer(tensor_impl::encode_tensor_data(tt::stl::make_const_span(buffer), spec, pad_value));
+
+    auto res = HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+    return tensor_impl::to_dtype(res, spec.data_type());
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 template <typename T>
 HostTensor from_span(ttsl::Span<const T> buffer, const TensorSpec& spec, T pad_value) {
+    if (!logical_matches_physical(spec)) {
+        // If the logical shape doesn't match the physical shape, we need to encode the data
+        // and write the result to a new buffer. This branch avoids the extra copy that
+        // would otherwise occur in the from_vector function call.
+        return CMAKE_UNIQUE_NAMESPACE::from_span_impl(buffer, spec, pad_value);
+    }
     return from_vector(std::vector<T>(buffer.begin(), buffer.end()), spec, pad_value);
 }
 
@@ -101,9 +137,7 @@ std::vector<T> to_vector_generic(const HostTensor& tensor) {
         tensor.dtype(),
         convert_to_data_type<T>());
 
-    HostBuffer host_buffer = host_buffer::get_host_buffer(tensor);
-
-    auto data = host_buffer.view_as<const T>();
+    auto data = host_buffer::get_as<const T>(tensor);
     if (logical_matches_physical(tensor.tensor_spec())) {
         return std::vector<T>(data.begin(), data.end());
     }
@@ -111,11 +145,9 @@ std::vector<T> to_vector_generic(const HostTensor& tensor) {
 }
 
 std::vector<float> to_vector_float(const HostTensor& tensor) {
-    HostBuffer host_buffer = host_buffer::get_host_buffer(tensor);
-
     switch (tensor.dtype()) {
         case DataType::BFLOAT16: {
-            auto buffer = host_buffer.view_as<const bfloat16>();
+            auto buffer = host_buffer::get_as<bfloat16>(tensor);
             std::vector<float> physical_data;
             physical_data.reserve(buffer.size());
             std::transform(buffer.begin(), buffer.end(), std::back_inserter(physical_data), [](bfloat16 val) {
@@ -127,16 +159,13 @@ std::vector<float> to_vector_float(const HostTensor& tensor) {
             return decode_tensor_data(ttsl::make_const_span(physical_data), tensor.tensor_spec());
         }
         case DataType::FLOAT32: {
-            auto buffer = host_buffer.view_as<const float>();
-            if (logical_matches_physical(tensor.tensor_spec())) {
-                return std::vector<float>(buffer.begin(), buffer.end());
-            }
+            auto buffer = host_buffer::get_as<float>(tensor);
             return decode_tensor_data(buffer, tensor.tensor_spec());
         }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
             const auto& tile = tensor.tensor_spec().tile();
-            auto buffer = host_buffer.view_as<const uint32_t>();
+            auto buffer = host_buffer::get_as<uint32_t>(tensor);
             std::vector<float> unpacked_data =
                 tensor.dtype() == DataType::BFLOAT8_B
                     ? unpack_bfp8_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile)

--- a/ttnn/core/tensor/host_tensor_factory.cpp
+++ b/ttnn/core/tensor/host_tensor_factory.cpp
@@ -126,7 +126,8 @@ HostTensor from_vector(std::vector<T>&& buffer, const TensorSpec& spec, T pad_va
                            ? HostBuffer(std::move(buffer))
                            : HostBuffer(encode_tensor_data(ttsl::make_const_span(buffer), spec, pad_value));
 
-    return HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+    auto res = HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+    return to_dtype(res, spec.data_type());
 }
 
 template <typename T>

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -316,6 +316,7 @@ template Tensor Tensor::from_vector<uint32_t>(
     std::optional<tt::tt_metal::QueueId> cq_id,
     uint32_t pad_value);
 
+template std::vector<float> Tensor::to_vector<float>(std::optional<tt::tt_metal::QueueId> cq_id) const;
 template std::vector<bfloat16> Tensor::to_vector<bfloat16>(std::optional<tt::tt_metal::QueueId> cq_id) const;
 template std::vector<int32_t> Tensor::to_vector<int32_t>(std::optional<tt::tt_metal::QueueId> cq_id) const;
 template std::vector<uint8_t> Tensor::to_vector<uint8_t>(std::optional<tt::tt_metal::QueueId> cq_id) const;

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -42,31 +43,6 @@
 namespace tt::tt_metal {
 namespace {
 std::atomic<std::uint64_t> tensor_id_counter{0};
-
-template <typename T>
-Tensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T pad_value) {
-    auto buffer_dtype = convert_to_data_type<T>();
-    auto buffer_spec =
-        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
-
-    size_t volume = spec.logical_shape().volume();
-
-    TT_FATAL(
-        !logical_matches_physical(spec),
-        "Logical matches physical, don't support that case, use Tensor::from_span instead!");
-
-    TT_FATAL(
-        buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
-    if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
-        TT_FATAL(spec.layout() == Layout::TILE, "Block float types are only supported in TILE layout");
-    }
-
-    auto host_buffer = HostBuffer(tensor_impl::encode_tensor_data(tt::stl::make_const_span(buffer), spec, pad_value));
-
-    auto res = Tensor(std::move(host_buffer), buffer_spec);
-    return to_dtype(res, spec.data_type());
-}
-
 }  // namespace
 
 Tensor::Tensor(
@@ -194,18 +170,13 @@ Tensor Tensor::from_span(
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     T pad_value) {
-    if (!logical_matches_physical(spec)) {
-        // If the logical shape doesn't match the physical shape, we need to encode the data
-        // and write the result to a new buffer. This branch avoids the extra copy that
-        // would otherwise occur in the from_vector function call.
-        auto res = from_span_impl(buffer, spec, static_cast<T>(pad_value));
-        res = to_dtype(res, spec.data_type());
-        if (device) {
-            res = res.to_device(device, spec.memory_config(), cq_id);
-        }
-        return res;
+    auto host_tensor = tensor_impl::host_tensor::from_span(buffer, spec, pad_value);
+    auto res = Tensor(std::move(host_tensor));
+    res = to_dtype(res, spec.data_type());
+    if (device) {
+        res = res.to_device(device, spec.memory_config(), cq_id);
     }
-    return from_vector(std::vector<T>(buffer.begin(), buffer.end()), spec, device, cq_id, pad_value);
+    return res;
 }
 
 template <typename T>
@@ -214,10 +185,8 @@ Tensor Tensor::from_borrowed_data(
     const tt::tt_metal::Shape& shape,
     tt::tt_metal::MemoryPin buffer_pin,
     const std::optional<Tile>& tile) {
-    size_t volume = shape.volume();
-    TT_FATAL(
-        buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
-    return Tensor(HostBuffer(buffer, std::move(buffer_pin)), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
+    auto host_tensor = tensor_impl::host_tensor::from_borrowed_data(buffer, shape, std::move(buffer_pin), tile);
+    return Tensor(std::move(host_tensor));
 }
 
 template <typename T>
@@ -227,24 +196,8 @@ Tensor Tensor::from_vector(
     distributed::MeshDevice* device,
     std::optional<tt::tt_metal::QueueId> cq_id,
     T pad_value) {
-    size_t volume = spec.logical_shape().volume();
-    TT_FATAL(
-        buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
-    if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
-        TT_FATAL(spec.layout() == Layout::TILE, "Block float types are only supported in TILE layout");
-    }
-
-    // Create host tensor with DataType matching buffer
-    auto buffer_dtype = convert_to_data_type<T>();
-    auto buffer_spec =
-        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
-
-    auto host_buffer =
-        logical_matches_physical(buffer_spec)
-            ? HostBuffer(std::move(buffer))
-            : HostBuffer(tensor_impl::encode_tensor_data(ttsl::make_const_span(buffer), spec, pad_value));
-    auto res = Tensor(std::move(host_buffer), buffer_spec);
-    // Convert to datatype from original spec
+    auto host_tensor = tensor_impl::host_tensor::from_vector(std::move(buffer), spec, pad_value);
+    auto res = Tensor(std::move(host_tensor));
     res = to_dtype(res, spec.data_type());
     if (device) {
         res = res.to_device(device, spec.memory_config(), cq_id);
@@ -255,37 +208,7 @@ Tensor Tensor::from_vector(
 template <>
 std::vector<float> Tensor::to_vector<float>(std::optional<tt::tt_metal::QueueId> cq_id) const {
     Tensor cpu_tensor = this->cpu(/*blocking=*/true, cq_id);
-    switch (cpu_tensor.dtype()) {
-        case DataType::BFLOAT16: {
-            auto buffer = host_buffer::get_as<bfloat16>(cpu_tensor);
-            std::vector<float> physical_data;
-            physical_data.reserve(buffer.size());
-            std::transform(buffer.begin(), buffer.end(), std::back_inserter(physical_data), [](bfloat16 val) {
-                return static_cast<float>(val);
-            });
-            if (logical_matches_physical(cpu_tensor.tensor_spec())) {
-                return physical_data;
-            }
-            return tensor_impl::decode_tensor_data(ttsl::make_const_span(physical_data), cpu_tensor.tensor_spec());
-        }
-        case DataType::FLOAT32: {
-            auto buffer = host_buffer::get_as<const float>(cpu_tensor);
-            return tensor_impl::decode_tensor_data(buffer, cpu_tensor.tensor_spec());
-        }
-        case DataType::BFLOAT8_B:
-        case DataType::BFLOAT4_B: {
-            const auto& tile = cpu_tensor.tensor_spec().tile();
-            auto buffer = host_buffer::get_as<const uint32_t>(cpu_tensor);
-            std::vector<float> unpacked_data =
-                cpu_tensor.tensor_spec().data_type() == DataType::BFLOAT8_B
-                    ? unpack_bfp8_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
-                    : unpack_bfp4_tiles_into_float_vec(buffer, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            return tensor_impl::decode_tensor_data(ttsl::make_const_span(unpacked_data), cpu_tensor.tensor_spec());
-        }
-        default: {
-            TT_THROW("Cannot convert tensor to vector for data type: {}", cpu_tensor.dtype());
-        }
-    }
+    return tensor_impl::host_tensor::to_vector<float>(cpu_tensor.host_tensor());
 }
 
 template <typename T>
@@ -296,11 +219,7 @@ std::vector<T> Tensor::to_vector(std::optional<tt::tt_metal::QueueId> cq_id) con
         this->dtype(),
         convert_to_data_type<T>());
     auto cpu_tensor = this->cpu(/*blocking=*/true, cq_id);
-    auto data = host_buffer::get_as<const T>(cpu_tensor);
-    if (logical_matches_physical(cpu_tensor.tensor_spec())) {
-        return std::vector<T>(data.begin(), data.end());
-    }
-    return tensor_impl::decode_tensor_data(data, cpu_tensor.tensor_spec());
+    return tensor_impl::host_tensor::to_vector<T>(cpu_tensor.host_tensor());
 }
 
 // Instantiate explicitly for the supported types.

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -205,19 +205,9 @@ Tensor Tensor::from_vector(
     return res;
 }
 
-template <>
-std::vector<float> Tensor::to_vector<float>(std::optional<tt::tt_metal::QueueId> cq_id) const {
-    Tensor cpu_tensor = this->cpu(/*blocking=*/true, cq_id);
-    return tensor_impl::host_tensor::to_vector<float>(cpu_tensor.host_tensor());
-}
-
 template <typename T>
 std::vector<T> Tensor::to_vector(std::optional<tt::tt_metal::QueueId> cq_id) const {
-    TT_FATAL(
-        this->dtype() == convert_to_data_type<T>(),
-        "Unsupported data type for to_vector: got {}, expected: {}",
-        this->dtype(),
-        convert_to_data_type<T>());
+    // Type support is checked by HostTensor::to_vector
     auto cpu_tensor = this->cpu(/*blocking=*/true, cq_id);
     return tensor_impl::host_tensor::to_vector<T>(cpu_tensor.host_tensor());
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -172,7 +172,6 @@ Tensor Tensor::from_span(
     T pad_value) {
     auto host_tensor = tensor_impl::host_tensor::from_span(buffer, spec, pad_value);
     auto res = Tensor(std::move(host_tensor));
-    res = to_dtype(res, spec.data_type());
     if (device) {
         res = res.to_device(device, spec.memory_config(), cq_id);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36877

### PR Type
Refactor

### Problem description
Runtime is lowering ttnn::Tensor to tt_metal as HostTensor and MeshTensor.
HostTensor has a certain set of host side ops that needs lowering.

### What's changed
This PR separates out ttnn::Tensor's creation utilities and `to_vector` to call their `HostTensor`counterpart.
Note all functions are still in ttnn land to ease review burden,
and will be lowered in a subsequent PR.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-tensor-creation)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/host-tensor-creation)
  - Unrelated 
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-tensor-creation)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/host-tensor-creation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/host-tensor-creation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/host-tensor-creation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/host-tensor-creation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
