### PR TITLE
[cleanup] Remove redundant mesh_device_ member from Tensor class

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -259,11 +259,6 @@ public:
     static std::uint64_t next_tensor_id();
 
 private:
-    // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
-    // If not set, the tensor can either be on host or allocated on a single device.
-    // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
-    std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
-
     void deallocate_impl(bool force);
 };
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -111,11 +111,7 @@ Tensor::Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tenso
 Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
-        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
-    if (device_storage().is_allocated()) {
-        mesh_device_ = device_storage().get_device();
-    }
-}
+        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
 
 Tensor& Tensor::operator=(const Tensor& other) {
     if (this == &other) {
@@ -125,7 +121,6 @@ Tensor& Tensor::operator=(const Tensor& other) {
     if (this->tensor_attributes != other.tensor_attributes) {
         this->tensor_attributes = other.tensor_attributes;
     }
-    this->mesh_device_ = other.mesh_device_;
     return *this;
 }
 
@@ -135,7 +130,6 @@ Tensor& Tensor::operator=(Tensor&& other) noexcept {
     if (this->tensor_attributes != other.tensor_attributes) {
         this->tensor_attributes = std::move(other.tensor_attributes);
     }
-    this->mesh_device_ = other.mesh_device_;
     return *this;
 }
 
@@ -625,8 +619,9 @@ const HostStorage& Tensor::host_storage() const& {
 }
 
 distributed::MeshDevice* Tensor::device() const {
-    if (this->mesh_device_.has_value()) {
-        return this->mesh_device_.value();
+    const auto* device_storage = std::get_if<DeviceStorage>(&this->storage());
+    if (device_storage != nullptr && device_storage->is_allocated()) {
+        return device_storage->get_device();
     }
     return nullptr;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -134,6 +134,6 @@ ttnn::prim::MoveDeviceOperation::tensor_return_value_t move(
             .output_mem_config = output_mem_config,
             .move_op_parallelization_strategy = move_op_parallelization_strategy,
             .backwards = backwards},
-        OperationType::tensor_args_t{.input_tensor = input_tensor, .output_tensor = output_tensor});
+        OperationType::tensor_args_t{.output_tensor = output_tensor, .input_tensor = input_tensor});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
@@ -19,9 +19,11 @@ struct MoveOperationAttributes {
 };
 
 // Tensor arguments - tensor parameters
+// Note: output_tensor is listed first so that device_operation framework can get
+// the device from it (input_tensor may be deallocated and have no device).
 struct MoveTensorArgs {
-    Tensor input_tensor;
     Tensor output_tensor;
+    Tensor input_tensor;
 };
 
 // Return types

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -28,13 +28,14 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
         // TODO: Should this throw error?
         return input_tensor;
     }
+    auto* device = input_tensor.device();
     input_tensor.device_storage().get_mesh_buffer_leak_ownership()->deallocate();
 
     if (mem_config) {
         output_tensor_spec = output_tensor_spec.with_memory_config(*mem_config);
     }
 
-    auto output_tensor = create_device_tensor(output_tensor_spec, input_tensor.device());
+    auto output_tensor = create_device_tensor(output_tensor_spec, device);
     auto output_mem_config = output_tensor.memory_config();
 
     // get_parallelization_strategy
@@ -52,7 +53,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
 
     // Input and output addresses won't overlap if they are in different memory substrates
     bool non_overlap = not move_within_same_mem_space;
-    const auto num_banks = input_tensor.device()->allocator()->get_num_banks(output_tensor.buffer()->buffer_type());
+    const auto num_banks = device->allocator()->get_num_banks(output_tensor.buffer()->buffer_type());
     uint32_t size_per_bank = tt::tt_metal::detail::calculate_bank_size_spread(
         output_tensor.buffer()->size(),
         output_tensor.buffer()->page_size(),
@@ -61,7 +62,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
 
     // If input and output buffers overlap, input has to be copied into circular buffer before writing to output
     // Only compute with storage cores allow CBs to be created
-    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     const auto num_l1_banks = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
     uint32_t size_per_l1_bank = tt::tt_metal::detail::calculate_bank_size_spread(
         output_tensor.buffer()->size(), output_tensor.buffer()->page_size(), num_l1_banks, hal::get_l1_alignment());
@@ -80,9 +81,9 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     }
 
     bool fits_in_cb =
-        (output_tensor.device()->allocator()->get_base_allocator_addr(HalMemType::L1) + size_per_l1_bank) <=
+        (device->allocator()->get_base_allocator_addr(HalMemType::L1) + size_per_l1_bank) <=
         (output_mem_config.buffer_type() == tt::tt_metal::BufferType::L1 ? output_tensor.buffer()->address()
-                                                                         : output_tensor.device()->l1_size_per_core());
+                                                                         : device->l1_size_per_core());
 
     ttnn::prim::MoveOpParallelizationStrategy move_op_parallelization_strategy =
         ttnn::prim::MoveOpParallelizationStrategy::MULTI_CORE;
@@ -109,6 +110,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         // TODO: Should this throw error?
         return {input_tensor};
     }
+    auto* device = input_tensor.device();
     input_tensor.device_storage().get_mesh_buffer_leak_ownership()->deallocate();
 
     auto output_tensor_spec = input_tensor.tensor_spec();
@@ -118,7 +120,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         output_tensor_spec = output_tensor_spec.with_memory_config(output_mem_config);
     }
 
-    auto output_tensor = create_device_tensor(output_tensor_spec, input_tensor.device());
+    auto output_tensor = create_device_tensor(output_tensor_spec, device);
     if (input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
         log_debug(
             tt::LogOp,


### PR DESCRIPTION
### Ticket
#21099

### Problem description
The `Tensor` class had a redundant `mesh_device_` member variable that cached a pointer to the `MeshDevice`. This was duplicating state that was already available through `DeviceStorage::get_device()`.

### What's changed
- Removed the `mesh_device_` member variable from the `Tensor` class
- Updated `Tensor::device()` to directly use `DeviceStorage::get_device()` instead of the cached pointer
- Removed `mesh_device_` assignments from the `DeviceStorage` constructor and copy/move assignment operators

This simplifies the code and eliminates the need to keep the cached pointer in sync with the actual storage state.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-mesh-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-mesh-device)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-mesh-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-mesh-device)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-mesh-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-mesh-device)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early