### PR TITLE
[skip ci] Change default system type to 'all' in BH demos

### DIFF
--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -27,7 +27,7 @@ on:
       system-type:
         description: 'Select system type to test'
         required: false
-        default: "P150 (1xP150)"
+        default: "all"
         type: choice
         options:
           - all


### PR DESCRIPTION
### Ticket
None

### What's changed
Workflow default is 1xP150, change to all

