### PR TITLE
fix(ttnn): update deepseek_prefill dispatch and combine operations

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_device_operation.cpp
@@ -71,18 +71,11 @@ CombineDeviceOperation::spec_return_value_t CombineDeviceOperation::compute_outp
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Get input shape to extract hidden_dim
     auto dispatched_shape = tensor_args.dispatched_buffer.tensor_spec().logical_shape();
-    uint32_t per_device_batch = dispatched_shape[0];  // Should be 1 for sharded input
     uint32_t hidden_dim = dispatched_shape[-1];
 
-    // Output shape: (per_device_batch, 1, seq_len_per_chip, num_experts_per_tok, hidden_dim)
-    // The extra dimension (1) allows proper composition across 2D mesh
-    // For sharded input on dim 0, per-device shape is (1, 1, seq_len_per_chip, num_experts_per_tok, hidden_dim)
+    // Output shape: (1, 1, seq_len_per_chip, num_experts_per_tok, hidden_dim)
     auto output_shape = ttnn::Shape(
-        {per_device_batch,
-         1,
-         operation_attributes.seq_len_per_chip,
-         operation_attributes.num_experts_per_tok,
-         hidden_dim});
+        {1, 1, operation_attributes.seq_len_per_chip, operation_attributes.num_experts_per_tok, hidden_dim});
 
     // Memory config and layout
     auto mem_config = operation_attributes.output_mem_config;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -72,9 +72,6 @@ DispatchDeviceOperation::spec_return_value_t DispatchDeviceOperation::compute_ou
 
     // Get the input tensor's per-device shape (sharded dimension)
     auto input_shape = tensor_args.input_tensor.tensor_spec().logical_shape();
-
-    // Extract per-device batch size from the input's first dimension (sharded on dim 0)
-    uint32_t per_device_batch = input_shape[0];  // This is 1 for input sharded on dim 0
     uint32_t hidden_dim = input_shape[-1];
 
     // Memory config for all output tensors (inherits sharding from input)
@@ -84,11 +81,9 @@ DispatchDeviceOperation::spec_return_value_t DispatchDeviceOperation::compute_ou
     auto layout = tt::tt_metal::Layout::ROW_MAJOR;
 
     // Define output shapes - these are PER-DEVICE shapes (not global shapes)
-    // When sharded on dim 0, each device should get shape [1, ...]
-    auto dispatch_buffer_shape =
-        ttnn::Shape({per_device_batch, 1, experts_per_chip, max_dispatched_tokens_per_expert, hidden_dim});
+    auto dispatch_buffer_shape = ttnn::Shape({1, 1, experts_per_chip, max_dispatched_tokens_per_expert, hidden_dim});
     auto dispatch_metadata_shape =
-        ttnn::Shape({per_device_batch, 1, experts_per_chip, max_dispatched_tokens_per_expert, metadata_len});
+        ttnn::Shape({1, 1, experts_per_chip, max_dispatched_tokens_per_expert, metadata_len});
 
     // Create TensorSpec objects with correct dtypes
     auto dispatch_buffer_spec = TensorSpec(
@@ -108,10 +103,11 @@ DispatchDeviceOperation::topology_return_value_t DispatchDeviceOperation::comput
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& input_topology = input_tensor.tensor_topology();
 
-    // Both output tensors use the same topology as the input
-    // (sharded on dimension 0 across the mesh)
+    // Both output tensors use explicit Shard placements across both mesh dimensions
     auto output_topology = tt::tt_metal::TensorTopology(
-        input_topology.distribution_shape(), input_topology.placements(), input_topology.mesh_coords());
+        input_topology.distribution_shape(),
+        {tt::tt_metal::distributed::MeshMapperConfig::Shard{0}, tt::tt_metal::distributed::MeshMapperConfig::Shard{1}},
+        input_topology.mesh_coords());
 
     return {output_topology, output_topology};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -29,7 +29,7 @@ struct DispatchDeviceOperation {
     using operation_attributes_t = DispatchParams;
     using tensor_args_t = DispatchInputs;
     using spec_return_value_t = std::array<ttnn::TensorSpec, 2>;
-    using topology_return_value_t = std::array<tt::tt_metal::TensorTopology, 2>;
+    using topology_return_value_t = std::vector<tt::tt_metal::TensorTopology>;
     using tensor_return_value_t = std::array<Tensor, 2>;
     using program_factory_t = std::variant<DispatchProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <variant>
 #include <array>
+#include <vector>
+#include <variant>
 
 #include "dispatch_types.hpp"
 #include "dispatch_program_factory.hpp"


### PR DESCRIPTION
## Summary
- Fix shard placement definition in dispatch operation: both rows and cols are sharded (not replicated as input)
- Change `topology_return_value_t` from `std::array` to `std::vector` so `compute_output_topologies` is invoked (the device_operation.hpp only calls this function when return type is `std::vector<tt::tt_metal::TensorTopology>`)
- Simplify output shapes by removing redundant `per_device_batch` variable

## Test plan
- [x] Build passes locally
- [x] BH E2E tests: https://github.com/tenstorrent/tt-metal/actions/runs/23339560434
- [x] T3K E2E tests: https://github.com/tenstorrent/tt-metal/actions/runs/23339681196

🤖 Generated with [Claude Code](https://claude.com/claude-code)