### PR TITLE
Updating GLX workflows to use perf vs functional

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -38,10 +38,24 @@ skus:
       - topology-6u
       - in-service
 
+  wh_galaxy_perf:
+    runs_on:
+      - arch-wormhole_b0
+      - pipeline-perf
+      - topology-6u
+      - in-service
+
   wh_galaxy_release:
     runs_on:
       - arch-wormhole_b0
       - pipeline-functional
+      - topology-6u
+      - in-release
+
+  wh_galaxy_perf_release:
+    runs_on:
+      - arch-wormhole_b0
+      - pipeline-perf
       - topology-6u
       - in-release
 
@@ -51,6 +65,27 @@ skus:
       - pipeline-functional
       - topology-6u
       - in-service
+
+  bh_galaxy_perf:
+    runs_on:
+      - arch-blackhole
+      - pipeline-perf
+      - topology-6u
+      - in-service
+
+  bh_galaxy_release:
+    runs_on:
+      - arch-blackhole
+      - pipeline-functional
+      - topology-6u
+      - in-release
+
+  bh_galaxy_perf_release:
+    runs_on:
+      - arch-blackhole
+      - pipeline-perf
+      - topology-6u
+      - in-release
 
   wh_n150:
     runs_on:

--- a/.github/workflows/galaxy-apc-fast-tests-impl.yaml
+++ b/.github/workflows/galaxy-apc-fast-tests-impl.yaml
@@ -47,6 +47,7 @@ jobs:
         ]
     runs-on:
       - arch-wormhole_b0
+      - pipeline-perf
       - ${{ inputs.topology }}
       - ${{ inputs.runner-label }}
     container:

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -84,7 +84,7 @@ jobs:
       - arch-wormhole_b0
       - ${{ inputs.topology }}
       - bare-metal
-      - pipeline-functional
+      - pipeline-perf
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -77,5 +77,5 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
-      enabled-skus: wh_galaxy
+      enabled-skus: wh_galaxy_perf
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/.github/workflows/galaxy-perf-tests.yaml
+++ b/.github/workflows/galaxy-perf-tests.yaml
@@ -72,5 +72,5 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       # Galaxy perf runs on Wormhole Galaxy (wh_galaxy) only.
-      enabled-skus: wh_galaxy
+      enabled-skus: wh_galaxy_perf
       model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -31,6 +31,7 @@ jobs:
     runs-on:
       - topology-6u
       - arch-wormhole_b0
+      - pipeline-functional
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
@@ -122,6 +123,7 @@ jobs:
     runs-on:
       - topology-6u
       - arch-wormhole_b0
+      - ${{ matrix.mlperf && 'pipeline-perf' || 'pipeline-functional' }}
       - ${{ inputs.extra-tag }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
       - ${{ inputs.extra-tag }}
       - topology-6u
       - arch-wormhole_b0
-      - pipeline-functional
+      - pipeline-perf
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
@@ -93,7 +93,7 @@ jobs:
       - ${{ inputs.extra-tag }}
       - topology-6u
       - arch-wormhole_b0
-      - pipeline-functional
+      - pipeline-perf
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -156,7 +156,7 @@
     pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "repeat2" --timeout 1000
   model: qwen3_32b
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
@@ -169,7 +169,7 @@
     pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-128k-b1" --timeout 1000
   model: qwen3_32b_long_context
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -16,7 +16,7 @@
   cmd: pytest models/tt_dit/tests/models/sd35/test_performance_sd35.py -k "4x8cfg1sp0tp1" --timeout=480
   model: sd35
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -28,7 +28,7 @@
   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1" --timeout=500
   model: flux1-dev
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -40,7 +40,7 @@
   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/motif/test_performance_motif.py -k "4x8cfg1sp0tp1" --timeout=1000
   model: motif
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -54,7 +54,7 @@
     pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8sp1tp0 and resolution_720p and t2v" --timeout=1200
   model: wan2-2
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 25
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -69,7 +69,7 @@
     pytest models/tt_dit/tests/models/mochi/test_performance_mochi.py -k "4x8sp1tp0 " --timeout=1000
   model: mochi
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
@@ -83,7 +83,7 @@
     pytest models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8" --timeout=1000
   model: qwenimage
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -95,7 +95,7 @@
   cmd: export MESH_DEVICE=TG && uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt && pytest models/demos/deepseek_v3/demo/test_decode_demo_perf.py --timeout=1200
   model: deepseek_v3
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U03HY7MK4BT
   team: models
@@ -122,7 +122,7 @@
   cmd: uv pip install -r models/demos/gpt_oss/requirements.txt && export HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ && TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ && pytest --timeout 600 models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_all_fused_ops_device_perf.py::test_all_fused_ops_device_perf -k "decode and 1"
   model: gpt-oss
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akirby/adding-labels)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akirby/adding-labels)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akirby/adding-labels)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akirby/adding-labels)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akirby/adding-labels)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akirby/adding-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akirby/adding-labels)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
