### PR TITLE
Gemma3 decode optimization Replicated tensors for ttnn.add

### DIFF
--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -218,7 +218,9 @@ class TransformerBlock(LightweightModule):
         residual = x
 
         # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
-        skip_mem_cfg = self.args.get_residual_mem_config(mode, self.prefetcher, special_case=True)
+        skip_mem_cfg = self.args.get_residual_mem_config(
+            mode, self.prefetcher, residual_replicated=self.post_ff_norm is not None
+        )
 
         # assert (
         #     x.memory_config() == skip_mem_cfg
@@ -232,7 +234,11 @@ class TransformerBlock(LightweightModule):
         # Norms take fractured inputs and output replicated across devices
         attn_norm_config = self.args.get_norm_config("attn", mode, self.prefetcher)
         attn_in, residual = self.attention_norm(
-            x, mode, norm_config=attn_norm_config, residual=residual, first_layer=self.first_layer
+            x,
+            mode,
+            norm_config=attn_norm_config,
+            residual=residual if self.pre_ff_norm else None,
+            skip_allgather=not self.first_layer,
         )
 
         # Attention takes replicated inputs and produces fractured outputs
@@ -272,13 +278,12 @@ class TransformerBlock(LightweightModule):
             #         dim=3,
             #         cluster_axis=1,
             #     )
-
-            hidden_states = self.pre_ff_norm(
-                hidden_states, mode, norm_config=pre_ff_norm_config, special_case_gather=True
+            hidden_states = ttnn.add(
+                residual, hidden_states, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None
             )
             residual = hidden_states
             pre_ff_norm_config = self.args.get_norm_config("ff", mode, self.prefetcher)
-            hidden_states = self.pre_ff_norm(hidden_states, mode, norm_config=pre_ff_norm_config)
+            hidden_states = self.pre_ff_norm(hidden_states, mode, norm_config=pre_ff_norm_config, skip_allgather=True)
 
         ttnn.deallocate(attn_out)
 

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -233,13 +233,16 @@ class TransformerBlock(LightweightModule):
 
         # Norms take fractured inputs and output replicated across devices
         attn_norm_config = self.args.get_norm_config("attn", mode, self.prefetcher)
-        attn_in, residual = self.attention_norm(
+        attn_in = self.attention_norm(
             x,
             mode,
             norm_config=attn_norm_config,
             residual=residual if self.pre_ff_norm else None,
             skip_allgather=not self.first_layer,
         )
+
+        if type(attn_in) is tuple:
+            attn_in, residual = attn_in
 
         # Attention takes replicated inputs and produces fractured outputs
         attn_out = self.attention.forward(

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -219,12 +219,13 @@ class TransformerBlock(LightweightModule):
 
         # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
         skip_mem_cfg = self.args.get_residual_mem_config(
-            mode, self.prefetcher, residual_replicated=self.post_ff_norm is not None
+            mode, self.prefetcher, residual_replicated=self.pre_ff_norm is not None
         )
 
-        # assert (
-        #     x.memory_config() == skip_mem_cfg
-        # ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
+        if self.pre_ff_norm is None:
+            assert (
+                x.memory_config() == skip_mem_cfg
+            ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
 
         # Choose the correct rotation matrices based on the mode
         rot_mats = (
@@ -238,7 +239,7 @@ class TransformerBlock(LightweightModule):
             mode,
             norm_config=attn_norm_config,
             residual=residual if self.pre_ff_norm else None,
-            skip_allgather=not self.first_layer,
+            skip_allgather=not self.first_layer and self.pre_ff_norm,
         )
 
         if type(attn_in) is tuple:

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -28,6 +28,7 @@ class TransformerBlock(LightweightModule):
         use_paged_kv_cache=False,
         attention_class=None,
         prefetcher=None,
+        first_layer=False,
     ):
         super().__init__()
 
@@ -47,6 +48,7 @@ class TransformerBlock(LightweightModule):
         self.model_config = args.get_model_config()
         self.is_mixture_of_experts = False
         self.layer_num = layer_num
+        self.first_layer = first_layer
         ActualAttentionClass = attention_class if attention_class is not None else DefaultAttention
 
         self.attention = ActualAttentionClass(
@@ -216,11 +218,11 @@ class TransformerBlock(LightweightModule):
         residual = x
 
         # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
-        skip_mem_cfg = self.args.get_residual_mem_config(mode, self.prefetcher)
+        skip_mem_cfg = self.args.get_residual_mem_config(mode, self.prefetcher, special_case=True)
 
-        assert (
-            x.memory_config() == skip_mem_cfg
-        ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
+        # assert (
+        #     x.memory_config() == skip_mem_cfg
+        # ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
 
         # Choose the correct rotation matrices based on the mode
         rot_mats = (
@@ -229,7 +231,9 @@ class TransformerBlock(LightweightModule):
 
         # Norms take fractured inputs and output replicated across devices
         attn_norm_config = self.args.get_norm_config("attn", mode, self.prefetcher)
-        attn_in = self.attention_norm(x, mode, norm_config=attn_norm_config)
+        attn_in, residual = self.attention_norm(
+            x, mode, norm_config=attn_norm_config, residual=residual, first_layer=self.first_layer
+        )
 
         # Attention takes replicated inputs and produces fractured outputs
         attn_out = self.attention.forward(
@@ -260,17 +264,17 @@ class TransformerBlock(LightweightModule):
         hidden_states = self.ff_norm(hidden_states, mode, norm_config=ff_norm_config)
 
         if self.pre_ff_norm is not None:
-            # Mesh partition ff_norm output to match residual sharding, skip if using distributed norm, because output is already sharded
-            if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
-                hidden_states = ttnn.mesh_partition(
-                    hidden_states,
-                    memory_config=hidden_states.memory_config(),
-                    dim=3,
-                    cluster_axis=1,
-                )
+            # # Mesh partition ff_norm output to match residual sharding, skip if using distributed norm, because output is already sharded
+            # if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
+            #     hidden_states = ttnn.mesh_partition(
+            #         hidden_states,
+            #         memory_config=hidden_states.memory_config(),
+            #         dim=3,
+            #         cluster_axis=1,
+            #     )
 
-            hidden_states = ttnn.add(
-                residual, hidden_states, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None
+            hidden_states = self.pre_ff_norm(
+                hidden_states, mode, norm_config=pre_ff_norm_config, special_case_gather=True
             )
             residual = hidden_states
             pre_ff_norm_config = self.args.get_norm_config("ff", mode, self.prefetcher)
@@ -291,13 +295,13 @@ class TransformerBlock(LightweightModule):
         if self.post_ff_norm is not None:
             post_ff_norm_config = self.args.get_norm_config("ff", mode, self.prefetcher)
             hidden_states = self.post_ff_norm(hidden_states, mode, norm_config=post_ff_norm_config)  # Gathered
-            if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
-                hidden_states = ttnn.mesh_partition(
-                    hidden_states,
-                    memory_config=hidden_states.memory_config(),
-                    dim=3,
-                    cluster_axis=1,
-                )
+            # if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
+            #     hidden_states = ttnn.mesh_partition(
+            #         hidden_states,
+            #         memory_config=hidden_states.memory_config(),
+            #         dim=3,
+            #         cluster_axis=1,
+            #     )
 
         out = ttnn.add(
             residual,

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -127,5 +127,5 @@ class DistributedNorm(LightweightModule):
                 num_buffers_per_channel=2,
             )
         if residual is not None:
-            return x, residual
+            return (x, residual)
         return x

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -51,7 +51,7 @@ class DistributedNorm(LightweightModule):
             )
         self.TG = TG
 
-    def forward(self, x, mode: Mode, norm_config=None):
+    def forward(self, x, mode: Mode, norm_config=None, special_case_gather=False, residual=None, first_layer=True):
         """Apply a norm, possibly gathering inputs if required."""
 
         sharded_output_config = norm_config.get("sharded_output_config") if norm_config else None
@@ -81,7 +81,12 @@ class DistributedNorm(LightweightModule):
         input_mem_cfg = sharded_output_config if mode == Mode.DECODE else ttnn.DRAM_MEMORY_CONFIG
 
         # Distributed norm already performs a gather
-        if self.args.is_multichip and not self.args.is_distributed_norm(mode):
+        if (
+            self.args.is_multichip
+            and not self.args.is_distributed_norm(mode)
+            and not special_case_gather
+            and first_layer
+        ):
             x = ttnn.experimental.all_gather_async(
                 x,
                 persistent_output_buffer=None,
@@ -102,6 +107,8 @@ class DistributedNorm(LightweightModule):
                 num_buffers_per_channel=2,
                 subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
             )
+            if residual is not None:
+                residual = x  # update residual to be the gathered version for use in post-ffn norm in decoder
         else:
             x = ttnn.to_memory_config(x, input_mem_cfg)
 
@@ -124,5 +131,6 @@ class DistributedNorm(LightweightModule):
                 num_workers_per_link=2,
                 num_buffers_per_channel=2,
             )
-
+        if residual is not None:
+            return x, residual
         return x

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -51,7 +51,7 @@ class DistributedNorm(LightweightModule):
             )
         self.TG = TG
 
-    def forward(self, x, mode: Mode, norm_config=None, special_case_gather=False, residual=None, first_layer=True):
+    def forward(self, x, mode: Mode, norm_config=None, skip_allgather=False, residual=None):
         """Apply a norm, possibly gathering inputs if required."""
 
         sharded_output_config = norm_config.get("sharded_output_config") if norm_config else None
@@ -81,12 +81,7 @@ class DistributedNorm(LightweightModule):
         input_mem_cfg = sharded_output_config if mode == Mode.DECODE else ttnn.DRAM_MEMORY_CONFIG
 
         # Distributed norm already performs a gather
-        if (
-            self.args.is_multichip
-            and not self.args.is_distributed_norm(mode)
-            and not special_case_gather
-            and first_layer
-        ):
+        if self.args.is_multichip and not self.args.is_distributed_norm(mode) and not skip_allgather:
             x = ttnn.experimental.all_gather_async(
                 x,
                 persistent_output_buffer=None,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -102,6 +102,7 @@ class Transformer(LightweightModule):
                 use_paged_kv_cache=use_paged_kv_cache,
                 attention_class=attention_class,
                 prefetcher=prefetcher,
+                first_layer=(i == 0),
             )
             for i in tqdm(range(self.n_layers))
         ]
@@ -598,7 +599,7 @@ class Transformer(LightweightModule):
             if mode == Mode.DECODE and not self.args.is_galaxy:
                 x = ttnn.to_memory_config(
                     x,
-                    self.args.get_residual_mem_config(mode, self.prefetcher),
+                    self.args.get_residual_mem_config(mode, self.prefetcher, special_case=i > 0),
                     activation_dtype,
                 )
             elif activation_dtype is not None and x.dtype != activation_dtype:
@@ -625,6 +626,13 @@ class Transformer(LightweightModule):
             return x
 
         # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
+        if mode == Mode.DECODE:
+            x = ttnn.mesh_partition(
+                x,
+                memory_config=x.memory_config(),
+                dim=3,
+                cluster_axis=1,
+            )
         if get_last_token != -1:
             x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
 

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -600,8 +600,8 @@ class Transformer(LightweightModule):
                 x = ttnn.to_memory_config(
                     x,
                     self.args.get_residual_mem_config(
-                        mode, self.prefetcher, residual_replicated=i > 0
-                    ),  # Optimization for models that use replicated residuals in decode - for now models that use pre and post ff norms in decoder (Gemam3 only)
+                        mode, self.prefetcher, residual_replicated=i > 0 and layer.pre_ff_norm is not None
+                    ),  # Optimization for models that use replicated residuals in decode - for now models that use pre and post ff norms in decoder (Gemma3 only)
                     activation_dtype,
                 )
             elif activation_dtype is not None and x.dtype != activation_dtype:
@@ -628,7 +628,7 @@ class Transformer(LightweightModule):
             return x
 
         # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
-        if mode == Mode.DECODE:
+        if mode == Mode.DECODE and self.layers[0].pre_ff_norm is not None:
             x = ttnn.mesh_partition(
                 x,
                 memory_config=x.memory_config(),

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -599,7 +599,9 @@ class Transformer(LightweightModule):
             if mode == Mode.DECODE and not self.args.is_galaxy:
                 x = ttnn.to_memory_config(
                     x,
-                    self.args.get_residual_mem_config(mode, self.prefetcher, special_case=i > 0),
+                    self.args.get_residual_mem_config(
+                        mode, self.prefetcher, residual_replicated=i > 0
+                    ),  # Optimization for models that use replicated residuals in decode - for now models that use pre and post ff norms in decoder (Gemam3 only)
                     activation_dtype,
                 )
             elif activation_dtype is not None and x.dtype != activation_dtype:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1107,30 +1107,18 @@ class ModelArgs:
             elif self.is_galaxy:
                 return ttnn.L1_MEMORY_CONFIG
             else:
-                if residual_replicated:
-                    residual_grid = self.dram_shard_core_grid_for_k(self.dim)
-                    return ttnn.create_sharded_memory_config(
-                        (
-                            self.tile_padded_batch_rows,
-                            self.dim // residual_grid.num_cores,
-                        ),
-                        residual_grid,
-                        ttnn.ShardStrategy.WIDTH,
-                        ttnn.ShardOrientation.ROW_MAJOR,
-                        use_height_and_width_as_shard_shape=True,
-                    )
-                else:
-                    residual_grid = self.dram_shard_core_grid_for_k(self.dim // self.num_devices)
-                    return ttnn.create_sharded_memory_config(
-                        (
-                            self.tile_padded_batch_rows,
-                            self.dim // residual_grid.num_cores // self.num_devices,
-                        ),
-                        residual_grid,
-                        ttnn.ShardStrategy.WIDTH,
-                        ttnn.ShardOrientation.ROW_MAJOR,
-                        use_height_and_width_as_shard_shape=True,
-                    )
+                num_devices = self.num_devices if not residual_replicated else 1
+                residual_grid = self.dram_shard_core_grid_for_k(self.dim // num_devices)
+                return ttnn.create_sharded_memory_config(
+                    (
+                        self.tile_padded_batch_rows,
+                        self.dim // residual_grid.num_cores // num_devices,
+                    ),
+                    residual_grid,
+                    ttnn.ShardStrategy.WIDTH,
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
         elif mode == Mode.PREFILL:
             return ttnn.DRAM_MEMORY_CONFIG
         else:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1087,7 +1087,7 @@ class ModelArgs:
     # RESIDUAL MEMORY CONFIGS
     # =========================================================================
     @lru_cache(maxsize=None)
-    def get_residual_mem_config(self, mode: Mode, prefetcher: Prefetcher = None):
+    def get_residual_mem_config(self, mode: Mode, prefetcher: Prefetcher = None, residual_replicated: bool = False):
         """Get the memory config for decode residual tensors."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
@@ -1107,7 +1107,7 @@ class ModelArgs:
             elif self.is_galaxy:
                 return ttnn.L1_MEMORY_CONFIG
             else:
-                if special_case:
+                if residual_replicated:
                     residual_grid = self.dram_shard_core_grid_for_k(self.dim)
                     return ttnn.create_sharded_memory_config(
                         (

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1107,17 +1107,30 @@ class ModelArgs:
             elif self.is_galaxy:
                 return ttnn.L1_MEMORY_CONFIG
             else:
-                residual_grid = self.dram_shard_core_grid_for_k(self.dim // self.num_devices)
-                return ttnn.create_sharded_memory_config(
-                    (
-                        self.tile_padded_batch_rows,
-                        self.dim // residual_grid.num_cores // self.num_devices,
-                    ),
-                    residual_grid,
-                    ttnn.ShardStrategy.WIDTH,
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    use_height_and_width_as_shard_shape=True,
-                )
+                if special_case:
+                    residual_grid = self.dram_shard_core_grid_for_k(self.dim)
+                    return ttnn.create_sharded_memory_config(
+                        (
+                            self.tile_padded_batch_rows,
+                            self.dim // residual_grid.num_cores,
+                        ),
+                        residual_grid,
+                        ttnn.ShardStrategy.WIDTH,
+                        ttnn.ShardOrientation.ROW_MAJOR,
+                        use_height_and_width_as_shard_shape=True,
+                    )
+                else:
+                    residual_grid = self.dram_shard_core_grid_for_k(self.dim // self.num_devices)
+                    return ttnn.create_sharded_memory_config(
+                        (
+                            self.tile_padded_batch_rows,
+                            self.dim // residual_grid.num_cores // self.num_devices,
+                        ),
+                        residual_grid,
+                        ttnn.ShardStrategy.WIDTH,
+                        ttnn.ShardOrientation.ROW_MAJOR,
+                        use_height_and_width_as_shard_shape=True,
+                    )
         elif mode == Mode.PREFILL:
             return ttnn.DRAM_MEMORY_CONFIG
         else:


### PR DESCRIPTION
Changing `residual` to be `REPLICATED` instead of `SHARDED` for multidevice tensors. With this `all_gather_async` for `LayerNorm` in `post_ff_norm` is escaped and `all_gather_async` for `LayerNorm` on start od decode. Basically with this output of each decoder layer is `REPLICATED` instead of `SHARDED`.
Performance gain from 15 t/s/u to 16.5 t/s/u.

CI before without changes https://github.com/tenstorrent/tt-shield/actions/runs/22738987835/job/65950490105
CI with changes https://github.com/tenstorrent/tt-shield/actions/runs/23348981565/job/67929395036