### PR TITLE
ci: deselect Falcon7B N300 decode bare-metal perf cases (Refs #40434)

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -71,11 +71,12 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      # TODO(ci): Re-enable WH B0 Falcon 7B decode batch32 bare-metal perf cases when PCC gates pass. Refs #40434
       - name: Run falcon7b model_perf test
         timeout-minutes: ${{ matrix.test-info.timeout }}
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          commands: pytest models/demos/falcon7b_common/tests -m models_performance_bare_metal
+          commands: pytest models/demos/falcon7b_common/tests -m models_performance_bare_metal --deselect "models/demos/falcon7b_common/tests/test_perf_falcon.py::TestParametrized::test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_128_bf16_l1_sharded-falcon_7b]" --deselect "models/demos/falcon7b_common/tests/test_perf_falcon.py::TestParametrized::test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_1024_bf16_l1_sharded-falcon_7b]" --deselect "models/demos/falcon7b_common/tests/test_perf_falcon.py::TestParametrized::test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_2047_bf16_l1_sharded-falcon_7b]"
         if: ${{ !cancelled() && matrix.test-info.model-group == 'llm_javelin' && (inputs.model == 'all' || inputs.model == 'falcon7b') }}
       - name: Run vanilla_unet model_perf test
         timeout-minutes: ${{ matrix.test-info.timeout }}


### PR DESCRIPTION
## Summary
Temporary CI relief for **(Single-card) Model perf tests** / **models-perf / llm_javelin N300 WH B0**: pytest now **deselects only** the three failing WH B0 decode batch32 bare-metal parametrizations that hit PCC assertion failures.

## Evidence
- Failing job: https://github.com/tenstorrent/tt-metal/actions/runs/23432509683/job/68163217671
- Tracking issue: Refs #40434 (non-closing)

## What changed
- `.github/workflows/perf-models-impl.yaml`: extend the existing `Run falcon7b model_perf test` `commands` with three `pytest --deselect` entries for:
  - `test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_128_bf16_l1_sharded-falcon_7b]`
  - `test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_1024_bf16_l1_sharded-falcon_7b]`
  - `test_perf_wh_bare_metal[wormhole_b0-1-decode_batch32_2047_bf16_l1_sharded-falcon_7b]`

Prefill cases and all other `models_performance_bare_metal` tests in that directory still run.

## Scope / rationale
Smallest blast radius that matches the logged failures: **three parametrized node IDs**, not the whole falcon7b perf step or matrix row.

## Re-enable criteria
Remove the `--deselect` flags (and the adjacent TODO comment) once PCC gates pass for those decode configs on N300 WH B0 (see #40434).

Made with [Cursor](https://cursor.com)