### PR TITLE
Lora SFT example with DDP

### DIFF
--- a/tt-train/docs/SFT_TRAINER.md
+++ b/tt-train/docs/SFT_TRAINER.md
@@ -80,6 +80,7 @@ SFTTrainer(
     callbacks=None,
     compute_loss_func=None,
     loss_composer=None,
+    attention_mask=None,
 )
 ```
 
@@ -95,6 +96,7 @@ SFTTrainer(
 | `callbacks` | `list[TrainerCallback] \| None` | Hooks into the training loop (see [Callbacks](#callbacks)). |
 | `compute_loss_func` | `Callable \| None` | Custom `(logits, batch) -> loss` replacing the default masked cross-entropy. |
 | `loss_composer` | `Any \| None` | Mesh composer for multi-device loss aggregation. Defaults to `concat_mesh_to_tensor_composer(device, 0)` which works for both single-device and DDP. Pass a custom composer to override. |
+| `attention_mask` | `Any \| None` | Attention mask passed as the second argument to `model(input_ids, mask)`. `None` (default) lets the model generate a causal mask on the fly. |
 
 ### Methods
 

--- a/tt-train/docs/SFT_TRAINER.md
+++ b/tt-train/docs/SFT_TRAINER.md
@@ -1,6 +1,6 @@
 # SFT Trainer
 
-Supervised Fine-Tuning (SFT) trainer for adapting language models on a single Tenstorrent device.
+Supervised Fine-Tuning (SFT) trainer for adapting language models on Tenstorrent devices.
 The API is inspired by [TRL's SFTTrainer](https://huggingface.co/docs/trl/en/sft_trainer) so that
 users who know TRL face minimal friction.
 
@@ -79,6 +79,7 @@ SFTTrainer(
     lr_schedule=None,
     callbacks=None,
     compute_loss_func=None,
+    loss_composer=None,
 )
 ```
 
@@ -93,6 +94,7 @@ SFTTrainer(
 | `lr_schedule` | `Callable[[int], float] \| None` | Custom `step -> lr` schedule. Overrides the default linear-warmup-then-constant. |
 | `callbacks` | `list[TrainerCallback] \| None` | Hooks into the training loop (see [Callbacks](#callbacks)). |
 | `compute_loss_func` | `Callable \| None` | Custom `(logits, batch) -> loss` replacing the default masked cross-entropy. |
+| `loss_composer` | `Any \| None` | Mesh composer passed to `loss.to_numpy(composer=...)` for multi-device loss aggregation (see [DDP / Multi-device](#ddp--multi-device)). |
 
 ### Methods
 
@@ -179,6 +181,7 @@ trainer = SFTTrainer(..., callbacks=[WandbLogger()])
 | Hook | Signature | When |
 |------|-----------|------|
 | `on_train_begin` | `(trainer)` | After `model.train()`, before first step. |
+| `on_before_optimizer_step` | `(trainer)` | After backward / gradient accumulation, before grad clipping and `optimizer.step()`. |
 | `on_step_end` | `(trainer, step, loss, lr)` | Every `log_interval` steps. |
 | `on_eval_end` | `(trainer, step, eval_loss)` | After each evaluation pass. |
 | `on_save` | `(trainer, step, path)` | After each checkpoint save. |
@@ -282,6 +285,58 @@ SFTConfig(max_grad_norm=1.0)
 
 Uses `ttml.core.clip_grad_norm` (L2 norm) after gradient accumulation and before the
 optimizer step. Set to `0.0` (default) to disable.
+
+---
+
+## DDP / Multi-device
+
+`SFTTrainer` supports distributed data-parallel (DDP) training without any
+DDP-specific configuration flags. Instead, three generic extension points are
+combined:
+
+1. **Collate function** -- create batch tensors with a `shard_tensor_to_mesh_mapper`
+   so that each device receives a slice of the global batch.
+2. **`on_before_optimizer_step` callback** -- call
+   `ttml.core.distributed.synchronize_gradients` to all-reduce gradients before
+   the optimiser step.
+3. **`loss_composer`** -- pass a `concat_mesh_to_tensor_composer` so that logged
+   loss values are aggregated across devices.
+
+```python
+import ttml
+from ttml.trainers import SFTConfig, SFTTrainer, TrainerCallback
+
+# -- device setup (caller responsibility) --
+autograd_ctx = ttml.autograd.AutoContext.get_instance()
+ttml.core.distributed.enable_fabric(num_devices)
+autograd_ctx.open_device([1, num_devices])
+autograd_ctx.initialize_parallelism_context(
+    ttml.autograd.DistributedConfig(enable_ddp=True)
+)
+
+device = autograd_ctx.get_device()
+shard_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+
+# -- gradient-sync callback --
+class DDPCallback(TrainerCallback):
+    def on_before_optimizer_step(self, trainer):
+        ttml.core.distributed.synchronize_gradients(trainer.model.parameters())
+
+# -- collate that shards along the batch dimension --
+def my_collate(examples, mapper=None):
+    ...  # pass mapper to Tensor.from_numpy(...)
+
+trainer = SFTTrainer(
+    ...,
+    callbacks=[DDPCallback()],
+    loss_composer=loss_composer,
+)
+trainer.train()
+```
+
+See [`sources/examples/lora_llama/train_lora_llama_sft.py`](../sources/examples/lora_llama/train_lora_llama_sft.py)
+for a complete DDP + LoRA example.
 
 ---
 

--- a/tt-train/docs/SFT_TRAINER.md
+++ b/tt-train/docs/SFT_TRAINER.md
@@ -94,7 +94,7 @@ SFTTrainer(
 | `lr_schedule` | `Callable[[int], float] \| None` | Custom `step -> lr` schedule. Overrides the default linear-warmup-then-constant. |
 | `callbacks` | `list[TrainerCallback] \| None` | Hooks into the training loop (see [Callbacks](#callbacks)). |
 | `compute_loss_func` | `Callable \| None` | Custom `(logits, batch) -> loss` replacing the default masked cross-entropy. |
-| `loss_composer` | `Any \| None` | Mesh composer passed to `loss.to_numpy(composer=...)` for multi-device loss aggregation (see [DDP / Multi-device](#ddp--multi-device)). |
+| `loss_composer` | `Any \| None` | Mesh composer for multi-device loss aggregation. Defaults to `concat_mesh_to_tensor_composer(device, 0)` which works for both single-device and DDP. Pass a custom composer to override. |
 
 ### Methods
 
@@ -291,16 +291,17 @@ optimizer step. Set to `0.0` (default) to disable.
 ## DDP / Multi-device
 
 `SFTTrainer` supports distributed data-parallel (DDP) training without any
-DDP-specific configuration flags. Instead, three generic extension points are
-combined:
+DDP-specific configuration flags. Two extension points are combined:
 
 1. **Collate function** -- create batch tensors with a `shard_tensor_to_mesh_mapper`
    so that each device receives a slice of the global batch.
 2. **`on_before_optimizer_step` callback** -- call
    `ttml.core.distributed.synchronize_gradients` to all-reduce gradients before
    the optimiser step.
-3. **`loss_composer`** -- pass a `concat_mesh_to_tensor_composer` so that logged
-   loss values are aggregated across devices.
+
+Loss aggregation across devices is handled automatically via a default
+`concat_mesh_to_tensor_composer(device, 0)`.  Pass a custom `loss_composer`
+to the `SFTTrainer` constructor to override.
 
 ```python
 import ttml
@@ -316,7 +317,6 @@ autograd_ctx.initialize_parallelism_context(
 
 device = autograd_ctx.get_device()
 shard_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
-loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
 
 # -- gradient-sync callback --
 class DDPCallback(TrainerCallback):
@@ -329,8 +329,7 @@ def my_collate(examples, mapper=None):
 
 trainer = SFTTrainer(
     ...,
-    callbacks=[DDPCallback()],
-    loss_composer=loss_composer,
+    callbacks=[DDPCallback()]
 )
 trainer.train()
 ```

--- a/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
+++ b/tt-train/sources/examples/gsm8k_finetune/gsm8k_finetune.py
@@ -32,7 +32,7 @@ from ttml.common.utils import (
     initialize_device,
     build_logits_mask,
     no_grad,
-    get_tt_metal_home,
+    get_tt_metal_runtime_root,
 )
 from ttml.common.data import build_causal_mask
 from ttml.datasets import Batch, InMemoryDataloader
@@ -425,6 +425,9 @@ def train():
 
     sched = SpeedrunScheduler(scheduler_config)
 
+    mask_np = build_causal_mask(max_sequence_length)
+    causal_mask = ttml.autograd.Tensor.from_numpy(mask_np, layout=ttnn.Layout.TILE, new_type=ttnn.DataType.BFLOAT16)
+
     trainer = SFTTrainer(
         model=tt_model,
         train_dataloader=train_loader,
@@ -432,6 +435,7 @@ def train():
         config=sft_config,
         optimizer=optimizer_cfg,
         lr_schedule=sched.lr_at,  # SpeedrunScheduler uses 0-based step index
+        attention_mask=causal_mask,
     )
 
     print(f"Starting training for max {training_config.steps} steps...")

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -17,11 +17,10 @@ from ttml.common.config import load_config
 from ttml.common.data import (
     CharTokenizer,
     load_shakespeare_text,
-    get_batch,
 )
 from ttml.common.utils import (
     set_seed,
-    get_tt_metal_home,
+    get_tt_metal_runtime_root,
     summary,
     get_loss_over_devices,
 )
@@ -370,13 +369,30 @@ def main():
         device = autograd_ctx.get_device()
         mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
 
+    # ── Data chunks ─────────────────────────────────────────────────────────
+    n_chunks = (len(train_ids) - 1) // seq_len
+    _chunk_order = np.arange(n_chunks)
+    np.random.shuffle(_chunk_order)
+    _chunk_ptr = 0
+
+    def get_chunk_batch():
+        nonlocal _chunk_order, _chunk_ptr
+        if _chunk_ptr + batch_size > len(_chunk_order):
+            np.random.shuffle(_chunk_order)
+            _chunk_ptr = 0
+        sel = _chunk_order[_chunk_ptr : _chunk_ptr + batch_size]
+        _chunk_ptr += batch_size
+        x = np.stack([train_ids[i * seq_len : i * seq_len + seq_len] for i in sel])
+        y = np.stack([train_ids[i * seq_len + 1 : i * seq_len + seq_len + 1] for i in sel])
+        return x.astype(np.uint32), y.astype(np.uint32)
+
     # ── Training loop ─────────────────────────────────────────────────────────
     model.train()
     is_first_step = True
 
     for step in range(1, steps + 1):
         t0 = time.perf_counter()
-        x_np, y_np = get_batch(train_ids, seq_len, batch_size)
+        x_np, y_np = get_chunk_batch()
 
         tt_x = ttml.autograd.Tensor.from_numpy(
             x_np.reshape(batch_size, 1, 1, seq_len),

--- a/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
@@ -71,7 +71,12 @@ class LossLogger(TrainerCallback):
     def on_train_end(self, trainer):
         import json
 
-        with open(self._path, "w") as f:
+        # Ensure the parent directory exists before writing the loss log.
+        dirpath = os.path.dirname(self._path)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
+
+        with open(self._path, "w", encoding="utf-8") as f:
             json.dump(self._records, f, indent=2)
         print(f"Loss log saved to {self._path}")
 

--- a/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
@@ -9,7 +9,6 @@ loop to :class:`SFTTrainer`.  DDP support is wired externally via:
 
 * A collate function that shards batch tensors across the mesh.
 * An ``on_before_optimizer_step`` callback that synchronises gradients.
-* A ``loss_composer`` for aggregated loss logging.
 """
 
 import argparse
@@ -333,14 +332,12 @@ def main():
     else:
         autograd_ctx.open_device([1, 1], [0])
 
-    # ── DDP mappers / composer ────────────────────────────────────────────────
+    # ── DDP mapper ────────────────────────────────────────────────────────────
 
     mapper = None
-    loss_composer = None
     if use_ddp:
         device = autograd_ctx.get_device()
         mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
-        loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
 
     # ── Model ─────────────────────────────────────────────────────────────────
 
@@ -422,7 +419,6 @@ def main():
             "weight_decay": WEIGHT_DECAY,
         },
         callbacks=callbacks,
-        loss_composer=loss_composer,
     )
 
     summary(trainer.model)

--- a/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Llama LoRA fine-tuning on Shakespeare using SFTTrainer, with optional DDP.
+
+This is a reimplementation of train_lora_llama.py that delegates the training
+loop to :class:`SFTTrainer`.  DDP support is wired externally via:
+
+* A collate function that shards batch tensors across the mesh.
+* An ``on_before_optimizer_step`` callback that synchronises gradients.
+* A ``loss_composer`` for aggregated loss logging.
+"""
+
+import argparse
+import os
+import re
+from functools import partial
+
+import ml_dtypes
+import numpy as np
+import ttnn
+import ttml
+
+from ttml.common.config import load_config
+from ttml.common.data import CharTokenizer, load_shakespeare_text
+from ttml.common.utils import get_tt_metal_runtime_root, set_seed, summary
+from ttml.datasets import Batch, InMemoryDataloader
+from ttml.models import RunnerType, WeightTyingType
+from ttml.models.llama import (
+    Llama,
+    LlamaConfig,
+    LlamaRopeScalingConfig,
+    load_from_safetensors,
+)
+from ttml.modules import LoraConfig
+from ttml.trainers import SFTConfig, SFTTrainer, TrainerCallback
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+BATCH_SIZE_DEFAULT = 1
+STEPS_DEFAULT = 500
+LR = 3e-4
+WEIGHT_DECAY = 0.01
+
+LORA_RANK = 8
+LORA_ALPHA = 16
+LORA_TARGET_MODULES = ["q_linear", "kv_linear", "out_linear"]
+LORA_DROPOUT = 0.05
+
+
+# ── DDP callback ──────────────────────────────────────────────────────────────
+
+
+class DDPCallback(TrainerCallback):
+    """Synchronise gradients across all DDP devices before the optimiser step."""
+
+    def on_before_optimizer_step(self, trainer):
+        ttml.core.distributed.synchronize_gradients(trainer.model.parameters())
+
+
+class LossLogger(TrainerCallback):
+    """Collect per-step losses and write them to a JSON file at the end."""
+
+    def __init__(self, path: str):
+        self._path = path
+        self._records: list[dict] = []
+
+    def on_step_end(self, trainer, step, loss, lr):
+        self._records.append({"step": step, "loss": loss, "lr": lr})
+
+    def on_train_end(self, trainer):
+        import json
+
+        with open(self._path, "w") as f:
+            json.dump(self._records, f, indent=2)
+        print(f"Loss log saved to {self._path}")
+
+
+# ── Dataset & collate ─────────────────────────────────────────────────────────
+
+
+class ShakespeareChunkDataset:
+    """Indexable dataset of non-overlapping (seq_len+1)-token windows."""
+
+    def __init__(self, token_ids: np.ndarray, seq_len: int):
+        self._ids = token_ids
+        self._seq_len = seq_len
+        self._n = (len(token_ids) - 1) // seq_len
+
+    def __len__(self):
+        return self._n
+
+    def __getitem__(self, idx):
+        start = idx * self._seq_len
+        return {
+            "input_ids": self._ids[start : start + self._seq_len].tolist(),
+            "labels": self._ids[start + 1 : start + self._seq_len + 1].tolist(),
+        }
+
+
+def causal_lm_collate(
+    examples: list,
+    seq_len: int,
+    mapper=None,
+) -> Batch:
+    """Collate for causal LM -- every token position contributes to the loss."""
+    batch_size = len(examples)
+
+    input_ids_np = np.zeros((batch_size, 1, 1, seq_len), dtype=np.uint32)
+    labels_np = np.zeros((batch_size, seq_len), dtype=np.uint32)
+    loss_mask_np = np.ones((batch_size, 1, seq_len, 1), dtype=np.float32)
+
+    for i, ex in enumerate(examples):
+        ids = ex["input_ids"][:seq_len]
+        lbs = ex["labels"][:seq_len]
+        n = len(ids)
+        input_ids_np[i, 0, 0, :n] = ids
+        labels_np[i, :n] = lbs
+        if n < seq_len:
+            loss_mask_np[i, 0, n:, 0] = 0.0
+
+    total = loss_mask_np.sum()
+    if total > 0:
+        loss_mask_np *= (batch_size * seq_len) / total
+
+    return Batch(
+        input_ids=ttml.autograd.Tensor.from_numpy(
+            input_ids_np,
+            ttnn.Layout.ROW_MAJOR,
+            ttnn.DataType.UINT32,
+            mapper,
+        ),
+        labels=ttml.autograd.Tensor.from_numpy(
+            labels_np,
+            ttnn.Layout.ROW_MAJOR,
+            ttnn.DataType.UINT32,
+            mapper,
+        ),
+        loss_mask=ttml.autograd.Tensor.from_numpy(
+            loss_mask_np.astype(ml_dtypes.bfloat16),
+            ttnn.Layout.TILE,
+            ttnn.DataType.BFLOAT16,
+            mapper,
+        ),
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def validate_mesh_graph_descriptor(mesh_shape: list[int]) -> None:
+    """Validate that the MGD file topology matches the requested mesh shape."""
+    mgd_path = os.environ.get("TT_MESH_GRAPH_DESC_PATH")
+    if not mgd_path:
+        print("WARNING: TT_MESH_GRAPH_DESC_PATH not set, skipping MGD validation")
+        return
+    if not os.path.isfile(mgd_path):
+        print(f"WARNING: MGD file not found: {mgd_path}, skipping validation")
+        return
+
+    with open(mgd_path) as f:
+        content = f.read()
+
+    dims_match = re.search(r"device_topology\s*\{[^}]*dims\s*:\s*\[\s*([\d\s,]+)\]", content)
+    if not dims_match:
+        print(f"WARNING: Could not parse dims from MGD file: {mgd_path}")
+        return
+
+    mgd_dims = [int(d.strip()) for d in dims_match.group(1).split(",")]
+    if list(mgd_dims) != list(mesh_shape):
+        raise RuntimeError(
+            f"Mesh shape mismatch!\n"
+            f"  Requested mesh_shape: {mesh_shape}\n"
+            f"  MGD device_topology dims: {mgd_dims}\n"
+            f"Please ensure --ddp value matches the MGD file."
+        )
+    print(f"MGD validated: dims={mgd_dims}, file={mgd_path}")
+
+
+def llama_config_from_yaml(yaml_config: dict, vocab_size: int) -> LlamaConfig:
+    """Build a LlamaConfig from a model YAML (transformer_config section)."""
+    tc = yaml_config.get("transformer_config", {})
+
+    rope_scaling = LlamaRopeScalingConfig()
+    if "rope_scaling" in tc:
+        rs = tc["rope_scaling"]
+        rope_scaling = LlamaRopeScalingConfig(
+            scaling_factor=rs.get("scaling_factor", rope_scaling.scaling_factor),
+            high_freq_factor=rs.get("high_freq_factor", rope_scaling.high_freq_factor),
+            low_freq_factor=rs.get("low_freq_factor", rope_scaling.low_freq_factor),
+            original_context_length=rs.get("original_context_length", rope_scaling.original_context_length),
+        )
+
+    runner_type = RunnerType.Default
+    if "runner_type" in tc:
+        runner_type = RunnerType.from_string(tc["runner_type"])
+
+    weight_tying = WeightTyingType.Disabled
+    if "weight_tying" in tc:
+        weight_tying = WeightTyingType.from_string(tc["weight_tying"])
+
+    return LlamaConfig(
+        hidden_size=tc.get("embedding_dim", 384),
+        num_hidden_layers=tc.get("num_blocks", 6),
+        num_attention_heads=tc.get("num_heads", 6),
+        num_key_value_heads=tc.get("num_groups", 3),
+        vocab_size=vocab_size,
+        max_position_embeddings=tc.get("max_sequence_length", 256),
+        rope_theta=tc.get("theta", 10000.0),
+        attention_dropout=tc.get("dropout_prob", 0.0),
+        mlp_dropout=tc.get("dropout_prob", 0.0),
+        runner_type=runner_type,
+        weight_tying=weight_tying,
+        rope_scaling=rope_scaling,
+    )
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Llama LoRA fine-tuning on Shakespeare (SFTTrainer)")
+    parser.add_argument(
+        "-m",
+        "--model_config",
+        type=str,
+        default=None,
+        help="Path to model config YAML. Resolved relative to tt-train/ if not absolute.",
+    )
+    parser.add_argument(
+        "--pretrained",
+        type=str,
+        default=None,
+        help="HuggingFace repo ID or local path to .safetensors weights.",
+    )
+    parser.add_argument(
+        "--ddp",
+        type=int,
+        default=1,
+        help="Number of devices for distributed data parallel (default: 1).",
+    )
+    parser.add_argument(
+        "--batch",
+        type=int,
+        default=BATCH_SIZE_DEFAULT,
+        help=f"Global batch size (default: {BATCH_SIZE_DEFAULT}).",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=STEPS_DEFAULT,
+        help=f"Number of training steps (default: {STEPS_DEFAULT}).",
+    )
+    parser.add_argument(
+        "--save_every",
+        type=int,
+        default=0,
+        help="Save checkpoint every N steps (0 = disabled).",
+    )
+    parser.add_argument(
+        "--save_dir",
+        type=str,
+        default="checkpoints",
+        help="Directory for checkpoints (default: checkpoints/).",
+    )
+    parser.add_argument(
+        "--loss_log",
+        type=str,
+        default=None,
+        help="Path to write per-step loss JSON (disabled if not set).",
+    )
+    return parser.parse_args()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main():
+    args = parse_args()
+    batch_size = args.batch
+    num_devices = args.ddp
+    use_ddp = num_devices > 1
+
+    set_seed(42)
+
+    # ── Data ──────────────────────────────────────────────────────────────────
+
+    text = load_shakespeare_text()
+    pretrained_path = None
+
+    if args.pretrained:
+        from pathlib import Path
+
+        from transformers import AutoTokenizer
+
+        src = args.pretrained
+        if Path(src).is_dir():
+            pretrained_path = src
+        else:
+            from huggingface_hub import snapshot_download
+
+            print(f"Downloading weights from HuggingFace: {src}")
+            pretrained_path = snapshot_download(src, allow_patterns=["*.safetensors"])
+            print(f"Weights downloaded to: {pretrained_path}")
+
+        hf_tokenizer = AutoTokenizer.from_pretrained(src)
+        vocab_size = (hf_tokenizer.vocab_size + 31) // 32 * 32
+        ids = np.array(hf_tokenizer.encode(text), dtype=np.uint32)
+        print(f"Using HF BPE tokenizer, vocab_size={hf_tokenizer.vocab_size} " f"(padded to {vocab_size})")
+    else:
+        tokenizer = CharTokenizer(text)
+        vocab_size = (tokenizer.vocab_size + 31) // 32 * 32
+        ids = np.array(tokenizer.encode(text), dtype=np.uint32)
+
+    n_train = int(len(ids) * 0.9)
+    train_ids = ids[:n_train]
+
+    # ── Device ────────────────────────────────────────────────────────────────
+
+    mesh_shape = [1, num_devices]
+    if use_ddp:
+        if batch_size % num_devices != 0:
+            raise ValueError(f"--batch ({batch_size}) must be divisible by --ddp ({num_devices})")
+        ttml.core.distributed.enable_fabric(num_devices)
+        validate_mesh_graph_descriptor(mesh_shape)
+
+    autograd_ctx = ttml.autograd.AutoContext.get_instance()
+    if use_ddp:
+        autograd_ctx.open_device(mesh_shape)
+        autograd_ctx.initialize_parallelism_context(ttml.autograd.DistributedConfig(enable_ddp=True))
+        print(f"DDP enabled: {num_devices} devices, mesh_shape={mesh_shape}")
+    else:
+        autograd_ctx.open_device([1, 1], [0])
+
+    # ── DDP mappers / composer ────────────────────────────────────────────────
+
+    mapper = None
+    loss_composer = None
+    if use_ddp:
+        device = autograd_ctx.get_device()
+        mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 0)
+        loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+
+    # ── Model ─────────────────────────────────────────────────────────────────
+
+    if args.model_config is not None:
+        tt_train_root = f"{get_tt_metal_runtime_root()}/tt-train"
+        print(f"Loading model config from: {args.model_config}")
+        yaml_config = load_config(args.model_config, tt_train_root)
+        llama_cfg = llama_config_from_yaml(yaml_config, vocab_size)
+    else:
+        llama_cfg = LlamaConfig(
+            hidden_size=384,
+            num_hidden_layers=6,
+            num_attention_heads=6,
+            num_key_value_heads=3,
+            vocab_size=vocab_size,
+            max_position_embeddings=256,
+            rope_theta=500000.0,
+        )
+
+    seq_len = llama_cfg.max_position_embeddings
+    print(
+        f"Model: hidden_size={llama_cfg.hidden_size}, "
+        f"layers={llama_cfg.num_hidden_layers}, "
+        f"heads={llama_cfg.num_attention_heads}, "
+        f"kv_heads={llama_cfg.num_key_value_heads}, "
+        f"seq_len={seq_len}"
+    )
+
+    model = Llama(llama_cfg)
+
+    if pretrained_path is not None:
+        print(f"Loading pretrained weights from: {pretrained_path}")
+        load_from_safetensors(model, pretrained_path, llama_cfg)
+
+    # ── Dataloader ────────────────────────────────────────────────────────────
+
+    dataset = ShakespeareChunkDataset(train_ids, seq_len)
+    collate = partial(causal_lm_collate, seq_len=seq_len, mapper=mapper)
+    train_loader = InMemoryDataloader(dataset, collate, batch_size=batch_size, shuffle=True)
+
+    # ── Callbacks ─────────────────────────────────────────────────────────────
+
+    callbacks: list[TrainerCallback] = []
+    if use_ddp:
+        callbacks.append(DDPCallback())
+    if args.loss_log:
+        callbacks.append(LossLogger(args.loss_log))
+
+    # ── LoRA + SFTTrainer ─────────────────────────────────────────────────────
+
+    peft_config = LoraConfig(
+        rank=LORA_RANK,
+        alpha=LORA_ALPHA,
+        target_modules=LORA_TARGET_MODULES,
+        lora_dropout=LORA_DROPOUT,
+    )
+
+    sft_config = SFTConfig(
+        max_steps=args.steps,
+        learning_rate=LR,
+        max_seq_len=seq_len,
+        save_interval=args.save_every,
+        checkpoint_dir=args.save_dir,
+        eval_interval=0,
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        train_dataloader=train_loader,
+        eval_dataloader=None,
+        config=sft_config,
+        peft_config=peft_config,
+        optimizer={
+            "type": "AdamW",
+            "lr": LR,
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "epsilon": 1e-8,
+            "weight_decay": WEIGHT_DECAY,
+        },
+        callbacks=callbacks,
+        loss_composer=loss_composer,
+    )
+
+    summary(trainer.model)
+    trainer.train()
+
+    autograd_ctx.close_device()
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -104,15 +104,17 @@ class SFTTrainer:
     defined by :class:`~ttml.modules.module_base.AbstractModuleBase` and
     :class:`~ttml.datasets.TTMLDataloader`.
 
-    Multi-device training (e.g. DDP) is supported by combining three
+    Multi-device training (e.g. DDP) is supported by combining two
     extension points:
 
     * A **collate function** that shards batch tensors across the mesh
       (via ``shard_tensor_to_mesh_mapper``).
     * The :meth:`~TrainerCallback.on_before_optimizer_step` callback to
       synchronise gradients before the optimiser step.
-    * The ``loss_composer`` constructor argument to aggregate loss values
-      across devices for logging.
+
+    Loss aggregation across devices is handled automatically via a default
+    ``concat_mesh_to_tensor_composer(device, 0)``.  Pass a custom
+    ``loss_composer`` to override.
 
     Example::
 
@@ -168,10 +170,8 @@ class SFTTrainer:
                 logic is bypassed entirely.
             loss_composer: Optional mesh composer passed to
                 ``loss.to_numpy(composer=...)`` when extracting scalar loss
-                values for logging.  For multi-device setups (e.g. DDP), pass
-                a ``concat_mesh_to_tensor_composer`` so that loss values are
-                aggregated across all devices.  ``None`` (default) leaves the
-                single-device behaviour unchanged.
+                values for logging. By default a `concat_mesh_to_tensor_composer` with dim=0 is used.
+                (Covers both single-device and multi-device DDP configurations.)
             attention_mask: Optional attention mask passed as the second
                 argument to ``model(input_ids, mask)``.  ``None`` (default)
                 lets the model generate a causal mask on the fly.
@@ -204,7 +204,7 @@ class SFTTrainer:
         self._loss_fn = ttml.ops.loss.cross_entropy_loss
         self._callbacks = callbacks or []
         self._compute_loss_override = compute_loss_func
-        self._loss_composer = loss_composer
+        self._loss_composer = self._build_loss_composer(loss_composer)
 
     # ------------------------------------------------------------------
     # Public API
@@ -392,6 +392,13 @@ class SFTTrainer:
             return peak_lr
 
         return schedule
+
+    def _build_loss_composer(self, loss_composer: Optional[Any] = None):
+        """Create a mesh composer for aggregating loss across devices."""
+        if loss_composer is not None:
+            return loss_composer
+        device = ttml.autograd.AutoContext.get_instance().get_device()
+        return ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
 
     @staticmethod
     def _enable_gradient_checkpointing(model: Any) -> None:

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Single-device Supervised Fine-Tuning (SFT) trainer."""
+"""Supervised Fine-Tuning (SFT) trainer."""
 
 from __future__ import annotations
 
@@ -22,7 +22,6 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 import ttml
-from ttml.common.data import build_causal_mask
 from ttml.common.utils import no_grad
 from ttml.datasets import Batch, TTMLDataloader
 
@@ -37,12 +36,13 @@ class TrainerCallback:
     def on_train_begin(self, trainer: "SFTTrainer") -> None:
         pass
 
-    def on_step_end(
-        self, trainer: "SFTTrainer", step: int, loss: float, lr: float
-    ) -> None:
+    def on_step_end(self, trainer: "SFTTrainer", step: int, loss: float, lr: float) -> None:
         pass
 
     def on_eval_end(self, trainer: "SFTTrainer", step: int, eval_loss: float) -> None:
+        pass
+
+    def on_before_optimizer_step(self, trainer: "SFTTrainer") -> None:
         pass
 
     def on_save(self, trainer: "SFTTrainer", step: int, path: str) -> None:
@@ -68,7 +68,8 @@ class SFTConfig:
         save_interval: Save a checkpoint every *N* steps (0 to disable).
         checkpoint_dir: Directory for checkpoint files.
         seed: Optional RNG seed for reproducibility.
-        max_seq_len: Maximum sequence length (used for the causal mask).
+        max_seq_len: Maximum sequence length (currently unused; kept for
+            backward compatibility).
         learning_rate: Peak learning rate, also used to initialise the default
             AdamW optimizer when no explicit optimizer is provided.
         warmup_steps: Linear warmup steps for the default schedule.
@@ -96,17 +97,22 @@ class SFTConfig:
 
 
 class SFTTrainer:
-    """Supervised fine-tuning trainer for a single Tenstorrent device.
-
-    .. note::
-        Multi-device (e.g. data-parallel, tensor-parallel) training is not
-        yet supported.  This is planned as a future enhancement.
-        TODO: extend to multi-device topologies.
+    """Supervised fine-tuning trainer for Tenstorrent devices.
 
     The trainer owns the training loop, optimizer, and scheduler.  It knows
     nothing about model internals or dataset structure — only the interfaces
     defined by :class:`~ttml.modules.module_base.AbstractModuleBase` and
     :class:`~ttml.datasets.TTMLDataloader`.
+
+    Multi-device training (e.g. DDP) is supported by combining three
+    extension points:
+
+    * A **collate function** that shards batch tensors across the mesh
+      (via ``shard_tensor_to_mesh_mapper``).
+    * The :meth:`~TrainerCallback.on_before_optimizer_step` callback to
+      synchronise gradients before the optimiser step.
+    * The ``loss_composer`` constructor argument to aggregate loss values
+      across devices for logging.
 
     Example::
 
@@ -133,6 +139,8 @@ class SFTTrainer:
         lr_schedule: Optional[Callable[[int], float]] = None,
         callbacks: Optional[list[TrainerCallback]] = None,
         compute_loss_func: Optional[Callable] = None,
+        loss_composer: Any = None,
+        attention_mask: Any = None,
     ) -> None:
         """
         Args:
@@ -158,6 +166,15 @@ class SFTTrainer:
                 caller is fully responsible for applying ``batch.loss_mask``
                 (or any other prompt/pad masking strategy); the default masking
                 logic is bypassed entirely.
+            loss_composer: Optional mesh composer passed to
+                ``loss.to_numpy(composer=...)`` when extracting scalar loss
+                values for logging.  For multi-device setups (e.g. DDP), pass
+                a ``concat_mesh_to_tensor_composer`` so that loss values are
+                aggregated across all devices.  ``None`` (default) leaves the
+                single-device behaviour unchanged.
+            attention_mask: Optional attention mask passed as the second
+                argument to ``model(input_ids, mask)``.  ``None`` (default)
+                lets the model generate a causal mask on the fly.
 
         Note:
             When ``config.gradient_checkpointing`` is ``True`` the model's
@@ -182,13 +199,12 @@ class SFTTrainer:
         self.step = 0  # 0-based; incremented after each optimizer step
 
         self._optimizer = self._build_optimizer(optimizer)
-        self._lr_schedule = (
-            lr_schedule if lr_schedule is not None else self._build_lr_schedule()
-        )
-        self._causal_mask = self._build_causal_mask()
+        self._lr_schedule = lr_schedule if lr_schedule is not None else self._build_lr_schedule()
+        self._attention_mask = attention_mask
         self._loss_fn = ttml.ops.loss.cross_entropy_loss
         self._callbacks = callbacks or []
         self._compute_loss_override = compute_loss_func
+        self._loss_composer = loss_composer
 
     # ------------------------------------------------------------------
     # Public API
@@ -227,27 +243,25 @@ class SFTTrainer:
             for _ in range(cfg.gradient_accumulation_steps):
                 batch = _next_batch()
                 loss = self._compute_loss(batch)
-                micro_losses.append(float(loss.to_numpy(ttnn.DataType.FLOAT32).mean()))
+                micro_losses.append(float(loss.to_numpy(ttnn.DataType.FLOAT32, composer=self._loss_composer).mean()))
 
-                scaled = ttml.ops.binary.mul(
-                    loss, 1.0 / cfg.gradient_accumulation_steps
-                )
-                scaled.backward(False)
+                if cfg.gradient_accumulation_steps > 1:
+                    loss = ttml.ops.binary.mul(loss, 1.0 / cfg.gradient_accumulation_steps)
+                loss.backward(False)
                 ttml.autograd.AutoContext.get_instance().reset_graph()
 
+            for cb in self._callbacks:
+                cb.on_before_optimizer_step(self)
+
             if cfg.max_grad_norm > 0:
-                ttml.core.clip_grad_norm(
-                    self.model.parameters(), cfg.max_grad_norm, 2.0, False
-                )
+                ttml.core.clip_grad_norm(self.model.parameters(), cfg.max_grad_norm, 2.0, False)
 
             self._optimizer.step()
             self.step += 1
 
             step_loss = float(np.mean(micro_losses))
             if cfg.log_interval > 0 and self.step % cfg.log_interval == 0:
-                bar.set_postfix(
-                    {"loss": f"{step_loss:.4f}", "lr": f"{lr:.2e}"}, refresh=False
-                )
+                bar.set_postfix({"loss": f"{step_loss:.4f}", "lr": f"{lr:.2e}"}, refresh=False)
                 for cb in self._callbacks:
                     cb.on_step_end(self, self.step, step_loss, lr)
 
@@ -265,11 +279,7 @@ class SFTTrainer:
                     for cb in self._callbacks:
                         cb.on_eval_end(self, self.step, val_loss)
 
-            if (
-                cfg.save_interval > 0
-                and self.step % cfg.save_interval == 0
-                and self.step > 0
-            ):
+            if cfg.save_interval > 0 and self.step % cfg.save_interval == 0 and self.step > 0:
                 self._save_checkpoint()
                 for cb in self._callbacks:
                     cb.on_save(
@@ -291,7 +301,7 @@ class SFTTrainer:
         If *compute_loss_func* was provided it is called instead of the
         default masked cross-entropy.
         """
-        logits = self.model(batch.input_ids, self._causal_mask)  # [B, 1, T, V]
+        logits = self.model(batch.input_ids, self._attention_mask)  # [B, 1, T, V]
         if self._compute_loss_override is not None:
             return self._compute_loss_override(logits, batch)
 
@@ -312,9 +322,7 @@ class SFTTrainer:
                     int(expected),
                 )
 
-        loss = self._loss_fn(
-            logits, batch.labels, ttml.ops.ReduceType.NONE
-        )  # [B, 1, T, 1]
+        loss = self._loss_fn(logits, batch.labels, ttml.ops.ReduceType.NONE)  # [B, 1, T, 1]
         loss = loss * batch.loss_mask  # zero out prompt + padding
         return ttml.ops.unary.mean(loss)
 
@@ -325,7 +333,7 @@ class SFTTrainer:
         with no_grad():
             for batch in self.eval_dataloader:
                 loss = self._compute_loss(batch)
-                losses.append(float(loss.to_numpy(ttnn.DataType.FLOAT32).mean()))
+                losses.append(float(loss.to_numpy(ttnn.DataType.FLOAT32, composer=self._loss_composer).mean()))
         self.model.train()
         return float(np.mean(losses))
 
@@ -397,9 +405,3 @@ class SFTTrainer:
         if cfg is None or not hasattr(cfg, "runner_type"):
             return
         target.config = replace(cfg, runner_type=ttml.models.RunnerType.MemoryEfficient)
-
-    def _build_causal_mask(self):
-        mask_np = build_causal_mask(self.config.max_seq_len)  # [1, 1, T, T]
-        return ttml.autograd.Tensor.from_numpy(
-            mask_np, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
-        )

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -309,7 +309,7 @@ class SFTTrainer:
         # should sum to B*T (one entry per token position).  A large deviation
         # usually indicates a custom collate that forgot to normalise.
         if batch.loss_mask is not None:
-            mask_np = batch.loss_mask.to_numpy(ttnn.DataType.FLOAT32)
+            mask_np = batch.loss_mask.to_numpy(ttnn.DataType.FLOAT32, composer=self._loss_composer)
             B, _, T, _ = mask_np.shape
             expected = float(B * T)
             actual = float(mask_np.sum())


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We need lora example with sft trainer + support for ddp in sft trainer

### What's changed
Small updates to sft trainer: 
- `on_before_optimizer_step` callback for gradient synchronization
- `loss_composer` parameter for multi-device loss aggregation in logging
- `attention_mask` parameter to pass an arbitrary mask (or None to let the model generate causal mask on the fly, which is faster)

Add train_lora_llama_sft.py -- reimplements the existing LoRA fine-tuning example using SFTTrainer + LoraConfig (HuggingFace PEFT-style API), with optional DDP and --loss_log for dumping per-step losses to JSON

Align data sampling in train_lora_llama.py -- replace random get_batch with shuffled-sequential chunk iteration matching InMemoryDataloader(shuffle=True), so both scripts produce identical losses

Update SFT_TRAINER.md with new constructor params, callback hook, and a DDP usage guide

I have verified that both sft and original script produce identical loss. 


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/sft_lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/sft_lora)