### PR TITLE
CI: refresh DeepSeek V3 decode Galaxy perf baselines (refs #39959)

### DIFF
--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,8 +40,9 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        # Galaxy CI baselines (refs #39959); 3% band covers recent main runs (~9.83–10.04 ms E2E).
-        pytest.param(9772.0, 167.0, 9939.0, 0.03, id="decode_e2e_perf"),
+        # Galaxy CI baselines (refs #39959). Centers are arithmetic means of four logged jobs (±3% must
+        # cover each): main runs 23085803049, 23108192002, 23138939045 and PR validation 23318003783.
+        pytest.param(9774.50, 168.37, 9942.87, 0.03, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,7 +40,8 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        pytest.param(10386.34, 191.52, 10577.85, 0.03, id="decode_e2e_perf"),
+        # Galaxy CI baselines (refs #39959); 3% band covers recent main runs (~9.83–10.04 ms E2E).
+        pytest.param(9772.0, 167.0, 9939.0, 0.03, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
## Summary
Refs #39959.

## Root cause
`test_decode_demo_perf[decode_e2e_perf]` compares profiler-derived 2-layer decode E2E time to a fixed golden. CI on Galaxy is **faster** than that golden: three consecutive failing main runs reported E2E **~9835–10043 µs** vs the old expected **10577.85 ± 3%** (band floor ~10260 µs), so the assertion failed on every run.

Kernel and op-to-op latency moved in the same direction (e.g. most recent job: kernel **9876.68 µs**, implied latency **~166.4 µs**).

CI logs also show profiler warnings that trace executions have **208** ops vs warmup reference **199**; this predates the threshold drift and may deserve a follow-up for alignment, but it does not block re-centering the golden on observed hardware.

## Change
Update `pytest.param` centers to **9772 / 167 / 9939 µs** (kernel + latency = E2E) so **±3%** comfortably covers the min/max across the three logged failures.

## Validation
- `python3 -m py_compile models/demos/deepseek_v3/demo/test_decode_demo_perf.py`
- No Galaxy hardware locally; numbers taken from job logs:
  - [run 23138939045 / job 67210729298](https://github.com/tenstorrent/tt-metal/actions/runs/23138939045/job/67210729298)
  - [run 23108192002 / job 67121287421](https://github.com/tenstorrent/tt-metal/actions/runs/23108192002/job/67121287421)
  - [run 23085803049 / job 67062640389](https://github.com/tenstorrent/tt-metal/actions/runs/23085803049/job/67062640389)

## CI plan
Re-run **(Galaxy) perf tests** → job **Galaxy DeepSeek V3 decode perf tests** after merge.

## Triggered validation run (PR branch)
- [(Galaxy) perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/23318003783) on `fix/ci-39959-deepseek-decode-perf-baseline`, `workflow_dispatch` with **`model=deepseek_v3`** (matrix filtered to DeepSeek only; no workflow-pruning commit).

## Auto-triage
Not used.

Made with [Cursor](https://cursor.com)
