### PR TITLE
Add support to run ResNet50 BF16 #39626

### DIFF
--- a/models/demos/vision/classification/resnet50/ttnn_resnet/tests/common/resnet50_test_infra.py
+++ b/models/demos/vision/classification/resnet50/ttnn_resnet/tests/common/resnet50_test_infra.py
@@ -196,8 +196,6 @@ class ResNet50TestInfra:
 
         if batch_size <= 2:
             pytest.skip("Batch size 1 and 2 are not supported with sharded data")
-        elif batch_size == 8:
-            pytest.skip("Skipping batch size 8 due to memory config issue")
         elif is_wormhole_b0() and batch_size == 20:
             pytest.skip("Skipping batch size 20 for Wormhole B0 due to fitting issue")
 
@@ -257,7 +255,9 @@ class ResNet50TestInfra:
         return inputs_mesh_mapper, weights_mesh_mapper, output_mesh_composer
 
     def setup_l1_sharded_input(self, device, torch_input_tensor=None):
-        if self.batch_size == 16:
+        if self.batch_size == 8:
+            core_grid = ttnn.CoreGrid(y=4, x=6)
+        elif self.batch_size == 16:
             core_grid = ttnn.CoreGrid(y=8, x=6)
         elif self.batch_size == 20:
             if is_blackhole():

--- a/models/demos/vision/classification/resnet50/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/vision/classification/resnet50/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -128,7 +128,9 @@ class resnet50Bottleneck:
                     enable_act_double_buffer=True if not (is_blackhole_p100(device) and batch_size > 16) else False,
                     enable_weights_double_buffer=True if input_width < 56 else False,
                     full_inner_dim=True,
-                    enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
+                    enable_activation_reuse=True
+                    if height_sharding and self.stride == 1 and not (is_wormhole_b0() and batch_size == 8)
+                    else False,
                 ),
             }
 
@@ -238,7 +240,9 @@ class resnet50Bottleneck:
                 enable_act_double_buffer=True,
                 enable_weights_double_buffer=True,
                 full_inner_dim=True,
-                enable_activation_reuse=True if height_sharding and self.stride == 1 else False,
+                enable_activation_reuse=True
+                if height_sharding and self.stride == 1 and not (is_wormhole_b0() and batch_size == 8)
+                else False,
             ),
         }
 
@@ -491,7 +495,13 @@ class resnet50:
         )
         num_cores_x = 8
         num_cores_y = 8
-        if self.batch_size == 16:
+        if self.batch_size == 8:
+            num_cores_x = 8
+            num_cores_y = 8
+            self.fold_compute_grid_size = ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
+            )
+        elif self.batch_size == 16:
             num_cores_x = 8
             num_cores_y = 8
             self.fold_compute_grid_size = ttnn.CoreRangeSet(
@@ -715,6 +725,11 @@ class resnet50:
         reshard = False
         height_shard = True
 
+        # For batch_size=8 on WH, tensor heights at layers 2-4 are not compatible
+        # with 8 y-cores for BLOCK sharding (e.g. 8*28*28=6272, 6272/8=784, not 32-aligned).
+        # Use height sharding for these layers instead.
+        batch8_wh_height_shard = is_wormhole_b0() and self.batch_size == 8
+
         logger.debug(f"==== Running layer 2 module 1")
         x, x_height, x_width = self.layer2_module1(
             x,
@@ -734,6 +749,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer2_module2",
         )
 
@@ -744,6 +760,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer2_module3",
         )
 
@@ -754,14 +771,20 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer2_module4",
         )
 
         reshard = is_blackhole()
         height_shard = is_blackhole()
         if is_wormhole_b0():
+            if batch8_wh_height_shard:
+                # For batch_size=8: 6272/8=784 not 32-aligned, use y=7: 6272/7=896 ✓
+                reshard_grid = ttnn.CoreGrid(x=8, y=7)
+            else:
+                reshard_grid = ttnn.CoreGrid(x=8, y=8)
             x = ttnn.to_memory_config(
-                x, ttnn.create_sharded_memory_config(x.shape, ttnn.CoreGrid(x=8, y=8), ttnn.ShardStrategy.BLOCK)
+                x, ttnn.create_sharded_memory_config(x.shape, reshard_grid, ttnn.ShardStrategy.BLOCK)
             )
 
         logger.debug(f"==== Running layer 3 module 1")
@@ -772,7 +795,7 @@ class resnet50:
             x_height,
             x_width,
             reshard_if_not_optimal=reshard,
-            height_sharding=height_shard,
+            height_sharding=True if batch8_wh_height_shard else height_shard,
             layer_module="layer3_module1",
         )
 
@@ -783,6 +806,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer3_module2",
         )
 
@@ -793,6 +817,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer3_module3",
         )
 
@@ -803,6 +828,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer3_module4",
         )
 
@@ -813,6 +839,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer3_module5",
         )
 
@@ -823,6 +850,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer3_module6",
         )
 
@@ -856,7 +884,7 @@ class resnet50:
             x_height,
             x_width,
             reshard_if_not_optimal=reshard,
-            height_sharding=height_shard,
+            height_sharding=True if batch8_wh_height_shard else height_shard,
             layer_module="layer4_module1",
         )
 
@@ -867,6 +895,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer4_module2",
         )
 
@@ -877,6 +906,7 @@ class resnet50:
             self.batch_size,
             x_height,
             x_width,
+            height_sharding=True if batch8_wh_height_shard else None,
             layer_module="layer4_module3",
         )
 
@@ -901,9 +931,9 @@ class resnet50:
             stride=[1, 1],
             padding=[0, 0, 0, 0],
             output_layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=self.model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=ttnn.init_device_compute_kernel_config(
-                self.device.arch(), math_fidelity=ttnn.MathFidelity.LoFi
+                self.device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),
         )
 

--- a/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_performant.py
+++ b/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_performant.py
@@ -19,7 +19,10 @@ from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.resnet
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
-    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+    (
+        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+        (8, ttnn.bfloat16, ttnn.bfloat16, ttnn.MathFidelity.HiFi2),
+    ),
 )
 @pytest.mark.parametrize("skip_compile_run", [True, False])
 def test_run_resnet50_inference(


### PR DESCRIPTION
### Ticket
#39626

### Problem description
Resnet50 test was failing for various reasons when using bf16.

### What's changed
A number of fixes and workarounds in the model to support running bf16 configs.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsmith/resnet-bf16)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsmith/resnet-bf16)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsmith/resnet-bf16)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsmith/resnet-bf16)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsmith/resnet-bf16)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsmith/resnet-bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsmith/resnet-bf16)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
