### PR TITLE
Adding output verification to deepseek demo test

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,50 @@ MODEL_PATH = Path(
     os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized")
 )
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
+
+
+def is_allowed_unicode_letter(char: str) -> bool:
+    """True for Latin and Greek script letters per Unicode character name."""
+    if not char.isalpha():
+        return False
+    name = unicodedata.name(char, "")
+    return name.startswith("LATIN ") or name.startswith("GREEK ")
+
+
+def find_disallowed_non_ascii_letter(text: str) -> tuple[int, str] | None:
+    """Find the first disallowed non-ASCII letter in the text."""
+    for char_index, char in enumerate(text):
+        if char.isascii() or not char.isalpha() or is_allowed_unicode_letter(char):
+            continue
+        return char_index, char
+    return None
+
+
+def validate_english_keyboard_output(results: dict) -> None:
+    generations = results.get("generations", [])
+    for generation_index, generation in enumerate(generations, start=1):
+        generated_text = generation.get("text")
+        if generated_text is None:
+            continue
+        if not isinstance(generated_text, str):
+            raise ValueError(
+                "Generated output text must be a string or None: "
+                f"generation_index={generation_index}, got={type(generated_text).__name__}"
+            )
+
+        bad_char = find_disallowed_non_ascii_letter(generated_text)
+        if bad_char is None:
+            continue
+
+        bad_char_index, bad_char = bad_char
+        unicode_name = unicodedata.name(bad_char, "UNKNOWN")
+        raise ValueError(
+            "Generated output contains disallowed non-Latin letter: "
+            f"generation_index={generation_index}, char_index={bad_char_index}, "
+            f"char={bad_char!r}, codepoint=U+{ord(bad_char):04X}, unicode_name={unicode_name}. "
+            "Punctuation/symbols and Latin letters (including accents, e.g. é) are allowed; "
+            "other scripts (e.g. CJK) are not."
+        )
 
 
 def _demo_case(
@@ -178,6 +223,7 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         run_kwargs["stop_at_eos"] = case["stop_at_eos"]
 
     results = run_demo(**run_kwargs)
+    validate_english_keyboard_output(results)
 
     # Full-demo cases can stop early on EOS; stress/profile cases disable EOS and
     # should always produce the requested token count.

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -4,9 +4,11 @@
 import json
 import os
 import unicodedata
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json, run_demo
 
@@ -14,6 +16,17 @@ MODEL_PATH = Path(
     os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized")
 )
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
+
+
+@lru_cache(maxsize=1)
+def get_total_model_layers(model_path: Path) -> int:
+    with open(model_path / "config.json", "r", encoding="utf-8") as config_file:
+        config = json.load(config_file)
+
+    total_layers = config.get("num_hidden_layers")
+    if not isinstance(total_layers, int):
+        raise ValueError(f"Expected integer num_hidden_layers in {(model_path / 'config.json')}, got {total_layers!r}")
+    return total_layers
 
 
 def is_allowed_unicode_letter(char: str) -> bool:
@@ -58,6 +71,16 @@ def validate_english_keyboard_output(results: dict) -> None:
             "Punctuation/symbols and Latin letters (including accents, e.g. é) are allowed; "
             "other scripts (e.g. CJK) are not."
         )
+
+
+def maybe_validate_english_keyboard_output(results: dict, override_num_layers: int | None) -> None:
+    total_layers = get_total_model_layers(MODEL_PATH)
+    num_layers = override_num_layers if override_num_layers is not None else total_layers
+    if num_layers < total_layers:
+        logger.info(f"Output validation is skipped as {num_layers} < {total_layers} layers.")
+        return
+
+    validate_english_keyboard_output(results)
 
 
 def _demo_case(
@@ -223,7 +246,7 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         run_kwargs["stop_at_eos"] = case["stop_at_eos"]
 
     results = run_demo(**run_kwargs)
-    validate_english_keyboard_output(results)
+    maybe_validate_english_keyboard_output(results, case["override_num_layers"])
 
     # Full-demo cases can stop early on EOS; stress/profile cases disable EOS and
     # should always produce the requested token count.


### PR DESCRIPTION
### Ticket
#40349

### Problem description
deepseek demo o/p is dumped in json file but it's not validated. Teacher forcing test validates model o/p accuracy but is running only 1 prompt for now. If only a few tokens are incorrect, this test still passes (ie. we get 5 Chinese characters, accuracy can still be >95%).

### What's changed
Adding some output verification, where it fails on non-English characters. Our prompts are completely in English, and I've allowed all forms of punctuation and emojis to pass, as well as Greek and Latin letters, because some science and history questions are present. This is flexible, yet adds more validation on test_demo which current has no accuracy check.

### Checklist
[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-demo-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-demo-accuracy)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=ds-demo-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:ds-demo-accuracy)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=ds-demo-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:ds-demo-accuracy)
[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=ds-demo-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:ds-demo-accuracy)