### PR TITLE
[skip ci] Migration step: Build LLK Docker images in the Metal CI

### DIFF
--- a/.github/scripts/llk-build-docker-images.sh
+++ b/.github/scripts/llk-build-docker-images.sh
@@ -94,8 +94,7 @@ build_and_push() {
     fi
 
     docker buildx build \
-        --push \
-        --output type=image,compression=zstd,oci-mediatypes=true \
+        --output type=image,compression=zstd,oci-mediatypes=true,push=true \
         --build-arg FROM_TAG=$DOCKER_TAG \
         $tags \
         -f $dockerfile \

--- a/.github/scripts/llk-build-docker-images.sh
+++ b/.github/scripts/llk-build-docker-images.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# MIGRATION NOTE: These images are staging for LLK-in-Metal; not consumed by CI yet.
+# tt_llk/.github/Dockerfile.ci still FROM ghcr.io/tenstorrent/tt-llk/... while this
+# script pushes to ghcr.io/$GITHUB_REPOSITORY/... — reconcile when CI starts using
+# these images or when LLK moves in-tree, then remove this note.
+
+set -euo pipefail
+
+# Base for Dockerfile.base (patches FROM ubuntu:22.04 in a temp file; tt_llk submodule stays vanilla).
+# Default matches upstream tt_llk. CI uses mirror.gcr.io for reliable Docker Hub access.
+#   LLK_UBUNTU_BASE_IMAGE=mirror.gcr.io/ubuntu:22.04
+LLK_UBUNTU_BASE_IMAGE="${LLK_UBUNTU_BASE_IMAGE:-ubuntu:22.04}"
+
+# LLK Docker images are built from the submodule content
+LLK_PATH="tt_metal/third_party/tt_llk"
+if [[ ! -d "$LLK_PATH" || ! -f "$LLK_PATH/.github/Dockerfile.base" ]]; then
+  echo "::error::tt_llk submodule is missing or not checked out (expected $LLK_PATH with .github/Dockerfile.base)." >&2
+  exit 1
+fi
+
+REPO="${GITHUB_REPOSITORY:-tenstorrent/tt-metal}"
+BASE_IMAGE_NAME=ghcr.io/$REPO/tt-llk-base-ubuntu-22-04
+CI_IMAGE_NAME=ghcr.io/$REPO/tt-llk-ci-ubuntu-22-04
+
+LLK_BASE_DOCKERFILE_PATCHED=$(mktemp)
+LLK_CI_DOCKERFILE_PATCHED=$(mktemp)
+trap 'rm -f "${LLK_BASE_DOCKERFILE_PATCHED}" "${LLK_CI_DOCKERFILE_PATCHED}"' EXIT
+
+# Patch Dockerfile.base to use the specified Ubuntu base image
+awk -v img="$LLK_UBUNTU_BASE_IMAGE" '
+  $0 == "FROM ubuntu:22.04" { print "FROM " img; next }
+  { print }
+' "$LLK_PATH/.github/Dockerfile.base" >"$LLK_BASE_DOCKERFILE_PATCHED"
+echo "LLK Dockerfile.base rootfs: ${LLK_UBUNTU_BASE_IMAGE}"
+
+# Patch Dockerfile.ci to use the Metal repo's base image location instead of tt-llk
+awk -v base_img="$BASE_IMAGE_NAME" '
+  /^FROM ghcr\.io\/tenstorrent\/tt-llk\/tt-llk-base-ubuntu-22-04:/ {
+    sub(/ghcr\.io\/tenstorrent\/tt-llk\/tt-llk-base-ubuntu-22-04/, base_img)
+  }
+  { print }
+' "$LLK_PATH/.github/Dockerfile.ci" >"$LLK_CI_DOCKERFILE_PATCHED"
+echo "LLK Dockerfile.ci base image: ${BASE_IMAGE_NAME}"
+
+# Compute the hash of the Dockerfile (uses migrated script in parent repo)
+# MIGRATION: This now uses .github/scripts/llk-get-docker-tag.sh instead of
+# the submodule's get-docker-tag.sh, so changes to this script will trigger rebuilds
+DOCKER_TAG=$(./.github/scripts/llk-get-docker-tag.sh)
+echo "Docker tag: $DOCKER_TAG"
+
+# Are we on main branch - use GITHUB_REF_NAME if available (GitHub Actions), otherwise fall back to git
+if [ -n "${GITHUB_REF_NAME-}" ]; then
+    ON_MAIN=$([ "${GITHUB_REF_NAME}" = "main" ] && echo "true" || echo "false")
+else
+    ON_MAIN=$(git branch --show-current 2>/dev/null | grep -q main && echo "true" || echo "false")
+fi
+
+export DOCKER_BUILDKIT=1
+
+build_and_push() {
+    local image_name=$1
+    local dockerfile=$2
+    local on_main=$3
+
+    if docker manifest inspect $image_name:$DOCKER_TAG > /dev/null 2>&1; then
+        echo "Image $image_name:$DOCKER_TAG already exists"
+
+        # If we're on main, update the latest tag even if the image exists
+        if [ "$on_main" = "true" ]; then
+            # Check if latest already points to this tag (compare manifest digests)
+            latest_digest=$(docker buildx imagetools inspect "$image_name:latest" 2>/dev/null | awk '/^Digest: / {print $2; exit}' || echo "")
+            current_digest=$(docker buildx imagetools inspect "$image_name:$DOCKER_TAG" 2>/dev/null | awk '/^Digest: / {print $2; exit}')
+
+            if [ "$latest_digest" != "$current_digest" ]; then
+                echo "Updating latest tag for $image_name"
+                docker buildx imagetools create -t $image_name:latest $image_name:$DOCKER_TAG
+            else
+                echo "Latest tag already points to $DOCKER_TAG"
+            fi
+        fi
+        return
+    fi
+
+    echo "Building and pushing image $image_name:$DOCKER_TAG"
+
+    if [ "$on_main" = "true" ]; then
+        tags="-t $image_name:$DOCKER_TAG -t $image_name:latest"
+    else
+        tags="-t $image_name:$DOCKER_TAG"
+    fi
+
+    docker buildx build \
+        --push \
+        --output type=image,compression=zstd,oci-mediatypes=true \
+        --build-arg FROM_TAG=$DOCKER_TAG \
+        $tags \
+        -f $dockerfile \
+        $LLK_PATH
+}
+
+# Build base image (patched Dockerfile: see LLK_UBUNTU_BASE_IMAGE above)
+build_and_push "$BASE_IMAGE_NAME" "$LLK_BASE_DOCKERFILE_PATCHED" "$ON_MAIN"
+
+# Build CI image from LLK submodule (using patched Dockerfile.ci with correct base image reference)
+build_and_push "$CI_IMAGE_NAME" "$LLK_CI_DOCKERFILE_PATCHED" "$ON_MAIN"
+
+echo "All LLK images built and pushed successfully"
+echo "CI_IMAGE_NAME:"
+echo "$CI_IMAGE_NAME:$DOCKER_TAG"
+
+# Output for GitHub Actions (if running in GHA)
+if [ -n "${GITHUB_OUTPUT-}" ]; then
+    echo "docker-image=$CI_IMAGE_NAME:$DOCKER_TAG" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/llk-get-docker-tag.sh
+++ b/.github/scripts/llk-get-docker-tag.sh
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -euo pipefail
+
 # MIGRATION: This script was moved from tt_llk/.github/scripts/get-docker-tag.sh
 # during the LLK-in-Metal migration. It now references files from both:
 #   - The tt_llk submodule (Dockerfile.*, tests/requirements.txt)
@@ -14,20 +16,24 @@
 LLK_PATH="${LLK_PATH:-tt_metal/third_party/tt_llk}"
 
 # Files within the tt_llk submodule
-DOCKERFILE_HASH_FILES="${LLK_PATH}/.github/Dockerfile.base \
-    ${LLK_PATH}/.github/Dockerfile.ci \
-    ${LLK_PATH}/.github/Dockerfile.ird \
-    ${LLK_PATH}/.github/Dockerfile.ird.slim \
-    ${LLK_PATH}/tests/requirements.txt \
-    ${LLK_PATH}/.github/scripts/install-tests-dependencies.sh"
+DOCKERFILE_HASH_FILES=(
+    "${LLK_PATH}/.github/Dockerfile.base"
+    "${LLK_PATH}/.github/Dockerfile.ci"
+    "${LLK_PATH}/.github/Dockerfile.ird"
+    "${LLK_PATH}/.github/Dockerfile.ird.slim"
+    "${LLK_PATH}/tests/requirements.txt"
+    "${LLK_PATH}/.github/scripts/install-tests-dependencies.sh"
+)
 
 # Files within the parent tt-metal repo (this is the migrated addition)
-METAL_BUILD_FILES=".github/scripts/llk-build-docker-images.sh \
-    .github/scripts/llk-get-docker-tag.sh"
+METAL_BUILD_FILES=(
+    ".github/scripts/llk-build-docker-images.sh"
+    ".github/scripts/llk-get-docker-tag.sh"
+)
 
 # Combine hashes from both submodule and parent repo files
-SUBMODULE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES 2>/dev/null | sha256sum | cut -d ' ' -f 1)
-PARENT_HASH=$(sha256sum $METAL_BUILD_FILES 2>/dev/null | sha256sum | cut -d ' ' -f 1)
+SUBMODULE_HASH=$(sha256sum "${DOCKERFILE_HASH_FILES[@]}" | sha256sum | cut -d ' ' -f 1)
+PARENT_HASH=$(sha256sum "${METAL_BUILD_FILES[@]}" | sha256sum | cut -d ' ' -f 1)
 COMBINED_HASH=$(echo "$SUBMODULE_HASH $PARENT_HASH" | sha256sum | cut -d ' ' -f 1)
 
 echo "dt-$COMBINED_HASH"

--- a/.github/scripts/llk-get-docker-tag.sh
+++ b/.github/scripts/llk-get-docker-tag.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# MIGRATION: This script was moved from tt_llk/.github/scripts/get-docker-tag.sh
+# during the LLK-in-Metal migration. It now references files from both:
+#   - The tt_llk submodule (Dockerfile.*, tests/requirements.txt)
+#   - The parent tt-metal repo (llk-build-docker-images.sh)
+#
+# Calculate hash from the following files. This hash is used to tag the docker images.
+# Any change in these files will result in a new docker image build.
+
+LLK_PATH="${LLK_PATH:-tt_metal/third_party/tt_llk}"
+
+# Files within the tt_llk submodule
+DOCKERFILE_HASH_FILES="${LLK_PATH}/.github/Dockerfile.base \
+    ${LLK_PATH}/.github/Dockerfile.ci \
+    ${LLK_PATH}/.github/Dockerfile.ird \
+    ${LLK_PATH}/.github/Dockerfile.ird.slim \
+    ${LLK_PATH}/tests/requirements.txt \
+    ${LLK_PATH}/.github/scripts/install-tests-dependencies.sh"
+
+# Files within the parent tt-metal repo (this is the migrated addition)
+METAL_BUILD_FILES=".github/scripts/llk-build-docker-images.sh \
+    .github/scripts/llk-get-docker-tag.sh"
+
+# Combine hashes from both submodule and parent repo files
+SUBMODULE_HASH=$(sha256sum $DOCKERFILE_HASH_FILES 2>/dev/null | sha256sum | cut -d ' ' -f 1)
+PARENT_HASH=$(sha256sum $METAL_BUILD_FILES 2>/dev/null | sha256sum | cut -d ' ' -f 1)
+COMBINED_HASH=$(echo "$SUBMODULE_HASH $PARENT_HASH" | sha256sum | cut -d ' ' -f 1)
+
+echo "dt-$COMBINED_HASH"

--- a/.github/workflows/build-all-docker-images.yaml
+++ b/.github/workflows/build-all-docker-images.yaml
@@ -48,6 +48,9 @@ on:
       manylinux-tag:
         description: "Docker tag for ManyLinux image"
         value: ${{ jobs.check-images.outputs.manylinux-tag }}
+      llk-ci-tag:
+        description: "Docker tag for LLK CI image (Ubuntu 22.04)"
+        value: ${{ jobs.check-images.outputs.llk-ci-tag }}
   workflow_dispatch:
 
 permissions:
@@ -75,11 +78,15 @@ jobs:
       # ManyLinux
       manylinux-tag: ${{ steps.manylinux-tags.outputs.manylinux-tag }}
       manylinux-needs-build: ${{ steps.manylinux-check.outputs.needs-build }}
+      # LLK (submodule; tag from hashed Dockerfiles inside tt_llk)
+      llk-ci-tag: ${{ steps.llk-check.outputs.llk-ci-tag }}
+      llk-needs-build: ${{ steps.llk-check.outputs.llk-needs-build }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       # Compute Ubuntu 22.04 tags
       - name: Compute Ubuntu 22.04 tags
@@ -158,6 +165,28 @@ jobs:
           else
             echo "ManyLinux image needs to be built"
             echo "needs-build=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check LLK CI image
+        id: llk-check
+        run: |
+          set -euo pipefail
+          LLK="tt_metal/third_party/tt_llk"
+          # MIGRATION: Uses migrated script in parent repo (.github/scripts/llk-get-docker-tag.sh)
+          # instead of the submodule's script, so changes to build scripts trigger rebuilds
+          if [ ! -d "$LLK" ] || [ ! -f "$LLK/.github/Dockerfile.base" ]; then
+            echo "::error::tt_llk submodule is missing or not checked out (expected $LLK with .github/Dockerfile.base). Initialize submodules in CI checkout or fix .gitmodules."
+            exit 1
+          fi
+          DOCKER_TAG=$(./.github/scripts/llk-get-docker-tag.sh)
+          TAG="ghcr.io/${{ github.repository }}/tt-llk-ci-ubuntu-22-04:${DOCKER_TAG}"
+          echo "llk-ci-tag=$TAG" >> "$GITHUB_OUTPUT"
+          if docker manifest inspect "$TAG" > /dev/null 2>&1; then
+            echo "LLK CI image exists"
+            echo "llk-needs-build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "LLK CI image needs to be built"
+            echo "llk-needs-build=true" >> "$GITHUB_OUTPUT"
           fi
 
   # Build Ubuntu 22.04 images
@@ -357,10 +386,36 @@ jobs:
           pull: true
           outputs: |
             type=registry,push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true
+
+  # MIGRATION STAGING: LLK images unused by CI today; revisit when consumers exist.
+  build-llk:
+    name: "🐳 LLK (Ubuntu 22.04)"
+    needs: check-images
+    if: needs.check-images.outputs.llk-needs-build == 'true'
+    timeout-minutes: 90
+    runs-on: tt-ubuntu-2204-large-stable
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push LLK images
+        shell: bash
+        env:
+          # Use Google Mirror for Docker Hub (Harbor doesn't proxy docker.io)
+          LLK_UBUNTU_BASE_IMAGE: mirror.gcr.io/ubuntu:22.04
+        run: .github/scripts/llk-build-docker-images.sh
+
   # Update latest tags on main
   tag-latest:
     name: "🔄 Update latest tags"
-    needs: [check-images, build-ubuntu-2204, build-ubuntu-2404, build-manylinux]
+    needs: [check-images, build-ubuntu-2204, build-ubuntu-2404, build-manylinux, build-llk]
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -388,4 +443,11 @@ jobs:
         uses: ./.github/actions/push-latest-image-to-ghcr
         with:
           docker-image-tag: ${{ needs.check-images.outputs.manylinux-tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Push latest LLK CI tag"
+        if: needs.check-images.outputs.llk-needs-build != 'true' || needs.build-llk.result == 'success'
+        uses: ./.github/actions/push-latest-image-to-ghcr
+        with:
+          docker-image-tag: ${{ needs.check-images.outputs.llk-ci-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -55,6 +55,10 @@ on:
       manylinux-tag:
         description: "Docker tag for the manylinux Docker image for building TT-Metalium et al"
         value: ${{ jobs.check-docker-images.outputs.manylinux-tag }}
+      llk-ci-tag:
+        # MIGRATION STAGING: requires tt_llk submodule; simplify when LLK moves in-tree
+        description: "Docker tag for the LLK CI Docker image (Ubuntu 22.04); requires tt_llk submodule checkout"
+        value: ${{ jobs.check-docker-images.outputs.llk-ci-tag }}
   workflow_dispatch:
     inputs:
       platform:
@@ -91,12 +95,15 @@ jobs:
       distro: ${{ steps.platform.outputs.distro }}
       version: ${{ steps.platform.outputs.version }}
       python-version: ${{ steps.python-version.outputs.version }}
+      llk-ci-exists: ${{ steps.llk-images.outputs.llk-ci-exists }}
+      llk-ci-tag: ${{ steps.llk-images.outputs.llk-ci-tag }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 1
+          submodules: recursive
 
       - name: Parse platform
         id: platform
@@ -186,6 +193,28 @@ jobs:
           else
             echo "${{ steps.tags.outputs.manylinux-tag }} does not exist"
             echo "manylinux-exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      # MIGRATION: Uses migrated script in parent repo that includes both submodule
+      # Dockerfiles and parent build scripts in the hash computation.
+      - name: Check LLK CI image
+        id: llk-images
+        run: |
+          set -euo pipefail
+          LLK="tt_metal/third_party/tt_llk"
+          if [ ! -d "$LLK" ] || [ ! -f "$LLK/.github/Dockerfile.base" ]; then
+            echo "::error::tt_llk submodule is missing or not checked out (expected $LLK with .github/Dockerfile.base). Initialize submodules in CI checkout or fix .gitmodules."
+            exit 1
+          fi
+          DOCKER_TAG=$(./.github/scripts/llk-get-docker-tag.sh)
+          TAG="ghcr.io/${{ github.repository }}/tt-llk-ci-ubuntu-22-04:${DOCKER_TAG}"
+          echo "llk-ci-tag=$TAG" >> "$GITHUB_OUTPUT"
+          if docker manifest inspect "$TAG" > /dev/null 2>&1; then
+            echo "LLK CI image exists: $TAG"
+            echo "llk-ci-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "LLK CI image missing: $TAG"
+            echo "llk-ci-exists=false" >> "$GITHUB_OUTPUT"
           fi
 
   # Build Ubuntu images
@@ -313,6 +342,31 @@ jobs:
           outputs: |
             type=registry,push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true
 
+  build-llk-images:
+    name: "🐳️ Build LLK Docker images"
+    needs: check-docker-images
+    if: needs.check-docker-images.outputs.llk-ci-exists != 'true'
+    timeout-minutes: 90
+    runs-on: tt-ubuntu-2204-large-stable
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          submodules: recursive
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push LLK images
+        shell: bash
+        env:
+          # Use Google Mirror for Docker Hub (Harbor doesn't proxy docker.io)
+          LLK_UBUNTU_BASE_IMAGE: mirror.gcr.io/ubuntu:22.04
+        run: .github/scripts/llk-build-docker-images.sh
+
   # Cannot use needs.build-*-images to ensure this job runs sequentially after the build jobs because it would break when the build jobs are skipped
   # Instead, this setup causes the tag-latest job to lag one run behind the actual build.
   # However, this isn't a huge issue because the image should already have been built on a branch before merging, and if it wasn't (like in a push scenario),
@@ -368,4 +422,11 @@ jobs:
         uses: ./.github/actions/push-latest-image-to-ghcr
         with:
           docker-image-tag: ${{ needs.check-docker-images.outputs.manylinux-tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Push latest LLK CI tag"
+        if: needs.check-docker-images.outputs.llk-ci-exists == 'true'
+        uses: ./.github/actions/push-latest-image-to-ghcr
+        with:
+          docker-image-tag: ${{ needs.check-docker-images.outputs.llk-ci-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Ticket
First step of tenstorrent/metal-internal-workflows/issues/983

### Problem description
Laying the groundwork to bring over LLK's CI.

### What's changed
Teach Metal CI to build LLK Docker images.
The hash calculation is a hybrid during the transition.  It will be cleaned up when LLK arrives in its new home.