### PR TITLE
[QSR] Add matmul_block tests

### DIFF
--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -37,6 +37,7 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <umd/device/types/arch.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -156,77 +157,133 @@ void matmul_tile(
 
     uint32_t num_input_tiles = 2 * M;
 
-    uint32_t src0_cb_index = 0;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(
-            num_input_tiles * single_tile_size_bfp16b, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, single_tile_size_bfp16b);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
+            .entry_size = single_tile_size_bfp16b,
+            .num_entries = num_input_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b};
+        tt_metal::experimental::dfb::DataflowBufferConfig dfb_src1_config = {
+            .entry_size = single_tile_size_bfp16b,
+            .num_entries = num_input_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b};
+        src0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_src0_config);
+        src1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_src1_config);
+    } else {
+        uint32_t src0_cb_index = 0;
+        tt_metal::CircularBufferConfig cb_src0_config =
+            tt_metal::CircularBufferConfig(
+                num_input_tiles * single_tile_size_bfp16b, {{src0_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src0_cb_index, single_tile_size_bfp16b);
+        tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
 
-    uint32_t src1_cb_index = 1;
-    tt_metal::CircularBufferConfig cb_src1_config =
-        tt_metal::CircularBufferConfig(
-            num_input_tiles * single_tile_size_bfp16b, {{src1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src1_cb_index, single_tile_size_bfp16b);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src1_config);
+        uint32_t src1_cb_index = 1;
+        tt_metal::CircularBufferConfig cb_src1_config =
+            tt_metal::CircularBufferConfig(
+                num_input_tiles * single_tile_size_bfp16b, {{src1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src1_cb_index, single_tile_size_bfp16b);
+        tt_metal::CreateCircularBuffer(program_, core, cb_src1_config);
+    }
 
     std::shared_ptr<distributed::MeshBuffer> src2_dram_buffer;
     std::shared_ptr<distributed::MeshBuffer> dst1_dram_buffer;
     if (cfg.with_bias) {  // with_bias only when M, N, or K > 1
-        distributed::DeviceLocalBufferConfig bias_buffer_config = {
-            .page_size = single_tile_size_bfp16b * N, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
-        distributed::ReplicatedBufferConfig bias_replicated_buffer_config = {.size = single_tile_size_bfp16b * N};
-        src2_dram_buffer =
-            distributed::MeshBuffer::create(bias_replicated_buffer_config, bias_buffer_config, mesh_device.get());
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            // NOT IMPLEMENTED FOR QUASAR YET
+        } else {
+            distributed::DeviceLocalBufferConfig bias_buffer_config = {
+                .page_size = single_tile_size_bfp16b * N,
+                .buffer_type = tt_metal::BufferType::DRAM,
+                .bottom_up = false};
+            distributed::ReplicatedBufferConfig bias_replicated_buffer_config = {.size = single_tile_size_bfp16b * N};
+            src2_dram_buffer =
+                distributed::MeshBuffer::create(bias_replicated_buffer_config, bias_buffer_config, mesh_device.get());
 
-        uint32_t src2_cb_index = 2;
-        tt_metal::CircularBufferConfig cb_src2_config =
-            tt_metal::CircularBufferConfig(
-                num_input_tiles * single_tile_size_bfp16b, {{src2_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(src2_cb_index, single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
+            uint32_t src2_cb_index = 2;
+            tt_metal::CircularBufferConfig cb_src2_config =
+                tt_metal::CircularBufferConfig(
+                    num_input_tiles * single_tile_size_bfp16b, {{src2_cb_index, tt::DataFormat::Float16_b}})
+                    .set_page_size(src2_cb_index, single_tile_size_bfp16b);
+            tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
+        }
     } else if (cfg.test_init_short) {  // This will be dummy input in uint16_t
-        uint32_t in2_id = 2;
-        uint32_t out1_id = 17;
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            // NOT IMPLEMENTED FOR QUASAR YET
+        } else {
+            uint32_t in2_id = 2;
+            uint32_t out1_id = 17;
 
-        distributed::DeviceLocalBufferConfig dummy_buffer_config = {
-            .page_size = single_tile_size_bfp16b * N, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
-        distributed::ReplicatedBufferConfig dummy_replicated_buffer_config = {.size = single_tile_size_bfp16b * N};
-        // This will be srcB in uint16_t
-        src2_dram_buffer =
-            distributed::MeshBuffer::create(dummy_replicated_buffer_config, dummy_buffer_config, mesh_device.get());
+            distributed::DeviceLocalBufferConfig dummy_buffer_config = {
+                .page_size = single_tile_size_bfp16b * N,
+                .buffer_type = tt_metal::BufferType::DRAM,
+                .bottom_up = false};
+            distributed::ReplicatedBufferConfig dummy_replicated_buffer_config = {.size = single_tile_size_bfp16b * N};
+            // This will be srcB in uint16_t
+            src2_dram_buffer =
+                distributed::MeshBuffer::create(dummy_replicated_buffer_config, dummy_buffer_config, mesh_device.get());
 
-        // This will be dummy output in uint16_t
-        dst1_dram_buffer =
-            distributed::MeshBuffer::create(dummy_replicated_buffer_config, dummy_buffer_config, mesh_device.get());
+            // This will be dummy output in uint16_t
+            dst1_dram_buffer =
+                distributed::MeshBuffer::create(dummy_replicated_buffer_config, dummy_buffer_config, mesh_device.get());
 
-        tt_metal::CircularBufferConfig cb_src2_config =
-            tt_metal::CircularBufferConfig(
-                num_input_tiles * single_tile_size_bfp16b, {{in2_id, tt::DataFormat::UInt16}})
-                .set_page_size(in2_id, single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
+            tt_metal::CircularBufferConfig cb_src2_config =
+                tt_metal::CircularBufferConfig(
+                    num_input_tiles * single_tile_size_bfp16b, {{in2_id, tt::DataFormat::UInt16}})
+                    .set_page_size(in2_id, single_tile_size_bfp16b);
+            tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
 
-        tt_metal::CircularBufferConfig cb_dst1_config =
-            tt_metal::CircularBufferConfig(
-                num_input_tiles * single_tile_size_bfp16b, {{out1_id, tt::DataFormat::UInt16}})
-                .set_page_size(out1_id, single_tile_size_bfp16b);
-        tt_metal::CreateCircularBuffer(program_, core, cb_dst1_config);
+            tt_metal::CircularBufferConfig cb_dst1_config =
+                tt_metal::CircularBufferConfig(
+                    num_input_tiles * single_tile_size_bfp16b, {{out1_id, tt::DataFormat::UInt16}})
+                    .set_page_size(out1_id, single_tile_size_bfp16b);
+            tt_metal::CreateCircularBuffer(program_, core, cb_dst1_config);
+        }
     }
 
     uint32_t ouput_cb_index = 16;
     vector<uint32_t> reader_l1_args;
     if (cfg.M > 1 || cfg.N > 1 || cfg.K > 1) {
-        uint32_t intermediate_cb_index = 24;
-        std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
-            {ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)},
-            {intermediate_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}};
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            // TODO: intermediate ?
+            tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
+                .entry_size = single_tile_size_out0,
+                .num_entries = num_tiles,
+                .producer_risc_mask = 0x100,
+                .num_producers = 1,
+                .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .consumer_risc_mask = 0x2,
+                .num_consumers = 1,
+                .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .enable_implicit_sync = false,
+                .data_format = cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
+            };
+            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_output_config);
+        } else {
+            uint32_t intermediate_cb_index = 24;
+            std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
+                {ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)},
+                {intermediate_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}};
 
-        CoreRangeSet cores(std::set<CoreRange>{CoreRange(core, core)});
-        tt_metal::CircularBufferConfig cb_output_config =
-            tt_metal::CircularBufferConfig(dram_buffer_size_out0, partials_and_out_data_format_spec)
-                .set_page_size(ouput_cb_index, single_tile_size_out0)
-                .set_page_size(intermediate_cb_index, single_tile_size_out0);
-        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+            CoreRangeSet cores(std::set<CoreRange>{CoreRange(core, core)});
+            tt_metal::CircularBufferConfig cb_output_config =
+                tt_metal::CircularBufferConfig(dram_buffer_size_out0, partials_and_out_data_format_spec)
+                    .set_page_size(ouput_cb_index, single_tile_size_out0)
+                    .set_page_size(intermediate_cb_index, single_tile_size_out0);
+            tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+        }
 
         reader_l1_args = {
             src0_dram_buffer->address(),
@@ -240,13 +297,29 @@ void matmul_tile(
             (std::uint32_t)(N * single_tile_size_bfp16b),
             cfg.with_bias};
     } else {
-        uint32_t num_output_tiles = 2;
-        tt_metal::CircularBufferConfig cb_output_config =
-            tt_metal::CircularBufferConfig(
-                num_output_tiles * single_tile_size_out0,
-                {{ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}})
-                .set_page_size(ouput_cb_index, single_tile_size_out0);
-        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+            tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
+                .entry_size = single_tile_size_out0,
+                .num_entries = num_tiles,
+                .producer_risc_mask = 0x100,
+                .num_producers = 1,
+                .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .consumer_risc_mask = 0x2,
+                .num_consumers = 1,
+                .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+                .enable_implicit_sync = false,
+                .data_format = cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
+            };
+            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_output_config);
+        } else {
+            uint32_t num_output_tiles = 2;
+            tt_metal::CircularBufferConfig cb_output_config =
+                tt_metal::CircularBufferConfig(
+                    num_output_tiles * single_tile_size_out0,
+                    {{ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}})
+                    .set_page_size(ouput_cb_index, single_tile_size_out0);
+            tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+        }
 
         reader_l1_args = {
             src0_dram_buffer->address(),
@@ -268,30 +341,66 @@ void matmul_tile(
         compute_defines["DST_ACCUM_MODE"] = "1";
     }
 
-    auto mm_reader_kernel = tt_metal::CreateKernel(
-        program_,
-        cfg.reader_kernel,
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+    KernelHandle mm_reader_kernel;
+    KernelHandle unary_writer_kernel;
+    KernelHandle compute_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        mm_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            cfg.reader_kernel,
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
 
-    auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
-        "tt_metal/kernels/dataflow/writer_unary.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+        unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tt_metal/kernels/dataflow/writer_unary.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
 
-    tt_metal::CreateKernel(
-        program_,
-        cfg.compute_kernel,
-        core,
-        tt_metal::ComputeConfig{
-            .math_fidelity = cfg.math_fidelity,
-            .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
-            .dst_full_sync_en = cfg.dst_full_sync_en,
-            .compile_args = cfg.compute_kernel_args,
-            .defines = compute_defines});
+        compute_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            cfg.compute_kernel,
+            core,
+            tt_metal::experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = 1,
+                .math_fidelity = cfg.math_fidelity,
+                .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
+                .dst_full_sync_en = cfg.dst_full_sync_en,
+                .compile_args = cfg.compute_kernel_args,
+                .defines = compute_defines});
+
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, src0_dfb, mm_reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, src1_dfb, mm_reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, dst_dfb, compute_kernel, unary_writer_kernel);
+    } else {
+        mm_reader_kernel = tt_metal::CreateKernel(
+            program_,
+            cfg.reader_kernel,
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+        unary_writer_kernel = tt_metal::CreateKernel(
+            program_,
+            "tt_metal/kernels/dataflow/writer_unary.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+        compute_kernel = tt_metal::CreateKernel(
+            program_,
+            cfg.compute_kernel,
+            core,
+            tt_metal::ComputeConfig{
+                .math_fidelity = cfg.math_fidelity,
+                .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
+                .dst_full_sync_en = cfg.dst_full_sync_en,
+                .compile_args = cfg.compute_kernel_args,
+                .defines = compute_defines});
+    }
 
     fixture->WriteBuffer(mesh_device, src0_dram_buffer, activations);
     fixture->WriteBuffer(mesh_device, src1_dram_buffer, weights);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <algorithm>
 #include <bit>
@@ -157,6 +158,9 @@ void matmul_tile(
 
     uint32_t num_input_tiles = 2 * M;
 
+    uint32_t src0_dfb = 0;
+    uint32_t src1_dfb = 0;
+    uint32_t dst_dfb = 0;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
         tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
             .entry_size = single_tile_size_bfp16b,
@@ -180,8 +184,8 @@ void matmul_tile(
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
             .data_format = tt::DataFormat::Float16_b};
-        src0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_src0_config);
-        src1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_src1_config);
+        src0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_src0_config);
+        src1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_src1_config);
     } else {
         uint32_t src0_cb_index = 0;
         tt_metal::CircularBufferConfig cb_src0_config =
@@ -270,7 +274,7 @@ void matmul_tile(
                 .enable_implicit_sync = false,
                 .data_format = cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
             };
-            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_output_config);
+            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_output_config);
         } else {
             uint32_t intermediate_cb_index = 24;
             std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
@@ -310,7 +314,7 @@ void matmul_tile(
                 .enable_implicit_sync = false,
                 .data_format = cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
             };
-            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_output_config);
+            dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_output_config);
         } else {
             uint32_t num_output_tiles = 2;
             tt_metal::CircularBufferConfig cb_output_config =
@@ -370,11 +374,11 @@ void matmul_tile(
                 .defines = compute_defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
-            program, src0_dfb, mm_reader_kernel, compute_kernel);
+            program_, src0_dfb, mm_reader_kernel, compute_kernel);
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
-            program, src1_dfb, mm_reader_kernel, compute_kernel);
+            program_, src1_dfb, mm_reader_kernel, compute_kernel);
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
-            program, dst_dfb, compute_kernel, unary_writer_kernel);
+            program_, dst_dfb, compute_kernel, unary_writer_kernel);
     } else {
         mm_reader_kernel = tt_metal::CreateKernel(
             program_,
@@ -405,7 +409,7 @@ void matmul_tile(
     fixture->WriteBuffer(mesh_device, src0_dram_buffer, activations);
     fixture->WriteBuffer(mesh_device, src1_dram_buffer, weights);
 
-    if (cfg.with_bias || cfg.test_init_short) {
+    if ((cfg.with_bias || cfg.test_init_short) && MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
         vector<uint32_t> bias(N * 512, 0);
         fixture->WriteBuffer(mesh_device, src2_dram_buffer, bias);
 
@@ -438,7 +442,9 @@ void matmul_tile(
 
     std::vector<uint32_t> golden_packed(golden_tilized_single.size());
     uint16_t math_fid_mask = 0xFFFF;
-    set_math_fid_masks(math_fid_mask, cfg.math_fidelity);
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        set_math_fid_masks(math_fid_mask, cfg.math_fidelity);
+    }
     for (auto i = 0; i < golden_tilized.size(); i++) {
         golden_tilized_single[i] = std::bit_cast<bfloat16>(
             static_cast<uint16_t>(std::bit_cast<uint16_t>(golden_tilized_single[i]) & math_fid_mask));
@@ -455,7 +461,7 @@ void matmul_tile(
 
     src0_dram_buffer->deallocate();
     src1_dram_buffer->deallocate();
-    if (cfg.with_bias || cfg.test_init_short) {
+    if ((cfg.with_bias || cfg.test_init_short) && MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
         if (cfg.test_init_short) {
             dst1_dram_buffer->deallocate();
         }
@@ -487,6 +493,9 @@ using namespace unit_tests_common::matmul::test_matmul_X_tile;
 */
 
 TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "TensixMatmulSingleTile not implemented for Quasar yet";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -515,6 +524,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulMultiTile) {
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "TensixMatmulMultiTile not implemented for Quasar yet";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -613,12 +625,16 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
                 for (const auto& device : devices_) {
                     matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
+                return;
             }
         }
     }
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShortWithDt) {
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "TensixMatmulBlockInitShortWithDt not implemented for Quasar yet";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -104,7 +104,11 @@ void set_math_fid_masks(uint16_t& math_fid_mask, MathFidelity math_fidelity = Ma
         }
         case MathFidelity::HiFi2:
         case MathFidelity::LoFi: {
-            math_fid_mask = 0xFFFE;
+            // Quasar's multiplier precision is higher,
+            // so math fidelity masking of the golden is not needed.
+            if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+                math_fid_mask = 0xFFFE;
+            }
             break;
         }
         default: {
@@ -121,6 +125,8 @@ void matmul_tile(
     vector<uint32_t> activations,
     vector<uint32_t> weights,
     vector<bfloat16> tensor_vals) {
+    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
+
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -161,7 +167,7 @@ void matmul_tile(
     uint32_t src0_dfb = 0;
     uint32_t src1_dfb = 0;
     uint32_t dst_dfb = 0;
-    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+    if (is_quasar) {
         tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
             .entry_size = single_tile_size_bfp16b,
             .num_entries = num_input_tiles,
@@ -205,8 +211,8 @@ void matmul_tile(
     std::shared_ptr<distributed::MeshBuffer> src2_dram_buffer;
     std::shared_ptr<distributed::MeshBuffer> dst1_dram_buffer;
     if (cfg.with_bias) {  // with_bias only when M, N, or K > 1
-        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-            // NOT IMPLEMENTED FOR QUASAR YET
+        if (is_quasar) {
+            // TensixMatmulMultiTile (the with_bias path) not implemented for Quasar yet
         } else {
             distributed::DeviceLocalBufferConfig bias_buffer_config = {
                 .page_size = single_tile_size_bfp16b * N,
@@ -224,8 +230,8 @@ void matmul_tile(
             tt_metal::CreateCircularBuffer(program_, core, cb_src2_config);
         }
     } else if (cfg.test_init_short) {  // This will be dummy input in uint16_t
-        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-            // NOT IMPLEMENTED FOR QUASAR YET
+        if (is_quasar) {
+            // TensixMatmulBlockInitShortWithDt (the init_short/with_dt path) not implemented for Quasar yet
         } else {
             uint32_t in2_id = 2;
             uint32_t out1_id = 17;
@@ -257,11 +263,10 @@ void matmul_tile(
         }
     }
 
-    uint32_t ouput_cb_index = 16;
+    uint32_t output_cb_index = 16;
     vector<uint32_t> reader_l1_args;
     if (cfg.M > 1 || cfg.N > 1 || cfg.K > 1) {
-        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-            // TODO: intermediate ?
+        if (is_quasar) {
             tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
                 .entry_size = single_tile_size_out0,
                 .num_entries = num_tiles,
@@ -278,13 +283,13 @@ void matmul_tile(
         } else {
             uint32_t intermediate_cb_index = 24;
             std::map<uint8_t, tt::DataFormat> partials_and_out_data_format_spec = {
-                {ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)},
+                {output_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)},
                 {intermediate_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}};
 
             CoreRangeSet cores(std::set<CoreRange>{CoreRange(core, core)});
             tt_metal::CircularBufferConfig cb_output_config =
                 tt_metal::CircularBufferConfig(dram_buffer_size_out0, partials_and_out_data_format_spec)
-                    .set_page_size(ouput_cb_index, single_tile_size_out0)
+                    .set_page_size(output_cb_index, single_tile_size_out0)
                     .set_page_size(intermediate_cb_index, single_tile_size_out0);
             tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
         }
@@ -301,7 +306,7 @@ void matmul_tile(
             (std::uint32_t)(N * single_tile_size_bfp16b),
             cfg.with_bias};
     } else {
-        if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        if (is_quasar) {
             tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
                 .entry_size = single_tile_size_out0,
                 .num_entries = num_tiles,
@@ -320,8 +325,8 @@ void matmul_tile(
             tt_metal::CircularBufferConfig cb_output_config =
                 tt_metal::CircularBufferConfig(
                     num_output_tiles * single_tile_size_out0,
-                    {{ouput_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}})
-                    .set_page_size(ouput_cb_index, single_tile_size_out0);
+                    {{output_cb_index, (cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)}})
+                    .set_page_size(output_cb_index, single_tile_size_out0);
             tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
         }
 
@@ -348,7 +353,7 @@ void matmul_tile(
     KernelHandle mm_reader_kernel;
     KernelHandle unary_writer_kernel;
     KernelHandle compute_kernel;
-    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+    if (is_quasar) {
         mm_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             cfg.reader_kernel,
@@ -409,7 +414,8 @@ void matmul_tile(
     fixture->WriteBuffer(mesh_device, src0_dram_buffer, activations);
     fixture->WriteBuffer(mesh_device, src1_dram_buffer, weights);
 
-    if ((cfg.with_bias || cfg.test_init_short) && MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+    // Skip bias/dummy buffer writes on Quasar — src2_dram_buffer is not created
+    if ((cfg.with_bias || cfg.test_init_short) && !is_quasar) {
         vector<uint32_t> bias(N * 512, 0);
         fixture->WriteBuffer(mesh_device, src2_dram_buffer, bias);
 
@@ -442,9 +448,7 @@ void matmul_tile(
 
     std::vector<uint32_t> golden_packed(golden_tilized_single.size());
     uint16_t math_fid_mask = 0xFFFF;
-    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
-        set_math_fid_masks(math_fid_mask, cfg.math_fidelity);
-    }
+    set_math_fid_masks(math_fid_mask, cfg.math_fidelity);
     for (auto i = 0; i < golden_tilized.size(); i++) {
         golden_tilized_single[i] = std::bit_cast<bfloat16>(
             static_cast<uint16_t>(std::bit_cast<uint16_t>(golden_tilized_single[i]) & math_fid_mask));
@@ -461,7 +465,8 @@ void matmul_tile(
 
     src0_dram_buffer->deallocate();
     src1_dram_buffer->deallocate();
-    if ((cfg.with_bias || cfg.test_init_short) && MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+    // Skip deallocation on Quasar — these buffers were never created (see above)
+    if ((cfg.with_bias || cfg.test_init_short) && !is_quasar) {
         if (cfg.test_init_short) {
             dst1_dram_buffer->deallocate();
         }
@@ -625,7 +630,6 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
                 for (const auto& device : devices_) {
                     matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
-                return;
             }
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
 #if (WITH_DT == 1)
     // Intentionally wrong init with different data formats
 #ifdef ARCH_QUASAR
-    // NOT IMPLEMENTED FOR QUASAR YET
+    // The TEST_INIT_SHORT WITH_DT path is not implemented for Quasar yet
 #else
     mm_block_init(
         tt::CBIndex::c_0,

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -18,12 +18,18 @@ void kernel_main() {
     uint32_t in1_block_tile_cnt = get_compile_time_arg_val(5);
     uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb0(0);
+    experimental::DataflowBuffer dfb1(1);
+    experimental::DataflowBuffer dfb_out(2);
+#endif
+
 #if (TEST_INIT_SHORT == 1)
+#if (WITH_DT == 1)
+    // Intentionally wrong init with different data formats
 #ifdef ARCH_QUASAR
     // NOT IMPLEMENTED FOR QUASAR YET
 #else
-#if (WITH_DT == 1)
-    // Intentionally wrong init with different data formats
     mm_block_init(
         tt::CBIndex::c_0,
         tt::CBIndex::c_2,
@@ -35,8 +41,20 @@ void kernel_main() {
     // Corrected init short with dt
     mm_block_init_short_with_dt(
         tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_2, false, dst_tile_cols, dst_tile_rows, block_tile_dim);
+#endif
 #elif (WITH_DT == 0)
     // Intentionally wrong init with same data formats
+#ifdef ARCH_QUASAR
+    mm_block_init(
+        dfb1.get_id(),
+        dfb0.get_id(),
+        dfb_out.get_id(),
+        false,
+        dst_tile_cols - 1,
+        dst_tile_rows - 1,
+        block_tile_dim - 1);
+    mm_block_init_short(dfb0.get_id(), dfb1.get_id(), false, dst_tile_cols, dst_tile_rows, block_tile_dim);
+#else
     mm_block_init(
         tt::CBIndex::c_1,
         tt::CBIndex::c_0,
@@ -51,10 +69,6 @@ void kernel_main() {
 #endif
 #elif (TEST_INIT_SHORT == 0)
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb0(0);
-    experimental::DataflowBuffer dfb1(1);
-    experimental::DataflowBuffer dfb_out(2);
-
     mm_block_init(dfb0.get_id(), dfb1.get_id(), dfb_out.get_id(), false, dst_tile_cols, dst_tile_rows, block_tile_dim);
 #else
     mm_block_init(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -5,6 +5,9 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/matmul.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#endif
 
 void kernel_main() {
     uint32_t block_tile_dim = get_compile_time_arg_val(0);
@@ -16,6 +19,9 @@ void kernel_main() {
     uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
 
 #if (TEST_INIT_SHORT == 1)
+#ifdef ARCH_QUASAR
+    // NOT IMPLEMENTED FOR QUASAR YET
+#else
 #if (WITH_DT == 1)
     // Intentionally wrong init with different data formats
     mm_block_init(
@@ -42,13 +48,31 @@ void kernel_main() {
     // Corrected init short
     mm_block_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1, false, dst_tile_cols, dst_tile_rows, block_tile_dim);
 #endif
+#endif
 #elif (TEST_INIT_SHORT == 0)
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb0(0);
+    experimental::DataflowBuffer dfb1(1);
+    experimental::DataflowBuffer dfb_out(2);
+
+    mm_block_init(dfb0.get_id(), dfb1.get_id(), dfb_out.get_id(), false, dst_tile_cols, dst_tile_rows, block_tile_dim);
+#else
     mm_block_init(
         tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16, false, dst_tile_cols, dst_tile_rows, block_tile_dim);
+#endif
 #endif
 
     acquire_dst();
     for (uint32_t b = 0; b < block_cnt; ++b) {
+#ifdef ARCH_QUASAR
+        dfb0.wait_front(in0_block_tile_cnt);
+        dfb1.wait_front(in1_block_tile_cnt);
+
+        matmul_block(dfb0.get_id(), dfb1.get_id(), 0, 0, 0, false, dst_tile_cols, dst_tile_rows, block_tile_dim);
+
+        dfb0.pop_front(in0_block_tile_cnt);
+        dfb1.pop_front(in1_block_tile_cnt);
+#else
         cb_wait_front(tt::CBIndex::c_0, in0_block_tile_cnt);
         cb_wait_front(tt::CBIndex::c_1, in1_block_tile_cnt);
 
@@ -56,14 +80,22 @@ void kernel_main() {
 
         cb_pop_front(tt::CBIndex::c_0, in0_block_tile_cnt);
         cb_pop_front(tt::CBIndex::c_1, in1_block_tile_cnt);
+#endif
     }
 
     // Pack out
+#ifdef ARCH_QUASAR
+    dfb_out.reserve_back(out_block_tile_cnt);
+    for (uint32_t i = 0; i < out_block_tile_cnt; ++i) {
+        pack_tile(i, dfb_out.get_id());
+    }
+    dfb_out.push_back(out_block_tile_cnt);
+#else
     cb_reserve_back(tt::CBIndex::c_16, out_block_tile_cnt);
     for (uint32_t i = 0; i < out_block_tile_cnt; ++i) {
         pack_tile(i, tt::CBIndex::c_16);
     }
     cb_push_back(tt::CBIndex::c_16, out_block_tile_cnt);
-
+#endif
     release_dst();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
@@ -90,7 +90,7 @@ void kernel_main() {
 
     if (with_bias) {
 #ifdef ARCH_QUASAR
-        // NOT IMPLEMENTED FOR QUASAR YET
+        // The with_bias path is not implemented for Quasar yet
 #else
         uint64_t src2_noc_addr = get_noc_addr_from_bank_id<true>(src2_dram_bank_id, src2_addr);
         l1_write_addr_in2 = get_write_ptr(cb_id_in2);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
@@ -6,6 +6,8 @@
 #include "api/dataflow/dataflow_api.h"
 #ifdef ARCH_QUASAR
 #include "experimental/dataflow_buffer.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc.h"
 #endif
 
 void kernel_main() {
@@ -41,35 +43,32 @@ void kernel_main() {
     experimental::DataflowBuffer dfb_in0(0);
     experimental::DataflowBuffer dfb_in1(1);
     experimental::Noc noc;
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram;
 #else
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
     constexpr uint32_t cb_id_in2 = 2;
-#endif
-
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;
     uint32_t l1_write_addr_in2;
+#endif
 
-    for(uint32_t i = 0; i < num_blocks; i++) {
-        uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_dram_bank_id, src0_addr);
-        uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_dram_bank_id, src1_addr);
-
+    for (uint32_t i = 0; i < num_blocks; i++) {
 #ifdef ARCH_QUASAR
         dfb_in0.reserve_back(in0_block_tile_cnt);
         dfb_in1.reserve_back(in1_block_tile_cnt);
 
-        l1_write_addr_in0 = dfb_in0.get_write_ptr();
-        l1_write_addr_in1 = dfb_in1.get_write_ptr();
-
-        noc_async_read(src0_noc_addr, l1_write_addr_in0, in0_block_size_bytes);
-        noc_async_read(src1_noc_addr, l1_write_addr_in1, in1_block_size_bytes);
+        noc.async_read(dram, dfb_in0, in0_block_size_bytes, {.bank_id = src0_dram_bank_id, .addr = src0_addr}, {});
+        noc.async_read(dram, dfb_in1, in1_block_size_bytes, {.bank_id = src1_dram_bank_id, .addr = src1_addr}, {});
 
         noc.async_read_barrier();
 
         dfb_in0.push_back(in0_block_tile_cnt);
         dfb_in1.push_back(in1_block_tile_cnt);
 #else
+        uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_dram_bank_id, src0_addr);
+        uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_dram_bank_id, src1_addr);
+
         cb_reserve_back(cb_id_in0, in0_block_tile_cnt);
         cb_reserve_back(cb_id_in1, in1_block_tile_cnt);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#endif
 
 void kernel_main() {
     uint32_t src0_addr            = get_arg_val<uint32_t>(0);
@@ -24,15 +27,25 @@ void kernel_main() {
     uint32_t in2_block_size_bytes;
 
     if (with_bias) {
+#ifdef ARCH_QUASAR
+        // NOT IMPLEMENTED FOR QUASAR YET
+#else
         src2_addr = get_arg_val<uint32_t>(10);
         src2_dram_bank_id = get_arg_val<uint32_t>(11);
         in2_block_tile_cnt = get_arg_val<uint32_t>(12);
         in2_block_size_bytes = get_arg_val<uint32_t>(13);
+#endif
     }
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb_in0(0);
+    experimental::DataflowBuffer dfb_in1(1);
+    experimental::Noc noc;
+#else
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
     constexpr uint32_t cb_id_in2 = 2;
+#endif
 
     uint32_t l1_write_addr_in0;
     uint32_t l1_write_addr_in1;
@@ -42,6 +55,21 @@ void kernel_main() {
         uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_dram_bank_id, src0_addr);
         uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_dram_bank_id, src1_addr);
 
+#ifdef ARCH_QUASAR
+        dfb_in0.reserve_back(in0_block_tile_cnt);
+        dfb_in1.reserve_back(in1_block_tile_cnt);
+
+        l1_write_addr_in0 = dfb_in0.get_write_ptr();
+        l1_write_addr_in1 = dfb_in1.get_write_ptr();
+
+        noc_async_read(src0_noc_addr, l1_write_addr_in0, in0_block_size_bytes);
+        noc_async_read(src1_noc_addr, l1_write_addr_in1, in1_block_size_bytes);
+
+        noc.async_read_barrier();
+
+        dfb_in0.push_back(in0_block_tile_cnt);
+        dfb_in1.push_back(in1_block_tile_cnt);
+#else
         cb_reserve_back(cb_id_in0, in0_block_tile_cnt);
         cb_reserve_back(cb_id_in1, in1_block_tile_cnt);
 
@@ -55,17 +83,21 @@ void kernel_main() {
 
         cb_push_back(cb_id_in0, in0_block_tile_cnt);
         cb_push_back(cb_id_in1, in1_block_tile_cnt);
-
+#endif
         src0_addr += in0_block_size_bytes;
         src1_addr += in1_block_size_bytes;
     }
 
     if (with_bias) {
+#ifdef ARCH_QUASAR
+        // NOT IMPLEMENTED FOR QUASAR YET
+#else
         uint64_t src2_noc_addr = get_noc_addr_from_bank_id<true>(src2_dram_bank_id, src2_addr);
         l1_write_addr_in2 = get_write_ptr(cb_id_in2);
         cb_reserve_back(cb_id_in2, in2_block_tile_cnt);
         noc_async_read(src2_noc_addr, l1_write_addr_in2, in2_block_size_bytes);
         noc_async_read_barrier();
         cb_push_back(cb_id_in2, in2_block_tile_cnt);
+#endif
     }
 }

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -185,6 +185,7 @@ ALWI void mm_init_short(
     state_configure(in1_cb_id, in0_cb_id, call_line);
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
+
 #endif  // TODO: AM; add Quasar implementation
 }
 
@@ -349,7 +350,11 @@ ALWI void mm_block_init_short(
     // Dynamic throttling is only available on Blackhole architecture
     MATH((throttled_mop_status = 0));
 #endif
-#endif  // TODO: AM; add Quasar implementation
+#else
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(
+        in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));  // transpose not yet implemented
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
+#endif
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -254,7 +254,18 @@ ALWI void mm_block_init(
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
     PACK((llk_pack_init<false, false>(out_cb_id)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
-#endif  // TODO: AM; add Quasar implementation
+#else
+    UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(
+        in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));  // transpose not yet implemented
+
+    MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
+    MATH((llk_math_pack_sync_init()));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
+
+    PACK((llk_pack_hw_configure(out_cb_id)));
+    PACK((llk_pack_init(out_cb_id)));
+#endif
 }
 
 // clang-format off
@@ -299,7 +310,10 @@ ALWI void matmul_block(
 #else
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
 #endif
-#endif  // TODO: AM; add Quasar implementation
+#else
+    UNPACK((llk_unpack_AB_matmul(in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, ct_dim, rt_dim, kt_dim)));
+    MATH((llk_math_matmul_block(ct_dim, rt_dim)));
+#endif
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -104,8 +104,9 @@ ALWI void mm_init(
     PACK((llk_pack_init(out_cb_id)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 #else
+    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
-    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));  // transpose not yet implemented
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init()));
@@ -185,7 +186,6 @@ ALWI void mm_init_short(
     state_configure(in1_cb_id, in0_cb_id, call_line);
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
-
 #endif  // TODO: AM; add Quasar implementation
 }
 
@@ -256,9 +256,9 @@ ALWI void mm_block_init(
     PACK((llk_pack_init<false, false>(out_cb_id)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 #else
+    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
     UNPACK((llk_unpack_hw_configure(in1_cb_id, in0_cb_id)));
-    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(
-        in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));  // transpose not yet implemented
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
 
     MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
     MATH((llk_math_pack_sync_init()));
@@ -351,8 +351,8 @@ ALWI void mm_block_init_short(
     MATH((throttled_mop_status = 0));
 #endif
 #else
-    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(
-        in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));  // transpose not yet implemented
+    ASSERT(transpose == 0);  // matmul transpose not yet implemented for Quasar
+    UNPACK((llk_unpack_AB_matmul_init<false /*transpose*/>(in0_cb_id, in1_cb_id, ct_dim, rt_dim, kt_dim)));
     MATH((llk_math_matmul_init<MATH_FIDELITY>(ct_dim, rt_dim)));
 #endif
 }

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -220,7 +220,9 @@ DataFormat get_single_pack_src_format(
     } else if (data_format == DataFormat::Fp8_e4m3) {
         pack_src_format = is_exp_b_format(unpack_conditional_dst_format) ? DataFormat::Float16_b : DataFormat::Float16;
     } else if (fp32_dest_acc_en) {
-        if (is_bfp_format(data_format)) {
+        if (arch == tt::ARCH::QUASAR && !tt::is_integer_format(data_format)) {
+            pack_src_format = DataFormat::Float32;
+        } else if (is_bfp_format(data_format)) {
             if (bfp8_pack_precise) {
                 pack_src_format = DataFormat::Float32;
             } else {

--- a/tt_metal/kernels/dataflow/writer_unary.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary.cpp
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 #include "experimental/endpoints.h"
 
 void kernel_main() {
@@ -11,16 +15,35 @@ void kernel_main() {
     uint32_t bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb_out(2);
+#else
     constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+    experimental::CircularBuffer cb(cb_id_out0);
+#endif
 
     // single-tile ublocks
+#ifdef ARCH_QUASAR
+    uint32_t ublock_size_bytes = dfb_out.get_entry_size();
+#else
     uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
+#endif
     uint32_t ublock_size_tiles = 1;
 
-    experimental::CircularBuffer cb(cb_id_out0);
     experimental::Noc noc;
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#ifdef ARCH_QUASAR
+        dfb_out.wait_front(ublock_size_tiles);
+        noc.async_write(
+            dfb_out,
+            experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
+            ublock_size_bytes,
+            {},
+            {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
+        dfb_out.pop_front(ublock_size_tiles);
+#else
         cb.wait_front(ublock_size_tiles);
         noc.async_write(
             cb,
@@ -30,6 +53,7 @@ void kernel_main() {
             {.bank_id = bank_id, .addr = dst_addr});
         noc.async_write_barrier();
         cb.pop_front(ublock_size_tiles);
+#endif
         dst_addr += ublock_size_bytes;
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Quasar bringup.

### What's changed
Addes block matmul tests with long and short init -> TensixMatmulBlock and TensixMatmulBlockInitShort.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/matmul_block)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/matmul_block)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/matmul_block)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/matmul_block)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/matmul_block)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/matmul_block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/matmul_block)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
