### PR TITLE
Change Mixtral FF2 to use minimal matmul

### DIFF
--- a/models/tt_transformers/tt/mixtral_mlp.py
+++ b/models/tt_transformers/tt/mixtral_mlp.py
@@ -110,14 +110,22 @@ class TtMixtralMLP(LightweightModule):
             ttnn.deallocate(w3_out)
             ttnn.deallocate(w1_out)
 
-            w2_out = ttnn.linear(
-                w2_in,
-                self.w2,
-                compute_kernel_config=compute_kernel_config,
-                core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
-                dtype=ttnn.bfloat8_b,
-                program_config=pc_2,
-            )
+            if seq_len > 128:
+                w2_out = ttnn.experimental.minimal_matmul(
+                    w2_in,
+                    self.w2,
+                    compute_kernel_config=compute_kernel_config,
+                    config=pc_2,
+                )
+            else:
+                w2_out = ttnn.linear(
+                    w2_in,
+                    self.w2,
+                    compute_kernel_config=compute_kernel_config,
+                    core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+                    dtype=ttnn.bfloat8_b,
+                    program_config=pc_2,
+                )
 
             ttnn.deallocate(w2_in)
 


### PR DESCRIPTION
This commit: https://github.com/tenstorrent/tt-metal/commit/df9b7c2d9b708ee4556297c1214bcbe3465c1ce8 forgot to add the minimal matmul to mixtral.