### PR TITLE
[skip ci] BH demos: don't fail when no models run

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -78,7 +78,6 @@ jobs:
   blackhole-demo-tests:
     needs: load-test-matrix
     # Skip entire job when test matrix is empty (to prevent GHA from erroring out the workflow on an empty strategy.matrix).
-    # Matrix JSON is jq -c compact; empty is exactly []. (length() is not available in all GHA expression versions.)
     if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -67,12 +67,18 @@ jobs:
           MATRIX: ${{ steps.build-matrix.outputs.matrix }}
         run: |
           filtered=$(echo "$MATRIX" | jq -c --arg model "${{ inputs.model }}" '[.[] | select(.["model-name"] == $model or (.["model-name"] == null))]')
+          count=$(echo "$filtered" | jq 'length')
+          if [[ "$count" -eq 0 ]]; then
+            echo "::warning::No demo tests match model '${{ inputs.model }}' for enabled SKU(s) '${{ inputs.enabled-skus }}'; demo matrix is empty and demo jobs will be skipped."
+          fi
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$filtered" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
   blackhole-demo-tests:
     needs: load-test-matrix
+    # Skip entire job when test matrix is empty (to prevent GHA from erroring out the workflow on an empty strategy.matrix)
+    if: ${{ length(fromJSON(needs.load-test-matrix.outputs.matrix)) > 0 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -77,8 +77,9 @@ jobs:
 
   blackhole-demo-tests:
     needs: load-test-matrix
-    # Skip entire job when test matrix is empty (to prevent GHA from erroring out the workflow on an empty strategy.matrix)
-    if: ${{ length(fromJSON(needs.load-test-matrix.outputs.matrix)) > 0 }}
+    # Skip entire job when test matrix is empty (to prevent GHA from erroring out the workflow on an empty strategy.matrix).
+    # Matrix JSON is jq -c compact; empty is exactly []. (length() is not available in all GHA expression versions.)
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
None

### Problem description
When running BH demos and the matrix doesn't have any models to run on the given SKU, the workflow fails with
```
Error when evaluating 'strategy' for job 'blackhole-demo-tests'. tenstorrent/tt-metal/.github/workflows/blackhole-demo-tests-impl.yaml@a92abe761cd5dabf11865e948e08ab2ba2c08f9d (Line: 79, Col: 21): Matrix vector 'test-group' does not contain any values
```
This shows up as a red pipeline when a developer chooses to run a model on all SKUs but the model doesn't run on all SKUs (e.g. running llama70b on all skus, but it doesn't run on 1xP150 so the pipeline fails even when all jobs pass)
E.g. 
https://github.com/tenstorrent/tt-metal/actions/runs/23355132679
https://github.com/tenstorrent/tt-metal/actions/runs/23366234352

### What's changed
When the model-to-run matrix is empty for a given SKU, warn instead of error

### Checklist

- [x] BH demos (no model runs here so workflow should pass instead of fail): https://github.com/tenstorrent/tt-metal/actions/runs/23366464988/job/67981783578
```
No demo tests match model 'llama3.3-70b' for enabled SKU(s) 'bh_p150_perf'; demo matrix is empty and demo jobs will be skipped.
```