### PR TITLE
Prefetch DRAM restore in multi-Q ring SDPA

### DIFF
--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Ring Joint Attention SDPA Tests for WAN 2.2 Model Shapes on Blackhole
+Ring Joint Attention SDPA Tests for Video Generation Models on Blackhole
 
-Tests Ring Joint Attention accuracy and determinism using WAN 2.2 model shapes
+Tests Ring Joint Attention accuracy and determinism using video generation model shapes
 on BH multi-chip setups (single ring 1xN or Galaxy 4x8 mesh).
 Perf tests are included but skipped on CI.
 
@@ -14,6 +14,7 @@ BH adaptation: uses init_device_compute_kernel_config instead of WormholeCompute
 import os
 import math
 import torch
+from dataclasses import dataclass, field
 from itertools import product
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
@@ -53,16 +54,59 @@ GALAXY_DEVICE_COUNT = 32
 GALAXY_TP_SIZE = 4
 GALAXY_SP_SIZE = 8
 
-# WAN 2.2 model workload configuration constants (per-device sequence lengths)
-GALAXY_SEQ_LENS_PER_DEVICE = [2368, 9472]  # WAN 2.2 Galaxy per-device
-NON_GALAXY_SEQ_LENS_PER_DEVICE = [2240, 8544]  # WAN 2.2 non-Galaxy per-device
-HEADS_PER_DEVICE = 10  # WAN 2.2 attention heads per device
-HEAD_DIMENSION = 128  # WAN 2.2 head dimension
+# ============================================================================
+# MODEL CONFIGURATIONS
+# ============================================================================
+#
+# Each model defines per-device sequence lengths for Galaxy and Quiet Box,
+# tuned so per-core work matches between platforms (11 vs 10 cores/head).
+# See test_instructions.md for full parallelization context.
+
 BATCH_SIZE = 1
 
-# Chunk size sweep parameters
-Q_CHUNK_SIZES = [224, 256, 288]
-K_CHUNK_SIZES = [128, 256, 512]
+
+@dataclass
+class ModelConfig:
+    """Benchmark configuration for a video generation model."""
+
+    galaxy_seq_per_device: int
+    non_galaxy_seq_per_device: int
+    heads_per_device: int  # After TP split (same for both platforms)
+    head_dim: int
+    q_chunk_sizes: list = field(default_factory=list)
+    k_chunk_sizes: list = field(default_factory=list)
+
+
+MODEL_CONFIGS = {
+    # WAN 2.2 — 1×Galaxy deployment (32 chips, ~75K total tokens at 720p)
+    "wan2_2_1xGLX": ModelConfig(
+        galaxy_seq_per_device=9472,
+        non_galaxy_seq_per_device=8544,
+        heads_per_device=10,
+        head_dim=128,
+        q_chunk_sizes=[224, 256, 288],
+        k_chunk_sizes=[128, 256, 512],
+    ),
+    # WAN 2.2 — 4×Galaxy deployment (128 chips, 720p split across 4 Galaxies)
+    "wan2_2_4xGLX": ModelConfig(
+        galaxy_seq_per_device=2368,
+        non_galaxy_seq_per_device=2240,
+        heads_per_device=10,
+        head_dim=128,
+        q_chunk_sizes=[224, 256, 288],
+        k_chunk_sizes=[128, 256, 512],
+    ),
+    # VideogenModel1 — 1×Galaxy deployment (115,200 total tokens)
+    # Single benchmark config: Sq_chunk_t=7 (q=224), k=512
+    "videogen_model1": ModelConfig(
+        galaxy_seq_per_device=14400,
+        non_galaxy_seq_per_device=13440,
+        heads_per_device=10,
+        head_dim=128,
+        q_chunk_sizes=[224],
+        k_chunk_sizes=[512],
+    ),
+}
 
 # Accuracy threshold constants
 DEFAULT_PCC_THRESHOLD = 0.994
@@ -149,13 +193,11 @@ def calculate_mesh_config(num_devices):
     return sp_size, tp_size, arch_type
 
 
-def generate_input_shapes():
+def generate_test_configs():
     """
-    Generate WAN 2.2 model input shapes based on available BH devices.
+    Generate (b, nh, s, d, q_chunk, k_chunk) tuples for all model configs.
 
-    Per-device sequence lengths are WAN 2.2 model shapes:
-    - Galaxy: 2368, 9472
-    - Non-Galaxy (BH T3K): 2240, 8544
+    Each model defines its own Q/K chunk sizes, so the cross-product is per-model.
 
     NOTE: Uses detect_devices_without_opening() to avoid holding device locks
     during pytest collection, which would block subprocess profiling.
@@ -165,24 +207,48 @@ def generate_input_shapes():
         return [], []
 
     sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
+    is_galaxy = arch_type.startswith("galaxy")
 
-    if arch_type.startswith("galaxy"):
-        seq_lens_per_device = GALAXY_SEQ_LENS_PER_DEVICE
-    else:
-        seq_lens_per_device = NON_GALAXY_SEQ_LENS_PER_DEVICE
+    configs = []
+    config_ids = []
 
-    shapes = []
-    shape_ids = []
+    for model_name, model in MODEL_CONFIGS.items():
+        seq_per_device = model.galaxy_seq_per_device if is_galaxy else model.non_galaxy_seq_per_device
+        total_seq = seq_per_device * sp_size
+        total_heads = model.heads_per_device * tp_size
 
-    for seq_len_per_device in seq_lens_per_device:
-        total_seq_len = seq_len_per_device * sp_size
-        total_heads = HEADS_PER_DEVICE * tp_size
+        for q_chunk, k_chunk in product(model.q_chunk_sizes, model.k_chunk_sizes):
+            configs.append((BATCH_SIZE, total_heads, total_seq, model.head_dim, q_chunk, k_chunk))
+            config_ids.append(f"{model_name}-{seq_per_device}x{sp_size}_h{total_heads}-k{k_chunk}-q{q_chunk}")
 
-        shape = [BATCH_SIZE, total_heads, total_seq_len, HEAD_DIMENSION]
-        shapes.append(shape)
-        shape_ids.append(f"wan2_2_compat_{seq_len_per_device}x{sp_size}_h{total_heads}")
+    return configs, config_ids
 
-    return shapes, shape_ids
+
+def generate_perf_table_configs():
+    """
+    Generate (model_name, b, nh, s, d) tuples for perf table tests.
+
+    One entry per model — the perf table sweeps Q/K chunk sizes internally.
+    """
+    num_devices = detect_devices_without_opening()
+    if num_devices < 2:
+        return [], []
+
+    sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
+    is_galaxy = arch_type.startswith("galaxy")
+
+    configs = []
+    config_ids = []
+
+    for model_name, model in MODEL_CONFIGS.items():
+        seq_per_device = model.galaxy_seq_per_device if is_galaxy else model.non_galaxy_seq_per_device
+        total_seq = seq_per_device * sp_size
+        total_heads = model.heads_per_device * tp_size
+
+        configs.append((model_name, BATCH_SIZE, total_heads, total_seq, model.head_dim))
+        config_ids.append(f"{model_name}_{seq_per_device}x{sp_size}_h{total_heads}")
+
+    return configs, config_ids
 
 
 def create_global_semaphores(mesh_device, cores, initial_value):
@@ -526,19 +592,18 @@ def run_ring_joint_sdpa(
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
 
-# Generate input shapes dynamically based on detected hardware
-INPUT_SHAPES, INPUT_IDS = generate_input_shapes()
+# Generate test parameters dynamically based on detected hardware
+TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs()
+PERF_TABLE_CONFIGS, PERF_TABLE_CONFIG_IDS = generate_perf_table_configs()
 
 
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
 @pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
+    "b, nh, s, d, q_chunk_size, k_chunk_size",
+    TEST_CONFIGS,
+    ids=TEST_CONFIG_IDS,
 )
 def test_ring_joint_attention_sdpa_sweep_perf_impl(b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
     """
@@ -550,12 +615,10 @@ def test_ring_joint_attention_sdpa_sweep_perf_impl(b, nh, s, d, q_chunk_size, k_
 
 # === TEST 2: ACCURACY VERIFICATION ===
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
 @pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
+    "b, nh, s, d, q_chunk_size, k_chunk_size",
+    TEST_CONFIGS,
+    ids=TEST_CONFIG_IDS,
 )
 def test_ring_joint_attention_sdpa_accuracy(b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
     """
@@ -586,12 +649,10 @@ def test_ring_joint_attention_sdpa_accuracy(b, nh, s, d, q_chunk_size, k_chunk_s
 
 # === TEST 3: DETERMINISM VERIFICATION ===
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("q_chunk_size", Q_CHUNK_SIZES, ids=[f"q{s}" for s in Q_CHUNK_SIZES])
-@pytest.mark.parametrize("k_chunk_size", K_CHUNK_SIZES, ids=[f"k{s}" for s in K_CHUNK_SIZES])
 @pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
+    "b, nh, s, d, q_chunk_size, k_chunk_size",
+    TEST_CONFIGS,
+    ids=TEST_CONFIG_IDS,
 )
 def test_ring_joint_attention_sdpa_determinism(b, nh, s, d, q_chunk_size, k_chunk_size, dtype):
     """
@@ -605,26 +666,31 @@ def test_ring_joint_attention_sdpa_determinism(b, nh, s, d, q_chunk_size, k_chun
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.timeout(1000)
 @pytest.mark.parametrize(
-    "b, nh, s, d",
-    INPUT_SHAPES,
-    ids=INPUT_IDS,
+    "model_name, b, nh, s, d",
+    PERF_TABLE_CONFIGS,
+    ids=PERF_TABLE_CONFIG_IDS,
 )
-def test_ring_joint_attention_create_perf_table(b, nh, s, d):
+def test_ring_joint_attention_create_perf_table(model_name, b, nh, s, d):
     """
     Sweep chunk sizes for ring joint attention SDPA and print a performance table.
     Skipped on CI - run locally with tracy profiler.
     """
     from tracy.process_model_log import run_device_profiler
 
+    model = MODEL_CONFIGS[model_name]
+
     num_devices = detect_devices_without_opening()
     sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
     ring_size = sp_size
+    is_galaxy = arch_type.startswith("galaxy")
+    seq_per_device = model.galaxy_seq_per_device if is_galaxy else model.non_galaxy_seq_per_device
+    total_heads = model.heads_per_device * tp_size
 
     if ring_size < 2:
         pytest.skip(f"Ring joint attention requires at least 2 devices, got {ring_size}")
 
     # Use hardcoded grid constants (cannot query device due to TLB conflicts with subprocess tests)
-    if arch_type.startswith("galaxy"):
+    if is_galaxy:
         full_grid_rows = GALAXY_GRID_ROWS
         total_compute_cores = GALAXY_SDPA_CORES
         total_cores = GALAXY_TOTAL_CORES
@@ -639,17 +705,16 @@ def test_ring_joint_attention_create_perf_table(b, nh, s, d):
     subdir = "ttnn_ring_joint_sdpa_performance"
     perf_results = []
 
-    for q_chunk_size, k_chunk_size in product(Q_CHUNK_SIZES, K_CHUNK_SIZES):
+    for q_chunk_size, k_chunk_size in product(model.q_chunk_sizes, model.k_chunk_sizes):
         float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
         cols = ["ATTRIBUTES"]
 
-        test_id = f"k{k_chunk_size}-q{q_chunk_size}-bf16"
-        shape_id = INPUT_IDS[INPUT_SHAPES.index([b, nh, s, d])]
+        config_id = f"{model_name}-{seq_per_device}x{sp_size}_h{total_heads}-k{k_chunk_size}-q{q_chunk_size}"
         command = (
             f"pytest tests/nightly/blackhole/ccl/"
             f"test_ring_joint_sdpa.py::"
             f"test_ring_joint_attention_sdpa_sweep_perf_impl"
-            f"[{shape_id}-{test_id}]"
+            f"[{config_id}-bf16]"
         )
 
         try:
@@ -750,7 +815,7 @@ def test_ring_joint_attention_create_perf_table(b, nh, s, d):
 
     # Print summary table
     print(f"\n{'='*190}")
-    print(f"Ring Joint Attention Performance Sweep: b={b}, nh={nh}, s={s}, d={d}")
+    print(f"Ring Joint Attention Performance Sweep: {model_name} — b={b}, nh={nh}, s={s}, d={d}")
     print(f"Architecture: {arch_type}, Ring size: {ring_size} devices")
     print(f"Total MM FLOPs (all devices): {mm_flops:,} ({mm_flops/1e9:.2f} GFLOPs)")
     print(f"Per-device workload: Q={s // ring_size} tokens, K/V={s} tokens (via ring), {nh} heads")

--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -73,66 +73,11 @@ BLACKHOLE_CLOCK_GHZ = 1.35  # Blackhole clock frequency in GHz
 MM_FLOPS_PER_CYCLE_PER_CORE = 2048  # Matrix multiply FLOPs per cycle per core
 
 
-def post_process_ops_log(
-    output_logs_subdir, float_columns=None, columns=None, sum_vals=True, op_name="", has_signposts=False
-):
-    """Process the ops log CSV and extract performance data."""
-    from tracy.process_model_log import get_latest_ops_log_filename
-    import pandas as pd
-
-    filename = get_latest_ops_log_filename(output_logs_subdir)
-    df = pd.read_csv(filename)
-
-    if has_signposts:
-        markers = df[df["OP TYPE"] == "signpost"]["OP CODE"]
-        start = markers[markers == "start"].index[0]
-        stop = markers[markers == "stop"].index[0]
-        df = df.iloc[start + 1 : stop]
-    if op_name != "":
-        df = df[df["OP CODE"] == op_name]
-
-    results = {}
-    if float_columns:
-        for col in float_columns:
-            df_filtered = df[df[col] != "-"]
-            if sum_vals:
-                results[col] = df_filtered[col].astype(float).sum()
-            else:
-                results[col] = df_filtered[col].astype(float).to_numpy()
-    if columns:
-        for col in columns:
-            df_filtered = df[df[col] != "-"]
-            results[col] = df_filtered[col]
-    else:
-        results = df
-    return results
-
-
-def compute_ring_joint_cores_used(seqlen, q_chunk_size, compute_cores, num_heads, ring_size):
-    """
-    Compute number of cores actually used for ring joint attention based on parallelization scheme.
-    """
-    B = BATCH_SIZE
-    local_seq_len = seqlen // ring_size
-    q_num_chunks = math.ceil(local_seq_len / q_chunk_size)
-
-    batch_parallel = min(B, compute_cores)
-    nh_parallel = min(compute_cores // batch_parallel, num_heads)
-    q_parallel = min(compute_cores // (batch_parallel * nh_parallel), q_num_chunks)
-
-    cores_used = batch_parallel * nh_parallel * q_parallel
-    return cores_used
-
-
-def compute_ring_joint_utilization(local_seqlen, total_seqlen, head_dim, num_heads_per_device, duration_ns, core_count):
-    """
-    Compute math utilization for ring joint attention.
-    """
-    mm_flops = 4 * local_seqlen * total_seqlen * head_dim * num_heads_per_device
-    cycles = duration_ns * BLACKHOLE_CLOCK_GHZ
-    theoretical_flops = core_count * cycles * MM_FLOPS_PER_CYCLE_PER_CORE
-    utilization = (mm_flops / theoretical_flops) * 100
-    return utilization
+from tests.nightly.sdpa_perf_utils import (
+    post_process_ops_log,
+    compute_cores_used as compute_ring_joint_cores_used,
+    compute_math_utilization as compute_ring_joint_utilization,
+)
 
 
 def fa_rand(*shape):

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -253,73 +253,16 @@ def test_sdpa_determinism(device, b, nh, s, d, q_chunk_size, k_chunk_size, dtype
     run_sdpa_determinism(device, b, nh, nh, s, d, q_chunk_size, k_chunk_size, dtype, num_iterations=num_iterations)
 
 
-def post_process_ops_log(
-    output_logs_subdir, float_columns=None, columns=None, sum_vals=True, op_name="", has_signposts=False
-):
-    """Process the ops log CSV and extract performance data."""
-    from tracy.process_model_log import get_latest_ops_log_filename
-    import pandas as pd
-
-    filename = get_latest_ops_log_filename(output_logs_subdir)
-    df = pd.read_csv(filename)
-
-    if has_signposts:
-        markers = df[df["OP TYPE"] == "signpost"]["OP CODE"]
-        start = markers[markers == "start"].index[0]
-        stop = markers[markers == "stop"].index[0]
-        df = df.iloc[start + 1 : stop]
-    if op_name != "":
-        df = df[df["OP CODE"] == op_name]
-
-    results = {}
-    if float_columns:
-        for col in float_columns:
-            df_filtered = df[df[col] != "-"]
-            if sum_vals:
-                results[col] = df_filtered[col].astype(float).sum()
-            else:
-                results[col] = df_filtered[col].astype(float).to_numpy()
-    if columns:
-        for col in columns:
-            df_filtered = df[df[col] != "-"]
-            results[col] = df_filtered[col]
-    else:
-        results = df
-    return results
-
-
-def compute_cores_used(seqlen, q_chunk_size, num_cores, num_heads):
-    """
-    Compute number of cores actually used based on parallelization scheme.
-
-    Parallelization hierarchy (from sdpa_program_factory.cpp):
-    1. batch_parallel_factor = min(B, num_cores)
-    2. nh_parallel_factor = min(num_cores / batch_parallel_factor, NQH)
-    3. q_parallel_factor = min(num_cores / (batch * nh), q_num_chunks)
-    """
-    B = 1
-    q_num_chunks = math.ceil(seqlen / q_chunk_size)
-
-    batch_parallel = min(B, num_cores)
-    nh_parallel = min(num_cores // batch_parallel, num_heads)
-    q_parallel = min(num_cores // (batch_parallel * nh_parallel), q_num_chunks)
-
-    cores_used = batch_parallel * nh_parallel * q_parallel
-    return cores_used
+from tests.nightly.sdpa_perf_utils import (
+    post_process_ops_log,
+    compute_cores_used,
+    compute_math_utilization,
+)
 
 
 def compute_sdpa_utilization(seqlen, head_dim, num_heads, duration_ns, core_count):
-    """
-    Compute math utilization for SDPA.
-
-    Returns:
-        Utilization as a percentage (0-100)
-    """
-    mm_flops = 4 * seqlen * seqlen * head_dim * num_heads
-    cycles = duration_ns * 1.35
-    theoretical_flops = core_count * cycles * 2048
-    utilization = (mm_flops / theoretical_flops) * 100
-    return utilization
+    """Single-chip SDPA utilization (local_seq == total_seq, arch=blackhole)."""
+    return compute_math_utilization(seqlen, seqlen, head_dim, num_heads, duration_ns, core_count)
 
 
 # === TEST 4: PERFORMANCE TABLE (skipped on CI) ===

--- a/tests/nightly/sdpa_perf_utils.py
+++ b/tests/nightly/sdpa_perf_utils.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared utilities for SDPA performance testing across architectures.
+
+Used by:
+- tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+- tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+- tests/nightly/t3000/ccl/test_ring_joint_attention.py
+"""
+
+import math
+
+
+# ============================================================================
+# Architecture constants
+# ============================================================================
+
+ARCH_CONSTANTS = {
+    "blackhole": {
+        "clock_ghz": 1.35,
+        "mm_flops_per_cycle_per_core": 2048,  # HiFi2: 4096 base / 2
+    },
+    "wormhole_b0": {
+        "clock_ghz": 1.0,
+        "mm_flops_per_cycle_per_core": 2048,  # HiFi2: 4096 base / 2
+    },
+}
+
+
+# ============================================================================
+# Tracy ops log processing
+# ============================================================================
+
+
+def post_process_ops_log(
+    output_logs_subdir, float_columns=None, columns=None, sum_vals=True, op_name="", has_signposts=False
+):
+    """Process the ops log CSV and extract performance data."""
+    from tracy.process_model_log import get_latest_ops_log_filename
+    import pandas as pd
+
+    filename = get_latest_ops_log_filename(output_logs_subdir)
+    df = pd.read_csv(filename)
+
+    if has_signposts:
+        markers = df[df["OP TYPE"] == "signpost"]["OP CODE"]
+        start = markers[markers == "start"].index[0]
+        stop = markers[markers == "stop"].index[0]
+        df = df.iloc[start + 1 : stop]
+    if op_name != "":
+        df = df[df["OP CODE"] == op_name]
+
+    results = {}
+    if float_columns:
+        for col in float_columns:
+            df_filtered = df[df[col] != "-"]
+            if sum_vals:
+                results[col] = df_filtered[col].astype(float).sum()
+            else:
+                results[col] = df_filtered[col].astype(float).to_numpy()
+    if columns:
+        for col in columns:
+            df_filtered = df[df[col] != "-"]
+            results[col] = df_filtered[col]
+    else:
+        results = df
+    return results
+
+
+# ============================================================================
+# Core utilization
+# ============================================================================
+
+
+def compute_cores_used(seqlen, q_chunk_size, num_cores, num_heads, ring_size=1):
+    """
+    Compute number of cores actually used based on parallelization scheme.
+
+    Parallelization hierarchy (from sdpa_program_factory.cpp):
+    1. batch_parallel_factor = min(B, num_cores)       — always 1 for B=1
+    2. nh_parallel_factor = min(num_cores, num_heads)
+    3. q_parallel_factor = min(num_cores / nh, q_num_chunks)
+
+    Args:
+        seqlen: Total (global) sequence length.
+        q_chunk_size: Q chunk size.
+        num_cores: Available compute cores.
+        num_heads: Attention heads on this device.
+        ring_size: Sequence-parallel ring size (1 for single-chip).
+    """
+    local_seq_len = seqlen // ring_size
+    q_num_chunks = math.ceil(local_seq_len / q_chunk_size)
+
+    nh_parallel = min(num_cores, num_heads)
+    q_parallel = min(num_cores // nh_parallel, q_num_chunks)
+
+    return nh_parallel * q_parallel
+
+
+# ============================================================================
+# Math utilization
+# ============================================================================
+
+
+def compute_math_utilization(
+    local_seqlen, total_seqlen, head_dim, num_heads, duration_ns, core_count, arch="blackhole"
+):
+    """
+    Compute math utilization as a percentage (0-100).
+
+    FLOPs model: 4 * local_seq * total_seq * head_dim * num_heads
+      (Q@K^T forward + backward = 2 * local * total * d * nh,
+       P@V  forward + backward = 2 * local * total * d * nh)
+
+    For single-chip, local_seqlen == total_seqlen.
+
+    Args:
+        local_seqlen: Per-device sequence length (= total_seqlen / ring_size).
+        total_seqlen: Global sequence length across all ring devices.
+        head_dim: Head dimension (d).
+        num_heads: Attention heads on this device.
+        duration_ns: Measured device kernel duration in nanoseconds.
+        core_count: Number of compute cores used.
+        arch: Architecture name ("blackhole" or "wormhole_b0").
+    """
+    constants = ARCH_CONSTANTS[arch]
+    mm_flops = 4 * local_seqlen * total_seqlen * head_dim * num_heads
+    cycles = duration_ns * constants["clock_ghz"]
+    theoretical_flops = core_count * cycles * constants["mm_flops_per_cycle_per_core"]
+    return (mm_flops / theoretical_flops) * 100 if theoretical_flops > 0 else 0

--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -2,6 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import math
+from itertools import product
+
 import torch
 
 import ttnn
@@ -14,6 +18,8 @@ from models.tt_dit.tests.unit.test_ring_joint_attention import (
     create_ring_joint_sdpa_submesh,
     wh_t3k_unit_test_params,
     mesh_device_map,
+    benchmark_model_input_shapes,
+    parallel_config_map,
 )
 
 
@@ -380,3 +386,194 @@ def test_ring_joint_sdpa_mochi_model_config(mesh_device, reset_seeds):
         use_column_major_ccl=False,
         use_wormhole_compute_kernel_config=False,
     )
+
+
+# ============================================================================
+# PERFORMANCE TABLE TEST — Math Utilization for WH T3K
+# ============================================================================
+
+# WH T3K grid constants (logical, before harvesting)
+WH_T3K_GRID_COLS = 8
+WH_T3K_GRID_ROWS = 8
+WH_T3K_CCL_COLUMN = 1  # Last column reserved for CCL
+
+PERF_Q_CHUNK_SIZES = [128, 256]
+PERF_K_CHUNK_SIZES = [256, 512]
+
+
+from tests.nightly.sdpa_perf_utils import post_process_ops_log, compute_cores_used, compute_math_utilization
+
+
+# --- Sweep perf impl: runs one config with skip_check for profiling ---
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
+@pytest.mark.parametrize("q_chunk_size", PERF_Q_CHUNK_SIZES, ids=[f"q{s}" for s in PERF_Q_CHUNK_SIZES])
+@pytest.mark.parametrize("k_chunk_size", PERF_K_CHUNK_SIZES, ids=[f"k{s}" for s in PERF_K_CHUNK_SIZES])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {"worker_l1_size": 1344544, "trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            ttnn.Topology.Linear,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["line"],
+)
+@pytest.mark.parametrize("mesh_device, num_links", [mesh_device_map["wh_t3k"]], ids=["2x4"], indirect=["mesh_device"])
+@pytest.mark.parametrize(
+    "input_shape, parallel_config",
+    [(benchmark_model_input_shapes[k], parallel_config_map["wh_t3k"][k]) for k in benchmark_model_input_shapes],
+    ids=list(benchmark_model_input_shapes.keys()),
+)
+def test_ring_joint_sdpa_sweep_perf(
+    mesh_device,
+    input_shape,
+    parallel_config,
+    q_chunk_size,
+    k_chunk_size,
+    num_links,
+    all_gather_topology,
+    reset_seeds,
+):
+    """Run ring joint SDPA with skip_check for performance profiling."""
+    run_test_ring_joint_sdpa(
+        mesh_device,
+        input_shape,
+        parallel_config,
+        q_chunk_size,
+        k_chunk_size,
+        n_iters=1,
+        trace_enabled=False,
+        num_links=num_links,
+        all_gather_topology=all_gather_topology,
+        skip_check=True,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# --- Perf table: spawns profiled subprocesses and computes math utilization ---
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
+@pytest.mark.timeout(1000)
+@pytest.mark.parametrize(
+    "model_id",
+    list(benchmark_model_input_shapes.keys()),
+)
+def test_ring_joint_sdpa_create_perf_table(model_id):
+    """
+    Sweep chunk sizes for ring joint attention on WH T3K and print a performance table
+    with math utilization. Requires TT_METAL_DEVICE_PROFILER=1.
+    """
+    from tracy.process_model_log import run_device_profiler
+
+    shape = benchmark_model_input_shapes[model_id]
+    parallel = parallel_config_map["wh_t3k"][model_id]
+    b, nh, base_seq_len, joint_seq_len, d = shape
+    rp_axis, rp_factor, up_axis, up_factor = parallel
+    ring_size = rp_factor
+    heads_per_device = nh / up_factor
+    local_seq_len = base_seq_len // ring_size
+
+    subdir = "t3k_ring_joint_sdpa_perf"
+    perf_results = []
+
+    for q_chunk_size, k_chunk_size in product(PERF_Q_CHUNK_SIZES, PERF_K_CHUNK_SIZES):
+        # Parametrize ID: input_shape-mesh_device-device_params-k_chunk-q_chunk
+        test_id = f"wormhole_b0-{model_id}-2x4-line-k{k_chunk_size}-q{q_chunk_size}"
+        command = (
+            f"pytest tests/nightly/t3000/ccl/"
+            f"test_ring_joint_attention.py::"
+            f"test_ring_joint_sdpa_sweep_perf"
+            f"[{test_id}]"
+        )
+
+        try:
+            run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+
+            float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+            r = post_process_ops_log(subdir, float_columns=float_cols, sum_vals=False)
+
+            measured_core_count = int(r["CORE COUNT"][0]) if len(r["CORE COUNT"]) > 0 else 0
+            duration_ns = (
+                int(r["DEVICE KERNEL DURATION [ns]"].max()) if len(r["DEVICE KERNEL DURATION [ns]"]) > 0 else 0
+            )
+
+            # Use measured core count from Tracy (accounts for harvesting).
+            # Subtract CCL column cores to get SDPA-only count.
+            effective_cores = measured_core_count - measured_core_count % WH_T3K_GRID_COLS
+            sdpa_cores = effective_cores - WH_T3K_CCL_COLUMN * (effective_cores // WH_T3K_GRID_COLS)
+            cores_used = compute_cores_used(base_seq_len, q_chunk_size, sdpa_cores, heads_per_device, ring_size)
+            cores_idle = sdpa_cores - cores_used
+            utilization = compute_math_utilization(
+                local_seq_len,
+                base_seq_len,
+                d,
+                heads_per_device,
+                duration_ns,
+                effective_cores,
+                arch="wormhole_b0",
+            )
+
+            q_num_chunks = math.ceil(local_seq_len / q_chunk_size)
+            max_q_parallel = sdpa_cores // int(heads_per_device) if heads_per_device > 0 else 1
+            q_per_core = math.ceil(q_num_chunks / max_q_parallel) if max_q_parallel > 0 else q_num_chunks
+            k_num_chunks = math.ceil(base_seq_len / k_chunk_size)
+            iters_per_core = q_per_core * k_num_chunks
+
+            perf_results.append(
+                {
+                    "q_chunk_size": q_chunk_size,
+                    "k_chunk_size": k_chunk_size,
+                    "measured_core_count": measured_core_count,
+                    "cores_used": cores_used,
+                    "cores_idle": cores_idle,
+                    "iters_per_core": iters_per_core,
+                    "duration_ns": duration_ns,
+                    "duration_ms": duration_ns / 1e6,
+                    "utilization": utilization,
+                }
+            )
+            logger.info(
+                f"q={q_chunk_size}, k={k_chunk_size}: {duration_ns/1e6:.3f} ms, "
+                f"util={utilization:.1f}%, cores={cores_used}/{sdpa_cores}"
+            )
+
+        except Exception as e:
+            if isinstance(e, KeyboardInterrupt):
+                raise
+            logger.error(f"Error with q={q_chunk_size}, k={k_chunk_size}: {e}")
+            perf_results.append({"q_chunk_size": q_chunk_size, "k_chunk_size": k_chunk_size, "duration_ns": None})
+
+    # Sort by duration (best first)
+    valid_results = [r for r in perf_results if r["duration_ns"] is not None]
+    valid_results.sort(key=lambda x: x["duration_ns"])
+
+    mm_flops = 4 * base_seq_len * base_seq_len * d * nh
+
+    print(f"\n{'='*140}")
+    print(f"WH T3K Ring Joint Attention Perf: {model_id} — b={b}, nh={nh}, s={base_seq_len}, d={d}")
+    print(f"Ring size: {ring_size}, TP: {up_factor}, Heads/device: {heads_per_device:.0f}, Local seq: {local_seq_len}")
+    measured_sdpa = valid_results[0]["cores_used"] + valid_results[0]["cores_idle"] if valid_results else 0
+    print(
+        f"Total MM FLOPs: {mm_flops/1e9:.2f} GFLOPs, SDPA cores: {measured_sdpa} (from Tracy, accounts for harvesting)"
+    )
+    print(f"{'='*140}")
+    header = "| Rank | q_chunk | k_chunk | Duration (ms) | Cores Used | Cores Idle | Iters/Core | Math Util |"
+    sep = "|------|---------|---------|---------------|------------|------------|------------|-----------|"
+    print(header)
+    print(sep)
+
+    for rank, result in enumerate(valid_results, 1):
+        print(
+            f"| {rank:4d} | {int(result['q_chunk_size']):7d} | {int(result['k_chunk_size']):7d} | "
+            f"{result['duration_ms']:13.3f} | {int(result['cores_used']):10d} | {int(result['cores_idle']):10d} | "
+            f"{int(result['iters_per_core']):10d} | {result['utilization']:8.1f}% |"
+        )
+
+    if valid_results:
+        best = valid_results[0]
+        print(
+            f"\nBest: q={best['q_chunk_size']}, k={best['k_chunk_size']} — "
+            f"{best['duration_ms']:.3f} ms, {best['utilization']:.1f}% math util, "
+            f"{best['cores_used']} cores, {best['iters_per_core']} iters/core"
+        )
+    print(f"{'='*140}\n")

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -70,6 +70,9 @@ struct RingAccumulatorState {
     AccumulatorHalf prev, cur;
 };
 
+// Sentinel for "no CB" — beyond the valid 0-31 range.
+constexpr uint32_t INVALID_CB = 32;
+
 /**
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
@@ -142,7 +145,8 @@ void reduce_c_row_group(
     bool do_eltwise_max,
     uint32_t sbh,
     uint32_t reduce_cols,
-    bool respect_trigger = false) {
+    bool respect_trigger = false,
+    uint32_t mirror_cb = INVALID_CB) {
     const uint32_t group_size = sbh;
     const uint32_t row_start = row_group_index * group_size;
 
@@ -184,6 +188,14 @@ void reduce_c_row_group(
 
     for (uint32_t i = 0; i < group_size; i++) {
         pack_tile<false>(i, out_cb);
+    }
+
+    // Dual-write: same DST data to writer's staging CB (e.g. cb_max_out).
+    // DST is read non-destructively by pack, so this is safe before tile_regs_release().
+    if (mirror_cb != INVALID_CB) {
+        for (uint32_t i = 0; i < group_size; i++) {
+            pack_tile<false>(i, mirror_cb);
+        }
     }
 
     tile_regs_release();
@@ -361,6 +373,9 @@ SDPA_NOINLINE void sub_exp_first_col_blocks(
  * Folds the sum correction tile(s) into the output correction's last DEST batch
  * when there's room, or appends a minimal extra batch otherwise.
  * Eliminates the separate init + acquire/release overhead for sum correction.
+ *
+ * ob_q_subblock controls read offset for out_in_cb and bcast_cb (0 when popped row-by-row).
+ * sum_q_subblock controls read offset for sum_in_cb (cumulative when not popped per-row).
  */
 template <uint32_t sbh_t, uint32_t sbw_t, uint32_t dst_size>
 void salad_correct_fused(
@@ -369,7 +384,8 @@ void salad_correct_fused(
     uint32_t bcast_cb,
     uint32_t out_out_cb,
     uint32_t sum_out_cb,
-    uint32_t q_subblock,
+    uint32_t ob_q_subblock,
+    uint32_t sum_q_subblock,
     uint32_t write_q_subblock) {
     constexpr uint32_t tiles_per_row = sbh_t;
     constexpr uint32_t tiles_per_column = sbw_t;
@@ -377,14 +393,17 @@ void salad_correct_fused(
     constexpr uint32_t last_out_cols = (sbw_t % col_batch == 0) ? col_batch : (sbw_t % col_batch);
     constexpr bool can_fuse_last = (last_out_cols * sbh_t + sbh_t <= dst_size);
 
-    const uint32_t read_row_base = q_subblock * tiles_per_row;
+    // out_in_cb and bcast_cb may be popped row-by-row (ob_q_subblock=0) while
+    // sum_in_cb retains cumulative indexing (sum_q_subblock=salad_row).
+    const uint32_t ob_row_base = ob_q_subblock * tiles_per_row;
+    const uint32_t sum_row_base = sum_q_subblock * tiles_per_row;
     const uint32_t write_row_base = write_q_subblock * tiles_per_row;
 
     mul_bcast_cols_init_short(out_in_cb, bcast_cb);
 
-    cb_wait_front(out_in_cb, (q_subblock + 1) * tiles_per_row * tiles_per_column);
-    cb_wait_front(sum_in_cb, (q_subblock + 1) * tiles_per_row);
-    cb_wait_front(bcast_cb, (q_subblock + 1) * tiles_per_row);
+    cb_wait_front(out_in_cb, (ob_q_subblock + 1) * tiles_per_row * tiles_per_column);
+    cb_wait_front(sum_in_cb, (sum_q_subblock + 1) * tiles_per_row);
+    cb_wait_front(bcast_cb, (ob_q_subblock + 1) * tiles_per_row);
 
     constexpr uint32_t last_batch_rem = tiles_per_column % col_batch;
     for (uint32_t col_base = 0; col_base < tiles_per_column; col_base += col_batch) {
@@ -397,13 +416,13 @@ void salad_correct_fused(
         uint32_t dst_index = 0;
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < cur_cols; j++) {
-                uint32_t in0_tile_index = (read_row_base + i) * tiles_per_column + col_base + j;
-                mul_tiles_bcast_cols(out_in_cb, bcast_cb, in0_tile_index, read_row_base + i, dst_index++);
+                uint32_t in0_tile_index = (ob_row_base + i) * tiles_per_column + col_base + j;
+                mul_tiles_bcast_cols(out_in_cb, bcast_cb, in0_tile_index, ob_row_base + i, dst_index++);
             }
         }
         if (fuse_sum_here) {
             for (uint32_t i = 0; i < tiles_per_row; i++) {
-                mul_tiles_bcast_cols(sum_in_cb, bcast_cb, read_row_base + i, read_row_base + i, dst_index++);
+                mul_tiles_bcast_cols(sum_in_cb, bcast_cb, sum_row_base + i, ob_row_base + i, dst_index++);
             }
         }
         tile_regs_commit();
@@ -441,7 +460,7 @@ void salad_correct_fused(
     if constexpr (!can_fuse_last) {
         tile_regs_acquire();
         for (uint32_t i = 0; i < tiles_per_row; i++) {
-            mul_tiles_bcast_cols(sum_in_cb, bcast_cb, read_row_base + i, read_row_base + i, i);
+            mul_tiles_bcast_cols(sum_in_cb, bcast_cb, sum_row_base + i, ob_row_base + i, i);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -659,7 +678,9 @@ static void sdpa_inner_loop_step(
     const uint32_t lw_partial_tile_idx = 0,
     const uint32_t active_Sk = Sk_chunk_t,
     const bool reduce_trigger = false,
-    const uint32_t actual_sbw = qkt_subblock_w) {
+    const uint32_t actual_sbw = qkt_subblock_w,
+    const uint32_t save_out_cb = INVALID_CB,
+    const uint32_t save_max_cb = INVALID_CB) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
     // TODO: pick up the size of dest from dest_helper once it is merged to main.
@@ -688,6 +709,9 @@ static void sdpa_inner_loop_step(
     cb_reserve_back(cb_qkt_im, Sq_chunk_t * KT_stride);
 
     cb_reserve_back(cur.sum, Sq_chunk_t);
+    if (save_max_cb != INVALID_CB) {
+        cb_reserve_back(save_max_cb, Sq_chunk_t);
+    }
 
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
@@ -808,8 +832,12 @@ static void sdpa_inner_loop_step(
                 !is_first_iter /*do_eltwise_max*/,
                 qkt_subblock_h,
                 active_Sk,
-                reduce_trigger);
+                reduce_trigger,
+                save_max_cb);
             cb_push_back(cur.max, qkt_subblock_h);
+            if (save_max_cb != INVALID_CB) {
+                cb_push_back(save_max_cb, qkt_subblock_h);
+            }
 #ifdef ARCH_BLACKHOLE
             PACK((llk_pack_mop_config<false, false, false>(cur.max, actual_sbw)));
 #endif
@@ -856,9 +884,13 @@ static void sdpa_inner_loop_step(
         uint32_t qktv_in0_index_offset = 0;
         uint32_t qktv_in0_wait_tiles = qktv_in0_row_tiles;
 
+        // When save_out_cb is set, V matmul + SALAD write to save_out_cb (cb_out) instead of cur.out.
+        // Writer drains save_out_cb row-by-row to DRAM during SALAD. cur.out stays empty.
+        const uint32_t out_cb = (save_out_cb != INVALID_CB) ? save_out_cb : cur.out;
+
         // V wait deferred: don't block here. The sub_exp drain loop below
         // doesn't touch V, so the reader's V DMA can overlap with the drain.
-        cb_reserve_back(cur.out, qktv_output_num_tiles);
+        cb_reserve_back(out_cb, qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
 #ifdef ARCH_BLACKHOLE
@@ -893,7 +925,7 @@ static void sdpa_inner_loop_step(
                     MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
                     uint32_t v_index_offset = 0;
                     if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(cur.out, cb_v_in, cur.out, cb_qkt_im);
+                        reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                     }
 #ifdef ARCH_BLACKHOLE
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, matmul_inner);
@@ -904,7 +936,7 @@ static void sdpa_inner_loop_step(
                         blocked_matmul_and_pack<false, vDHt, vDHt>(
                             cb_qkt_im,
                             cb_v_in,
-                            cur.out,
+                            out_cb,
                             qktv_in0_index_offset + kt_sub * matmul_inner,
                             kt_sub * matmul_inner * vDHt + v_index_offset,
                             0,
@@ -916,7 +948,7 @@ static void sdpa_inner_loop_step(
                         v_index_offset += qktv_subblock_w;
                     }
                     if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(cb_v_in, cur.out, cb_qkt_im, cur.out);
+                        reconfig_data_format(cb_v_in, out_cb, cb_qkt_im, out_cb);
                     }
                 }
 
@@ -933,31 +965,36 @@ static void sdpa_inner_loop_step(
         [[maybe_unused]] auto normalize_row = [&](uint32_t& pushed, uint32_t sbh) {
             MaybeDeviceZoneScopedN(profiling_enabled, "ROW_NORM");
             cb_push_back(cur.sum, sbh);
-            cb_push_back(cur.out, sbh * vDHt);
+            cb_push_back(out_cb, sbh * vDHt);
             normalize_row_streaming<profiling_enabled, vDHt, dst_size>(
-                cur.sum, cur.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
+                cur.sum, out_cb, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
             pushed++;
         };
 
         // SALAD correction lambda — works for both full subblocks (sbh=qktv_h) and
         // remainder (sbh=qktv_remainder_h). Normalization is independently guarded at call sites.
+        // prev.out is consumed row-by-row: always read from CB front, then pop after use.
         auto salad_correct_row = [&](uint32_t salad_row, uint32_t w_salad, uint32_t sbh) {
             PACK((llk_pack_reconfig_l1_acc(1)));
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "S_CORR_FUSED");
+                // ob_q_subblock=0: prev.out and cb_exp_max_diff are popped row-by-row (read from front).
+                // sum_q_subblock=salad_row: prev.sum uses cumulative indexing (not popped per-row).
                 if constexpr (has_qktv_remainder) {
                     if (sbh == qktv_remainder_h) {
                         salad_correct_fused<qktv_remainder_h, vDHt, dst_size>(
-                            prev.out, prev.sum, cb_exp_max_diff, cur.out, cur.sum, salad_row, w_salad);
+                            prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                     } else {
                         salad_correct_fused<qktv_h, vDHt, dst_size>(
-                            prev.out, prev.sum, cb_exp_max_diff, cur.out, cur.sum, salad_row, w_salad);
+                            prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                     }
                 } else {
                     salad_correct_fused<qktv_h, vDHt, dst_size>(
-                        prev.out, prev.sum, cb_exp_max_diff, cur.out, cur.sum, salad_row, w_salad);
+                        prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                 }
             }
+            cb_pop_front(cb_exp_max_diff, sbh);
+            cb_pop_front(prev.out, sbh * vDHt);
             PACK((llk_pack_reconfig_l1_acc(0)));
         };
 
@@ -996,7 +1033,7 @@ static void sdpa_inner_loop_step(
                 MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
                 uint32_t v_index_offset = 0;
                 if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cur.out, cb_v_in, cur.out, cb_qkt_im);
+                    reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
                 }
 #ifdef ARCH_BLACKHOLE
                 mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, active_Sk);
@@ -1007,7 +1044,7 @@ static void sdpa_inner_loop_step(
                     blocked_matmul_and_pack<false, vDHt, vDHt>(
                         cb_qkt_im,
                         cb_v_in,
-                        cur.out,
+                        out_cb,
                         qktv_in0_index_offset,
                         v_index_offset,
                         w_q,
@@ -1019,11 +1056,11 @@ static void sdpa_inner_loop_step(
                     v_index_offset += qktv_subblock_w;
                 }
                 if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_v_in, cur.out, cb_qkt_im, cur.out);
+                    reconfig_data_format(cb_v_in, out_cb, cb_qkt_im, out_cb);
                 }
             }
 
-            // SALAD corrections for previous group (always full, h=qktv_h)
+            // SALAD corrections for previous group (always full, h=qktv_h) + row-by-row push
             if (!is_first_iter) {
                 // Last main-loop iteration: hoist drain's sub_exp so both salads
                 // (current row and drain row) chain back-to-back with one FPU init.
@@ -1047,15 +1084,27 @@ static void sdpa_inner_loop_step(
                     salad_correct_row(drain_salad_row, drain_w, drain_h);
                     if (is_last_iter) {
                         normalize_row(pushed_rows, drain_h);
+                    } else {
+                        cb_push_back(cur.sum, drain_h);
+                        cb_push_back(out_cb, drain_h * vDHt);
+                        pushed_rows++;
                     }
                 } else {
                     salad_correct_row(salad_row, w_salad, qktv_h);
                     if (is_last_iter) {
                         normalize_row(pushed_rows, qktv_h);
+                    } else {
+                        cb_push_back(cur.sum, qktv_h);
+                        cb_push_back(out_cb, qktv_h * vDHt);
+                        pushed_rows++;
                     }
                 }
             } else if (is_last_iter) {
                 normalize_row(pushed_rows, qktv_h);
+            } else {
+                cb_push_back(cur.sum, qktv_h);
+                cb_push_back(out_cb, qktv_h * vDHt);
+                pushed_rows++;
             }
 
             qktv_in0_index_offset += cur_h * KT_stride;
@@ -1078,21 +1127,27 @@ static void sdpa_inner_loop_step(
                 }
                 if (is_last_iter) {
                     normalize_row(pushed_rows, drain_h);
+                } else {
+                    cb_push_back(cur.sum, drain_h);
+                    cb_push_back(out_cb, drain_h * vDHt);
+                    pushed_rows++;
                 }
             } else {
                 // Drain was hoisted into the last main-loop iteration above.
-                // Only first-K-chunk normalize remains.
-                if (is_first_iter && is_last_iter) {
-                    normalize_row(pushed_rows, drain_h);
+                // For is_first_iter (no SALAD), the drain row still needs push/normalize.
+                if (is_first_iter) {
+                    if (is_last_iter) {
+                        normalize_row(pushed_rows, drain_h);
+                    } else {
+                        cb_push_back(cur.sum, drain_h);
+                        cb_push_back(out_cb, drain_h * vDHt);
+                        pushed_rows++;
+                    }
                 }
             }
         }
 
-        // Bulk push — skip on last iteration when rows are consumed by normalization.
-        if (!is_last_iter) {
-            cb_push_back(cur.sum, Sq_chunk_t);
-            cb_push_back(cur.out, qktv_output_num_tiles);
-        }
+        // All rows pushed individually — no bulk push needed.
 
         cb_pop_front(cb_v_in, KT_stride * vDHt);
         cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
@@ -1239,11 +1294,10 @@ void sdpa_standard_v2(
                 is_padded ? padded_sbw : full_sbw);
 
             // Post-iteration cleanup
+            // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
             if (!is_first) {
-                cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
                 cb_pop_front(prev.max, Sq_chunk_t);
                 cb_pop_front(prev.sum, Sq_chunk_t);
-                cb_pop_front(prev.out, Sq_chunk_t * vDHt);
             }
 
             if (is_last) {
@@ -1379,11 +1433,13 @@ void sdpa_ring_v2(
         // First ring iteration starts fresh; subsequent ones have prior accumulated state.
         const bool is_first_kv_for_this_q = (ring_iter == 0);
 
-        // Multi Q-chunk: restore accumulators from DRAM on non-first ring iterations.
-        if (q_per_core > 1 && ring_iter > 0) {
-            copy_block(cb_prev_out, q_prev.out, out_chunk_tiles);
-            copy_block(cb_max_in, q_prev.max, Sq_chunk_t);
-            copy_block(cb_sum_in, q_prev.sum, Sq_chunk_t);
+        // Multi Q-chunk restore: K0 reads prev accumulators directly from staging buffers
+        // (cb_prev_out, cb_max_in, cb_sum_in) — no copy_block needed.
+        // After K0's swap, reset q_cur to original accumulator CBs for normal ping-pong.
+        const AccumulatorHalf original_prev = q_prev;
+        const bool restore_from_staging = (q_per_core > 1 && ring_iter > 0);
+        if (restore_from_staging) {
+            q_prev = {cb_sum_in, cb_max_in, cb_prev_out};
         }
 
         uint32_t KV_chunks_processed = 0;
@@ -1400,9 +1456,17 @@ void sdpa_ring_v2(
             KV_chunks_processed_in_iter++;
 
             const bool is_first = is_first_kv_for_this_q && (KV_chunks_processed == 1);
+            const bool is_last_k = (KV_chunks_processed == total_valid_kv);
 
             // Last K chunk of last ring_iter triggers per-row normalization
-            const bool is_last = is_last_ring_iter && (KV_chunks_processed == total_valid_kv);
+            const bool is_last_k_of_last_ring_iter = is_last_ring_iter && is_last_k;
+
+            // Signal writer that last K-chunk is starting (for row-by-row DMA save/restore).
+            constexpr uint32_t cb_signal = tt::CBIndex::c_12;
+            if (is_last_k && q_per_core > 1) {
+                cb_reserve_back(cb_signal, 1);
+                cb_push_back(cb_signal, 1);
+            }
 
             // Determine if this K chunk needs masking (partial tile within a tile boundary)
             const bool is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
@@ -1438,6 +1502,16 @@ void sdpa_ring_v2(
                 chunk_sbw = joint_n_sbw;
             }
 
+            // On last K-chunk of non-last ring iters (multi-Q), redirect output, sum, and max
+            // to writer-staging CBs, eliminating post-loop copy_block calls.
+            // Writer drains cb_out row-by-row during SALAD; cb_sum_out and cb_max_out bulk after.
+            const bool save_to_staging = is_last_k && !is_last_ring_iter && q_per_core > 1;
+            const uint32_t step_save_out_cb = save_to_staging ? cb_out : INVALID_CB;
+            const uint32_t step_save_max_cb = save_to_staging ? cb_max_out : INVALID_CB;
+            if (save_to_staging) {
+                q_cur.sum = cb_sum_out;
+            }
+
             sdpa_inner_loop_step<
                 false,  // profiling_enabled
                 Sq_chunk_t,
@@ -1467,27 +1541,32 @@ void sdpa_ring_v2(
                 cb_mask_in>(
                 q_prev,
                 q_cur,
-                is_last,
+                is_last_k_of_last_ring_iter,
                 is_first,
                 apply_mask,
                 lw_partial_tile_idx,
                 active_Sk_param,
                 can_reduce_trigger && (active_Sk_param == Sk_chunk_t),
-                chunk_sbw);
+                chunk_sbw,
+                step_save_out_cb,
+                step_save_max_cb);
 
             // Post-iteration cleanup: pop previous values and swap aliases
+            // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
             if (!is_first) {
-                cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
                 cb_pop_front(q_prev.max, Sq_chunk_t);
                 cb_pop_front(q_prev.sum, Sq_chunk_t);
-                cb_pop_front(q_prev.out, Sq_chunk_t * vDHt);
             }
 
-            if (is_last) {
+            if (is_last_k_of_last_ring_iter) {
                 // Normalization consumed cur.sum and cur.out; pop cur.max.
                 cb_pop_front(q_cur.max, Sq_chunk_t);
             } else {
                 std::swap(q_prev, q_cur);
+                // After K0's swap, q_cur holds staging buffers. Reset to original accumulator CBs.
+                if (restore_from_staging && KV_chunks_processed == 1) {
+                    q_cur = {original_prev.sum, original_prev.max, original_prev.out};
+                }
             }
         }
 
@@ -1505,13 +1584,13 @@ void sdpa_ring_v2(
             acc_state.cur = q_cur;
         } else if (!is_last_ring_iter) {
             // Multi Q-chunk: save raw accumulators to DRAM via writer CBs.
-            // q_prev holds final accumulators after the last swap.
-            if constexpr (!uniform_format) {
-                pack_reconfig_data_format(cb_out);
-            }
-            copy_block(q_prev.out, cb_out, out_chunk_tiles);
-            copy_block(q_prev.max, cb_max_out, Sq_chunk_t);
-            copy_block(q_prev.sum, cb_sum_out, Sq_chunk_t);
+            // Out tiles already saved row-by-row via cb_out during last K-chunk SALAD.
+            // Sum already in cb_sum_out (redirected via q_cur.sum on last K-chunk).
+            // Max already in cb_max_out (dual-write from DST during reduce on last K-chunk).
+            // Pop the accumulator CB for max — dual-write doesn't replace the alias,
+            // so the accumulator CB still has tiles from the last K-chunk's reduce.
+            // (Sum doesn't need this because planting replaced the alias entirely.)
+            cb_pop_front(q_prev.max, Sq_chunk_t);
         }
         // On last ring_iter: normalized output already in cb_out from normalize_row_streaming
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1077,6 +1077,10 @@ static void sdpa_inner_loop_step(
                     salad_correct_row(salad_row, w_salad, qktv_h);
                     if (is_last_iter) {
                         normalize_row(pushed_rows, qktv_h);
+                    } else {
+                        cb_push_back(cur.sum, qktv_h);
+                        cb_push_back(out_cb, qktv_h * vDHt);
+                        pushed_rows++;
                     }
 
                     const uint32_t drain_w = has_qktv_remainder ? ((qktv_q_num_subblocks - pushed_rows) * qktv_h)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -278,29 +278,15 @@ void write_output_and_lse(
 struct QChunkInfo {
     bool is_joint_q;
     Slice out_slice;
-    uint32_t end_seq_tile;
     uint32_t stats_seq_start_tile;
     uint32_t stats_seq_end_tile;
 };
 
-// Compute output slice and stats tile range for one Q chunk.
-// is_joint_q distinguishes local-sequence Q chunks from joint-context Q chunks,
-// which write to different output tensors and have different causal extents.
-//
-// @param q_chunk             Q chunk index within [0, num_q_chunks) (local then joint)
-// @param nb                  Batch index
-// @param nq                  Head index
-// @param ring_id             Device ID that owns the current ring iteration's KV shard
-// @param num_local_q_chunks  Number of Q chunks from the local sequence (joint starts after)
-// @param Sq_chunk_t          Q chunk size in tiles
-// @param DHt                 Head dimension in tiles
-// @param Lt                  Joint (cross-attention context) sequence length in tiles
-// @param local_padded_Nt     Per-device padded local sequence length in tiles
+// Compute DRAM address info (output slice + stats range) for one Q chunk.
 inline QChunkInfo get_q_chunk_info(
     const uint32_t q_chunk,
     const uint32_t nb,
     const uint32_t nq,
-    const uint32_t ring_id,
     const uint32_t num_local_q_chunks,
     const uint32_t Sq_chunk_t,
     const uint32_t DHt,
@@ -311,7 +297,6 @@ inline QChunkInfo get_q_chunk_info(
     if (info.is_joint_q) {
         const uint32_t joint_out_row_start_tile = (q_chunk - num_local_q_chunks) * Sq_chunk_t;
         info.out_slice = Slice(nb, nq, joint_out_row_start_tile, joint_out_row_start_tile + Sq_chunk_t, 0, DHt);
-        info.end_seq_tile = Lt;
         info.stats_seq_start_tile = local_padded_Nt + (q_chunk - num_local_q_chunks) * Sq_chunk_t;
         info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
         info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt + Lt);
@@ -319,13 +304,17 @@ inline QChunkInfo get_q_chunk_info(
     } else {
         const uint32_t out_row_start_tile = q_chunk * Sq_chunk_t;
         info.out_slice = Slice(nb, nq, out_row_start_tile, out_row_start_tile + Sq_chunk_t, 0, DHt);
-        info.end_seq_tile = local_padded_Nt * (ring_id + 1);
         info.stats_seq_start_tile = q_chunk * Sq_chunk_t;
         info.stats_seq_end_tile = info.stats_seq_start_tile + Sq_chunk_t;
         info.stats_seq_start_tile = std::min(info.stats_seq_start_tile, local_padded_Nt);
         info.stats_seq_end_tile = std::min(info.stats_seq_end_tile, local_padded_Nt);
     }
     return info;
+}
+
+// Padding boundary for write paths — needs ring_id to know how far the valid sequence extends.
+inline uint32_t get_end_seq_tile(const QChunkInfo& qi, uint32_t ring_id, uint32_t Lt, uint32_t local_padded_Nt) {
+    return qi.is_joint_q ? Lt : local_padded_Nt * (ring_id + 1);
 }
 
 void kernel_main() {
@@ -357,7 +346,7 @@ void kernel_main() {
     constexpr bool use_streaming_compute = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t is_causal = get_compile_time_arg_val(25) == 1;
     constexpr uint32_t is_balanced = get_compile_time_arg_val(26) == 1;
-    constexpr uint32_t subblock_h = get_compile_time_arg_val(27);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(27);
 
     constexpr auto out_args = TensorAccessorArgs<28>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
@@ -504,8 +493,9 @@ void kernel_main() {
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
-                const auto qi = get_q_chunk_info(
-                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const auto qi =
+                    get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
 
                 // 1. Complete restore + intra-ring prefetch (ring_iter > 0 only)
                 if (!single_q_chunk && ring_iter > 0) {
@@ -531,15 +521,7 @@ void kernel_main() {
                         const uint32_t nq_next = (next_q % (NH * num_q_chunks)) / num_q_chunks;
                         const uint32_t qc_next = next_q % num_q_chunks;
                         const auto qi_next = get_q_chunk_info(
-                            qc_next,
-                            nb_next,
-                            nq_next,
-                            ring_id,
-                            num_local_q_chunks,
-                            Sq_chunk_t,
-                            vDHt,
-                            Lt,
-                            local_padded_Nt);
+                            qc_next, nb_next, nq_next, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                         issue_restore_reads(
                             qi_next.is_joint_q ? joint_out_generator : out_generator,
                             stats_writer,
@@ -567,8 +549,8 @@ void kernel_main() {
                     const uint32_t nb0 = gq0 / (NH * num_q_chunks);
                     const uint32_t nq0 = (gq0 % (NH * num_q_chunks)) / num_q_chunks;
                     const uint32_t qc0 = gq0 % num_q_chunks;
-                    const auto qi0 = get_q_chunk_info(
-                        qc0, nb0, nq0, 0 /*unused*/, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                    const auto qi0 =
+                        get_q_chunk_info(qc0, nb0, nq0, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                     issue_restore_reads(
                         qi0.is_joint_q ? joint_out_generator : out_generator,
                         stats_writer,
@@ -600,15 +582,14 @@ void kernel_main() {
                     write_out_row_by_row(
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         qi.out_slice,
-                        qi.end_seq_tile,
+                        end_seq_tile,
                         cb_out,
                         tile_bytes,
-                        subblock_h);
+                        out_subblock_h);
                     noc_async_write_barrier();
                 } else if (!single_q_chunk) {
-                    // Accumulators are raw compute state — all tiles are valid (including padded rows).
-                    // Use 0xFFFFFFFF to bypass maybe_write_tile's padding skip, matching restore's
-                    // end_seq_tile = 0xFFFFFFFF convention.
+                    // Accumulators are raw compute state — all tiles are valid (including padded rows),
+                    // so bypass maybe_write_tile's padding skip (same convention as restore reads).
                     constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
                     save_accumulators_with_trid(
                         qi.is_joint_q ? joint_out_generator : out_generator,
@@ -627,7 +608,7 @@ void kernel_main() {
                         cb_sum_out,
                         tile_bytes,
                         stats_tile_bytes,
-                        subblock_h,
+                        out_subblock_h,
                         q_trid(q_index));
                 }
             }
@@ -640,8 +621,9 @@ void kernel_main() {
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
 
-                const auto qi = get_q_chunk_info(
-                    q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const auto qi =
+                    get_q_chunk_info(q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile(qi, ring_id, Lt, local_padded_Nt);
 
                 // Only truly causal case appear in the iteration with local KV
                 // Other iterations will just skip the computation with subsequent KV chunks
@@ -675,7 +657,7 @@ void kernel_main() {
                         nq,
                         Sq_chunk_t,
                         qi.out_slice,
-                        qi.end_seq_tile,
+                        end_seq_tile,
                         qi.stats_seq_start_tile,
                         qi.stats_seq_end_tile,
                         cb_prev_out,
@@ -692,7 +674,7 @@ void kernel_main() {
                     nq,
                     Sq_chunk_t,
                     qi.out_slice,
-                    qi.end_seq_tile,
+                    end_seq_tile,
                     qi.stats_seq_start_tile,
                     qi.stats_seq_end_tile,
                     cb_out,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -374,6 +374,7 @@ void kernel_main() {
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
     constexpr uint32_t cb_sum_out = tt::CBIndex::c_10;
     constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
+    constexpr uint32_t cb_signal = tt::CBIndex::c_12;
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
@@ -508,18 +509,18 @@ void kernel_main() {
                     //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
                     // Without this, Q[j+1]'s wB(TRID_INNER) would stall on Q[j]'s
                     // current-ring save (near-zero flight time) for q_per_core >= 5.
-                    const uint32_t next_q = global_q_chunk + 1;
-                    if (next_q < global_q_end) {
-                        const uint32_t next_q_index = next_q - global_q_start;
+                    const uint32_t next_q_index = q_index + 1;
+                    if (next_q_index < q_per_core) {
                         const uint32_t next_trid = q_trid(next_q_index);
                         // First inner Q (next_q_index==1) needs the barrier; subsequent
                         // inner Qs (next_q_index>1 && next_trid==TRID_INNER) don't.
                         if (next_trid != TRID_INNER || next_q_index == 1) {
                             noc_async_write_barrier_with_trid(next_trid);
                         }
-                        const uint32_t nb_next = next_q / (NH * num_q_chunks);
-                        const uint32_t nq_next = (next_q % (NH * num_q_chunks)) / num_q_chunks;
-                        const uint32_t qc_next = next_q % num_q_chunks;
+                        const uint32_t next_q_global = global_q_chunk + 1;
+                        const uint32_t nb_next = next_q_global / (NH * num_q_chunks);
+                        const uint32_t nq_next = (next_q_global % (NH * num_q_chunks)) / num_q_chunks;
+                        const uint32_t qc_next = next_q_global % num_q_chunks;
                         const auto qi_next = get_q_chunk_info(
                             qc_next, nb_next, nq_next, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
                         issue_restore_reads(
@@ -572,7 +573,6 @@ void kernel_main() {
                 // === Compute runs K-loop for this Q chunk ===
 
                 // Wait for compute to signal last K-chunk start (multi-Q only).
-                constexpr uint32_t cb_signal = tt::CBIndex::c_12;
                 if (!single_q_chunk) {
                     cb_wait_front(cb_signal, 1);
                     cb_pop_front(cb_signal, 1);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -56,29 +56,12 @@ void read_prev_output_and_lse(
     cb_push_back(cb_lse_in, Sq_chunk_t);
 }
 
-// Deferred-norm reader: restores raw (un-normalized) accumulators from DRAM for multi-Q-chunk.
-// Reads output, running max, and running sum — the full online-softmax state needed to continue
-// accumulation from a previous ring iteration.
-// Pushes into: cb_prev_out (c_7), cb_max_in (c_6), cb_sum_in (c_11).
-//
-// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
-// @param stats_writer        TensorAccessor for the stats DRAM tensor
-// @param stats_tile_logical  Tile shape of the stats tensor
-// @param nb                  Batch index
-// @param nq                  Head index
-// @param Sq_chunk_t          Q chunk size in tiles
-// @param out_slice           Row/col tile range in the output tensor for this Q chunk
-// @param end_seq_tile        Last valid sequence tile (for padding-aware reads)
-// @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's max/sum
-// @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
-// @param sum_offset          Row offset into stats tensor where sum tiles start (= local_padded_Nt + Lt)
-// @param cb_prev_out         CB for previous output tiles (c_7)
-// @param cb_max_in           CB for previous max tiles (c_6)
-// @param cb_sum_in           CB for previous sum tiles (c_11)
-// @param tile_bytes          Output tile size in bytes
-// @param stats_tile_bytes    Stats tile size in bytes
+// Non-blocking restore: reserves CB space and issues NOC reads for all 3 accumulators.
+// Call complete_restore() later to barrier and push.
+// Split from blocking read_prev_accumulators to enable prefetch: issue reads for Q[q+1]
+// while Q[q]'s K-loop runs, hiding DRAM read latency behind compute.
 template <typename ReaderType, typename TensorAccessorType>
-void read_prev_accumulators(
+void issue_restore_reads(
     const PaddedAddrGenerator<ReaderType>& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const TensorTileShape& stats_tile_logical,
@@ -86,7 +69,6 @@ void read_prev_accumulators(
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
     const Slice out_slice,
-    const uint32_t end_seq_tile,
     const uint32_t stats_seq_start_tile,
     const uint32_t stats_seq_end_tile,
     const uint32_t sum_offset,
@@ -95,59 +77,117 @@ void read_prev_accumulators(
     const uint32_t cb_sum_in,
     const uint32_t tile_bytes,
     const uint32_t stats_tile_bytes) {
-    // Read previous output
-    read_block(cat_out_generator, out_slice, end_seq_tile, cb_prev_out, tile_bytes, false);
+    // All accumulator tiles are valid (we wrote them), so bypass maybe_read_tile's
+    // padding logic. This decouples restore from ring_id, enabling cross-ring prefetch.
+    constexpr uint32_t end_seq_tile = 0xFFFFFFFF;
 
-    // Read max from stats DRAM (first half)
+    // Issue output reads (reserve + async reads, no barrier)
+    const uint32_t out_rows = out_slice.get_d2_size();
+    const uint32_t out_cols = out_slice.get_d3_size();
+    const uint32_t out_num_tiles = out_rows * out_cols;
+    cb_reserve_back(cb_prev_out, out_num_tiles);
+    const uint32_t out_base_ptr = get_write_ptr(cb_prev_out);
+    for (uint32_t row = 0; row < out_rows; ++row) {
+        uint32_t write_ptr = out_base_ptr + row * out_cols * tile_bytes;
+        for (uint32_t col = 0; col < out_cols; ++col) {
+            cat_out_generator.maybe_read_tile(
+                out_slice.d0,
+                out_slice.d1,
+                out_slice.d2_start + row,
+                out_slice.d3_start + col,
+                end_seq_tile,
+                write_ptr);
+            write_ptr += tile_bytes;
+        }
+    }
+
+    // Issue max reads
     cb_reserve_back(cb_max_in, Sq_chunk_t);
     uint32_t max_addr = get_write_ptr(cb_max_in);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
         noc_async_read_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_addr);
         max_addr += stats_tile_bytes;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_max_in, Sq_chunk_t);
 
-    // Read sum from stats DRAM (second half, offset by sum_offset)
+    // Issue sum reads
     cb_reserve_back(cb_sum_in, Sq_chunk_t);
     uint32_t sum_addr = get_write_ptr(cb_sum_in);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
         noc_async_read_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_addr);
         sum_addr += stats_tile_bytes;
     }
+    // NO barrier, NO push — caller must call complete_restore()
+}
+
+// Complete a previously issued restore — single barrier for all 3 CBs, then push.
+void complete_restore(
+    const uint32_t cb_prev_out,
+    const uint32_t out_num_tiles,
+    const uint32_t cb_max_in,
+    const uint32_t cb_sum_in,
+    const uint32_t Sq_chunk_t) {
     noc_async_read_barrier();
+    cb_push_back(cb_prev_out, out_num_tiles);
+    cb_push_back(cb_max_in, Sq_chunk_t);
     cb_push_back(cb_sum_in, Sq_chunk_t);
 }
 
-// Deferred-norm writer: saves raw accumulators to DRAM for multi-Q-chunk between ring iterations.
-// Drains output, running max, and running sum from compute CBs to the DRAM tensors.
-// Reads from: cb_out (c_16), cb_max_out (c_17), cb_sum_out (c_10).
-//
-// @param cat_out_generator   Address generator for the output DRAM tensor (local or joint)
-// @param stats_writer        TensorAccessor for the stats DRAM tensor
-// @param stats_tile_logical  Tile shape of the stats tensor
-// @param nb                  Batch index
-// @param nq                  Head index
-// @param Sq_chunk_t          Q chunk size in tiles
-// @param out_slice           Row/col tile range in the output tensor for this Q chunk
-// @param end_seq_tile        Last valid sequence tile
-// @param stats_seq_start_tile  First tile row in stats tensor for this Q chunk's max/sum
-// @param stats_seq_end_tile    One-past-last tile row (clamped to sequence bounds)
-// @param sum_offset          Row offset into stats tensor where sum tiles start (= local_padded_Nt + Lt)
-// @param cb_out              CB to drain output tiles from (c_16, pushed by compute)
-// @param cb_max_out          CB to drain max tiles from (c_17, pushed by compute)
-// @param cb_sum_out          CB to drain sum tiles from (c_10, pushed by compute)
-// @param tile_bytes          Output tile size in bytes
-// @param stats_tile_bytes    Stats tile size in bytes
+// Three transaction IDs for fine-grained write barrier tracking.
+// Q[0] → TRID_FIRST, Q[1..N-2] → TRID_INNER, Q[N-1] → TRID_LAST.
+// Each barrier waits for a save that completed at least one full K-loop ago.
+// Start from 1 — TRID 0 is the default for all NOC writes and must not be used
+// for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row on last
+// ring iter) would inflate the outstanding count and stall the barrier.
+constexpr uint32_t TRID_FIRST = 1;
+constexpr uint32_t TRID_INNER = 2;
+constexpr uint32_t TRID_LAST = 3;
+
+// Row-by-row drain of output tiles from cb_out to DRAM.
+// Waits for each row group (sbh tile-rows), writes to DRAM, pops.
+// Overlaps DMA with compute: writes issue as soon as each row is ready.
+template <typename ReaderType>
+void write_out_row_by_row(
+    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const Slice& out_slice,
+    const uint32_t end_seq_tile,
+    const uint32_t cb_out,
+    const uint32_t tile_bytes,
+    const uint32_t sbh) {
+    const uint32_t out_rows = out_slice.get_d2_size();
+    const uint32_t out_cols = out_slice.get_d3_size();
+    const uint32_t row_tiles = sbh * out_cols;
+    const uint32_t num_row_groups = out_rows / sbh;
+
+    for (uint32_t rg = 0; rg < num_row_groups; ++rg) {
+        cb_wait_front(cb_out, row_tiles);
+        uint32_t read_ptr = get_read_ptr(cb_out);
+        for (uint32_t r = 0; r < sbh; r++) {
+            for (uint32_t col = 0; col < out_cols; ++col) {
+                cat_out_generator.maybe_write_tile(
+                    out_slice.d0,
+                    out_slice.d1,
+                    out_slice.d2_start + rg * sbh + r,
+                    out_slice.d3_start + col,
+                    end_seq_tile,
+                    read_ptr);
+                read_ptr += tile_bytes;
+            }
+        }
+        cb_pop_front(cb_out, row_tiles);
+    }
+}
+
+// Save all 3 accumulators (out, max, sum) to DRAM, tagged with a TRID for prefetch barriers.
+// Output is drained row-by-row (overlapping with compute's SALAD pushes); max/sum are bulk-drained.
 template <typename ReaderType, typename TensorAccessorType>
-void write_accumulators(
+void save_accumulators_with_trid(
     const PaddedAddrGenerator<ReaderType>& cat_out_generator,
     const TensorAccessorType& stats_writer,
     const TensorTileShape& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
-    const Slice out_slice,
+    const Slice& out_slice,
     const uint32_t end_seq_tile,
     const uint32_t stats_seq_start_tile,
     const uint32_t stats_seq_end_tile,
@@ -156,28 +196,35 @@ void write_accumulators(
     const uint32_t cb_max_out,
     const uint32_t cb_sum_out,
     const uint32_t tile_bytes,
-    const uint32_t stats_tile_bytes) {
-    // Write output
-    write_block(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes);
+    const uint32_t stats_tile_bytes,
+    const uint32_t sbh,
+    const uint32_t save_trid) {
+    noc_async_write_set_trid(save_trid);
 
-    // Write max to stats DRAM (first half)
+    write_out_row_by_row(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh);
+
+    // Bulk drain of max/sum
     cb_wait_front(cb_max_out, Sq_chunk_t);
+    cb_wait_front(cb_sum_out, Sq_chunk_t);
+
     uint32_t max_write_addr = get_read_ptr(cb_max_out);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
         noc_async_write_tile(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
         max_write_addr += stats_tile_bytes;
     }
-    noc_async_writes_flushed();
-    cb_pop_front(cb_max_out, Sq_chunk_t);
 
-    // Write sum to stats DRAM (second half, offset by sum_offset)
-    cb_wait_front(cb_sum_out, Sq_chunk_t);
     uint32_t sum_write_addr = get_read_ptr(cb_sum_out);
     for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
         noc_async_write_tile(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
         sum_write_addr += stats_tile_bytes;
     }
-    noc_async_writes_flushed();
+
+    noc_async_write_flushed_with_trid(save_trid);
+    // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_out_row_by_row on last ring iter).
+    // Without this, subsequent noc_async_write calls would inflate save_trid's outstanding count,
+    // causing noc_async_write_barrier_with_trid(save_trid) to wait for unrelated writes.
+    noc_async_write_set_trid(0);
+    cb_pop_front(cb_max_out, Sq_chunk_t);
     cb_pop_front(cb_sum_out, Sq_chunk_t);
 }
 
@@ -309,8 +356,9 @@ void kernel_main() {
     constexpr bool use_streaming_compute = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t is_causal = get_compile_time_arg_val(25) == 1;
     constexpr uint32_t is_balanced = get_compile_time_arg_val(26) == 1;
+    constexpr uint32_t subblock_h = get_compile_time_arg_val(27);
 
-    constexpr auto out_args = TensorAccessorArgs<27>();
+    constexpr auto out_args = TensorAccessorArgs<28>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
 
@@ -433,8 +481,24 @@ void kernel_main() {
             // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
             const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
             const bool single_q_chunk = (global_q_end - global_q_start == 1);
+            constexpr uint32_t sum_offset = local_padded_Nt + Lt;
+            constexpr uint32_t out_num_tiles = Sq_chunk_t * vDHt;
+
+            const uint32_t q_per_core = global_q_end - global_q_start;
+            const uint32_t last_q_index = q_per_core - 1;
+
+            auto q_trid = [last_q_index](uint32_t q_idx) -> uint32_t {
+                if (q_idx == 0) {
+                    return TRID_FIRST;
+                }
+                if (q_idx == last_q_index) {
+                    return TRID_LAST;
+                }
+                return TRID_INNER;
+            };
 
             for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
+                const uint32_t q_index = global_q_chunk - global_q_start;
                 const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
@@ -442,20 +506,68 @@ void kernel_main() {
                 const auto qi = get_q_chunk_info(
                     q_chunk, nb, nq, ring_id, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
 
-                constexpr uint32_t sum_offset = local_padded_Nt + Lt;
-
+                // 1. Complete restore + intra-ring prefetch (ring_iter > 0 only)
                 if (!single_q_chunk && ring_iter > 0) {
-                    read_prev_accumulators(
-                        qi.is_joint_q ? joint_out_generator : out_generator,
+                    complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
+
+                    // Intra-ring prefetch: issue reads for Q[q+1] during Q[q]'s K-loop.
+                    // Barrier on Q[q+1]'s trid — its save completed at least one K-loop ago.
+                    const uint32_t next_q = global_q_chunk + 1;
+                    if (next_q < global_q_end) {
+                        const uint32_t next_q_index = next_q - global_q_start;
+                        noc_async_write_barrier_with_trid(q_trid(next_q_index));
+                        const uint32_t nb_next = next_q / (NH * num_q_chunks);
+                        const uint32_t nq_next = (next_q % (NH * num_q_chunks)) / num_q_chunks;
+                        const uint32_t qc_next = next_q % num_q_chunks;
+                        const auto qi_next = get_q_chunk_info(
+                            qc_next,
+                            nb_next,
+                            nq_next,
+                            ring_id,
+                            num_local_q_chunks,
+                            Sq_chunk_t,
+                            vDHt,
+                            Lt,
+                            local_padded_Nt);
+                        issue_restore_reads(
+                            qi_next.is_joint_q ? joint_out_generator : out_generator,
+                            stats_writer,
+                            stats_tile_logical,
+                            nb_next,
+                            nq_next,
+                            Sq_chunk_t,
+                            qi_next.out_slice,
+                            qi_next.stats_seq_start_tile,
+                            qi_next.stats_seq_end_tile,
+                            sum_offset,
+                            cb_prev_out,
+                            cb_max_in,
+                            cb_sum_in,
+                            tile_bytes,
+                            stats_tile_bytes);
+                    }
+                }
+
+                // 2. Cross-ring prefetch: Q[N-1] → Q[0] of next ring iter.
+                // Reads fly during Q[N-1]'s K-loop + save drain.
+                if (!single_q_chunk && !is_last_ring_iter && (global_q_chunk + 1 >= global_q_end)) {
+                    noc_async_write_barrier_with_trid(TRID_FIRST);
+                    const uint32_t gq0 = global_q_start;
+                    const uint32_t nb0 = gq0 / (NH * num_q_chunks);
+                    const uint32_t nq0 = (gq0 % (NH * num_q_chunks)) / num_q_chunks;
+                    const uint32_t qc0 = gq0 % num_q_chunks;
+                    const auto qi0 = get_q_chunk_info(
+                        qc0, nb0, nq0, 0 /*unused*/, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, local_padded_Nt);
+                    issue_restore_reads(
+                        qi0.is_joint_q ? joint_out_generator : out_generator,
                         stats_writer,
                         stats_tile_logical,
-                        nb,
-                        nq,
+                        nb0,
+                        nq0,
                         Sq_chunk_t,
-                        qi.out_slice,
-                        qi.end_seq_tile,
-                        qi.stats_seq_start_tile,
-                        qi.stats_seq_end_tile,
+                        qi0.out_slice,
+                        qi0.stats_seq_start_tile,
+                        qi0.stats_seq_end_tile,
                         sum_offset,
                         cb_prev_out,
                         cb_max_in,
@@ -464,15 +576,30 @@ void kernel_main() {
                         stats_tile_bytes);
                 }
 
+                // === Compute runs K-loop for this Q chunk ===
+
+                // Wait for compute to signal last K-chunk start (multi-Q only).
+                constexpr uint32_t cb_signal = tt::CBIndex::c_12;
+                if (!single_q_chunk) {
+                    cb_wait_front(cb_signal, 1);
+                    cb_pop_front(cb_signal, 1);
+                }
+
                 if (is_last_ring_iter) {
-                    write_block(
+                    write_out_row_by_row(
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         qi.out_slice,
                         qi.end_seq_tile,
                         cb_out,
-                        tile_bytes);
+                        tile_bytes,
+                        subblock_h);
+                    noc_async_write_barrier();
                 } else if (!single_q_chunk) {
-                    write_accumulators(
+                    // Accumulators are raw compute state — all tiles are valid (including padded rows).
+                    // Use 0xFFFFFFFF to bypass maybe_write_tile's padding skip, matching restore's
+                    // end_seq_tile = 0xFFFFFFFF convention.
+                    constexpr uint32_t all_tiles_valid = 0xFFFFFFFF;
+                    save_accumulators_with_trid(
                         qi.is_joint_q ? joint_out_generator : out_generator,
                         stats_writer,
                         stats_tile_logical,
@@ -480,7 +607,7 @@ void kernel_main() {
                         nq,
                         Sq_chunk_t,
                         qi.out_slice,
-                        qi.end_seq_tile,
+                        all_tiles_valid,
                         qi.stats_seq_start_tile,
                         qi.stats_seq_end_tile,
                         sum_offset,
@@ -488,10 +615,13 @@ void kernel_main() {
                         cb_max_out,
                         cb_sum_out,
                         tile_bytes,
-                        stats_tile_bytes);
+                        stats_tile_bytes,
+                        subblock_h,
+                        q_trid(q_index));
                 }
             }
-            noc_async_write_barrier();
+            // No global write_barrier — per-trid barriers in the Q loop
+            // ensure each save has landed before its data is read back.
         } else {
             for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
                 // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -134,7 +134,8 @@ void complete_restore(
 
 // Three transaction IDs for fine-grained write barrier tracking.
 // Q[0] → TRID_FIRST, Q[1..N-2] → TRID_INNER, Q[N-1] → TRID_LAST.
-// Each barrier waits for a save that completed at least one full K-loop ago.
+// Only 3 barriers fire per ring iteration (one per TRID):
+//   Q[0]: wB(TRID_INNER), Q[N-2]: wB(TRID_LAST), Q[N-1]: wB(TRID_FIRST).
 // Start from 1 — TRID 0 is the default for all NOC writes and must not be used
 // for per-TRID barriers, as unrelated writes (e.g. write_out_row_by_row on last
 // ring iter) would inflate the outstanding count and stall the barrier.
@@ -511,11 +512,21 @@ void kernel_main() {
                     complete_restore(cb_prev_out, out_num_tiles, cb_max_in, cb_sum_in, Sq_chunk_t);
 
                     // Intra-ring prefetch: issue reads for Q[q+1] during Q[q]'s K-loop.
-                    // Barrier on Q[q+1]'s trid — its save completed at least one K-loop ago.
+                    // Only barrier when next Q's TRID hasn't been cleared yet this ring iter:
+                    //   Q[0]: wB(TRID_INNER) — clears all prev-ring inner saves
+                    //   Q[N-2]: wB(TRID_LAST) — clears prev-ring Q[N-1] save
+                    //   Q[1..N-3]: skip — TRID_INNER already cleared at Q[0]
+                    // Without this, Q[j+1]'s wB(TRID_INNER) would stall on Q[j]'s
+                    // current-ring save (near-zero flight time) for q_per_core >= 5.
                     const uint32_t next_q = global_q_chunk + 1;
                     if (next_q < global_q_end) {
                         const uint32_t next_q_index = next_q - global_q_start;
-                        noc_async_write_barrier_with_trid(q_trid(next_q_index));
+                        const uint32_t next_trid = q_trid(next_q_index);
+                        // First inner Q (next_q_index==1) needs the barrier; subsequent
+                        // inner Qs (next_q_index>1 && next_trid==TRID_INNER) don't.
+                        if (next_trid != TRID_INNER || next_q_index == 1) {
+                            noc_async_write_barrier_with_trid(next_trid);
+                        }
                         const uint32_t nb_next = next_q / (NH * num_q_chunks);
                         const uint32_t nq_next = (next_q % (NH * num_q_chunks)) / num_q_chunks;
                         const uint32_t qc_next = next_q % num_q_chunks;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -462,6 +462,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         (std::uint32_t)use_streaming_compute,
         args.is_causal,
         args.is_balanced,
+        (std::uint32_t)out_out_subblock_h,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
@@ -690,6 +691,13 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         auto c_sum_in_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{tt::CBIndex::c_11, stats_df}})
                                    .set_page_size(tt::CBIndex::c_11, stats_tile_size);
         CreateCircularBuffer(program, core_grid, c_sum_in_config);
+
+        // Signal CB (c_12): compute signals writer when last K-chunk starts.
+        // 1 page suffices: writer pops during SALAD before compute pushes the next Q's signal.
+        constexpr uint32_t signal_page_size = 16;
+        auto c_signal_config = CircularBufferConfig(signal_page_size, {{tt::CBIndex::c_12, tt::DataFormat::UInt16}})
+                                   .set_page_size(tt::CBIndex::c_12, signal_page_size);
+        CreateCircularBuffer(program, core_grid, c_signal_config);
     }
 
     uint32_t q_addr = input_tensor_q.buffer()->address();


### PR DESCRIPTION
Two optimizations that eliminate DRAM round-trip stalls at Q-chunk boundaries in multi-Q ring SDPA (q_per_core > 1):

1. Zero-copy accumulator save (compute side, compute_streaming.hpp)

   Eliminate all three copy_block calls on the compute critical path. Each accumulator uses a different technique based on whether UNPACK reads it during the step:

   - Output (save_out_cb): alias redirect to cb_out, writer drains row-by-row during SALAD. UNPACK never reads cb_out (normalize only fires on last ring iter). [existing, renamed from save_cb]
   - Sum (q_cur.sum = cb_sum_out): alias redirect, same pattern as output. UNPACK never reads cur.sum on non-last ring iters.
   - Max (save_max_cb / mirror_cb): dual-write from DST in reduce_c_row_group — pack same tiles to both accumulator CB (UNPACK reads) and cb_max_out (writer drains). Alias redirect fails here due to two-consumer race on pages_acked when writer pops previous Q's cb_max_out while UNPACK reads current Q's.

   cb_exp_max_diff is now popped per-row in salad_correct_row (matching
   prev.out), simplifying mul_bcast_cols_l1_acc / mul_block_bcast_cols_acc
   to always read from CB front instead of cumulative offsets.

2. Prefetch DRAM restore pipeline (writer side, ring_joint_writer.cpp)

   Split blocking read_prev_accumulators into non-blocking issue_restore_reads + complete_restore. The writer prefetches Q[q+1]'s restore during Q[q]'s K-loop (intra-ring) and Q[0] of the next ring iteration during Q[N-1]'s K-loop (cross-ring). Read barriers are effectively instant since reads fly for K K-chunks.

   Three TRIDs (FIRST/INNER/LAST) provide per-Q write barriers — save_accumulators_with_trid flushes writes with a TRID, and the corresponding barrier fires before the next restore on that TRID. No global noc_async_write_barrier on the non-last-ring path.

Ring 8544/q288/k512 perf (CCLs disabled, math util):
  Before: 66.2%
  After:  67.2%  (+1.0 pp)

PCC on both critical configs: 0.9998, RMSE < 0.006. Single-chip (sdpa_standard_v2) perf unchanged.

  - Code review guidelines: https://gist.github.com/djordjenTT/092651246eb430628a48ff7e766829d6#file-prefetch_code_review_guidelines-md
  - Kernel analysis (sections 8.8, 9, 12): https://gist.github.com/djordjenTT/092651246eb430628a48ff7e766829d6#file-sdpa_ring_v2_kernel_analysis-md — prefetch pipeline, save/restore CB ownership, TRID flight time with timing diagrams

### Checklist

- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/23347502613)
- [x] [(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/runs/23347563661)

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/sdpa_deferred_norm_prefetch_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/sdpa_deferred_norm_prefetch_v4)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dnijemcevic/sdpa_deferred_norm_prefetch_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dnijemcevic/sdpa_deferred_norm_prefetch_v4)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/sdpa_deferred_norm_prefetch_v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/sdpa_deferred_norm_prefetch_v4)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

