### PR TITLE
Add sub_core_grid support to bitwise ops and where TSS

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1369,3 +1369,186 @@ def test_bitwise_right_shift_subcore_grid_tensor_scalar(device, shape, sub_core_
     result = ttnn.to_torch(result_tt)
 
     assert torch.equal(result, golden)
+
+
+# ── sub_core_grid tests for bitwise_or ──────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+def test_bitwise_or_subcore_grid_tensor_tensor(device, shape, sub_core_grid):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+    y_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_or)
+    golden = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_or(x_tt, y_tt, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scalar", [7, 0xFF, 0])
+def test_bitwise_or_subcore_grid_tensor_scalar(device, shape, sub_core_grid, scalar):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_or)
+    golden = golden_fn(x_torch, scalar)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_or(x_tt, scalar, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+# ── sub_core_grid tests for bitwise_xor ─────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+def test_bitwise_xor_subcore_grid_tensor_tensor(device, shape, sub_core_grid):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+    y_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_xor)
+    golden = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_xor(x_tt, y_tt, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scalar", [7, 0xFF, 0])
+def test_bitwise_xor_subcore_grid_tensor_scalar(device, shape, sub_core_grid, scalar):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_xor)
+    golden = golden_fn(x_torch, scalar)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_xor(x_tt, scalar, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+# ── sub_core_grid tests for bitwise_left_shift / logical_left_shift ──────────
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+def test_bitwise_left_shift_subcore_grid_tensor_tensor(device, shape, sub_core_grid):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+    y_torch = torch.randint(0, 15, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
+    golden = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_left_shift(x_tt, y_tt, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6))]),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scalar", [1, 4, 0])
+def test_bitwise_left_shift_subcore_grid_tensor_scalar(device, shape, sub_core_grid, scalar):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
+    golden = golden_fn(x_torch, scalar)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_left_shift(x_tt, scalar, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1221,3 +1221,151 @@ def test_binary_remainder_fmod_int32_range_1e15(input_shapes, ttnn_op, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+def test_bitwise_and_subcore_grid_tensor_tensor(device, shape, sub_core_grid):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+    y_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden = torch.bitwise_and(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_and(x_tt, y_tt, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scalar", [7, 0xFF, 0])
+def test_bitwise_and_subcore_grid_tensor_scalar(device, shape, sub_core_grid, scalar):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden = torch.bitwise_and(x_torch, torch.tensor(scalar, dtype=torch.int32))
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_and(x_tt, scalar, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+def test_bitwise_right_shift_subcore_grid_tensor_tensor(device, shape, sub_core_grid):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+    y_torch = torch.randint(0, 31, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
+    golden = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_right_shift(x_tt, y_tt, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scalar", [4, 0, 15])
+def test_bitwise_right_shift_subcore_grid_tensor_scalar(device, shape, sub_core_grid, scalar):
+    torch.manual_seed(0)
+    x_torch = torch.randint(-1000, 1000, shape, dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
+    golden = golden_fn(x_torch, scalar)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result_tt = ttnn.bitwise_right_shift(x_tt, scalar, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(result_tt)
+
+    assert torch.equal(result, golden)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -731,9 +731,9 @@ def test_binary_div_int32_full_range(input_shapes, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[
-        torch_input_tensor_b == 0
-    ] = 1  # avoid division by zero since nan and inf are not representable in int32
+    torch_input_tensor_b[torch_input_tensor_b == 0] = (
+        1  # avoid division by zero since nan and inf are not representable in int32
+    )
 
     golden_function = ttnn.get_golden_function(ttnn.div)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -818,9 +818,9 @@ def test_div_int32_rounding_modes(input_shapes, low_a, high_a, low_b, high_b, ro
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch_input_tensor_b[:num_elements].reshape(input_shapes)
 
-    torch_input_tensor_b[
-        torch_input_tensor_b == 0
-    ] = 1  # avoid division by zero since nan and inf are not representable in int32
+    torch_input_tensor_b[torch_input_tensor_b == 0] = (
+        1  # avoid division by zero since nan and inf are not representable in int32
+    )
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -976,9 +976,9 @@ def test_binary_divide_int32_full_range(input_shapes, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[
-        torch_input_tensor_b == 0
-    ] = 1  # avoid division by zero since nan and inf are not representable in int32
+    torch_input_tensor_b[torch_input_tensor_b == 0] = (
+        1  # avoid division by zero since nan and inf are not representable in int32
+    )
 
     golden_function = ttnn.get_golden_function(ttnn.divide)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -1194,9 +1194,9 @@ def test_binary_remainder_fmod_int32_range_1e15(input_shapes, ttnn_op, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[
-        torch_input_tensor_b == 0
-    ] = 1  # avoid division by zero since nan and inf are not representable in int32
+    torch_input_tensor_b[torch_input_tensor_b == 0] = (
+        1  # avoid division by zero since nan and inf are not representable in int32
+    )
 
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -1373,6 +1373,7 @@ def test_bitwise_right_shift_subcore_grid_tensor_scalar(device, shape, sub_core_
 
 # ── sub_core_grid tests for bitwise_or ──────────────────────────────────────
 
+
 @pytest.mark.parametrize(
     "shape, sub_core_grid",
     [
@@ -1434,6 +1435,7 @@ def test_bitwise_or_subcore_grid_tensor_scalar(device, shape, sub_core_grid, sca
 
 # ── sub_core_grid tests for bitwise_xor ─────────────────────────────────────
 
+
 @pytest.mark.parametrize(
     "shape, sub_core_grid",
     [
@@ -1494,6 +1496,7 @@ def test_bitwise_xor_subcore_grid_tensor_scalar(device, shape, sub_core_grid, sc
 
 
 # ── sub_core_grid tests for bitwise_left_shift / logical_left_shift ──────────
+
 
 @pytest.mark.parametrize(
     "shape, sub_core_grid",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -731,9 +731,9 @@ def test_binary_div_int32_full_range(input_shapes, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[torch_input_tensor_b == 0] = (
-        1  # avoid division by zero since nan and inf are not representable in int32
-    )
+    torch_input_tensor_b[
+        torch_input_tensor_b == 0
+    ] = 1  # avoid division by zero since nan and inf are not representable in int32
 
     golden_function = ttnn.get_golden_function(ttnn.div)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -818,9 +818,9 @@ def test_div_int32_rounding_modes(input_shapes, low_a, high_a, low_b, high_b, ro
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch_input_tensor_b[:num_elements].reshape(input_shapes)
 
-    torch_input_tensor_b[torch_input_tensor_b == 0] = (
-        1  # avoid division by zero since nan and inf are not representable in int32
-    )
+    torch_input_tensor_b[
+        torch_input_tensor_b == 0
+    ] = 1  # avoid division by zero since nan and inf are not representable in int32
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -976,9 +976,9 @@ def test_binary_divide_int32_full_range(input_shapes, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[torch_input_tensor_b == 0] = (
-        1  # avoid division by zero since nan and inf are not representable in int32
-    )
+    torch_input_tensor_b[
+        torch_input_tensor_b == 0
+    ] = 1  # avoid division by zero since nan and inf are not representable in int32
 
     golden_function = ttnn.get_golden_function(ttnn.divide)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
@@ -1194,9 +1194,9 @@ def test_binary_remainder_fmod_int32_range_1e15(input_shapes, ttnn_op, device):
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
     )
 
-    torch_input_tensor_b[torch_input_tensor_b == 0] = (
-        1  # avoid division by zero since nan and inf are not representable in int32
-    )
+    torch_input_tensor_b[
+        torch_input_tensor_b == 0
+    ] = 1  # avoid division by zero since nan and inf are not representable in int32
 
     golden_function = ttnn.get_golden_function(ttnn_op)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -841,3 +841,62 @@ def test_where_subcore_grid(device, shape, sub_core_grid, dtype, scalar, variant
     result = ttnn.to_torch(ttnn_result)
 
     assert torch_equal_nan(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 7, 32, 96]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "scalar_true, scalar_false",
+    [
+        (15.5, 31.2),
+        (0.0, -11.33),
+    ],
+)
+@pytest.mark.parametrize("condition", [1, 0])
+def test_where_tss_subcore_grid(device, shape, sub_core_grid, dtype, scalar_true, scalar_false, condition):
+    torch.manual_seed(0)
+
+    ttnn_dtype = ttnn.bfloat16 if dtype == torch.bfloat16 else ttnn.float32
+
+    C = make_condition_tensor(shape, dtype, condition)
+
+    golden = torch.where(C.bool(), scalar_true, scalar_false)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_result = ttnn.where(ttnn_C, scalar_true, scalar_false, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(ttnn_result)
+
+    if dtype == torch.bfloat16:
+        assert_with_pcc(result, golden)
+    else:
+        assert torch_equal_nan(result, golden)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -379,7 +379,8 @@ struct ExecuteBitwiseAnd {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -389,7 +390,8 @@ struct ExecuteBitwiseAnd {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteBitwiseOr {
@@ -467,7 +469,8 @@ struct ExecuteBitwiseRightShift {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -477,7 +480,8 @@ struct ExecuteBitwiseRightShift {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteLogicalLeftShift : ExecuteBitwiseLeftShift {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -403,7 +403,8 @@ struct ExecuteBitwiseOr {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -413,7 +414,8 @@ struct ExecuteBitwiseOr {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteBitwiseXor {
@@ -425,7 +427,8 @@ struct ExecuteBitwiseXor {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -435,7 +438,8 @@ struct ExecuteBitwiseXor {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteBitwiseLeftShift {
@@ -447,7 +451,8 @@ struct ExecuteBitwiseLeftShift {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -457,7 +462,8 @@ struct ExecuteBitwiseLeftShift {
         ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations = {},
         ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations = {},
-        std::optional<bool> use_legacy = std::nullopt);
+        std::optional<bool> use_legacy = std::nullopt,
+        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 struct ExecuteBitwiseRightShift {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -685,6 +685,7 @@ void bind_bitwise_binary_ops_operation(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): restrict execution to a subset of cores (e.g. for subdevice use). Defaults to `None`.
 
 
         Returns:
@@ -813,6 +814,7 @@ void bind_logical_binary_ops_operation(
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): restrict execution to a subset of cores (e.g. for subdevice use). Defaults to `None`.
 
 
         Returns:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -730,7 +730,8 @@ void bind_bitwise_binary_ops_operation(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     scalar,
@@ -739,7 +740,8 @@ void bind_bitwise_binary_ops_operation(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             nb::arg("input_tensor_a"),
             nb::arg("input_b"),
@@ -749,7 +751,8 @@ void bind_bitwise_binary_ops_operation(
             nb::arg("activations") = nb::cast(ttnn::SmallVector<unary::EltwiseUnaryWithParam>()),
             nb::arg("input_tensor_a_activations") = nb::cast(ttnn::SmallVector<unary::EltwiseUnaryWithParam>()),
             nb::arg("input_tensor_b_activations") = nb::cast(ttnn::SmallVector<unary::EltwiseUnaryWithParam>()),
-            nb::arg("use_legacy") = nb::none()},
+            nb::arg("use_legacy") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none()},
 
         // tensor and tensor
         ttnn::nanobind_overload_t{
@@ -761,7 +764,8 @@ void bind_bitwise_binary_ops_operation(
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_a_activations,
                const ttnn::SmallVector<unary::EltwiseUnaryWithParam>& input_tensor_b_activations,
-               const std::optional<bool>& use_legacy) -> ttnn::Tensor {
+               const std::optional<bool>& use_legacy,
+               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
                 return self(
                     input_tensor_a,
                     input_tensor_b,
@@ -770,7 +774,8 @@ void bind_bitwise_binary_ops_operation(
                     activations,
                     input_tensor_a_activations,
                     input_tensor_b_activations,
-                    use_legacy);
+                    use_legacy,
+                    sub_core_grids);
             },
             nb::arg("input_tensor_a"),
             nb::arg("input_tensor_b"),
@@ -781,6 +786,7 @@ void bind_bitwise_binary_ops_operation(
             nb::arg("input_tensor_a_activations") = nb::cast(ttnn::SmallVector<unary::EltwiseUnaryWithParam>()),
             nb::arg("input_tensor_b_activations") = nb::cast(ttnn::SmallVector<unary::EltwiseUnaryWithParam>()),
             nb::arg("use_legacy") = nb::none(),
+            nb::arg("sub_core_grids") = nb::none(),
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -1005,7 +1005,10 @@ Tensor ExecuteBitwiseAnd::invoke(
             sub_core_grids);
     }
 
-    return ttnn::bitwise_and(input_tensor_a, input_b, memory_config, optional_output_tensor);
+    // Legacy-only path: force use_legacy=true to avoid recursive re-entry
+    // into the registered ExecuteBitwiseAnd operation.
+    return BinaryOperation<operations::binary::BinaryOpType::BITWISE_AND>::invoke(
+        input_tensor_a, input_b, std::nullopt, memory_config, optional_output_tensor, {}, {}, {}, true);
 }
 
 // Bitwise OR
@@ -1075,7 +1078,10 @@ Tensor ExecuteBitwiseOr::invoke(
             sub_core_grids);
     }
 
-    return ttnn::bitwise_or(input_tensor_a, input_b, memory_config, optional_output_tensor);
+    // Legacy-only path: force use_legacy=true to avoid recursive re-entry
+    // into the registered ExecuteBitwiseOr operation.
+    return BinaryOperation<operations::binary::BinaryOpType::BITWISE_OR>::invoke(
+        input_tensor_a, input_b, std::nullopt, memory_config, optional_output_tensor, {}, {}, {}, true);
 }
 
 // Bitwise XOR
@@ -1145,7 +1151,10 @@ Tensor ExecuteBitwiseXor::invoke(
             sub_core_grids);
     }
 
-    return ttnn::bitwise_xor(input_tensor_a, input_b, memory_config, optional_output_tensor);
+    // Legacy-only path: force use_legacy=true to avoid recursive re-entry
+    // into the registered ExecuteBitwiseXor operation.
+    return BinaryOperation<operations::binary::BinaryOpType::BITWISE_XOR>::invoke(
+        input_tensor_a, input_b, std::nullopt, memory_config, optional_output_tensor, {}, {}, {}, true);
 }
 
 // Bitwise Left Shift
@@ -1215,7 +1224,10 @@ Tensor ExecuteBitwiseLeftShift::invoke(
             sub_core_grids);
     }
 
-    return ttnn::bitwise_left_shift(input_tensor_a, input_b, memory_config, optional_output_tensor);
+    // Legacy-only path: force use_legacy=true to avoid recursive re-entry
+    // into the registered ExecuteBitwiseLeftShift operation.
+    return BinaryOperation<operations::binary::BinaryOpType::LEFT_SHIFT>::invoke(
+        input_tensor_a, input_b, std::nullopt, memory_config, optional_output_tensor, {}, {}, {}, true);
 }
 
 // Bitwise Right Shift
@@ -1285,7 +1297,10 @@ Tensor ExecuteBitwiseRightShift::invoke(
             sub_core_grids);
     }
 
-    return ttnn::bitwise_right_shift(input_tensor_a, input_b, memory_config, optional_output_tensor);
+    // Legacy-only path: force use_legacy=true to avoid recursive re-entry
+    // into the registered ExecuteBitwiseRightShift operation.
+    return BinaryOperation<operations::binary::BinaryOpType::RIGHT_SHIFT>::invoke(
+        input_tensor_a, input_b, std::nullopt, memory_config, optional_output_tensor, {}, {}, {}, true);
 }
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -1017,7 +1017,8 @@ Tensor ExecuteBitwiseOr::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1035,7 +1036,8 @@ Tensor ExecuteBitwiseOr::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return BinaryOperationSfpu<operations::binary::BinaryOpType::BITWISE_OR>::invoke(
@@ -1050,7 +1052,8 @@ Tensor ExecuteBitwiseOr::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1068,7 +1071,8 @@ Tensor ExecuteBitwiseOr::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return ttnn::bitwise_or(input_tensor_a, input_b, memory_config, optional_output_tensor);
@@ -1083,7 +1087,8 @@ Tensor ExecuteBitwiseXor::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1101,7 +1106,8 @@ Tensor ExecuteBitwiseXor::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return BinaryOperationSfpu<operations::binary::BinaryOpType::BITWISE_XOR>::invoke(
@@ -1116,7 +1122,8 @@ Tensor ExecuteBitwiseXor::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1134,7 +1141,8 @@ Tensor ExecuteBitwiseXor::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return ttnn::bitwise_xor(input_tensor_a, input_b, memory_config, optional_output_tensor);
@@ -1149,7 +1157,8 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1167,7 +1176,8 @@ Tensor ExecuteBitwiseLeftShift::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return BinaryOperationSfpu<operations::binary::BinaryOpType::LEFT_SHIFT>::invoke(
@@ -1182,7 +1192,8 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1200,7 +1211,8 @@ Tensor ExecuteBitwiseLeftShift::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return ttnn::bitwise_left_shift(input_tensor_a, input_b, memory_config, optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -939,7 +939,8 @@ Tensor ExecuteBitwiseAnd::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -957,7 +958,8 @@ Tensor ExecuteBitwiseAnd::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return BinaryOperationSfpu<operations::binary::BinaryOpType::BITWISE_AND>::invoke(
@@ -980,7 +982,8 @@ Tensor ExecuteBitwiseAnd::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -998,7 +1001,8 @@ Tensor ExecuteBitwiseAnd::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return ttnn::bitwise_and(input_tensor_a, input_b, memory_config, optional_output_tensor);
@@ -1211,7 +1215,8 @@ Tensor ExecuteBitwiseRightShift::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1229,7 +1234,8 @@ Tensor ExecuteBitwiseRightShift::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return BinaryOperationSfpu<operations::binary::BinaryOpType::RIGHT_SHIFT>::invoke(
@@ -1244,7 +1250,8 @@ Tensor ExecuteBitwiseRightShift::invoke(
     ttsl::Span<const unary::EltwiseUnaryWithParam> post_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    std::optional<bool> use_legacy) {
+    std::optional<bool> use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     if (not(use_legacy ? *use_legacy
                        : binary::is_legacy_only(
                              input_tensor_a,
@@ -1262,7 +1269,8 @@ Tensor ExecuteBitwiseRightShift::invoke(
             post_activations,
             lhs_activations,
             rhs_activations,
-            use_legacy);
+            use_legacy,
+            sub_core_grids);
     }
 
     return ttnn::bitwise_right_shift(input_tensor_a, input_b, memory_config, optional_output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -190,11 +190,7 @@ Tensor invoke_impl(
     const std::optional<Tensor>& output,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     log_debug(tt::LogOp, "Where LLK - TSS");
-    //  TODO: add sub_core_grids functionality to Unary Infra
-    if (sub_core_grids.has_value()) {
-        TT_THROW("Subcore grids are not supported for WhereOperation TSS variant");
-    }
-    return ttnn::where_tss(condition, t_true, t_false, memory_config, output);
+    return ttnn::where_tss(condition, t_true, t_false, memory_config, output, sub_core_grids);
 }
 
 }  // namespace
@@ -223,10 +219,7 @@ Tensor WhereOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    if (sub_core_grids.has_value()) {
-        TT_THROW("Subcore grids are not supported for WhereOperation TSS variant");
-    }
-    return ttnn::where_tss(predicate, value_true, value_false, memory_config, output);
+    return ttnn::where_tss(predicate, value_true, value_false, memory_config, output, sub_core_grids);
 }
 
 template Tensor WhereOperation::invoke<int32_t>(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -187,7 +187,8 @@ Tensor where_tss(
     const operations::unary::ScalarVariant& value_true,
     const operations::unary::ScalarVariant& value_false,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     Tensor input = condition;
     // Check if we have any float scalars
     bool has_float_scalar = std::holds_alternative<float>(value_true) || std::holds_alternative<float>(value_false);
@@ -205,7 +206,7 @@ Tensor where_tss(
         value_true,
         value_false);
 
-    return operations::unary::detail::unary_impl(input, {param}, memory_config, optional_output_tensor);
+    return operations::unary::detail::unary_impl(input, {param}, memory_config, optional_output_tensor, sub_core_grids);
 }
 
 Tensor xielu(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -338,7 +338,8 @@ Tensor where_tss(
     const operations::unary::ScalarVariant& value_true,
     const operations::unary::ScalarVariant& value_false,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
-    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 Tensor selu(
     const Tensor& input_tensor,


### PR DESCRIPTION
Closes #40383

## Summary

Adds `sub_core_grids` support to bitwise ops and `ttnn.where` TSS, unblocking guided decoding for `llama3_70b_galaxy`.

Ops covered: `ttnn.bitwise_and`, `ttnn.bitwise_right_shift`, `ttnn.bitwise_or`, `ttnn.bitwise_xor`, `ttnn.bitwise_left_shift`, `ttnn.where` (TSS)

## Changes

- `binary_composite.hpp` - Added `sub_core_grids` param to all bitwise `Execute*` structs
- `binary_composite_op.cpp` - Pass `sub_core_grids` through to `BinaryOperation<>::invoke()`
- `binary_nanobind.cpp` - Exposed `sub_core_grids` kwarg in Python bindings
- `unary.hpp` / `unary.cpp` - Added `sub_core_grids` to `where_tss`
- `ternary.cpp` - Wire `sub_core_grids` through to `where_tss`

## Tests

All passing locally on Wormhole N150:
- `test_bitwise_and_subcore_grid_tensor_tensor` / `tensor_scalar`
- `test_bitwise_right_shift_subcore_grid_tensor_tensor` / `tensor_scalar`
- `test_bitwise_or_subcore_grid_tensor_tensor` / `tensor_scalar`
- `test_bitwise_xor_subcore_grid_tensor_tensor` / `tensor_scalar`
- `test_bitwise_left_shift_subcore_grid_tensor_tensor` / `tensor_scalar`
- `test_where_tss_subcore_grid`

## CI Runs

| Workflow | Run | Status |
|----------|-----|--------|
| Sanity tests | [#23344949985](https://github.com/tenstorrent/tt-metal/actions/runs/23344949985) | ✅ |
| Blackhole post-commit | [#23344951313](https://github.com/tenstorrent/tt-metal/actions/runs/23344951313) | ✅ |
| L2 nightly (eltwise) | [#23341849661](https://github.com/tenstorrent/tt-metal/actions/runs/23341849661) | ❌ pre-existing — `test_bw_unary_assign_opt_output` fails on `main` too (fixed by #40402) |

Generated with Claude Code