### PR TITLE
[Cleanup] Move fabric init logic from Device to dedicated init class

### DIFF
--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -10,7 +10,9 @@
 #include "tt_metal/fabric/fabric_builder.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
+#include "impl/context/metal_env_impl.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
+#include <tt-metalium/experimental/context/metal_env.hpp>
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000
@@ -20,10 +22,11 @@ bool isFabricUnitTest() { return false; }
 
 namespace tt::tt_fabric {
 
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::tt_metal::IDevice* device) {
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(
+    tt::tt_metal::IDevice* device, tt::tt_metal::MetalEnvImpl& env) {
     auto fabric_program_ptr = std::make_unique<tt::tt_metal::Program>();
 
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& control_plane = env.get_control_plane();
     auto& fabric_context = control_plane.get_fabric_context();
 
     // Use FabricBuilder to coordinate the build phases
@@ -41,18 +44,9 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     builder.create_kernels();
 
     // Compile the program
-    tt::tt_metal::detail::CompileProgram(
-        device, *fabric_program_ptr, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+    tt::tt_metal::detail::CompileProgram(device, *fabric_program_ptr, env.get_rtoptions().get_fast_dispatch());
 
     return fabric_program_ptr;
-}
-
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device) {
-    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-    if (tt_fabric::is_tt_fabric_config(fabric_config)) {
-        return create_and_compile_tt_fabric_program(device);
-    }
-    return nullptr;
 }
 
 void configure_fabric_cores(tt::tt_metal::IDevice* device) {

--- a/tt_metal/fabric/fabric_init.hpp
+++ b/tt_metal/fabric/fabric_init.hpp
@@ -6,11 +6,13 @@
 
 #include "device.hpp"
 #include "tt_metal.hpp"
+#include "impl/context/metal_env_impl.hpp"
 
 namespace tt::tt_fabric {
 
 // Compile fabric kernels needed to support scaleout systems.
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device);
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(
+    tt::tt_metal::IDevice* device, tt::tt_metal::MetalEnvImpl& env);
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for fabric kernels on this device.
 void configure_fabric_cores(tt::tt_metal::IDevice* device);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -52,7 +52,6 @@
 #include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
-#include "tt_metal/fabric/fabric_init.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -366,50 +365,6 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
 }
 
 void Device::init_command_queue_device() { TT_FATAL(false, "Call init_command_queue_device_with_topology instead"); }
-
-bool Device::compile_fabric() {
-    fabric_program_ = tt::tt_fabric::create_and_compile_fabric_program(this);
-    return fabric_program_ != nullptr;
-}
-
-void Device::configure_fabric() {
-    if (fabric_program_ == nullptr) {
-        return;
-    }
-
-    tt::tt_fabric::configure_fabric_cores(this);
-
-    fabric_program_->impl().finalize_offsets(this);
-
-    detail::WriteRuntimeArgsToDevice(this, *fabric_program_, using_fast_dispatch_);
-    detail::ConfigureDeviceWithProgram(this, *fabric_program_, using_fast_dispatch_);
-
-    // Note: the l1_barrier below is needed to be sure writes to cores that
-    // don't get the GO mailbox have all landed
-    MetalEnvImpl& env_impl = MetalEnvAccessor(*env_).impl();
-    env_impl.get_cluster().l1_barrier(this->id());
-    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->impl().logical_cores();
-    const auto& hal = env_impl.get_hal();
-    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
-         programmable_core_type_index++) {
-        CoreType core_type = hal.get_core_type(programmable_core_type_index);
-        for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
-            auto* kg = fabric_program_->impl().kernels_on_core(logical_core, programmable_core_type_index);
-            dev_msgs::launch_msg_t::View msg = kg->launch_msg.view();
-            dev_msgs::go_msg_t::ConstView go_msg = kg->go_msg.view();
-            msg.kernel_config().host_assigned_id() = fabric_program_->get_runtime_id();
-
-            auto physical_core = this->virtual_core_from_logical_core(logical_core, core_type);
-            tt::llrt::write_launch_msg_to_core(
-                this->id(),
-                physical_core,
-                msg,
-                go_msg,
-                hal.get_dev_addr(this->get_programmable_core_type(physical_core), HalL1MemAddrType::LAUNCH));
-        }
-    }
-    log_info(tt::LogMetal, "Fabric initialized on Device {}", this->id_);
-}
 
 bool Device::initialize(
     const uint8_t num_hw_cqs,

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -141,8 +141,6 @@ public:
 
     void init_command_queue_device_with_topology(DispatchTopology* topology);
 
-    bool compile_fabric();
-    void configure_fabric();
     // Puts device into reset
     bool close() override;
 
@@ -226,9 +224,6 @@ private:
 
     // TODO #20966: Remove this member
     std::weak_ptr<distributed::MeshDevice> mesh_device;
-
-    // Fabric program includes ethernet router kernel
-    std::unique_ptr<Program> fabric_program_;
 
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
     uint8_t num_hw_cqs_ = 1;

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -20,8 +20,51 @@
 #include "fabric/fabric_host_utils.hpp"
 #include "fabric/fabric_context.hpp"
 #include "fabric/fabric_builder_context.hpp"
+#include "fabric/fabric_init.hpp"
+#include "llrt.hpp"
+#include "program/program_impl.hpp"
 
 namespace tt::tt_metal {
+
+namespace detail {
+
+void configure_device(MetalEnv& env, Device* dev, std::unique_ptr<Program>& fabric_program) {
+    tt::tt_fabric::configure_fabric_cores(dev);
+
+    fabric_program->impl().finalize_offsets(dev);
+
+    bool using_fast_dispatch = MetalEnvAccessor(env).impl().get_rtoptions().get_fast_dispatch();
+    detail::WriteRuntimeArgsToDevice(dev, *fabric_program, using_fast_dispatch);
+    detail::ConfigureDeviceWithProgram(dev, *fabric_program, using_fast_dispatch);
+
+    // Note: the l1_barrier below is needed to be sure writes to cores that
+    // don't get the GO mailbox have all landed
+    MetalEnvImpl& env_impl = MetalEnvAccessor(env).impl();
+    env_impl.get_cluster().l1_barrier(dev->id());
+    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program->impl().logical_cores();
+    const auto& hal = env_impl.get_hal();
+    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+         programmable_core_type_index++) {
+        CoreType core_type = hal.get_core_type(programmable_core_type_index);
+        for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
+            auto* kg = fabric_program->impl().kernels_on_core(logical_core, programmable_core_type_index);
+            dev_msgs::launch_msg_t::View msg = kg->launch_msg.view();
+            dev_msgs::go_msg_t::ConstView go_msg = kg->go_msg.view();
+            msg.kernel_config().host_assigned_id() = fabric_program->get_runtime_id();
+
+            auto physical_core = dev->virtual_core_from_logical_core(logical_core, core_type);
+            tt::llrt::write_launch_msg_to_core(
+                dev->id(),
+                physical_core,
+                msg,
+                go_msg,
+                hal.get_dev_addr(dev->get_programmable_core_type(physical_core), HalL1MemAddrType::LAUNCH));
+        }
+    }
+    log_info(tt::LogMetal, "Fabric initialized on Device {}", dev->id());
+}
+
+}  // namespace detail
 
 FabricFirmwareInitializer::FabricFirmwareInitializer(
     std::shared_ptr<const ContextDescriptor> descriptor, tt::tt_fabric::ControlPlane& control_plane) :
@@ -49,7 +92,7 @@ void FabricFirmwareInitializer::init(
     } else if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
         log_info(tt::LogMetal, "Compiling fabric to setup fabric context for fabric termination");
         for (auto* dev : devices_) {
-            dev->compile_fabric();
+            tt::tt_fabric::create_and_compile_fabric_program(dev, MetalEnvAccessor(descriptor_->env()).impl());
         }
     } else {
         log_info(tt::LogMetal, "Fabric initialized through Fabric Manager");
@@ -63,27 +106,28 @@ void FabricFirmwareInitializer::configure() {
     initialized_ = true;
 }
 
+void FabricFirmwareInitializer::cleanup_state(std::unordered_set<InitializerKey>& init_done) {
+    init_done.erase(key);
+    devices_.clear();
+    initialized_ = false;
+    fabric_programs_.clear();
+}
+
 void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& init_done) {
     TT_FATAL(
         !init_done.contains(InitializerKey::Dispatch),
         "FabricFirmwareInitializer must be torn down after DispatchKernelInitializer");
     if (descriptor_->is_mock_device()) {
         log_info(tt::LogMetal, "Skipping fabric teardown for mock devices");
-        init_done.erase(key);
-        return;
-    }
-    if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
-        devices_.clear();
-        initialized_ = false;
-        init_done.erase(key);
+        cleanup_state(init_done);
         return;
     }
 
     tt_fabric::FabricConfig fabric_config = descriptor_->fabric_config();
-    if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
-        devices_.clear();
-        initialized_ = false;
-        init_done.erase(key);
+    // Might want to skip terminating fabric if we want to leave fabric routers running
+    if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC) ||
+        !tt_fabric::is_tt_fabric_config(fabric_config)) {
+        cleanup_state(init_done);
         return;
     }
 
@@ -132,9 +176,7 @@ void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& ini
             dev, master_router_logical_core, termination_signal_address, termination_signal, CoreType::ETH);
     }
 
-    devices_.clear();
-    initialized_ = false;
-    init_done.erase(key);
+    cleanup_state(init_done);
 }
 
 void FabricFirmwareInitializer::post_teardown() {
@@ -147,14 +189,18 @@ bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }
 void FabricFirmwareInitializer::compile_and_configure_fabric() {
     std::vector<std::shared_future<Device*>> events;
     events.reserve(devices_.size());
+
+    std::mutex fabric_programs_mutex;
     for (auto* dev : devices_) {
-        events.emplace_back(detail::async([dev]() {
-            if (dev->compile_fabric()) {
-                return dev;
+        events.emplace_back(detail::async([dev, &fabric_programs_mutex, this]() {
+            auto fabric_program =
+                tt::tt_fabric::create_and_compile_fabric_program(dev, MetalEnvAccessor(descriptor_->env()).impl());
+            // nullptr if no builders
+            if (fabric_program) {
+                std::lock_guard lock(fabric_programs_mutex);
+                fabric_programs_[dev] = std::move(fabric_program);
             }
-            // Compile failure mostly comes from Nebula (TG)
-            log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
-            return static_cast<Device*>(nullptr);
+            return dev;
         }));
     }
 
@@ -162,10 +208,11 @@ void FabricFirmwareInitializer::compile_and_configure_fabric() {
         return;
     }
 
+    // Serial execution due to UMD writes not being thread safe
     for (const auto& event : events) {
         auto* dev = event.get();
-        if (dev) {
-            dev->configure_fabric();
+        if (fabric_programs_.contains(dev)) {
+            detail::configure_device(descriptor_->env(), dev, fabric_programs_[dev]);
         }
     }
 }

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -6,6 +6,7 @@
 
 #include "device/device_impl.hpp"
 #include "firmware_initializer.hpp"
+#include <unordered_map>
 
 namespace tt::tt_fabric {
 class ControlPlane;
@@ -38,9 +39,15 @@ private:
     // Compute the fabric router sync timeout from runtime options.
     uint32_t get_fabric_router_sync_timeout_ms() const;
 
+    // Clears internal state
+    void cleanup_state(std::unordered_set<InitializerKey>& init_done);
+
     tt::tt_fabric::ControlPlane& control_plane_;
     std::vector<Device*> devices_;
     bool initialized_ = false;
+
+    // Fabric program that was created for each of the devices from init()
+    std::unordered_map<Device*, std::unique_ptr<Program>> fabric_programs_;
 };
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40148

### Problem description
- Init and Teardown logic for Fabric belongs in the `FabricFirmwareInitializer`

### What's changed
- Move Fabric init from Device to `FabricFirmwareInitializer`
- Change create_and_compile_fabric_program to never return a nullptr. We already check if Fabric needs to be enabled using `is_tt_fabric_config()` beforehand, so it won't ever return a nullptr and the nullptr checks are not required.

### Checklist

- [ ] [![Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Anhuang%2Fmove-fabric-init-funcs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/move-fabric-init-funcs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/move-fabric-init-funcs)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/move-fabric-init-funcs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/move-fabric-init-funcs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/move-fabric-init-funcs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/move-fabric-init-funcs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
