### PR TITLE
Teacher-fored dual demo hang fix for high batch deepseek

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -511,7 +511,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Clean up sampling trace state
         try:
             if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
-                ttnn.synchronize_device(self.mesh_device)
                 self.sampling_generator.reset_trace()
         except Exception as e:
             logger.warning(f"Failed to reset sampling trace state: {e}")
@@ -1680,7 +1679,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                 if self.enable_trace and batch_idx > 0:
                     # Previous batch deallocates trace-owned sampling output tensors.
                     # Reset trace so the next batch captures fresh outputs.
-                    ttnn.synchronize_device(self.mesh_device)
                     self.sampling_generator.reset_trace()
                 self._reset_sampling_state(
                     self.sampling_params,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Teacher-fored dual demo hang was introduced for high batch deepseek

### What's changed
Removed ttnn.synchronize calls.

### Checklist

[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-dual-tf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-dual-tf-fix)
[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=ds-dual-tf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:ds-dual-tf-fix)