### PR TITLE
deepseekv3: skip dual multihost MTP smoke

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -356,8 +356,9 @@ jobs:
             generated/artifacts/dual_demo_full_results.json
           if-no-files-found: warn
 
+      # Temporary skip: dual MTP smoke currently times out in CI and keeps the multihost workflow red.
       - name: Run dual MTP demo parity smoke test
-        if: ${{ (inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ false && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -381,7 +382,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
 
       - name: Upload dual MTP demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ false && always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-mtp-output-${{ github.run_id }}

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -356,7 +356,8 @@ jobs:
             generated/artifacts/dual_demo_full_results.json
           if-no-files-found: warn
 
-      # Temporary skip: dual MTP smoke currently times out in CI and keeps the multihost workflow red.
+      # Temporary skip while https://github.com/tenstorrent/tt-metal/pull/40317
+      # attempts a proper fix; dual MTP smoke currently times out in CI.
       - name: Run dual MTP demo parity smoke test
         if: ${{ false && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run


### PR DESCRIPTION
## Summary
- temporarily skip the dual MTP demo parity smoke step in the multi-host DeepSeek V3 workflow until [#40317](https://github.com/tenstorrent/tt-metal/pull/40317) is fixed
- skip the matching artifact upload while the step is disabled
- keep the rest of the workflow unchanged while the dual MTP runtime issue is investigated

## Testing
- `git diff --check`
- validation evidence: [run 23338133211](https://github.com/tenstorrent/tt-metal/actions/runs/23338133211) reached `models/demos/deepseek_v3/demo/test_mtp_demo.py::test_mtp_demp_compare_outputs[smoke_2_prompts_32_tokens]` in job `67885586769` and then hit the 40-minute step timeout

## CI Badge
[![DeepSeek V3 Multi-Host Tests (yieldthought/skip-dual-mtp-smoke)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=yieldthought%2Fskip-dual-mtp-smoke)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ayieldthought%2Fskip-dual-mtp-smoke)
