### PR TITLE
fix: fix multicore multirow ttnn.gather bug fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_gather.py
@@ -240,8 +240,8 @@ def test_gather_sub_core_grids(input_shape, index_shape, dim, device):
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim",
     [
-        ([32, 32, 256 * TILE_HEIGHT], [32, 32, 256 * TILE_HEIGHT], -1),
-        ([64, 64, 512 * TILE_HEIGHT], [64, 64, 512 * TILE_HEIGHT], -1),
+        ([32, 32, 64 * TILE_HEIGHT], [32, 32, 64 * TILE_HEIGHT], -1),
+        ([64, 64, 128 * TILE_HEIGHT], [64, 64, 128 * TILE_HEIGHT], -1),
     ],
 )
 def test_gather_multirow(input_shape, index_shape, dim, device):

--- a/tests/ttnn/unit_tests/operations/data_movement/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_gather.py
@@ -235,3 +235,30 @@ def test_gather_sub_core_grids(input_shape, index_shape, dim, device):
 
     assert ttnn_gather.shape == index.shape
     assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim",
+    [
+        ([32, 32, 256 * TILE_HEIGHT], [32, 32, 256 * TILE_HEIGHT], -1),
+        ([64, 64, 512 * TILE_HEIGHT], [64, 64, 512 * TILE_HEIGHT], -1),
+    ],
+)
+def test_gather_multirow(input_shape, index_shape, dim, device):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16
+    max_uint32 = np.iinfo(np.uint32).max
+    max_idx_val = min(input_shape[dim], max_uint32)
+    input = torch.randn(input_shape, dtype=torch_dtype)
+    index = torch.randint(0, max_idx_val, index_shape, dtype=torch.int64)
+
+    torch_gather = torch.gather(input, dim, index)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_index = ttnn.from_torch(index, ttnn.uint32, layout=ttnn.Layout.TILE, device=device)
+
+    ttnn_gather = ttnn.gather(ttnn_input, dim, index=ttnn_index)
+
+    assert ttnn_gather.shape == index.shape
+    assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp
@@ -81,10 +81,12 @@ void kernel_main() {
     constexpr uint32_t output_tensor_data_format_size =
         get_tile_size(output_tensor_cb_index) / get_tile_hw(input_tensor_cb_index);
 
-    uint32_t current_index_tile_id = core_id;
-
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
+            const uint32_t current_index_tile_id = core_id + core_loop * total_number_of_cores;
+            if (current_index_tile_id >= Wt_index) {
+                break;
+            }
             // Read index data
             cb_reserve_back(input_index_tensor_cb_index, one_tile);
 
@@ -150,7 +152,6 @@ void kernel_main() {
             }  // wi loop
             cb_push_back(output_tensor_cb_index, one_tile);
             cb_pop_front(input_index_tensor_cb_index, one_tile);
-            current_index_tile_id += total_number_of_cores;
         }  // core_loop_count loop
     }  // h loop
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp
@@ -46,10 +46,12 @@ void kernel_main() {
     const auto output_tensor_dram =
         TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_tensor_tile_size_bytes);
 
-    uint32_t current_index_tile_id = core_id;
-
     for (uint32_t h = 0; h < Ht; h++) {
         for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
+            const uint32_t current_index_tile_id = core_id + core_loop * total_number_of_cores;
+            if (current_index_tile_id >= Wt_index) {
+                break;
+            }
             // Read input data
             for (uint32_t w = 0; w < Wt_input; w++) {
                 cb_reserve_back(input_tensor_cb_index, one_tile);
@@ -67,7 +69,6 @@ void kernel_main() {
             noc_async_write_barrier();
             cb_pop_front(output_tensor_cb_index, one_tile);
 
-            current_index_tile_id += total_number_of_cores;
         }  // core_loop_count loop
     }  // h loop
 }


### PR DESCRIPTION
In multicore multirow path in ttnn.gather, there is a PCC drop issue. Move 'current_index_tile_id's position inside of loop to init multirow

### Ticket
[#40389](https://github.com/tenstorrent/tt-metal/issues/40389)

### Problem description
In multi-core and multi-row path, there is a PCC drop issue when using ttnn.gather operation.
When loop move row0 to row1, `current_index_tile_id` value has wrong index.

### What's changed

I move `current_index_tile_id` variable to inner loop, assigned the correct index.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
