### PR TITLE
Fix argument names for the backwards operation 

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_assign.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_assign.py
@@ -92,7 +92,7 @@ def test_bw_unary_assign_opt_output(input_shapes, device):
         opt_tensor, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
     pages_before = ttnn._ttnn.reports.get_buffer_pages(device)
-    ttnn.assign_bw(grad_tensor, input_tensor, input_grad=input_grad, queue_id=0)
+    ttnn.assign_bw(grad_tensor, input_tensor, input_a_grad=input_grad, queue_id=0)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device))
 
     tt_output_tensor_on_device = [input_grad]
@@ -119,7 +119,7 @@ def test_bw_unary_assign_opt_output_rm(input_shapes, device):
         opt_tensor, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
     pages_before = ttnn._ttnn.reports.get_buffer_pages(device)
-    ttnn.assign_bw(grad_tensor, input_tensor, input_grad=input_grad, queue_id=0)
+    ttnn.assign_bw(grad_tensor, input_tensor, input_a_grad=input_grad, queue_id=0)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device))
 
     tt_output_tensor_on_device = [input_grad]
@@ -166,8 +166,8 @@ def test_bw_binary_assign_opt_output(input_shapes, device, are_required_outputs)
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        input_grad=input_grad,
-        other_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
         queue_id=cq_id,
     )
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device))

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
@@ -789,7 +789,7 @@ void bind_binary_backward_assign(nb::module_& mod) {
             nb::arg("input_tensor"),
             nb::kw_only(),
             nb::arg("memory_config") = nb::none(),
-            nb::arg("input_grad") = nb::none()),
+            nb::arg("input_a_grad") = nb::none()),
         ttnn::overload_t(
             nb::overload_cast<
                 const Tensor&,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp
@@ -800,13 +800,13 @@ void bind_binary_backward_assign(nb::module_& mod) {
                 std::optional<Tensor>,
                 std::optional<Tensor>>(&ttnn::assign_bw),
             nb::arg("grad_tensor"),
-            nb::arg("input_tensor"),
-            nb::arg("other_tensor"),
+            nb::arg("input_tensor_a"),
+            nb::arg("input_tensor_b"),
             nb::kw_only(),
             nb::arg("are_required_outputs") = std::vector<bool>{true, true},
             nb::arg("memory_config") = nb::none(),
-            nb::arg("input_grad") = nb::none(),
-            nb::arg("other_grad") = nb::none()));
+            nb::arg("input_a_grad") = nb::none(),
+            nb::arg("input_b_grad") = nb::none()));
 }
 
 }  // namespace


### PR DESCRIPTION
### Ticket


### Problem description

errors like "incompatible function arguments" in nightly (e.g. https://github.com/tenstorrent/tt-metal/actions/runs/23293570549/job/67735830814 ) were caused by the rename of the arguments in https://github.com/tenstorrent/tt-metal/pull/39698/changes#top for the operation -- this PR reverses the argument name change to the original names

Names before the aforementioned PR merged: 

https://github.com/tenstorrent/tt-metal/blob/4d4fead3587e455f41faac13ec55094fc63bbe4d/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_nanobind.cpp#L1010-L1017

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:martemov/backward-operation-arg-name-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:martemov/backward-operation-arg-name-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:martemov/backward-operation-arg-name-fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:martemov/backward-operation-arg-name-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:martemov/backward-operation-arg-name-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=martemov/backward-operation-arg-name-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:martemov/backward-operation-arg-name-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
