### PR TITLE
[TT-Transformers] Add padding to vocab-size to improve top-k performance on multichip systems

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1519,12 +1519,12 @@ def test_demo_text(
                 # Faster-than-expected TTFT observed in CI; lower target and widen tolerance to avoid false failures.
                 "N300_Qwen2.5-7B": (90, 1.25),  # (value, high_tolerance_ratio)
                 # T3K targets
-                "T3K_Llama-3.1-70B": (205, 1.25),
+                "T3K_Llama-3.1-70B": (73, 1.25),
                 # Faster-than-expected TTFT observed in CI; lower target and widen tolerance to avoid false failures.
                 "T3K_Qwen2.5-72B": (240, 1.40),  # (value, high_tolerance_ratio)
                 # Faster-than-expected TTFT observed in CI; lower the target and keep tolerance to avoid false failures.
                 "T3K_Qwen2.5-Coder-32B": (100, 1.27),  # (value, high_tolerance_ratio)
-                "T3K_Qwen3-32B": 110,  # Issue: Perf regression being tracked on issue #29834
+                "T3K_Qwen3-32B": 43,
             }
             ci_target_decode_tok_s_u = {
                 # N150 targets - higher is better
@@ -1536,10 +1536,10 @@ def test_demo_text(
                 # Slightly relaxed to accommodate normal variance in CI while still flagging regressions
                 "N300_Qwen2.5-7B": 21.0,
                 # T3K targets
-                "T3K_Llama-3.1-70B": 15,
+                "T3K_Llama-3.1-70B": 16,
                 "T3K_Qwen2.5-72B": 13.25,
                 "T3K_Qwen2.5-Coder-32B": 20,
-                "T3K_Qwen3-32B": 19,
+                "T3K_Qwen3-32B": 24,
             }
 
             # Only call verify_perf if the model_device_key exists in the targets

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -4,10 +4,7 @@
 
 import pytest
 
-from models.tt_transformers.tt.model_config import (
-    compute_padded_vocab_size,
-    should_pad_sampling_logits_to_power_of_2,
-)
+from models.tt_transformers.tt.model_config import compute_padded_vocab_size, should_pad_sampling_logits_to_power_of_2
 
 
 @pytest.mark.parametrize(

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -4,7 +4,10 @@
 
 import pytest
 
-from models.tt_transformers.tt.model_config import compute_padded_vocab_size
+from models.tt_transformers.tt.model_config import (
+    compute_padded_vocab_size,
+    should_pad_sampling_logits_to_power_of_2,
+)
 
 
 @pytest.mark.parametrize(
@@ -29,3 +32,20 @@ def test_compute_padded_vocab_size(vocab_size, num_devices, expected):
 def test_compute_padded_vocab_size_rejects_invalid_num_devices():
     with pytest.raises(ValueError, match="num_devices must be >= 1"):
         compute_padded_vocab_size(32000, 0)
+
+
+@pytest.mark.parametrize(
+    ("base_model_name", "padded_vocab_size", "sampling_splits", "expected"),
+    [
+        ("Llama-3.1-70B", 128256, 4, True),
+        ("Llama-3.1-70B", 131072, 4, False),
+        ("Llama-3.1-8B", 128256, 4, False),
+    ],
+)
+def test_should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits, expected):
+    assert should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits) is expected
+
+
+def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits():
+    with pytest.raises(ValueError, match="sampling_splits must be >= 1"):
+        should_pad_sampling_logits_to_power_of_2("Llama-3.1-70B", 128256, 0)

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -91,11 +91,13 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
 def should_pad_sampling_logits_to_power_of_2(base_model_name: str, padded_vocab_size: int, sampling_splits: int) -> bool:
     # Enable optional sampling padding for models that regress to single-core TopK.
     if sampling_splits < 1:
-        raise ValueError(f"sampling_splits must be >= 1, got {sampling_splits}")
-
-    # This is hardcoded on purpose just to target Llama-3.1-70B for the fix. If removed then all models receive a fix
-    if base_model_name != "Llama-3.1-70B":
+        logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
         return False
+
+    # Issue: https://github.com/tenstorrent/tt-metal/issues/40399
+    # Uncomment this if you want fix for specific models only. Currently only Llama 3.1 70B model experienced perf. degradation 
+    # if base_model_name != "Llama-3.1-70B":
+    #    return False
 
     per_device_vocab = padded_vocab_size // sampling_splits
     return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0
@@ -2627,13 +2629,13 @@ class ModelArgs:
                 "Qwen2.5-7B and Qwen2.5-VL-7B is only supported on 2 or 4 devices, run on an N300 or use MESH_DEVICE=N150x4"
             )
 
-        if self.num_devices:
+        if self.num_devices > 0:
             sampling_splits = self.num_devices if self.cluster_shape != [1, 1] else 2
             # Only enable this optimization on the non-multi-step sampling path.
             # The [1, 1] mesh path splits logits before TopK today and would need
             # matching input padding in `TTSampling.sample()` to safely use it.
-            self.pad_logits_to_power_of_2 = self.cluster_shape != [1, 1] and should_pad_sampling_logits_to_power_of_2(
-                self.base_model_name, self.padded_vocab_size, sampling_splits
+            self.pad_logits_to_power_of_2 = self.cluster_shape != [1, 1] and (
+                should_pad_sampling_logits_to_power_of_2(self.base_model_name, self.padded_vocab_size, sampling_splits)
             )
         else:
             self.pad_logits_to_power_of_2 = False

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -88,14 +88,16 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     return nearest_multiple(vocab_size, ttnn.TILE_SIZE * num_devices)
 
 
-def should_pad_sampling_logits_to_power_of_2(base_model_name: str, padded_vocab_size: int, sampling_splits: int) -> bool:
+def should_pad_sampling_logits_to_power_of_2(
+    base_model_name: str, padded_vocab_size: int, sampling_splits: int
+) -> bool:
     # Enable optional sampling padding for models that regress to single-core TopK.
     if sampling_splits < 1:
         logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
         return False
 
     # Issue: https://github.com/tenstorrent/tt-metal/issues/40399
-    # Uncomment this if you want fix for specific models only. Currently only Llama 3.1 70B model experienced perf. degradation 
+    # Uncomment this if you want fix for specific models only. Currently only Llama 3.1 70B model experienced perf. degradation
     # if base_model_name != "Llama-3.1-70B":
     #    return False
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -88,6 +88,19 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     return nearest_multiple(vocab_size, ttnn.TILE_SIZE * num_devices)
 
 
+def should_pad_sampling_logits_to_power_of_2(base_model_name: str, padded_vocab_size: int, sampling_splits: int) -> bool:
+    # Enable optional sampling padding for models that regress to single-core TopK.
+    if sampling_splits < 1:
+        raise ValueError(f"sampling_splits must be >= 1, got {sampling_splits}")
+
+    # This is hardcoded on purpose just to target Llama-3.1-70B for the fix. If removed then all models receive a fix
+    if base_model_name != "Llama-3.1-70B":
+        return False
+
+    per_device_vocab = padded_vocab_size // sampling_splits
+    return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0
+
+
 class MathFidelitySetting(Enum):
     LOFI = "lofi"
     HIFI2 = "hifi2"
@@ -2613,6 +2626,17 @@ class ModelArgs:
             raise AssertionError(
                 "Qwen2.5-7B and Qwen2.5-VL-7B is only supported on 2 or 4 devices, run on an N300 or use MESH_DEVICE=N150x4"
             )
+
+        if self.num_devices:
+            sampling_splits = self.num_devices if self.cluster_shape != [1, 1] else 2
+            # Only enable this optimization on the non-multi-step sampling path.
+            # The [1, 1] mesh path splits logits before TopK today and would need
+            # matching input padding in `TTSampling.sample()` to safely use it.
+            self.pad_logits_to_power_of_2 = self.cluster_shape != [1, 1] and should_pad_sampling_logits_to_power_of_2(
+                self.base_model_name, self.padded_vocab_size, sampling_splits
+            )
+        else:
+            self.pad_logits_to_power_of_2 = False
 
         self.unpadded_hidden_dim = self.hidden_dim
         # Don't need to pad for CPU runs

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -91,15 +91,10 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
 def should_pad_sampling_logits_to_power_of_2(
     base_model_name: str, padded_vocab_size: int, sampling_splits: int
 ) -> bool:
-    # Enable optional sampling padding for models that regress to single-core TopK.
+    # Enable optional sampling padding for models that regress to single-core TopK. More info at issue #40399
     if sampling_splits < 1:
         logger.warning(f"Sampling_splits must be >= 1, got {sampling_splits}")
         return False
-
-    # Issue: https://github.com/tenstorrent/tt-metal/issues/40399
-    # Uncomment this if you want fix for specific models only. Currently only Llama 3.1 70B model experienced perf. degradation
-    # if base_model_name != "Llama-3.1-70B":
-    #    return False
 
     per_device_vocab = padded_vocab_size // sampling_splits
     return per_device_vocab > 0 and (per_device_vocab & (per_device_vocab - 1)) != 0


### PR DESCRIPTION
### Problem description
Llama-3.3-70B, Qwen-3-32B and other models had a performance drop in throughput. For Llama-3.3-70B it went from 15.2 tok/s/user to 14 tok/s/user on T3K devices on the `performance-ci-32 test`. 

### What's changed
The perf drop happened with this commit: https://github.com/tenstorrent/tt-metal/commit/927a5409f43b370e00053805fe2d5206ed87f4c0

This commit included changes to top-k calculations and fixes on this op. One of the changes was the inclusion of bionic sort which required inputs to be in power of 2 sizes to work correctly. Because of that additional check was added which checked for that. If the check failed decode sampling of Top is not done on multiple chips but failed back to single core calculation. This would decrease performance significantly on multi chip devices. 

Llama-3.3-70B has vocabulary size of 128256 and in the current code `compute_padded_vocab_size()` only pads to a tile-aligned multiple of `32 * num_devices`, not a power of two, in `model_config.py`. On a Loudbox -> TP=8, the per-device width is `128256 / 8 = 16032`, which passes the old multi-core checks (`>=8192, <65536, k<=64`). However this number is not a power of 2 so it fails the new power-of-two check. Because of that the decode sampling of TopK falls back to single core and this kill throughput.

The fix in this PR checks enforces a check on TT-Transformer models to see if the vocab_size // num_devices is a power of two, and pads it if needed.
For Llama-3.3-70B, this fix increases performance from previous 14 tok/s/user to 16.2 tok/s/user.

### Checklist

#### Model tests
- [ ] T3K Demo - https://github.com/tenstorrent/tt-metal/actions/runs/23487549333
- [ ] Single card demo - https://github.com/tenstorrent/tt-metal/actions/runs/23487554651