### PR TITLE
Add link retrain logging for exabox validation script

### DIFF
--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -154,6 +154,8 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
 fi
 
 run_cluster_validation() {
+    local validation_output_path="$1"
+
     if [[ -n "$FACTORY_DESCRIPTOR_PATH" ]]; then
         local descriptor_args=(--factory-descriptor-path "$FACTORY_DESCRIPTOR_PATH")
     else
@@ -172,7 +174,8 @@ run_cluster_validation() {
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
             --send-traffic \
-            --num-iterations 10
+            --num-iterations 10 \
+            --output-path "$validation_output_path"
     else
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
@@ -181,7 +184,8 @@ run_cluster_validation() {
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
             --send-traffic \
-            --num-iterations 10
+            --num-iterations 10 \
+            --output-path "$validation_output_path"
     fi
 }
 
@@ -298,6 +302,9 @@ for ((i=1; i<=ITERATIONS; i++)); do
             echo "Skipping validation due to mpirun failure"
         fi
 
+        echo ""
+        echo "Running cluster validation..."
+        run_cluster_validation "$OUTPUT_DIR/iteration_${i}"
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"
@@ -317,7 +324,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
             echo ""
 
             echo "Re-running cluster validation..."
-            run_cluster_validation
+            run_cluster_validation "$OUTPUT_DIR/iteration_${i}_retry"
             echo "Iteration $i retry completed at $(date)"
             echo "=========================================="
         } 2>&1 | tee "$LOG_FILE_RETRY"
@@ -326,5 +333,37 @@ for ((i=1; i<=ITERATIONS; i++)); do
     echo "Iteration $i logged to $LOG_FILE"
     echo ""
 done
+
+# Aggregate link retrain reports across all iterations
+RETRAIN_SUMMARY="$OUTPUT_DIR/link_retrain_summary.csv"
+retrain_csvs=()
+while IFS= read -r -d '' csv; do
+    retrain_csvs+=("$csv")
+done < <(find "$OUTPUT_DIR" -name "link_retrain_report.csv" -print0 2>/dev/null | sort -z)
+
+if [[ ${#retrain_csvs[@]} -gt 0 ]]; then
+    echo "=========================================="
+    echo "LINK RETRAIN SUMMARY (across all iterations)"
+    echo "=========================================="
+    echo "Iterations with retraining: ${#retrain_csvs[@]}"
+    echo ""
+
+    {
+        echo "Iteration,Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count"
+        for csv in "${retrain_csvs[@]}"; do
+            iter_dir=$(basename "$(dirname "$csv")")
+            tail -n +2 "$csv" | while IFS= read -r line; do
+                echo "${iter_dir},${line}"
+            done
+        done
+    } > "$RETRAIN_SUMMARY"
+
+    column -t -s, "$RETRAIN_SUMMARY"
+    echo ""
+    echo "Full retrain summary written to: $RETRAIN_SUMMARY"
+    echo ""
+else
+    echo "No link retraining events detected across $ITERATIONS iterations."
+fi
 
 echo "All $ITERATIONS iterations completed!"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -256,8 +256,14 @@ echo "Number of iterations: $ITERATIONS"
 echo "Output directory: $OUTPUT_DIR"
 echo ""
 
-# Create output directory if it doesn't exist
+# Create output directory if it doesn't exist and resolve to an absolute path so
+# that paths passed into Docker containers refer to the same location on the host.
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+# Ensure the output directory is bind-mounted into containers so per-iteration
+# CSVs survive container exit and are visible to the host-side aggregation step.
+EXTRA_VOLUMES+=("$OUTPUT_DIR")
 
 # Main testing loop
 for ((i=1; i<=ITERATIONS; i++)); do
@@ -297,24 +303,21 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
             echo ""
             echo "Running cluster validation..."
-            run_cluster_validation
+            run_cluster_validation "$OUTPUT_DIR/iteration_${i}"
         else
             echo "Skipping validation due to mpirun failure"
         fi
 
-        echo ""
-        echo "Running cluster validation..."
-        run_cluster_validation "$OUTPUT_DIR/iteration_${i}"
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"
 
     if [[ "$RERUN_ON_RETRAIN" == true ]] && grep -q "Ethernet Links were Retrained" "$LOG_FILE"; then
-        OUTPUT_DIR_RETRY="${OUTPUT_DIR}_retry"
-
-        mkdir -p "$OUTPUT_DIR_RETRY"
-
-        LOG_FILE_RETRY="$OUTPUT_DIR_RETRY/cluster_validation_iteration_${i}_retry.log"
+        # Keep all retry artifacts (log + per-iteration retrain CSV) under the same base
+        # output directory so the end-of-run aggregation finds everything in one scan.
+        ITER_RETRY_DIR="$OUTPUT_DIR/iteration_${i}_retry"
+        mkdir -p "$ITER_RETRY_DIR"
+        LOG_FILE_RETRY="$ITER_RETRY_DIR/cluster_validation_iteration_${i}_retry.log"
 
         {
             echo "=========================================="
@@ -324,7 +327,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
             echo ""
 
             echo "Re-running cluster validation..."
-            run_cluster_validation "$OUTPUT_DIR/iteration_${i}_retry"
+            run_cluster_validation "$ITER_RETRY_DIR"
             echo "Iteration $i retry completed at $(date)"
             echo "=========================================="
         } 2>&1 | tee "$LOG_FILE_RETRY"
@@ -334,36 +337,63 @@ for ((i=1; i<=ITERATIONS; i++)); do
     echo ""
 done
 
-# Aggregate link retrain reports across all iterations
+# ----------------------------------------------------------------------------
+# End-of-run aggregation: produce a single CSV with one row per retrained link
+# and the total number of retrains observed across the entire run (all
+# iterations + retries). Per-iteration link_retrain_report.csv files are
+# written by the C++ tool inside each iteration's output directory.
+# ----------------------------------------------------------------------------
 RETRAIN_SUMMARY="$OUTPUT_DIR/link_retrain_summary.csv"
+
 retrain_csvs=()
 while IFS= read -r -d '' csv; do
     retrain_csvs+=("$csv")
-done < <(find "$OUTPUT_DIR" -name "link_retrain_report.csv" -print0 2>/dev/null | sort -z)
+done < <(find "$OUTPUT_DIR" -name "link_retrain_report.csv" -print0 2>/dev/null | sort -zV)
 
-if [[ ${#retrain_csvs[@]} -gt 0 ]]; then
-    echo "=========================================="
-    echo "LINK RETRAIN SUMMARY (across all iterations)"
-    echo "=========================================="
-    echo "Iterations with retraining: ${#retrain_csvs[@]}"
-    echo ""
+echo "=========================================="
+echo "LINK RETRAIN SUMMARY (across all iterations)"
+echo "=========================================="
 
-    {
-        echo "Iteration,Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count"
-        for csv in "${retrain_csvs[@]}"; do
-            iter_dir=$(basename "$(dirname "$csv")")
-            tail -n +2 "$csv" | while IFS= read -r line; do
-                echo "${iter_dir},${line}"
-            done
-        done
-    } > "$RETRAIN_SUMMARY"
-
-    column -t -s, "$RETRAIN_SUMMARY"
+if [[ ${#retrain_csvs[@]} -eq 0 ]]; then
+    echo "No link retraining events detected across $ITERATIONS iteration(s)."
     echo ""
-    echo "Full retrain summary written to: $RETRAIN_SUMMARY"
-    echo ""
-else
-    echo "No link retraining events detected across $ITERATIONS iterations."
+    echo "All $ITERATIONS iterations completed!"
+    exit 0
 fi
+
+echo "Iterations (incl. retries) with retraining: ${#retrain_csvs[@]}"
+echo ""
+
+# Sum Retrain_Count per (Host,Tray,ASIC,Channel,Unique_ID) across all CSVs.
+# Each per-iteration CSV has header: Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count
+{
+    echo "Host,Tray,ASIC,Channel,Unique_ID,Total_Retrain_Count"
+    awk -F, '
+        FNR == 1 { next }                       # skip per-file header
+        {
+            key = $1 FS $2 FS $3 FS $4 FS $5
+            counts[key] += $6
+        }
+        END {
+            for (k in counts) print k FS counts[k]
+        }
+    ' "${retrain_csvs[@]}" | sort -t, -k1,1 -k2,2n -k3,3n -k4,4n
+} > "$RETRAIN_SUMMARY"
+
+if command -v column >/dev/null 2>&1; then
+    column -t -s, "$RETRAIN_SUMMARY"
+else
+    cat "$RETRAIN_SUMMARY"
+fi
+
+# Total retrain events across all links (sum of the rightmost column).
+TOTAL_RETRAIN_EVENTS=$(awk -F, 'NR > 1 { s += $6 } END { print s+0 }' "$RETRAIN_SUMMARY")
+UNIQUE_LINKS=$(($(wc -l < "$RETRAIN_SUMMARY") - 1))
+
+echo ""
+echo "Unique links retrained: $UNIQUE_LINKS"
+echo "Total retrain events: $TOTAL_RETRAIN_EVENTS"
+echo "Full retrain summary written to: $RETRAIN_SUMMARY"
+echo ""
 
 echo "All $ITERATIONS iterations completed!"

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -382,7 +382,16 @@ int main(int argc, char* argv[]) {
     constexpr uint32_t MAX_RETRAINS_BEFORE_FAILURE =
         5;  // If links don't come up after 5 retrains, the system is in an unrecoverable state.
     uint32_t num_retrains = 0;
+    std::unordered_map<EthChannelIdentifier, uint32_t> link_retrain_counts;
     while (!missing_asic_topology.empty() && link_retrain_supported && num_retrains < MAX_RETRAINS_BEFORE_FAILURE) {
+        auto retrained_links = collect_retrained_link_identifiers(missing_asic_topology, physical_system_descriptor);
+        for (const auto& link_id : retrained_links) {
+            link_retrain_counts[link_id]++;
+        }
+        log_output_rank0(
+            "Link Retrain Iteration " + std::to_string(num_retrains + 1) + ": Retraining " +
+            std::to_string(retrained_links.size()) + " link endpoints");
+
         reset_ethernet_links(physical_system_descriptor, missing_asic_topology);
         links_reset = true;
         num_retrains++;
@@ -402,10 +411,12 @@ int main(int argc, char* argv[]) {
 
     distributed_context.barrier();
     if (num_retrains == MAX_RETRAINS_BEFORE_FAILURE && !missing_asic_topology.empty()) {
+        log_link_retrain_summary(link_retrain_counts, num_retrains, input_args.output_path);
         TT_THROW("Encountered unrecoverable state. Please check the system and try again.");
         return -1;
     }
     if (links_reset) {
+        log_link_retrain_summary(link_retrain_counts, num_retrains, input_args.output_path);
         // Return and ask user to run again, otherwise some incorrect HW states might persist and cause hangs
         log_output_rank0("Ethernet Links were Retrained. Please run the validation tool again to issue traffic.");
         return 0;

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1294,6 +1294,93 @@ void forward_link_reset_metadata_from_controller(
     }
 }
 
+std::vector<EthChannelIdentifier> collect_retrained_link_identifiers(
+    const tt::tt_metal::AsicTopology& missing_topology, const PhysicalSystemDescriptor& physical_system_descriptor) {
+    std::vector<EthChannelIdentifier> retrained_links;
+    const auto& asic_descriptors = physical_system_descriptor.get_asic_descriptors();
+
+    for (const auto& [asic_id, asic_connections] : missing_topology) {
+        if (!asic_descriptors.contains(asic_id)) {
+            continue;
+        }
+        const auto& asic_desc = asic_descriptors.at(asic_id);
+
+        for (const auto& [dst_asic_id, eth_connections] : asic_connections) {
+            for (const auto& eth_connection : eth_connections) {
+                retrained_links.push_back(EthChannelIdentifier{
+                    .host = asic_desc.host_name,
+                    .asic_id = asic_desc.unique_id,
+                    .tray_id = asic_desc.tray_id,
+                    .asic_location = asic_desc.asic_location,
+                    .channel = eth_connection.src_chan,
+                });
+            }
+        }
+    }
+
+    return retrained_links;
+}
+
+void log_link_retrain_summary(
+    const std::unordered_map<EthChannelIdentifier, uint32_t>& link_retrain_counts,
+    uint32_t total_retrain_iterations,
+    const std::filesystem::path& output_path) {
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+
+    if (*distributed_context.rank() != 0) {
+        return;
+    }
+
+    if (link_retrain_counts.empty()) {
+        return;
+    }
+
+    log_output_rank0(
+        "Link Retraining Summary: " + std::to_string(link_retrain_counts.size()) + " link endpoints retrained over " +
+        std::to_string(total_retrain_iterations) + " iteration(s)");
+
+    std::cout << std::endl;
+    std::cout << "╔═══════════════════════════════════════════════════════════════════════════════╗" << std::endl;
+    std::cout << "║                          LINK RETRAINING REPORT                              ║" << std::endl;
+    std::cout << "╚═══════════════════════════════════════════════════════════════════════════════╝" << std::endl;
+    std::cout << "Total Retrained Link Endpoints: " << link_retrain_counts.size() << std::endl;
+    std::cout << "Total Retrain Iterations: " << total_retrain_iterations << std::endl << std::endl;
+
+    std::cout << std::left << std::setw(20) << "Host" << std::setw(6) << "Tray" << std::setw(6) << "ASIC"
+              << std::setw(5) << "Ch" << std::setw(14) << "Unique ID" << std::setw(16) << "Retrain Count" << std::endl;
+
+    std::cout << std::string(67, '-') << std::endl;
+
+    for (const auto& [channel_id, retrain_count] : link_retrain_counts) {
+        std::stringstream uid_stream;
+        uid_stream << "0x" << std::hex << std::setfill('0') << std::setw(10) << *channel_id.asic_id;
+
+        std::cout << std::left << std::setw(20) << channel_id.host << std::setw(6) << *channel_id.tray_id
+                  << std::setw(6) << *channel_id.asic_location << std::setw(5) << static_cast<int>(channel_id.channel)
+                  << std::setw(14) << uid_stream.str() << std::dec << std::setfill(' ') << std::setw(16)
+                  << retrain_count << std::endl;
+    }
+
+    std::cout << std::string(67, '-') << std::endl << std::endl;
+
+    std::filesystem::create_directories(output_path);
+    std::filesystem::path csv_path = output_path / "link_retrain_report.csv";
+    std::ofstream csv_file(csv_path);
+
+    if (csv_file.is_open()) {
+        csv_file << "Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count" << std::endl;
+        for (const auto& [channel_id, retrain_count] : link_retrain_counts) {
+            csv_file << channel_id.host << "," << *channel_id.tray_id << "," << *channel_id.asic_location << ","
+                     << static_cast<int>(channel_id.channel) << ","
+                     << "0x" << std::hex << *channel_id.asic_id << std::dec << "," << retrain_count << std::endl;
+        }
+        csv_file.close();
+        log_output_rank0("✓ Link retrain report written to: " + csv_path.string());
+    } else {
+        log_output_rank0("✗ Warning: Could not open CSV file for writing: " + csv_path.string());
+    }
+}
+
 void reset_local_ethernet_links(
     const PhysicalSystemDescriptor& physical_system_descriptor, const tt::tt_metal::AsicTopology& asic_topology) {
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -14,6 +14,8 @@
 #include <future>
 #include <chrono>
 #include <exception>
+#include <system_error>
+#include <tuple>
 #include <unordered_set>
 #include <thread>
 
@@ -1335,50 +1337,76 @@ void log_link_retrain_summary(
         return;
     }
 
-    log_output_rank0(
-        "Link Retraining Summary: " + std::to_string(link_retrain_counts.size()) + " link endpoints retrained over " +
-        std::to_string(total_retrain_iterations) + " iteration(s)");
+    // Sort entries by (host, tray, asic_location, channel) for stable, diff-friendly output
+    // across runs. std::unordered_map iteration order is unspecified.
+    std::vector<std::pair<EthChannelIdentifier, uint32_t>> sorted_entries(
+        link_retrain_counts.begin(), link_retrain_counts.end());
+    std::sort(sorted_entries.begin(), sorted_entries.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.first.host, *lhs.first.tray_id, *lhs.first.asic_location, lhs.first.channel) <
+               std::tie(rhs.first.host, *rhs.first.tray_id, *rhs.first.asic_location, rhs.first.channel);
+    });
 
-    std::cout << std::endl;
-    std::cout << "╔═══════════════════════════════════════════════════════════════════════════════╗" << std::endl;
-    std::cout << "║                          LINK RETRAINING REPORT                              ║" << std::endl;
-    std::cout << "╚═══════════════════════════════════════════════════════════════════════════════╝" << std::endl;
-    std::cout << "Total Retrained Link Endpoints: " << link_retrain_counts.size() << std::endl;
-    std::cout << "Total Retrain Iterations: " << total_retrain_iterations << std::endl << std::endl;
+    auto format_unique_id = [](const auto& asic_id) {
+        std::stringstream ss;
+        ss << "0x" << std::hex << std::setfill('0') << std::setw(10) << *asic_id;
+        return ss.str();
+    };
+
+    uint32_t total_retrain_events = 0;
+    for (const auto& entry : sorted_entries) {
+        total_retrain_events += entry.second;
+    }
+
+    log_output_rank0(
+        "Link Retraining Summary: " + std::to_string(sorted_entries.size()) + " link endpoint(s) retrained over " +
+        std::to_string(total_retrain_iterations) + " retrain iteration(s)");
+
+    constexpr int kBannerWidth = 67;
+    const std::string banner_line(kBannerWidth, '=');
+    std::cout << '\n' << banner_line << '\n';
+    std::cout << "                       LINK RETRAINING REPORT" << '\n';
+    std::cout << banner_line << '\n';
+    std::cout << "Unique link endpoints retrained: " << sorted_entries.size() << '\n';
+    std::cout << "Retrain loop iterations:         " << total_retrain_iterations << '\n';
+    std::cout << "Total retrain events:            " << total_retrain_events << "\n\n";
 
     std::cout << std::left << std::setw(20) << "Host" << std::setw(6) << "Tray" << std::setw(6) << "ASIC"
-              << std::setw(5) << "Ch" << std::setw(14) << "Unique ID" << std::setw(16) << "Retrain Count" << std::endl;
+              << std::setw(5) << "Ch" << std::setw(14) << "Unique ID" << std::setw(16) << "Retrain Count" << '\n';
+    std::cout << std::string(kBannerWidth, '-') << '\n';
 
-    std::cout << std::string(67, '-') << std::endl;
-
-    for (const auto& [channel_id, retrain_count] : link_retrain_counts) {
-        std::stringstream uid_stream;
-        uid_stream << "0x" << std::hex << std::setfill('0') << std::setw(10) << *channel_id.asic_id;
-
+    for (const auto& [channel_id, retrain_count] : sorted_entries) {
         std::cout << std::left << std::setw(20) << channel_id.host << std::setw(6) << *channel_id.tray_id
                   << std::setw(6) << *channel_id.asic_location << std::setw(5) << static_cast<int>(channel_id.channel)
-                  << std::setw(14) << uid_stream.str() << std::dec << std::setfill(' ') << std::setw(16)
-                  << retrain_count << std::endl;
+                  << std::setw(14) << format_unique_id(channel_id.asic_id) << std::setw(16) << retrain_count << '\n';
+    }
+    std::cout << std::string(kBannerWidth, '-') << "\n\n";
+
+    // Best-effort CSV emission. Any filesystem failure is logged but must not throw,
+    // because this runs on the link-retrain early-exit path before TT_THROW.
+    std::error_code ec;
+    std::filesystem::create_directories(output_path, ec);
+    if (ec) {
+        log_output_rank0(
+            "[WARN] Could not create output directory for link retrain report: " + output_path.string() + " (" +
+            ec.message() + ")");
+        return;
     }
 
-    std::cout << std::string(67, '-') << std::endl << std::endl;
-
-    std::filesystem::create_directories(output_path);
-    std::filesystem::path csv_path = output_path / "link_retrain_report.csv";
+    const std::filesystem::path csv_path = output_path / "link_retrain_report.csv";
     std::ofstream csv_file(csv_path);
-
-    if (csv_file.is_open()) {
-        csv_file << "Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count" << std::endl;
-        for (const auto& [channel_id, retrain_count] : link_retrain_counts) {
-            csv_file << channel_id.host << "," << *channel_id.tray_id << "," << *channel_id.asic_location << ","
-                     << static_cast<int>(channel_id.channel) << ","
-                     << "0x" << std::hex << *channel_id.asic_id << std::dec << "," << retrain_count << std::endl;
-        }
-        csv_file.close();
-        log_output_rank0("✓ Link retrain report written to: " + csv_path.string());
-    } else {
-        log_output_rank0("✗ Warning: Could not open CSV file for writing: " + csv_path.string());
+    if (!csv_file.is_open()) {
+        log_output_rank0("[WARN] Could not open CSV file for writing: " + csv_path.string());
+        return;
     }
+
+    csv_file << "Host,Tray,ASIC,Channel,Unique_ID,Retrain_Count\n";
+    for (const auto& [channel_id, retrain_count] : sorted_entries) {
+        csv_file << channel_id.host << ',' << *channel_id.tray_id << ',' << *channel_id.asic_location << ','
+                 << static_cast<int>(channel_id.channel) << ',' << format_unique_id(channel_id.asic_id) << ','
+                 << retrain_count << '\n';
+    }
+    csv_file.close();
+    log_output_rank0("Link retrain report written to: " + csv_path.string());
 }
 
 void reset_local_ethernet_links(

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -78,6 +78,14 @@ bool generate_link_metrics(
 void reset_ethernet_links(
     const PhysicalSystemDescriptor& physical_system_descriptor, const tt_metal::AsicTopology& asic_topology);
 
+std::vector<EthChannelIdentifier> collect_retrained_link_identifiers(
+    const tt_metal::AsicTopology& missing_topology, const PhysicalSystemDescriptor& physical_system_descriptor);
+
+void log_link_retrain_summary(
+    const std::unordered_map<EthChannelIdentifier, uint32_t>& link_retrain_counts,
+    uint32_t total_retrain_iterations,
+    const std::filesystem::path& output_path);
+
 tt_metal::AsicTopology build_reset_topology(
     const std::string& reset_host,
     uint32_t reset_tray_id,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We want logging for the run_validation.sh script regarding which links retrain during the validation process

### What's changed
Added link retrain logging, both per run and overall for multiple sequential runs

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/exabox-retrain-log-stats)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/exabox-retrain-log-stats)