### PR TITLE
deepseekv3: fix multihost MTP smoke selectors

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -322,9 +322,8 @@ jobs:
           if-no-files-found: warn
 
       # ── Demo tests ──────────────────────────────────────────────────────
-      # Branch-local validation hook: skip the long dual demo on this branch so the MTP smoke step can run.
       - name: Run dual demo test (256 prompts, 1 batch)
-        if: ${{ github.ref_name != 'yieldthought/fix-dual-mtp-selector' && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ (inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -348,7 +347,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
 
       - name: Upload dual demo output artifacts
-        if: ${{ github.ref_name != 'yieldthought/fix-dual-mtp-selector' && always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-output-${{ github.run_id }}

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -322,8 +322,9 @@ jobs:
           if-no-files-found: warn
 
       # ── Demo tests ──────────────────────────────────────────────────────
+      # Branch-local validation hook: skip the long dual demo on this branch so the MTP smoke step can run.
       - name: Run dual demo test (256 prompts, 1 batch)
-        if: ${{ (inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ github.ref_name != 'yieldthought/fix-dual-mtp-selector' && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -347,7 +348,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
 
       - name: Upload dual demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ github.ref_name != 'yieldthought/fix-dual-mtp-selector' && always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-output-${{ github.run_id }}

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -244,7 +244,7 @@ run_dual_demo_mtp_test() {
     setup_dual_galaxy_env
     local timeout=$(_demo_timeout 2400)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[dual_full_demo_mtp]' 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_mtp_demo.py::test_mtp_demp_compare_outputs[smoke_2_prompts_32_tokens]' 2>&1 | tee generated/artifacts/dual_demo_mtp_output.log"
 }
 
 run_quad_demo_test() {
@@ -263,7 +263,7 @@ run_quad_demo_mtp_test() {
     setup_quad_galaxy_env
     local timeout=$(_demo_timeout 3600)
 
-    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_demo.py::test_demo[quad_full_demo_mtp]' 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
+    _run_deepseekv3_tt bash -c "set -o pipefail; pytest -svvv --timeout=$timeout 'models/demos/deepseek_v3/demo/test_mtp_demo.py::test_mtp_demp_compare_outputs[smoke_2_prompts_32_tokens]' 2>&1 | tee generated/artifacts/quad_demo_mtp_output.log"
 }
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- fix the dual and quad multihost MTP smoke selectors to target `test_mtp_demo.py`
- keep the existing dual/quad artifact names and workflow wiring unchanged

## Testing
- `git diff --check`
- trigger `multi-host-deepseekv3.yaml` with `setup=dual` and `demo=true`

## CI Badge
[![DeepSeek V3 Multi-Host Tests (yieldthought/fix-dual-mtp-selector)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=yieldthought%2Ffix-dual-mtp-selector)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ayieldthought%2Ffix-dual-mtp-selector)
