### PR TITLE
Fix UINT32 untilize perf model and add regression test (#34072)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -2955,3 +2955,36 @@ def test_untilize_uint32_large_width(device, use_multicore, tensor_shape, input_
     result = ttnn.to_torch(untilized)
 
     assert_equal(result, torch_tensor)
+
+
+@pytest.mark.parametrize("use_multicore", [True, False])
+@pytest.mark.parametrize(
+    "tensor_shape",
+    [
+        [1, 1, 32, 512],  # 16 tiles wide (exceeds 4-tile DEST limit for 32-bit types)
+        [1, 1, 32, 4704],  # 147 tiles wide (from issue #34072 repro)
+    ],
+)
+@pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_untilize_float32_large_width(device, use_multicore, tensor_shape, input_buffer_type):
+    """
+    Regression test for FLOAT32 untilize with large widths.
+
+    FLOAT32 uses 32-bit DEST accumulation mode which reduces the DEST register capacity
+    from 8 to 4 tiles in half-sync mode. Widths exceeding this limit must fall back to
+    block-based untilize instead of pack_untilize.
+    """
+    torch.manual_seed(42)
+
+    torch_tensor = torch.randn(tensor_shape, dtype=torch.float32)
+
+    input_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, input_buffer_type)
+    output_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    tile_tensor = ttnn.from_torch(
+        torch_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_memory_config
+    )
+    untilized = ttnn.untilize(tile_tensor, memory_config=output_memory_config, use_multicore=use_multicore)
+    result = ttnn.to_torch(untilized)
+
+    assert_with_pcc(result, torch_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -2922,3 +2922,36 @@ def test_untilize_nd_shard_to_same_shard_spec_uneven_input_shard_spec(
     ttnn_output_tensor = ttnn.untilize(input_ttnn_tensor)
 
     assert_equal(input_torch_tensor, ttnn.to_torch(ttnn_output_tensor))
+
+
+@pytest.mark.parametrize("use_multicore", [True, False])
+@pytest.mark.parametrize(
+    "tensor_shape",
+    [
+        [1, 1, 32, 512],  # 16 tiles wide (exceeds 4-tile DEST limit for 32-bit types)
+        [1, 1, 32, 4704],  # 147 tiles wide (from issue #34072 repro)
+    ],
+)
+@pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_untilize_uint32_large_width(device, use_multicore, tensor_shape, input_buffer_type):
+    """
+    Regression test for issue #34072: UINT32 untilize corruption for large tensors.
+
+    UINT32 uses 32-bit DEST accumulation mode which reduces the DEST register capacity
+    from 8 to 4 tiles in half-sync mode. Widths exceeding this limit must fall back to
+    block-based untilize instead of pack_untilize.
+    """
+    torch.manual_seed(42)
+
+    torch_tensor = torch.randint(0, 1000, tensor_shape, dtype=torch.int32)
+
+    input_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, input_buffer_type)
+    output_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    tile_tensor = ttnn.from_torch(
+        torch_tensor, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_memory_config
+    )
+    untilized = ttnn.untilize(tile_tensor, memory_config=output_memory_config, use_multicore=use_multicore)
+    result = ttnn.to_torch(untilized)
+
+    assert_equal(result, torch_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -2929,7 +2929,7 @@ def test_untilize_nd_shard_to_same_shard_spec_uneven_input_shard_spec(
     "tensor_shape",
     [
         [1, 1, 32, 512],  # 16 tiles wide (exceeds 4-tile DEST limit for 32-bit types)
-        [1, 1, 32, 4704],  # 147 tiles wide (from issue #34072 repro)
+        [1, 1, 32, 4704],  # 4704 elements = 147 tiles wide; issue #34072 used 4704 tiles (150,528 elements)
     ],
 )
 @pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
@@ -2937,9 +2937,10 @@ def test_untilize_uint32_large_width(device, use_multicore, tensor_shape, input_
     """
     Regression test for issue #34072: UINT32 untilize corruption for large tensors.
 
-    UINT32 uses 32-bit DEST accumulation mode which reduces the DEST register capacity
-    from 8 to 4 tiles in half-sync mode. Widths exceeding this limit must fall back to
-    block-based untilize instead of pack_untilize.
+    UINT32 uses 32-bit DEST accumulation mode, which reduces the effective DEST register
+    capacity from 8 to 4 tiles in half-sync mode. For widths that exceed this limit, the
+    untilize kernel block-splits the width dimension and invokes pack_untilize_block on
+    each chunk instead of processing the entire row in a single DEST transaction.
     """
     torch.manual_seed(42)
 
@@ -2954,7 +2955,7 @@ def test_untilize_uint32_large_width(device, use_multicore, tensor_shape, input_
     untilized = ttnn.untilize(tile_tensor, memory_config=output_memory_config, use_multicore=use_multicore)
     result = ttnn.to_torch(untilized)
 
-    assert_equal(result, torch_tensor)
+    assert_equal(torch_tensor, result)
 
 
 @pytest.mark.parametrize("use_multicore", [True, False])
@@ -2962,7 +2963,7 @@ def test_untilize_uint32_large_width(device, use_multicore, tensor_shape, input_
     "tensor_shape",
     [
         [1, 1, 32, 512],  # 16 tiles wide (exceeds 4-tile DEST limit for 32-bit types)
-        [1, 1, 32, 4704],  # 147 tiles wide (from issue #34072 repro)
+        [1, 1, 32, 4704],  # 4704 elements = 147 tiles wide; issue #34072 used 4704 tiles (150,528 elements)
     ],
 )
 @pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
@@ -2970,9 +2971,10 @@ def test_untilize_float32_large_width(device, use_multicore, tensor_shape, input
     """
     Regression test for FLOAT32 untilize with large widths.
 
-    FLOAT32 uses 32-bit DEST accumulation mode which reduces the DEST register capacity
-    from 8 to 4 tiles in half-sync mode. Widths exceeding this limit must fall back to
-    block-based untilize instead of pack_untilize.
+    FLOAT32 uses 32-bit DEST accumulation mode, which reduces the effective DEST register
+    capacity from 8 to 4 tiles in half-sync mode. For widths that exceed this limit, the
+    untilize kernel block-splits the width dimension and invokes pack_untilize_block on
+    each chunk instead of processing the entire row in a single DEST transaction.
     """
     torch.manual_seed(42)
 
@@ -2987,4 +2989,4 @@ def test_untilize_float32_large_width(device, use_multicore, tensor_shape, input
     untilized = ttnn.untilize(tile_tensor, memory_config=output_memory_config, use_multicore=use_multicore)
     result = ttnn.to_torch(untilized)
 
-    assert_with_pcc(result, torch_tensor, 0.9999)
+    assert_with_pcc(torch_tensor, result, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -374,7 +374,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<UntilizeDeviceOperation::tensor_return_value_t>
 UntilizeDeviceOperation::create_op_performance_model(
-    const UntilizeDeviceOperation::operation_attributes_t& /*op_attr*/,
+    const UntilizeDeviceOperation::operation_attributes_t& op_attr,
     const UntilizeDeviceOperation::tensor_args_t& inputs,
     tensor_return_value_t& output) {
     const auto& input_tensor = inputs.input;
@@ -385,7 +385,8 @@ UntilizeDeviceOperation::create_op_performance_model(
     uint32_t num_tiles =
         std::ceil(static_cast<float>(input_tensor.physical_volume()) / static_cast<float>(single_tile_size));
     int compute_cycles = 0;
-    const int max_tiles_per_row = 8;
+    // DEST register capacity in half-sync mode: 4 tiles for 32-bit types (UINT32/FLOAT32), 8 for 16-bit
+    const int max_tiles_per_row = op_attr.fp32_dest_acc_en ? 4 : 8;
     const int latency_untilize = 390;      // measured latency for untilize_block
     const int latency_pack_untilize = 80;  // measured latency for pack_untilize_block
     if (std::ceil(static_cast<float>(input_tensor.padded_shape()[-1]) / static_cast<float>(tile_width)) <=

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -374,7 +374,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<UntilizeDeviceOperation::tensor_return_value_t>
 UntilizeDeviceOperation::create_op_performance_model(
-    const UntilizeDeviceOperation::operation_attributes_t& op_attr,
+    const UntilizeDeviceOperation::operation_attributes_t& /*op_attr*/,
     const UntilizeDeviceOperation::tensor_args_t& inputs,
     tensor_return_value_t& output) {
     const auto& input_tensor = inputs.input;
@@ -385,8 +385,9 @@ UntilizeDeviceOperation::create_op_performance_model(
     uint32_t num_tiles =
         std::ceil(static_cast<float>(input_tensor.physical_volume()) / static_cast<float>(single_tile_size));
     int compute_cycles = 0;
-    // DEST register capacity in half-sync mode: 4 tiles for 32-bit types (UINT32/FLOAT32), 8 for 16-bit
-    const int max_tiles_per_row = op_attr.fp32_dest_acc_en ? 4 : 8;
+    // DEST register capacity in half-sync mode: 4 tiles for 32-bit element types, 8 for 16-bit
+    const bool is_32bit_element = input_tensor.element_size() == 4;
+    const int max_tiles_per_row = is_32bit_element ? 4 : 8;
     const int latency_untilize = 390;      // measured latency for untilize_block
     const int latency_pack_untilize = 80;  // measured latency for pack_untilize_block
     if (std::ceil(static_cast<float>(input_tensor.padded_shape()[-1]) / static_cast<float>(tile_width)) <=


### PR DESCRIPTION
## Summary
- Fix performance model in `untilize_device_operation.cpp` to use correct DEST register capacity for 32-bit types: 4 tiles in half-sync mode instead of hardcoded 8. Uses `element_size() == 4` to detect 32-bit types (UINT32/FLOAT32/INT32), giving more accurate cycle estimates.
- Add `test_untilize_uint32_large_width` and `test_untilize_float32_large_width` regression tests for issue #34072, covering UINT32 and FLOAT32 untilize with widths exceeding the DEST limit (512 and 4704 elements wide), both single-core and multi-core, with L1 and DRAM input buffers.

Note: The kernel-level correctness fix was already landed via PR #39294 (untilize helpers integration with `DEST_AUTO_LIMIT`). This PR adds regression tests to prevent future regressions and fixes the perf model.

Closes #34072

## Test plan
- [x] `test_untilize_uint32_large_width` — 8 parametrized cases, all passing
- [x] `test_untilize_float32_large_width` — 8 parametrized cases, all passing
- [ ] Run existing untilize test suite for regressions