### PR TITLE
[skip ci] Bump up per test timeout for whisper demo to 600s

### DIFF
--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -10,7 +10,7 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 - name: whisper performance
-  cmd: pytest models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
+  cmd: pytest models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation" --timeout=1800
   skus:
     bh_p150_perf:
       timeout: 10
@@ -19,7 +19,7 @@
   model-name: whisper
 
 - name: whisper nightly
-  cmd: pytest tests/nightly/single_card/whisper
+  cmd: pytest tests/nightly/single_card/whisper --timeout=1800
   skus:
     bh_p150:
       timeout: 10

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -10,7 +10,7 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 - name: whisper performance
-  cmd: pytest models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation" --timeout=1800
+  cmd: pytest models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation" --timeout=600
   skus:
     bh_p150_perf:
       timeout: 10
@@ -19,7 +19,7 @@
   model-name: whisper
 
 - name: whisper nightly
-  cmd: pytest tests/nightly/single_card/whisper --timeout=1800
+  cmd: pytest tests/nightly/single_card/whisper --timeout=600
   skus:
     bh_p150:
       timeout: 10


### PR DESCRIPTION
### Ticket
None

### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/23329161142/job/67867843448#step:11:3683
Looks like https://github.com/tenstorrent/tt-metal/pull/40001 may have increased the per-test runtime past the default of 300s

### What's changed
Bump up the per-test runtime

### Checklist

- [x] Whisper demo BH https://github.com/tenstorrent/tt-metal/actions/runs/23366005689 (nightly whisper fails on unrelated PCC issue)

