### PR TITLE
Pi0 initial optimizations 1-4

### DIFF
--- a/models/experimental/pi0/tt/ttnn_gemma.py
+++ b/models/experimental/pi0/tt/ttnn_gemma.py
@@ -601,9 +601,6 @@ class GemmaBlockTTNN:
         )
         hidden_states = ttnn.add(hidden_states, attn_output)
         ttnn.deallocate(attn_output)
-        ttnn.ReadDeviceProfiler(
-            self.device
-        )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         # Pre-MLP norm
         normed = rms_norm_ttnn(
@@ -617,9 +614,6 @@ class GemmaBlockTTNN:
         ttnn.deallocate(normed)
         hidden_states = ttnn.add(hidden_states, mlp_output)
         ttnn.deallocate(mlp_output)
-        ttnn.ReadDeviceProfiler(
-            self.device
-        )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         return hidden_states, new_cache
 

--- a/models/experimental/pi0/tt/ttnn_paligemma.py
+++ b/models/experimental/pi0/tt/ttnn_paligemma.py
@@ -355,9 +355,6 @@ class PaliGemmaBackboneTTNN:
             )
             if use_cache:
                 new_cache.append(new_kv)
-            ttnn.ReadDeviceProfiler(
-                self.device
-            )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         # Final norm using TTNN
         hidden_states = rms_norm_ttnn(
@@ -404,9 +401,6 @@ class PaliGemmaBackboneTTNN:
             )
             if use_cache:
                 new_cache.append(new_kv)
-            ttnn.ReadDeviceProfiler(
-                self.device
-            )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         # Final norm using TTNN
         hidden_states = rms_norm_ttnn(

--- a/models/experimental/pi0/tt/ttnn_pi0_model.py
+++ b/models/experimental/pi0/tt/ttnn_pi0_model.py
@@ -53,6 +53,7 @@ class PI0ModelTTNN:
         config: PI0ModelConfig,
         weight_loader: PI0WeightLoader,
         device: ttnn.Device,
+        enable_profiler_flush: bool = False,
     ):
         """
         Initialize PI0 model with TTNN.
@@ -61,10 +62,15 @@ class PI0ModelTTNN:
             config: Model configuration
             weight_loader: Loaded weights
             device: TTNN device
+            enable_profiler_flush: If True, flush device profiler buffer once per
+                denoising step and once after prefix processing. Default False
+                to avoid overhead in production. Enable when building profiler
+                perf sheets.
         """
         self.config = config
         self.weight_loader = weight_loader
         self.device = device
+        self.enable_profiler_flush = enable_profiler_flush
 
         # Initialize denoising config
         self.denoise_config = DenoiseConfig(
@@ -206,6 +212,9 @@ class PI0ModelTTNN:
         # Step 2: Forward prefix through VLM and cache KV
         _, prefix_kv_cache = self.backbone.forward_vlm(prefix_embs, use_cache=True)
 
+        if self.enable_profiler_flush:
+            ttnn.ReadDeviceProfiler(self.device)
+
         # Get timesteps using pure Python list (for control flow on host)
         num_steps = self.denoise_config.num_steps
         # Create timesteps as Python list: [1.0, 0.9, 0.8, ..., 0.0]
@@ -266,10 +275,8 @@ class PI0ModelTTNN:
             velocity_scaled = ttnn.mul(velocity, dt)
             x_t_ttnn = ttnn.add(x_t_ttnn, velocity_scaled, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-            # Clear profiler buffer after each denoising step (~500 ops)
-            ttnn.ReadDeviceProfiler(
-                self.device
-            )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
+            if self.enable_profiler_flush:
+                ttnn.ReadDeviceProfiler(self.device)
 
         # Convert back to PyTorch only at the very end (1 transfer instead of 10!)
         return x_t_ttnn

--- a/models/experimental/pi0/tt/ttnn_pi0_model.py
+++ b/models/experimental/pi0/tt/ttnn_pi0_model.py
@@ -159,6 +159,7 @@ class PI0ModelTTNN:
         state: ttnn.Tensor,
         noisy_actions: ttnn.Tensor,
         timestep: ttnn.Tensor,
+        state_emb: Optional[ttnn.Tensor] = None,
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, Optional[ttnn.Tensor]]:
         """
         Embed suffix (state + noisy actions + timestep) using TTNN.
@@ -167,11 +168,13 @@ class PI0ModelTTNN:
             state: Robot state (TTNN)
             noisy_actions: Noisy actions (TTNN)
             timestep: Diffusion timestep (TTNN)
+            state_emb: Optional pre-computed state embedding to avoid
+                redundant projection when state is constant across steps.
 
         Returns:
             Tuple of (embeddings, padding_mask, attention_mask, adarms_cond)
         """
-        return self.suffix_embedding.embed_suffix(state, noisy_actions, timestep)
+        return self.suffix_embedding.embed_suffix(state, noisy_actions, timestep, state_emb=state_emb)
 
     def sample_actions(
         self,
@@ -241,6 +244,9 @@ class PI0ModelTTNN:
         # The tensor is small (batch * 50 * 32 = 1600 floats), so transfer is negligible
         x_t_ttnn = self.x_t_ttnn
 
+        # OPTIMIZATION: Pre-compute state embedding once (constant across all denoising steps)
+        cached_state_emb = self.suffix_embedding.embed_state(state_ttnn)
+
         # Step 4: Denoising loop (stays on device!)
         for i in range(num_steps):
             t = timesteps[i]  # Already Python float
@@ -252,7 +258,10 @@ class PI0ModelTTNN:
             t_tensor = ttnn.reshape(t_tensor, (batch_size,))
 
             # Embed suffix (x_t_ttnn already on device - no transfer!)
-            suffix_embs, suffix_pad, suffix_att, _ = self.embed_suffix(state_ttnn, x_t_ttnn, t_tensor)
+            # Pass cached state embedding to avoid redundant state_proj linear per step
+            suffix_embs, suffix_pad, suffix_att, _ = self.embed_suffix(
+                state_ttnn, x_t_ttnn, t_tensor, state_emb=cached_state_emb
+            )
 
             # Forward through expert with cached prefix KV
             expert_output, _ = self.backbone.forward_expert(

--- a/models/experimental/pi0/tt/ttnn_pi0_model.py
+++ b/models/experimental/pi0/tt/ttnn_pi0_model.py
@@ -21,6 +21,7 @@ Optimizations:
     3. Single transfer at the end for final actions
 """
 
+import math
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -79,11 +80,6 @@ class PI0ModelTTNN:
             action_horizon=config.action_horizon,
         )
 
-        pad_steps = ((self.denoise_config.num_steps + 31) // 32) * 32
-
-        # Create timestep indices on device using ttnn.arange
-        self.timestep_indices = ttnn.arange(0, pad_steps, 1, device=self.device, dtype=ttnn.bfloat16)
-
         x_t_torch = torch.randn(1, self.config.action_horizon, self.config.action_dim)
         self.x_t_ttnn = ttnn.from_torch(
             x_t_torch,
@@ -95,6 +91,12 @@ class PI0ModelTTNN:
 
         # Initialize components
         self._init_components()
+
+        # OPTIMIZATION: Pre-compute sinusoidal timestep embeddings for all denoising steps.
+        # The 10 timesteps [1.0, 0.9, ..., 0.1] are deterministic, so their sinusoidal
+        # embeddings can be computed once on host and stored on device. This replaces
+        # ~150 TTNN ops (15 ops x 10 steps) with 10 slice ops during inference.
+        self._precompute_timestep_embeddings()
 
     def _init_components(self):
         """Initialize all model components."""
@@ -133,6 +135,42 @@ class PI0ModelTTNN:
             embed_language_fn=self.backbone.embed_language_tokens,
         )
 
+    def _precompute_timestep_embeddings(self):
+        """Pre-compute sinusoidal timestep embeddings for all denoising steps.
+
+        Computes on host (one-time cost) and transfers to device as a single
+        tensor of shape (num_steps, expert_width). During inference, each step
+        just slices one row instead of running ~15 TTNN ops.
+        """
+        num_steps = self.denoise_config.num_steps
+        expert_width = self.config.expert_config.width
+        half_dim = expert_width // 2
+
+        # Timestep values: [1.0, 0.9, 0.8, ..., 0.1] (excludes final 0.0)
+        timestep_values = torch.tensor([1.0 - i / num_steps for i in range(num_steps)], dtype=torch.float32)
+
+        # Sinusoidal embedding (matches create_sinusoidal_pos_embedding logic)
+        min_period, max_period = 4e-3, 4.0
+        fraction = torch.linspace(0.0, 1.0, half_dim, dtype=torch.float64)
+        period = min_period * (max_period / min_period) ** fraction
+        scaling_factor = (1.0 / period) * 2 * math.pi
+        sin_input = scaling_factor[None, :] * timestep_values[:, None].to(torch.float64)
+        all_time_embs = torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=1).to(
+            torch.float32
+        )  # (num_steps, expert_width)
+
+        # Transfer to device as a single tensor
+        self.cached_time_embs = ttnn.from_torch(
+            all_time_embs,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # Pre-compute dt values (Python floats, used for Euler step scaling)
+        self._dt_values = [-(1.0 / num_steps)] * num_steps
+
     def embed_prefix(
         self,
         images: List[torch.Tensor],
@@ -160,6 +198,7 @@ class PI0ModelTTNN:
         noisy_actions: ttnn.Tensor,
         timestep: ttnn.Tensor,
         state_emb: Optional[ttnn.Tensor] = None,
+        time_emb: Optional[ttnn.Tensor] = None,
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, Optional[ttnn.Tensor]]:
         """
         Embed suffix (state + noisy actions + timestep) using TTNN.
@@ -167,14 +206,18 @@ class PI0ModelTTNN:
         Args:
             state: Robot state (TTNN)
             noisy_actions: Noisy actions (TTNN)
-            timestep: Diffusion timestep (TTNN)
+            timestep: Diffusion timestep (TTNN). Unused when time_emb is provided.
             state_emb: Optional pre-computed state embedding to avoid
                 redundant projection when state is constant across steps.
+            time_emb: Optional pre-computed timestep embedding to avoid
+                redundant sinusoidal computation when timesteps are known.
 
         Returns:
             Tuple of (embeddings, padding_mask, attention_mask, adarms_cond)
         """
-        return self.suffix_embedding.embed_suffix(state, noisy_actions, timestep, state_emb=state_emb)
+        return self.suffix_embedding.embed_suffix(
+            state, noisy_actions, timestep, state_emb=state_emb, time_emb=time_emb
+        )
 
     def sample_actions(
         self,
@@ -218,26 +261,8 @@ class PI0ModelTTNN:
         if self.enable_profiler_flush:
             ttnn.ReadDeviceProfiler(self.device)
 
-        # Get timesteps using pure Python list (for control flow on host)
         num_steps = self.denoise_config.num_steps
-        # Create timesteps as Python list: [1.0, 0.9, 0.8, ..., 0.0]
-        timesteps = [1.0 - i / num_steps for i in range(num_steps + 1)]
-
-        # OPTIMIZATION: Pre-compute all timestep tensors on device using TTNN
-        pad_steps = ((num_steps + 31) // 32) * 32
-
-        # Create timestep indices on device using ttnn.arange
-        timestep_indices = self.timestep_indices
-        timestep_indices = ttnn.to_layout(timestep_indices, ttnn.TILE_LAYOUT)
-
-        # Convert to timestep values: 1.0 - index / num_steps
-        timestep_values = ttnn.multiply(timestep_indices, -1.0 / num_steps)
-        timesteps_ttnn = ttnn.add(timestep_values, 1.0)
-        timesteps_ttnn = ttnn.reshape(timesteps_ttnn, (1, pad_steps))
-
-        # Cleanup
-        ttnn.deallocate(timestep_indices)
-        ttnn.deallocate(timestep_values)
+        expert_width = self.config.expert_config.width
 
         # Step 3: Sample initial noise (small tensor - host generation is fine)
         # Note: Using torch.randn ensures PCC compatibility with PyTorch reference
@@ -249,18 +274,15 @@ class PI0ModelTTNN:
 
         # Step 4: Denoising loop (stays on device!)
         for i in range(num_steps):
-            t = timesteps[i]  # Already Python float
-            t_next = timesteps[i + 1]
-            dt = t_next - t  # Negative since we go from 1.0 to 0.0
+            dt = self._dt_values[i]
 
-            # OPTIMIZATION: Slice timestep from pre-computed tensor (no transfer per step!)
-            t_tensor = ttnn.slice(timesteps_ttnn, [0, i], [batch_size, i + 1])
-            t_tensor = ttnn.reshape(t_tensor, (batch_size,))
+            # OPTIMIZATION: Slice pre-computed sinusoidal timestep embedding (1 slice vs ~15 ops)
+            time_emb = ttnn.slice(self.cached_time_embs, [i, 0], [i + 1, expert_width])
 
             # Embed suffix (x_t_ttnn already on device - no transfer!)
-            # Pass cached state embedding to avoid redundant state_proj linear per step
+            # Pass cached state embedding and pre-computed time embedding
             suffix_embs, suffix_pad, suffix_att, _ = self.embed_suffix(
-                state_ttnn, x_t_ttnn, t_tensor, state_emb=cached_state_emb
+                state_ttnn, x_t_ttnn, None, state_emb=cached_state_emb, time_emb=time_emb
             )
 
             # Forward through expert with cached prefix KV

--- a/models/experimental/pi0/tt/ttnn_prefix.py
+++ b/models/experimental/pi0/tt/ttnn_prefix.py
@@ -190,10 +190,6 @@ class PrefixEmbeddingTTNN:
         # Create zeros mask directly on device (no host transfer needed)
         prefix_att_masks = self.prefix_att_masks
 
-        ttnn.ReadDeviceProfiler(
-            self.device
-        )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
-
         return prefix_embs, prefix_pad_masks, prefix_att_masks
 
 

--- a/models/experimental/pi0/tt/ttnn_siglip.py
+++ b/models/experimental/pi0/tt/ttnn_siglip.py
@@ -852,9 +852,6 @@ class SigLIPVisionTowerTTNN:
         # Run through TTNN transformer blocks
         for block in self.blocks:
             hidden_states = block.forward(hidden_states)
-            ttnn.ReadDeviceProfiler(
-                self.device
-            )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         # Final layer norm (on device)
         if self.post_ln_weight is not None:

--- a/models/experimental/pi0/tt/ttnn_suffix.py
+++ b/models/experimental/pi0/tt/ttnn_suffix.py
@@ -199,6 +199,7 @@ class SuffixEmbeddingTTNN:
         noisy_actions: ttnn.Tensor,
         timestep: ttnn.Tensor,
         state_emb: Optional[ttnn.Tensor] = None,
+        time_emb: Optional[ttnn.Tensor] = None,
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, Optional[ttnn.Tensor]]:
         """
         Create suffix embeddings using TTNN operations.
@@ -206,10 +207,13 @@ class SuffixEmbeddingTTNN:
         Args:
             state: TTNN tensor (batch_size, state_dim) or None
             noisy_actions: TTNN tensor (batch_size, action_horizon, action_dim)
-            timestep: TTNN tensor (batch_size,)
+            timestep: TTNN tensor (batch_size,). Unused when time_emb is provided.
             state_emb: Optional pre-computed state embedding (batch_size, 1, expert_width).
                 When provided, skips the state_proj linear and uses this directly.
                 Useful for caching across denoising steps where state is constant.
+            time_emb: Optional pre-computed timestep embedding (batch_size, expert_width).
+                When provided, skips the sinusoidal embedding computation.
+                Useful when all timestep embeddings are pre-computed at init.
 
         Returns:
             Tuple of (suffix_embs, pad_masks, att_masks, adarms_cond)
@@ -228,8 +232,9 @@ class SuffixEmbeddingTTNN:
             if state_emb is not None:
                 embs.append(state_emb)
 
-        # Embed timestep
-        time_emb = self.embed_timestep(timestep)
+        # Embed timestep (skip if pre-computed time_emb provided)
+        if time_emb is None:
+            time_emb = self.embed_timestep(timestep)
 
         # Embed actions
         action_emb = self.embed_actions(noisy_actions)

--- a/models/experimental/pi0/tt/ttnn_suffix.py
+++ b/models/experimental/pi0/tt/ttnn_suffix.py
@@ -190,9 +190,6 @@ class SuffixEmbeddingTTNN:
             bias=self.weights["action_time_mlp_out.bias"],
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-        ttnn.ReadDeviceProfiler(
-            self.device
-        )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         return x, None
 
@@ -271,10 +268,6 @@ class SuffixEmbeddingTTNN:
                 (batch_size, 1),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
-
-        ttnn.ReadDeviceProfiler(
-            self.device
-        )  # Clear device profiler buffer, this helps resolve a issue when building profiler perf sheets
 
         return suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond
 

--- a/models/experimental/pi0/tt/ttnn_suffix.py
+++ b/models/experimental/pi0/tt/ttnn_suffix.py
@@ -198,6 +198,7 @@ class SuffixEmbeddingTTNN:
         state: ttnn.Tensor,
         noisy_actions: ttnn.Tensor,
         timestep: ttnn.Tensor,
+        state_emb: Optional[ttnn.Tensor] = None,
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, Optional[ttnn.Tensor]]:
         """
         Create suffix embeddings using TTNN operations.
@@ -206,6 +207,9 @@ class SuffixEmbeddingTTNN:
             state: TTNN tensor (batch_size, state_dim) or None
             noisy_actions: TTNN tensor (batch_size, action_horizon, action_dim)
             timestep: TTNN tensor (batch_size,)
+            state_emb: Optional pre-computed state embedding (batch_size, 1, expert_width).
+                When provided, skips the state_proj linear and uses this directly.
+                Useful for caching across denoising steps where state is constant.
 
         Returns:
             Tuple of (suffix_embs, pad_masks, att_masks, adarms_cond)
@@ -219,7 +223,8 @@ class SuffixEmbeddingTTNN:
 
         # Embed state (PI0 only, not PI05)
         if not self.config.pi05:
-            state_emb = self.embed_state(state)
+            if state_emb is None:
+                state_emb = self.embed_state(state)
             if state_emb is not None:
                 embs.append(state_emb)
 


### PR DESCRIPTION
### Problem description
Targeting runtime optimizations numbered 1-4 listed [here](https://github.com/tenstorrent/tt-metal/issues/37943).

### Perf Change
Same as before

Before
```
2026-03-19 20:17:03.960 | INFO    | pi0.tests.perf.test_perf_e2e:test_perf_pi0_ttnn:207 - Average model time=338.84 ms
2026-03-19 20:17:03.960 | INFO    | pi0.tests.perf.test_perf_e2e:test_perf_pi0_ttnn:208 - Average model performance=2.95 fps
```

After 
```
2026-03-19 22:40:07.849 | INFO     | pi0.tests.perf.test_perf_e2e:test_perf_pi0_ttnn:207 - Average model time=338.68 ms
2026-03-19 22:40:07.849 | INFO     | pi0.tests.perf.test_perf_e2e:test_perf_pi0_ttnn:208 - Average model performance=2.95 fps
```