### PR TITLE
[feature] add vc2 support for fabric

### DIFF
--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -333,6 +333,7 @@ jobs:
             cmd: |
               TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
               TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
+              TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
               TT_FABRIC_PROFILE_RX_CH_FWD=1 TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_code_profiling.yaml
             timeout: 15
     name: Blackhole ${{ matrix.runner-group.runner-label }} ${{ matrix.test-group.name }}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -459,11 +459,16 @@ struct ChipSendTypeHandler<ChipSendType::CHIP_MULTICAST, true> {
 };
 
 // Forward declaration for NOC operation function pointer types
+// SenderKernelTrafficConfig is now a template on EdmSenderT, but NOC operations
+// don't depend on EdmSenderT (they only access layout-identical members like
+// packet_header, payload_size_bytes, metadata). We use the default instantiation
+// for function pointer types since all instantiations have identical layout.
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct SenderKernelTrafficConfig;
 
 namespace NocOperationTypes {
-using ParseSetupFunc = void (*)(SenderKernelTrafficConfig*, size_t&);
-using UpdateHeaderFunc = void (*)(SenderKernelTrafficConfig*);
+using ParseSetupFunc = void (*)(SenderKernelTrafficConfig<>*, size_t&);
+using UpdateHeaderFunc = void (*)(SenderKernelTrafficConfig<>*);
 
 struct Operations {
     ParseSetupFunc parse_and_setup;
@@ -473,23 +478,23 @@ struct Operations {
 
 // NOC Operation Class Declarations (implementations after SenderKernelTrafficConfig)
 struct NocWriteSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<>* config);
 };
 
 struct NocAtomicSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<>* config);
 };
 
 struct NocFusedSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<>* config);
 };
 
 struct NocScatterWriteSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<>* config);
 };
 
 /* ****************************************************************************
@@ -508,15 +513,16 @@ struct MuxCachedInfo {
  * Provides type-erased storage for both WorkerToFabricEdmSender and
  * WorkerToFabricMuxSender connections with runtime dispatch.
  * *****************************************************************************/
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct FabricConnectionArray {
     // TODO: get the num buffers more systematically
     static constexpr uint8_t NUM_BUFFERS = 8;
 
     using MuxConnectionType = tt::tt_fabric::WorkerToFabricMuxSender<NUM_BUFFERS>;
-    static constexpr size_t MAX_CONNECTION_SIZE = std::max(sizeof(WorkerToFabricEdmSender), sizeof(MuxConnectionType));
+    static constexpr size_t MAX_CONNECTION_SIZE = std::max(sizeof(EdmSenderT), sizeof(MuxConnectionType));
 
     // Type-erased storage for connections (sized for maximum)
-    alignas(std::max(alignof(WorkerToFabricEdmSender), alignof(MuxConnectionType)))
+    alignas(std::max(alignof(EdmSenderT), alignof(MuxConnectionType)))
         std::array<char, MAX_NUM_FABRIC_CONNECTIONS * MAX_CONNECTION_SIZE> storage;
     std::array<bool, MAX_NUM_FABRIC_CONNECTIONS> is_mux;
 
@@ -527,8 +533,8 @@ struct FabricConnectionArray {
     uint8_t num_connections = 0;
 
     // Accessors with proper type casting
-    FORCE_INLINE WorkerToFabricEdmSender& get_fabric_connection(uint8_t idx) {
-        return *reinterpret_cast<WorkerToFabricEdmSender*>(storage.data() + idx * MAX_CONNECTION_SIZE);
+    FORCE_INLINE EdmSenderT& get_fabric_connection(uint8_t idx) {
+        return *reinterpret_cast<EdmSenderT*>(storage.data() + idx * MAX_CONNECTION_SIZE);
     }
 
     FORCE_INLINE MuxConnectionType& get_mux_connection(uint8_t idx) {
@@ -578,8 +584,8 @@ struct FabricConnectionArray {
                 new (&get_mux_connection(i)) MuxConnectionType(conn);
             } else {
                 // Initialize fabric connection using placement new
-                auto conn = WorkerToFabricEdmSender::build_from_args<core_type>(rt_args_idx);
-                new (&get_fabric_connection(i)) WorkerToFabricEdmSender(conn);
+                auto conn = EdmSenderT::template build_from_args<core_type>(rt_args_idx);
+                new (&get_fabric_connection(i)) EdmSenderT(conn);
             }
         }
     }
@@ -616,13 +622,13 @@ struct FabricConnectionArray {
     FORCE_INLINE void wait_for_empty_write_slot(void* conn_ptr, uint8_t idx) {
         if constexpr (BENCHMARK_MODE) {
             // Fast path: no runtime check, direct cast
-            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot();
+            static_cast<EdmSenderT*>(conn_ptr)->wait_for_empty_write_slot();
         } else {
             // Normal path: runtime dispatch using cached is_mux array
             if (is_mux[idx]) {
                 static_cast<MuxConnectionType*>(conn_ptr)->wait_for_empty_write_slot();
             } else {
-                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->wait_for_empty_write_slot();
+                static_cast<EdmSenderT*>(conn_ptr)->wait_for_empty_write_slot();
             }
         }
     }
@@ -631,14 +637,14 @@ struct FabricConnectionArray {
     template <bool BENCHMARK_MODE = false>
     FORCE_INLINE void send_header_non_blocking(void* conn_ptr, uint8_t idx, uint32_t header_addr) {
         if constexpr (BENCHMARK_MODE) {
-            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_flush_non_blocking_from_address(
+            static_cast<EdmSenderT*>(conn_ptr)->send_payload_flush_non_blocking_from_address(
                 header_addr, sizeof(PACKET_HEADER_TYPE));
         } else {
             if (is_mux[idx]) {
                 static_cast<MuxConnectionType*>(conn_ptr)->send_payload_flush_non_blocking_from_address(
                     header_addr, sizeof(PACKET_HEADER_TYPE));
             } else {
-                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_flush_non_blocking_from_address(
+                static_cast<EdmSenderT*>(conn_ptr)->send_payload_flush_non_blocking_from_address(
                     header_addr, sizeof(PACKET_HEADER_TYPE));
             }
         }
@@ -648,14 +654,14 @@ struct FabricConnectionArray {
     template <bool BENCHMARK_MODE = false>
     FORCE_INLINE void send_payload_without_header(void* conn_ptr, uint8_t idx, uint32_t payload_addr, size_t size) {
         if constexpr (BENCHMARK_MODE) {
-            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_without_header_non_blocking_from_address(
+            static_cast<EdmSenderT*>(conn_ptr)->send_payload_without_header_non_blocking_from_address(
                 payload_addr, size);
         } else {
             if (is_mux[idx]) {
                 static_cast<MuxConnectionType*>(conn_ptr)->send_payload_without_header_non_blocking_from_address(
                     payload_addr, size);
             } else {
-                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_without_header_non_blocking_from_address(
+                static_cast<EdmSenderT*>(conn_ptr)->send_payload_without_header_non_blocking_from_address(
                     payload_addr, size);
             }
         }
@@ -665,14 +671,14 @@ struct FabricConnectionArray {
     template <bool BENCHMARK_MODE = false>
     FORCE_INLINE void send_header_flush_blocking(void* conn_ptr, uint8_t idx, uint32_t header_addr) {
         if constexpr (BENCHMARK_MODE) {
-            static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_flush_blocking_from_address(
+            static_cast<EdmSenderT*>(conn_ptr)->send_payload_flush_blocking_from_address(
                 header_addr, sizeof(PACKET_HEADER_TYPE));
         } else {
             if (is_mux[idx]) {
                 static_cast<MuxConnectionType*>(conn_ptr)->send_payload_flush_blocking_from_address(
                     header_addr, sizeof(PACKET_HEADER_TYPE));
             } else {
-                static_cast<WorkerToFabricEdmSender*>(conn_ptr)->send_payload_flush_blocking_from_address(
+                static_cast<EdmSenderT*>(conn_ptr)->send_payload_flush_blocking_from_address(
                     header_addr, sizeof(PACKET_HEADER_TYPE));
             }
         }
@@ -683,7 +689,7 @@ struct FabricConnectionArray {
     FORCE_INLINE void send_payload_with_header(
         void* conn_ptr, uint8_t idx, uint32_t payload_addr, size_t payload_size, uint32_t header_addr) {
         if constexpr (BENCHMARK_MODE) {
-            auto* conn = static_cast<WorkerToFabricEdmSender*>(conn_ptr);
+            auto* conn = static_cast<EdmSenderT*>(conn_ptr);
             if (payload_size > 0) {
                 conn->send_payload_without_header_non_blocking_from_address(payload_addr, payload_size);
             }
@@ -696,7 +702,7 @@ struct FabricConnectionArray {
                 }
                 conn->send_payload_flush_non_blocking_from_address(header_addr, sizeof(PACKET_HEADER_TYPE));
             } else {
-                auto* conn = static_cast<WorkerToFabricEdmSender*>(conn_ptr);
+                auto* conn = static_cast<EdmSenderT*>(conn_ptr);
                 if (payload_size > 0) {
                     conn->send_payload_without_header_non_blocking_from_address(payload_addr, payload_size);
                 }
@@ -707,9 +713,10 @@ struct FabricConnectionArray {
 };
 
 // Line sync for each fabric connection (used by SyncKernelConfig)
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct LineSyncConfig {
     LineSyncConfig(
-        FabricConnectionArray* connection_array,
+        FabricConnectionArray<EdmSenderT>* connection_array,
         uint8_t connection_idx,
         const uint32_t packet_header_address,
         const uint32_t line_sync_val) :
@@ -749,7 +756,7 @@ struct LineSyncConfig {
     }
 
 private:
-    FabricConnectionArray* connection_manager_;
+    FabricConnectionArray<EdmSenderT>* connection_manager_;
     void* connection_ptr_;    // Cached connection pointer
     uint8_t connection_idx_;  // Index into the connection array
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header;
@@ -945,9 +952,10 @@ private:
     static constexpr uint32_t CREDIT_STRIDE_WORDS = CREDIT_ADDRESS_STRIDE / sizeof(uint32_t);
 };
 
+template <typename EdmSenderT>
 struct SenderKernelTrafficConfig {
     SenderKernelTrafficConfig(
-        FabricConnectionArray* connection_array,
+        FabricConnectionArray<EdmSenderT>* connection_array,
         uint8_t connection_idx,
         const SenderTrafficConfigMetadata& metadata,
         const uint32_t packet_header_address) :
@@ -1013,7 +1021,9 @@ struct SenderKernelTrafficConfig {
         ASSERT(noc_ops_.parse_and_setup != nullptr);
         ASSERT(noc_ops_.update_header != nullptr);
 
-        noc_ops_.parse_and_setup(this, arg_idx);
+        // Cast to default instantiation for function pointer compatibility
+        // (all instantiations have identical layout, only EdmSenderT pointer type differs)
+        noc_ops_.parse_and_setup(reinterpret_cast<SenderKernelTrafficConfig<>*>(this), arg_idx);
     }
 
     void setup_payload_buffer(uint32_t payload_buffer_address, uint32_t payload_buffer_size) {
@@ -1027,7 +1037,7 @@ struct SenderKernelTrafficConfig {
 
     bool has_packets_to_send() const { return num_packets_processed < metadata.num_packets; }
 
-    FORCE_INLINE void setup_credit_update_noc_state(const WorkerToFabricEdmSender& adapter, uint8_t noc) {
+    FORCE_INLINE void setup_credit_update_noc_state(const EdmSenderT& adapter, uint8_t noc) {
         auto packed_val = pack_value_for_inc_on_write_stream_reg_write(-1);
         const uint64_t noc_sem_addr =
             get_noc_addr(adapter.edm_noc_x, adapter.edm_noc_y, adapter.edm_buffer_remote_free_slots_update_addr, noc);
@@ -1038,7 +1048,7 @@ struct SenderKernelTrafficConfig {
     template <bool BENCHMARK_MODE>
     FORCE_INLINE void send_packets_stateful(const uint32_t num_packets, const uint32_t num_warmup) {
         ASSERT(connection_ptr_ != nullptr);
-        auto* conn = static_cast<WorkerToFabricEdmSender*>(connection_ptr_);
+        auto* conn = static_cast<EdmSenderT*>(connection_ptr_);
 
         // Perform stateful noc send by filling buffers with headers, first, then performing credit-only NOC sends
         // Phase 1: Warmup — send actual headers to fill all buffer slots
@@ -1070,7 +1080,7 @@ struct SenderKernelTrafficConfig {
         if constexpr (BENCHMARK_MODE){
             connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
             // STEP 3: Send packet
-            auto* conn = static_cast<WorkerToFabricEdmSender*>(connection_ptr_);
+            auto* conn = static_cast<EdmSenderT*>(connection_ptr_);
             if (num_packets_processed < conn->num_buffers_per_channel) {
                 conn->send_payload_flush_non_blocking_from_address((uint32_t)packet_header, sizeof(PACKET_HEADER_TYPE));
             } else {
@@ -1137,12 +1147,12 @@ struct SenderKernelTrafficConfig {
 private:
     void update_header_for_next_packet() {
         if (payload_buffer_) {
-            noc_ops_.update_header(this);
+            noc_ops_.update_header(reinterpret_cast<SenderKernelTrafficConfig<>*>(this));
         }
     }
 
 public:
-    FabricConnectionArray* connection_manager_;
+    FabricConnectionArray<EdmSenderT>* connection_manager_;
     void* connection_ptr_;    // Cached connection pointer
     uint8_t connection_idx_;  // Index into the connection array
 
@@ -1173,7 +1183,7 @@ private:
 };
 
 // NOC Operation Implementations (now that SenderKernelTrafficConfig is fully defined)
-inline void NocWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx) {
+inline void NocWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
     auto fields = NocUnicastWriteFields::build_from_args<true>(arg_idx);
 
     uint64_t noc_addr = get_noc_addr_helper(fields.dst_noc_encoding, fields.dst_address);
@@ -1183,7 +1193,7 @@ inline void NocWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficCo
     config->payload_size_bytes = fields.payload_size_bytes;
 }
 
-inline void NocWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig* config) {
+inline void NocWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
     const auto& fields = config->noc_fields_.write_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     uint32_t dest_address = fields.dst_address + buffer_offset;
@@ -1191,7 +1201,7 @@ inline void NocWriteSenderOperations::update_header_impl(SenderKernelTrafficConf
     config->packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc_addr}, fields.payload_size_bytes);
 }
 
-inline void NocAtomicSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx) {
+inline void NocAtomicSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
     auto fields = NocUnicastAtomicIncFields::build_from_args<true>(arg_idx);
 
     uint64_t noc_addr = get_noc_addr_helper(fields.dst_noc_encoding, fields.dst_address);
@@ -1201,11 +1211,11 @@ inline void NocAtomicSenderOperations::parse_and_setup_impl(SenderKernelTrafficC
     config->payload_size_bytes = 0;
 }
 
-inline void NocAtomicSenderOperations::update_header_impl(SenderKernelTrafficConfig* config) {
+inline void NocAtomicSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
     // No-op - atomic operations use fixed addresses
 }
 
-inline void NocFusedSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx) {
+inline void NocFusedSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
     auto fields = NocUnicastWriteAtomicIncFields::build_from_args<true>(arg_idx);
 
     uint64_t write_noc_addr =
@@ -1221,7 +1231,7 @@ inline void NocFusedSenderOperations::parse_and_setup_impl(SenderKernelTrafficCo
     config->payload_size_bytes = fields.write_fields.payload_size_bytes;
 }
 
-inline void NocFusedSenderOperations::update_header_impl(SenderKernelTrafficConfig* config) {
+inline void NocFusedSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
     const auto& fields = config->noc_fields_.write_atomic_inc_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     uint32_t write_dest_address = fields.write_fields.dst_address + buffer_offset;
@@ -1234,7 +1244,8 @@ inline void NocFusedSenderOperations::update_header_impl(SenderKernelTrafficConf
         fields.write_fields.payload_size_bytes);
 }
 
-inline void NocScatterWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig* config, size_t& arg_idx) {
+inline void NocScatterWriteSenderOperations::parse_and_setup_impl(
+    SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
     auto fields = NocUnicastScatterWriteFields::build_from_args<true>(arg_idx);
 
     ASSERT(fields.chunk_count == NocUnicastScatterWriteFields::MAX_CHUNKS);
@@ -1250,7 +1261,7 @@ inline void NocScatterWriteSenderOperations::parse_and_setup_impl(SenderKernelTr
     config->payload_size_bytes = fields.payload_size_bytes;
 }
 
-inline void NocScatterWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig* config) {
+inline void NocScatterWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
     const auto& fields = config->noc_fields_.scatter_write_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     ASSERT(fields.chunk_count == NocUnicastScatterWriteFields::MAX_CHUNKS);
@@ -1531,7 +1542,8 @@ template <
     uint8_t NUM_TRAFFIC_CONFIGS,
     bool IS_2D_FABRIC,
     bool LINE_SYNC,
-    uint8_t NUM_LOCAL_SYNC_CORES>
+    uint8_t NUM_LOCAL_SYNC_CORES,
+    typename EdmSenderT = WorkerToFabricEdmSender>
 struct SenderKernelConfig {
     static constexpr bool MASTER_SYNC_CORE = false;
 
@@ -1571,13 +1583,13 @@ struct SenderKernelConfig {
 
     SenderKernelMemoryMap memory_map;
 
-    FabricConnectionArray connections;
+    FabricConnectionArray<EdmSenderT> connections;
 
     alignas(LocalSyncConfig<MASTER_SYNC_CORE, NUM_LOCAL_SYNC_CORES>)
         std::array<char, sizeof(LocalSyncConfig<MASTER_SYNC_CORE, NUM_LOCAL_SYNC_CORES>)> local_sync_config_storage;
     std::array<uint8_t, NUM_TRAFFIC_CONFIGS> traffic_config_to_fabric_connection_map;
 
-    using TrafficConfigType = SenderKernelTrafficConfig;
+    using TrafficConfigType = SenderKernelTrafficConfig<EdmSenderT>;
 
     alignas(
         TrafficConfigType) std::array<char, NUM_TRAFFIC_CONFIGS * sizeof(TrafficConfigType)> traffic_configs_storage;
@@ -1686,7 +1698,7 @@ struct ReceiverCreditManager {
     // Initialize with credit info and fabric connection array
     template <bool IS_2D_FABRIC>
     void init(
-        size_t& arg_idx, FabricConnectionArray* connections, uint8_t connection_idx, uint32_t credit_header_address) {
+        size_t& arg_idx, FabricConnectionArray<>* connections, uint8_t connection_idx, uint32_t credit_header_address) {
         connection_manager_ = connections;
         connection_idx_ = connection_idx;
         accumulated_credits_ = 0;
@@ -1745,7 +1757,7 @@ private:
             connection_ptr_, connection_idx_, (uint32_t)packet_header_);
     }
 
-    FabricConnectionArray* connection_manager_ = nullptr;
+    FabricConnectionArray<>* connection_manager_ = nullptr;
     void* connection_ptr_ = nullptr;  // Cached connection pointer
     uint8_t connection_idx_ = 0;
     uint32_t accumulated_credits_ = 0;
@@ -2083,7 +2095,7 @@ private:
     }
 
     ReceiverKernelMemoryMap memory_map;
-    FabricConnectionArray credit_connections;
+    FabricConnectionArray<> credit_connections;
     std::array<uint8_t, NUM_TRAFFIC_CONFIGS> traffic_config_to_credit_connection_map;
 
     // Credit managers - one per traffic config
@@ -2199,9 +2211,9 @@ struct SyncKernelConfig {
 
     SenderKernelMemoryMap memory_map;
 
-    FabricConnectionArray sync_connections;
+    FabricConnectionArray<> sync_connections;
 
-    using LineSyncConfigType = LineSyncConfig;
+    using LineSyncConfigType = LineSyncConfig<>;
     alignas(LineSyncConfigType)
         std::array<char, NUM_SYNC_FABRIC_CONNECTIONS * sizeof(LineSyncConfigType)> line_sync_configs_storage;
     alignas(LocalSyncConfig<true, NUM_LOCAL_SYNC_CORES>)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -746,8 +746,9 @@ struct LineSyncConfig {
     }
 
     void global_sync_start() {
-        connection_manager_->wait_for_empty_write_slot<false>(connection_ptr_, connection_idx_);
-        connection_manager_->send_header_non_blocking<false>(connection_ptr_, connection_idx_, (uint32_t)packet_header);
+        connection_manager_->template wait_for_empty_write_slot<false>(connection_ptr_, connection_idx_);
+        connection_manager_->template send_header_non_blocking<false>(
+            connection_ptr_, connection_idx_, (uint32_t)packet_header);
     }
 
     void global_sync_finish(uint8_t sync_iter) {
@@ -1078,7 +1079,7 @@ struct SenderKernelTrafficConfig {
 
         // STEP 2: Wait for space
         if constexpr (BENCHMARK_MODE){
-            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            connection_manager_->template wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
             // STEP 3: Send packet
             auto* conn = static_cast<EdmSenderT*>(connection_ptr_);
             if (num_packets_processed < conn->num_buffers_per_channel) {
@@ -1087,17 +1088,17 @@ struct SenderKernelTrafficConfig {
                 fabric_detail::update_credits_and_slots<STATEFUL_NOC>(conn);
             }
         } else {
-            connection_manager_->wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
+            connection_manager_->template wait_for_empty_write_slot<BENCHMARK_MODE>(connection_ptr_, connection_idx_);
             // STEP 3: Send packet
             if (payload_size_bytes > 0 && payload_buffer_) {
                 payload_buffer_->fill_data(metadata.seed);
 
                 // Send payload without header
-                connection_manager_->send_payload_without_header<BENCHMARK_MODE>(
+                connection_manager_->template send_payload_without_header<BENCHMARK_MODE>(
                     connection_ptr_, connection_idx_, payload_buffer_->get_physical_address(), payload_size_bytes);
             }
             // Send header
-            connection_manager_->send_header_non_blocking<BENCHMARK_MODE>(
+            connection_manager_->template send_header_non_blocking<BENCHMARK_MODE>(
                 connection_ptr_, connection_idx_, (uint32_t)packet_header);
         }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_kernels_utils.hpp
@@ -458,43 +458,46 @@ struct ChipSendTypeHandler<ChipSendType::CHIP_MULTICAST, true> {
     }
 };
 
-// Forward declaration for NOC operation function pointer types
-// SenderKernelTrafficConfig is now a template on EdmSenderT, but NOC operations
-// don't depend on EdmSenderT (they only access layout-identical members like
-// packet_header, payload_size_bytes, metadata). We use the default instantiation
-// for function pointer types since all instantiations have identical layout.
 template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct SenderKernelTrafficConfig;
 
-namespace NocOperationTypes {
-using ParseSetupFunc = void (*)(SenderKernelTrafficConfig<>*, size_t&);
-using UpdateHeaderFunc = void (*)(SenderKernelTrafficConfig<>*);
+// NOC op structs and function pointer types are all templated on EdmSenderT.
+// VC_ID is a compile-time arg so each binary contains exactly one EdmSenderT
+// instantiation — function pointer types match call sites exactly, no casting needed.
+template <typename EdmSenderT = WorkerToFabricEdmSender>
+struct NocOperationTypes {
+    using ParseSetupFunc = void (*)(SenderKernelTrafficConfig<EdmSenderT>*, size_t&);
+    using UpdateHeaderFunc = void (*)(SenderKernelTrafficConfig<EdmSenderT>*);
 
-struct Operations {
-    ParseSetupFunc parse_and_setup;
-    UpdateHeaderFunc update_header;
+    struct Operations {
+        ParseSetupFunc parse_and_setup;
+        UpdateHeaderFunc update_header;
+    };
 };
-}  // namespace NocOperationTypes
 
 // NOC Operation Class Declarations (implementations after SenderKernelTrafficConfig)
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct NocWriteSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig<>* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config);
 };
 
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct NocAtomicSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig<>* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config);
 };
 
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct NocFusedSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig<>* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config);
 };
 
+template <typename EdmSenderT = WorkerToFabricEdmSender>
 struct NocScatterWriteSenderOperations {
-    static void parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx);
-    static void update_header_impl(SenderKernelTrafficConfig<>* config);
+    static void parse_and_setup_impl(SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx);
+    static void update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config);
 };
 
 /* ****************************************************************************
@@ -998,23 +1001,22 @@ struct SenderKernelTrafficConfig {
         uint32_t noc_type_raw = get_local_arg_val<uint32_t>(arg_idx++);
         noc_send_type_ = static_cast<NocSendType>(noc_type_raw);
 
-        // Validate NOC send type and set up operations
         switch (noc_send_type_) {
             case NocSendType::NOC_UNICAST_WRITE:
-                noc_ops_.parse_and_setup = NocWriteSenderOperations::parse_and_setup_impl;
-                noc_ops_.update_header = NocWriteSenderOperations::update_header_impl;
+                noc_ops_.parse_and_setup = NocWriteSenderOperations<EdmSenderT>::parse_and_setup_impl;
+                noc_ops_.update_header = NocWriteSenderOperations<EdmSenderT>::update_header_impl;
                 break;
             case NocSendType::NOC_UNICAST_ATOMIC_INC:
-                noc_ops_.parse_and_setup = NocAtomicSenderOperations::parse_and_setup_impl;
-                noc_ops_.update_header = NocAtomicSenderOperations::update_header_impl;
+                noc_ops_.parse_and_setup = NocAtomicSenderOperations<EdmSenderT>::parse_and_setup_impl;
+                noc_ops_.update_header = NocAtomicSenderOperations<EdmSenderT>::update_header_impl;
                 break;
             case NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC:
-                noc_ops_.parse_and_setup = NocFusedSenderOperations::parse_and_setup_impl;
-                noc_ops_.update_header = NocFusedSenderOperations::update_header_impl;
+                noc_ops_.parse_and_setup = NocFusedSenderOperations<EdmSenderT>::parse_and_setup_impl;
+                noc_ops_.update_header = NocFusedSenderOperations<EdmSenderT>::update_header_impl;
                 break;
             case NocSendType::NOC_UNICAST_SCATTER_WRITE:
-                noc_ops_.parse_and_setup = NocScatterWriteSenderOperations::parse_and_setup_impl;
-                noc_ops_.update_header = NocScatterWriteSenderOperations::update_header_impl;
+                noc_ops_.parse_and_setup = NocScatterWriteSenderOperations<EdmSenderT>::parse_and_setup_impl;
+                noc_ops_.update_header = NocScatterWriteSenderOperations<EdmSenderT>::update_header_impl;
                 break;
             default: ASSERT(false); break;
         }
@@ -1022,9 +1024,7 @@ struct SenderKernelTrafficConfig {
         ASSERT(noc_ops_.parse_and_setup != nullptr);
         ASSERT(noc_ops_.update_header != nullptr);
 
-        // Cast to default instantiation for function pointer compatibility
-        // (all instantiations have identical layout, only EdmSenderT pointer type differs)
-        noc_ops_.parse_and_setup(reinterpret_cast<SenderKernelTrafficConfig<>*>(this), arg_idx);
+        noc_ops_.parse_and_setup(this, arg_idx);
     }
 
     void setup_payload_buffer(uint32_t payload_buffer_address, uint32_t payload_buffer_size) {
@@ -1139,16 +1139,15 @@ struct SenderKernelTrafficConfig {
 
     bool has_wrapped() const { return payload_buffer_ ? payload_buffer_->has_wrapped() : false; }
 
-    // Friend classes for operation implementations
-    friend struct NocWriteSenderOperations;
-    friend struct NocAtomicSenderOperations;
-    friend struct NocFusedSenderOperations;
-    friend struct NocScatterWriteSenderOperations;
+    friend struct NocWriteSenderOperations<EdmSenderT>;
+    friend struct NocAtomicSenderOperations<EdmSenderT>;
+    friend struct NocFusedSenderOperations<EdmSenderT>;
+    friend struct NocScatterWriteSenderOperations<EdmSenderT>;
 
 private:
     void update_header_for_next_packet() {
         if (payload_buffer_) {
-            noc_ops_.update_header(reinterpret_cast<SenderKernelTrafficConfig<>*>(this));
+            noc_ops_.update_header(this);
         }
     }
 
@@ -1167,7 +1166,7 @@ public:
 
 private:
     NocSendType noc_send_type_;
-    NocOperationTypes::Operations noc_ops_;
+    typename NocOperationTypes<EdmSenderT>::Operations noc_ops_;
 
     union NocFields {
         NocUnicastWriteFields write_fields;
@@ -1184,7 +1183,9 @@ private:
 };
 
 // NOC Operation Implementations (now that SenderKernelTrafficConfig is fully defined)
-inline void NocWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
+template <typename EdmSenderT>
+inline void NocWriteSenderOperations<EdmSenderT>::parse_and_setup_impl(
+    SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx) {
     auto fields = NocUnicastWriteFields::build_from_args<true>(arg_idx);
 
     uint64_t noc_addr = get_noc_addr_helper(fields.dst_noc_encoding, fields.dst_address);
@@ -1194,7 +1195,8 @@ inline void NocWriteSenderOperations::parse_and_setup_impl(SenderKernelTrafficCo
     config->payload_size_bytes = fields.payload_size_bytes;
 }
 
-inline void NocWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
+template <typename EdmSenderT>
+inline void NocWriteSenderOperations<EdmSenderT>::update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config) {
     const auto& fields = config->noc_fields_.write_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     uint32_t dest_address = fields.dst_address + buffer_offset;
@@ -1202,7 +1204,9 @@ inline void NocWriteSenderOperations::update_header_impl(SenderKernelTrafficConf
     config->packet_header->to_noc_unicast_write(NocUnicastCommandHeader{noc_addr}, fields.payload_size_bytes);
 }
 
-inline void NocAtomicSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
+template <typename EdmSenderT>
+inline void NocAtomicSenderOperations<EdmSenderT>::parse_and_setup_impl(
+    SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx) {
     auto fields = NocUnicastAtomicIncFields::build_from_args<true>(arg_idx);
 
     uint64_t noc_addr = get_noc_addr_helper(fields.dst_noc_encoding, fields.dst_address);
@@ -1212,11 +1216,14 @@ inline void NocAtomicSenderOperations::parse_and_setup_impl(SenderKernelTrafficC
     config->payload_size_bytes = 0;
 }
 
-inline void NocAtomicSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
+template <typename EdmSenderT>
+inline void NocAtomicSenderOperations<EdmSenderT>::update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config) {
     // No-op - atomic operations use fixed addresses
 }
 
-inline void NocFusedSenderOperations::parse_and_setup_impl(SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
+template <typename EdmSenderT>
+inline void NocFusedSenderOperations<EdmSenderT>::parse_and_setup_impl(
+    SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx) {
     auto fields = NocUnicastWriteAtomicIncFields::build_from_args<true>(arg_idx);
 
     uint64_t write_noc_addr =
@@ -1232,7 +1239,8 @@ inline void NocFusedSenderOperations::parse_and_setup_impl(SenderKernelTrafficCo
     config->payload_size_bytes = fields.write_fields.payload_size_bytes;
 }
 
-inline void NocFusedSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
+template <typename EdmSenderT>
+inline void NocFusedSenderOperations<EdmSenderT>::update_header_impl(SenderKernelTrafficConfig<EdmSenderT>* config) {
     const auto& fields = config->noc_fields_.write_atomic_inc_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     uint32_t write_dest_address = fields.write_fields.dst_address + buffer_offset;
@@ -1245,8 +1253,9 @@ inline void NocFusedSenderOperations::update_header_impl(SenderKernelTrafficConf
         fields.write_fields.payload_size_bytes);
 }
 
-inline void NocScatterWriteSenderOperations::parse_and_setup_impl(
-    SenderKernelTrafficConfig<>* config, size_t& arg_idx) {
+template <typename EdmSenderT>
+inline void NocScatterWriteSenderOperations<EdmSenderT>::parse_and_setup_impl(
+    SenderKernelTrafficConfig<EdmSenderT>* config, size_t& arg_idx) {
     auto fields = NocUnicastScatterWriteFields::build_from_args<true>(arg_idx);
 
     ASSERT(fields.chunk_count == NocUnicastScatterWriteFields::MAX_CHUNKS);
@@ -1262,7 +1271,9 @@ inline void NocScatterWriteSenderOperations::parse_and_setup_impl(
     config->payload_size_bytes = fields.payload_size_bytes;
 }
 
-inline void NocScatterWriteSenderOperations::update_header_impl(SenderKernelTrafficConfig<>* config) {
+template <typename EdmSenderT>
+inline void NocScatterWriteSenderOperations<EdmSenderT>::update_header_impl(
+    SenderKernelTrafficConfig<EdmSenderT>* config) {
     const auto& fields = config->noc_fields_.scatter_write_fields;
     uint32_t buffer_offset = config->payload_buffer_->get_current_offset();
     ASSERT(fields.chunk_count == NocUnicastScatterWriteFields::MAX_CHUNKS);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_test_sender.cpp
@@ -17,8 +17,14 @@ constexpr uint8_t NUM_LOCAL_SYNC_CORES = get_compile_time_arg_val(5);
 constexpr uint32_t KERNEL_CONFIG_BUFFER_SIZE = get_compile_time_arg_val(6);
 constexpr bool HAS_MUX_CONNECTIONS = get_compile_time_arg_val(7);
 constexpr uint8_t NUM_MUXES_TO_TERMINATE = get_compile_time_arg_val(8);
+constexpr uint8_t VC_ID = get_compile_time_arg_val(9);
 
-using SenderKernelConfigType = SenderKernelConfig<NUM_TRAFFIC_CONFIGS, IS_2D_FABRIC, LINE_SYNC, NUM_LOCAL_SYNC_CORES>;
+// Select the EDM sender adapter type based on VC_ID:
+// VC0/VC1 use WorkerToFabricEdmSender (stream ID 22), VC2 uses WorkerToFabricEdmSenderVC2 (stream ID 30)
+using EdmSenderType = std::conditional_t<VC_ID == 2, WorkerToFabricEdmSenderVC2, WorkerToFabricEdmSender>;
+
+using SenderKernelConfigType =
+    SenderKernelConfig<NUM_TRAFFIC_CONFIGS, IS_2D_FABRIC, LINE_SYNC, NUM_LOCAL_SYNC_CORES, EdmSenderType>;
 
 // Static assertion to ensure this config fits within the allocated kernel config region
 static_assert(
@@ -64,7 +70,7 @@ void kernel_main() {
 
     auto send_packets_stateful = [&](){
         auto* traffic_config = sender_config->traffic_config_ptrs[0];
-        auto* conn = static_cast<WorkerToFabricEdmSender*>(traffic_config->connection_ptr_);
+        auto* conn = static_cast<EdmSenderType*>(traffic_config->connection_ptr_);
         const uint32_t num_packets = traffic_config->metadata.num_packets;
         const uint32_t num_warmup = conn->num_buffers_per_channel;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
@@ -5,8 +5,9 @@
 # VC2 functional tests -- requires TT_METAL_ENABLE_FABRIC_VC2=1 environment variable
 
 Tests:
-  ### VC2 NON-Z NEIGHBOR EXCHANGE ###
+  ## VC2 NON-Z NEIGHBOR EXCHANGE ###
   - name: "VC2MeshNeighbourExchange"
+    enable_flow_control: true
     fabric_setup:
       topology: Mesh
       use_vc2: true
@@ -18,7 +19,252 @@ Tests:
 
     defaults:
       ftype: unicast
-      num_packets: 100
+      num_packets: 40000
 
     patterns:
       - type: neighbor_exchange
+
+  - name: "VC2MeshNeighbourExchangeVC2"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    parametrization_params:
+      num_links: [1]
+      ntype: [unicast_write]
+      size: [2048]
+
+    defaults:
+      ftype: unicast
+      num_packets: 40000
+
+    patterns:
+      - type: neighbor_exchange
+        vc_id: 2
+      - type: neighbor_exchange
+        vc_id: 0
+
+  - name: "MeshNeighbourExchangeVC2Unidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 4096
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+
+  - name: "MeshNeighbourExchangeVC0UnidirectionalInactiveVC2"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 4096
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+
+  - name: "MeshNeighbourExchangeVC0Unidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 4096
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+
+  - name: "MeshNeighbourExchangeVC0VC2Unidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 4096
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+
+
+  - name: "MeshNeighbourExchangeVC0Bidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+
+    parametrization_params:
+      num_links: [1]
+    #   ntype: [unicast_write]
+    #   size: [2048]
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        # vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1]
+      - device: [0, [0, 1]] # Source is physical chip 0
+        # vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 0]] # Destination is physical chip 1
+
+  - name: "VC2MeshNeighbourExchangeVC0Bidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    parametrization_params:
+      num_links: [1]
+      ntype: [unicast_write]
+      size: [2048]
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1]
+      - device: [0, [0, 1]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 0]] # Destination is physical chip 1
+
+  - name: "VC2MeshNeighbourExchangeVC2Bidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    parametrization_params:
+      num_links: [1]
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1]
+      - device: [0, [0, 1]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 0]] # Destination is physical chip 1
+
+  - name: "VC2MeshNeighbourExchangeVC0VC2Bidirectional"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      use_vc2: true
+
+    parametrization_params:
+      num_links: [1]
+
+    senders:
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+      - device: [0, [0, 0]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 1]] # Destination is physical chip 1
+      - device: [0, [0, 1]] # Source is physical chip 0
+        vc_id: 0
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 0]] # Destination is physical chip 1
+      - device: [0, [0, 1]] # Source is physical chip 0
+        vc_id: 2
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 2048
+            num_packets: 40000
+            destination:
+              device: [0, [0, 0]] # Destination is physical chip 1

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# VC2 functional tests -- requires TT_METAL_ENABLE_FABRIC_VC2=1 environment variable
+
+Tests:
+  ### VC2 NON-Z NEIGHBOR EXCHANGE ###
+  - name: "VC2NeighborExchangeUnicast"
+    fabric_setup:
+      topology: NeighborExchange
+      use_vc2: true
+
+    parametrization_params:
+      num_links: [1]
+      ntype: [unicast_write]
+      size: [2048]
+
+    defaults:
+      ftype: unicast
+      num_packets: 100
+
+    patterns:
+      - type: neighbor_exchange

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_vc2_at_least_2x2_mesh.yaml
@@ -6,9 +6,9 @@
 
 Tests:
   ### VC2 NON-Z NEIGHBOR EXCHANGE ###
-  - name: "VC2NeighborExchangeUnicast"
+  - name: "VC2MeshNeighbourExchange"
     fabric_setup:
-      topology: NeighborExchange
+      topology: Mesh
       use_vc2: true
 
     parametrization_params:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -174,6 +174,10 @@ int main(int argc, char** argv) {
             tt::tt_metal::MetalContext::instance().rtoptions().set_enable_fabric_bw_telemetry(true);
         }
 
+        if (test_config.fabric_setup.use_vc2) {
+            tt::tt_metal::MetalContext::instance().rtoptions().set_enable_fabric_vc2(true);
+        }
+
         log_info(
             tt::LogTest,
             "Opening devices with topology: {} and fabric_tensix_config: {}",

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -219,7 +219,7 @@ public:
         if (new_fabric_config != current_fabric_config_ || fabric_tensix_config != current_fabric_tensix_config_ ||
             reliability_mode != current_fabric_reliability_mode_ ||
             fabric_setup.max_packet_size != current_max_packet_size_ ||
-            channel_trimming_mode != current_channel_trimming_mode_) {
+            channel_trimming_mode != current_channel_trimming_mode_ || fabric_setup.use_vc2 != current_use_vc2_) {
             if (are_devices_open_) {
                 log_info(tt::LogTest, "Closing devices and switching to new fabric config: {}", new_fabric_config);
                 close_devices();
@@ -277,6 +277,7 @@ public:
         current_fabric_reliability_mode_ = tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         current_max_packet_size_ = std::nullopt;
         current_channel_trimming_mode_ = ChannelTrimmingMode::NONE;
+        current_use_vc2_ = false;
         are_devices_open_ = false;
     }
 
@@ -1779,6 +1780,7 @@ private:
         tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE};
     std::optional<uint32_t> current_max_packet_size_{std::nullopt};
     ChannelTrimmingMode current_channel_trimming_mode_{ChannelTrimmingMode::NONE};
+    bool current_use_vc2_{false};
     std::shared_ptr<MeshDevice> mesh_device_;
     std::shared_ptr<MeshWorkload> mesh_workload_;
     MeshId local_mesh_id_;
@@ -1888,6 +1890,7 @@ private:
         current_fabric_tensix_config_ = fabric_tensix_config;
         current_fabric_reliability_mode_ = reliability_mode;
         current_max_packet_size_ = fabric_setup.max_packet_size;
+        current_use_vc2_ = fabric_setup.use_vc2;
         are_devices_open_ = true;
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -59,6 +59,7 @@ struct ParsedTrafficPatternConfig {
     std::optional<ParsedDestinationConfig> destination;
     std::optional<uint32_t> atomic_inc_val;
     std::optional<uint32_t> mcast_start_hops;
+    std::optional<uint8_t> vc_id;  // VC selection: 0=VC0 (default), 2=VC2. Forwarded to generated senders.
 };
 
 struct ParsedSenderConfig {
@@ -67,8 +68,7 @@ struct ParsedSenderConfig {
     std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<ParsedTrafficPatternConfig> patterns;
     std::optional<uint32_t> link_id;  // Link ID for multi-link tests
-    bool use_vc2 = false;             // VC2: use private VC2 connection API instead of public API
-    uint8_t vc_id = 0;                // VC selection: 0=VC0 (default), 2=VC2
+    std::optional<uint8_t> vc_id;     // VC selection: 0=VC0 (default), 2=VC2
 };
 
 // Resolved structures (after resolution) - use FabricNodeId
@@ -95,6 +95,7 @@ struct TrafficPatternConfig {
     std::optional<DestinationConfig> destination;
     std::optional<uint32_t> atomic_inc_val;
     std::optional<uint32_t> mcast_start_hops;
+    std::optional<uint8_t> vc_id;  // VC selection: 0=VC0 (default), 2=VC2
 
     // Credit info
     std::optional<SenderCreditInfo> sender_credit_info;  // For sender
@@ -106,9 +107,9 @@ struct SenderConfig {
     std::optional<CoreCoord> core;
     std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<TrafficPatternConfig> patterns;
-    uint32_t link_id = 0;  // Link ID for multi-link tests
-    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
-    uint8_t vc_id = 0;     // VC selection: 0=VC0 (default), 2=VC2
+    uint32_t link_id = 0;          // Link ID for multi-link tests
+    std::optional<uint8_t> vc_id;  // VC selection: 0=VC0 (default), 2=VC2
+    bool use_vc2() const { return vc_id.value_or(0) == 2; }
 };
 
 // Sync configuration for a single device

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -67,6 +67,7 @@ struct ParsedSenderConfig {
     std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<ParsedTrafficPatternConfig> patterns;
     std::optional<uint32_t> link_id;  // Link ID for multi-link tests
+    bool use_vc2 = false;             // VC2: use private VC2 connection API instead of public API
 };
 
 // Resolved structures (after resolution) - use FabricNodeId
@@ -105,6 +106,7 @@ struct SenderConfig {
     std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<TrafficPatternConfig> patterns;
     uint32_t link_id = 0;  // Link ID for multi-link tests
+    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
 };
 
 // Sync configuration for a single device
@@ -139,6 +141,7 @@ struct TestFabricSetup {
     std::optional<std::string> torus_config;  // For Torus topology: "X", "Y", or "XY"
     std::optional<uint32_t> max_packet_size;  // Custom max packet size for router
     bool enable_channel_trimming = false;     // When true, test is expanded into CAPTURE + REPLAY phases
+    bool use_vc2 = false;                     // When true, use private VC2 connection API instead of public API
 };
 
 struct HighLevelPatternConfig {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -68,6 +68,7 @@ struct ParsedSenderConfig {
     std::vector<ParsedTrafficPatternConfig> patterns;
     std::optional<uint32_t> link_id;  // Link ID for multi-link tests
     bool use_vc2 = false;             // VC2: use private VC2 connection API instead of public API
+    uint8_t vc_id = 0;                // VC selection: 0=VC0 (default), 2=VC2
 };
 
 // Resolved structures (after resolution) - use FabricNodeId
@@ -107,6 +108,7 @@ struct SenderConfig {
     std::vector<TrafficPatternConfig> patterns;
     uint32_t link_id = 0;  // Link ID for multi-link tests
     bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
+    uint8_t vc_id = 0;     // VC selection: 0=VC0 (default), 2=VC2
 };
 
 // Sync configuration for a single device

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -22,6 +22,9 @@
 
 namespace tt::tt_fabric::fabric_tests {
 
+static constexpr uint8_t default_worker_vc_id = 0;
+static constexpr uint8_t vc2_worker_vc_id = 2;
+
 // Performance test mode - replaces separate latency_test_mode and benchmark_mode booleans
 enum class PerformanceTestMode {
     NONE,       // No performance testing (functional test only)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -132,6 +132,13 @@ ParsedTrafficPatternConfig YamlConfigParser::parse_traffic_pattern_config(const 
     if (pattern_yaml["mcast_start_hops"]) {
         config.mcast_start_hops = parse_scalar<uint32_t>(pattern_yaml["mcast_start_hops"]);
     }
+    if (pattern_yaml["vc_id"]) {
+        config.vc_id = parse_scalar<uint8_t>(pattern_yaml["vc_id"]);
+        TT_FATAL(
+            config.vc_id.value() == 0 || config.vc_id.value() == 2,
+            "vc_id must be 0 or 2, got {}",
+            config.vc_id.value());
+    }
 
     return config;
 }
@@ -158,7 +165,10 @@ ParsedSenderConfig YamlConfigParser::parse_sender_config(
     }
     if (sender_yaml["vc_id"]) {
         config.vc_id = parse_scalar<uint8_t>(sender_yaml["vc_id"]);
-        TT_FATAL(config.vc_id == 0 || config.vc_id == 2, "vc_id must be 0 or 2, got {}", config.vc_id);
+        TT_FATAL(
+            config.vc_id.value() == 0 || config.vc_id.value() == 2,
+            "vc_id must be 0 or 2, got {}",
+            config.vc_id.value());
     }
 
     const auto& patterns_yaml = sender_yaml["patterns"];
@@ -1051,12 +1061,7 @@ SenderConfig TestConfigBuilder::resolve_sender_config(const ParsedSenderConfig& 
     resolved_sender.device = resolve_device_identifier(parsed_sender.device, device_info_provider_);
     resolved_sender.noc_id = parsed_sender.noc_id;
     resolved_sender.link_id = parsed_sender.link_id.value_or(0);
-    resolved_sender.use_vc2 = parsed_sender.use_vc2;
     resolved_sender.vc_id = parsed_sender.vc_id;
-    // vc_id=2 implies use_vc2=true
-    if (resolved_sender.vc_id == 2) {
-        resolved_sender.use_vc2 = true;
-    }
 
     resolve_core_config(parsed_sender, resolved_sender);
 
@@ -2041,11 +2046,8 @@ void TestConfigBuilder::add_senders_from_pairs(
 
     test.senders.reserve(test.senders.size() + generated_senders.size());
     for (const auto& [src_node, patterns] : generated_senders) {
-        test.senders.emplace_back(ParsedSenderConfig{
-            .device = src_node,
-            .patterns = patterns,
-            .use_vc2 = test.fabric_setup.use_vc2,
-            .vc_id = static_cast<uint8_t>(test.fabric_setup.use_vc2 ? 2 : 0)});
+        test.senders.emplace_back(
+            ParsedSenderConfig{.device = src_node, .patterns = patterns, .vc_id = base_pattern.vc_id});
     }
 }
 
@@ -2144,7 +2146,6 @@ void TestConfigBuilder::split_senders_by_direction_for_benchmark(ParsedTestConfi
                 split_sender.core = sender.core;
                 split_sender.noc_id = sender.noc_id;
                 split_sender.link_id = sender.link_id;
-                split_sender.use_vc2 = sender.use_vc2;
                 split_sender.vc_id = sender.vc_id;
                 split_sender.patterns = std::move(patterns);
                 new_senders.push_back(std::move(split_sender));
@@ -2411,11 +2412,8 @@ void YamlTestConfigSerializer::to_yaml(YAML::Emitter& out, const SenderConfig& c
     out << YAML::Key << "link_id";
     out << YAML::Value << config.link_id;
 
-    if (config.use_vc2) {
-        out << YAML::Key << "use_vc2" << YAML::Value << true;
-    }
-    if (config.vc_id != 0) {
-        out << YAML::Key << "vc_id" << YAML::Value << static_cast<int>(config.vc_id);
+    if (config.vc_id.has_value() && config.vc_id.value() != 0) {
+        out << YAML::Key << "vc_id" << YAML::Value << static_cast<int>(config.vc_id.value());
     }
 
     out << YAML::Key << "patterns";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -156,6 +156,10 @@ ParsedSenderConfig YamlConfigParser::parse_sender_config(
     if (sender_yaml["link_id"]) {
         config.link_id = parse_scalar<uint32_t>(sender_yaml["link_id"]);
     }
+    if (sender_yaml["vc_id"]) {
+        config.vc_id = parse_scalar<uint8_t>(sender_yaml["vc_id"]);
+        TT_FATAL(config.vc_id == 0 || config.vc_id == 2, "vc_id must be 0 or 2, got {}", config.vc_id);
+    }
 
     const auto& patterns_yaml = sender_yaml["patterns"];
     TT_FATAL(patterns_yaml.IsSequence(), "Expected patterns to be a sequence");
@@ -1048,6 +1052,11 @@ SenderConfig TestConfigBuilder::resolve_sender_config(const ParsedSenderConfig& 
     resolved_sender.noc_id = parsed_sender.noc_id;
     resolved_sender.link_id = parsed_sender.link_id.value_or(0);
     resolved_sender.use_vc2 = parsed_sender.use_vc2;
+    resolved_sender.vc_id = parsed_sender.vc_id;
+    // vc_id=2 implies use_vc2=true
+    if (resolved_sender.vc_id == 2) {
+        resolved_sender.use_vc2 = true;
+    }
 
     resolve_core_config(parsed_sender, resolved_sender);
 
@@ -2032,8 +2041,11 @@ void TestConfigBuilder::add_senders_from_pairs(
 
     test.senders.reserve(test.senders.size() + generated_senders.size());
     for (const auto& [src_node, patterns] : generated_senders) {
-        test.senders.emplace_back(
-            ParsedSenderConfig{.device = src_node, .patterns = patterns, .use_vc2 = test.fabric_setup.use_vc2});
+        test.senders.emplace_back(ParsedSenderConfig{
+            .device = src_node,
+            .patterns = patterns,
+            .use_vc2 = test.fabric_setup.use_vc2,
+            .vc_id = static_cast<uint8_t>(test.fabric_setup.use_vc2 ? 2 : 0)});
     }
 }
 
@@ -2133,6 +2145,7 @@ void TestConfigBuilder::split_senders_by_direction_for_benchmark(ParsedTestConfi
                 split_sender.noc_id = sender.noc_id;
                 split_sender.link_id = sender.link_id;
                 split_sender.use_vc2 = sender.use_vc2;
+                split_sender.vc_id = sender.vc_id;
                 split_sender.patterns = std::move(patterns);
                 new_senders.push_back(std::move(split_sender));
             }
@@ -2400,6 +2413,9 @@ void YamlTestConfigSerializer::to_yaml(YAML::Emitter& out, const SenderConfig& c
 
     if (config.use_vc2) {
         out << YAML::Key << "use_vc2" << YAML::Value << true;
+    }
+    if (config.vc_id != 0) {
+        out << YAML::Key << "vc_id" << YAML::Value << static_cast<int>(config.vc_id);
     }
 
     out << YAML::Key << "patterns";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -432,6 +432,10 @@ TestFabricSetup YamlConfigParser::parse_fabric_setup(const YAML::Node& fabric_se
         fabric_setup.enable_channel_trimming = parse_scalar<bool>(fabric_setup_yaml["enable_channel_trimming"]);
     }
 
+    if (fabric_setup_yaml["use_vc2"]) {
+        fabric_setup.use_vc2 = parse_scalar<bool>(fabric_setup_yaml["use_vc2"]);
+    }
+
     return fabric_setup;
 }
 
@@ -1043,6 +1047,7 @@ SenderConfig TestConfigBuilder::resolve_sender_config(const ParsedSenderConfig& 
     resolved_sender.device = resolve_device_identifier(parsed_sender.device, device_info_provider_);
     resolved_sender.noc_id = parsed_sender.noc_id;
     resolved_sender.link_id = parsed_sender.link_id.value_or(0);
+    resolved_sender.use_vc2 = parsed_sender.use_vc2;
 
     resolve_core_config(parsed_sender, resolved_sender);
 
@@ -2027,7 +2032,8 @@ void TestConfigBuilder::add_senders_from_pairs(
 
     test.senders.reserve(test.senders.size() + generated_senders.size());
     for (const auto& [src_node, patterns] : generated_senders) {
-        test.senders.emplace_back(ParsedSenderConfig{.device = src_node, .patterns = patterns});
+        test.senders.emplace_back(
+            ParsedSenderConfig{.device = src_node, .patterns = patterns, .use_vc2 = test.fabric_setup.use_vc2});
     }
 }
 
@@ -2126,6 +2132,7 @@ void TestConfigBuilder::split_senders_by_direction_for_benchmark(ParsedTestConfi
                 split_sender.core = sender.core;
                 split_sender.noc_id = sender.noc_id;
                 split_sender.link_id = sender.link_id;
+                split_sender.use_vc2 = sender.use_vc2;
                 split_sender.patterns = std::move(patterns);
                 new_senders.push_back(std::move(split_sender));
             }
@@ -2391,6 +2398,10 @@ void YamlTestConfigSerializer::to_yaml(YAML::Emitter& out, const SenderConfig& c
     out << YAML::Key << "link_id";
     out << YAML::Value << config.link_id;
 
+    if (config.use_vc2) {
+        out << YAML::Key << "use_vc2" << YAML::Value << true;
+    }
+
     out << YAML::Key << "patterns";
     out << YAML::Value;
     out << YAML::BeginSeq;
@@ -2520,6 +2531,9 @@ void YamlTestConfigSerializer::to_yaml(YAML::Emitter& out, const TestFabricSetup
     out << YAML::Value << config.num_links;
     if (config.enable_channel_trimming) {
         out << YAML::Key << "enable_channel_trimming" << YAML::Value << true;
+    }
+    if (config.use_vc2) {
+        out << YAML::Key << "use_vc2" << YAML::Value << true;
     }
     out << YAML::EndMap;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -243,6 +243,7 @@ inline TrafficPatternType merge_patterns(const TrafficPatternType& base, const T
     merged.num_packets = specific.num_packets.has_value() ? specific.num_packets : base.num_packets;
     merged.atomic_inc_val = specific.atomic_inc_val.has_value() ? specific.atomic_inc_val : base.atomic_inc_val;
     merged.mcast_start_hops = specific.mcast_start_hops.has_value() ? specific.mcast_start_hops : base.mcast_start_hops;
+    merged.vc_id = specific.vc_id.has_value() ? specific.vc_id : base.vc_id;
 
     // Special handling for nested destination
     if (specific.destination.has_value()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -555,6 +555,7 @@ void TestContext::process_traffic_config(TestConfig& config) {
                 .atomic_inc_address = dest.atomic_inc_address,
                 .link_id = sender.link_id,
                 .noc_id = sender.noc_id,
+                .use_vc2 = sender.use_vc2,
                 .sender_credit_info = pattern.sender_credit_info,
                 .credit_return_batch_size = pattern.credit_return_batch_size,
             };
@@ -616,7 +617,8 @@ void TestContext::add_traffic_config(const TestTrafficConfig& traffic_config) {
         .dst_noc_encoding = dst_noc_encoding,
         .payload_buffer_size = payload_buffer_size,
         .link_id = traffic_config.link_id,
-        .noc_id = traffic_config.noc_id};
+        .noc_id = traffic_config.noc_id,
+        .use_vc2 = traffic_config.use_vc2};
 
     TestTrafficReceiverConfig receiver_config = {
         .parameters = traffic_config.parameters,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -555,7 +555,7 @@ void TestContext::process_traffic_config(TestConfig& config) {
                 .atomic_inc_address = dest.atomic_inc_address,
                 .link_id = sender.link_id,
                 .noc_id = sender.noc_id,
-                .vc_id = sender.vc_id.value_or(0),
+                .vc_id = sender.vc_id.value_or(tt::tt_fabric::fabric_tests::default_worker_vc_id),
                 .sender_credit_info = pattern.sender_credit_info,
                 .credit_return_batch_size = pattern.credit_return_batch_size,
             };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -555,7 +555,7 @@ void TestContext::process_traffic_config(TestConfig& config) {
                 .atomic_inc_address = dest.atomic_inc_address,
                 .link_id = sender.link_id,
                 .noc_id = sender.noc_id,
-                .use_vc2 = sender.use_vc2,
+                .vc_id = sender.vc_id.value_or(0),
                 .sender_credit_info = pattern.sender_credit_info,
                 .credit_return_batch_size = pattern.credit_return_batch_size,
             };
@@ -618,7 +618,7 @@ void TestContext::add_traffic_config(const TestTrafficConfig& traffic_config) {
         .payload_buffer_size = payload_buffer_size,
         .link_id = traffic_config.link_id,
         .noc_id = traffic_config.noc_id,
-        .use_vc2 = traffic_config.use_vc2};
+        .vc_id = traffic_config.vc_id};
 
     TestTrafficReceiverConfig receiver_config = {
         .parameters = traffic_config.parameters,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -878,14 +878,21 @@ void TestDevice::create_sender_kernels() {
         bool has_mux_connections = connection_manager_.is_mux_client(core);
         uint32_t num_muxes_to_terminate = connection_manager_.get_num_muxes_to_terminate();
 
-        // Determine VC ID for this sender (all configs on a core use same vc_id)
-        uint8_t sender_vc_id = 0;
+        // All configs on a core must share the same vc_id: the kernel is compiled with a single
+        // VC_ID template arg and all EDM connection runtime args are interpreted using that adapter
+        // type. Mixing VC0 and VC2 configs on the same core would silently corrupt connection parsing.
+        const uint8_t first_vc_id =
+            sender.configs_.empty() ? default_worker_vc_id : sender.configs_.front().first.vc_id;
         for (const auto& [config, _] : sender.configs_) {
-            if (config.use_vc2()) {
-                sender_vc_id = vc2_worker_vc_id;
-                break;
-            }
+            TT_FATAL(
+                config.vc_id == first_vc_id,
+                "All sender configs on a core must use the same vc_id, but found vc_id={} and vc_id={} on the same "
+                "core. "
+                "Split configs onto separate cores to mix VCs.",
+                first_vc_id,
+                config.vc_id);
         }
+        uint8_t sender_vc_id = first_vc_id;
 
         // Compile-time args (FLOW_CONTROL_ENABLED removed - now handled per-traffic-config)
         std::vector<uint32_t> ct_args = {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -882,7 +882,7 @@ void TestDevice::create_sender_kernels() {
         uint8_t sender_vc_id = 0;
         for (const auto& [config, _] : sender.configs_) {
             if (config.use_vc2()) {
-                sender_vc_id = 2;
+                sender_vc_id = vc2_worker_vc_id;
                 break;
             }
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -275,10 +275,13 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
         } else {
             // Generate fabric connection args directly using passed parameters
             const auto neighbor_node_id = route_manager->get_neighbor_node_id(fabric_node_id, key.direction);
-            // TODO: VC2-specific sender kernel needs dedicated connection path.
-            // For now, use_vc2 only enables VC2 on the fabric (RT option) but senders still use VC0.
-            append_fabric_connection_rt_args(
-                fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            if (key.use_vc2) {
+                append_fabric_vc2_connection_rt_args(
+                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            } else {
+                append_fabric_connection_rt_args(
+                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            }
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -275,13 +275,10 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
         } else {
             // Generate fabric connection args directly using passed parameters
             const auto neighbor_node_id = route_manager->get_neighbor_node_id(fabric_node_id, key.direction);
-            if (key.use_vc2) {
-                append_fabric_vc2_connection_rt_args(
-                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
-            } else {
-                append_fabric_connection_rt_args(
-                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
-            }
+            // TODO: VC2-specific sender kernel needs dedicated connection path.
+            // For now, use_vc2 only enables VC2 on the fabric (RT option) but senders still use VC0.
+            append_fabric_connection_rt_args(
+                fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -13,8 +13,8 @@ namespace tt::tt_fabric::fabric_tests {
 // ====================================
 
 void FabricConnectionManager::register_client(
-    const CoreCoord& core, RoutingDirection direction, uint32_t link_idx, TestWorkerType worker_type, bool use_vc2) {
-    ConnectionKey key = {direction, link_idx, use_vc2};
+    const CoreCoord& core, RoutingDirection direction, uint32_t link_idx, TestWorkerType worker_type, uint8_t vc_id) {
+    ConnectionKey key = {direction, link_idx, vc_id};
     auto& conn = connections_[key];
 
     // Store worker type for this core (for channel assignment later)
@@ -275,7 +275,7 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
         } else {
             // Generate fabric connection args directly using passed parameters
             const auto neighbor_node_id = route_manager->get_neighbor_node_id(fabric_node_id, key.direction);
-            if (key.use_vc2) {
+            if (key.use_vc2()) {
                 append_fabric_vc2_connection_rt_args(
                     fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
             } else {
@@ -412,7 +412,7 @@ void TestSender::add_config(TestTrafficSenderConfig config) {
         this->test_device_ptr_->connection_manager_,
         outgoing_direction,
         config.link_id,
-        config.use_vc2);
+        config.vc_id);
 
     this->configs_.emplace_back(std::move(config), fabric_connection_key);
 }
@@ -615,7 +615,7 @@ ConnectionKey TestDevice::register_fabric_connection(
     FabricConnectionManager& connection_mgr,
     RoutingDirection outgoing_direction,
     uint32_t link_idx,
-    bool use_vc2) {
+    uint8_t vc_id) {
     // Get available link indices for this direction (to validate link_idx)
     std::vector<uint32_t> available_link_indices = get_forwarding_link_indices_in_direction(outgoing_direction);
 
@@ -634,7 +634,7 @@ ConnectionKey TestDevice::register_fabric_connection(
         static_cast<int>(outgoing_direction));
 
     // Check if this core already registered this connection
-    ConnectionKey connection_key{outgoing_direction, link_idx, use_vc2};
+    ConnectionKey connection_key{outgoing_direction, link_idx, vc_id};
     auto registered_keys = connection_mgr.get_connection_keys_for_core(logical_core, worker_type);
 
     if (std::find(registered_keys.begin(), registered_keys.end(), connection_key) != registered_keys.end()) {
@@ -643,7 +643,7 @@ ConnectionKey TestDevice::register_fabric_connection(
     }
 
     // Register the new connection with the connection manager
-    connection_mgr.register_client(logical_core, outgoing_direction, link_idx, worker_type, use_vc2);
+    connection_mgr.register_client(logical_core, outgoing_direction, link_idx, worker_type, vc_id);
 
     log_debug(
         tt::LogTest,
@@ -879,10 +879,9 @@ void TestDevice::create_sender_kernels() {
         uint32_t num_muxes_to_terminate = connection_manager_.get_num_muxes_to_terminate();
 
         // Determine VC ID for this sender (all configs on a core use same vc_id)
-        // use_vc2=true on a sender config implies vc_id=2
         uint8_t sender_vc_id = 0;
         for (const auto& [config, _] : sender.configs_) {
-            if (config.use_vc2) {
+            if (config.use_vc2()) {
                 sender_vc_id = 2;
                 break;
             }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -878,6 +878,16 @@ void TestDevice::create_sender_kernels() {
         bool has_mux_connections = connection_manager_.is_mux_client(core);
         uint32_t num_muxes_to_terminate = connection_manager_.get_num_muxes_to_terminate();
 
+        // Determine VC ID for this sender (all configs on a core use same vc_id)
+        // use_vc2=true on a sender config implies vc_id=2
+        uint8_t sender_vc_id = 0;
+        for (const auto& [config, _] : sender.configs_) {
+            if (config.use_vc2) {
+                sender_vc_id = 2;
+                break;
+            }
+        }
+
         // Compile-time args (FLOW_CONTROL_ENABLED removed - now handled per-traffic-config)
         std::vector<uint32_t> ct_args = {
             is_2D_routing_enabled,
@@ -888,7 +898,8 @@ void TestDevice::create_sender_kernels() {
             num_local_sync_cores,                                /* num local sync cores */
             sender_memory_map_->common.get_kernel_config_size(), /* kernel config buffer size */
             has_mux_connections ? 1u : 0u,                       /* HAS_MUX_CONNECTIONS */
-            num_muxes_to_terminate                               /* NUM_MUXES_TO_TERMINATE */
+            num_muxes_to_terminate,                              /* NUM_MUXES_TO_TERMINATE */
+            sender_vc_id                                         /* VC_ID */
         };
 
         // Runtime args with connection type information

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -4,6 +4,7 @@
 
 #include <tt_stl/reflection.hpp>
 #include "tt_fabric_test_device_setup.hpp"
+#include "tt_metal/fabric/fabric_vc2_connection.hpp"
 
 namespace tt::tt_fabric::fabric_tests {
 
@@ -12,8 +13,8 @@ namespace tt::tt_fabric::fabric_tests {
 // ====================================
 
 void FabricConnectionManager::register_client(
-    const CoreCoord& core, RoutingDirection direction, uint32_t link_idx, TestWorkerType worker_type) {
-    ConnectionKey key = {direction, link_idx};
+    const CoreCoord& core, RoutingDirection direction, uint32_t link_idx, TestWorkerType worker_type, bool use_vc2) {
+    ConnectionKey key = {direction, link_idx, use_vc2};
     auto& conn = connections_[key];
 
     // Store worker type for this core (for channel assignment later)
@@ -274,8 +275,13 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
         } else {
             // Generate fabric connection args directly using passed parameters
             const auto neighbor_node_id = route_manager->get_neighbor_node_id(fabric_node_id, key.direction);
-            append_fabric_connection_rt_args(
-                fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            if (key.use_vc2) {
+                append_fabric_vc2_connection_rt_args(
+                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            } else {
+                append_fabric_connection_rt_args(
+                    fabric_node_id, neighbor_node_id, key.link_idx, program_handle, core, rt_args);
+            }
         }
     }
 
@@ -405,7 +411,8 @@ void TestSender::add_config(TestTrafficSenderConfig config) {
         TestWorkerType::SENDER,
         this->test_device_ptr_->connection_manager_,
         outgoing_direction,
-        config.link_id);
+        config.link_id,
+        config.use_vc2);
 
     this->configs_.emplace_back(std::move(config), fabric_connection_key);
 }
@@ -607,7 +614,8 @@ ConnectionKey TestDevice::register_fabric_connection(
     TestWorkerType worker_type,
     FabricConnectionManager& connection_mgr,
     RoutingDirection outgoing_direction,
-    uint32_t link_idx) {
+    uint32_t link_idx,
+    bool use_vc2) {
     // Get available link indices for this direction (to validate link_idx)
     std::vector<uint32_t> available_link_indices = get_forwarding_link_indices_in_direction(outgoing_direction);
 
@@ -626,7 +634,7 @@ ConnectionKey TestDevice::register_fabric_connection(
         static_cast<int>(outgoing_direction));
 
     // Check if this core already registered this connection
-    ConnectionKey connection_key{outgoing_direction, link_idx};
+    ConnectionKey connection_key{outgoing_direction, link_idx, use_vc2};
     auto registered_keys = connection_mgr.get_connection_keys_for_core(logical_core, worker_type);
 
     if (std::find(registered_keys.begin(), registered_keys.end(), connection_key) != registered_keys.end()) {
@@ -635,7 +643,7 @@ ConnectionKey TestDevice::register_fabric_connection(
     }
 
     // Register the new connection with the connection manager
-    connection_mgr.register_client(logical_core, outgoing_direction, link_idx, worker_type);
+    connection_mgr.register_client(logical_core, outgoing_direction, link_idx, worker_type, use_vc2);
 
     log_debug(
         tt::LogTest,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -40,14 +40,16 @@ namespace tt::tt_fabric::fabric_tests {
 struct ConnectionKey {
     RoutingDirection direction;
     uint32_t link_idx;
-    bool use_vc2 = false;
+    uint8_t vc_id = 0;  // 0=VC0, 2=VC2
+
+    bool use_vc2() const { return vc_id == 2; }
 
     bool operator==(const ConnectionKey& other) const {
-        return direction == other.direction && link_idx == other.link_idx && use_vc2 == other.use_vc2;
+        return direction == other.direction && link_idx == other.link_idx && vc_id == other.vc_id;
     }
 
     bool operator<(const ConnectionKey& other) const {
-        return std::tie(direction, link_idx, use_vc2) < std::tie(other.direction, other.link_idx, other.use_vc2);
+        return std::tie(direction, link_idx, vc_id) < std::tie(other.direction, other.link_idx, other.vc_id);
     }
 };
 
@@ -55,7 +57,7 @@ struct ConnectionKey {
 struct ConnectionKeyHash {
     std::size_t operator()(const ConnectionKey& key) const {
         return std::hash<int>()(static_cast<int>(key.direction)) ^ (std::hash<uint32_t>()(key.link_idx) << 1) ^
-               (std::hash<bool>()(key.use_vc2) << 2);
+               (std::hash<uint8_t>()(key.vc_id) << 2);
     }
 };
 
@@ -123,7 +125,7 @@ public:
         RoutingDirection direction,
         uint32_t link_idx,
         TestWorkerType worker_type,
-        bool use_vc2 = false);
+        uint8_t vc_id = 0);
 
     // Processing: Call once at start of create_kernels()
     // local_alloc: allocator for on-demand mux core allocation
@@ -403,7 +405,7 @@ private:
         FabricConnectionManager& connection_mgr,
         RoutingDirection outgoing_direction,
         uint32_t link_idx,
-        bool use_vc2 = false);
+        uint8_t vc_id = 0);
 
     MeshCoordinate coord_;
     std::shared_ptr<IDeviceInfoProvider> device_info_provider_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -40,20 +40,22 @@ namespace tt::tt_fabric::fabric_tests {
 struct ConnectionKey {
     RoutingDirection direction;
     uint32_t link_idx;
+    bool use_vc2 = false;
 
     bool operator==(const ConnectionKey& other) const {
-        return direction == other.direction && link_idx == other.link_idx;
+        return direction == other.direction && link_idx == other.link_idx && use_vc2 == other.use_vc2;
     }
 
     bool operator<(const ConnectionKey& other) const {
-        return std::tie(direction, link_idx) < std::tie(other.direction, other.link_idx);
+        return std::tie(direction, link_idx, use_vc2) < std::tie(other.direction, other.link_idx, other.use_vc2);
     }
 };
 
 // Hash function for ConnectionKey to enable unordered_map
 struct ConnectionKeyHash {
     std::size_t operator()(const ConnectionKey& key) const {
-        return std::hash<int>()(static_cast<int>(key.direction)) ^ (std::hash<uint32_t>()(key.link_idx) << 1);
+        return std::hash<int>()(static_cast<int>(key.direction)) ^ (std::hash<uint32_t>()(key.link_idx) << 1) ^
+               (std::hash<bool>()(key.use_vc2) << 2);
     }
 };
 
@@ -117,7 +119,11 @@ public:
 
     // Register a connection from a core in a specific direction and link
     void register_client(
-        const CoreCoord& core, RoutingDirection direction, uint32_t link_idx, TestWorkerType worker_type);
+        const CoreCoord& core,
+        RoutingDirection direction,
+        uint32_t link_idx,
+        TestWorkerType worker_type,
+        bool use_vc2 = false);
 
     // Processing: Call once at start of create_kernels()
     // local_alloc: allocator for on-demand mux core allocation
@@ -396,7 +402,8 @@ private:
         TestWorkerType worker_type,
         FabricConnectionManager& connection_mgr,
         RoutingDirection outgoing_direction,
-        uint32_t link_idx);
+        uint32_t link_idx,
+        bool use_vc2 = false);
 
     MeshCoordinate coord_;
     std::shared_ptr<IDeviceInfoProvider> device_info_provider_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
@@ -258,6 +258,7 @@ struct TestTrafficConfig {
     std::optional<uint32_t> atomic_inc_address;
     uint32_t link_id = 0;  // Link ID for multi-link tests
     std::optional<tt::tt_metal::NOC> noc_id;
+    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
 
     // Credit info (copied from pattern if populated by allocator)
     std::optional<SenderCreditInfo> sender_credit_info;
@@ -293,6 +294,7 @@ struct TestTrafficSenderConfig {
     uint32_t payload_buffer_size;  // Add payload buffer size field
     uint32_t link_id = 0;          // Link ID for multi-link tests
     std::optional<tt::tt_metal::NOC> noc_id;
+    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
 
     // Credit flow info (when enable_flow_control is true)
     std::optional<SenderCreditInfo> sender_credit_info;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
@@ -258,7 +258,8 @@ struct TestTrafficConfig {
     std::optional<uint32_t> atomic_inc_address;
     uint32_t link_id = 0;  // Link ID for multi-link tests
     std::optional<tt::tt_metal::NOC> noc_id;
-    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
+    uint8_t vc_id = 0;  // VC selection: 0=VC0 (default), 2=VC2
+    bool use_vc2() const { return vc_id == 2; }
 
     // Credit info (copied from pattern if populated by allocator)
     std::optional<SenderCreditInfo> sender_credit_info;
@@ -294,7 +295,8 @@ struct TestTrafficSenderConfig {
     uint32_t payload_buffer_size;  // Add payload buffer size field
     uint32_t link_id = 0;          // Link ID for multi-link tests
     std::optional<tt::tt_metal::NOC> noc_id;
-    bool use_vc2 = false;  // VC2: use private VC2 connection API instead of public API
+    uint8_t vc_id = 0;  // VC selection: 0=VC0 (default), 2=VC2
+    bool use_vc2() const { return vc_id == 2; }
 
     // Credit flow info (when enable_flow_control is true)
     std::optional<SenderCreditInfo> sender_credit_info;

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -337,8 +337,10 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
 
         }};
 
-    auto get_num_buffer_slots =
-        [](Topology topology, size_t arch_index, size_t num_active_vcs) -> const std::vector<PerVcBufferSlots>& {
+    auto get_num_buffer_slots = [](Topology topology,
+                                   size_t arch_index,
+                                   bool vc1_present,
+                                   bool vc2_present) -> const std::vector<PerVcBufferSlots>& {
         // Architecture-specific buffer slot configurations per VC, split by active VC count
         // Format: {vc0_sender, vc0_receiver, vc1_sender, vc1_receiver, vc2_sender, vc2_receiver}
 
@@ -408,6 +410,29 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
                 {1, 1, 1, 1, 1, 1}   // Option 6: supports VC0+VC1+VC2, smallest
             }};
 
+        // VC0+VC2 mesh options (no VC1): vc1 slots = 0, vc2 mirrors vc0-only reduced values
+        static const std::vector<std::vector<PerVcBufferSlots>> vc0_vc2_mesh_buffer_slot_options = {
+            // WORMHOLE_B0
+            {
+                {7, 11, 0, 0, 2, 4},  // Option 1: supports VC0+VC2
+                {4, 8, 0, 0, 2, 4},   // Option 2: supports VC0+VC2, smaller VC0
+                {4, 8, 0, 0, 2, 2},   // Option 3: supports VC0+VC2, smaller VC2 receiver
+                {2, 4, 0, 0, 2, 2},   // Option 4: supports VC0+VC2, smaller overall
+                {2, 4, 0, 0, 1, 1},   // Option 5: supports VC0+VC2, smaller overall
+                {2, 2, 0, 0, 1, 1},   // Option 6: supports VC0+VC2, smaller overall
+                {1, 1, 0, 0, 1, 1}    // Option 7: supports VC0+VC2, smallest
+            },
+            // BLACKHOLE
+            {
+                {7, 11, 0, 0, 2, 4},  // Option 1: supports VC0+VC2
+                {4, 8, 0, 0, 2, 4},   // Option 2: supports VC0+VC2, smaller VC0
+                {4, 8, 0, 0, 2, 2},   // Option 3: supports VC0+VC2, smaller VC2 receiver
+                {2, 4, 0, 0, 2, 2},   // Option 4: supports VC0+VC2, smaller overall
+                {2, 4, 0, 0, 1, 1},   // Option 5: supports VC0+VC2, smaller overall
+                {2, 2, 0, 0, 1, 1},   // Option 6: supports VC0+VC2, smaller overall
+                {1, 1, 0, 0, 1, 1}    // Option 7: supports VC0+VC2, smallest
+            }};
+
         static const std::vector<std::vector<PerVcBufferSlots>> other_buffer_slot_options = {
             // WORMHOLE_B0
             {{16, 16, 0, 0, 0, 0},  // Only VC0 for non-mesh topologies.
@@ -436,16 +461,22 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             vc0_only_mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_mesh_slots(
             vc0_vc1_mesh_buffer_slot_options);
+        static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc2_mesh_slots(
+            vc0_vc2_mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_vc2_mesh_slots(
             vc0_vc1_vc2_mesh_buffer_slot_options);
         static tt::stl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(
             other_buffer_slot_options);
 
         if (topology == Topology::Mesh || topology == Topology::Torus) {
-            if (num_active_vcs >= 3) {
+            // Select table based on which VCs are actually active
+            if (vc1_present && vc2_present) {
                 return vc0_vc1_vc2_mesh_slots.get()[arch_index];
             }
-            if (num_active_vcs >= 2) {
+            if (vc2_present) {
+                return vc0_vc2_mesh_slots.get()[arch_index];
+            }
+            if (vc1_present) {
                 return vc0_vc1_mesh_slots.get()[arch_index];
             }
             return vc0_only_mesh_slots.get()[arch_index];
@@ -518,6 +549,32 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
 
         // Validate that we found a valid option
         if (!found_valid_option) {
+            // Debug: print topology and table info
+            log_warning(tt::LogFabric, "  buffer_slot_options.size(): {}", buffer_slot_options.size());
+            // Debug: print all options tried
+            for (size_t idx = 0; idx < buffer_slot_options.size(); ++idx) {
+                auto& opt = buffer_slot_options[idx];
+                auto total = (num_vc0_sender_channels * opt.vc0_sender_slots +
+                              num_vc0_receiver_channels * opt.vc0_receiver_slots +
+                              num_vc1_sender_channels * opt.vc1_sender_slots +
+                              num_vc1_receiver_channels * opt.vc1_receiver_slots +
+                              num_vc2_sender_channels * opt.vc2_sender_slots +
+                              num_vc2_receiver_channels * opt.vc2_receiver_slots) *
+                             this->channel_buffer_size_bytes;
+                log_warning(
+                    tt::LogFabric,
+                    "  Option {}: vc0({},{}) vc1({},{}) vc2({},{}) = {} bytes (avail: {}, buf_size: {})",
+                    idx,
+                    opt.vc0_sender_slots,
+                    opt.vc0_receiver_slots,
+                    opt.vc1_sender_slots,
+                    opt.vc1_receiver_slots,
+                    opt.vc2_sender_slots,
+                    opt.vc2_receiver_slots,
+                    total,
+                    this->available_channel_buffering_space,
+                    this->channel_buffer_size_bytes);
+            }
             TT_THROW(
                 "Failed to find suitable buffer slot configuration. VC1 needed: {}, VC2 needed: {}, VC0 channels: {} "
                 "senders/{} "
@@ -593,18 +650,13 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     size_t vc1_sender_buffer_slots, vc1_receiver_buffer_slots;
     size_t vc2_sender_buffer_slots, vc2_receiver_buffer_slots;
 
-    // Determine how many VCs are active based on channel usage
-    size_t num_active_vcs = 1;
-    if (num_used_sender_channels_per_vc[1] > 0 || num_used_receiver_channels_per_vc[1] > 0) {
-        num_active_vcs = 2;
-    }
-    if (num_used_sender_channels_per_vc[2] > 0 || num_used_receiver_channels_per_vc[2] > 0) {
-        num_active_vcs = 3;
-    }
+    // Determine which VCs are active based on channel usage
+    bool vc1_present = (num_used_sender_channels_per_vc[1] > 0 || num_used_receiver_channels_per_vc[1] > 0);
+    bool vc2_present = (num_used_sender_channels_per_vc[2] > 0 || num_used_receiver_channels_per_vc[2] > 0);
 
-    // Get optimal buffer slots considering all VCs
+    // Get optimal buffer slots considering active VCs
     get_optimal_num_slots_per_vc(
-        get_num_buffer_slots(topology, arch_index, num_active_vcs),
+        get_num_buffer_slots(topology, arch_index, vc1_present, vc2_present),
         num_used_sender_channels_per_vc[0],
         num_used_receiver_channels_per_vc[0],
         num_used_sender_channels_per_vc[1],

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -749,8 +749,8 @@ void ComputeMeshRouterBuilder::create_kernel(tt::tt_metal::Program& program, con
     if (ctx.is_2D_routing) {
         defines["FABRIC_2D"] = "";
 
-        // FABRIC_2D_VC1_ACTIVE: Set when router has VC1
-        bool vc1_active = channel_mapping_.get_num_virtual_channels() > 1;
+        // FABRIC_2D_VC1_ACTIVE: Set when router actually has VC1 channels
+        bool vc1_active = channel_mapping_.get_num_sender_channels_for_vc(1) > 0;
         if (vc1_active) {
             defines["FABRIC_2D_VC1_ACTIVE"] = "";
         }

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -771,6 +771,12 @@ void ComputeMeshRouterBuilder::create_kernel(tt::tt_metal::Program& program, con
             defines["FABRIC_2D_VC1_SERVICED"] = "";
         }
 
+        // FABRIC_2D_VC2_SERVICED: Set when router has VC2 sender channels
+        bool vc2_active = channel_mapping_.get_num_sender_channels_for_vc(2) > 0;
+        if (vc2_active) {
+            defines["FABRIC_2D_VC2_SERVICED"] = "";
+        }
+
         // FABRIC_2D_VC0_CROSSOVER_TO_VC1: Set for inter-mesh routers that perform VC0→VC1 crossover
         // Inter-mesh routers crossover incoming VC0 traffic to downstream intra-mesh VC1
         bool vc0_crossover_to_vc1 = is_inter_mesh_ && intermesh_config.requires_vc1_full_mesh;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -786,10 +786,14 @@ FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
     this->receiver_channel_to_downstream_adapter =
         std::make_shared<tt::tt_fabric::StaticSizedChannelConnectionWriterAdapter>(
             *static_allocator, config.topology, direction);
-    // worker is always index 0.
-    // rest of the downstream buffer index addresses will be populated when building connections to downstream edm
-    // channels.
+    // Worker channels need their buffer-index-counter L1 address set so the EDM kernel can reset it on each launch.
+    // Channel 0 is always a worker. VC2 is also a worker channel when active.
     downstream_vcs_sender_channel_buffer_index_semaphore_id[0] = sender_channels_buffer_index_semaphore_id[0];
+    if (static_allocator->get_num_sender_channels(2) > 0) {
+        size_t vc2_flat = static_allocator->get_num_sender_channels(0) + static_allocator->get_num_sender_channels(1);
+        downstream_vcs_sender_channel_buffer_index_semaphore_id[vc2_flat] =
+            sender_channels_buffer_index_semaphore_id[vc2_flat];
+    }
 
     // Add this log right at the beginning of the constructor body
     log_debug(
@@ -1070,10 +1074,29 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         StreamRegAssignments::IncrementOnWrite::sender_channel_6_free_slots_stream_id;
     named_args["SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID"] =
         StreamRegAssignments::IncrementOnWrite::sender_channel_7_free_slots_stream_id;
-    named_args["SENDER_CHANNEL_8_FREE_SLOTS_STREAM_ID"] =
-        StreamRegAssignments::IncrementOnWrite::vc2_sender_free_slots_stream_id;
-    named_args["SENDER_CHANNEL_9_FREE_SLOTS_STREAM_ID"] =
-        StreamRegAssignments::IncrementOnWrite::vc2_sender_free_slots_stream_id;
+    // Channels 8 and 9 are 0 by default (padding). The firmware array
+    // sender_channel_free_slots_stream_ids[] is sized to MAX_NUM_SENDER_CHANNELS (10) but only
+    // indices 0..NUM_SENDER_CHANNELS-1 are accessed at runtime (via is_sender_channel_serviced[] guard).
+    //
+    // Channel layout by router type:
+    //   Non-Z mesh (no VC1):  indices 0-3 = VC0 (IDs 22-25),  index 4 = VC2 (ID 30 when enabled)
+    //   Non-Z mesh (with VC1): indices 0-3 = VC0, 4-6/7 = VC1, last = VC2 (ID 30 when enabled)
+    //   Z-router:              indices 0-4 = VC0, 5-8 = VC1 (mapped but NOT serviced by firmware —
+    //                          Z-routers don't step through VC1 sender channels), index 9 = VC2
+    //
+    // For Z-routers, VC1 sender channels (5-8) exist in the flat index space for layout compatibility
+    // but is_sender_channel_serviced[5..8] is false, so their stream IDs are never read by firmware.
+    // This is why indices 8 and 9 can safely be 0 — they are only accessed when VC2 is enabled,
+    // at which point the override below sets the correct one to stream ID 30.
+    named_args["SENDER_CHANNEL_8_FREE_SLOTS_STREAM_ID"] = 0;
+    named_args["SENDER_CHANNEL_9_FREE_SLOTS_STREAM_ID"] = 0;
+    // VC2 sender is always the last used channel. Override its stream ID to 30 (VC2 flow control).
+    // The flat index varies by config: non-Z without VC1 = index 4, non-Z with VC1 = index 7/8,
+    // Z-router = index 9.
+    if (actual_sender_channels_vc2 > 0 && num_sender_channels > 0) {
+        named_args[fmt::format("SENDER_CHANNEL_{}_FREE_SLOTS_STREAM_ID", num_sender_channels - 1)] =
+            StreamRegAssignments::IncrementOnWrite::vc2_sender_free_slots_stream_id;
+    }
     named_args["VC2_RECEIVER_FREE_SLOTS_STREAM_ID"] =
         StreamRegAssignments::IncrementOnWrite::vc2_receiver_free_slots_stream_id;
     named_args["TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID"] =
@@ -1468,6 +1491,19 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             sender_channels_flow_control_semaphore_id[i] = 0;
             sender_channels_connection_semaphore_id[i] = 0;
             sender_channels_buffer_index_semaphore_id[i] = 0;
+        }
+        // VC2 supports a worker connection, so if it's present we'kk add the relevant book-keeping
+        auto* static_allocator =
+            dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
+        const auto vc2_flat =
+            static_allocator->get_num_sender_channels(0) + static_allocator->get_num_sender_channels(1);
+        if (static_allocator->get_num_sender_channels(2) > 0) {
+            sender_channels_buffer_index_semaphore_id[vc2_flat] =
+                config.sender_channels_buffer_index_semaphore_address[vc2_flat];
+            sender_channels_flow_control_semaphore_id[vc2_flat] =
+                config.sender_channels_local_flow_control_semaphore_address[vc2_flat];
+            sender_channels_connection_semaphore_id[vc2_flat] =
+                config.sender_channels_connection_semaphore_address[vc2_flat];
         }
     } else {
         const bool is_2D_routing =

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1492,7 +1492,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
             sender_channels_connection_semaphore_id[i] = 0;
             sender_channels_buffer_index_semaphore_id[i] = 0;
         }
-        // VC2 supports a worker connection, so if it's present we'kk add the relevant book-keeping
+        // VC2 supports a worker connection, so if it's present we'll add the relevant book-keeping
         auto* static_allocator =
             dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(config.channel_allocator.get());
         const auto vc2_flat =

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -286,11 +286,9 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
         bool is_blackhole = (arch == tt::ARCH::BLACKHOLE);
         bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
         bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
+        // VC2 requires: RT option enabled + VC1 active + Blackhole + no UDM/mux
         const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
         config.requires_vc2 = rtoptions.get_enable_fabric_vc2() && is_blackhole && !is_udm_mode && !is_mux_extension;
-        TT_FATAL(
-            !rtoptions.get_enable_fabric_vc2(),
-            "TT_METAL_ENABLE_FABRIC_VC2 is not yet supported — VC2 feature is under development");
     }
 
     return config;

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -23,11 +23,12 @@ void FabricBuilderContext::compute_max_channel_counts() {
     std::vector<FabricRouterChannelMapping> possible_mappings;
 
     // Always have MESH routers
+    bool needs_vc_config = intermesh_vc_config_.requires_vc1 || intermesh_vc_config_.requires_vc2;
     possible_mappings.emplace_back(
         topology,
         false,  // no tensix
         RouterVariant::MESH,
-        intermesh_vc_config_.requires_vc1 ? &intermesh_vc_config_ : nullptr,
+        needs_vc_config ? &intermesh_vc_config_ : nullptr,
         false);
 
     // If Z routers exist in this fabric, add Z_ROUTER mapping
@@ -47,12 +48,14 @@ void FabricBuilderContext::compute_max_channel_counts() {
     for (const auto& mapping : possible_mappings) {
         uint32_t num_vcs = mapping.get_num_virtual_channels();
         for (uint32_t vc = 0; vc < num_vcs; ++vc) {
-            max_sender_channels_per_vc_[vc] = std::max(
-                max_sender_channels_per_vc_[vc],
-                static_cast<std::size_t>(mapping.get_num_sender_channels_for_vc(vc)));
-            max_receiver_channels_per_vc_[vc] = std::max(
-                max_receiver_channels_per_vc_[vc],
-                static_cast<std::size_t>(1u));  // Always 1 receiver per VC
+            auto sender_count = mapping.get_num_sender_channels_for_vc(vc);
+            max_sender_channels_per_vc_[vc] =
+                std::max(max_sender_channels_per_vc_[vc], static_cast<std::size_t>(sender_count));
+            // Count a receiver for this VC if the mapping created one.
+            // A VC has a receiver if it has a LogicalReceiverChannelKey{vc, 0} in the map.
+            auto receiver_count = mapping.get_num_receiver_channels_for_vc(vc);
+            max_receiver_channels_per_vc_[vc] =
+                std::max(max_receiver_channels_per_vc_[vc], static_cast<std::size_t>(receiver_count));
         }
     }
 }
@@ -120,12 +123,20 @@ std::unique_ptr<FabricEriscDatamoverConfig> FabricBuilderContext::create_edm_con
         .direction = direction,
     };
 
+    // MUX/UDM modes are mutually exclusive with VC2 — zero out VC2 channels
+    auto sender_channels = max_sender_channels_per_vc_;
+    auto receiver_channels = max_receiver_channels_per_vc_;
+    if (fabric_tensix_config == FabricTensixConfig::MUX || fabric_tensix_config == FabricTensixConfig::UDM) {
+        sender_channels[2] = 0;
+        receiver_channels[2] = 0;
+    }
+
     return std::make_unique<FabricEriscDatamoverConfig>(
         fabric_context_.get_fabric_channel_buffer_size_bytes(),
         fabric_context_.get_fabric_topology(),
         edm_options,
-        max_sender_channels_per_vc_,      // Max for this fabric instance
-        max_receiver_channels_per_vc_);   // Max for this fabric instance
+        sender_channels,
+        receiver_channels);
 }
 
 FabricEriscDatamoverConfig& FabricBuilderContext::get_fabric_router_config(
@@ -227,68 +238,69 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& mesh_graph = control_plane.get_mesh_graph();
 
-    // Check if multiple meshes exist
+    auto config = IntermeshVCConfig::disabled();
+
+    // Check if multiple meshes exist — needed for VC1 (intermesh traffic)
     const auto& mesh_ids = mesh_graph.get_mesh_ids();
     constexpr size_t single_mesh_count = 1;
-    if (mesh_ids.size() <= single_mesh_count) {
-        return IntermeshVCConfig::disabled();
-    }
+    bool is_multi_mesh = mesh_ids.size() > single_mesh_count;
 
-    // Check if intermesh connections exist (use inter_mesh_connectivity which has actual parsed connections)
-    const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
+    if (is_multi_mesh) {
+        // Check if intermesh connections exist (use inter_mesh_connectivity which has actual parsed connections)
+        const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();
 
-    // Count total intermesh connections across all meshes
-    size_t total_intermesh_connections = 0;
-    for (const auto& mesh_connections : inter_mesh_connectivity) {
-        for (const auto& chip_connections : mesh_connections) {
-            total_intermesh_connections += chip_connections.size();
+        // Count total intermesh connections across all meshes
+        size_t total_intermesh_connections = 0;
+        for (const auto& mesh_connections : inter_mesh_connectivity) {
+            for (const auto& chip_connections : mesh_connections) {
+                total_intermesh_connections += chip_connections.size();
+            }
         }
-    }
 
-    if (total_intermesh_connections == 0) {
-        return IntermeshVCConfig::disabled();
-    }
-
-    // Detect Z vs XY intermesh by checking for Z-direction connections in inter-mesh connectivity
-    bool has_z_routers = false;
-    for (const auto& mesh_connections : inter_mesh_connectivity) {
-        for (const auto& chip_connections : mesh_connections) {
-            for (const auto& [dst_mesh_id, router_edge] : chip_connections) {
-                if (router_edge.port_direction == RoutingDirection::Z) {
-                    has_z_routers = true;
+        if (total_intermesh_connections > 0) {
+            // Detect Z vs XY intermesh by checking for Z-direction connections in inter-mesh connectivity
+            bool has_z_routers = false;
+            for (const auto& mesh_connections : inter_mesh_connectivity) {
+                for (const auto& chip_connections : mesh_connections) {
+                    for (const auto& [dst_mesh_id, router_edge] : chip_connections) {
+                        if (router_edge.port_direction == RoutingDirection::Z) {
+                            has_z_routers = true;
+                            break;
+                        }
+                    }
+                    if (has_z_routers) {
+                        break;
+                    }
+                }
+                if (has_z_routers) {
                     break;
                 }
             }
-            if (has_z_routers) {
-                break;
-            }
-        }
-        if (has_z_routers) {
-            break;
+
+            // Default to FULL_MESH when intermesh exists
+            // TODO: Implement detection logic for:
+            //   - EDGE_ONLY: Check if workload only needs edge nodes (optimization)
+            //   - FULL_MESH_WITH_PASS_THROUGH: Check if any mesh forwards traffic between other meshes
+            constexpr bool needs_mesh_pass_through = false;
+
+            config = needs_mesh_pass_through ? IntermeshVCConfig::full_mesh_with_pass_through()
+                                             : IntermeshVCConfig::full_mesh();
+
+            // Set router type based on detection
+            config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
         }
     }
 
-    // Default to FULL_MESH when intermesh exists
-    // TODO: Implement detection logic for:
-    //   - EDGE_ONLY: Check if workload only needs edge nodes (optimization)
-    //   - FULL_MESH_WITH_PASS_THROUGH: Check if any mesh forwards traffic between other meshes
-    constexpr bool needs_mesh_pass_through = false;
-
-    auto config =
-        needs_mesh_pass_through ? IntermeshVCConfig::full_mesh_with_pass_through() : IntermeshVCConfig::full_mesh();
-
-    // Set router type based on detection
-    config.router_type = has_z_routers ? IntermeshRouterType::Z_INTERMESH : IntermeshRouterType::XY_INTERMESH;
-
-    if (config.requires_vc1) {
+    // VC2 is independent of VC1 — only requires: RT option + Blackhole + no UDM/mux + 2D topology
+    // (2D topology check happens in initialize_vc2_mappings, not here)
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    if (rtoptions.get_enable_fabric_vc2()) {
         auto arch = tt::tt_metal::MetalContext::instance().hal().get_arch();
         auto tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
         bool is_blackhole = (arch == tt::ARCH::BLACKHOLE);
         bool is_udm_mode = (tensix_config == FabricTensixConfig::UDM);
         bool is_mux_extension = (tensix_config == FabricTensixConfig::MUX);
-        // VC2 requires: RT option enabled + VC1 active + Blackhole + no UDM/mux
-        const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-        config.requires_vc2 = rtoptions.get_enable_fabric_vc2() && is_blackhole && !is_udm_mode && !is_mux_extension;
+        config.requires_vc2 = is_blackhole && !is_udm_mode && !is_mux_extension;
     }
 
     return config;

--- a/tt_metal/fabric/fabric_router_channel_mapping.cpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.cpp
@@ -156,16 +156,17 @@ void FabricRouterChannelMapping::initialize_vc2_mappings() {
         // Mesh router VC2: 1 sender + 1 receiver
         if (intermesh_vc_config_ && intermesh_vc_config_->requires_vc2) {
             // VC2 sender at last flat index (after VC0 + VC1 senders)
-            // VC1 mesh sender count depends on whether device has Z router
-            uint32_t mesh_vc1_sender_count = has_z_on_device_ ? 4 : 3;
+            // Use actual VC1 sender count (0 if VC1 not active, 3 or 4 if active)
+            uint32_t actual_vc1_sender_count = get_num_sender_channels_for_vc(1);
             uint32_t mesh_vc2_base_sender_channel =
-                builder_config::num_sender_channels_2d_mesh + mesh_vc1_sender_count;  // 4 + 3|4 = 7|8
+                builder_config::num_sender_channels_2d_mesh + actual_vc1_sender_count;
 
             sender_channel_map_[LogicalSenderChannelKey{2, 0}] =
                 InternalSenderChannelMapping{BuilderType::ERISC, mesh_vc2_base_sender_channel};
 
-            // VC2 receiver at index 2 (after VC0=0, VC1=1)
-            constexpr uint32_t mesh_vc2_receiver_channel = 2;
+            // VC2 receiver after VC0 and VC1 receivers (index 1 if VC1 disabled, index 2 if VC1 active)
+            uint32_t num_vc1_receivers = (intermesh_vc_config_ && intermesh_vc_config_->requires_vc1) ? 1 : 0;
+            uint32_t mesh_vc2_receiver_channel = 1 + num_vc1_receivers;  // VC0=0, then VC1 if active, then VC2
             receiver_channel_map_[LogicalReceiverChannelKey{2, 0}] =
                 InternalReceiverChannelMapping{BuilderType::ERISC, mesh_vc2_receiver_channel};
         }
@@ -262,6 +263,19 @@ uint32_t FabricRouterChannelMapping::get_num_sender_channels_for_vc(uint32_t vc)
         default:
             return no_channels;
     }
+}
+
+uint32_t FabricRouterChannelMapping::get_num_receiver_channels_for_vc(uint32_t vc) const {
+    // Count receiver channels for this VC by checking the receiver channel map
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < builder_config::num_max_receiver_channels; ++i) {
+        if (receiver_channel_map_.contains(LogicalReceiverChannelKey{vc, i})) {
+            count++;
+        } else {
+            break;  // Channels are created sequentially
+        }
+    }
+    return count;
 }
 
 std::vector<InternalSenderChannelMapping> FabricRouterChannelMapping::get_all_sender_mappings() const {

--- a/tt_metal/fabric/fabric_router_channel_mapping.hpp
+++ b/tt_metal/fabric/fabric_router_channel_mapping.hpp
@@ -105,6 +105,7 @@ public:
     uint32_t get_num_virtual_channels() const;
 
     uint32_t get_num_sender_channels_for_vc(uint32_t vc) const;
+    uint32_t get_num_receiver_channels_for_vc(uint32_t vc) const;
 
     std::vector<InternalSenderChannelMapping> get_all_sender_mappings() const;
 

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/fabric/fabric_vc2_connection.hpp"
+
+#include <cstdint>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt_stl/assert.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
+#include <optional>
+#include <vector>
+
+#include "erisc_datamover_builder.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
+#include "fabric_host_utils.hpp"
+#include "fabric_context.hpp"
+#include "fabric_builder_context.hpp"
+
+namespace tt::tt_fabric {
+
+template <typename ProgramOrDescriptor>
+void append_fabric_vc2_connection_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const FabricNodeId& dst_fabric_node_id,
+    const uint32_t link_idx,
+    ProgramOrDescriptor& worker_program_or_desc,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args) {
+    TT_FATAL(
+        src_fabric_node_id != dst_fabric_node_id,
+        "Expected different src and dst chip ids but got same, Src: {}, Dst: {}",
+        src_fabric_node_id,
+        dst_fabric_node_id);
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& fabric_context = control_plane.get_fabric_context();
+    const bool is_2d_fabric = fabric_context.is_2D_routing_enabled();
+
+    // Resolve forwarding direction (same logic as public API)
+    std::optional<RoutingDirection> forwarding_direction;
+    if (is_2d_fabric) {
+        forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+    } else {
+        for (const auto& direction : FabricContext::routing_directions) {
+            auto neighbors = control_plane.get_chip_neighbors(src_fabric_node_id, direction);
+            auto neighbor_mesh_chips = neighbors.find(dst_fabric_node_id.mesh_id);
+            if (neighbor_mesh_chips == neighbors.end() ||
+                (std::find(
+                     neighbor_mesh_chips->second.begin(),
+                     neighbor_mesh_chips->second.end(),
+                     dst_fabric_node_id.chip_id) == neighbor_mesh_chips->second.end())) {
+                continue;
+            }
+            forwarding_direction = direction;
+            break;
+        }
+    }
+    TT_FATAL(
+        forwarding_direction.has_value(),
+        "Could not find any forwarding direction from src {} to dst {}",
+        src_fabric_node_id,
+        dst_fabric_node_id);
+
+    const auto candidate_eth_chans =
+        control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction.value());
+    TT_FATAL(
+        link_idx < candidate_eth_chans.size(),
+        "Requested link index {} is out of bounds. {} ethernet channels available to forward b/w src {} and dst {}",
+        link_idx,
+        candidate_eth_chans.size(),
+        src_fabric_node_id,
+        dst_fabric_node_id);
+
+    const auto forwarding_links = get_forwarding_link_indices_in_direction(
+        control_plane, src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
+    TT_FATAL(
+        std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
+        "Requested link index {} cannot be used for forwarding b/w src {} and dst {}. Valid forwarding links are {}",
+        link_idx,
+        src_fabric_node_id,
+        dst_fabric_node_id,
+        forwarding_links);
+
+    const auto fabric_router_channel = candidate_eth_chans[link_idx];
+
+    // Create semaphores (same pattern as public API, WORKER core type only)
+    uint32_t worker_teardown_semaphore_id;
+    uint32_t worker_buffer_index_semaphore_id;
+    uint32_t worker_flow_control_semaphore_id;
+
+    if constexpr (std::is_same_v<ProgramOrDescriptor, tt::tt_metal::ProgramDescriptor>) {
+        auto teardown_sem_id_opt = worker_program_or_desc.find_available_semaphore_id(worker_core, CoreType::WORKER);
+        TT_FATAL(teardown_sem_id_opt.has_value(), "No available semaphore ID for teardown semaphore");
+        worker_teardown_semaphore_id = teardown_sem_id_opt.value();
+        worker_program_or_desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = worker_teardown_semaphore_id,
+            .core_type = CoreType::WORKER,
+            .core_ranges = CoreRangeSet(CoreRange(worker_core, worker_core)),
+            .initial_value = 0});
+
+        auto buffer_index_sem_id_opt =
+            worker_program_or_desc.find_available_semaphore_id(worker_core, CoreType::WORKER);
+        TT_FATAL(buffer_index_sem_id_opt.has_value(), "No available semaphore ID for buffer index semaphore");
+        worker_buffer_index_semaphore_id = buffer_index_sem_id_opt.value();
+        worker_program_or_desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = worker_buffer_index_semaphore_id,
+            .core_type = CoreType::WORKER,
+            .core_ranges = CoreRangeSet(CoreRange(worker_core, worker_core)),
+            .initial_value = 0});
+
+        auto flow_control_sem_id_opt =
+            worker_program_or_desc.find_available_semaphore_id(worker_core, CoreType::WORKER);
+        TT_FATAL(flow_control_sem_id_opt.has_value(), "No available semaphore ID for flow control semaphore");
+        worker_flow_control_semaphore_id = flow_control_sem_id_opt.value();
+        worker_program_or_desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
+            .id = worker_flow_control_semaphore_id,
+            .core_type = CoreType::WORKER,
+            .core_ranges = CoreRangeSet(CoreRange(worker_core, worker_core)),
+            .initial_value = 0});
+    } else {
+        worker_teardown_semaphore_id =
+            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
+        worker_buffer_index_semaphore_id =
+            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
+        worker_flow_control_semaphore_id =
+            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
+    }
+
+    // Resolve VC2 sender channel addresses via explicit SenderWorkerAdapterSpec
+    const auto router_direction = control_plane.routing_direction_to_eth_direction(forwarding_direction.value());
+
+    ChipId src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
+    CoreCoord fabric_router_virtual_core =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+            src_chip_id, fabric_router_channel);
+
+    const auto& edm_config = fabric_context.get_builder_context().get_fabric_router_config();
+    auto* channel_allocator = edm_config.channel_allocator.get();
+    auto* const static_channel_allocator =
+        dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
+    TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be FabricStaticSizedChannelsAllocator");
+
+    // VC2 sender is at the last flat index: after all VC0 and VC1 senders
+    const auto vc2_sender_channel =
+        static_channel_allocator->get_num_sender_channels(0) + static_channel_allocator->get_num_sender_channels(1);
+
+    tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
+        .edm_noc_x = fabric_router_virtual_core.x,
+        .edm_noc_y = fabric_router_virtual_core.y,
+        .edm_buffer_base_addr = static_channel_allocator->get_sender_channel_base_address(vc2_sender_channel),
+        .num_buffers_per_channel = static_channel_allocator->get_sender_channel_number_of_slots(vc2_sender_channel),
+        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[vc2_sender_channel],
+        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[vc2_sender_channel],
+        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[vc2_sender_channel],
+        .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
+        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[vc2_sender_channel],
+        .edm_direction = router_direction};
+
+    append_worker_to_fabric_edm_sender_rt_args(
+        edm_connection,
+        worker_flow_control_semaphore_id,
+        worker_teardown_semaphore_id,
+        worker_buffer_index_semaphore_id,
+        worker_args);
+}
+
+// Explicit template instantiations
+template void append_fabric_vc2_connection_rt_args<tt::tt_metal::Program>(
+    const FabricNodeId&,
+    const FabricNodeId&,
+    uint32_t,
+    tt::tt_metal::Program&,
+    const CoreCoord&,
+    std::vector<uint32_t>&);
+
+template void append_fabric_vc2_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
+    const FabricNodeId&,
+    const FabricNodeId&,
+    uint32_t,
+    tt::tt_metal::ProgramDescriptor&,
+    const CoreCoord&,
+    std::vector<uint32_t>&);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_metal/fabric/fabric_vc2_connection.hpp"
 
+#include <tt_stl/fmt.hpp>
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program.hpp>
@@ -246,7 +247,7 @@ void append_fabric_vc2_connection_rt_args(
     log_trace(tt::LogFabric, "\tVC2 connection. buffer_size_bytes: {}", edm_connection.buffer_size_bytes);
     log_trace(
         tt::LogFabric, "\tVC2 connection. buffer_index_semaphore_id: {}", edm_connection.buffer_index_semaphore_id);
-    log_trace(tt::LogFabric, "\tVC2 connection. edm_direction: {}", edm_connection.edm_direction);
+    log_trace(tt::LogFabric, "\tVC2 connection. edm_direction: {}", static_cast<int>(edm_connection.edm_direction));
     append_worker_to_fabric_edm_sender_rt_args(
         edm_connection,
         worker_flow_control_semaphore_id,

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -163,7 +163,7 @@ void append_fabric_vc2_connection_rt_args(
     const auto vc2_sender_channel_flat = num_vc0_senders + num_vc1_senders;
     const auto total_sender_channels = num_vc0_senders + num_vc1_senders + num_vc2_senders;
 
-    log_info(
+    log_trace(
         tt::LogFabric,
         "VC2 flat index diagnostic: vc0_senders={}, vc1_senders={}, vc2_senders={}, "
         "vc2_flat_idx={}, total_senders={}, config.num_used_sender_channels={}",
@@ -201,7 +201,7 @@ void append_fabric_vc2_connection_rt_args(
 
     // Dump ALL sender channel addresses so we can see the full picture
     for (size_t i = 0; i < total_sender_channels; i++) {
-        log_info(
+        log_trace(
             tt::LogFabric,
             "  sender_ch[{}]: conn_sem=0x{:x}, conn_info=0x{:x}, flow_ctrl=0x{:x}, buf_idx=0x{:x}{}",
             i,
@@ -232,21 +232,21 @@ void append_fabric_vc2_connection_rt_args(
         .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[vc2_sender_channel_flat],
         .edm_direction = router_direction};
 
-    log_info(tt::LogFabric, "VC2 connection. edm_buffer_base_addr: {}", edm_connection.edm_buffer_base_addr);
-    log_info(tt::LogFabric, "\tVC2 connection. num_buffers_per_channel: {}", edm_connection.num_buffers_per_channel);
-    log_info(tt::LogFabric, "\tVC2 connection. edm_l1_sem_addr: {}", edm_connection.edm_l1_sem_addr);
-    log_info(
+    log_trace(tt::LogFabric, "VC2 connection. edm_buffer_base_addr: {}", edm_connection.edm_buffer_base_addr);
+    log_trace(tt::LogFabric, "\tVC2 connection. num_buffers_per_channel: {}", edm_connection.num_buffers_per_channel);
+    log_trace(tt::LogFabric, "\tVC2 connection. edm_l1_sem_addr: {}", edm_connection.edm_l1_sem_addr);
+    log_trace(
         tt::LogFabric,
         "\tVC2 connection. edm_connection_handshake_addr: {}",
         edm_connection.edm_connection_handshake_addr);
-    log_info(
+    log_trace(
         tt::LogFabric,
         "\tVC2 connection. edm_worker_location_info_addr: {}",
         edm_connection.edm_worker_location_info_addr);
-    log_info(tt::LogFabric, "\tVC2 connection. buffer_size_bytes: {}", edm_connection.buffer_size_bytes);
-    log_info(
+    log_trace(tt::LogFabric, "\tVC2 connection. buffer_size_bytes: {}", edm_connection.buffer_size_bytes);
+    log_trace(
         tt::LogFabric, "\tVC2 connection. buffer_index_semaphore_id: {}", edm_connection.buffer_index_semaphore_id);
-    log_info(tt::LogFabric, "\tVC2 connection. edm_direction: {}", edm_connection.edm_direction);
+    log_trace(tt::LogFabric, "\tVC2 connection. edm_direction: {}", edm_connection.edm_direction);
     append_worker_to_fabric_edm_sender_rt_args(
         edm_connection,
         worker_flow_control_semaphore_id,

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -42,6 +42,13 @@ void append_fabric_vc2_connection_rt_args(
 
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane.get_fabric_context();
+    const auto& builder_context = fabric_context.get_builder_context();
+    TT_FATAL(
+        builder_context.requires_vc2(),
+        "VC2 connection requested but VC2 is not enabled. "
+        "VC2 requires: 2D fabric topology (Mesh/Torus), multi-mesh configuration, Blackhole architecture, "
+        "no UDM/mux extension mode, and TT_METAL_ENABLE_FABRIC_VC2 runtime option. "
+        "Current topology may not meet these conditions.");
     const bool is_2d_fabric = fabric_context.is_2D_routing_enabled();
 
     // Resolve forwarding direction (same logic as public API)

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -155,22 +155,98 @@ void append_fabric_vc2_connection_rt_args(
         dynamic_cast<tt::tt_fabric::FabricStaticSizedChannelsAllocator*>(channel_allocator);
     TT_FATAL(static_channel_allocator != nullptr, "Channel allocator must be FabricStaticSizedChannelsAllocator");
 
-    // VC2 sender is at the last flat index: after all VC0 and VC1 senders
-    const auto vc2_sender_channel =
-        static_channel_allocator->get_num_sender_channels(0) + static_channel_allocator->get_num_sender_channels(1);
+    // VC2 sender is at the last flat index: after all VC0 and VC1 senders.
+    // Used for flat edm_config arrays (indexed across all VCs).
+    const auto num_vc0_senders = static_channel_allocator->get_num_sender_channels(0);
+    const auto num_vc1_senders = static_channel_allocator->get_num_sender_channels(1);
+    const auto num_vc2_senders = static_channel_allocator->get_num_sender_channels(2);
+    const auto vc2_sender_channel_flat = num_vc0_senders + num_vc1_senders;
+    const auto total_sender_channels = num_vc0_senders + num_vc1_senders + num_vc2_senders;
+
+    log_info(
+        tt::LogFabric,
+        "VC2 flat index diagnostic: vc0_senders={}, vc1_senders={}, vc2_senders={}, "
+        "vc2_flat_idx={}, total_senders={}, config.num_used_sender_channels={}",
+        num_vc0_senders,
+        num_vc1_senders,
+        num_vc2_senders,
+        vc2_sender_channel_flat,
+        total_sender_channels,
+        edm_config.num_used_sender_channels);
+    TT_FATAL(
+        vc2_sender_channel_flat < edm_config.num_used_sender_channels,
+        "VC2 flat index {} is out of bounds for edm_config arrays (num_used_sender_channels={}). "
+        "Allocator counts: vc0={}, vc1={}, vc2={}",
+        vc2_sender_channel_flat,
+        edm_config.num_used_sender_channels,
+        num_vc0_senders,
+        num_vc1_senders,
+        num_vc2_senders);
+    TT_FATAL(num_vc2_senders > 0, "VC2 connection requested but allocator reports 0 VC2 sender channels");
+
+    // Cross-check: verify the addresses at the VC2 flat index are non-zero
+    TT_FATAL(
+        edm_config.sender_channels_connection_semaphore_address[vc2_sender_channel_flat] != 0,
+        "VC2 connection_semaphore_address is 0 at flat index {}. "
+        "This indicates the config did not allocate L1 for the VC2 sender channel.",
+        vc2_sender_channel_flat);
+    TT_FATAL(
+        edm_config.sender_channels_worker_conn_info_base_address[vc2_sender_channel_flat] != 0,
+        "VC2 worker_conn_info_base_address is 0 at flat index {}.",
+        vc2_sender_channel_flat);
+    TT_FATAL(
+        edm_config.sender_channels_local_flow_control_semaphore_address[vc2_sender_channel_flat] != 0,
+        "VC2 flow_control_semaphore_address is 0 at flat index {}.",
+        vc2_sender_channel_flat);
+
+    // Dump ALL sender channel addresses so we can see the full picture
+    for (size_t i = 0; i < total_sender_channels; i++) {
+        log_info(
+            tt::LogFabric,
+            "  sender_ch[{}]: conn_sem=0x{:x}, conn_info=0x{:x}, flow_ctrl=0x{:x}, buf_idx=0x{:x}{}",
+            i,
+            edm_config.sender_channels_connection_semaphore_address[i],
+            edm_config.sender_channels_worker_conn_info_base_address[i],
+            edm_config.sender_channels_local_flow_control_semaphore_address[i],
+            edm_config.sender_channels_buffer_index_semaphore_address[i],
+            (i == vc2_sender_channel_flat) ? " <-- VC2" : "");
+    }
+
+    // VC2 has exactly one sender channel at VC-relative index 0.
+    // The allocator's 2D API requires (vc_id=2, channel_id=0).
+    static constexpr size_t vc2_id = 2;
+    static constexpr size_t vc2_channel_idx = 0;
 
     tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
         .edm_noc_x = fabric_router_virtual_core.x,
         .edm_noc_y = fabric_router_virtual_core.y,
-        .edm_buffer_base_addr = static_channel_allocator->get_sender_channel_base_address(vc2_sender_channel),
-        .num_buffers_per_channel = static_channel_allocator->get_sender_channel_number_of_slots(vc2_sender_channel),
-        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[vc2_sender_channel],
-        .edm_connection_handshake_addr = edm_config.sender_channels_connection_semaphore_address[vc2_sender_channel],
-        .edm_worker_location_info_addr = edm_config.sender_channels_worker_conn_info_base_address[vc2_sender_channel],
+        .edm_buffer_base_addr = static_channel_allocator->get_sender_channel_base_address(vc2_id, vc2_channel_idx),
+        .num_buffers_per_channel =
+            static_channel_allocator->get_sender_channel_number_of_slots(vc2_id, vc2_channel_idx),
+        .edm_l1_sem_addr = edm_config.sender_channels_local_flow_control_semaphore_address[vc2_sender_channel_flat],
+        .edm_connection_handshake_addr =
+            edm_config.sender_channels_connection_semaphore_address[vc2_sender_channel_flat],
+        .edm_worker_location_info_addr =
+            edm_config.sender_channels_worker_conn_info_base_address[vc2_sender_channel_flat],
         .buffer_size_bytes = edm_config.channel_buffer_size_bytes,
-        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[vc2_sender_channel],
+        .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[vc2_sender_channel_flat],
         .edm_direction = router_direction};
 
+    log_info(tt::LogFabric, "VC2 connection. edm_buffer_base_addr: {}", edm_connection.edm_buffer_base_addr);
+    log_info(tt::LogFabric, "\tVC2 connection. num_buffers_per_channel: {}", edm_connection.num_buffers_per_channel);
+    log_info(tt::LogFabric, "\tVC2 connection. edm_l1_sem_addr: {}", edm_connection.edm_l1_sem_addr);
+    log_info(
+        tt::LogFabric,
+        "\tVC2 connection. edm_connection_handshake_addr: {}",
+        edm_connection.edm_connection_handshake_addr);
+    log_info(
+        tt::LogFabric,
+        "\tVC2 connection. edm_worker_location_info_addr: {}",
+        edm_connection.edm_worker_location_info_addr);
+    log_info(tt::LogFabric, "\tVC2 connection. buffer_size_bytes: {}", edm_connection.buffer_size_bytes);
+    log_info(
+        tt::LogFabric, "\tVC2 connection. buffer_index_semaphore_id: {}", edm_connection.buffer_index_semaphore_id);
+    log_info(tt::LogFabric, "\tVC2 connection. edm_direction: {}", edm_connection.edm_direction);
     append_worker_to_fabric_edm_sender_rt_args(
         edm_connection,
         worker_flow_control_semaphore_id,

--- a/tt_metal/fabric/fabric_vc2_connection.hpp
+++ b/tt_metal/fabric/fabric_vc2_connection.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+
+namespace tt::tt_fabric {
+
+// Private VC2 connection API -- Metal-layer only, not published under public fabric API.
+// Uses VC2 sender channel (last flat index) instead of channel 0.
+// Only supports CoreType::WORKER (VC2 is for worker injection only).
+template <typename ProgramOrDescriptor = tt::tt_metal::Program>
+void append_fabric_vc2_connection_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const FabricNodeId& dst_fabric_node_id,
+    uint32_t link_idx,
+    ProgramOrDescriptor& worker_program_or_desc,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -68,7 +68,8 @@ struct WorkerToFabricEdmSenderBase {
     static_assert(VC_ID == 0 || VC_ID == 2, "Only VC_ID 0 and 2 are supported");
     // VC0 uses stream 22 (sender_channel_0 free slots); VC2 uses stream 30.
     static constexpr uint32_t STREAM_ID =
-        VC_ID == 2 ? 30u : tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
+        VC_ID == 2 ? tt::tt_fabric::connection_interface::vc2_sender_free_slots_stream_id
+                   : tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
     static constexpr bool ENABLE_STATEFUL_WRITE_CREDIT_TO_DOWNSTREAM_EDM =
 #if !defined(DEBUG_PRINT_ENABLED) and !defined(WATCHER_ENABLED)
         true;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -38,6 +38,14 @@ using WorkerToFabricEdmSenderImpl =
 
 using WorkerToFabricEdmSender = WorkerToFabricEdmSenderImpl<false, 0>;
 
+// VC2 worker adapter: same template as VC0/VC1 but uses stream ID 30
+// (VC2 sender free-slots increment-on-write register, established in Phase 1/4)
+template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0>
+using WorkerToFabricEdmSenderVC2Impl =
+    WorkerToFabricEdmSenderBase<I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, EDM_NUM_BUFFER_SLOTS, 30>;
+
+using WorkerToFabricEdmSenderVC2 = WorkerToFabricEdmSenderVC2Impl<false, 0>;
+
 namespace fabric_detail{
     template <bool STATEFUL_NOC>
     void update_credits_and_slots(WorkerToFabricEdmSender*);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -24,25 +24,20 @@
 
 namespace tt::tt_fabric {
 
-template <
-    bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE,
-    uint8_t EDM_NUM_BUFFER_SLOTS = 0,
-    uint32_t STREAM_ID = tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id>
+template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0, uint8_t VC_ID = 0>
 struct WorkerToFabricEdmSenderBase;
 
-// Type alias preserving the current name for all existing callers.
-// Stream ID 22 (sender_channel_0 free slots) is the default for VC0/VC1 worker connections.
+// VC0/VC1: connection info read from L1 conn table populated by device-init.
 template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0>
 using WorkerToFabricEdmSenderImpl =
     WorkerToFabricEdmSenderBase<I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, EDM_NUM_BUFFER_SLOTS>;
 
 using WorkerToFabricEdmSender = WorkerToFabricEdmSenderImpl<false, 0>;
 
-// VC2 worker adapter: same template as VC0/VC1 but uses stream ID 30
-// (VC2 sender free-slots increment-on-write register, established in Phase 1/4)
+// VC2: infrastructure connection — addresses passed as runtime args, stream ID 30.
 template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS = 0>
 using WorkerToFabricEdmSenderVC2Impl =
-    WorkerToFabricEdmSenderBase<I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, EDM_NUM_BUFFER_SLOTS, 30>;
+    WorkerToFabricEdmSenderBase<I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, EDM_NUM_BUFFER_SLOTS, 2>;
 
 using WorkerToFabricEdmSenderVC2 = WorkerToFabricEdmSenderVC2Impl<false, 0>;
 
@@ -68,12 +63,12 @@ namespace fabric_detail{
  * As the adapter writes into the EDM, it updates the local wrptr. As the EDM reads from its local L1 channel buffer,
  * it will notify the worker/adapter (here) by updating the worker remote_rdptr to carry the value of the EDM rdptr.
  */
-template <
-    bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE,
-    uint8_t EDM_NUM_BUFFER_SLOTS,
-    uint32_t STREAM_ID>
+template <bool I_USE_STREAM_REG_FOR_CREDIT_RECEIVE, uint8_t EDM_NUM_BUFFER_SLOTS, uint8_t VC_ID>
 struct WorkerToFabricEdmSenderBase {
-    static_assert(STREAM_ID <= 31, "Stream ID must be in range 0-31");
+    static_assert(VC_ID == 0 || VC_ID == 2, "Only VC_ID 0 and 2 are supported");
+    // VC0 uses stream 22 (sender_channel_0 free slots); VC2 uses stream 30.
+    static constexpr uint32_t STREAM_ID =
+        VC_ID == 2 ? 30u : tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
     static constexpr bool ENABLE_STATEFUL_WRITE_CREDIT_TO_DOWNSTREAM_EDM =
 #if !defined(DEBUG_PRINT_ENABLED) and !defined(WATCHER_ENABLED)
         true;
@@ -110,7 +105,9 @@ struct WorkerToFabricEdmSenderBase {
 
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24959
         // remove redundant nested constructor to avoid copy
-        if constexpr (my_core_type == ProgrammableCoreType::TENSIX) {
+        if constexpr (my_core_type == ProgrammableCoreType::TENSIX && VC_ID == 0) {
+            // VC0: connection info is populated into the L1 conn table by device-init;
+            // read it by eth channel index.
             tt_l1_ptr tensix_fabric_connections_l1_info_t* connection_info =
                 reinterpret_cast<tt_l1_ptr tensix_fabric_connections_l1_info_t*>(MEM_TENSIX_FABRIC_CONNECTIONS_BASE);
             uint32_t eth_channel = get_arg_val<uint32_t>(arg_idx++);
@@ -129,6 +126,7 @@ struct WorkerToFabricEdmSenderBase {
                 reinterpret_cast<uintptr_t>(&aligned_conn->worker_flow_control_semaphore));
             worker_free_slots_stream_id = static_cast<uint32_t>(conn->worker_free_slots_stream_id);
         } else {
+            // VC2 (TENSIX or ETH): addresses are passed directly as runtime args — no L1 conn table.
             // TODO: will be deprecated. currently for ethernet dispatch case
             //       ethernet core need to have same memory mapping as worker
             direction = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++));

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_interface.hpp
@@ -20,4 +20,7 @@ static constexpr uint32_t close_connection_request_value = 2;
 // fabric router of new packets available.
 static constexpr uint32_t sender_channel_0_free_slots_stream_id = 22;
 
+// VC2 worker sender flow control stream ID (dual-use with tensix_relay; VC2 and UDM/mux are mutually exclusive)
+static constexpr uint32_t vc2_sender_free_slots_stream_id = 30;
+
 };  // namespace tt::tt_fabric::connection_interface

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -132,6 +132,8 @@ static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_
 
 constexpr size_t VC0_RECEIVER_CHANNEL = 0;
 constexpr size_t VC1_RECEIVER_CHANNEL = 1;
+// VC2 receiver is after VC0 (and VC1 if active). For single-hop, the receiver writes locally.
+constexpr size_t VC2_RECEIVER_CHANNEL = (ACTUAL_VC1_SENDER_CHANNELS > 0) ? 2 : 1;
 
 // Doesn't REALLY matter but for consistency I picked the next available ID
 constexpr size_t worker_info_offset_past_connection_semaphore = 32;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_speedy_path.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_speedy_path.hpp
@@ -22,37 +22,46 @@ struct SpeedySenderState {
     uint32_t sender_amort_counter = 0;
 };
 
+template <size_t VC_ID>
 struct SpeedyReceiverState {
     uint32_t unacked_sends = 0;
-    uint8_t current_write_trid = RX_CH_TRID_STARTS[0];
-    uint8_t pending_flush_trid = RX_CH_TRID_STARTS[0] + 1;
+    uint8_t current_write_trid = RX_CH_TRID_STARTS[VC_ID];
+    uint8_t pending_flush_trid = RX_CH_TRID_STARTS[VC_ID] + 1;
     uint32_t pending_flush_batch_count = 0;
     bool has_pending_flush = false;
 };
 
-struct NoOpSpeedyState {};
+template <size_t VC_ID>
+struct NoOpSpeedyReceiverState {};
 
-using ActualSpeedySenderState = std::conditional_t<super_speedy_mode, SpeedySenderState, NoOpSpeedyState>;
+struct NoOpSpeedySenderState {};
 
-using ActualSpeedyReceiverState = std::conditional_t<super_speedy_mode, SpeedyReceiverState, NoOpSpeedyState>;
+template <bool SuperSpeedyModeEnabled>
+using ActualSpeedySenderState = std::conditional_t<SuperSpeedyModeEnabled, SpeedySenderState, NoOpSpeedySenderState>;
 
+template <bool SuperSpeedyModeEnabled, size_t VC_ID>
+using ActualSpeedyReceiverState =
+    std::conditional_t<SuperSpeedyModeEnabled, SpeedyReceiverState<VC_ID>, NoOpSpeedyReceiverState<VC_ID>>;
+
+template <bool SuperSpeedyModeEnabled, size_t VC_ID>
 FORCE_INLINE void speedy_state_copy_in(
-    ActualSpeedySenderState& local_sender,
-    ActualSpeedyReceiverState& local_receiver,
-    const ActualSpeedySenderState& persistent_sender,
-    const ActualSpeedyReceiverState& persistent_receiver) {
-    if constexpr (super_speedy_mode) {
+    ActualSpeedySenderState<SuperSpeedyModeEnabled>& local_sender,
+    ActualSpeedyReceiverState<SuperSpeedyModeEnabled, VC_ID>& local_receiver,
+    const ActualSpeedySenderState<SuperSpeedyModeEnabled>& persistent_sender,
+    const ActualSpeedyReceiverState<SuperSpeedyModeEnabled, VC_ID>& persistent_receiver) {
+    if constexpr (SuperSpeedyModeEnabled) {
         local_sender = persistent_sender;
         local_receiver = persistent_receiver;
     }
 }
 
+template <bool SuperSpeedyModeEnabled, size_t VC_ID>
 FORCE_INLINE void speedy_state_copy_out(
-    ActualSpeedySenderState& persistent_sender,
-    ActualSpeedyReceiverState& persistent_receiver,
-    const ActualSpeedySenderState& local_sender,
-    const ActualSpeedyReceiverState& local_receiver) {
-    if constexpr (super_speedy_mode) {
+    ActualSpeedySenderState<SuperSpeedyModeEnabled>& persistent_sender,
+    ActualSpeedyReceiverState<SuperSpeedyModeEnabled, VC_ID>& persistent_receiver,
+    const ActualSpeedySenderState<SuperSpeedyModeEnabled>& local_sender,
+    const ActualSpeedyReceiverState<SuperSpeedyModeEnabled, VC_ID>& local_receiver) {
+    if constexpr (SuperSpeedyModeEnabled) {
         persistent_sender = local_sender;
         persistent_receiver = local_receiver;
     }
@@ -64,7 +73,7 @@ FORCE_INLINE void speedy_state_copy_out(
 template <
     uint8_t sender_channel_index,
     uint8_t to_receiver_pkts_sent_id,
-    bool enable_first_level_ack,
+    size_t SENDER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL,
     typename SenderChannelT,
     typename WorkerInterfaceT,
     typename ReceiverPointersT,
@@ -141,7 +150,7 @@ FORCE_INLINE bool run_sender_channel_step_speedy(
 
     // We only want to actually bother checking for completions after a certain number of sent packets are outstanding
     // since the instructions to actually process each inbound completion from receiver is somewhat costly
-    bool check_completions = sender_state.sender_amort_counter > SENDER_CREDIT_AMORTIZATION_FREQUENCY;
+    bool check_completions = sender_state.sender_amort_counter >= SENDER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL;
     if (check_completions) {
         int32_t completions = sender_channel_from_receiver_credits
                                   .template get_num_unprocessed_completions_from_receiver<ENABLE_RISC_CPU_DATA_CACHE>();
@@ -155,7 +164,7 @@ FORCE_INLINE bool run_sender_channel_step_speedy(
 
     // Similarly only send back the credit to the worker very infrequently since it's a very
     // expensive operation.
-    bool send_credits = sender_state.completion_count >= SENDER_CREDIT_AMORTIZATION_FREQUENCY;
+    bool send_credits = sender_state.completion_count >= SENDER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL;
     if (send_credits) {
         send_credits_to_upstream_workers<false /*deadlock_avoidance*/, false /*SKIP_LIVENESS*/>(
             local_sender_channel_worker_interface, sender_state.completion_count, channel_connection_established);
@@ -168,27 +177,23 @@ FORCE_INLINE bool run_sender_channel_step_speedy(
 /*
  * A fast neighbour exchange only receiver channel step impl
  */
-static constexpr uint8_t pingpong_trid_a = RX_CH_TRID_STARTS[0];
-static constexpr uint8_t pingpong_trid_b = RX_CH_TRID_STARTS[0] + 1;
 static_assert(
     !super_speedy_mode || NUM_TRANSACTION_IDS >= 2,
     "Ping-pong TRID requires at least 2 transaction IDs per receiver channel");
-static_assert(!super_speedy_mode || pingpong_trid_a == 0, "Ping-pong TRID flip uses '1 - trid', requires trid_a == 0");
 
 template <
     uint8_t receiver_channel,
+    uint8_t producer_sender_channel_index,
     uint8_t to_receiver_pkts_sent_id,
-    bool enable_first_level_ack,
-    size_t DOWNSTREAM_EDM_SIZE,
+    size_t RECEIVER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL,
     typename WriteTridTracker,
     typename ReceiverChannelBufferT,
     typename ReceiverChannelPointersT,
-    typename DownstreamSenderT,
     typename LocalRelayInterfaceT,
-    typename LocalTelemetryT>
+    typename LocalTelemetryT,
+    size_t VC_ID>
 FORCE_INLINE bool run_receiver_channel_step_speedy(
     ReceiverChannelBufferT& local_receiver_channel,
-    std::array<DownstreamSenderT, DOWNSTREAM_EDM_SIZE>& downstream_edm_interfaces,
     LocalRelayInterfaceT& local_relay_interface,
     ReceiverChannelPointersT& receiver_channel_pointers,
     WriteTridTracker& receiver_channel_trid_tracker,
@@ -196,7 +201,7 @@ FORCE_INLINE bool run_receiver_channel_step_speedy(
     ReceiverChannelResponseCreditSender& receiver_channel_response_credit_sender,
     const tt::tt_fabric::routing_l1_info_t& routing_table,
     LocalTelemetryT& local_fabric_telemetry,
-    SpeedyReceiverState& receiver_state) {
+    SpeedyReceiverState<VC_ID>& receiver_state) {
     bool progress = false;
     auto& wr_sent_counter = receiver_channel_pointers.wr_sent_counter;
     auto pkts_received = get_ptr_val<to_receiver_pkts_sent_id>();
@@ -240,7 +245,8 @@ FORCE_INLINE bool run_receiver_channel_step_speedy(
     // The pending TRID is checked eagerly (every call) to minimize credit return latency.
     // Only the batch flip requires reaching the threshold.
     // when we pass the threshold of unacked messages,
-    if ((receiver_state.unacked_sends >= RECEIVER_CREDIT_AMORTIZATION_FREQUENCY) && !receiver_state.has_pending_flush) {
+    if ((receiver_state.unacked_sends >= RECEIVER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL) &&
+        !receiver_state.has_pending_flush) {
         receiver_state.pending_flush_trid = receiver_state.current_write_trid;
         receiver_state.pending_flush_batch_count = receiver_state.unacked_sends;
         receiver_state.current_write_trid = 1 - receiver_state.current_write_trid;
@@ -254,7 +260,9 @@ FORCE_INLINE bool run_receiver_channel_step_speedy(
             auto& completion_counter = receiver_channel_pointers.completion_counter;
             completion_counter.increment_n(receiver_state.pending_flush_batch_count);
             receiver_send_completion_ack<false /*CHECK_BUSY*/>(
-                receiver_channel_response_credit_sender, 0, receiver_state.pending_flush_batch_count);
+                receiver_channel_response_credit_sender,
+                producer_sender_channel_index,
+                receiver_state.pending_flush_batch_count);
 
             receiver_state.unacked_sends -= receiver_state.pending_flush_batch_count;
             receiver_state.has_pending_flush = false;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -319,7 +319,9 @@ static_assert(sender_channel_free_slots_stream_ids[0] == 22);
 static_assert(sender_channel_free_slots_stream_ids[1] == 23);
 static_assert(sender_channel_free_slots_stream_ids[2] == 24);
 static_assert(sender_channel_free_slots_stream_ids[3] == 25);
-static_assert(sender_channel_free_slots_stream_ids[4] == 26);
+// Stream IDs 22..29 for VC0/VC1 channels, stream ID 30 for VC2 sender (last channel when VC2 active).
+// Dynamic assignment means we can only assert the first few are sequential.
+static_assert(sender_channel_free_slots_stream_ids[4] == 26 || sender_channel_free_slots_stream_ids[4] == 30);
 static_assert(sender_channel_free_slots_stream_ids[5] == 27);
 static_assert(sender_channel_free_slots_stream_ids[6] == 28);
 static_assert(sender_channel_free_slots_stream_ids[7] == 29);
@@ -2231,17 +2233,31 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     // This value defines the number of loop iterations we perform of the main control sequence before exiting
     // to check for termination and context switch. Removing the these checks from the inner loop can drastically
     // improve performance. The value of 32 was chosen somewhat empirically and then raised up slightly.
-    static ActualSpeedySenderState persistent_speedy_sender_state;
-    static ActualSpeedyReceiverState persistent_speedy_receiver_state;
+    static ActualSpeedySenderState<super_speedy_mode> persistent_speedy_sender_state;
+    static ActualSpeedyReceiverState<super_speedy_mode, 0> persistent_speedy_receiver_state;
+#if defined(FABRIC_2D_VC2_SERVICED)
+    static ActualSpeedySenderState<true> persistent_speedy_sender_state_vc2;
+    static ActualSpeedyReceiverState<true, 2> persistent_speedy_receiver_state_vc2;
+#endif
     auto execute_main_loop = [&]() {
-        ActualSpeedySenderState local_speedy_sender_state;
-        ActualSpeedyReceiverState local_speedy_receiver_state;
-        speedy_state_copy_in(
+        ActualSpeedySenderState<super_speedy_mode> local_speedy_sender_state;
+        ActualSpeedyReceiverState<super_speedy_mode, 0> local_speedy_receiver_state;
+#if defined(FABRIC_2D_VC2_SERVICED)
+        ActualSpeedySenderState<true> local_speedy_sender_state_vc2;
+        ActualSpeedyReceiverState<true, 2> local_speedy_receiver_state_vc2;
+#endif
+        speedy_state_copy_in<super_speedy_mode, 0>(
             local_speedy_sender_state,
             local_speedy_receiver_state,
             persistent_speedy_sender_state,
             persistent_speedy_receiver_state);
-        // while (!got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr) && !state_manager_l1->is_non_run_command_pending/*<ENABLE_RISC_CPU_DATA_CACHE>*/()) {
+#if defined(FABRIC_2D_VC2_SERVICED)
+        speedy_state_copy_in<true, 2>(
+            local_speedy_sender_state_vc2,
+            local_speedy_receiver_state_vc2,
+            persistent_speedy_sender_state_vc2,
+            persistent_speedy_receiver_state_vc2);
+#endif
         while (continue_running_main_run_loop<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr, state_manager_l1)) {
             did_something = false;
 
@@ -2267,6 +2283,20 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         local_sender_channel_free_slots_stream_ids[0]);
                 }
             }
+#if defined(FABRIC_2D_VC2_SERVICED)
+            if constexpr (is_sender_channel_serviced[VC2_SENDER_CHANNEL_START]) {
+                auto check_connection_status =
+                    !channel_connection_established[VC2_SENDER_CHANNEL_START] ||
+                    local_sender_channel_worker_interfaces.template get<VC2_SENDER_CHANNEL_START>()
+                        .has_worker_teardown_request();
+                if (check_connection_status) {
+                    check_worker_connections<MY_ETH_CHANNEL, ENABLE_RISC_CPU_DATA_CACHE>(
+                        local_sender_channel_worker_interfaces.template get<VC2_SENDER_CHANNEL_START>(),
+                        channel_connection_established[VC2_SENDER_CHANNEL_START],
+                        local_sender_channel_free_slots_stream_ids[VC2_SENDER_CHANNEL_START]);
+                }
+            }
+#endif
             for (size_t i = 0; i < iterations_between_ctx_switch_and_teardown_checks; i++) {
                 if constexpr (super_speedy_mode) {
                     router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
@@ -2275,7 +2305,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         tx_progress |= run_sender_channel_step_speedy<
                             0,
                             to_receiver_packets_sent_streams[VC0_RECEIVER_CHANNEL],
-                            ENABLE_FIRST_LEVEL_ACK_VC0>(
+                            SENDER_CREDIT_AMORTIZATION_FREQUENCY>(
                             local_sender_channels.template get<0>(),
                             local_sender_channel_worker_interfaces.template get<0>(),
                             outbound_to_receiver_channel_pointer_ch0,
@@ -2292,12 +2322,11 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #if defined(FABRIC_2D_VC0_CROSSOVER_TO_VC1)
                         rx_progress |= run_receiver_channel_step_speedy<
                             0,
+                            0,  // producer sender channel index
                             to_receiver_packets_sent_streams[0],
-                            ENABLE_FIRST_LEVEL_ACK_VC0,
-                            VC1_DOWNSTREAM_EDM_SIZE,
+                            RECEIVER_CREDIT_AMORTIZATION_FREQUENCY,
                             decltype(receiver_channel_0_trid_tracker)>(
                             local_receiver_channels.template get<0>(),
-                            downstream_edm_noc_interfaces_vc1,
                             local_relay_interface,
                             receiver_channel_pointers_ch0,
                             receiver_channel_0_trid_tracker,
@@ -2309,12 +2338,11 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #else
                         rx_progress |= run_receiver_channel_step_speedy<
                             0,
+                            0,  // producer sender channel index
                             to_receiver_packets_sent_streams[0],
-                            ENABLE_FIRST_LEVEL_ACK_VC0,
-                            VC0_DOWNSTREAM_EDM_SIZE,
+                            RECEIVER_CREDIT_AMORTIZATION_FREQUENCY,
                             decltype(receiver_channel_0_trid_tracker)>(
                             local_receiver_channels.template get<0>(),
-                            downstream_edm_noc_interfaces_vc0,
                             local_relay_interface,
                             receiver_channel_pointers_ch0,
                             receiver_channel_0_trid_tracker,
@@ -2496,37 +2524,49 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #endif  // FABRIC_2D_VC1_SERVICED
 
 #if defined(FABRIC_2D_VC2_SERVICED)
-                    // VC2: single sender channel (worker-injected, single-hop neighbour exchange)
-                    tx_progress |= run_sender_channel_step<
-                        VC2_RECEIVER_CHANNEL,
-                        VC2_SENDER_CHANNEL_START,
-                        false>(  // No first-level ack for VC2
-                        local_sender_channels,
-                        local_sender_channel_worker_interfaces,
-                        outbound_to_receiver_channel_pointer_ch2,
-                        remote_receiver_channels,
-                        channel_connection_established,
-                        local_sender_channel_free_slots_stream_ids,
-                        sender_channel_from_receiver_credits,
-                        inner_loop_perf_telemetry_collector,
-                        local_fabric_telemetry);
-
-                    // VC2 receiver: single-hop local write only (no forwarding)
-                    rx_progress |= run_receiver_channel_step<
-                        VC2_RECEIVER_CHANNEL,
-                        false,                    // No first-level ack for VC2
-                        VC0_DOWNSTREAM_EDM_SIZE,  // Dummy size (forwarding disabled for VC2)
-                        DownstreamSenderVC0T,
-                        decltype(local_relay_interface)>(
-                        local_receiver_channels,
-                        downstream_edm_noc_interfaces_vc0,  // Dummy (forwarding disabled)
-                        local_relay_interface,
-                        receiver_channel_pointers_ch2,
-                        receiver_channel_2_trid_tracker,
-                        port_direction_table,
-                        receiver_channel_response_credit_senders,
-                        routing_table,
-                        local_fabric_telemetry);
+                    if constexpr (is_sender_channel_serviced[VC2_SENDER_CHANNEL_START]) {
+                        constexpr size_t SENDER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL_VC2 = 1;
+                        tx_progress |= run_sender_channel_step_speedy<
+                            VC2_SENDER_CHANNEL_START,
+                            to_receiver_packets_sent_streams[VC2_RECEIVER_CHANNEL],
+                            SENDER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL_VC2>(
+                            local_sender_channels.template get<VC2_SENDER_CHANNEL_START>(),
+                            local_sender_channel_worker_interfaces.template get<VC2_SENDER_CHANNEL_START>(),
+                            outbound_to_receiver_channel_pointer_ch2,
+                            remote_receiver_channels.template get<VC2_RECEIVER_CHANNEL>(),
+                            channel_connection_established[VC2_SENDER_CHANNEL_START],
+                            local_sender_channel_free_slots_stream_ids[VC2_SENDER_CHANNEL_START],
+                            sender_channel_from_receiver_credits[VC2_SENDER_CHANNEL_START],
+                            inner_loop_perf_telemetry_collector,
+                            local_fabric_telemetry,
+                            local_speedy_sender_state_vc2);
+                    }
+                    if constexpr (is_receiver_channel_serviced[VC2_RECEIVER_CHANNEL]) {
+                        constexpr size_t RECEIVER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL_VC2 = 1;
+                        rx_progress |= run_receiver_channel_step_speedy<
+                            VC2_RECEIVER_CHANNEL,
+                            VC2_SENDER_CHANNEL_START,
+                            to_receiver_packets_sent_streams[VC2_RECEIVER_CHANNEL],
+                            RECEIVER_CREDIT_AMORTIZATION_FREQUENCY_LOCAL_VC2,
+                            decltype(receiver_channel_2_trid_tracker)>(
+                            local_receiver_channels.template get<VC2_RECEIVER_CHANNEL>(),
+                            local_relay_interface,
+                            receiver_channel_pointers_ch2,
+                            receiver_channel_2_trid_tracker,
+                            port_direction_table,
+                            receiver_channel_response_credit_senders[VC2_RECEIVER_CHANNEL],
+                            routing_table,
+                            local_fabric_telemetry,
+                            local_speedy_receiver_state_vc2);
+                    }
+                    static_assert(
+                        is_sender_channel_serviced[VC2_SENDER_CHANNEL_START] ^
+                            is_receiver_channel_serviced[VC2_RECEIVER_CHANNEL],
+                        "VC2 receiver channel not serviced");
+                    static_assert(
+                        !is_sender_channel_serviced[VC2_SENDER_CHANNEL_START] ||
+                            !sender_ch_live_check_skip[VC2_SENDER_CHANNEL_START],
+                        "VC2 receiver channel not serviced");
 #endif  // FABRIC_2D_VC2_SERVICED
                 }
             }
@@ -2579,11 +2619,18 @@ FORCE_INLINE void run_fabric_edm_main_loop(
             }
         }
 
-        speedy_state_copy_out(
+        speedy_state_copy_out<super_speedy_mode, 0>(
             persistent_speedy_sender_state,
             persistent_speedy_receiver_state,
             local_speedy_sender_state,
             local_speedy_receiver_state);
+#if defined(FABRIC_2D_VC2_SERVICED)
+        speedy_state_copy_out<true, 2>(
+            persistent_speedy_sender_state_vc2,
+            persistent_speedy_receiver_state_vc2,
+            local_speedy_sender_state_vc2,
+            local_speedy_receiver_state_vc2);
+#endif
     };
 
     uint64_t loop_start_cycles;
@@ -2662,7 +2709,17 @@ void
 // to 0.
 template <size_t i>
 constexpr size_t get_credits_init_val() {
-    return i == 0 ? 0 : SENDER_NUM_BUFFERS_ARRAY[i];
+    if (i == 0) {
+        // channel 0 is ALWAYS a worker kernel
+        return 0;
+    }
+#if defined(FABRIC_2D_VC2_SERVICED)
+    if (i == VC2_SENDER_CHANNEL_START) {
+        // VC2 only supports neighbour exchange with "transient" connections
+        return 0;
+    }
+#endif
+    return SENDER_NUM_BUFFERS_ARRAY[i];
 };
 
 // SFINAE helper to initialize a single sender channel worker interface
@@ -2968,7 +3025,9 @@ void kernel_main() {
         init_ptr_val<to_sender_packets_acked_streams[2]>(0);
         init_ptr_val<to_sender_packets_acked_streams[3]>(0);
 
-        // Initialize completion streams and sender channel free slots for channels 2-7 using compile-time loop
+        // Initialize completion streams and sender channel free slots for channels 2..MAX-1 using compile-time loop.
+        // Index sequence covers Is=0..7 → channels 2..9 (MAX_NUM_SENDER_CHANNELS=10).
+        // VC2 sender channel is at flat index NUM_SENDER_CHANNELS-1 (e.g. index 8 for 4+4+1 config).
         // SENDER_NUM_BUFFERS_ARRAY[] is sized to NUM_SENDER_CHANNELS, which is the number of used sender channels.
         [&]<size_t... Is>(std::index_sequence<Is...>) {
             (([&]() {
@@ -2978,7 +3037,7 @@ void kernel_main() {
                  }
              }()),
              ...);
-        }(std::make_index_sequence<6>{});
+        }(std::make_index_sequence<8>{});
     }
 
 #if !defined(FABRIC_2D_VC1_ACTIVE)

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2143,6 +2143,10 @@ template <
     ,
     typename TransactionIdTrackerCH1
 #endif  // FABRIC_2D_VC1_ACTIVE
+#if defined(FABRIC_2D_VC2_SERVICED)
+    ,
+    typename TransactionIdTrackerCH2
+#endif  // FABRIC_2D_VC2_SERVICED
     >
 FORCE_INLINE void run_fabric_edm_main_loop(
     EthReceiverChannels& local_receiver_channels,
@@ -2157,6 +2161,9 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #if defined(FABRIC_2D_VC1_ACTIVE)
     TransactionIdTrackerCH1& receiver_channel_1_trid_tracker,
 #endif  // FABRIC_2D_VC1_ACTIVE
+#if defined(FABRIC_2D_VC2_SERVICED)
+    TransactionIdTrackerCH2& receiver_channel_2_trid_tracker,
+#endif  // FABRIC_2D_VC2_SERVICED
     std::array<uint8_t, num_eth_ports>& port_direction_table,
     std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
     size_t did_nothing_count = 0;
@@ -2200,6 +2207,9 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 #if defined(FABRIC_2D_VC2_SERVICED)
     auto outbound_to_receiver_channel_pointer_ch2 =
         outbound_to_receiver_channel_pointers.template get<VC2_RECEIVER_CHANNEL>();
+
+    auto receiver_channel_pointers_ch2 = receiver_channel_pointers.template get<VC2_RECEIVER_CHANNEL>();
+    receiver_channel_pointers_ch2.reset();
 #endif  // FABRIC_2D_VC2_SERVICED
 
     if constexpr (skip_src_ch_id_update) {
@@ -2500,6 +2510,23 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         sender_channel_from_receiver_credits,
                         inner_loop_perf_telemetry_collector,
                         local_fabric_telemetry);
+
+                    // VC2 receiver: single-hop local write only (no forwarding)
+                    rx_progress |= run_receiver_channel_step<
+                        VC2_RECEIVER_CHANNEL,
+                        false,                    // No first-level ack for VC2
+                        VC0_DOWNSTREAM_EDM_SIZE,  // Dummy size (forwarding disabled for VC2)
+                        DownstreamSenderVC0T,
+                        decltype(local_relay_interface)>(
+                        local_receiver_channels,
+                        downstream_edm_noc_interfaces_vc0,  // Dummy (forwarding disabled)
+                        local_relay_interface,
+                        receiver_channel_pointers_ch2,
+                        receiver_channel_2_trid_tracker,
+                        port_direction_table,
+                        receiver_channel_response_credit_senders,
+                        routing_table,
+                        local_fabric_telemetry);
 #endif  // FABRIC_2D_VC2_SERVICED
                 }
             }
@@ -2756,6 +2783,15 @@ FORCE_INLINE void teardown(
         edm_to_local_chip_noc,
         edm_to_downstream_noc> receiver_channel_1_trid_tracker
 #endif
+#if defined(FABRIC_2D_VC2_SERVICED)
+    ,
+    WriteTransactionIdTracker<
+        RECEIVER_NUM_BUFFERS_ARRAY[VC2_RECEIVER_CHANNEL],
+        NUM_TRANSACTION_IDS,
+        RX_CH_TRID_STARTS[VC2_RECEIVER_CHANNEL],
+        edm_to_local_chip_noc,
+        edm_to_downstream_noc> receiver_channel_2_trid_tracker
+#endif  // FABRIC_2D_VC2_SERVICED
 ) {
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();
@@ -2768,6 +2804,11 @@ FORCE_INLINE void teardown(
         receiver_channel_1_trid_tracker.all_buffer_slot_transactions_acked();
     }
 #endif
+#if defined(FABRIC_2D_VC2_SERVICED)
+    if constexpr (is_receiver_channel_serviced[VC2_RECEIVER_CHANNEL]) {
+        receiver_channel_2_trid_tracker.all_buffer_slot_transactions_acked();
+    }
+#endif  // FABRIC_2D_VC2_SERVICED
 
     // at minimum, the below call must be updated because in dynamic noc mode, the counters would be shared, so you'd
     // want a sync before this and coordination about which erisc should do the reset (only one of them should do it)
@@ -3370,6 +3411,17 @@ void kernel_main() {
     receiver_channel_1_trid_tracker.init();
 #endif  // FABRIC_2D_VC1_ACTIVE
 
+#if defined(FABRIC_2D_VC2_SERVICED)
+    WriteTransactionIdTracker<
+        RECEIVER_NUM_BUFFERS_ARRAY[VC2_RECEIVER_CHANNEL],
+        NUM_TRANSACTION_IDS,
+        RX_CH_TRID_STARTS[VC2_RECEIVER_CHANNEL],
+        edm_to_local_chip_noc,
+        edm_to_downstream_noc>
+        receiver_channel_2_trid_tracker;
+    receiver_channel_2_trid_tracker.init();
+#endif  // FABRIC_2D_VC2_SERVICED
+
 #ifdef ARCH_BLACKHOLE
     // A Blackhole hardware bug requires all noc inline writes to be non-posted so we hardcode to false here
     // A more detailed description can be found in `noc_inline_dw_write` in the `dataflow_api` header file
@@ -3612,6 +3664,9 @@ void kernel_main() {
 #if defined(FABRIC_2D_VC1_ACTIVE)
         receiver_channel_1_trid_tracker,
 #endif  // FABRIC_2D_VC1_ACTIVE
+#if defined(FABRIC_2D_VC2_SERVICED)
+        receiver_channel_2_trid_tracker,
+#endif  // FABRIC_2D_VC2_SERVICED
         port_direction_table,
         local_sender_channel_free_slots_stream_ids);
     WAYPOINT("LPDN");
@@ -3624,6 +3679,10 @@ void kernel_main() {
         ,
         receiver_channel_1_trid_tracker
 #endif
+#if defined(FABRIC_2D_VC2_SERVICED)
+        ,
+        receiver_channel_2_trid_tracker
+#endif  // FABRIC_2D_VC2_SERVICED
     );
 
     set_l1_data_cache<false>();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2197,6 +2197,11 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     receiver_channel_pointers_ch1.reset();
 #endif  // FABRIC_2D_VC1_ACTIVE
 
+#if defined(FABRIC_2D_VC2_SERVICED)
+    auto outbound_to_receiver_channel_pointer_ch2 =
+        outbound_to_receiver_channel_pointers.template get<VC2_RECEIVER_CHANNEL>();
+#endif  // FABRIC_2D_VC2_SERVICED
+
     if constexpr (skip_src_ch_id_update) {
         receiver_channel_pointers_ch0.set_src_chan_id(BufferIndex{0}, remote_worker_sender_channel);
     }
@@ -2479,6 +2484,23 @@ FORCE_INLINE void run_fabric_edm_main_loop(
                         routing_table,
                         local_fabric_telemetry);
 #endif  // FABRIC_2D_VC1_SERVICED
+
+#if defined(FABRIC_2D_VC2_SERVICED)
+                    // VC2: single sender channel (worker-injected, single-hop neighbour exchange)
+                    tx_progress |= run_sender_channel_step<
+                        VC2_RECEIVER_CHANNEL,
+                        VC2_SENDER_CHANNEL_START,
+                        false>(  // No first-level ack for VC2
+                        local_sender_channels,
+                        local_sender_channel_worker_interfaces,
+                        outbound_to_receiver_channel_pointer_ch2,
+                        remote_receiver_channels,
+                        channel_connection_established,
+                        local_sender_channel_free_slots_stream_ids,
+                        sender_channel_from_receiver_credits,
+                        inner_loop_perf_telemetry_collector,
+                        local_fabric_telemetry);
+#endif  // FABRIC_2D_VC2_SERVICED
                 }
             }
 

--- a/tt_metal/fabric/sources.cmake
+++ b/tt_metal/fabric/sources.cmake
@@ -40,6 +40,7 @@ set(FABRIC_SOURCES
     channel_trimming_io.cpp
     channel_trimming_report.cpp
     fabric.cpp
+    fabric_vc2_connection.cpp
     fabric_init.cpp
     fabric_host_utils.cpp
     fabric_switch_manager.cpp


### PR DESCRIPTION
 Add VC2 (Virtual Channel 2) Support to Fabric
                                                                                                                                                                                                                                                                                                                                                    
#  Summary                                             
                                                                                                                                                                                                                                                                                                                                                    
  This PR adds a third virtual channel (VC2) to the Blackhole fabric router, enabling a dedicated (neighbour exchange) traffic lane for 2D (+ intermesh) workloads. The main intent is to allow additional/parallel data planes to operate over the fabric router. For example, the dispatch over fabric on T3K could instead use this VC and return an additional link back to the workload (assuming operating on mesh topologies). Future work could enable VC2 with other topologies. VC2 is gated behind the TT_METAL_ENABLE_FABRIC_VC2 environment variable and is currently supported on Blackhole 2D mesh configurations  (non-UDM, non-mux).  Connections to VC2 are considered non-static, although the intended use-case is to have the connection remain long-lived. This simplifies the initial bringup and API work. Future work may enable a persistent connection on VC2 (this would also have a tangible performance benefit due to removing some instructions for VC2 connection status polling.           
                                                                                                                                                                                                                                                                                                                                                    
#  Changes                                             
                                         
  Firmware / Router                                                                                                                                                                                                                                                                                                                                 
  - Bumped MAX_NUM_VCS to 3 and MAX_NUM_SENDER_CHANNELS / MAX_NUM_RECEIVER_CHANNELS to 10/3 to accommodate VC2's additional channels
  - Extended compile-time arg arrays for sender and receiver channels; added VC2-specific stream register IDs (sender stream 30, receiver stream 31)                                                                                                                                                                                                
  - Added a VC2 receiver channel step to the firmware main loop, conditional on DISABLE_RX_CH2                                                      
  - Replaced the firmware VC boundary heuristic with actual per-VC channel count derivation from FabricBuilderContext                                                                                                                                                                                                                               
  - Extended WorkerToFabricEdmSenderBase with a VC_ID template parameter; VC2 uses stream 30 (vc2_sender_free_slots_stream_id) vs VC0's stream 22                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                    
##  Host / Builder                                                                                                                                                                                                                                                                                                                                    
  - Added requires_vc2 predicate to IntermeshVCConfig and FabricBuilderContext, derived from is_blackhole && !is_udm_mode && !is_mux_extension                                                                                                                                                                                                      
  - Extended PerVcBufferSlots with VC2 fields and split buffer slot tables accordingly                                                                                                                                                                                                                                                              
  - Added initialize_vc2_mappings() to populate VC2 channel routing entries in FabricRouterChannelMapping
  - Added fabric_vc2_connection.cpp/hpp: private Metal-layer API (FabricVC2Connection) for opening a VC2 sender connection from a host-side worker, mirroring the existing VC0 public API                                                                                                                                                           
  - Conditional CT arg emission: VC2 args (ACTUAL_VC2, DISABLE_RX_CH2, VC2 stream IDs) are only emitted when requires_vc2() is true                                                                                                                                                                                                                 
  - Named stream ID constants (vc2_sender_free_slots_stream_id = 30, vc2_receiver_free_slots_stream_id = 31) added to erisc_datamover_builder.hpp and fabric_connection_interface.hpp                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                    
##  Test Infrastructure                                                                                                                                                                                                                                                                                                                               
  - Added vc_id field to SenderConfig, TrafficPatternConfig, TestTrafficConfig, and ConnectionKey; propagated through config parsing and dispatch                                                                                                                                                                                                   
  - Worker sender kernel (tt_fabric_test_sender.cpp) dispatches to FabricVC2Connection when vc_id == 2                                                                                                                                                                                                                                              
  - Added test_fabric_vc2_at_least_2x2_mesh.yaml: VC2 end-to-end test suite covering unicast/multicast, variable packet sizes, and multi-hop patterns on 2×2+ mesh
  - Added default_worker_vc_id = 0 and vc2_worker_vc_id = 2 named constants to eliminate magic numbers                                                                                                                                                                                                                                              
  - Fabric fixture now relaunches if use_vc2 changes between test runs                                                                                                                                                                                                                                                                              
  - Added VC2 test to the tm-fabric-tests QB CI pipeline (fabric infra unit tests group)                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                    
##  Testing                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                    
  - All existing fabric sanity / unit / stability tests continue to pass (VC2 is off by default)                                                                                                                                                                                                                                                    
  - test_fabric_vc2_at_least_2x2_mesh.yaml exercises the full VC2 send path end-to-end on BH 2D mesh hardware

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/fabric-3vc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/fabric-3vc)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/fabric-3vc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-3vc)
- [x] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/fabric-3vc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/fabric-3vc) - same failures as [on main](https://github.com/tenstorrent/tt-metal/actions/runs/23414082874)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

Future changes to commonize append fabric rt args between VC0 and VC2 codepaths and to improve test coverage
