### PR TITLE
Add StateDictWeightProvider weight path for demo CLI

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/README.md
+++ b/models/demos/deepseek_v3_b1/demo/README.md
@@ -6,8 +6,20 @@ The demo runs prefill + decode over `DeepSeekV3` sockets and streams decoded tex
 
 ## Requirements
 
-- **Mesh shape:** The demo requires a **4×2** mesh. The CLI will fail at startup if the mesh shape does not match.
+- **Process count:** The pod pipeline expects **4**, **16**, or **64** distributed ranks (single galaxy vs scaleout). Startup fails if the count does not match.
 - Slow dispatch mode must be enabled (see below).
+
+## Weight loading (`--weights`)
+
+| Mode | Flag | Extra args | Behavior |
+|------|------|------------|----------|
+| **Cached tensorbin** | `--weights real` (default) | `--cache-path` (required) | Loads pre-generated `.tensorbin` + `manifest.json` from the weight cache (same layout as `scripts/generate_cache.py`). |
+| **HF safetensors + prepare** | `--weights state_dict` | `--model-path` (required) | Uses `LazyStateDict` ([`models/demos/deepseek_v3/utils/lazy_state_dict.py`](../../deepseek_v3/utils/lazy_state_dict.py)) over a local HuggingFace checkpoint (`model.safetensors.index.json` + shards) and runs the same `prepare_*` path as synthetic weights (`StateDictWeightProvider` in [`weight_provider.py`](weight_provider.py)) — no tensorbin cache. |
+| **Synthetic** | `--weights synthetic` | — | Random HF-shaped tensors through `prepare_*` for bring-up (no disk weights). |
+
+Optional overrides (all modes): `--dense-layer-id-override`, `--moe-layer-id-override` (see `python -m models.demos.deepseek_v3_b1.demo.cli --help`).
+
+Other common flags: `--prompt`, `--max-new-tokens`, `--tokenizer`, `--fp32` / `--no-fp32`, `--persistent-mode` / `--no-persistent-mode`.
 
 ## Running the demo on single galaxy
 
@@ -19,16 +31,31 @@ export TT_METAL_HOME=$PWD
 tt-smi -glx_reset
 python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
 tt-run --rank-binding bh_4x2_multi_mesh_rank_binding.yaml  \
-    python -m models.demos.deepseek_v3_b1.demo.cli --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache --layer-id-offset 4
+    python -m models.demos.deepseek_v3_b1.demo.cli \
+    --weights real \
+    --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache
 ```
 
-Adjust `--cache-path` to your prepared weight cache location and `--layer-id-offset` as needed. You can also pass `--prompt` and `--max-new-tokens`, for example:
+**From HuggingFace weights on disk (no cache):**
 
-## Running the demo on single-pod:
+```bash
+tt-run --rank-binding bh_4x2_multi_mesh_rank_binding.yaml  \
+    python -m models.demos.deepseek_v3_b1.demo.cli \
+    --weights state_dict \
+    --model-path /path/to/DeepSeek-V3
+```
+
+Adjust `--cache-path` or `--model-path` to your machine. You can add `--prompt`, `--max-new-tokens`, etc.
+
+## Running the demo on single-pod
 
 ```bash
 ./tools/scaleout/exabox/recover.sh --hosts bh-glx-d06u08,bh-glx-d06u02,bh-glx-d05u08,bh-glx-d05u02 # Modify with your 4 hosts
 python3 models/demos/deepseek_v3_b1/scaleout_configs/generate_blitz_decode_pipeline_configs.py models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config_single_pod.yaml # Generate pipeline config for 1 pod
 tt-run --mpi-args "--map-by rankfile:file=blitz_decode_pipeline_rank_file_single_pod --bind-to hwt:overload-allowed --host bh-glx-d05u02:4,bh-glx-d05u08:4,bh-glx-d06u02:4,bh-glx-d06u08:4 --tag-output" --rank-binding blitz_decode_pipeline_rank_binding_single_pod.yaml \
-    python -m models.demos.deepseek_v3_b1.demo.cli --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache --layer-id-offset 4
+    python -m models.demos.deepseek_v3_b1.demo.cli \
+    --weights real \
+    --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache
 ```
+
+Use `--weights state_dict --model-path ...` similarly if you want runtime preparation from safetensors instead of a cache.

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -9,6 +9,7 @@ import contextlib
 import os
 import sys
 from pathlib import Path
+from typing import Literal
 
 from loguru import logger
 from transformers import AutoTokenizer
@@ -71,15 +72,21 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cache-path",
         type=Path,
-        required=True,
+        default=None,
         help="Path to the weight cache directory (required for --weights real)",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=None,
+        help="Local HuggingFace model dir with model.safetensors.index.json (required for --weights state_dict)",
     )
     parser.add_argument(
         "--weights",
         type=str,
-        choices=("synthetic", "real"),
-        default="synthetic",
-        help="Use synthetic or real (cached) weights (default: synthetic)",
+        choices=("synthetic", "real", "state_dict"),
+        default="real",
+        help="synthetic: random prepare path; real: load tensorbin cache; state_dict: HF safetensors + prepare path",
     )
     parser.add_argument(
         "--fp32",
@@ -119,8 +126,9 @@ def run_demo(
     prompt: str,
     max_new_tokens: int,
     tokenizer_name_or_path: str,
-    cache_path: Path,
-    use_real_weights: bool = False,
+    weights_mode: Literal["synthetic", "real", "state_dict"] = "real",
+    cache_path: Path | None = None,
+    model_path: Path | None = None,
     lm_head_fp32_dest_acc_en: bool = True,
     lm_head_persistent_mode: bool = True,
     dense_layer_id_override: int | None = None,
@@ -134,8 +142,9 @@ def run_demo(
         # Initialize model pipeline
         model_pipeline = ModelPipeline(
             mesh_device=mesh_device,
+            weights_mode=weights_mode,
             cache_path=cache_path,
-            use_real_weights=use_real_weights,
+            model_path=model_path,
             lm_head_fp32_dest_acc_en=lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode=lm_head_persistent_mode,
             dense_layer_id_override=dense_layer_id_override,
@@ -170,12 +179,22 @@ def main(argv: list[str] | None = None) -> int:
     parser = create_parser()
     args = parser.parse_args(argv)
 
+    if args.weights == "real" and args.cache_path is None:
+        parser.error("--cache-path is required when --weights real")
+    if args.weights == "state_dict":
+        if args.model_path is None:
+            parser.error("--model-path is required when --weights state_dict")
+        index_path = args.model_path / "model.safetensors.index.json"
+        if not index_path.is_file():
+            parser.error(f"--model-path must contain model.safetensors.index.json (missing {index_path})")
+
     run_demo(
         prompt=args.prompt,
         max_new_tokens=args.max_new_tokens,
         tokenizer_name_or_path=args.tokenizer,
+        weights_mode=args.weights,
         cache_path=args.cache_path,
-        use_real_weights=(args.weights == "real"),
+        model_path=args.model_path,
         lm_head_fp32_dest_acc_en=args.fp32,
         lm_head_persistent_mode=args.persistent_mode,
         dense_layer_id_override=args.dense_layer_id_override,

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 import torch
 from loguru import logger
@@ -15,6 +16,7 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.pipeline import create_pipeline_configuration_from_num_procs
 from models.demos.deepseek_v3_b1.demo.weight_provider import (
     CacheWeightProvider,
+    StateDictWeightProvider,
     SyntheticWeightProvider,
     WeightProvider,
 )
@@ -25,8 +27,10 @@ class ModelPipeline:
     def __init__(
         self,
         mesh_device: ttnn.MeshDevice,
-        cache_path: Path,
-        use_real_weights: bool,
+        *,
+        weights_mode: Literal["synthetic", "real", "state_dict"] = "real",
+        cache_path: Path | None = None,
+        model_path: Path | None = None,
         lm_head_fp32_dest_acc_en: bool = True,
         lm_head_persistent_mode: bool = True,
         dense_layer_id_override: int | None = None,
@@ -34,7 +38,7 @@ class ModelPipeline:
     ):
         logger.info(
             "Initializing DeepSeek V3 B1 pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
-            "real" if use_real_weights else "synthetic",
+            weights_mode,
             lm_head_fp32_dest_acc_en,
             lm_head_persistent_mode,
         )
@@ -49,7 +53,18 @@ class ModelPipeline:
         ttnn.enable_asynchronous_slow_dispatch(self.mesh_device)
 
         # Each host loads/creates only the weights for its stage via the provider.
-        provider: WeightProvider = CacheWeightProvider(cache_path) if use_real_weights else SyntheticWeightProvider()
+        if weights_mode == "real":
+            if cache_path is None:
+                raise ValueError("weights_mode='real' requires cache_path")
+            provider: WeightProvider = CacheWeightProvider(cache_path)
+        elif weights_mode == "state_dict":
+            if model_path is None:
+                raise ValueError("weights_mode='state_dict' requires model_path")
+            provider = StateDictWeightProvider(model_path)
+        elif weights_mode == "synthetic":
+            provider = SyntheticWeightProvider()
+        else:
+            raise ValueError(f"Unknown weights_mode: {weights_mode!r}")
         config = create_pipeline_configuration_from_num_procs(
             num_procs,
             provider,

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -4,7 +4,8 @@
 
 """
 Weight providers for the DeepSeek V3 B1 demo pipeline.
-CacheWeightProvider loads from disk; SyntheticWeightProvider builds deterministic synthetic weights.
+CacheWeightProvider loads from disk; SyntheticWeightProvider builds deterministic synthetic weights;
+StateDictWeightProvider loads HuggingFace safetensors and runs the same prepare_* path as synthetic.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from typing import Protocol
 import torch
 
 import ttnn
+from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3_b1.prepare_weights import (
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
@@ -261,3 +263,37 @@ class SyntheticWeightProvider:
         sd = _build_synthetic_dense_state_dict(layer_id)
         bdw = BlitzDecodeWeights(device)
         return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
+
+
+class StateDictWeightProvider:
+    """Load real HF safetensors via LazyStateDict and prepare weights at runtime (no tensorbin cache)."""
+
+    def __init__(self, model_path: Path) -> None:
+        model_path = Path(model_path)
+        assert model_path.exists(), f"Model path does not exist: {model_path}"
+        assert model_path.is_dir(), f"Model path is not a directory: {model_path}"
+        self._state_dict = LazyStateDict(model_path)
+
+    def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
+        return prepare_embedding_weights(self._state_dict, device, move_to_device=True)
+
+    def load_lm_head(self, device: ttnn.MeshDevice) -> DeepSeekV3LMHeadWeights:
+        return prepare_lm_head_weights(self._state_dict, device, move_to_device=True)
+
+    def load_moe_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3MoELayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        bdw = BlitzDecodeWeights(device)
+        return prepare_moe_layer_weights(
+            bdw,
+            self._state_dict,
+            layer_id,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+            move_to_device=True,
+        )
+
+    def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+
+        bdw = BlitzDecodeWeights(device)
+        return prepare_dense_layer_weights(bdw, self._state_dict, layer_id, move_to_device=True)


### PR DESCRIPTION
### Summary

This commit adds StateDictWeightProvider which loads HuggingFace safetensors via LazyStateDict and runs the same prepare_* pipeline as synthetic weights, avoiding pre-built tensorbin caches.

ModelPipeline now selects weights via weights_mode (synthetic | real | state_dict) with optional cache_path and model_path. CLI adds --weights state_dict, --model-path, and conditional --cache-path; validate index JSON for state_dict mode.

- [x] Blackhole post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/23343957627