### PR TITLE
[Feature]: Parallel Program launch for SD

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -379,7 +379,7 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
 
 // 4x8 benchmark: 32 unique programs on 32 devices (1:1 mapping)
 // Expects parallel dispatch with thread pool.
-// This replicates the deepseek blitz case of 32 indendepent programs dispatched across 32 devices on a GLX
+// This replicates the deepseek blitz case of 32 independent programs dispatched across 32 devices on a GLX
 TEST_F(MeshDeviceFixture4x8DispatchAgnostic, ParallelizationBenchmark) {
     constexpr uint32_t num_programs = 32;
     constexpr uint32_t num_devices = 32;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -377,6 +377,90 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
+// 2x4 test for parallelization experiments (8 devices)
+// Measures metrics for multiple parallelize program launches
+TEST_F(MeshDeviceFixture2x4DispatchAgnostic, ParallelizationBenchmark) {
+    uint32_t num_programs = 128;
+    uint32_t num_iterations = 20;
+    auto random_seed = 0;
+    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
+    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    srand(seed);
+
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+        num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
+    std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
+
+    // Setup: Create workloads with a single program spanning all devices
+    double setup_enqueue_time_ms = 0.0;
+    int workload_count = 0;
+
+    // Range covering 8 devices: {0,0} to {1,3}
+    MeshCoordinateRange devices_0(MeshCoordinate{0, 0});
+    MeshCoordinateRange devices_1(MeshCoordinate{0, 1});
+    MeshCoordinateRange devices_2(MeshCoordinate{0, 2});
+    MeshCoordinateRange devices_3(MeshCoordinate{0, 3});
+    MeshCoordinateRange devices_4(MeshCoordinate{1, 0});
+    MeshCoordinateRange devices_5(MeshCoordinate{1, 1});
+    MeshCoordinateRange devices_6(MeshCoordinate{1, 2});
+    MeshCoordinateRange devices_7(MeshCoordinate{1, 3});
+
+    // Launch a unique program on a device
+    // In total total 8 programs for this workload (which should be launched in parallel)
+    for (int i = 0; i < num_programs; i += 8) {
+        std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
+        workload->add_program(devices_0, std::move(*programs[i]));
+        workload->add_program(devices_1, std::move(*programs[i + 1]));
+        workload->add_program(devices_2, std::move(*programs[i + 2]));
+        workload->add_program(devices_3, std::move(*programs[i + 3]));
+        workload->add_program(devices_4, std::move(*programs[i + 4]));
+        workload->add_program(devices_5, std::move(*programs[i + 5]));
+        workload->add_program(devices_6, std::move(*programs[i + 6]));
+        workload->add_program(devices_7, std::move(*programs[i + 7]));
+        auto t0 = std::chrono::steady_clock::now();
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
+        auto t1 = std::chrono::steady_clock::now();
+        setup_enqueue_time_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        workload_count++;
+        mesh_workloads.push_back(workload);
+    }
+
+    std::cout << "\n2x4 Setup Phase (First-time compile + dispatch)\n";
+    std::cout << "Workloads created: " << workload_count << "\n";
+    std::cout << "Total setup time : " << setup_enqueue_time_ms << " ms\n";
+    std::cout << "Avg per workload : " << (setup_enqueue_time_ms / workload_count) << " ms\n";
+
+    // Benchmark steady-state re-execution
+    auto start_total = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < num_iterations; i++) {
+        if (i % 100 == 0) {
+            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
+        }
+        for (auto& workload : mesh_workloads) {
+            EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
+        }
+    }
+    auto end_enqueue = std::chrono::steady_clock::now();
+
+    Finish(mesh_device_->mesh_command_queue());
+    auto end_total = std::chrono::steady_clock::now();
+
+    auto total_duration_ms = std::chrono::duration<double, std::milli>(end_total - start_total).count();
+    auto enqueue_duration_ms = std::chrono::duration<double, std::milli>(end_enqueue - start_total).count();
+    auto finish_duration_ms = std::chrono::duration<double, std::milli>(end_total - end_enqueue).count();
+    int total_workload_dispatches = num_iterations * mesh_workloads.size();
+
+    std::cout << "\n2x4 Benchmark Phase (Steady-state re-execution)";
+    std::cout << "Total workload dispatches: " << total_workload_dispatches << "\n";
+    std::cout << "Total time               : " << (total_duration_ms / 1000) << " seconds\n";
+    std::cout << "Enqueue time (wall)      : " << enqueue_duration_ms << " ms\n";
+    std::cout << "Finish() time            : " << finish_duration_ms << " ms\n";
+    std::cout << "Avg per workload dispatch: " << (total_duration_ms / total_workload_dispatches) << " ms\n";
+    std::cout << "Throughput               : " << (total_workload_dispatches / (total_duration_ms / 1000))
+              << " workloads/sec\n";
+}
+
 TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {
     uint32_t num_programs_0 = 16;
     uint32_t num_programs_1 = 24;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -377,88 +377,40 @@ TEST_F(MeshWorkloadTest2x4, SimultaneousMeshWorkloads) {
     Finish(mesh_device_->mesh_command_queue());
 }
 
-// 2x4 test for parallelization experiments (8 devices)
-// Measures metrics for multiple parallelize program launches
-TEST_F(MeshDeviceFixture2x4DispatchAgnostic, ParallelizationBenchmark) {
-    uint32_t num_programs = 128;
-    uint32_t num_iterations = 20;
-    auto random_seed = 0;
-    uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
-    srand(seed);
+// 4x8 benchmark: 32 unique programs on 32 devices (1:1 mapping)
+// Expects parallel dispatch with thread pool.
+// This replicates the deepseek blitz case of 32 indendepent programs dispatched across 32 devices on a GLX
+TEST_F(MeshDeviceFixture4x8DispatchAgnostic, ParallelizationBenchmark) {
+    constexpr uint32_t num_programs = 32;
+    constexpr uint32_t num_devices = 32;
 
-    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
-        num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
-    std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
+    auto programs = tt::tt_metal::distributed::test::utils::create_benchmark_programs(
+        num_programs, mesh_device_->compute_with_storage_grid_size(), true);
 
-    // Setup: Create workloads with a single program spanning all devices
-    double setup_enqueue_time_ms = 0.0;
-    int workload_count = 0;
-
-    // Range covering 8 devices: {0,0} to {1,3}
-    MeshCoordinateRange devices_0(MeshCoordinate{0, 0});
-    MeshCoordinateRange devices_1(MeshCoordinate{0, 1});
-    MeshCoordinateRange devices_2(MeshCoordinate{0, 2});
-    MeshCoordinateRange devices_3(MeshCoordinate{0, 3});
-    MeshCoordinateRange devices_4(MeshCoordinate{1, 0});
-    MeshCoordinateRange devices_5(MeshCoordinate{1, 1});
-    MeshCoordinateRange devices_6(MeshCoordinate{1, 2});
-    MeshCoordinateRange devices_7(MeshCoordinate{1, 3});
-
-    // Launch a unique program on a device
-    // In total total 8 programs for this workload (which should be launched in parallel)
-    for (int i = 0; i < num_programs; i += 8) {
-        std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
-        workload->add_program(devices_0, std::move(*programs[i]));
-        workload->add_program(devices_1, std::move(*programs[i + 1]));
-        workload->add_program(devices_2, std::move(*programs[i + 2]));
-        workload->add_program(devices_3, std::move(*programs[i + 3]));
-        workload->add_program(devices_4, std::move(*programs[i + 4]));
-        workload->add_program(devices_5, std::move(*programs[i + 5]));
-        workload->add_program(devices_6, std::move(*programs[i + 6]));
-        workload->add_program(devices_7, std::move(*programs[i + 7]));
-        auto t0 = std::chrono::steady_clock::now();
-        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
-        auto t1 = std::chrono::steady_clock::now();
-        setup_enqueue_time_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-        workload_count++;
-        mesh_workloads.push_back(workload);
+    std::vector<MeshCoordinateRange> devices;
+    devices.reserve(num_devices);
+    for (uint32_t d = 0; d < num_devices; d++) {
+        devices.emplace_back(MeshCoordinate{d / 8, d % 8});
     }
 
-    std::cout << "\n2x4 Setup Phase (First-time compile + dispatch)\n";
-    std::cout << "Workloads created: " << workload_count << "\n";
-    std::cout << "Total setup time : " << setup_enqueue_time_ms << " ms\n";
-    std::cout << "Avg per workload : " << (setup_enqueue_time_ms / workload_count) << " ms\n";
-
-    // Benchmark steady-state re-execution
-    auto start_total = std::chrono::steady_clock::now();
-
-    for (int i = 0; i < num_iterations; i++) {
-        if (i % 100 == 0) {
-            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
-        }
-        for (auto& workload : mesh_workloads) {
-            EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
-        }
+    std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
+    for (uint32_t d = 0; d < num_devices; d++) {
+        workload->add_program(devices[d], std::move(*programs[d]));
     }
-    auto end_enqueue = std::chrono::steady_clock::now();
 
+    auto t0 = std::chrono::steady_clock::now();
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
+    auto t1 = std::chrono::steady_clock::now();
     Finish(mesh_device_->mesh_command_queue());
-    auto end_total = std::chrono::steady_clock::now();
+    auto t2 = std::chrono::steady_clock::now();
 
-    auto total_duration_ms = std::chrono::duration<double, std::milli>(end_total - start_total).count();
-    auto enqueue_duration_ms = std::chrono::duration<double, std::milli>(end_enqueue - start_total).count();
-    auto finish_duration_ms = std::chrono::duration<double, std::milli>(end_total - end_enqueue).count();
-    int total_workload_dispatches = num_iterations * mesh_workloads.size();
+    auto enqueue_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    auto finish_ms = std::chrono::duration<double, std::milli>(t2 - t1).count();
 
-    std::cout << "\n2x4 Benchmark Phase (Steady-state re-execution)";
-    std::cout << "Total workload dispatches: " << total_workload_dispatches << "\n";
-    std::cout << "Total time               : " << (total_duration_ms / 1000) << " seconds\n";
-    std::cout << "Enqueue time (wall)      : " << enqueue_duration_ms << " ms\n";
-    std::cout << "Finish() time            : " << finish_duration_ms << " ms\n";
-    std::cout << "Avg per workload dispatch: " << (total_duration_ms / total_workload_dispatches) << " ms\n";
-    std::cout << "Throughput               : " << (total_workload_dispatches / (total_duration_ms / 1000))
-              << " workloads/sec\n";
+    log_info(tt::LogTest, "ParallelizationBenchmark: {} programs on {} devices", num_programs, num_devices);
+    log_info(tt::LogTest, "Enqueue time: {} ms", enqueue_ms);
+    log_info(tt::LogTest, "Finish time: {} ms", finish_ms);
+    log_info(tt::LogTest, "Total time: {} ms", enqueue_ms + finish_ms);
 }
 
 TEST_F(MeshWorkloadTest4x8, SimultaneousMeshWorkloads) {

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -393,13 +393,13 @@ TEST_F(MeshDeviceFixture4x8DispatchAgnostic, ParallelizationBenchmark) {
         devices.emplace_back(MeshCoordinate{d / 8, d % 8});
     }
 
-    std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
+    MeshWorkload workload;
     for (uint32_t d = 0; d < num_devices; d++) {
-        workload->add_program(devices[d], std::move(*programs[d]));
+        workload.add_program(devices[d], std::move(*programs[d]));
     }
 
     auto t0 = std::chrono::steady_clock::now();
-    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
     auto t1 = std::chrono::steady_clock::now();
     Finish(mesh_device_->mesh_command_queue());
     auto t2 = std::chrono::steady_clock::now();

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -411,6 +411,95 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     return programs;
 }
 
+std::vector<std::shared_ptr<Program>> create_benchmark_programs(
+    uint32_t num_programs, CoreCoord worker_grid_size, bool unique_per_program) {
+    uint32_t MAX_LOOP = 100;
+
+    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet cr_set(cr);
+
+    std::vector<std::shared_ptr<Program>> programs;
+    programs.reserve(num_programs);
+
+    std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+    std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
+
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    constexpr uint32_t l1_cb_test_budget = 1024 * 32;
+    uint32_t page_size = l1_cb_test_budget / max_cbs;
+
+    uint32_t NUM_CBS = max_cbs;
+    uint32_t NUM_SEMS = NUM_SEMAPHORES;
+
+    // Deterministic rt args: use max_runtime_args for unique, 0 for common
+    auto [unique_rtargs, common_rtargs] = create_runtime_args(max_runtime_args, 0, 0, 0);
+    uint32_t num_unique_rtargs = unique_rtargs.size();
+    uint32_t num_common_rtargs = common_rtargs.size();
+
+    for (uint32_t i = 0; i < num_programs; i++) {
+        Program& program = *programs.emplace_back(std::make_shared<Program>());
+
+        // Create CBs
+        for (uint32_t j = 0; j < NUM_CBS; j++) {
+            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}})
+                                                 .set_page_size(j, page_size * (j + 1));
+            CreateCircularBuffer(program, cr_set, cb_config);
+        }
+
+        // Create Semaphores
+        for (uint32_t j = 0; j < NUM_SEMS; j++) {
+            CreateSemaphore(program, cr_set, j + 1);
+        }
+
+        // Program ID as compile-time arg forces unique compilation per program
+        uint32_t program_id = unique_per_program ? i : 0;
+        std::vector<uint32_t> compile_args = {
+            MAX_LOOP,
+            MAX_LOOP,
+            MAX_LOOP,
+            NUM_CBS,
+            NUM_SEMS,
+            num_unique_rtargs,
+            num_common_rtargs,
+            page_size,
+            program_id};
+
+        // Always create all 3 kernels (BRISC, NCRISC, TRISC)
+        auto dummy_brisc_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = compile_args,
+                .defines = data_movement_defines});
+        SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, unique_rtargs);
+        SetCommonRuntimeArgs(program, dummy_brisc_kernel, common_rtargs);
+
+        auto dummy_ncrisc_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+            cr_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = compile_args,
+                .defines = data_movement_defines});
+        SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, unique_rtargs);
+        SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, common_rtargs);
+
+        auto dummy_trisc_kernel = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp",
+            cr_set,
+            ComputeConfig{.math_approx_mode = false, .compile_args = compile_args, .defines = compute_defines});
+        SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, unique_rtargs);
+        SetCommonRuntimeArgs(program, dummy_trisc_kernel, common_rtargs);
+    }
+    return programs;
+}
+
 ScopedEnvVar::ScopedEnvVar(const char* name, const char* value) : name_(name) {
     // Save original value
     const char* original = std::getenv(name);

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -411,14 +411,14 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     return programs;
 }
 
-std::vector<std::shared_ptr<Program>> create_benchmark_programs(
+std::vector<std::unique_ptr<Program>> create_benchmark_programs(
     uint32_t num_programs, CoreCoord worker_grid_size, bool unique_per_program) {
     uint32_t MAX_LOOP = 100;
 
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set(cr);
 
-    std::vector<std::shared_ptr<Program>> programs;
+    std::vector<std::unique_ptr<Program>> programs;
     programs.reserve(num_programs);
 
     std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
@@ -437,7 +437,7 @@ std::vector<std::shared_ptr<Program>> create_benchmark_programs(
     uint32_t num_common_rtargs = common_rtargs.size();
 
     for (uint32_t i = 0; i < num_programs; i++) {
-        Program& program = *programs.emplace_back(std::make_shared<Program>());
+        Program& program = *programs.emplace_back(std::make_unique<Program>());
 
         // Create CBs
         for (uint32_t j = 0; j < NUM_CBS; j++) {

--- a/tests/tt_metal/distributed/utils.hpp
+++ b/tests/tt_metal/distributed/utils.hpp
@@ -34,6 +34,13 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     uint32_t seed,
     const std::unordered_set<CoreCoord>& active_eth_cores = {});
 
+// Deterministic program creation for benchmarking.
+// Each program has 3 kernels (BRISC, NCRISC, TRISC) with fixed loop counts.
+// If unique_per_program is true, each program gets a unique compile-time arg (program_id),
+// forcing recompilation. If false, all programs are identical (same binary can be reused).
+std::vector<std::shared_ptr<Program>> create_benchmark_programs(
+    uint32_t num_programs, CoreCoord worker_grid_size, bool unique_per_program = true);
+
 // RAII guard for managing a single environment variable
 class ScopedEnvVar {
 public:

--- a/tests/tt_metal/distributed/utils.hpp
+++ b/tests/tt_metal/distributed/utils.hpp
@@ -38,7 +38,7 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
 // Each program has 3 kernels (BRISC, NCRISC, TRISC) with fixed loop counts.
 // If unique_per_program is true, each program gets a unique compile-time arg (program_id),
 // forcing recompilation. If false, all programs are identical (same binary can be reused).
-std::vector<std::shared_ptr<Program>> create_benchmark_programs(
+std::vector<std::unique_ptr<Program>> create_benchmark_programs(
     uint32_t num_programs, CoreCoord worker_grid_size, bool unique_per_program = true);
 
 // RAII guard for managing a single environment variable

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -181,13 +181,12 @@ protected:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
     uint32_t max_cbs_{};
 
-protected:
     Config config_;
 };
 
-class MeshDeviceFixture2x4DispatchAgnostic : public MeshDeviceFixtureBase {
+class MeshDeviceFixture4x8DispatchAgnostic : public MeshDeviceFixtureBase {
 protected:
-    MeshDeviceFixture2x4DispatchAgnostic() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}}) {}
+    MeshDeviceFixture4x8DispatchAgnostic() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{4, 8}}) {}
 
     void SetUp() override {
         const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -181,8 +181,60 @@ protected:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
     uint32_t max_cbs_{};
 
-private:
+protected:
     Config config_;
+};
+
+class MeshDeviceFixture2x4DispatchAgnostic : public MeshDeviceFixtureBase {
+protected:
+    MeshDeviceFixture2x4DispatchAgnostic() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{2, 4}}) {}
+
+    void SetUp() override {
+        const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        if (config_.arch.has_value() && *config_.arch != arch) {
+            GTEST_SKIP() << fmt::format(
+                "Skipping MeshDevice test suite on a machine with architecture {} that does not match the requested "
+                "architecture {}",
+                arch,
+                *config_.arch);
+        }
+
+        const auto system_mesh_shape = tt::tt_metal::MetalContext::instance().get_system_mesh().shape();
+        if (config_.mesh_shape.has_value() && config_.mesh_shape->mesh_size() > system_mesh_shape.mesh_size()) {
+            GTEST_SKIP() << fmt::format(
+                "Skipping MeshDevice test suite on a machine with SystemMesh {} that is smaller than the requested "
+                "mesh "
+                "shape {}",
+                system_mesh_shape,
+                *config_.mesh_shape);
+        }
+
+        init_max_cbs();
+
+        // Use ethernet dispatch for more than 1 CQ on T3K/N300
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+        bool is_n300_or_t3k_cluster =
+            cluster_type == tt::tt_metal::ClusterType::T3K or cluster_type == tt::tt_metal::ClusterType::N300;
+        auto core_type =
+            (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
+
+        if (config_.fabric_config != tt_fabric::FabricConfig::DISABLED) {
+            tt_fabric::SetFabricConfig(
+                config_.fabric_config,
+                tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+                std::nullopt,
+                config_.fabric_tensix_config,
+                config_.fabric_udm_mode);
+        }
+        mesh_device_ = MeshDevice::create(
+            MeshDeviceConfig(config_.mesh_shape.value_or(system_mesh_shape), config_.mesh_offset),
+            config_.l1_small_size,
+            config_.trace_region_size,
+            config_.num_cqs,
+            core_type,
+            {},
+            config_.worker_l1_size);
+    }
 };
 
 // Fixtures that determine the mesh device type automatically.

--- a/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
@@ -9,6 +9,9 @@
 
 namespace tt::tt_metal {
 
+class IDevice;
+class Program;
+
 namespace distributed {
 class MeshDevice;
 }  // namespace distributed
@@ -52,6 +55,10 @@ private:
     uint32_t num_fd_inits_ = 0;
     static std::unique_ptr<DispatchContext, Deleter> dispatch_context_ptr_;
 };
+
+// Dispatches a pre-compiled program to a device. Requires prior LaunchProgram call on another device
+// to compile and finalize the program. Uses thread-local launch messages for safe concurrent dispatch.
+void DispatchCompiledProgramToDevice(IDevice* device, Program& program);
 
 }  // namespace experimental
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -217,6 +217,12 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
 // - Takes the device out of reset
 bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
+// Dispatches an already-compiled program to a device. Unlike LaunchProgram, this function assumes the program has
+// already been compiled, finalized, and had circular buffers allocated by a prior LaunchProgram call on another device.
+// It performs per-device PCIe writes (runtime args, device configuration, launch messages) using thread-local copies
+// of launch messages to avoid mutating shared program state, making it safe for concurrent invocation across devices.
+void DispatchCompiledProgramToDevice(IDevice* device, Program& program);
+
 /**
  * Generate a (unique) per device ID for a program (potentially) running across multiple devices. The generated ID is
  * used by the performance profiler.

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -217,12 +217,6 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
 // - Takes the device out of reset
 bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
-// Dispatches an already-compiled program to a device. Unlike LaunchProgram, this function assumes the program has
-// already been compiled, finalized, and had circular buffers allocated by a prior LaunchProgram call on another device.
-// It performs per-device PCIe writes (runtime args, device configuration, launch messages) using thread-local copies
-// of launch messages to avoid mutating shared program state, making it safe for concurrent invocation across devices.
-void DispatchCompiledProgramToDevice(IDevice* device, Program& program);
-
 /**
  * Generate a (unique) per device ID for a program (potentially) running across multiple devices. The generated ID is
  * used by the performance profiler.

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -137,87 +137,75 @@ void SDMeshCommandQueue::wait_for_cores_idle() {
     }
 }
 
-void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
-    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
-        return;  // Skip workload execution for mock devices
-    }
+void SDMeshCommandQueue::launch_program_for_range(
+    const MeshCoordinateRange& coord_range, Program& program, bool blocking) {
+    const auto& program_cores = program.impl().logical_cores();
 
-    auto lock = lock_api_function_();
+    bool need_wait = false;
+    std::vector<std::vector<CoreCoord>> cores_to_wait;
+    ChipId device_id = 0;
 
-    if (!asynchronous_slow_dispatch_enabled_) {
-        wait_for_cores_idle();
-    }
-
-    for (auto& [coord_range, program] : mesh_workload.get_programs()) {
-        const auto& program_cores = program.impl().logical_cores();
-
-        // Collect local devices for this program, handling async idle checks
-        std::vector<IDevice*> local_devices;
-        for (const auto& coord : coord_range) {
-            if (!mesh_device_->impl().is_local(coord)) {
-                continue;
-            }
-            auto* device = mesh_device_->impl().get_device(coord);
+    // Collect local devices for this program, handling async idle checks
+    std::vector<IDevice*> local_devices;
+    for (const auto& coord : coord_range) {
+        if (!mesh_device_->impl().is_local(coord)) {
+            continue;
+        }
+        auto* device = mesh_device_->impl().get_device(coord);
+        need_wait = false;
+        {
+            std::lock_guard<std::mutex> guard(logical_cores_mutex_);
             if (asynchronous_slow_dispatch_enabled_) {
                 auto it = logical_cores_for_previous_workload_.find(device->id());
                 if (it != logical_cores_for_previous_workload_.end()) {
                     const auto& previous_cores = it->second;
                     if (logical_cores_intersect(previous_cores, program_cores)) {
-                        tt::llrt::internal_::wait_for_idle(device->id(), previous_cores);
-                        logical_cores_for_previous_workload_.erase(device->id());
+                        // Store the data so the thread does waiting after exiting
+                        // the critical section
+                        need_wait = true;
+                        cores_to_wait = previous_cores;
+                        device_id = device->id();
+                        logical_cores_for_previous_workload_.erase(device_id);
                     }
                 }
             }
-            local_devices.push_back(device);
         }
 
-        if (local_devices.empty()) {
-            continue;
+        if (need_wait) {
+            tt::llrt::internal_::wait_for_idle(device_id, cores_to_wait);
         }
 
-        // Serial: full LaunchProgram on the first device (compiles, finalizes, allocates CBs, etc.)
-        tt_metal::detail::LaunchProgram(local_devices[0], program, false);
+        local_devices.push_back(device);
+    }
 
-        // Parallel: dispatch already-compiled program to remaining devices
-        if (local_devices.size() > 1 && launch_thread_pool_) {
-            for (size_t i = 1; i < local_devices.size(); i++) {
-                auto* device = local_devices[i];
-                launch_thread_pool_->enqueue(
-                    [device, &program]() { tt_metal::detail::DispatchCompiledProgramToDevice(device, program); },
-                    device->id());
-            }
-            launch_thread_pool_->wait();
-        } else {
-            for (size_t i = 1; i < local_devices.size(); i++) {
-                tt_metal::detail::DispatchCompiledProgramToDevice(local_devices[i], program);
-            }
+    if (local_devices.empty()) {
+        return;
+    }
+
+    // 1st launch program, needs to be serial:
+    // full LaunchProgram on the first device (compiles, finalizes, allocates CBs, etc.)
+    tt_metal::detail::LaunchProgram(local_devices[0], program, false);
+
+    // Remaining device launches can be parallelized: dispatch already-compiled program to remaining devices
+    for (size_t i = 1; i < local_devices.size(); i++) {
+        tt_metal::detail::DispatchCompiledProgramToDevice(local_devices[i], program);
+    }
+
+    std::vector<IDevice*> local_devices_for_wait;
+    for (const auto& coord : coord_range) {
+        if (mesh_device_->impl().is_local(coord)) {
+            local_devices_for_wait.push_back(mesh_device_->impl().get_device(coord));
         }
     }
 
-    for (auto& [coord_range, program] : mesh_workload.get_programs()) {
-        const auto& program_cores = program.impl().logical_cores();
-
-        std::vector<IDevice*> local_devices_for_wait;
-        for (const auto& coord : coord_range) {
-            if (mesh_device_->impl().is_local(coord)) {
-                local_devices_for_wait.push_back(mesh_device_->impl().get_device(coord));
-            }
+    if (blocking) {
+        // Can be parallelized: wait across all devices
+        for (auto* device : local_devices_for_wait) {
+            tt_metal::detail::WaitProgramDone(device, program);
         }
-
-        if (blocking) {
-            // Parallel wait across all devices
-            if (local_devices_for_wait.size() > 1 && launch_thread_pool_) {
-                for (auto* device : local_devices_for_wait) {
-                    launch_thread_pool_->enqueue(
-                        [device, &program]() { tt_metal::detail::WaitProgramDone(device, program); }, device->id());
-                }
-                launch_thread_pool_->wait();
-            } else {
-                for (auto* device : local_devices_for_wait) {
-                    tt_metal::detail::WaitProgramDone(device, program);
-                }
-            }
-        } else {
+    } else {
+        {
+            std::lock_guard<std::mutex> guard(logical_cores_mutex_);
             for (auto* device : local_devices_for_wait) {
                 if (!asynchronous_slow_dispatch_enabled_ ||
                     !logical_cores_for_previous_workload_.contains(device->id())) {
@@ -243,6 +231,38 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
                     }
                 }
             }
+        }
+    }
+}
+
+void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
+        return;  // Skip workload execution for mock devices
+    }
+
+    auto lock = lock_api_function_();
+
+    if (!asynchronous_slow_dispatch_enabled_) {
+        wait_for_cores_idle();
+    }
+
+    auto& range_program_map = mesh_workload.get_programs();
+    const auto num_threads = range_program_map.size();
+    launch_thread_pool_ = create_device_bound_thread_pool(num_threads);
+    if (num_threads > 1) {
+        uint32_t thread_idx = 0;
+        for (auto& [coord_range, program] : range_program_map) {
+            launch_thread_pool_->enqueue(
+                [this, &coord_range, &program, blocking]() {
+                    launch_program_for_range(coord_range, program, blocking);
+                },
+                thread_idx++);
+        }
+
+        launch_thread_pool_->wait();
+    } else {
+        for (auto& [coord_range, program] : range_program_map) {
+            launch_program_for_range(coord_range, program, blocking);
         }
     }
 }

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -239,10 +239,20 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     if (launch_thread_pool_) {
         // Dispatch programs in parallel
         for (auto& [coord_range, program] : range_program_map) {
-            auto first_coord = *coord_range.begin();
-            const auto* const device = mesh_device_->impl().get_device(first_coord);
+            // Find first local device for thread binding
+            IDevice* device = nullptr;
+            for (const auto& coord : coord_range) {
+                if (mesh_device_->impl().is_local(coord)) {
+                    device = mesh_device_->impl().get_device(coord);
+                    break;
+                }
+            }
+            if (!device) {
+                continue;  // No local work for this host
+            }
+            auto* program_ptr = &program;
             launch_thread_pool_->enqueue(
-                [this, &coord_range, &program, blocking]() { dispatch_program(coord_range, program, blocking); },
+                [this, coord_range, program_ptr, blocking]() { dispatch_program(coord_range, *program_ptr, blocking); },
                 device->id());
         }
         launch_thread_pool_->wait();

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/program/program_impl.hpp"
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
+#include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/graph_tracking.hpp>
@@ -190,7 +191,7 @@ void SDMeshCommandQueue::dispatch_program(const MeshCoordinateRange& coord_range
     // since 1 program can span multiple devices on different PCIe links.
     // For 1:1 program-to-device mapping, this loop is empty.
     for (size_t i = 1; i < local_devices.size(); i++) {
-        tt_metal::detail::DispatchCompiledProgramToDevice(local_devices[i], program);
+        tt_metal::experimental::DispatchCompiledProgramToDevice(local_devices[i], program);
     }
 
     if (blocking) {

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -22,23 +22,16 @@ namespace {
 bool logical_cores_intersect(
     const std::vector<std::vector<tt::tt_metal::CoreCoord>>& previous_cores,
     const std::vector<std::vector<tt::tt_metal::CoreCoord>>& current_cores) {
+    // Build a set from previous_cores only, then probe with current_cores directly.
     std::unordered_set<tt::tt_metal::CoreCoord> previous_cores_set;
-    std::unordered_set<tt::tt_metal::CoreCoord> current_cores_set;
-
-    for (const auto& previous_core_group : previous_cores) {
-        for (const auto& previous_core : previous_core_group) {
-            previous_cores_set.insert(previous_core);
-        }
+    for (const auto& core_group : previous_cores) {
+        previous_cores_set.insert(core_group.begin(), core_group.end());
     }
-    for (const auto& current_core_group : current_cores) {
-        for (const auto& current_core : current_core_group) {
-            current_cores_set.insert(current_core);
-        }
-    }
-
-    for (const auto& core : current_cores_set) {
-        if (previous_cores_set.contains(core)) {
-            return true;
+    for (const auto& core_group : current_cores) {
+        for (const auto& core : core_group) {
+            if (previous_cores_set.contains(core)) {
+                return true;
+            }
         }
     }
     return false;
@@ -58,7 +51,12 @@ SDMeshCommandQueue::SDMeshCommandQueue(
         id,
         create_passthrough_thread_pool(mesh_device->impl().get_context_id()),
         std::move(lock_api_function)),
-    active_distributed_context_(std::move(distributed_context)) {}
+    active_distributed_context_(std::move(distributed_context)) {
+    auto local_devices = mesh_device->get_devices();
+    if (local_devices.size() > 1) {
+        launch_thread_pool_ = create_device_bound_thread_pool(local_devices);
+    }
+}
 
 std::optional<MeshTraceId> SDMeshCommandQueue::trace_id() const {
     TT_THROW("Trace not supported for slow dispatch");
@@ -152,6 +150,9 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
 
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         const auto& program_cores = program.impl().logical_cores();
+
+        // Collect local devices for this program, handling async idle checks
+        std::vector<IDevice*> local_devices;
         for (const auto& coord : coord_range) {
             if (!mesh_device_->impl().is_local(coord)) {
                 continue;
@@ -161,26 +162,66 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
                 auto it = logical_cores_for_previous_workload_.find(device->id());
                 if (it != logical_cores_for_previous_workload_.end()) {
                     const auto& previous_cores = it->second;
-                    // Only block before launching the current program if the previous program used the same cores
                     if (logical_cores_intersect(previous_cores, program_cores)) {
                         tt::llrt::internal_::wait_for_idle(device->id(), previous_cores);
-                        // Clear the active cores in use for this device, since we blocked
-                        // on them
                         logical_cores_for_previous_workload_.erase(device->id());
                     }
                 }
             }
+            local_devices.push_back(device);
+        }
 
-            tt_metal::detail::LaunchProgram(device, program, false);
+        if (local_devices.empty()) {
+            continue;
+        }
+
+        // Serial: full LaunchProgram on the first device (compiles, finalizes, allocates CBs, etc.)
+        tt_metal::detail::LaunchProgram(local_devices[0], program, false);
+
+        // Parallel: dispatch already-compiled program to remaining devices
+        if (local_devices.size() > 1 && launch_thread_pool_) {
+            for (size_t i = 1; i < local_devices.size(); i++) {
+                auto* device = local_devices[i];
+                launch_thread_pool_->enqueue(
+                    [device, &program]() { tt_metal::detail::DispatchCompiledProgramToDevice(device, program); },
+                    device->id());
+            }
+            launch_thread_pool_->wait();
+        } else {
+            for (size_t i = 1; i < local_devices.size(); i++) {
+                tt_metal::detail::DispatchCompiledProgramToDevice(local_devices[i], program);
+            }
         }
     }
 
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
+        const auto& program_cores = program.impl().logical_cores();
+
+        std::vector<IDevice*> local_devices_for_wait;
         for (const auto& coord : coord_range) {
             if (mesh_device_->impl().is_local(coord)) {
-                auto* device = mesh_device_->impl().get_device(coord);
-                if (blocking) {
+                local_devices_for_wait.push_back(mesh_device_->impl().get_device(coord));
+            }
+        }
+
+        if (blocking) {
+            // Parallel wait across all devices
+            if (local_devices_for_wait.size() > 1 && launch_thread_pool_) {
+                for (auto* device : local_devices_for_wait) {
+                    launch_thread_pool_->enqueue(
+                        [device, &program]() { tt_metal::detail::WaitProgramDone(device, program); }, device->id());
+                }
+                launch_thread_pool_->wait();
+            } else {
+                for (auto* device : local_devices_for_wait) {
                     tt_metal::detail::WaitProgramDone(device, program);
+                }
+            }
+        } else {
+            for (auto* device : local_devices_for_wait) {
+                if (!asynchronous_slow_dispatch_enabled_ ||
+                    !logical_cores_for_previous_workload_.contains(device->id())) {
+                    logical_cores_for_previous_workload_[device->id()] = program_cores;
                 } else {
                     if (!(asynchronous_slow_dispatch_enabled_ and
                           logical_cores_for_previous_workload_.contains(device->id()))) {

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include <utility>
+#include <unordered_set>
 #include <llrt/tt_cluster.hpp>
 #include <llrt/llrt.hpp>
 #include <distributed/mesh_device_impl.hpp>
@@ -52,9 +53,11 @@ SDMeshCommandQueue::SDMeshCommandQueue(
         create_passthrough_thread_pool(mesh_device->impl().get_context_id()),
         std::move(lock_api_function)),
     active_distributed_context_(std::move(distributed_context)) {
-    auto local_devices = mesh_device->get_devices();
+    // Init thread pool with all local devices for parallel dispatch.
+    // One thread per device enables NUMA-aware CPU binding.
+    auto local_devices = mesh_device_->get_devices();
     if (local_devices.size() > 1) {
-        launch_thread_pool_ = create_device_bound_thread_pool(local_devices);
+        launch_thread_pool_ = create_device_bound_thread_pool(mesh_device_->impl().get_context_id(), local_devices);
     }
 }
 
@@ -137,13 +140,8 @@ void SDMeshCommandQueue::wait_for_cores_idle() {
     }
 }
 
-void SDMeshCommandQueue::launch_program_for_range(
-    const MeshCoordinateRange& coord_range, Program& program, bool blocking) {
+void SDMeshCommandQueue::dispatch_program(const MeshCoordinateRange& coord_range, Program& program, bool blocking) {
     const auto& program_cores = program.impl().logical_cores();
-
-    bool need_wait = false;
-    std::vector<std::vector<CoreCoord>> cores_to_wait;
-    ChipId device_id = 0;
 
     // Collect local devices for this program, handling async idle checks
     std::vector<IDevice*> local_devices;
@@ -152,7 +150,9 @@ void SDMeshCommandQueue::launch_program_for_range(
             continue;
         }
         auto* device = mesh_device_->impl().get_device(coord);
-        need_wait = false;
+        bool need_wait = false;
+        std::vector<std::vector<CoreCoord>> cores_to_wait;
+        ChipId device_id = 0;
         {
             std::lock_guard<std::mutex> guard(logical_cores_mutex_);
             if (asynchronous_slow_dispatch_enabled_) {
@@ -182,52 +182,40 @@ void SDMeshCommandQueue::launch_program_for_range(
         return;
     }
 
-    // 1st launch program, needs to be serial:
-    // full LaunchProgram on the first device (compiles, finalizes, allocates CBs, etc.)
+    // First device: full LaunchProgram (compiles, finalizes, allocates CBs, dispatches)
     tt_metal::detail::LaunchProgram(local_devices[0], program, false);
 
-    // Remaining device launches can be parallelized: dispatch already-compiled program to remaining devices
+    // Remaining devices: dispatch pre-compiled binary only.
+    // TODO: This loop can be parallelized with a inner thread loop
+    // since 1 program can span multiple devices on different PCIe links.
+    // For 1:1 program-to-device mapping, this loop is empty.
     for (size_t i = 1; i < local_devices.size(); i++) {
         tt_metal::detail::DispatchCompiledProgramToDevice(local_devices[i], program);
     }
 
-    std::vector<IDevice*> local_devices_for_wait;
-    for (const auto& coord : coord_range) {
-        if (mesh_device_->impl().is_local(coord)) {
-            local_devices_for_wait.push_back(mesh_device_->impl().get_device(coord));
-        }
-    }
-
     if (blocking) {
         // Can be parallelized: wait across all devices
-        for (auto* device : local_devices_for_wait) {
+        for (auto* device : local_devices) {
             tt_metal::detail::WaitProgramDone(device, program);
         }
     } else {
         {
             std::lock_guard<std::mutex> guard(logical_cores_mutex_);
-            for (auto* device : local_devices_for_wait) {
+            for (auto* device : local_devices) {
                 if (!asynchronous_slow_dispatch_enabled_ ||
                     !logical_cores_for_previous_workload_.contains(device->id())) {
                     logical_cores_for_previous_workload_[device->id()] = program_cores;
                 } else {
-                    if (!(asynchronous_slow_dispatch_enabled_ and
-                          logical_cores_for_previous_workload_.contains(device->id()))) {
-                        // Device had no active cores until this program was launched
-                        logical_cores_for_previous_workload_[device->id()] = program.impl().logical_cores();
-                    } else {
-                        // Device had active cores before this program was launched
-                        // Merge the active cores from the previous program with the active cores from the current
-                        // program
-                        const auto& hal =
-                            tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
-                        auto program_cores = program.impl().logical_cores();
-                        for (uint32_t core_type_index = 0; core_type_index < hal.get_programmable_core_type_count();
-                             core_type_index++) {
-                            auto& active_cores = logical_cores_for_previous_workload_[device->id()][core_type_index];
-                            auto curr_active_cores = program_cores[core_type_index];
-                            active_cores.insert(active_cores.end(), curr_active_cores.begin(), curr_active_cores.end());
-                        }
+                    // Device had active cores before this program was launched
+                    // Merge the active cores from the previous program with the active cores from the current
+                    // program
+                    const auto& hal = tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
+                    auto program_cores = program.impl().logical_cores();
+                    for (uint32_t core_type_index = 0; core_type_index < hal.get_programmable_core_type_count();
+                         core_type_index++) {
+                        auto& active_cores = logical_cores_for_previous_workload_[device->id()][core_type_index];
+                        auto curr_active_cores = program_cores[core_type_index];
+                        active_cores.insert(active_cores.end(), curr_active_cores.begin(), curr_active_cores.end());
                     }
                 }
             }
@@ -247,22 +235,21 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
 
     auto& range_program_map = mesh_workload.get_programs();
-    const auto num_threads = range_program_map.size();
-    launch_thread_pool_ = create_device_bound_thread_pool(num_threads);
-    if (num_threads > 1) {
-        uint32_t thread_idx = 0;
-        for (auto& [coord_range, program] : range_program_map) {
-            launch_thread_pool_->enqueue(
-                [this, &coord_range, &program, blocking]() {
-                    launch_program_for_range(coord_range, program, blocking);
-                },
-                thread_idx++);
-        }
 
+    if (launch_thread_pool_) {
+        // Dispatch programs in parallel
+        for (auto& [coord_range, program] : range_program_map) {
+            auto first_coord = *coord_range.begin();
+            const auto* const device = mesh_device_->impl().get_device(first_coord);
+            launch_thread_pool_->enqueue(
+                [this, &coord_range, &program, blocking]() { dispatch_program(coord_range, program, blocking); },
+                device->id());
+        }
         launch_thread_pool_->wait();
     } else {
+        // Single device: sequential launch
         for (auto& [coord_range, program] : range_program_map) {
-            launch_program_for_range(coord_range, program, blocking);
+            dispatch_program(coord_range, program, blocking);
         }
     }
 }

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -74,6 +74,8 @@ private:
     std::unordered_map<ChipId, std::vector<std::vector<CoreCoord>>> logical_cores_for_previous_workload_;
 
     bool asynchronous_slow_dispatch_enabled_ = false;
+
+    std::shared_ptr<ThreadPool> launch_thread_pool_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -76,6 +76,8 @@ private:
     bool asynchronous_slow_dispatch_enabled_ = false;
 
     std::shared_ptr<ThreadPool> launch_thread_pool_;
+    void launch_program_for_range(const MeshCoordinateRange& coord_range, Program& program, bool blocking);
+    std::mutex logical_cores_mutex_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -76,7 +76,7 @@ private:
     bool asynchronous_slow_dispatch_enabled_ = false;
 
     std::shared_ptr<ThreadPool> launch_thread_pool_;
-    void launch_program_for_range(const MeshCoordinateRange& coord_range, Program& program, bool blocking);
+    void dispatch_program(const MeshCoordinateRange& coord_range, Program& program, bool blocking);
     std::mutex logical_cores_mutex_;
 };
 

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -219,6 +219,7 @@ public:
     void allocate_circular_buffers(const IDevice* device);
     void allocate_dataflow_buffers(const IDevice* device);
     bool is_finalized() const;
+    bool is_compiled() const { return !compiled_.empty(); }
     void set_finalized();
     void allocate_kernel_bin_buf_on_device(IDevice* device);
     bool is_cached() const { return this->cached_device_hash_.has_value(); }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -852,6 +852,42 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
     }
 }
 
+void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
+    ZoneScoped;
+
+    detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
+    detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
+
+    auto device_id = device->id();
+
+    MetalContext::instance().get_cluster().dram_barrier(device_id);
+    MetalContext::instance().get_cluster().l1_barrier(device_id);
+
+    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+         programmable_core_type_index++) {
+        CoreType core_type = hal.get_core_type(programmable_core_type_index);
+        for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
+            auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
+            auto runtime_id = program.get_runtime_id();
+
+            // Use a thread-local copy of launch_msg to avoid racing on the shared KernelGroup state
+            dev_msgs::launch_msg_t local_launch_msg = kg->launch_msg;
+            local_launch_msg.view().kernel_config().host_assigned_id() =
+                runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device_id);
+
+            auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
+            tt::llrt::write_launch_msg_to_core(
+                device_id,
+                physical_core,
+                local_launch_msg.view(),
+                kg->go_msg.view(),
+                device->get_dev_addr(physical_core, HalL1MemAddrType::LAUNCH));
+        }
+    }
+}
+
 void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -446,6 +446,60 @@ std::map<ChipId, IDevice*> CreateDevices(
     return ret_devices;
 }
 
+void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
+    ZoneScoped;
+
+    auto device_id = device->id();
+
+    // Verify program was prepared by prior LaunchProgram call
+    TT_FATAL(
+        program.impl().is_finalized(),
+        "Program must be finalized before calling DispatchCompiledProgramToDevice (target device {}). "
+        "Call LaunchProgram on another device first.",
+        device_id);
+    TT_FATAL(
+        program.impl().is_compiled(),
+        "Program must be compiled on at least one device before calling DispatchCompiledProgramToDevice (target device "
+        "{}). "
+        "Call LaunchProgram on another device first.",
+        device_id);
+
+    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
+    TT_FATAL(
+        !logical_cores_used_in_program.empty(),
+        "Program has no logical cores to dispatch to device {}. Ensure the program has kernels.",
+        device_id);
+
+    detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
+    detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
+
+    MetalContext::instance().get_cluster().dram_barrier(device_id);
+    MetalContext::instance().get_cluster().l1_barrier(device_id);
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+         programmable_core_type_index++) {
+        CoreType core_type = hal.get_core_type(programmable_core_type_index);
+        HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
+        for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
+            auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
+            auto runtime_id = program.get_runtime_id();
+
+            // Use a thread-local copy of launch_msg to avoid racing on the shared KernelGroup state
+            dev_msgs::launch_msg_t local_launch_msg = kg->launch_msg;
+            local_launch_msg.view().kernel_config().host_assigned_id() =
+                runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device_id);
+
+            auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
+            tt::llrt::write_launch_msg_to_core(
+                device_id,
+                physical_core,
+                local_launch_msg.view(),
+                kg->go_msg.view(),
+                hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH));
+        }
+    }
+}
+
 }  // namespace experimental
 
 namespace detail {
@@ -849,42 +903,6 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
     }  // Profiler scope end
     if (wait_until_cores_done) {
         detail::ReadDeviceProfilerResults(device);
-    }
-}
-
-void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
-    ZoneScoped;
-
-    detail::WriteRuntimeArgsToDevice(device, program, /*force_slow_dispatch=*/false);
-    detail::ConfigureDeviceWithProgram(device, program, /*force_slow_dispatch=*/false);
-
-    auto device_id = device->id();
-
-    MetalContext::instance().get_cluster().dram_barrier(device_id);
-    MetalContext::instance().get_cluster().l1_barrier(device_id);
-
-    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
-    const auto& hal = MetalContext::instance().hal();
-    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
-         programmable_core_type_index++) {
-        CoreType core_type = hal.get_core_type(programmable_core_type_index);
-        for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
-            auto* kg = program.impl().kernels_on_core(logical_core, programmable_core_type_index);
-            auto runtime_id = program.get_runtime_id();
-
-            // Use a thread-local copy of launch_msg to avoid racing on the shared KernelGroup state
-            dev_msgs::launch_msg_t local_launch_msg = kg->launch_msg;
-            local_launch_msg.view().kernel_config().host_assigned_id() =
-                runtime_id == 0 ? 0 : detail::EncodePerDeviceProgramID(runtime_id, device_id);
-
-            auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
-            tt::llrt::write_launch_msg_to_core(
-                device_id,
-                physical_core,
-                local_launch_msg.view(),
-                kg->go_msg.view(),
-                device->get_dev_addr(physical_core, HalL1MemAddrType::LAUNCH));
-        }
     }
 }
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
Slow dispatch on multi-device systems (e.g. Galaxy) dispatches programs serially. We can dispatch these independent programs to different devices in parallel and increase throughput over PCIe.

### What's changed
- Create a thread pool (NUMA aware) in `SDMeshCommandQueue` (one thread per device)
- `dispatch_program()` for thread safe per-program dispatch
- `DispatchCompiledProgramToDevice()` API for dispatching pre-compiled binaries concurrently

With this change:
- 1:1 program to device mapping (e.g., 32 programs on 32 devices on a galaxy): Fully parallel dispatch
- 1:N program to device mapping: First device compiles, remaining devices dispatch pre-compiled binary (sequential inner loop)
- Single device: Falls back to sequential dispatch.

Testing:
- Added `MeshDeviceFixture4x8DispatchAgnostic` fixture for benchmarks on Galaxy.
- Benchmark tests: ParallelizationBenchmark (32 programs × 32 devices) with `create_benchmark_programs()` utility for deterministic program creation.
- Observed avg speed up: ~6.5x while dispatching 32 programs to 32 devices in parallel on a Galaxy.
- Multiple TSan enabled test runs flagged no races.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/sd_multithreaded)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/sd_multithreaded)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/sd_multithreaded)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/sd_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/sd_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/sd_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/sd_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
