### PR TITLE
Resolving dual stress demo buffer deallocation + sample trace release

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -511,6 +511,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Clean up sampling trace state
         try:
             if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
+                ttnn.synchronize_device(self.mesh_device)
                 self.sampling_generator.reset_trace()
         except Exception as e:
             logger.warning(f"Failed to reset sampling trace state: {e}")
@@ -1676,6 +1677,11 @@ class DeepseekGenerator(WarmupForwardMixin):
             if self.sample_on_device:
                 # reset sampling state for each repeat batch, o/p tokens will be different for each repeat batch
                 assert self.sampling_params is not None, "sampling_params must be set when sampling on device"
+                if self.enable_trace and batch_idx > 0:
+                    # Previous batch deallocates trace-owned sampling output tensors.
+                    # Reset trace so the next batch captures fresh outputs.
+                    ttnn.synchronize_device(self.mesh_device)
+                    self.sampling_generator.reset_trace()
                 self._reset_sampling_state(
                     self.sampling_params,
                     self.batch_size,
@@ -1756,7 +1762,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                             prefill_logits_sampled_host = self._tokens_from_device(
                                 prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
                             )
-                            pred_token = prefill_logits_sampled_host[0]
+                            pred_token = int(prefill_logits_sampled_host[0].item())
                             ttnn.deallocate(prefill_logits)
                             ttnn.deallocate(prefill_logits_sampled_device)
                         else:


### PR DESCRIPTION
### Ticket
#40454

### Problem description
Dual demo stress was failing due to improper buffer allocation & sample trace release.

### What's changed
Proper tensor allocation & deallocation and sampling trace release.

### Checklist

[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dual-demo-stress-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dual-demo-stress-fix)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=dual-demo-stress-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:dual-demo-stress-fix)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=dual-demo-stress-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:dual-demo-stress-fix)
[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=dual-demo-stress-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:dual-demo-stress-fix)