### PR TITLE
Revert "Update Deepseek MLA to store and use Prefill-mode and height-sharded `sin`, `cos`, `trans_mat` to avoid transposes in RoPE (#39575)"

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1896,14 +1896,20 @@ class MLA1D(AbstractModule):
 
         # KV RoPE
         # 1,1,32,64 1x2 [32,32]
+        tt_kv_rope = ttnn.transpose(
+            tt_kv_rope, 1, 2, memory_config=cfg["kv_rope_reshard"]
+        )  # [1, bsz, 1, qk_rope_head_dim]        # 1,32,1,64 interleaved | should be: 4x8 [32,64]
         tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
             tt_kv_rope,
-            rope_tensors["cos_matrix_prefill_shape"],
-            rope_tensors["sin_matrix_prefill_shape"],
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
             rope_tensors["trans_matrix"],
-            is_decode_mode=False,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            is_decode_mode=True,
         )
+        # 1,32,1,64 4x8 [32,64]
+        tt_kv_rope = ttnn.transpose(
+            tt_kv_rope, 1, 2, memory_config=ttnn.L1_MEMORY_CONFIG
+        )  # [1, 1, bsz, qk_rope_head_dim]
         # 1,1,32,64 L1 interleaved
         tt_kv_nope = ttnn.to_memory_config(tt_kv_nope, memory_config=ttnn.L1_MEMORY_CONFIG)
 

--- a/models/demos/deepseek_v3/tt/rope.py
+++ b/models/demos/deepseek_v3/tt/rope.py
@@ -217,6 +217,7 @@ class RotarySetup:
             A list containing the cos matrix, sin matrix, and transformation matrix.
             If return_rot_idxs is True, it will also return the rotary positional embedding indices.
         """
+
         device = self.device
 
         # If position_idxs is a torch tensor, get the TTNN version of it
@@ -237,9 +238,12 @@ class RotarySetup:
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch, dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch, dim]
 
+        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
+        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
+
         if self.batch_size_per_row % ttnn.TILE_SIZE != 0:
-            cos = cos[:, :, : self.batch_size_per_row, :]
-            sin = sin[:, :, : self.batch_size_per_row, :]
+            cos = cos[:, : self.batch_size_per_row, :, :]
+            sin = sin[:, : self.batch_size_per_row, :, :]
 
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.dim),
@@ -249,37 +253,12 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
-        # For using height-sharded prefill-mode in decode with batch reinterpreted as seq_len
-        # Possible because `rotary_embedding_llama` is (almost) an eltwise op.
-        cos_matrix_prefill_shape = ttnn.to_memory_config(
-            cos, memory_config=mem_config
-        )  # ttnn.interleaved_to_sharded(cos, mem_config)
-        sin_matrix_prefill_shape = ttnn.to_memory_config(
-            sin, memory_config=mem_config
-        )  # ttnn.interleaved_to_sharded(sin, mem_config)
-
-        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
-        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
         cos = ttnn.interleaved_to_sharded(cos, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.dim]
         sin = ttnn.interleaved_to_sharded(sin, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.dim]
 
         if return_rot_idxs:
-            return {
-                "cos_matrix": cos,
-                "sin_matrix": sin,
-                "trans_matrix": self.transformation_mat,
-                "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
-                "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
-                "trans_matrix_prefill_shape": self.transformation_mat_prefill,
-            }, rot_idxs
-        return {
-            "cos_matrix": cos,
-            "sin_matrix": sin,
-            "trans_matrix": self.transformation_mat,
-            "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
-            "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
-            "trans_matrix_prefill_shape": self.transformation_mat_prefill,
-        }
+            return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}, rot_idxs
+        return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}
 
     def get_rot_mats_from_rot_idxs(
         self, rot_idxs: ttnn.Tensor, return_rot_idxs: bool = False
@@ -298,7 +277,6 @@ class RotarySetup:
         """
         assert isinstance(rot_idxs, ttnn.Tensor), "rot_idxs must be a TTNN tensor"
         assert len(rot_idxs.shape) == 2 and rot_idxs.shape[0] == 1, "rot_idxs must be a [1, batch] tensor"
-
         # All operations below are pure ttnn ops (no from_torch/as_tensor)
         embedding_layout = ttnn.TILE_LAYOUT
         cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=embedding_layout)  # [1, batch, dim]
@@ -307,9 +285,12 @@ class RotarySetup:
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch, dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch, dim]
 
+        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
+        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
+
         if self.batch_size_per_row % ttnn.TILE_SIZE != 0:
-            cos = cos[:, :, : self.batch_size_per_row, :]
-            sin = sin[:, :, : self.batch_size_per_row, :]
+            cos = cos[:, : self.batch_size_per_row, :, :]
+            sin = sin[:, : self.batch_size_per_row, :, :]
 
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.dim),
@@ -319,34 +300,9 @@ class RotarySetup:
             use_height_and_width_as_shard_shape=True,
         )
 
-        # For using height-sharded prefill-mode in decode with batch reinterpreted as seq_len
-        # Possible because `rotary_embedding_llama` is (almost) an eltwise op.
-        cos_matrix_prefill_shape = ttnn.to_memory_config(
-            cos, memory_config=mem_config
-        )  # ttnn.interleaved_to_sharded(cos, mem_config)
-        sin_matrix_prefill_shape = ttnn.to_memory_config(
-            sin, memory_config=mem_config
-        )  # ttnn.interleaved_to_sharded(sin, mem_config)
-
-        cos = ttnn.transpose(cos, 1, 2)  # [1, batch, 1[32], dim]
-        sin = ttnn.transpose(sin, 1, 2)  # [1, batch, 1[32], dim]
         cos = ttnn.interleaved_to_sharded(cos, mem_config)
         sin = ttnn.interleaved_to_sharded(sin, mem_config)
 
         if return_rot_idxs:
-            return {
-                "cos_matrix": cos,
-                "sin_matrix": sin,
-                "trans_matrix": self.transformation_mat,
-                "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
-                "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
-                "trans_matrix_prefill_shape": self.transformation_mat_prefill,
-            }, rot_idxs
-        return {
-            "cos_matrix": cos,
-            "sin_matrix": sin,
-            "trans_matrix": self.transformation_mat,
-            "cos_matrix_prefill_shape": cos_matrix_prefill_shape,
-            "sin_matrix_prefill_shape": sin_matrix_prefill_shape,
-            "trans_matrix_prefill_shape": self.transformation_mat_prefill,
-        }
+            return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}, rot_idxs
+        return {"cos_matrix": cos, "sin_matrix": sin, "trans_matrix": self.transformation_mat}


### PR DESCRIPTION
This reverts commit acd55ca853b2023c9029189fee15b19819795356.

### Ticket
[#40347](https://github.com/tenstorrent/tt-metal/issues/40347)

### Problem description
Dual demo output is garbage because of new commit.

### What's changed
Commit right before this one produced good dual demo outputs, therefore reverting this culprit.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{revert-acd55ca853b-pr}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{revert-acd55ca853b-pr}})