### PR TITLE
Make hf rope traceable

### DIFF
--- a/models/tt_transformers/tests/conftest.py
+++ b/models/tt_transformers/tests/conftest.py
@@ -35,3 +35,10 @@ def pytest_addoption(parser):
         default=False,
         help="Whether to use HF-style rope, if not passed, the default mllama will be used",
     )
+    parser.addoption(
+        "--rope-perf-mode",
+        action="store",
+        default="full",
+        choices=("full", "prefill", "decode"),
+        help="For test_rope_performance: full = prefill+decode Tracy runs; prefill or decode = that phase only",
+    )

--- a/models/tt_transformers/tests/conftest.py
+++ b/models/tt_transformers/tests/conftest.py
@@ -35,10 +35,3 @@ def pytest_addoption(parser):
         default=False,
         help="Whether to use HF-style rope, if not passed, the default mllama will be used",
     )
-    parser.addoption(
-        "--rope-perf-mode",
-        action="store",
-        default="full",
-        choices=("full", "prefill", "decode"),
-        help="For test_rope_performance: full = prefill+decode Tracy runs; prefill or decode = that phase only",
-    )

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Device profiling harness: compare rotary-embedding op time (HF vs mllama RoPE) via Tracy + simple_text_demo.
+
+Runs selected phase(s) via `--rope-perf-mode` (full, prefill, or decode): 1 layer, seqlen 1024, 2 generated
+tokens, batch sizes 1 and 32 under `python -m tracy`, parses the ops CSV, prints a Markdown table, and
+removes temp dirs on success.
+
+Set the model with env `HF_MODEL` only.
+Optional: set env `MESH_DEVICE` (e.g. ``N150``, ``N300``) — passed through to the Tracy subprocess via
+``os.environ.copy()`` in :func:`_rope_perf_subprocess_env`, same as ``simple_text_demo`` expects.
+
+Example:
+  HF_MODEL=meta-llama/Llama-3.2-1B-Instruct pytest models/tt_transformers/tests/test_rope_performance.py -s
+  HF_MODEL=... pytest ... --rope-perf-mode prefill
+"""
+import csv
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import pytest
+
+# Subprocess owns the mesh; parent must not open UMD / hold the device (see test_device_perf.py
+# lines 23–26). Do not call ttnn.get_num_devices() here — it acquires CHIP_IN_USE and deadlocks the child.
+pytestmark = pytest.mark.no_reset_default_device
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEMO_TEST = "models/tt_transformers/demo/simple_text_demo.py::test_demo_text"
+# Tracy respawns pytest using shell=True + " ".join(argv), so `-k "a and b"` cannot appear on the command line.
+# Pytest parses PYTEST_ADDOPTS with shlex in the child process instead (see _pytest/config/__init__.py).
+PYTEST_ADDOPTS_DEVICE_PERF = '-k "device-perf and performance"'
+
+ROPE_OPS = frozenset(
+    {
+        "RotaryEmbeddingDeviceOperation",
+        "RotaryEmbeddingLlamaDeviceOperation",
+        "RotaryEmbeddingLlamaFusedQKDeviceOperation",
+    }
+)
+
+COL_TRACE = "METAL TRACE ID"
+COL_SESSION = "METAL TRACE REPLAY SESSION ID"
+COL_OP = "OP CODE"
+COL_DEVICE = "DEVICE ID"
+COL_DUR = "DEVICE FW DURATION [ns]"
+
+
+def model_display_id(hf_model: str) -> str:
+    return hf_model.replace("/", "_").replace("-", "_")
+
+
+def parse_ns(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if s == "" or s == "-":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def find_ops_perf_csv(output_root: Path, name_append: str) -> Path:
+    """Mirror Tracy layout: OUTPUT/reports/<name_append>/<YYYY_MM_DD_HH_MM_SS>/ops_perf*.csv"""
+    cfg_dir = output_root / "reports" / name_append
+    if not cfg_dir.is_dir():
+        raise FileNotFoundError(f"No reports subdir for {name_append!r} under {output_root}")
+    ts_dirs = [d for d in cfg_dir.iterdir() if d.is_dir()]
+    if not ts_dirs:
+        raise FileNotFoundError(f"No timestamp subdirs under {cfg_dir}")
+    latest = sorted(ts_dirs, key=lambda p: p.name, reverse=True)[0]
+    matches = sorted(latest.glob("ops_perf*.csv"))
+    if len(matches) != 1:
+        raise FileNotFoundError(f"Expected one ops_perf*.csv in {latest}, found {len(matches)}")
+    return matches[0]
+
+
+def load_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8", errors="replace") as f:
+        return list(csv.DictReader(f))
+
+
+def per_step_rope_ns(rows: list[dict[str, str]]) -> list[tuple[Any, Any, float, float]]:
+    """
+    Returns list of (trace_id, session_id, sum_max_ns, sum_mean_ns) per trace/session,
+    matching diff_rope_prof.per_step_rope_ops_time + scalar grouping.
+    """
+    warmup_indices = [i for i, r in enumerate(rows) if "warmup" in str(r.get(COL_OP, "")).lower()]
+    if len(warmup_indices) >= 1:
+        # Warmup, if present, is a signpost that takes one row, so we skip it
+        body = rows[warmup_indices[-1] + 1 :]
+    else:
+        body = rows
+    rot_rows = [r for r in body if r.get(COL_OP) in ROPE_OPS]
+    if not rot_rows:
+        raise ValueError("No rotary embedding ops after filtering")
+
+    # _op_index = cumcount per (trace, session, op, device)
+    cum: dict[tuple[Any, Any, Any, Any], int] = defaultdict(int)
+    keyed: list[tuple[tuple[Any, Any, Any, int], float | None]] = []
+    for r in rot_rows:
+        tid = r.get(COL_TRACE)
+        sid = r.get(COL_SESSION)
+        op = r.get(COL_OP)
+        dev = r.get(COL_DEVICE)
+        gk = (tid, sid, op, dev)
+        idx = cum[gk]
+        cum[gk] = idx + 1
+        keyed.append(((tid, sid, op, idx), parse_ns(r.get(COL_DUR))))
+
+    # Inner group: (trace, session, op, op_index) -> max/mean of DEVICE FW over rows in group
+    inner_groups: dict[tuple[Any, Any, Any, int], list[float]] = defaultdict(list)
+    for k, dur in keyed:
+        if dur is not None:
+            inner_groups[k].append(dur)
+
+    inner_sums: dict[tuple[Any, Any], list[tuple[float, float]]] = defaultdict(list)
+    for (tid, sid, op, op_i), vals in inner_groups.items():
+        if not vals:
+            continue
+        mx = max(vals)
+        mean = sum(vals) / len(vals)
+        inner_sums[(tid, sid)].append((mx, mean))
+
+    out: list[tuple[Any, Any, float, float]] = []
+    for (tid, sid), pairs in inner_sums.items():
+        smx = sum(p[0] for p in pairs)
+        smn = sum(p[1] for p in pairs)
+        out.append((tid, sid, smx, smn))
+    return out
+
+
+def scalar_rope_time_ns(rows: list[dict[str, str]]) -> tuple[float, float]:
+    per = per_step_rope_ns(rows)
+    if not per:
+        raise ValueError("No per-step rope aggregates")
+    n = len(per)
+    max_mean = sum(t[2] for t in per) / n
+    mean_mean = sum(t[3] for t in per) / n
+    return max_mean, mean_mean
+
+
+def pct_diff(hf_val: float, llama_val: float) -> float:
+    if hf_val == 0:
+        return float("nan")
+    return 100.0 * (hf_val - llama_val) / hf_val
+
+
+def ratio(hf_val: float, llama_val: float) -> float:
+    if llama_val == 0:
+        return float("nan")
+    return hf_val / llama_val
+
+
+def _rope_perf_demo_pytest_args(*, batch_size: int, use_hf_rope: bool, mode: str) -> list[str]:
+    """Arguments after ``python -m pytest`` for the simple_text_demo RoPE perf configuration."""
+    args = [
+        DEMO_TEST,
+        "--mode",
+        mode,
+        "--num_layers",
+        "1",
+        "--max_seq_len",
+        "1024",
+        "--max_generated_tokens",
+        "2",
+        "--batch_size",
+        str(batch_size),
+    ]
+    if use_hf_rope:
+        args.append("--use_hf_rope")
+    return args
+
+
+def rope_perf_pytest_argv(*, batch_size: int, use_hf_rope: bool, mode: str = "prefill") -> list[str]:
+    """
+    Full argv to run the demo test under pytest without Tracy (same workload as the Tracy harness).
+
+    Example: ``subprocess.run(rope_perf_pytest_argv(...), cwd=repo_root, env=env, check=True)``
+    """
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        *_rope_perf_demo_pytest_args(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode),
+    ]
+
+
+def rope_perf_tracy_argv(*, output_dir: Path | str, run_name: str, pytest_argv: list[str]) -> list[str]:
+    """
+    Wrap a full ``python -m pytest ...`` argv produced by :func:`rope_perf_pytest_argv` with Tracy.
+
+    ``pytest_argv`` must be ``[sys.executable, '-m', 'pytest', ...]`` so everything after ``pytest``
+    is forwarded to the child pytest invocation.
+    """
+    if len(pytest_argv) < 3 or pytest_argv[1:3] != ["-m", "pytest"]:
+        raise ValueError("pytest_argv must start with [executable, '-m', 'pytest', ...]")
+    demo_args = pytest_argv[3:]
+    return [
+        sys.executable,
+        "-m",
+        "tracy",
+        "-v",
+        "-r",
+        "-p",
+        "-o",
+        str(output_dir),
+        "-n",
+        run_name,
+        "--check-exit-code",
+        "-m",
+        "pytest",
+        *demo_args,
+    ]
+
+
+def _run_tracy(
+    *,
+    repo_root: Path,
+    env: dict[str, str],
+    argv: list[str],
+    timeout_sec: int | None = None,
+) -> None:
+    subprocess.run(
+        argv,
+        cwd=repo_root,
+        env=env,
+        check=True,
+        timeout=timeout_sec if timeout_sec is not None else int(os.environ.get("ROPE_PERF_TRACY_TIMEOUT_SEC", "3600")),
+    )
+
+
+def _run_tracy_demo(
+    *,
+    repo_root: Path,
+    hf_model: str,
+    batch_size: int,
+    use_hf_rope: bool,
+    run_name: str,
+    mode: str,
+) -> list[dict[str, str]]:
+    env = _rope_perf_subprocess_env(hf_model=hf_model)
+
+    with TemporaryDirectory(prefix="rope_perf_") as tmp:
+        pytest_cmd = rope_perf_pytest_argv(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode)
+        argv = rope_perf_tracy_argv(output_dir=tmp, run_name=run_name, pytest_argv=pytest_cmd)
+        _run_tracy(repo_root=repo_root, env=env, argv=argv)
+        csv_path = find_ops_perf_csv(Path(tmp), run_name)
+        return load_rows(csv_path)
+
+
+def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
+    """Environment for the rope-perf demo subprocess (with or without Tracy).
+
+    Starts from ``os.environ.copy()`` so ``MESH_DEVICE`` and other vars are inherited unchanged; only
+    rope-perf-specific keys are overwritten below. Do not inherit parent pytest's ``PYTEST_ADDOPTS``;
+    device-perf test selection is applied via ``PYTEST_ADDOPTS`` (see module comment above).
+    """
+    env = os.environ.copy()
+    env["HF_MODEL"] = hf_model
+    env["TT_METAL_DEVICE_PROFILER"] = "1"
+    env["PYTEST_ADDOPTS"] = PYTEST_ADDOPTS_DEVICE_PERF
+    return env
+
+
+def _rope_perf_demo_modes(rope_perf_mode: str) -> tuple[str, ...]:
+    """Map ``--rope-perf-mode`` to simple_text_demo ``--mode`` values (prefill and/or decode)."""
+    key = rope_perf_mode.strip().lower()
+    if key == "full":
+        return ("prefill", "decode")
+    if key == "prefill":
+        return ("prefill",)
+    if key == "decode":
+        return ("decode",)
+    raise ValueError(f"Invalid rope perf mode: {rope_perf_mode!r}")
+
+
+def _markdown_table(rows: list[dict[str, Any]]) -> str:
+    headers = [
+        "model_id",
+        "mode",
+        "gen_tok",
+        "batch_size",
+        "pct_diff_max_%",
+        "pct_diff_mean_%",
+        "ratio_max",
+        "ratio_mean",
+        "hf_rope_max_mean_ns",
+        "mllama_rope_max_mean_ns",
+    ]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for r in rows:
+        lines.append("| " + " | ".join(str(r[h]) for h in headers) + " |")
+    return "\n".join(lines)
+
+
+@pytest.mark.timeout(14400)
+def test_rope_performance_comparison_table(request):
+    """
+    Compare HF vs mllama RoPE device time for phase(s) selected by ``--rope-perf-mode`` (full, prefill,
+    or decode), bs in {1, 32}, 1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
+    Optional ``MESH_DEVICE`` is inherited by the Tracy subprocess. Prints a Markdown table (run pytest with -s).
+    """
+    hf_model = os.environ.get("HF_MODEL")
+    assert (
+        hf_model is not None
+    ), "HF_MODEL is not set, it needs to be set to a HuggingFace model name, for example: export HF_MODEL=meta-llama/Llama-3.2-1B-Instruct"
+    rope_perf_mode = request.config.getoption("--rope-perf-mode")
+    demo_modes = _rope_perf_demo_modes(rope_perf_mode)
+    model_id = model_display_id(hf_model)
+
+    table_rows: list[dict[str, Any]] = []
+    for mode in demo_modes:
+        for batch_size in (1, 32):
+            base = f"ropeperf_{mode}_g2_sl1024_bs{batch_size}"
+            llama_rows = _run_tracy_demo(
+                repo_root=REPO_ROOT,
+                hf_model=hf_model,
+                batch_size=batch_size,
+                use_hf_rope=False,
+                run_name=f"{base}_mllama",
+                mode=mode,
+            )
+            hf_rows = _run_tracy_demo(
+                repo_root=REPO_ROOT,
+                hf_model=hf_model,
+                batch_size=batch_size,
+                use_hf_rope=True,
+                run_name=f"{base}_hf",
+                mode=mode,
+            )
+            lm, lmean = scalar_rope_time_ns(llama_rows)
+            hm, hmean = scalar_rope_time_ns(hf_rows)
+            table_rows.append(
+                {
+                    "model_id": model_id,
+                    "mode": mode,
+                    "gen_tok": 2,
+                    "batch_size": batch_size,
+                    "pct_diff_max_%": f"{pct_diff(hm, lm):.2f}",
+                    "pct_diff_mean_%": f"{pct_diff(hmean, lmean):.2f}",
+                    "ratio_max": f"{ratio(hm, lm):.4f}",
+                    "ratio_mean": f"{ratio(hmean, lmean):.4f}",
+                    "hf_rope_max_mean_ns": f"{hm:.0f}",
+                    "mllama_rope_max_mean_ns": f"{lm:.0f}",
+                }
+            )
+
+    md = _markdown_table(table_rows)
+    mesh_device_env = os.environ.get("MESH_DEVICE")
+    mesh_device_display = mesh_device_env if mesh_device_env else "(unset — demo mesh from available devices)"
+    print("\n### RoPE device time (HF vs mllama)\n")
+    print(f"`HF_MODEL`: `{hf_model}`")
+    print(f"`MESH_DEVICE`: `{mesh_device_display}`")
+    print(f"`--rope-perf-mode`: `{rope_perf_mode}` (demo phases: {', '.join(demo_modes)})\n")
+    print(
+        "*Difference metrics (per table row, using aggregated HF vs mllama RoPE nanoseconds):* "
+        "`pct_diff_*` = 100 × (HF − mllama) / HF (%); "
+        "`ratio_*` = HF / mllama.\n"
+    )
+    print(md)
+    print()

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -6,7 +6,7 @@ Device profiling harness: compare rotary-embedding op time (HF vs mllama RoPE) v
 
 Runs once per parametrized demo phase (``prefill`` or ``decode``): 1 layer, seqlen 1024, 2 generated
 tokens, batch sizes 1 and 32 under `python -m tracy`, parses the ops CSV and captured demo logs (TTFT,
-decode tok/s/user), prints a Markdown table, and removes temp dirs on success.
+decode tok/s/user), logs a Markdown table (via loguru), and removes temp dirs on success.
 
 Set the model with env `HF_MODEL` only. Phase is selected via :func:`pytest.mark.parametrize` on
 ``rope_perf_mode`` (``prefill`` or ``decode``).
@@ -28,6 +28,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 import pytest
+from loguru import logger
 
 # Subprocess owns the mesh; parent must not open UMD / hold the device (see test_device_perf.py
 # lines 23–26). Do not call ttnn.get_num_devices() here — it acquires CHIP_IN_USE and deadlocks the child.
@@ -285,8 +286,8 @@ def _run_tracy(
     timeout_sec: int | None = None,
 ) -> str:
     """
-    Run Tracy + pytest; capture combined stdout/stderr for parsing demo perf logs, and echo to the parent
-    console so ``pytest -s`` still shows child output.
+    Run Tracy + pytest; capture combined stdout/stderr for parsing demo perf logs, and log child output
+    with ``logger.info`` so ``pytest -s`` still shows it (via loguru sinks).
     """
     proc = subprocess.run(
         argv,
@@ -298,9 +299,9 @@ def _run_tracy(
         text=True,
     )
     if proc.stdout:
-        print(proc.stdout, end="")
+        logger.info(proc.stdout)
     if proc.stderr:
-        print(proc.stderr, end="", file=sys.stderr)
+        logger.info(proc.stderr)
     return (proc.stdout or "") + "\n" + (proc.stderr or "")
 
 
@@ -372,7 +373,7 @@ def test_rope_performance_comparison_table(rope_perf_mode: str):
     """
     Compare HF vs mllama RoPE device time for ``rope_perf_mode`` (prefill or decode), bs in {1, 32},
     1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
-    Optional ``MESH_DEVICE`` is inherited by the Tracy subprocess. Prints a Markdown table (run pytest with -s).
+    Optional ``MESH_DEVICE`` is inherited by the Tracy subprocess. Logs a Markdown table (run pytest with -s).
     """
     hf_model = os.environ.get("HF_MODEL")
     assert (
@@ -429,11 +430,11 @@ def test_rope_performance_comparison_table(rope_perf_mode: str):
     md = _markdown_table(table_rows)
     mesh_device_env = os.environ.get("MESH_DEVICE")
     mesh_device_display = mesh_device_env if mesh_device_env else "(unset — demo mesh from available devices)"
-    print("\n### RoPE device time (HF vs mllama)\n")
-    print(f"`HF_MODEL`: `{hf_model}`")
-    print(f"`MESH_DEVICE`: `{mesh_device_display}`")
-    print(f"`rope_perf_mode`: `{rope_perf_mode}`")
-    print(
+    logger.info("\n### RoPE device time (HF vs mllama)\n")
+    logger.info(f"`HF_MODEL`: `{hf_model}`")
+    logger.info(f"`MESH_DEVICE`: `{mesh_device_display}`")
+    logger.info(f"`rope_perf_mode`: `{rope_perf_mode}`")
+    logger.info(
         "*Difference metrics (per table row; HF vs mllama):* "
         "`pct_diff_ttft_%` / `pct_diff_tok_s_u_%` / `pct_diff_rope_*` = 100 × (HF − mllama) / HF. "
         "For TTFT and RoPE (time), a positive % means HF uses more time than mllama. "
@@ -441,5 +442,5 @@ def test_rope_performance_comparison_table(rope_perf_mode: str):
         "`ratio_*` = HF / mllama. "
         "`delta_rope_max_mean_ns` = HF − mllama (aggregated RoPE max-mean ns).\n"
     )
-    print(md)
-    print()
+    logger.info(md)
+    logger.info("")

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -4,17 +4,18 @@
 """
 Device profiling harness: compare rotary-embedding op time (HF vs mllama RoPE) via Tracy + simple_text_demo.
 
-Runs selected phase(s) via `--rope-perf-mode` (full, prefill, or decode): 1 layer, seqlen 1024, 2 generated
-tokens, batch sizes 1 and 32 under `python -m tracy`, parses the ops CSV, prints a Markdown table, and
-removes temp dirs on success.
+Runs selected phase(s) per module constant :data:`ROPE_PERF_MODE` (``"full"``, ``"prefill"``, or
+``"decode"``): 1 layer, seqlen 1024, 2 generated tokens, batch sizes 1 and 32 under `python -m tracy`,
+parses the ops CSV, prints a Markdown table, and removes temp dirs on success.
 
-Set the model with env `HF_MODEL` only.
+Set the model with env `HF_MODEL` only. Edit ``ROPE_PERF_MODE`` in this file to change which demo phase(s)
+run (``full`` = prefill + decode; ``prefill`` or ``decode`` = that phase only).
+
 Optional: set env `MESH_DEVICE` (e.g. ``N150``, ``N300``) — passed through to the Tracy subprocess via
 ``os.environ.copy()`` in :func:`_rope_perf_subprocess_env`, same as ``simple_text_demo`` expects.
 
 Example:
   HF_MODEL=meta-llama/Llama-3.2-1B-Instruct pytest models/tt_transformers/tests/test_rope_performance.py -s
-  HF_MODEL=... pytest ... --rope-perf-mode prefill
 """
 import csv
 import os
@@ -36,6 +37,11 @@ DEMO_TEST = "models/tt_transformers/demo/simple_text_demo.py::test_demo_text"
 # Tracy respawns pytest using shell=True + " ".join(argv), so `-k "a and b"` cannot appear on the command line.
 # Pytest parses PYTEST_ADDOPTS with shlex in the child process instead (see _pytest/config/__init__.py).
 PYTEST_ADDOPTS_DEVICE_PERF = '-k "device-perf and performance"'
+
+TIMEOUT_TEST = 1200
+
+# Which simple_text_demo phase(s) to profile: "full" (prefill + decode), "prefill", or "decode".
+ROPE_PERF_MODE = "full"
 
 ROPE_OPS = frozenset(
     {
@@ -160,7 +166,9 @@ def ratio(hf_val: float, llama_val: float) -> float:
     return hf_val / llama_val
 
 
-def _rope_perf_demo_pytest_args(*, batch_size: int, use_hf_rope: bool, mode: str) -> list[str]:
+def _rope_perf_demo_pytest_args(
+    *, batch_size: int, use_hf_rope: bool, mode: str, timeout: int | None = None
+) -> list[str]:
     """Arguments after ``python -m pytest`` for the simple_text_demo RoPE perf configuration."""
     args = [
         DEMO_TEST,
@@ -177,10 +185,15 @@ def _rope_perf_demo_pytest_args(*, batch_size: int, use_hf_rope: bool, mode: str
     ]
     if use_hf_rope:
         args.append("--use_hf_rope")
+    if timeout is not None:
+        args.append("--timeout")
+        args.append(str(timeout))
     return args
 
 
-def rope_perf_pytest_argv(*, batch_size: int, use_hf_rope: bool, mode: str = "prefill") -> list[str]:
+def rope_perf_pytest_argv(
+    *, batch_size: int, use_hf_rope: bool, mode: str = "prefill", timeout: int | None = None
+) -> list[str]:
     """
     Full argv to run the demo test under pytest without Tracy (same workload as the Tracy harness).
 
@@ -190,7 +203,7 @@ def rope_perf_pytest_argv(*, batch_size: int, use_hf_rope: bool, mode: str = "pr
         sys.executable,
         "-m",
         "pytest",
-        *_rope_perf_demo_pytest_args(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode),
+        *_rope_perf_demo_pytest_args(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode, timeout=timeout),
     ]
 
 
@@ -246,11 +259,12 @@ def _run_tracy_demo(
     use_hf_rope: bool,
     run_name: str,
     mode: str,
+    timeout: int | None = None,
 ) -> list[dict[str, str]]:
     env = _rope_perf_subprocess_env(hf_model=hf_model)
 
     with TemporaryDirectory(prefix="rope_perf_") as tmp:
-        pytest_cmd = rope_perf_pytest_argv(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode)
+        pytest_cmd = rope_perf_pytest_argv(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode, timeout=timeout)
         argv = rope_perf_tracy_argv(output_dir=tmp, run_name=run_name, pytest_argv=pytest_cmd)
         _run_tracy(repo_root=repo_root, env=env, argv=argv)
         csv_path = find_ops_perf_csv(Path(tmp), run_name)
@@ -272,7 +286,7 @@ def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
 
 
 def _rope_perf_demo_modes(rope_perf_mode: str) -> tuple[str, ...]:
-    """Map ``--rope-perf-mode`` to simple_text_demo ``--mode`` values (prefill and/or decode)."""
+    """Map :data:`ROPE_PERF_MODE` / mode string to simple_text_demo ``--mode`` values (prefill and/or decode)."""
     key = rope_perf_mode.strip().lower()
     if key == "full":
         return ("prefill", "decode")
@@ -306,18 +320,17 @@ def _markdown_table(rows: list[dict[str, Any]]) -> str:
 
 
 @pytest.mark.timeout(14400)
-def test_rope_performance_comparison_table(request):
+def test_rope_performance_comparison_table():
     """
-    Compare HF vs mllama RoPE device time for phase(s) selected by ``--rope-perf-mode`` (full, prefill,
-    or decode), bs in {1, 32}, 1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
+    Compare HF vs mllama RoPE device time for phase(s) from :data:`ROPE_PERF_MODE` (full, prefill, or decode),
+    bs in {1, 32}, 1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
     Optional ``MESH_DEVICE`` is inherited by the Tracy subprocess. Prints a Markdown table (run pytest with -s).
     """
     hf_model = os.environ.get("HF_MODEL")
     assert (
         hf_model is not None
     ), "HF_MODEL is not set, it needs to be set to a HuggingFace model name, for example: export HF_MODEL=meta-llama/Llama-3.2-1B-Instruct"
-    rope_perf_mode = request.config.getoption("--rope-perf-mode")
-    demo_modes = _rope_perf_demo_modes(rope_perf_mode)
+    demo_modes = _rope_perf_demo_modes(ROPE_PERF_MODE)
     model_id = model_display_id(hf_model)
 
     table_rows: list[dict[str, Any]] = []
@@ -331,6 +344,7 @@ def test_rope_performance_comparison_table(request):
                 use_hf_rope=False,
                 run_name=f"{base}_mllama",
                 mode=mode,
+                timeout=TIMEOUT_TEST,
             )
             hf_rows = _run_tracy_demo(
                 repo_root=REPO_ROOT,
@@ -339,6 +353,7 @@ def test_rope_performance_comparison_table(request):
                 use_hf_rope=True,
                 run_name=f"{base}_hf",
                 mode=mode,
+                timeout=TIMEOUT_TEST,
             )
             lm, lmean = scalar_rope_time_ns(llama_rows)
             hm, hmean = scalar_rope_time_ns(hf_rows)
@@ -363,7 +378,7 @@ def test_rope_performance_comparison_table(request):
     print("\n### RoPE device time (HF vs mllama)\n")
     print(f"`HF_MODEL`: `{hf_model}`")
     print(f"`MESH_DEVICE`: `{mesh_device_display}`")
-    print(f"`--rope-perf-mode`: `{rope_perf_mode}` (demo phases: {', '.join(demo_modes)})\n")
+    print(f"`ROPE_PERF_MODE`: `{ROPE_PERF_MODE}` (demo phases: {', '.join(demo_modes)})\n")
     print(
         "*Difference metrics (per table row, using aggregated HF vs mllama RoPE nanoseconds):* "
         "`pct_diff_*` = 100 × (HF − mllama) / HF (%); "

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -6,7 +6,7 @@ Device profiling harness: compare rotary-embedding op time (HF vs mllama RoPE) v
 
 Runs selected phase(s) per module constant :data:`ROPE_PERF_MODE` (``"full"``, ``"prefill"``, or
 ``"decode"``): 1 layer, seqlen 1024, 2 generated tokens, batch sizes 1 and 32 under `python -m tracy`,
-parses the ops CSV, prints a Markdown table, and removes temp dirs on success.
+parses the ops CSV and captured demo logs (TTFT, decode tok/s/user), prints a Markdown table, and removes temp dirs on success.
 
 Set the model with env `HF_MODEL` only. Edit ``ROPE_PERF_MODE`` in this file to change which demo phase(s)
 run (``full`` = prefill + decode; ``prefill`` or ``decode`` = that phase only).
@@ -19,6 +19,7 @@ Example:
 """
 import csv
 import os
+import re
 import subprocess
 import sys
 from collections import defaultdict
@@ -166,6 +167,50 @@ def ratio(hf_val: float, llama_val: float) -> float:
     return hf_val / llama_val
 
 
+# Logged by simple_text_demo.py after inference (see Performance metrics block).
+_RE_TTFT_MS = re.compile(r"Average Time to First Token \(TTFT\):\s*([0-9.]+)\s*ms")
+_RE_AVG_SPEED = re.compile(
+    r"Average speed:\s*([0-9.]+)\s*ms @\s*([0-9.]+)\s*tok/s/user",
+    re.IGNORECASE,
+)
+
+
+def parse_simple_text_demo_perf_log(log: str) -> tuple[float | None, float | None]:
+    """
+    Parse TTFT (ms) and decode throughput (tok/s/user) from captured pytest/demo subprocess output.
+
+    If a pattern appears multiple times (e.g. several tests), the last match is used.
+    """
+    ttft_hits = _RE_TTFT_MS.findall(log)
+    speed_hits = _RE_AVG_SPEED.findall(log)
+    ttft_ms = float(ttft_hits[-1]) if ttft_hits else None
+    tok_s_u = float(speed_hits[-1][1]) if speed_hits else None
+    return ttft_ms, tok_s_u
+
+
+def _fmt_pct_diff(hf_val: float | None, llama_val: float | None) -> str:
+    if hf_val is None or llama_val is None:
+        return "n/a"
+    if hf_val == 0:
+        return "n/a"
+    return f"{pct_diff(hf_val, llama_val):.2f}"
+
+
+def _fmt_ratio_metric(hf_val: float | None, llama_val: float | None) -> str:
+    if hf_val is None or llama_val is None:
+        return "n/a"
+    r = ratio(hf_val, llama_val)
+    if r != r:  # NaN
+        return "n/a"
+    return f"{r:.4f}"
+
+
+def _fmt_float_opt(x: float | None, *, ndigits: int) -> str:
+    if x is None:
+        return "n/a"
+    return f"{x:.{ndigits}f}"
+
+
 def _rope_perf_demo_pytest_args(
     *, batch_size: int, use_hf_rope: bool, mode: str, timeout: int | None = None
 ) -> list[str]:
@@ -241,14 +286,25 @@ def _run_tracy(
     env: dict[str, str],
     argv: list[str],
     timeout_sec: int | None = None,
-) -> None:
-    subprocess.run(
+) -> str:
+    """
+    Run Tracy + pytest; capture combined stdout/stderr for parsing demo perf logs, and echo to the parent
+    console so ``pytest -s`` still shows child output.
+    """
+    proc = subprocess.run(
         argv,
         cwd=repo_root,
         env=env,
         check=True,
         timeout=timeout_sec if timeout_sec is not None else int(os.environ.get("ROPE_PERF_TRACY_TIMEOUT_SEC", "3600")),
+        capture_output=True,
+        text=True,
     )
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+    return (proc.stdout or "") + "\n" + (proc.stderr or "")
 
 
 def _run_tracy_demo(
@@ -260,15 +316,15 @@ def _run_tracy_demo(
     run_name: str,
     mode: str,
     timeout: int | None = None,
-) -> list[dict[str, str]]:
+) -> tuple[list[dict[str, str]], str]:
     env = _rope_perf_subprocess_env(hf_model=hf_model)
 
     with TemporaryDirectory(prefix="rope_perf_") as tmp:
         pytest_cmd = rope_perf_pytest_argv(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode, timeout=timeout)
         argv = rope_perf_tracy_argv(output_dir=tmp, run_name=run_name, pytest_argv=pytest_cmd)
-        _run_tracy(repo_root=repo_root, env=env, argv=argv)
+        captured_log = _run_tracy(repo_root=repo_root, env=env, argv=argv)
         csv_path = find_ops_perf_csv(Path(tmp), run_name)
-        return load_rows(csv_path)
+        return load_rows(csv_path), captured_log
 
 
 def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
@@ -303,12 +359,21 @@ def _markdown_table(rows: list[dict[str, Any]]) -> str:
         "mode",
         "gen_tok",
         "batch_size",
-        "pct_diff_max_%",
-        "pct_diff_mean_%",
-        "ratio_max",
-        "ratio_mean",
+        "hf_ttft_ms",
+        "mllama_ttft_ms",
+        "pct_diff_ttft_%",
+        "ratio_ttft",
+        "hf_tok_s_u",
+        "mllama_tok_s_u",
+        "pct_diff_tok_s_u_%",
+        "ratio_tok_s_u",
         "hf_rope_max_mean_ns",
         "mllama_rope_max_mean_ns",
+        "delta_rope_max_mean_ns",
+        "pct_diff_rope_max_%",
+        "pct_diff_rope_mean_%",
+        "ratio_rope_max",
+        "ratio_rope_mean",
     ]
     lines = [
         "| " + " | ".join(headers) + " |",
@@ -337,7 +402,7 @@ def test_rope_performance_comparison_table():
     for mode in demo_modes:
         for batch_size in (1, 32):
             base = f"ropeperf_{mode}_g2_sl1024_bs{batch_size}"
-            llama_rows = _run_tracy_demo(
+            llama_rows, llama_log = _run_tracy_demo(
                 repo_root=REPO_ROOT,
                 hf_model=hf_model,
                 batch_size=batch_size,
@@ -346,7 +411,7 @@ def test_rope_performance_comparison_table():
                 mode=mode,
                 timeout=TIMEOUT_TEST,
             )
-            hf_rows = _run_tracy_demo(
+            hf_rows, hf_log = _run_tracy_demo(
                 repo_root=REPO_ROOT,
                 hf_model=hf_model,
                 batch_size=batch_size,
@@ -357,18 +422,29 @@ def test_rope_performance_comparison_table():
             )
             lm, lmean = scalar_rope_time_ns(llama_rows)
             hm, hmean = scalar_rope_time_ns(hf_rows)
+            hf_ttft_ms, hf_tok_s_u = parse_simple_text_demo_perf_log(hf_log)
+            ml_ttft_ms, ml_tok_s_u = parse_simple_text_demo_perf_log(llama_log)
             table_rows.append(
                 {
                     "model_id": model_id,
                     "mode": mode,
                     "gen_tok": 2,
                     "batch_size": batch_size,
-                    "pct_diff_max_%": f"{pct_diff(hm, lm):.2f}",
-                    "pct_diff_mean_%": f"{pct_diff(hmean, lmean):.2f}",
-                    "ratio_max": f"{ratio(hm, lm):.4f}",
-                    "ratio_mean": f"{ratio(hmean, lmean):.4f}",
+                    "hf_ttft_ms": _fmt_float_opt(hf_ttft_ms, ndigits=2),
+                    "mllama_ttft_ms": _fmt_float_opt(ml_ttft_ms, ndigits=2),
+                    "pct_diff_ttft_%": _fmt_pct_diff(hf_ttft_ms, ml_ttft_ms),
+                    "ratio_ttft": _fmt_ratio_metric(hf_ttft_ms, ml_ttft_ms),
+                    "hf_tok_s_u": _fmt_float_opt(hf_tok_s_u, ndigits=2),
+                    "mllama_tok_s_u": _fmt_float_opt(ml_tok_s_u, ndigits=2),
+                    "pct_diff_tok_s_u_%": _fmt_pct_diff(hf_tok_s_u, ml_tok_s_u),
+                    "ratio_tok_s_u": _fmt_ratio_metric(hf_tok_s_u, ml_tok_s_u),
                     "hf_rope_max_mean_ns": f"{hm:.0f}",
                     "mllama_rope_max_mean_ns": f"{lm:.0f}",
+                    "delta_rope_max_mean_ns": f"{hm - lm:.0f}",
+                    "pct_diff_rope_max_%": f"{pct_diff(hm, lm):.2f}",
+                    "pct_diff_rope_mean_%": f"{pct_diff(hmean, lmean):.2f}",
+                    "ratio_rope_max": f"{ratio(hm, lm):.4f}",
+                    "ratio_rope_mean": f"{ratio(hmean, lmean):.4f}",
                 }
             )
 
@@ -380,9 +456,12 @@ def test_rope_performance_comparison_table():
     print(f"`MESH_DEVICE`: `{mesh_device_display}`")
     print(f"`ROPE_PERF_MODE`: `{ROPE_PERF_MODE}` (demo phases: {', '.join(demo_modes)})\n")
     print(
-        "*Difference metrics (per table row, using aggregated HF vs mllama RoPE nanoseconds):* "
-        "`pct_diff_*` = 100 × (HF − mllama) / HF (%); "
-        "`ratio_*` = HF / mllama.\n"
+        "*Difference metrics (per table row; HF vs mllama):* "
+        "`pct_diff_ttft_%` / `pct_diff_tok_s_u_%` / `pct_diff_rope_*` = 100 × (HF − mllama) / HF. "
+        "For TTFT and RoPE (time), a positive % means HF uses more time than mllama. "
+        "For decode `tok/s/user`, a positive % means HF is faster (higher throughput). "
+        "`ratio_*` = HF / mllama. "
+        "`delta_rope_max_mean_ns` = HF − mllama (aggregated RoPE max-mean ns).\n"
     )
     print(md)
     print()

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -4,12 +4,12 @@
 """
 Device profiling harness: compare rotary-embedding op time (HF vs mllama RoPE) via Tracy + simple_text_demo.
 
-Runs selected phase(s) per module constant :data:`ROPE_PERF_MODE` (``"full"``, ``"prefill"``, or
-``"decode"``): 1 layer, seqlen 1024, 2 generated tokens, batch sizes 1 and 32 under `python -m tracy`,
-parses the ops CSV and captured demo logs (TTFT, decode tok/s/user), prints a Markdown table, and removes temp dirs on success.
+Runs once per parametrized demo phase (``prefill`` or ``decode``): 1 layer, seqlen 1024, 2 generated
+tokens, batch sizes 1 and 32 under `python -m tracy`, parses the ops CSV and captured demo logs (TTFT,
+decode tok/s/user), prints a Markdown table, and removes temp dirs on success.
 
-Set the model with env `HF_MODEL` only. Edit ``ROPE_PERF_MODE`` in this file to change which demo phase(s)
-run (``full`` = prefill + decode; ``prefill`` or ``decode`` = that phase only).
+Set the model with env `HF_MODEL` only. Phase is selected via :func:`pytest.mark.parametrize` on
+``rope_perf_mode`` (``prefill`` or ``decode``).
 
 Optional: set env `MESH_DEVICE` (e.g. ``N150``, ``N300``) — passed through to the Tracy subprocess via
 ``os.environ.copy()`` in :func:`_rope_perf_subprocess_env`, same as ``simple_text_demo`` expects.
@@ -40,9 +40,6 @@ DEMO_TEST = "models/tt_transformers/demo/simple_text_demo.py::test_demo_text"
 PYTEST_ADDOPTS_DEVICE_PERF = '-k "device-perf and performance"'
 
 TIMEOUT_TEST = 1200
-
-# Which simple_text_demo phase(s) to profile: "full" (prefill + decode), "prefill", or "decode".
-ROPE_PERF_MODE = "full"
 
 ROPE_OPS = frozenset(
     {
@@ -342,7 +339,7 @@ def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
 
 
 def _rope_perf_demo_modes(rope_perf_mode: str) -> tuple[str, ...]:
-    """Map :data:`ROPE_PERF_MODE` / mode string to simple_text_demo ``--mode`` values (prefill and/or decode)."""
+    """Map ``rope_perf_mode`` / mode string to simple_text_demo ``--mode`` values (prefill and/or decode)."""
     key = rope_perf_mode.strip().lower()
     if key == "full":
         return ("prefill", "decode")
@@ -385,17 +382,18 @@ def _markdown_table(rows: list[dict[str, Any]]) -> str:
 
 
 @pytest.mark.timeout(14400)
-def test_rope_performance_comparison_table():
+@pytest.mark.parametrize("rope_perf_mode", ["prefill", "decode"])
+def test_rope_performance_comparison_table(rope_perf_mode: str):
     """
-    Compare HF vs mllama RoPE device time for phase(s) from :data:`ROPE_PERF_MODE` (full, prefill, or decode),
-    bs in {1, 32}, 1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
+    Compare HF vs mllama RoPE device time for ``rope_perf_mode`` (prefill or decode), bs in {1, 32},
+    1 layer, seqlen 1024, 2 generated tokens. Model from ``HF_MODEL`` env only.
     Optional ``MESH_DEVICE`` is inherited by the Tracy subprocess. Prints a Markdown table (run pytest with -s).
     """
     hf_model = os.environ.get("HF_MODEL")
     assert (
         hf_model is not None
     ), "HF_MODEL is not set, it needs to be set to a HuggingFace model name, for example: export HF_MODEL=meta-llama/Llama-3.2-1B-Instruct"
-    demo_modes = _rope_perf_demo_modes(ROPE_PERF_MODE)
+    demo_modes = _rope_perf_demo_modes(rope_perf_mode)
     model_id = model_display_id(hf_model)
 
     table_rows: list[dict[str, Any]] = []
@@ -454,7 +452,7 @@ def test_rope_performance_comparison_table():
     print("\n### RoPE device time (HF vs mllama)\n")
     print(f"`HF_MODEL`: `{hf_model}`")
     print(f"`MESH_DEVICE`: `{mesh_device_display}`")
-    print(f"`ROPE_PERF_MODE`: `{ROPE_PERF_MODE}` (demo phases: {', '.join(demo_modes)})\n")
+    print(f"`rope_perf_mode`: `{rope_perf_mode}` (demo phases: {', '.join(demo_modes)})\n")
     print(
         "*Difference metrics (per table row; HF vs mllama):* "
         "`pct_diff_ttft_%` / `pct_diff_tok_s_u_%` / `pct_diff_rope_*` = 100 × (HF − mllama) / HF. "

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -307,14 +307,13 @@ def _run_tracy(
 def _run_tracy_demo(
     *,
     repo_root: Path,
-    hf_model: str,
     batch_size: int,
     use_hf_rope: bool,
     run_name: str,
     mode: str,
     timeout: int | None = None,
 ) -> tuple[list[dict[str, str]], str]:
-    env = _rope_perf_subprocess_env(hf_model=hf_model)
+    env = _rope_perf_subprocess_env()
 
     with TemporaryDirectory(prefix="rope_perf_") as tmp:
         pytest_cmd = rope_perf_pytest_argv(batch_size=batch_size, use_hf_rope=use_hf_rope, mode=mode, timeout=timeout)
@@ -324,7 +323,7 @@ def _run_tracy_demo(
         return load_rows(csv_path), captured_log
 
 
-def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
+def _rope_perf_subprocess_env() -> dict[str, str]:
     """Environment for the rope-perf demo subprocess (with or without Tracy).
 
     Starts from ``os.environ.copy()`` so ``MESH_DEVICE`` and other vars are inherited unchanged; only
@@ -332,22 +331,8 @@ def _rope_perf_subprocess_env(*, hf_model: str) -> dict[str, str]:
     device-perf test selection is applied via ``PYTEST_ADDOPTS`` (see module comment above).
     """
     env = os.environ.copy()
-    env["HF_MODEL"] = hf_model
-    env["TT_METAL_DEVICE_PROFILER"] = "1"
     env["PYTEST_ADDOPTS"] = PYTEST_ADDOPTS_DEVICE_PERF
     return env
-
-
-def _rope_perf_demo_modes(rope_perf_mode: str) -> tuple[str, ...]:
-    """Map ``rope_perf_mode`` / mode string to simple_text_demo ``--mode`` values (prefill and/or decode)."""
-    key = rope_perf_mode.strip().lower()
-    if key == "full":
-        return ("prefill", "decode")
-    if key == "prefill":
-        return ("prefill",)
-    if key == "decode":
-        return ("decode",)
-    raise ValueError(f"Invalid rope perf mode: {rope_perf_mode!r}")
 
 
 def _markdown_table(rows: list[dict[str, Any]]) -> str:
@@ -393,58 +378,53 @@ def test_rope_performance_comparison_table(rope_perf_mode: str):
     assert (
         hf_model is not None
     ), "HF_MODEL is not set, it needs to be set to a HuggingFace model name, for example: export HF_MODEL=meta-llama/Llama-3.2-1B-Instruct"
-    demo_modes = _rope_perf_demo_modes(rope_perf_mode)
     model_id = model_display_id(hf_model)
-
     table_rows: list[dict[str, Any]] = []
-    for mode in demo_modes:
-        for batch_size in (1, 32):
-            base = f"ropeperf_{mode}_g2_sl1024_bs{batch_size}"
-            llama_rows, llama_log = _run_tracy_demo(
-                repo_root=REPO_ROOT,
-                hf_model=hf_model,
-                batch_size=batch_size,
-                use_hf_rope=False,
-                run_name=f"{base}_mllama",
-                mode=mode,
-                timeout=TIMEOUT_TEST,
-            )
-            hf_rows, hf_log = _run_tracy_demo(
-                repo_root=REPO_ROOT,
-                hf_model=hf_model,
-                batch_size=batch_size,
-                use_hf_rope=True,
-                run_name=f"{base}_hf",
-                mode=mode,
-                timeout=TIMEOUT_TEST,
-            )
-            lm, lmean = scalar_rope_time_ns(llama_rows)
-            hm, hmean = scalar_rope_time_ns(hf_rows)
-            hf_ttft_ms, hf_tok_s_u = parse_simple_text_demo_perf_log(hf_log)
-            ml_ttft_ms, ml_tok_s_u = parse_simple_text_demo_perf_log(llama_log)
-            table_rows.append(
-                {
-                    "model_id": model_id,
-                    "mode": mode,
-                    "gen_tok": 2,
-                    "batch_size": batch_size,
-                    "hf_ttft_ms": _fmt_float_opt(hf_ttft_ms, ndigits=2),
-                    "mllama_ttft_ms": _fmt_float_opt(ml_ttft_ms, ndigits=2),
-                    "pct_diff_ttft_%": _fmt_pct_diff(hf_ttft_ms, ml_ttft_ms),
-                    "ratio_ttft": _fmt_ratio_metric(hf_ttft_ms, ml_ttft_ms),
-                    "hf_tok_s_u": _fmt_float_opt(hf_tok_s_u, ndigits=2),
-                    "mllama_tok_s_u": _fmt_float_opt(ml_tok_s_u, ndigits=2),
-                    "pct_diff_tok_s_u_%": _fmt_pct_diff(hf_tok_s_u, ml_tok_s_u),
-                    "ratio_tok_s_u": _fmt_ratio_metric(hf_tok_s_u, ml_tok_s_u),
-                    "hf_rope_max_mean_ns": f"{hm:.0f}",
-                    "mllama_rope_max_mean_ns": f"{lm:.0f}",
-                    "delta_rope_max_mean_ns": f"{hm - lm:.0f}",
-                    "pct_diff_rope_max_%": f"{pct_diff(hm, lm):.2f}",
-                    "pct_diff_rope_mean_%": f"{pct_diff(hmean, lmean):.2f}",
-                    "ratio_rope_max": f"{ratio(hm, lm):.4f}",
-                    "ratio_rope_mean": f"{ratio(hmean, lmean):.4f}",
-                }
-            )
+    for batch_size in (1, 32):
+        base = f"ropeperf_{rope_perf_mode}_g2_sl1024_bs{batch_size}"
+        llama_rows, llama_log = _run_tracy_demo(
+            repo_root=REPO_ROOT,
+            batch_size=batch_size,
+            use_hf_rope=False,
+            run_name=f"{base}_mllama",
+            mode=rope_perf_mode,
+            timeout=TIMEOUT_TEST,
+        )
+        hf_rows, hf_log = _run_tracy_demo(
+            repo_root=REPO_ROOT,
+            batch_size=batch_size,
+            use_hf_rope=True,
+            run_name=f"{base}_hf",
+            mode=rope_perf_mode,
+            timeout=TIMEOUT_TEST,
+        )
+        lm, lmean = scalar_rope_time_ns(llama_rows)
+        hm, hmean = scalar_rope_time_ns(hf_rows)
+        hf_ttft_ms, hf_tok_s_u = parse_simple_text_demo_perf_log(hf_log)
+        ml_ttft_ms, ml_tok_s_u = parse_simple_text_demo_perf_log(llama_log)
+        table_rows.append(
+            {
+                "model_id": model_id,
+                "mode": rope_perf_mode,
+                "gen_tok": 2,
+                "batch_size": batch_size,
+                "hf_ttft_ms": _fmt_float_opt(hf_ttft_ms, ndigits=2),
+                "mllama_ttft_ms": _fmt_float_opt(ml_ttft_ms, ndigits=2),
+                "pct_diff_ttft_%": _fmt_pct_diff(hf_ttft_ms, ml_ttft_ms),
+                "ratio_ttft": _fmt_ratio_metric(hf_ttft_ms, ml_ttft_ms),
+                "hf_tok_s_u": _fmt_float_opt(hf_tok_s_u, ndigits=2),
+                "mllama_tok_s_u": _fmt_float_opt(ml_tok_s_u, ndigits=2),
+                "pct_diff_tok_s_u_%": _fmt_pct_diff(hf_tok_s_u, ml_tok_s_u),
+                "ratio_tok_s_u": _fmt_ratio_metric(hf_tok_s_u, ml_tok_s_u),
+                "hf_rope_max_mean_ns": f"{hm:.0f}",
+                "mllama_rope_max_mean_ns": f"{lm:.0f}",
+                "delta_rope_max_mean_ns": f"{hm - lm:.0f}",
+                "pct_diff_rope_max_%": f"{pct_diff(hm, lm):.2f}",
+                "pct_diff_rope_mean_%": f"{pct_diff(hmean, lmean):.2f}",
+                "ratio_rope_max": f"{ratio(hm, lm):.4f}",
+                "ratio_rope_mean": f"{ratio(hmean, lmean):.4f}",
+            }
+        )
 
     md = _markdown_table(table_rows)
     mesh_device_env = os.environ.get("MESH_DEVICE")
@@ -452,7 +432,7 @@ def test_rope_performance_comparison_table(rope_perf_mode: str):
     print("\n### RoPE device time (HF vs mllama)\n")
     print(f"`HF_MODEL`: `{hf_model}`")
     print(f"`MESH_DEVICE`: `{mesh_device_display}`")
-    print(f"`rope_perf_mode`: `{rope_perf_mode}` (demo phases: {', '.join(demo_modes)})\n")
+    print(f"`rope_perf_mode`: `{rope_perf_mode}`")
     print(
         "*Difference metrics (per table row; HF vs mllama):* "
         "`pct_diff_ttft_%` / `pct_diff_tok_s_u_%` / `pct_diff_rope_*` = 100 × (HF − mllama) / HF. "

--- a/models/tt_transformers/tests/test_rope_performance.py
+++ b/models/tt_transformers/tests/test_rope_performance.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -18,6 +18,7 @@ Example:
   HF_MODEL=meta-llama/Llama-3.2-1B-Instruct pytest models/tt_transformers/tests/test_rope_performance.py -s
 """
 import csv
+import math
 import os
 import re
 import subprocess
@@ -198,7 +199,7 @@ def _fmt_ratio_metric(hf_val: float | None, llama_val: float | None) -> str:
     if hf_val is None or llama_val is None:
         return "n/a"
     r = ratio(hf_val, llama_val)
-    if r != r:  # NaN
+    if math.isnan(r):
         return "n/a"
     return f"{r:.4f}"
 

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -521,20 +521,18 @@ class Attention(LightweightModule):
         return q_heads_1BQD, k_heads_1BKD
 
     def _hf_rope_decode(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos):
-        int_current_pos = int(ttnn.to_torch(ttnn.get_device_tensors(current_pos)[0])[0])
-
         q_heads_1BQD = ttnn.experimental.rotary_embedding(
             q_heads_pre_rot_1BQD,
             rot_mats[0],
             rot_mats[1],
-            int_current_pos,
+            0,
         )
 
         k_heads_1BKD = ttnn.experimental.rotary_embedding(
             k_heads_pre_rot_1BKD,
             rot_mats[0],
             rot_mats[1],
-            int_current_pos,
+            0,
         )
         # This is done because rotary_embedding outputs are padded in the num_heads dimension both steps
         # reshape (indicating the padding size) as the slicing are required for attention to work properly

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -545,8 +545,9 @@ class Attention(LightweightModule):
             sin_b = sin[:, :, b : b + 1, :]
             q_rot = ttnn.experimental.rotary_embedding(q_b, cos_b, sin_b, 0)
             k_rot = ttnn.experimental.rotary_embedding(k_b, cos_b, sin_b, 0)
-            q_il_parts.append(ttnn.sharded_to_interleaved(q_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
-            k_il_parts.append(ttnn.sharded_to_interleaved(k_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
+            q_il_parts.append(ttnn.to_memory_config(q_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
+            k_il_parts.append(ttnn.to_memory_config(k_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
+
             ttnn.deallocate(q_rot)
             ttnn.deallocate(k_rot)
 

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -521,21 +521,53 @@ class Attention(LightweightModule):
         return q_heads_1BQD, k_heads_1BKD
 
     def _hf_rope_decode(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos):
-        q_heads_1BQD = ttnn.experimental.rotary_embedding(
-            q_heads_pre_rot_1BQD,
-            rot_mats[0],
-            rot_mats[1],
-            0,
-        )
+        cos, sin = rot_mats[0], rot_mats[1]
+        # Must match padded batch in rot_mats (rope) and nlp_create_qkv_heads_decode output; avoids
+        # ttnn.Tensor.shape host read for graph capture / trace.
+        B_iter = self.batch_size_per_device_group
 
-        k_heads_1BKD = ttnn.experimental.rotary_embedding(
-            k_heads_pre_rot_1BKD,
-            rot_mats[0],
-            rot_mats[1],
-            0,
-        )
-        # This is done because rotary_embedding outputs are padded in the num_heads dimension both steps
-        # reshape (indicating the padding size) as the slicing are required for attention to work properly
+        if q_heads_pre_rot_1BQD.dtype != ttnn.bfloat16:
+            q_heads_pre_rot_1BQD = ttnn.typecast(q_heads_pre_rot_1BQD, dtype=ttnn.bfloat16)
+        if k_heads_pre_rot_1BKD.dtype != ttnn.bfloat16:
+            k_heads_pre_rot_1BKD = ttnn.typecast(k_heads_pre_rot_1BKD, dtype=ttnn.bfloat16)
+
+        q_out_mem = q_heads_pre_rot_1BQD.memory_config()
+        k_out_mem = k_heads_pre_rot_1BKD.memory_config()
+
+        # Sharded concat only supports the last dim (width) on height-sharded tensors, not batch (dim=1).
+        # Merge per-batch rotary outputs in interleaved space, then resharding to match create_qkv_heads.
+        q_il_parts = []
+        k_il_parts = []
+        for b in range(B_iter):
+            q_b = q_heads_pre_rot_1BQD[:, b : b + 1, :, :]
+            k_b = k_heads_pre_rot_1BKD[:, b : b + 1, :, :]
+            cos_b = cos[:, :, b : b + 1, :]
+            sin_b = sin[:, :, b : b + 1, :]
+            q_rot = ttnn.experimental.rotary_embedding(q_b, cos_b, sin_b, 0)
+            k_rot = ttnn.experimental.rotary_embedding(k_b, cos_b, sin_b, 0)
+            q_il_parts.append(ttnn.sharded_to_interleaved(q_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
+            k_il_parts.append(ttnn.sharded_to_interleaved(k_rot, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16))
+            ttnn.deallocate(q_rot)
+            ttnn.deallocate(k_rot)
+
+        if B_iter == 1:
+            q_merged_il = q_il_parts[0]
+            k_merged_il = k_il_parts[0]
+        else:
+            q_merged_il = ttnn.concat(q_il_parts, dim=1)
+            k_merged_il = ttnn.concat(k_il_parts, dim=1)
+            for t in q_il_parts:
+                ttnn.deallocate(t)
+            for t in k_il_parts:
+                ttnn.deallocate(t)
+
+        q_heads_1BQD = ttnn.interleaved_to_sharded(q_merged_il, q_out_mem)
+        k_heads_1BKD = ttnn.interleaved_to_sharded(k_merged_il, k_out_mem)
+        ttnn.deallocate(q_merged_il)
+        ttnn.deallocate(k_merged_il)
+        # ttnn.experimental.rotary_embedding pads the head count on axis=-2 up to 32 (tile alignment).
+        # After per-batch rotary + merge, tensors still carry that padding; reshape states the true logical
+        # head count vs padded shape, then we slice to the real n_local_*_heads for SDPA / cache.
         q_heads_1BQD = ttnn.reshape(
             q_heads_1BQD,
             (1, self.batch_size_per_device_group, self.n_local_heads, self.head_dim),

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -734,6 +734,7 @@ class HfRotarySetup(LightweightModule):
             raise NotImplementedError("use_qk_fused")
         self.batch_size = batch_size
         self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
 
         self.device = device
         # Generate the cos/sin matrices in HF format (no Meta permutation)
@@ -755,6 +756,11 @@ class HfRotarySetup(LightweightModule):
             rope_scaling=rope_scaling,
             datatype=datatype,
         )
+
+        # Store 2D versions for embedding lookup (trace-compatible slicing)
+        # Reshape from [1, 1, max_seq_len, head_dim] to [max_seq_len, head_dim]
+        self.cos_matrix_2d = ttnn.reshape(self.cos_matrix, (max_seq_len, head_dim))
+        self.sin_matrix_2d = ttnn.reshape(self.sin_matrix, (max_seq_len, head_dim))
 
         self.transformation_mat = None
         self.transformation_mat_prefill = None
@@ -794,34 +800,61 @@ class HfRotarySetup(LightweightModule):
     def get_rot_mats(
         self, position_idxs: Union[torch.Tensor, ttnn.Tensor], return_rot_idxs: bool = False
     ) -> List[ttnn.Tensor]:
-        """Get rotation matrices (cos/sin) for HF-style RoPE.
+        """Get rotation matrices (cos/sin) for HF-style RoPE, sliced by position.
 
-        This method is designed for use with ttnn.experimental.rotary_embedding (HF-style),
-        which has a different API signature than Meta-style RoPE. It returns the full,
-        unsliced cos/sin cache matrices.
+        This method pre-slices the cos/sin cache at the given position index, returning
+        matrices with shape [1, 1, 1, head_dim]. This enables trace-compatible usage with
+        ttnn.experimental.rotary_embedding by using token_idx=0 (a compile-time constant).
 
-        NOTE: This behaves differently from RotarySetup.get_rot_mats() due to different
-        underlying RoPE implementations:
-        - HfRotarySetup (this class): Uses HF-style RoPE (ttnn.experimental.rotary_embedding)
-          which expects the full cos/sin cache and performs position slicing internally.
-          Returns the raw, unsliced cache matrices regardless of position_idxs.
-        - RotarySetup: Uses Meta-style RoPE with embedding-based position slicing.
-          Returns cos/sin matrices sliced by position_idxs and sharded across batch dimension.
-
-        This design allows both setup classes to be used interchangeably in attention modules
-        without the caller needing to know which RoPE implementation is being used.
+        The workaround for tracing:
+        1. Pre-slice cos/sin cache at position_idx: cache[:, :, position_idx:position_idx+1, :]
+        2. Return sliced cache with shape [1, 1, 1, head_dim] (position values at index 0)
+        3. Caller uses ttnn.experimental.rotary_embedding with token_idx=0
 
         Args:
-            position_idxs: Position indices (accepted for API compatibility but not used for slicing).
+            position_idxs: Position index as a scalar torch.Tensor or ttnn.Tensor.
+                          For decode mode, this should be a single position value (or batch of
+                          identical values). Only the first value is used for slicing.
             return_rot_idxs: If True, also return the position indices unchanged.
 
         Returns:
-            List of [cos, sin] tensors containing the full rotation cache (not sliced by position).
+            List of [cos, sin] tensors with shape [1, 1, 1, head_dim], sliced at position_idx.
             If return_rot_idxs=True, returns ([cos, sin], position_idxs).
         """
+        if isinstance(position_idxs, ttnn.Tensor):
+            # Use ttnn.embedding for on-device index lookup (trace-compatible)
+            # This avoids any host-device data transfer
+            # position_idxs shape: [1, batch] or similar - we use first element
+            # cos/sin_matrix_2d shape: [max_seq_len, head_dim]
+            # Output from embedding: [1, 1, head_dim] (using first position only)
+
+            # Slice to get just the first position index: [1, 1]
+            rot_idx = position_idxs[:, :1] if len(position_idxs.shape) == 2 else position_idxs[:1]
+
+            # Embedding lookup: [1, 1] indices into [max_seq_len, head_dim] -> [1, 1, head_dim]
+            cos_emb = ttnn.embedding(rot_idx, self.cos_matrix_2d, layout=ttnn.TILE_LAYOUT)
+            sin_emb = ttnn.embedding(rot_idx, self.sin_matrix_2d, layout=ttnn.TILE_LAYOUT)
+
+            # Reshape to [1, 1, 1, head_dim] for compatibility with rotary_embedding
+            cos_sliced = ttnn.unsqueeze_to_4D(cos_emb)  # [1, 1, 1, head_dim]
+            sin_sliced = ttnn.unsqueeze_to_4D(sin_emb)  # [1, 1, 1, head_dim]
+        else:
+            # For torch.Tensor or int, extract position and use Python slicing
+            if isinstance(position_idxs, torch.Tensor):
+                if position_idxs.numel() == 1:
+                    position_idx = int(position_idxs.item())
+                else:
+                    position_idx = int(position_idxs[0].item())
+            else:
+                position_idx = int(position_idxs)
+
+            # Slice cos/sin at position_idx: [1, 1, max_seq_len, head_dim] -> [1, 1, 1, head_dim]
+            cos_sliced = self.cos_matrix[:, :, position_idx : position_idx + 1, :]
+            sin_sliced = self.sin_matrix[:, :, position_idx : position_idx + 1, :]
+
         if return_rot_idxs:
-            return [self.cos_matrix, self.sin_matrix], position_idxs
-        return [self.cos_matrix, self.sin_matrix]
+            return [cos_sliced, sin_sliced], position_idxs
+        return [cos_sliced, sin_sliced]
 
     def get_both_trans_mats(self) -> Dict[str, ttnn.Tensor]:
         return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -800,57 +800,40 @@ class HfRotarySetup(LightweightModule):
     def get_rot_mats(
         self, position_idxs: Union[torch.Tensor, ttnn.Tensor], return_rot_idxs: bool = False
     ) -> List[ttnn.Tensor]:
-        """Get rotation matrices (cos/sin) for HF-style RoPE, sliced by position.
+        """Get rotation matrices (cos/sin) for HF-style RoPE, one row per batch slot.
 
-        This method pre-slices the cos/sin cache at the given position index, returning
-        matrices with shape [1, 1, 1, head_dim]. This enables trace-compatible usage with
-        ttnn.experimental.rotary_embedding by using token_idx=0 (a compile-time constant).
-
-        The workaround for tracing:
-        1. Pre-slice cos/sin cache at position_idx: cache[:, :, position_idx:position_idx+1, :]
-        2. Return sliced cache with shape [1, 1, 1, head_dim] (position values at index 0)
-        3. Caller uses ttnn.experimental.rotary_embedding with token_idx=0
+        Decode attention slices ``cos[:, :, b:b+1, :]`` / ``sin`` to ``[1, 1, 1, head_dim]`` and
+        calls ``ttnn.experimental.rotary_embedding(..., token_idx=0)`` per batch index (trace-safe
+        fixed loop). Prefill uses full-sequence cos/sin from separate tensors.
 
         Args:
-            position_idxs: Position index as a scalar torch.Tensor or ttnn.Tensor.
-                          For decode mode, this should be a single position value (or batch of
-                          identical values). Only the first value is used for slicing.
-            return_rot_idxs: If True, also return the position indices unchanged.
+            position_idxs: Per-batch positions. Device ``ttnn.Tensor`` ``[1, batch_padded]`` (``uint32``,
+                same padding as ``get_rot_idxs``) for trace, or 1D / ``[1, batch]`` ``torch.Tensor``
+                (processed via ``get_rot_idxs``). Each batch slot must appear explicitly in the index
+                tensor; there is no special case for a single position replicated across
+                ``batch_size`` or for a Python ``int``.
+            return_rot_idxs: If True, also return ``position_idxs`` unchanged.
 
         Returns:
-            List of [cos, sin] tensors with shape [1, 1, 1, head_dim], sliced at position_idx.
-            If return_rot_idxs=True, returns ([cos, sin], position_idxs).
+            ``[cos, sin]`` with shape ``[1, 1, batch_padded, head_dim]``.
         """
         if isinstance(position_idxs, ttnn.Tensor):
-            # Use ttnn.embedding for on-device index lookup (trace-compatible)
-            # This avoids any host-device data transfer
-            # position_idxs shape: [1, batch] or similar - we use first element
-            # cos/sin_matrix_2d shape: [max_seq_len, head_dim]
-            # Output from embedding: [1, 1, head_dim] (using first position only)
-
-            # Slice to get just the first position index: [1, 1]
-            rot_idx = position_idxs[:, :1] if len(position_idxs.shape) == 2 else position_idxs[:1]
-
-            # Embedding lookup: [1, 1] indices into [max_seq_len, head_dim] -> [1, 1, head_dim]
+            rot_idx = position_idxs
+            if len(rot_idx.shape) == 1:
+                rot_idx = ttnn.unsqueeze(rot_idx, 0)
             cos_emb = ttnn.embedding(rot_idx, self.cos_matrix_2d, layout=ttnn.TILE_LAYOUT)
             sin_emb = ttnn.embedding(rot_idx, self.sin_matrix_2d, layout=ttnn.TILE_LAYOUT)
-
-            # Reshape to [1, 1, 1, head_dim] for compatibility with rotary_embedding
-            cos_sliced = ttnn.unsqueeze_to_4D(cos_emb)  # [1, 1, 1, head_dim]
-            sin_sliced = ttnn.unsqueeze_to_4D(sin_emb)  # [1, 1, 1, head_dim]
+            cos_sliced = ttnn.unsqueeze_to_4D(cos_emb)
+            sin_sliced = ttnn.unsqueeze_to_4D(sin_emb)
+        elif isinstance(position_idxs, torch.Tensor):
+            idx_1d = position_idxs.reshape(-1)
+            rot_idx = self.get_rot_idxs(idx_1d)
+            cos_emb = ttnn.embedding(rot_idx, self.cos_matrix_2d, layout=ttnn.TILE_LAYOUT)
+            sin_emb = ttnn.embedding(rot_idx, self.sin_matrix_2d, layout=ttnn.TILE_LAYOUT)
+            cos_sliced = ttnn.unsqueeze_to_4D(cos_emb)
+            sin_sliced = ttnn.unsqueeze_to_4D(sin_emb)
         else:
-            # For torch.Tensor or int, extract position and use Python slicing
-            if isinstance(position_idxs, torch.Tensor):
-                if position_idxs.numel() == 1:
-                    position_idx = int(position_idxs.item())
-                else:
-                    position_idx = int(position_idxs[0].item())
-            else:
-                position_idx = int(position_idxs)
-
-            # Slice cos/sin at position_idx: [1, 1, max_seq_len, head_dim] -> [1, 1, 1, head_dim]
-            cos_sliced = self.cos_matrix[:, :, position_idx : position_idx + 1, :]
-            sin_sliced = self.sin_matrix[:, :, position_idx : position_idx + 1, :]
+            raise TypeError(f"position_idxs must be torch.Tensor or ttnn.Tensor, got {type(position_idxs)}")
 
         if return_rot_idxs:
             return [cos_sliced, sin_sliced], position_idxs

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -68,6 +68,9 @@ run_t3000_llama3_tests() {
     echo "LOG_METAL: Llama3 tests for $hf_model completed"
   done
 
+  HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" --use-hf-rope; fail+=$?
+  echo "LOG_METAL: Llama3 tests for $llama8b with HF-style rope completed"
+
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -68,7 +68,7 @@ run_t3000_llama3_tests() {
     echo "LOG_METAL: Llama3 tests for $hf_model completed"
   done
 
-  HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" --use-hf-rope; fail+=$?
+  HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" --use_hf_rope; fail+=$?
   echo "LOG_METAL: Llama3 tests for $llama8b with HF-style rope completed"
 
   # Record the end time

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -68,6 +68,7 @@ run_t3000_llama3_tests() {
     echo "LOG_METAL: Llama3 tests for $hf_model completed"
   done
 
+  tt_cache=$TT_CACHE_HOME/$llama8b
   HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py --timeout 600 -k "not performance-ci-stress-1" --use_hf_rope; fail+=$?
   echo "LOG_METAL: Llama3 tests for $llama8b with HF-style rope completed"
 


### PR DESCRIPTION
## Ticket
[#40278](https://github.com/tenstorrent/tt-metal/issues/40278)

## Problem description
Goal: 
 * Make HF-style RoPE trace friendly so it can be profiled(Tracy), and compared fairly against the existing Llama RoPE  before dropping the latter.
 * Add HF RoPE support for batch_size > 1.
 * Compare performance .

What broke tracing before: In decode, the code read current_pos back to the host (ttnn → torch → int) and passed that integer into ttnn.experimental.rotary_embedding. That host-dependent position is what made the op (and therefore the model) non-traceable.

### What's changed

New slicing contract: HfRotarySetup.get_rot_mats no longer returns the full cos/sin caches for HF RoPE. It returns cos/sin already narrowed to the current token: shape [1, 1, batch_padded, head_dim], i.e. “the row for this position” sits at index 0 inside those tensors (for each element in the batch). For on-device position_idxs it uses ttnn.embedding into 2D tables (cos_matrix_2d / sin_matrix_2d) so indexing stays on-device.

Attention change: _hf_rope_decode always calls rotary_embedding with token_idx=0, because the real position is encoded in the sliced rot mats. It's not possible to apply different rotiations to each element of a batch so, finally, _hf_rope_decode  makes use of a workaround to support  batch_size > 1, `ttnn.experimental.rotary_embedding` is called once per each element in the batch (passing token_idx=0 for each element of the batch and slicing a sub-rot_mat accordingly containing different rotations). 


Profiling harness: test_rope_performance.py runs the simple_text_demo workload under python -m tracy, toggles --use_hf_rope, parses ops_perf*.csv, and prints a Markdown table (HF vs mllama RoPE device time). It’s meant as a repeatable benchmark for humans and for agents tuning the RoPE op. CI also gains a simple_text_demo run with --use-hf-rope on T3000 demos so HF RoPE stays exercised.

## Performance evaluation

Performance comparison between HF and Llama RoPEs. We need to keep track of the performance of HF RoPE, before dropping Llama RoPE, HF version performance must be the same of better than Llama. Here we show the performance, with device level ops profiling and model level peformance metrics. For device level performance the profiling harness is used.

Llama3 8B and Qwen3 32 B are compared. 

### Device level profiling

This data compares device time spent on RoPE ops, it aggregates OPs across devices by taking the max of them, it also takes into account that an OP can be executed several times per Attention layer execution (for example, llama rope OP is fused, so there is only once call per Attention execution, while HF rope OP is executed two times the batch size) .

*Difference metrics (per table row, using aggregated HF vs mllama RoPE nanoseconds):* `pct_diff_*` = 100 * (HF - mllama) / HF (%); `ratio_*` = HF / mllama*
`MESH_DEVICE`: `T3K`

#### Prefill

| model_id | mode | gen_tok | batch_size | pct_diff_max_% | pct_diff_mean_% | ratio_max | ratio_mean | hf_rope_max_mean_ns | mllama_rope_max_mean_ns |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| meta_llama_Llama_3.1_8B_Instruct | prefill | 2 | 1 | -44.81 | -47.09 | 0.6906 | 0.6799 | 34735 | 50299 |
| meta_llama_Llama_3.1_8B_Instruct | prefill | 2 | 32 | 41.92 | 40.23 | 1.7217 | 1.6731 | 274207 | 159269 |
| Qwen_Qwen3_32B | prefill | 2 | 1 | -60.58 | -63.64 | 0.6228 | 0.6111 | 36995 | 59406 |
| Qwen_Qwen3_32B | prefill | 2 | 32 | 14.32 | 9.95 | 1.1671 | 1.1105 | 394608 | 338097 |

For prefill, there is a slight difference, when batch_size=1 HF rope is faster (HF is around 0.65 times Llama in both cases), while for batch_size=32 it's slower.

#### Decode

| model_id | mode | gen_tok | batch_size | pct_diff_max_% | pct_diff_mean_% | ratio_max | ratio_mean | hf_rope_max_mean_ns | mllama_rope_max_mean_ns |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| meta_llama_Llama_3.1_8B_Instruct | decode | 2 | 1 | 68.54 | 68.58 | 3.1788 | 3.1828 | 15292 | 4811 |
| meta_llama_Llama_3.1_8B_Instruct | decode | 2 | 32 | 99.57 | 99.56 | 231.9009 | 226.3088 | 1327246 | 5723 |
| Qwen_Qwen3_32B | decode | 2 | 1 | 68.97 | 68.66 | 3.2223 | 3.1909 | 15544 | 4824 |
| Qwen_Qwen3_32B | decode | 2 | 32 | 99.57 | 99.56 | 231.7987 | 226.6300 | 1327975 | 5729 |


As can be seen, HF RoPE in decode mode is much slower than Llama RoPE, especially in the batch_size=32 case, where it's around 220 times slower. Such huge difference is due to the workaround introduced for having batch_size>1, in previous performance analyses there was a much smaller difference.

Further analysis of Tracy profiling using `tt-perf-report` (as well as custom analysis code that have produced similar results), has shown that the percentage of time spent on RoPE operations has a huge difference: 

* Llama RoPE OPs time 0,3% 
* HF RoPE Ops time 22,2 %

This is only considering the test_rope_performance.py setup, where only 1 attention layer is used, while LM Head and Embeddings are taken into account, so for a full model setup, where the number of attention layers is higher, this percentage will probably be higher. Moreover, the workaround includes not just Rotary OPs, but also slicing, concatenation and tensor memory layout transformations, so the overhead may be even higher.  

These tables are generated by running:

```bash
# Llama3 8B
MESH_DEVICE=T3K HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_rope_performance.py -s

# Qwen3 32B
MESH_DEVICE=T3K HF_MODEL=Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_rope_performance.py -s
 ```

### Model level performance comparison

This data is extracted from `models/tt_transformers/demo/simple_text_demo.py` logs, those are the exact commands used to run the script, each command is executed 5 times and the mean is extracted:

** Llama-3.1-8B**
```
HF_MODEL="meta-llama/Llama-3.1-8B-Instruct" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-1 and performance" \
    --max_generated_tokens "200" \
    --batch_size "1" \
    --timeout 2400 \
    -s
HF_MODEL="meta-llama/Llama-3.1-8B-Instruct" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-32 and performance and not log-probs" \
    --max_generated_tokens "200" \
    --batch_size "32" \
    --timeout 2400 \
    -s
HF_MODEL="meta-llama/Llama-3.1-8B-Instruct" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-1 and performance" \
    --max_generated_tokens "200" \
    --batch_size "1" \
    --use_hf_rope \
    --timeout 2400 \
    -s
HF_MODEL="meta-llama/Llama-3.1-8B-Instruct" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-32 and performance and not log-probs" \
    --max_generated_tokens "200" \
    --batch_size "32" \
    --use_hf_rope \
    --timeout 2400 \
    -s
```
**Qwen3-32B**
```
HF_MODEL="Qwen/Qwen3-32B" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-1 and performance" \
    --max_generated_tokens "200" \
    --batch_size "1" \
    --timeout 2400 \
    -s
HF_MODEL="Qwen/Qwen3-32B" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-32 and performance and not log-probs" \
    --max_generated_tokens "200" \
    --batch_size "32" \
    --timeout 2400 \
    -s
HF_MODEL="Qwen/Qwen3-32B" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-1 and performance" \
    --max_generated_tokens "200" \
    --batch_size "1" \
    --use_hf_rope \
    --timeout 2400 \
    -s
HF_MODEL="Qwen/Qwen3-32B" MESH_DEVICE="T3K" pytest models/tt_transformers/demo/simple_text_demo.py::test_demo_text \
    -k "batch-32 and performance and not log-probs" \
    --max_generated_tokens "200" \
    --batch_size "32" \
    --use_hf_rope \
    --timeout 2400 \
    -s
```
Differences are shown in percentage as `(HF_value - Llama_Value) / HF_value`, so positive is better for tok_s_user and negative is better for ttft

|    | model_tag   | mesh_device   |   gen_tok |   batch_size |   percentage_diff_ttft_ms |   percentage_diff_tok_s_user |   llama_tok_s_user |   hf_tok_s_user |   llama_ttft_ms |   hf_ttft_ms |
|---:|:------------|:--------------|----------:|-------------:|--------------------------:|-----------------------------:|-------------------:|----------------:|----------------:|-------------:|
|  0 | llama8b     | T3K           |       200 |            1 |                  3.37653  |                     -5.21187 |             66.94  |          63.624 |          38.174 |       39.508 |
|  1 | llama8b     | T3K           |       200 |           32 |                  0.78356  |                   -414.541   |             53.502 |          10.398 |          13.422 |       13.528 |
|  2 | qwen32      | T3K           |       200 |            1 |                 -0.989732 |                     -3.22272 |             25.88  |          25.072 |          97.956 |       96.996 |
|  3 | qwen32      | T3K           |       200 |           32 |                  0.391718 |                   -348.71    |             22.606 |           5.038 |          39.16  |       39.314 |

Again, especially in the batch_size=32 case, the HF-rope performance is much worse: 
 * For Llama3 8B:  53.502 vs 10.398 T/S/U.
 * For Qwen3 32B 22.606 vs 5.038 T/S/U.
 
This is not surprising after noticing in the previous device level profiling, that the proportion of time spent on RoPE is now clearly signficant due to the loop workaround.

For batch_size=1, as expected, the T/S/U are on par.


## Checklist

### Model tests

- [x] [Unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/24031140018) Passing.
- [x] [T3K Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/24032563168) Passing (failing cases are also failing in main).

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/40278-make-hf-rope-traceable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/40278-make-hf-rope-traceable) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/40278-make-hf-rope-traceable) |