### PR TITLE
Add per-core allocation for Sharded L1 Tensor

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -179,24 +179,34 @@ TEST(OverlappedAllocators, InvalidAllocator) {
             ::testing::HasSubstr("Invalid allocator ID 2 (num_allocators=2)")));
 }
 
-TEST(OverlappedAllocators, InvalidAPIsForOverlappedAllocators) {
-    // Create bank manager with 2 allocators (0 and 1)
+TEST(OverlappedAllocators, ResetAndShrinkSucceedWhenOtherAllocatorsEmpty) {
+    // Create bank manager with 2 allocators (0 and 1), no allocations
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
 
-    // Test accessing an API that only works for single allocator
+    // reset_size and shrink_size succeed when other allocators have no active allocations
+    EXPECT_NO_THROW(bank_manager.reset_size(AllocatorID{0}));
+    EXPECT_NO_THROW(bank_manager.reset_size(AllocatorID{1}));
+    EXPECT_NO_THROW(bank_manager.shrink_size(1024, true, AllocatorID{0}));
+    EXPECT_NO_THROW(bank_manager.shrink_size(1024, true, AllocatorID{1}));
+}
+
+TEST(OverlappedAllocators, ResetAndShrinkFailWhenOtherAllocatorsActive) {
+    // Create bank manager with 2 allocators (0 and 1)
+    BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
+    BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
+    const CoreRangeSet grid({CoreRange({0, 0}, {0, 0})});
+
+    // Allocate on allocator 1
+    bank_manager.allocate_buffer(1024, 1024, false, grid, std::nullopt, AllocatorID{1});
+
+    // reset_size/shrink_size on allocator 0 should fail because allocator 1 has active allocations
     EXPECT_THAT(
         [&]() { bank_manager.reset_size(AllocatorID{0}); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
-    EXPECT_THAT(
-        [&]() { bank_manager.reset_size(AllocatorID{1}); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has active allocations")));
     EXPECT_THAT(
         [&]() { bank_manager.shrink_size(1024, true, AllocatorID{0}); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
-    EXPECT_THAT(
-        [&]() { bank_manager.shrink_size(1024, true, AllocatorID{1}); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has active allocations")));
 }
 
 TEST(OverlappedAllocators, DeallocateAllAndClear) {

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for per-core L1 allocation via Buffer::per_core_allocation().
+// These tests require a real device (slow dispatch).
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/device.hpp>
+#include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+class PerCoreAllocationTest : public MeshDeviceSingleCardBufferFixture {};
+
+// Use 1024-byte page size to be safely above all alignment requirements
+// (FreeListOpt internally uses DRAM alignment which may be larger than L1 alignment)
+static constexpr DeviceAddr PAGE_SIZE = 1024;
+
+TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u) << "Need at least 2 compute cores";
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = PAGE_SIZE * num_cores;
+
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED).set_per_core_allocation(true);
+
+    auto buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+
+    ASSERT_TRUE(buf->per_core_allocation());
+
+    // Verify each core has an address within L1 range
+    auto cores = corerange_to_cores(CoreRangeSet(core_range), std::nullopt, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        auto addr = buf->per_core_address(cores[i]);
+        EXPECT_GT(addr, 0u) << "Core " << i << " address should be non-zero (above L1 base)";
+        EXPECT_LT(addr, device->l1_size_per_core()) << "Core " << i << " address exceeds L1 size";
+    }
+}
+
+TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u);
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = 2 * PAGE_SIZE * num_cores;
+
+    // Create per-core buffer
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED).set_per_core_allocation(true);
+    auto per_core_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+
+    // Create lockstep buffer on same cores
+    auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    auto lockstep_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
+
+    // Both should be allocated successfully
+    EXPECT_TRUE(per_core_buf->is_allocated());
+    EXPECT_TRUE(lockstep_buf->is_allocated());
+
+    // Lockstep address should not overlap any per-core address
+    auto lockstep_addr = lockstep_buf->address();
+    auto cores = corerange_to_cores(CoreRangeSet(core_range), std::nullopt, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        auto pc_addr = per_core_buf->per_core_address(cores[i]);
+        EXPECT_NE(lockstep_addr, pc_addr) << "Lockstep address overlaps per-core address at core " << i;
+    }
+}
+
+TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u);
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = 2 * PAGE_SIZE * num_cores;
+
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED).set_per_core_allocation(true);
+
+    // Create and destroy a buffer
+    {
+        auto buf1 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+        EXPECT_TRUE(buf1->per_core_allocation());
+        // buf1 destroyed here, freeing per-core allocations
+    }
+
+    // Create another buffer on same cores — should succeed (space was freed)
+    auto buf2 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    EXPECT_TRUE(buf2->per_core_allocation());
+    EXPECT_TRUE(buf2->is_allocated());
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for per-core allocation using BankManager's AllocatorDependencies.
+//
+// The per-core allocation model uses N+1 allocators inside one BankManager:
+//   Allocator 0       = lockstep  (same address on all banks/cores)
+//   Allocator 1..N    = per-bank  (independent address per bank/core)
+//
+// Dependency graph:
+//   Allocator 0 depends on {1, 2, ..., N}  — lockstep must avoid all per-bank regions
+//   Allocator k depends on {0}              — per-bank must avoid lockstep regions
+//   Per-bank allocators are independent of each other (separate physical L1s)
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include "tt_metal/impl/allocator/bank_manager.hpp"
+
+namespace per_core_bank_manager_tests {
+
+using namespace tt::tt_metal;
+using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+
+// Helper: build the per-core dependency graph for N banks.
+BankManager::AllocatorDependencies make_per_core_dependencies(uint32_t num_banks) {
+    std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> deps_map;
+    ttsl::SmallVector<AllocatorID> lockstep_deps;
+    for (uint32_t i = 1; i <= num_banks; i++) {
+        lockstep_deps.push_back(AllocatorID{i});
+        deps_map[AllocatorID{i}] = {AllocatorID{0}};
+    }
+    deps_map[AllocatorID{0}] = lockstep_deps;
+    return BankManager::AllocatorDependencies{deps_map};
+}
+
+// Helper: create a BankManager with per-core dependencies.
+BankManager make_per_core_bank_manager(uint64_t bank_size, uint32_t alignment, uint32_t num_banks) {
+    std::vector<int64_t> bank_offsets(num_banks, 0);
+    auto deps = make_per_core_dependencies(num_banks);
+    return BankManager(
+        BufferType::DRAM,
+        bank_offsets,
+        bank_size,
+        alignment,
+        /*dram_alignment_bytes=*/alignment,
+        /*alloc_offset=*/0,
+        /*disable_interleaved=*/false,
+        deps);
+}
+
+DeviceAddr alloc(BankManager& bm, uint32_t size, AllocatorID id, bool bottom_up = true) {
+    return bm.allocate_buffer(size, size, bottom_up, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, id);
+}
+
+void dealloc(BankManager& bm, DeviceAddr addr, AllocatorID id) { bm.deallocate_buffer(addr, id); }
+
+constexpr AllocatorID LOCKSTEP{0};
+constexpr AllocatorID BANK0{1};
+constexpr AllocatorID BANK1{2};
+
+}  // namespace per_core_bank_manager_tests
+
+using namespace per_core_bank_manager_tests;
+
+// Per-bank allocators are independent: different sizes yield different second-alloc offsets.
+TEST(PerCoreAllocation, BanksAllocateDifferentSizes) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    auto addr_b0 = alloc(bm, 1024, BANK0);
+    auto addr_b1 = alloc(bm, 8192, BANK1);
+    EXPECT_EQ(addr_b0, 0u);
+    EXPECT_EQ(addr_b1, 0u);
+
+    auto addr_b0_2 = alloc(bm, 1024, BANK0);
+    auto addr_b1_2 = alloc(bm, 1024, BANK1);
+    EXPECT_EQ(addr_b0_2, 1024u);
+    EXPECT_EQ(addr_b1_2, 8192u);
+}
+
+// Lockstep allocation must skip regions occupied by any per-bank allocator.
+TEST(PerCoreAllocation, LockstepAvoidsPerBankRegions) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    alloc(bm, 4096, BANK0);  // [0, 4096)
+    alloc(bm, 2048, BANK1);  // [0, 2048)
+
+    // Lockstep must start after the max per-bank extent
+    auto lockstep_addr = alloc(bm, 1024, LOCKSTEP);
+    EXPECT_EQ(lockstep_addr, 4096u);
+}
+
+// Per-bank allocation must skip regions occupied by the lockstep allocator.
+TEST(PerCoreAllocation, PerBankAvoidsLockstepRegion) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    alloc(bm, 4096, LOCKSTEP);  // [0, 4096) on all banks
+
+    auto addr_b0 = alloc(bm, 1024, BANK0);
+    auto addr_b1 = alloc(bm, 1024, BANK1);
+    EXPECT_EQ(addr_b0, 4096u);
+    EXPECT_EQ(addr_b1, 4096u);
+}
+
+// Deallocating per-bank regions lets lockstep reuse that space.
+TEST(PerCoreAllocation, DeallocatePerBankFreesForLockstep) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    auto b0 = alloc(bm, 4096, BANK0);
+    auto b1 = alloc(bm, 4096, BANK1);
+    EXPECT_EQ(alloc(bm, 1024, LOCKSTEP), 4096u);
+
+    dealloc(bm, b0, BANK0);
+    dealloc(bm, b1, BANK1);
+
+    // Lockstep can now reuse [0, 4096)
+    EXPECT_EQ(alloc(bm, 1024, LOCKSTEP), 0u);
+}
+
+// Scale test: 110 banks (realistic Blackhole core count).
+TEST(PerCoreAllocation, HundredTenBanksScaling) {
+    constexpr uint32_t NUM_BANKS = 110;
+    auto deps = make_per_core_dependencies(NUM_BANKS);
+    EXPECT_EQ(deps.num_allocators(), NUM_BANKS + 1);
+
+    std::vector<int64_t> bank_offsets(NUM_BANKS, 0);
+    BankManager bm(BufferType::DRAM, bank_offsets, 1024 * 1024, 1024, 1024, 0, false, deps);
+    CoreRangeSet grid(CoreRange(CoreCoord(0, 0), CoreCoord(NUM_BANKS - 1, 0)));
+
+    // Allocate different sizes on each bank
+    for (uint32_t i = 0; i < NUM_BANKS; i++) {
+        uint32_t size = (i + 1) * 1024;
+        auto addr = bm.allocate_buffer(size, size, true, grid, 1, AllocatorID{i + 1});
+        EXPECT_EQ(addr, 0u);  // All start at 0 (independent)
+    }
+
+    // Lockstep must start after the largest per-bank allocation (110KB)
+    auto ls = bm.allocate_buffer(1024, 1024, true, grid, std::nullopt, AllocatorID{0});
+    EXPECT_EQ(ls, 110u * 1024);
+}

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -5,6 +5,8 @@ set(UNIT_TESTS_API_SOURCES
     allocator/test_free_list_opt_allocator.cpp
     allocator/test_l1_banking_allocator.cpp
     allocator/test_overlapped_bank_manager.cpp
+    allocator/test_per_core_bank_manager.cpp
+    allocator/test_per_core_allocation.cpp
     circular_buffer/test_CircularBuffer_allocation.cpp
     circular_buffer/test_CircularBuffer_creation.cpp
     circular_buffer/test_CircularBuffer_non_blocking.cpp

--- a/tests/ttnn/unit_tests/base_functionality/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_per_core_allocation.py
@@ -1,0 +1,455 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for per-core L1 allocation via MemoryConfig(per_core_allocation=True).
+
+Each test creates single-core HEIGHT_SHARDED tensors with per_core_allocation=True,
+which triggers the per-bank allocator (AllocatorID bank_id+1) instead of lockstep.
+"""
+
+import pytest
+import torch
+import ttnn
+
+pytestmark = pytest.mark.use_module_device
+
+
+class PerCoreMemMap:
+    """Track expected per-core allocator addresses for test validation.
+
+    The L1 per-bank allocator is TOP-DOWN: allocations grow from the top of
+    the L1 address space downward. Each core has an independent free-list
+    starting from the same top address.
+
+    Derive L1_TOP from the first allocation: L1_TOP = first_addr + first_size.
+    """
+
+    def __init__(self, first_addr, first_size):
+        self.l1_top = first_addr + first_size
+        self.expected = {}
+        # Per-core: list of (addr, size) — active allocations
+        self._core_allocs = {}
+
+    def alloc(self, label, core_id, size):
+        """Record a top-down allocation and compute expected address.
+
+        Scans from top downward, finds first gap that fits.
+        """
+        if core_id not in self._core_allocs:
+            self._core_allocs[core_id] = []
+
+        allocs = self._core_allocs[core_id]
+        # Sort by address descending (top-down scan)
+        sorted_allocs = sorted(allocs, key=lambda x: x[0], reverse=True)
+
+        # Try to fit in gaps between allocations (scanning top-down)
+        candidate = self.l1_top - size
+        for a_addr, a_size in sorted_allocs:
+            a_end = a_addr + a_size
+            if candidate >= a_end:
+                # Fits above this allocation
+                break
+            # Blocked by this allocation, try below it
+            candidate = a_addr - size
+
+        allocs.append((candidate, size))
+        self.expected[label] = candidate
+        return candidate
+
+    def free(self, core_id, addr):
+        """Record a deallocation."""
+        self._core_allocs[core_id] = [(a, s) for a, s in self._core_allocs[core_id] if a != addr]
+
+    def validate(self, actual):
+        """Assert actual address map matches expected."""
+        assert actual == self.expected, f"Address map mismatch:\n" + "\n".join(
+            f"  {k}: expected={self.expected[k]:#x} actual={'MISSING' if k not in actual else f'{actual[k]:#x}'}"
+            f"{' MISMATCH' if self.expected[k] != actual.get(k) else ''}"
+            for k in self.expected
+        )
+
+
+def _create_single_core_tensor(device, core, shard_bytes):
+    """Create a single-core HEIGHT_SHARDED L1 tensor with per-core allocation."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+        per_core_allocation=True,
+    )
+    data = torch.zeros(1, shard_bytes, dtype=torch.uint8)
+    return ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+
+def test_per_core_tensors_get_same_address(device):
+    """Two single-core tensors on different cores can share the same L1 address,
+    proving they use independent per-bank allocators (not lockstep)."""
+    shard_bytes = 1024
+    core0 = ttnn.CoreCoord(0, 0)
+    core1 = ttnn.CoreCoord(1, 0)
+
+    t0 = _create_single_core_tensor(device, core0, shard_bytes)
+    t1 = _create_single_core_tensor(device, core1, shard_bytes)
+
+    # Per-bank allocators are independent — both cores can get the same address
+    # With lockstep, t1 would get a different address since t0 consumed it
+    addr0 = t0.buffer_address()
+    addr1 = t1.buffer_address()
+    assert addr0 == addr1, f"Expected same address on different cores (per-bank allocators), got {addr0} vs {addr1}"
+
+
+def test_per_core_round_trip(device):
+    """Data written to a per-core allocated tensor reads back correctly."""
+    shard_bytes = 2048
+    core = ttnn.CoreCoord(0, 0)
+
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+        per_core_allocation=True,
+    )
+    data = torch.arange(shard_bytes, dtype=torch.uint8).reshape(1, shard_bytes)
+    tensor = ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+    result = ttnn.to_torch(ttnn.from_device(tensor))
+    assert torch.equal(data, result), "Round-trip data mismatch"
+
+
+def test_per_core_sharded_dealloc_realloc(device):
+    """Deallocate a per-core sharded tensor and reallocate — verifies deallocation frees per-core space.
+
+    1. Allocate a per-core sharded tensor across all cores
+    2. Record per-core addresses
+    3. Delete it
+    4. Allocate again — should get the same addresses (space was freed and reused)
+    """
+    grid = device.compute_with_storage_grid_size()
+    num_cores = grid.x * grid.y
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+
+    SHARD_BYTES = 2048
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    shard_spec = ttnn.ShardSpec(core_grid, [1, SHARD_BYTES], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+        per_core_allocation=True,
+    )
+    data = torch.zeros(num_cores, SHARD_BYTES, dtype=torch.uint8)
+
+    # First allocation
+    t1 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
+    addrs1 = [t1.per_core_buffer_address(c) for c in cores]
+
+    # Deallocate
+    del t1
+
+    # Second allocation — should reuse the same per-core space
+    t2 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
+    addrs2 = [t2.per_core_buffer_address(c) for c in cores]
+
+    assert (
+        addrs1 == addrs2
+    ), f"Expected same addresses after dealloc/realloc:\n  first:  {[f'{a:#x}' for a in addrs1]}\n  second: {[f'{a:#x}' for a in addrs2]}"
+
+
+def test_per_core_tetris_allocation(device):
+    """Tetris-style allocation across 4 cores with alloc/free/realloc patterns.
+
+    Exercises independent per-bank free-lists with varied sizes, frees, and
+    reallocations. All expected addresses are computed by PerCoreMemMap and
+    validated against actual device addresses.
+    """
+    num_cores = 4
+    cores = [ttnn.CoreCoord(i, 0) for i in range(num_cores)]
+
+    # Allocation script: (label, action, core_index, size)
+    #   action: "alloc" or "free"
+    #   For "free", size is ignored — we free the tensor stored under label.
+    script = [
+        # Round 1: initial allocations across all cores
+        ("c0_a", "alloc", 0, 2048),
+        ("c1_a", "alloc", 1, 4096),
+        ("c2_a", "alloc", 2, 1024),
+        ("c3_a", "alloc", 3, 3072),
+        # Round 2: second alloc on some cores
+        ("c0_b", "alloc", 0, 1024),
+        ("c1_b", "alloc", 1, 512),
+        ("c2_b", "alloc", 2, 2048),
+        # Round 3: free some, then reallocate
+        ("c0_a", "free", 0, 0),
+        ("c1_a", "free", 1, 0),
+        ("c0_c", "alloc", 0, 2048),  # reuses c0_a's freed space
+        ("c1_c", "alloc", 1, 2048),  # fits in c1_a's freed 4096 gap
+        ("c1_d", "alloc", 1, 1024),  # also fits in remaining c1_a gap
+        # Round 4: more on core 3
+        ("c3_b", "alloc", 3, 512),
+        ("c3_a", "free", 3, 0),
+        ("c3_c", "alloc", 3, 3072),  # reuses c3_a's freed space
+    ]
+
+    tensors = {}  # label → ttnn.Tensor
+    actual = {}
+    mem = None
+
+    for label, action, core_idx, size in script:
+        if action == "alloc":
+            t = _create_single_core_tensor(device, cores[core_idx], size)
+            if mem is None:
+                mem = PerCoreMemMap(t.buffer_address(), size)
+            mem.alloc(label, core_idx, size)
+            actual[label] = t.buffer_address()
+            tensors[label] = t
+        elif action == "free":
+            freed_addr = mem.expected[label]
+            del tensors[label]
+            mem.free(core_idx, freed_addr)
+            del actual[label]
+            del mem.expected[label]
+
+    mem.validate(actual)
+
+
+def _create_lockstep_tensor(device, core, shard_bytes):
+    """Create a single-core HEIGHT_SHARDED L1 tensor with lockstep (default) allocation."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    data = torch.zeros(1, shard_bytes, dtype=torch.uint8)
+    return ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+
+def _addr_ranges_overlap(addr_a, size_a, addr_b, size_b):
+    """Check if two address ranges [a, a+size_a) and [b, b+size_b) overlap."""
+    return addr_a < addr_b + size_b and addr_b < addr_a + size_a
+
+
+def test_per_core_and_lockstep_coexist(device):
+    """Interleave per-core and lockstep allocations across multiple cores.
+
+    Verifies:
+    - Per-core and lockstep use different allocator pools (no address reuse)
+    - No address range overlaps between any per-core and lockstep allocation
+    - Freeing per-core doesn't affect lockstep, and vice versa
+    - Both pools can allocate independently after the other has allocated
+    """
+    num_cores = 4
+    cores = [ttnn.CoreCoord(i, 0) for i in range(num_cores)]
+
+    # Track all allocations: (label, addr, size, kind)
+    allocs = []
+    tensors = {}
+
+    # Round 1: per-core allocations on each core (different sizes)
+    pc_sizes = [2048, 4096, 1024, 3072]
+    for i, size in enumerate(pc_sizes):
+        label = f"pc_c{i}_{size}"
+        t = _create_single_core_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Round 2: lockstep allocations on same cores
+    ls_sizes = [1024, 2048, 512, 1024]
+    for i, size in enumerate(ls_sizes):
+        label = f"ls_c{i}_{size}"
+        t = _create_lockstep_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "lockstep"))
+
+    # Round 3: more per-core after lockstep
+    for i, size in enumerate([512, 1024]):
+        label = f"pc2_c{i}_{size}"
+        t = _create_single_core_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Round 4: free some per-core, allocate lockstep in the freed cores
+    del tensors["pc_c0_2048"]
+    del tensors["pc_c1_4096"]
+    ls_after_free_sizes = [2048, 2048]
+    for i, size in enumerate(ls_after_free_sizes):
+        label = f"ls_after_free_c{i}_{size}"
+        t = _create_lockstep_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "lockstep"))
+
+    # Round 5: free some lockstep, allocate per-core
+    del tensors["ls_c2_512"]
+    del tensors["ls_c3_1024"]
+    pc_after_free_sizes = [512, 1024]
+    for i, size in enumerate(pc_after_free_sizes):
+        label = f"pc_after_free_c{i+2}_{size}"
+        t = _create_single_core_tensor(device, cores[i + 2], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Validate: no per-core allocation overlaps with any lockstep allocation on the same core
+    # (Per-core allocs on different cores CAN share addresses — that's the point)
+    # Group by core for overlap checking
+    for i in range(num_cores):
+        core_pc = [(l, a, s) for l, a, s, k in allocs if k == "per_core" and l in tensors and f"_c{i}_" in l]
+        core_ls = [(l, a, s) for l, a, s, k in allocs if k == "lockstep" and l in tensors and f"_c{i}_" in l]
+        for pc_label, pc_addr, pc_size in core_pc:
+            for ls_label, ls_addr, ls_size in core_ls:
+                assert not _addr_ranges_overlap(pc_addr, pc_size, ls_addr, ls_size), (
+                    f"Overlap on core {i}: {pc_label}=[{pc_addr:#x}, +{pc_size}) vs "
+                    f"{ls_label}=[{ls_addr:#x}, +{ls_size})"
+                )
+
+    # Validate: all remaining tensors are still allocated
+    for label, t in tensors.items():
+        assert t.is_allocated(), f"{label} should still be allocated"
+
+
+def test_all_cores_lockstep_then_per_core_then_reverse(device):
+    """Allocate on ALL L1 cores: lockstep first then per-core, then deallocate and reverse order.
+
+    This stresses the dependency-aware path in the bank manager:
+    - Phase 1: lockstep on all cores → per-core on all cores (lockstep first, deps empty initially)
+    - Phase 2: deallocate all → per-core on all cores → lockstep on all cores (deps non-empty for lockstep)
+    Validates no overlaps in either phase.
+    """
+    grid = device.compute_with_storage_grid_size()
+    num_cores = grid.x * grid.y
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+
+    shard_bytes = 2048
+
+    # --- Phase 1: lockstep first, then per-core ---
+    lockstep_tensors = {}
+    per_core_tensors = {}
+
+    # Lockstep on all cores
+    for i, core in enumerate(cores):
+        lockstep_tensors[i] = _create_lockstep_tensor(device, core, shard_bytes)
+
+    # Per-core on all cores
+    for i, core in enumerate(cores):
+        per_core_tensors[i] = _create_single_core_tensor(device, core, shard_bytes)
+
+    # Validate: no overlaps between lockstep and per-core on same core
+    for i in range(num_cores):
+        ls_addr = lockstep_tensors[i].buffer_address()
+        pc_addr = per_core_tensors[i].buffer_address()
+        assert not _addr_ranges_overlap(
+            ls_addr, shard_bytes, pc_addr, shard_bytes
+        ), f"Phase 1 overlap on core {i}: lockstep={ls_addr:#x} per_core={pc_addr:#x}"
+
+    # Deallocate all
+    lockstep_tensors.clear()
+    per_core_tensors.clear()
+
+    # --- Phase 2: per-core first, then lockstep ---
+
+    # Per-core on all cores (varying sizes)
+    pc_sizes = [1024 + (i % 4) * 1024 for i in range(num_cores)]  # 1024, 2048, 3072, 4096, ...
+    for i, core in enumerate(cores):
+        per_core_tensors[i] = _create_single_core_tensor(device, core, pc_sizes[i])
+
+    # Lockstep on all cores — this triggers the dependency-aware path
+    # because per-bank allocators now have allocations
+    for i, core in enumerate(cores):
+        lockstep_tensors[i] = _create_lockstep_tensor(device, core, shard_bytes)
+
+    # Validate: no overlaps
+    for i in range(num_cores):
+        ls_addr = lockstep_tensors[i].buffer_address()
+        pc_addr = per_core_tensors[i].buffer_address()
+        assert not _addr_ranges_overlap(ls_addr, shard_bytes, pc_addr, pc_sizes[i]), (
+            f"Phase 2 overlap on core {i}: lockstep={ls_addr:#x}+{shard_bytes} " f"per_core={pc_addr:#x}+{pc_sizes[i]}"
+        )
+
+    # All tensors still alive
+    for i in range(num_cores):
+        assert lockstep_tensors[i].is_allocated()
+        assert per_core_tensors[i].is_allocated()
+
+
+def test_triangle_allocation_then_uniform_sharded(device):
+    """Triangle per-core allocation on ALL compute cores, then a per-core sharded tensor.
+
+    Phase 1: Create increasing-size per-core tensors (triangle pattern) on every
+    core in the compute grid. Core at flat index i gets (i+1) * TILE_BYTES.
+    This consumes different amounts of L1 per core.
+
+    Phase 2: Allocate one HEIGHT_SHARDED per-core tensor across all cores.
+    Since each core's per-bank allocator has consumed a different amount
+    (the triangle), the resulting per-core addresses should be strictly
+    decreasing with flat index (inverse triangle).
+    """
+    grid = device.compute_with_storage_grid_size()
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+    num_cores = len(cores)
+
+    TILE_BYTES = 1024  # above DRAM alignment to avoid min_allocation_size issues
+
+    # Phase 1: Triangle allocation — flat index i gets (i+1) * TILE_BYTES
+    triangle_tensors = {}
+    for i, core in enumerate(cores):
+        size = (i + 1) * TILE_BYTES
+        triangle_tensors[i] = _create_single_core_tensor(device, core, size)
+
+    # Phase 2: Allocate one HEIGHT_SHARDED per-core tensor across all cores
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    shard_bytes = TILE_BYTES
+    shard_spec = ttnn.ShardSpec(core_grid, [1, shard_bytes], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+        per_core_allocation=True,
+    )
+    sharded_data = torch.zeros(num_cores, shard_bytes, dtype=torch.uint8)
+    sharded_tensor = ttnn.from_torch(
+        sharded_data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+    # Verify: per-core addresses form an inverse triangle
+    # Core at flat index 0 consumed least → highest address
+    # Core at flat index N-1 consumed most → lowest address
+    addrs = [sharded_tensor.per_core_buffer_address(c) for c in cores]
+    for i in range(num_cores - 1):
+        assert addrs[i] > addrs[i + 1], (
+            f"Expected inverse triangle: core {i} ({cores[i].x},{cores[i].y}) addr={addrs[i]:#x} "
+            f"should be > core {i+1} ({cores[i+1].x},{cores[i+1].y}) addr={addrs[i+1]:#x}"
+        )
+
+    # All tensors still alive
+    for i in range(num_cores):
+        assert triangle_tensors[i].is_allocated()
+    assert sharded_tensor.is_allocated()

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -153,10 +153,17 @@ public:
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 
+    BufferShardingArgs& set_per_core_allocation(bool enable) {
+        per_core_allocation_ = enable;
+        return *this;
+    }
+    bool per_core_allocation() const { return per_core_allocation_; }
+
 private:
     std::optional<BufferDistributionSpec> buffer_distribution_spec_;
     std::optional<ShardSpecBuffer> shard_spec_;
     TensorMemoryLayout buffer_layout_ = TensorMemoryLayout::INTERLEAVED;
+    bool per_core_allocation_ = false;
 };
 
 bool is_sharded(const TensorMemoryLayout& layout);
@@ -250,6 +257,12 @@ public:
     std::optional<uint32_t> num_cores() const;
     const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
 
+    // Per-core allocation API
+    bool per_core_allocation() const { return per_core_allocation_; }
+    DeviceAddr per_core_address(CoreCoord core) const;
+    const std::unordered_map<CoreCoord, DeviceAddr>& per_core_addresses() const { return per_core_addresses_; }
+    void copy_per_core_addresses_from(const Buffer& other);
+
     // Returns the buffer that owns the underlying device memory.
     // Typically returns itself unless the buffer was created with a view method.
     std::shared_ptr<Buffer> root_buffer();
@@ -285,7 +298,10 @@ private:
     // Deallocate is allowed to be called multiple times on the same buffer
     void deallocate();
     void deallocate_impl();
+    friend class AllocatorImpl;
     friend void DeallocateBuffer(Buffer& buffer);
+
+    void set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs);
 
     DeviceAddr translate_page_address(DeviceAddr offset, uint32_t bank_id) const;
 
@@ -310,6 +326,10 @@ private:
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
 
     std::optional<BufferDistributionSpec> buffer_distribution_spec_;
+
+    // Per-core allocation state
+    bool per_core_allocation_ = false;
+    std::unordered_map<CoreCoord, DeviceAddr> per_core_addresses_;
 
     // The root buffer is the buffer that owns the underlying device memory.
     // The root buffer is populated only when the buffer was created with a view method.

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -43,6 +43,16 @@ public:
     const std::optional<ShardSpec>& shard_spec() const { return shard_spec_; }
     const std::optional<NdShardSpec>& nd_shard_spec() const { return nd_shard_spec_; }
     bool created_with_nd_shard_spec() const { return created_with_nd_shard_spec_; }
+    bool per_core_allocation() const { return per_core_allocation_; }
+    MemoryConfig& set_per_core_allocation(bool enable) {
+        if (enable) {
+            TT_FATAL(buffer_type_ == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+            TT_FATAL(is_sharded(), "per_core_allocation requires a sharded memory layout");
+            TT_FATAL(!created_with_nd_shard_spec_, "per_core_allocation is not supported with NdShardSpec");
+        }
+        per_core_allocation_ = enable;
+        return *this;
+    }
 
     MemoryConfig with_shard_spec(std::optional<ShardSpec> shard_spec) const {
         return MemoryConfig(memory_layout_, buffer_type_, std::move(shard_spec));
@@ -53,10 +63,20 @@ public:
     bool is_dram() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
-        "memory_layout", "buffer_type", "shard_spec", "nd_shard_spec", "created_with_nd_shard_spec");
+        "memory_layout",
+        "buffer_type",
+        "shard_spec",
+        "nd_shard_spec",
+        "created_with_nd_shard_spec",
+        "per_core_allocation");
     auto attribute_values() const {
         return std::forward_as_tuple(
-            memory_layout_, buffer_type_, shard_spec_, nd_shard_spec_, created_with_nd_shard_spec_);
+            memory_layout_,
+            buffer_type_,
+            shard_spec_,
+            nd_shard_spec_,
+            created_with_nd_shard_spec_,
+            per_core_allocation_);
     }
 
     static MemoryConfig create_with_prepopulated_shard_specs(
@@ -81,6 +101,7 @@ private:
     std::optional<ShardSpec> shard_spec_ = std::nullopt;
     std::optional<NdShardSpec> nd_shard_spec_ = std::nullopt;
     bool created_with_nd_shard_spec_ = false;
+    bool per_core_allocation_ = false;
 };
 
 std::ostream& operator<<(std::ostream& os, const MemoryConfig& config);

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -97,6 +97,7 @@ public:
     DeviceAddr size() const;
     DeviceAddr device_local_size() const { return device_local_size_; }
     DeviceAddr address() const { return address_; };
+    DeviceAddr per_core_address(const CoreCoord& core) const;
 
     MeshBufferLayout global_layout() const;
     const MeshBufferConfig& global_config() const { return config_; }

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -133,6 +133,14 @@ void MeshBuffer::initialize_device_buffers() {
             device_local_config_.sharding_args,
             device_local_config_.bottom_up,
             /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
+        // For per-core allocation, propagate per-core addresses from the backing buffer.
+        if (buffer->per_core_allocation()) {
+            TT_FATAL(
+                std::holds_alternative<OwnedBufferState>(state_),
+                "Per-core allocation is not supported for externally-owned MeshBuffers");
+            auto& owned = std::get<OwnedBufferState>(state_);
+            buffer->copy_per_core_addresses_from(*owned.backing_buffer);
+        }
         return buffer;
     };
 
@@ -180,6 +188,12 @@ MeshDevice* MeshBuffer::device() const {
 
 Buffer* MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
     return buffers_.at(device_coord).value().get();
+}
+
+DeviceAddr MeshBuffer::per_core_address(const CoreCoord& core) const {
+    auto* buffer = get_reference_buffer();
+    TT_FATAL(buffer->per_core_allocation(), "Buffer does not use per-core allocation");
+    return buffer->per_core_address(core);
 }
 
 Buffer* MeshBuffer::get_reference_buffer() const {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -122,6 +122,28 @@ DeviceAddr AllocatorImpl::allocate_buffer(Buffer* buffer) {
     if (config_->disable_interleaved) {
         TT_FATAL(num_cores.has_value(), "Interleaved allocation is disabled, see validate_num_banks");
     }
+
+    // Per-core allocation path: each core gets an independent address
+    if (buffer->per_core_allocation()) {
+        TT_FATAL(buffer_type == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+        TT_FATAL(buffer->has_shard_spec(), "per_core_allocation requires a shard_spec with core grid");
+        const auto& grid = buffer->shard_spec().tensor_shard_spec.grid;
+        bool row_major = buffer->shard_spec().tensor_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+        auto cores = corerange_to_cores(grid, std::nullopt, row_major);
+        DeviceAddr alloc_size = buffer->aligned_size_per_bank();
+
+        std::unordered_map<CoreCoord, DeviceAddr> addrs;
+        for (const auto& core : cores) {
+            auto bank_id = logical_core_to_bank_ids_.at(BufferType::L1).at(core).at(0);
+            addrs[core] = l1_manager_->allocate_buffer(
+                alloc_size, page_size, bottom_up, config_->compute_grid, /*num_shards=*/1, AllocatorID{bank_id + 1});
+        }
+        buffer->set_per_core_addresses(std::move(addrs));
+        allocated_buffers_.insert(buffer);
+        return buffer->per_core_address(cores[0]);
+    }
+
     switch (buffer_type) {
         case BufferType::DRAM:
             address = dram_manager_->allocate_buffer(size, page_size, bottom_up, config_->compute_grid, num_cores);
@@ -150,6 +172,19 @@ void AllocatorImpl::deallocate_buffer(Buffer* buffer) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto address = buffer->address();
     auto buffer_type = buffer->buffer_type();
+
+    // Per-core deallocation path
+    if (buffer->per_core_allocation()) {
+        TT_FATAL(buffer_type == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+        for (const auto& [core, addr] : buffer->per_core_addresses()) {
+            auto bank_id = logical_core_to_bank_ids_.at(BufferType::L1).at(core).at(0);
+            l1_manager_->deallocate_buffer(addr, AllocatorID{bank_id + 1});
+        }
+        allocated_buffers_.erase(buffer);
+        return;
+    }
+
     switch (buffer_type) {
         case BufferType::DRAM: dram_manager_->deallocate_buffer(address); break;
         case BufferType::L1: l1_manager_->deallocate_buffer(address); break;
@@ -418,6 +453,9 @@ AllocatorImpl::~AllocatorImpl() {
 
 AllocatorState AllocatorImpl::extract_state() const {
     std::lock_guard<std::mutex> lock(mutex_);
+    for (auto* buf : allocated_buffers_) {
+        TT_FATAL(!buf->per_core_allocation(), "extract_state does not yet support per-core L1 allocations");
+    }
 
     std::unordered_map<BufferType, AllocatorState::BufferTypeState> states_per_buffer_type;
 
@@ -448,6 +486,9 @@ AllocatorState AllocatorImpl::extract_state() const {
 
 void AllocatorImpl::override_state(const AllocatorState& state) {
     std::lock_guard<std::mutex> lock(mutex_);
+    for (auto* buf : allocated_buffers_) {
+        TT_FATAL(!buf->per_core_allocation(), "override_state does not yet support per-core L1 allocations");
+    }
 
     // Clear all buffer types
     dram_manager_->deallocate_all();

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -631,7 +631,12 @@ MemoryBlockTable BankManager::get_memory_block_table(
 
 void BankManager::shrink_size(
     DeviceAddr shrink_size, bool bottom_up, BankManager::AllocatorDependencies::AllocatorID allocator_id) {
-    TT_FATAL(allocator_dependencies_.num_allocators() == 1, "Expected single allocator!");
+    for (uint32_t i = 0; i < allocator_dependencies_.num_allocators(); i++) {
+        if (i == allocator_id.get()) {
+            continue;
+        }
+        TT_FATAL(allocated_buffers_[i].empty(), "Cannot shrink allocator size: allocator {} has active allocations", i);
+    }
     auto* alloc = this->get_allocator_from_id(allocator_id);
     if (alloc) {
         alloc->shrink_size(shrink_size, bottom_up);
@@ -639,7 +644,12 @@ void BankManager::shrink_size(
 }
 
 void BankManager::reset_size(BankManager::AllocatorDependencies::AllocatorID allocator_id) {
-    TT_FATAL(allocator_dependencies_.num_allocators() == 1, "Expected single allocator!");
+    for (uint32_t i = 0; i < allocator_dependencies_.num_allocators(); i++) {
+        if (i == allocator_id.get()) {
+            continue;
+        }
+        TT_FATAL(allocated_buffers_[i].empty(), "Cannot reset allocator size: allocator {} has active allocations", i);
+    }
     auto* alloc = this->get_allocator_from_id(allocator_id);
     if (alloc) {
         alloc->reset_size();

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -118,6 +118,17 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
     uint64_t interleaved_address_limit = static_cast<uint64_t>(config_->worker_l1_size - l1_bank_size);
     uint64_t allocatable_l1_size =
         static_cast<uint64_t>(config_->worker_l1_size) - config_->l1_unreserved_base - config_->l1_small_size;
+    // Always build per-core dependency graph (N+1 allocators: lockstep + per-bank)
+    using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+    std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> deps_map;
+    ttsl::SmallVector<AllocatorID> lockstep_deps;
+    for (uint32_t i = 1; i <= num_l1_banks; i++) {
+        lockstep_deps.push_back(AllocatorID{i});
+        deps_map[AllocatorID{i}] = {AllocatorID{0}};
+    }
+    deps_map[AllocatorID{0}] = lockstep_deps;
+    BankManager::AllocatorDependencies l1_deps{deps_map};
+
     // Assuming top down allocation for L1 buffers so the allocatable memory space is the top l1_bank_size bytes of L1
     l1_manager_ = std::make_unique<BankManager>(
         BufferType::L1,
@@ -127,7 +138,8 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
         config_->l1_alignment,
         config_->dram_alignment,
         config_->l1_unreserved_base,
-        config_->disable_interleaved);
+        config_->disable_interleaved,
+        l1_deps);
     log_debug(
         tt::LogMetal,
         "Configured partition params: worker_l1_size:0x{:X}, "

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -291,7 +291,8 @@ Buffer::Buffer(
     owns_data_(owns_data),
     page_size_(page_size),
     shard_spec_(sharding_args.shard_spec()),
-    buffer_distribution_spec_(sharding_args.buffer_distribution_spec()) {
+    buffer_distribution_spec_(sharding_args.buffer_distribution_spec()),
+    per_core_allocation_(sharding_args.per_core_allocation()) {
     TT_FATAL(this->device_ != nullptr, "Device needs to not be null.");
     if (this->sub_device_id_.has_value()) {
         validate_sub_device_id(this->sub_device_id_, this->device_, buffer_type, shard_spec_);
@@ -386,6 +387,8 @@ std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
     if (region.offset == 0 && region.size == size()) {
         return shared_from_this();
     }
+
+    TT_FATAL(!per_core_allocation_, "Buffer::view() with sub-regions is not supported for per-core allocated buffers");
 
     auto buffer = Buffer::create(
         device_,
@@ -565,6 +568,19 @@ DeviceAddr Buffer::aligned_size_per_bank() const {
     return tt::tt_metal::detail::calculate_bank_size_spread(
         this->aligned_size(), this->aligned_page_size(), num_banks, this->alignment());
 }
+
+DeviceAddr Buffer::per_core_address(CoreCoord core) const {
+    TT_FATAL(per_core_allocation_, "Buffer::per_core_address() called on buffer without per-core allocation enabled");
+    auto it = per_core_addresses_.find(core);
+    TT_FATAL(it != per_core_addresses_.end(), "No per-core address for core ({}, {})", core.x, core.y);
+    return it->second;
+}
+
+void Buffer::set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs) {
+    per_core_addresses_ = std::move(addrs);
+}
+
+void Buffer::copy_per_core_addresses_from(const Buffer& other) { per_core_addresses_ = other.per_core_addresses_; }
 
 ShardSpecBuffer Buffer::shard_spec() const {
     TT_FATAL(is_sharded(this->buffer_layout_), "Buffer not sharded");

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -227,8 +227,12 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const tt::tt_metal
             nd_shard_spec->orientation,
             nd_shard_spec->shard_distribution_strategy);
     }
-    return BufferShardingArgs(
-        std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());
+    auto sharding_args =
+        BufferShardingArgs(std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());
+    if (memory_config_.per_core_allocation()) {
+        sharding_args.set_per_core_allocation(true);
+    }
+    return sharding_args;
 }
 
 size_t TensorLayout::compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const {

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -58,7 +58,8 @@ bool MemoryConfig::is_dram() const { return buffer_type_ == BufferType::DRAM; }
 
 bool operator==(const MemoryConfig& config_a, const MemoryConfig& config_b) {
     return config_a.buffer_type() == config_b.buffer_type() && config_a.memory_layout() == config_b.memory_layout() &&
-           config_a.shard_spec() == config_b.shard_spec();
+           config_a.shard_spec() == config_b.shard_spec() &&
+           config_a.per_core_allocation() == config_b.per_core_allocation();
 }
 
 bool operator!=(const MemoryConfig& config_a, const MemoryConfig& config_b) { return not(config_a == config_b); }
@@ -76,6 +77,7 @@ nlohmann::json ttsl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(
     json_object["memory_layout"] = config.memory_layout();
     json_object["buffer_type"] = config.buffer_type();
     json_object["created_with_nd_shard_spec"] = config.created_with_nd_shard_spec();
+    json_object["per_core_allocation"] = config.per_core_allocation();
     if (config.created_with_nd_shard_spec()) {
         if (config.nd_shard_spec().has_value()) {
             json_object["nd_shard_spec"] = ttsl::json::to_json(config.nd_shard_spec().value());
@@ -93,13 +95,22 @@ tt::tt_metal::MemoryConfig ttsl::json::from_json_t<tt::tt_metal::MemoryConfig>::
     auto memory_layout = json_object["memory_layout"].get<tt::tt_metal::TensorMemoryLayout>();
     auto buffer_type = json_object["buffer_type"].get<tt::tt_metal::BufferType>();
     auto created_with_nd_shard_spec = json_object["created_with_nd_shard_spec"].get<bool>();
+    auto per_core_allocation = json_object.value("per_core_allocation", false);
     if (created_with_nd_shard_spec) {
         auto nd_shard_spec = ttsl::json::from_json<tt::tt_metal::NdShardSpec>(json_object["nd_shard_spec"]);
-        return tt::tt_metal::MemoryConfig(buffer_type, std::move(nd_shard_spec));
+        auto config = tt::tt_metal::MemoryConfig(buffer_type, std::move(nd_shard_spec));
+        if (per_core_allocation) {
+            config.set_per_core_allocation(true);
+        }
+        return config;
     }
     std::optional<tt::tt_metal::ShardSpec> shard_spec;
     if (json_object.contains("shard_spec")) {
         shard_spec = ttsl::json::from_json<tt::tt_metal::ShardSpec>(json_object["shard_spec"]);
     }
-    return tt::tt_metal::MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
+    auto config = tt::tt_metal::MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
+    if (per_core_allocation) {
+        config.set_per_core_allocation(true);
+    }
+    return config;
 }

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -250,12 +250,16 @@ MemoryConfig TensorSpec::populate_nd_shard_spec_from_legacy() const {
         nd_shard_spec.shard_distribution_strategy = ShardDistributionStrategy::GRID_2D;
     }
 
-    return MemoryConfig::create_with_prepopulated_shard_specs(
+    auto result = MemoryConfig::create_with_prepopulated_shard_specs(
         mem_config.memory_layout(),
         mem_config.buffer_type(),
         mem_config.shard_spec(),
         std::move(nd_shard_spec),
         mem_config.created_with_nd_shard_spec());
+    if (mem_config.per_core_allocation()) {
+        result.set_per_core_allocation(true);
+    }
+    return result;
 }
 
 std::optional<MemoryConfig> TensorSpec::populate_legacy_shard_spec_from_nd() const {

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1324,6 +1324,25 @@ void pytensor_module(nb::module_& mod) {
 
         )doc")
         .def(
+            "per_core_buffer_address",
+            [](const Tensor& self, const CoreCoord& core) -> uint32_t {
+                TT_FATAL(is_device_tensor(self), "{} doesn't support per_core_buffer_address", self.storage_type());
+                const auto& storage = self.device_storage();
+                TT_FATAL(storage.mesh_buffer != nullptr, "Tensor is not allocated.");
+                return storage.mesh_buffer->per_core_address(core);
+            },
+            nb::arg("core"),
+            R"doc(
+            Get the per-core L1 address for a specific core.
+
+            Only available for tensors allocated with per_core_allocation=True.
+
+            .. code-block:: python
+
+                address = tt_tensor.per_core_buffer_address(ttnn.CoreCoord(0, 0))
+
+        )doc")
+        .def(
             "get_layout", [](const Tensor& self) { return self.layout(); }, R"doc(
             Get memory layout of TT Tensor.
 

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -410,12 +410,17 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             [](MemoryConfig* t,
                TensorMemoryLayout memory_layout,
                BufferType buffer_type,
-               std::optional<ShardSpec> shard_spec) {
+               std::optional<ShardSpec> shard_spec,
+               bool per_core_allocation) {
                 new (t) MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
+                if (per_core_allocation) {
+                    t->set_per_core_allocation(true);
+                }
             },
             nb::arg("memory_layout") = TensorMemoryLayout::INTERLEAVED,
             nb::arg("buffer_type") = BufferType::DRAM,
             nb::arg("shard_spec") = nb::none(),
+            nb::arg("per_core_allocation") = false,
             R"doc(
                 Create MemoryConfig class.
                 If interleaved is set to True, tensor data will be interleaved across multiple DRAM banks on TT Accelerator device.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38745?issue=tenstorrent%7Ctt-metal%7C39984)

### Problem description
DeepSeek requires to use per-core allocation for l1 tensors, especially for Compressed Tensor, it is pre-requisite to have per-core allocator to save memory space. Currently only lock-step is allowed.

### What's changed
First PR to expose per-core allocation flag to Tensor level, propagate down from memory config, to mesh buffer, buffer, allocator, etc. 
```

Python user code                                                                                                                                                                                               
  │                                                                                                                                                                                                            
  │  mem_config = ttnn.MemoryConfig(..., per_core_allocation=True)                                                                                                                                               
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  nanobind (ttnn-nanobind/tensor.cpp)                                                                                                                                                                            
  │                                                                                                                                                                                                              
  │  Constructs MemoryConfig, calls set_per_core_allocation(true)
  │  Validates: L1 only, sharded, no NdShardSpec                                                                                                                                                                 
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  TensorLayout / TensorSpec                                                                                                                                                                                      
  │                                                                                                                                                                                                              
  │  Propagates per_core_allocation flag from MemoryConfig                                                                                                                                                     
  │  onto BufferShardingArgs                                                                                                                                                                                     
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  MeshBuffer::create() (mesh_buffer.cpp)                                                                                                                                                                         
  │                                                                                                                                                                                                              
  │  Creates a backing Buffer with the sharding args                                                                                                                                                             
  │  (this is what triggers actual allocation)                                                                                                                                                                   
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  Buffer::create() → Buffer constructor (buffer.cpp)                                                                                                                                                             
  │                                                                                                                                                                                                              
  │  Stores per_core_allocation_ from BufferShardingArgs
  │  Calls allocate_impl()                                                                                                                                                                                       
  │                                                                                                                                                                                                            
  ▼                                                                                                                                                                                                              
  AllocatorImpl::allocate_buffer() (allocator.cpp)                                                                                                                                                             
  │                                                                                                                                                                                                              
  │  For each core in shard grid:
  │    ├─ Looks up core's L1 bank_id                                                                                                                                                                             
  │    └─ Calls l1_manager_->allocate_buffer() with per-bank AllocatorID                                                                                                                                         
  │       (independent allocation, not lockstep)                                                                                                                                                                 
  │                                                                                                                                                                                                              
  │  Calls buffer->set_per_core_addresses(addrs)  [private, via friend]                                                                                                                                          
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                            
  MeshBuffer::initialize_device_buffers() (mesh_buffer.cpp)                                                                                                                                                      
  │                                                                                                                                                                                                              
  │  Creates device-local Buffers at the backing buffer's address
  │  (no allocation — placed at known address)                                                                                                                                                                   
  │                                                                                                                                                                                                              
  │  Calls buffer->copy_per_core_addresses_from(backing_buffer)  [public]                                                                                                                                        
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                            
  Buffer ready with per-core addresses  
```

Following PR will add support to compressed tensor side.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/compressed_tensor6)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/compressed_tensor6)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/compressed_tensor6)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
