### PR TITLE
Add per-core allocation for Sharded L1 Tensor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@ tt_metal/impl/event @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass
 tt_metal/impl/flatbuffer/ @cfjchu @kmabeeTT @nsmithtt @tenstorrent/codeowner-bypass
 tt_metal/impl/kernels/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @sagarwalTT @tenstorrent/codeowner-bypass
 tt_metal/impl/lightmetal/ @kmabeeTT @gsarabandoTT @tenstorrent/codeowner-bypass
+tt_metal/impl/per_core_allocation/ @yugaoTT @cfjchu @tenstorrent/codeowner-bypass
 tt_metal/impl/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
 tt_metal/impl/program/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @sidnadTT @tenstorrent/codeowner-bypass
 tt_metal/impl/sub_device/ @abhullar-tt @jbaumanTT @tt-asaigal @tt-aho @tenstorrent/codeowner-bypass

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for per-core L1 allocation via experimental::per_core_allocation.
+// These tests require a real device (slow dispatch).
+
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
+
+namespace tt::tt_metal {
+
+namespace per_core = experimental::per_core_allocation;
+
+class PerCoreAllocationTest : public MeshDeviceSingleCardBufferFixture {
+protected:
+    void SetUp() override {
+        // Enable HYBRID allocator mode before device creation.
+        setenv("TT_METAL_ALLOCATOR_MODE_HYBRID", "1", /*overwrite=*/1);
+
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        std::vector<ChipId> ids;
+        for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids()) {
+            ids.push_back(id);
+        }
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        id_to_device_ = distributed::MeshDevice::create_unit_meshes(
+            ids, l1_small_size_, trace_region_size_, 1, dispatch_core_config, {}, DEFAULT_WORKER_L1_SIZE);
+        devices_.clear();
+        for (const auto& [device_id, device] : id_to_device_) {
+            devices_.push_back(device);
+        }
+        this->num_devices_ = this->devices_.size();
+        init_max_cbs();
+    }
+
+    void TearDown() override {
+        MeshDeviceSingleCardBufferFixture::TearDown();
+        unsetenv("TT_METAL_ALLOCATOR_MODE_HYBRID");
+    }
+};
+
+// Use 1024-byte page size to be safely above all alignment requirements
+// (FreeListOpt internally uses DRAM alignment which may be larger than L1 alignment)
+static constexpr DeviceAddr PAGE_SIZE = 1024;
+
+TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u) << "Need at least 2 compute cores";
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = PAGE_SIZE * num_cores;
+
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
+
+    auto buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+
+    ASSERT_TRUE(per_core::is_per_core_allocation(*buf));
+
+    // Verify each core has an address within L1 range
+    auto cores = corerange_to_cores(CoreRangeSet(core_range), std::nullopt, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        auto addr = per_core::get_per_core_address(*buf, cores[i]);
+        EXPECT_GT(addr, 0u) << "Core " << i << " address should be non-zero (above L1 base)";
+        EXPECT_LT(addr, device->l1_size_per_core()) << "Core " << i << " address exceeds L1 size";
+    }
+}
+
+TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u);
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = 2 * PAGE_SIZE * num_cores;
+
+    // Create per-core buffer
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
+    auto per_core_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+
+    // Create lockstep buffer on same cores
+    auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    auto lockstep_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
+
+    // Both should be allocated successfully
+    EXPECT_TRUE(per_core_buf->is_allocated());
+    EXPECT_TRUE(lockstep_buf->is_allocated());
+
+    // Lockstep address should not overlap any per-core address
+    auto lockstep_addr = lockstep_buf->address();
+    auto cores = corerange_to_cores(CoreRangeSet(core_range), std::nullopt, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        auto pc_addr = per_core::get_per_core_address(*per_core_buf, cores[i]);
+        EXPECT_NE(lockstep_addr, pc_addr) << "Lockstep address overlaps per-core address at core " << i;
+    }
+}
+
+TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
+    auto* device = this->devices_[0]->get_devices()[0];
+    auto compute_grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores = static_cast<uint32_t>(std::min<size_t>(4, compute_grid.x));
+    ASSERT_GE(num_cores, 2u);
+
+    CoreRange core_range(CoreCoord(0, 0), CoreCoord(num_cores - 1, 0));
+    std::array<uint32_t, 2> shard_shape = {32, 32};
+    std::array<uint32_t, 2> page_shape = {32, 32};
+    std::array<uint32_t, 2> tensor2d_shape = {num_cores, 1};
+
+    ShardSpecBuffer shard_spec(
+        CoreRangeSet(core_range), shard_shape, ShardOrientation::ROW_MAJOR, page_shape, tensor2d_shape);
+
+    DeviceAddr total_size = 2 * PAGE_SIZE * num_cores;
+
+    auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
+    experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
+
+    // Create and destroy a buffer
+    {
+        auto buf1 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+        EXPECT_TRUE(per_core::is_per_core_allocation(*buf1));
+        // buf1 destroyed here, freeing per-core allocations
+    }
+
+    // Create another buffer on same cores — should succeed (space was freed)
+    auto buf2 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    EXPECT_TRUE(per_core::is_per_core_allocation(*buf2));
+    EXPECT_TRUE(buf2->is_allocated());
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for per-core allocation using BankManager's AllocatorDependencies.
+//
+// The per-core allocation model uses N+1 allocators inside one BankManager:
+//   Allocator 0       = lockstep  (same address on all banks/cores)
+//   Allocator 1..N    = per-bank  (independent address per bank/core)
+//
+// Dependency graph:
+//   Allocator 0 depends on {1, 2, ..., N}  — lockstep must avoid all per-bank regions
+//   Allocator k depends on {0}              — per-bank must avoid lockstep regions
+//   Per-bank allocators are independent of each other (separate physical L1s)
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include "tt_metal/impl/allocator/bank_manager.hpp"
+
+namespace per_core_bank_manager_tests {
+
+using namespace tt::tt_metal;
+using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+
+// Helper: build the per-core dependency graph for N banks.
+BankManager::AllocatorDependencies make_per_core_dependencies(uint32_t num_banks) {
+    std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> deps_map;
+    ttsl::SmallVector<AllocatorID> lockstep_deps;
+    for (uint32_t i = 1; i <= num_banks; i++) {
+        lockstep_deps.push_back(AllocatorID{i});
+        deps_map[AllocatorID{i}] = {AllocatorID{0}};
+    }
+    deps_map[AllocatorID{0}] = lockstep_deps;
+    return BankManager::AllocatorDependencies{deps_map};
+}
+
+// Helper: create a BankManager with per-core dependencies.
+BankManager make_per_core_bank_manager(uint64_t bank_size, uint32_t alignment, uint32_t num_banks) {
+    std::vector<int64_t> bank_offsets(num_banks, 0);
+    auto deps = make_per_core_dependencies(num_banks);
+    return BankManager(
+        BufferType::DRAM,
+        bank_offsets,
+        bank_size,
+        alignment,
+        /*dram_alignment_bytes=*/alignment,
+        /*alloc_offset=*/0,
+        /*disable_interleaved=*/false,
+        deps);
+}
+
+DeviceAddr alloc(BankManager& bm, uint32_t size, AllocatorID id, bool bottom_up = true) {
+    return bm.allocate_buffer(size, size, bottom_up, CoreRangeSet(std::vector<CoreRange>{}), std::nullopt, id);
+}
+
+void dealloc(BankManager& bm, DeviceAddr addr, AllocatorID id) { bm.deallocate_buffer(addr, id); }
+
+constexpr AllocatorID LOCKSTEP{0};
+constexpr AllocatorID BANK0{1};
+constexpr AllocatorID BANK1{2};
+
+}  // namespace per_core_bank_manager_tests
+
+using namespace per_core_bank_manager_tests;
+
+// Per-bank allocators are independent: different sizes yield different second-alloc offsets.
+TEST(PerCoreAllocation, BanksAllocateDifferentSizes) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    auto addr_b0 = alloc(bm, 1024, BANK0);
+    auto addr_b1 = alloc(bm, 8192, BANK1);
+    EXPECT_EQ(addr_b0, 0u);
+    EXPECT_EQ(addr_b1, 0u);
+
+    auto addr_b0_2 = alloc(bm, 1024, BANK0);
+    auto addr_b1_2 = alloc(bm, 1024, BANK1);
+    EXPECT_EQ(addr_b0_2, 1024u);
+    EXPECT_EQ(addr_b1_2, 8192u);
+}
+
+// Lockstep allocation must skip regions occupied by any per-bank allocator.
+TEST(PerCoreAllocation, LockstepAvoidsPerBankRegions) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    alloc(bm, 4096, BANK0);  // [0, 4096)
+    alloc(bm, 2048, BANK1);  // [0, 2048)
+
+    // Lockstep must start after the max per-bank extent
+    auto lockstep_addr = alloc(bm, 1024, LOCKSTEP);
+    EXPECT_EQ(lockstep_addr, 4096u);
+}
+
+// Per-bank allocation must skip regions occupied by the lockstep allocator.
+TEST(PerCoreAllocation, PerBankAvoidsLockstepRegion) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    alloc(bm, 4096, LOCKSTEP);  // [0, 4096) on all banks
+
+    auto addr_b0 = alloc(bm, 1024, BANK0);
+    auto addr_b1 = alloc(bm, 1024, BANK1);
+    EXPECT_EQ(addr_b0, 4096u);
+    EXPECT_EQ(addr_b1, 4096u);
+}
+
+// Deallocating per-bank regions lets lockstep reuse that space.
+TEST(PerCoreAllocation, DeallocatePerBankFreesForLockstep) {
+    auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
+
+    auto b0 = alloc(bm, 4096, BANK0);
+    auto b1 = alloc(bm, 4096, BANK1);
+    EXPECT_EQ(alloc(bm, 1024, LOCKSTEP), 4096u);
+
+    dealloc(bm, b0, BANK0);
+    dealloc(bm, b1, BANK1);
+
+    // Lockstep can now reuse [0, 4096)
+    EXPECT_EQ(alloc(bm, 1024, LOCKSTEP), 0u);
+}
+
+// Scale test: 110 banks (realistic Blackhole core count).
+TEST(PerCoreAllocation, HundredTenBanksScaling) {
+    constexpr uint32_t NUM_BANKS = 110;
+    auto deps = make_per_core_dependencies(NUM_BANKS);
+    EXPECT_EQ(deps.num_allocators(), NUM_BANKS + 1);
+
+    std::vector<int64_t> bank_offsets(NUM_BANKS, 0);
+    BankManager bm(BufferType::DRAM, bank_offsets, 1024 * 1024, 1024, 1024, 0, false, deps);
+    CoreRangeSet grid(CoreRange(CoreCoord(0, 0), CoreCoord(NUM_BANKS - 1, 0)));
+
+    // Allocate different sizes on each bank
+    for (uint32_t i = 0; i < NUM_BANKS; i++) {
+        uint32_t size = (i + 1) * 1024;
+        auto addr = bm.allocate_buffer(size, size, true, grid, 1, AllocatorID{i + 1});
+        EXPECT_EQ(addr, 0u);  // All start at 0 (independent)
+    }
+
+    // Lockstep must start after the largest per-bank allocation (110KB)
+    auto ls = bm.allocate_buffer(1024, 1024, true, grid, std::nullopt, AllocatorID{0});
+    EXPECT_EQ(ls, 110u * 1024);
+}

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -5,6 +5,8 @@ set(UNIT_TESTS_API_SOURCES
     allocator/test_free_list_opt_allocator.cpp
     allocator/test_l1_banking_allocator.cpp
     allocator/test_overlapped_bank_manager.cpp
+    allocator/test_per_core_bank_manager.cpp
+    allocator/test_per_core_allocation.cpp
     circular_buffer/test_CircularBuffer_allocation.cpp
     circular_buffer/test_CircularBuffer_creation.cpp
     circular_buffer/test_CircularBuffer_non_blocking.cpp

--- a/tests/ttnn/unit_tests/base_functionality/per_core_allocation/conftest.py
+++ b/tests/ttnn/unit_tests/base_functionality/per_core_allocation/conftest.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local conftest that enables HYBRID allocator mode for all tests in this directory.
+The env var is set before device creation and removed on teardown.
+"""
+
+import os
+import pytest
+import ttnn
+
+
+@pytest.fixture(scope="module")
+def device(request):
+    """Module-scoped device with HYBRID allocator mode enabled via env var."""
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+
+    original_default_device = ttnn.GetDefaultDevice()
+
+    device_id = request.config.getoption("device_id")
+    device = ttnn.CreateDevice(device_id=device_id)
+    ttnn.SetDefaultDevice(device)
+
+    yield device
+
+    ttnn.SetDefaultDevice(original_default_device)
+    ttnn.close_device(device)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)

--- a/tests/ttnn/unit_tests/base_functionality/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/base_functionality/per_core_allocation/test_per_core_allocation.py
@@ -1,0 +1,454 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for per-core L1 allocation via MemoryConfig.experimental_set_per_core_allocation().
+
+Each test creates single-core HEIGHT_SHARDED tensors with experimental_set_per_core_allocation(),
+which triggers the per-bank allocator (AllocatorID bank_id+1) instead of lockstep.
+
+The local conftest.py sets TT_METAL_ALLOCATOR_MODE_HYBRID=1 and creates the device.
+"""
+
+import torch
+import ttnn
+
+
+class PerCoreMemMap:
+    """Track expected per-core allocator addresses for test validation.
+
+    The L1 per-bank allocator is TOP-DOWN: allocations grow from the top of
+    the L1 address space downward. Each core has an independent free-list
+    starting from the same top address.
+
+    Derive L1_TOP from the first allocation: L1_TOP = first_addr + first_size.
+    """
+
+    def __init__(self, first_addr, first_size):
+        self.l1_top = first_addr + first_size
+        self.expected = {}
+        # Per-core: list of (addr, size) — active allocations
+        self._core_allocs = {}
+
+    def alloc(self, label, core_id, size):
+        """Record a top-down allocation and compute expected address.
+
+        Scans from top downward, finds first gap that fits.
+        """
+        if core_id not in self._core_allocs:
+            self._core_allocs[core_id] = []
+
+        allocs = self._core_allocs[core_id]
+        # Sort by address descending (top-down scan)
+        sorted_allocs = sorted(allocs, key=lambda x: x[0], reverse=True)
+
+        # Try to fit in gaps between allocations (scanning top-down)
+        candidate = self.l1_top - size
+        for a_addr, a_size in sorted_allocs:
+            a_end = a_addr + a_size
+            if candidate >= a_end:
+                # Fits above this allocation
+                break
+            # Blocked by this allocation, try below it
+            candidate = a_addr - size
+
+        allocs.append((candidate, size))
+        self.expected[label] = candidate
+        return candidate
+
+    def free(self, core_id, addr):
+        """Record a deallocation."""
+        self._core_allocs[core_id] = [(a, s) for a, s in self._core_allocs[core_id] if a != addr]
+
+    def validate(self, actual):
+        """Assert actual address map matches expected."""
+        assert actual == self.expected, f"Address map mismatch:\n" + "\n".join(
+            f"  {k}: expected={self.expected[k]:#x} actual={'MISSING' if k not in actual else f'{actual[k]:#x}'}"
+            f"{' MISMATCH' if self.expected[k] != actual.get(k) else ''}"
+            for k in self.expected
+        )
+
+
+def _create_single_core_tensor(device, core, shard_bytes):
+    """Create a single-core HEIGHT_SHARDED L1 tensor with per-core allocation."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    data = torch.zeros(1, shard_bytes, dtype=torch.uint8)
+    return ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+
+def test_per_core_tensors_get_same_address(device):
+    """Two single-core tensors on different cores can share the same L1 address,
+    proving they use independent per-bank allocators (not lockstep)."""
+    shard_bytes = 1024
+    core0 = ttnn.CoreCoord(0, 0)
+    core1 = ttnn.CoreCoord(1, 0)
+
+    t0 = _create_single_core_tensor(device, core0, shard_bytes)
+    t1 = _create_single_core_tensor(device, core1, shard_bytes)
+
+    # Per-bank allocators are independent — both cores can get the same address
+    # With lockstep, t1 would get a different address since t0 consumed it
+    addr0 = t0.buffer_address()
+    addr1 = t1.buffer_address()
+    assert addr0 == addr1, f"Expected same address on different cores (per-bank allocators), got {addr0} vs {addr1}"
+
+
+def test_per_core_round_trip(device):
+    """Data written to a per-core allocated tensor reads back correctly."""
+    shard_bytes = 2048
+    core = ttnn.CoreCoord(0, 0)
+
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    data = torch.arange(shard_bytes, dtype=torch.uint8).reshape(1, shard_bytes)
+    tensor = ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+    result = ttnn.to_torch(ttnn.from_device(tensor))
+    assert torch.equal(data, result), "Round-trip data mismatch"
+
+
+def test_per_core_sharded_dealloc_realloc(device):
+    """Deallocate a per-core sharded tensor and reallocate — verifies deallocation frees per-core space.
+
+    1. Allocate a per-core sharded tensor across all cores
+    2. Record per-core addresses
+    3. Delete it
+    4. Allocate again — should get the same addresses (space was freed and reused)
+    """
+    grid = device.compute_with_storage_grid_size()
+    num_cores = grid.x * grid.y
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+
+    SHARD_BYTES = 2048
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    shard_spec = ttnn.ShardSpec(core_grid, [1, SHARD_BYTES], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    data = torch.zeros(num_cores, SHARD_BYTES, dtype=torch.uint8)
+
+    # First allocation
+    t1 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
+    addrs1 = [t1.experimental_per_core_buffer_address(c) for c in cores]
+
+    # Deallocate
+    del t1
+
+    # Second allocation — should reuse the same per-core space
+    t2 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
+    addrs2 = [t2.experimental_per_core_buffer_address(c) for c in cores]
+
+    assert (
+        addrs1 == addrs2
+    ), f"Expected same addresses after dealloc/realloc:\n  first:  {[f'{a:#x}' for a in addrs1]}\n  second: {[f'{a:#x}' for a in addrs2]}"
+
+
+def test_per_core_tetris_allocation(device):
+    """Tetris-style allocation across 4 cores with alloc/free/realloc patterns.
+
+    Exercises independent per-bank free-lists with varied sizes, frees, and
+    reallocations. All expected addresses are computed by PerCoreMemMap and
+    validated against actual device addresses.
+    """
+    num_cores = 4
+    cores = [ttnn.CoreCoord(i, 0) for i in range(num_cores)]
+
+    # Allocation script: (label, action, core_index, size)
+    #   action: "alloc" or "free"
+    #   For "free", size is ignored — we free the tensor stored under label.
+    script = [
+        # Round 1: initial allocations across all cores
+        ("c0_a", "alloc", 0, 2048),
+        ("c1_a", "alloc", 1, 4096),
+        ("c2_a", "alloc", 2, 1024),
+        ("c3_a", "alloc", 3, 3072),
+        # Round 2: second alloc on some cores
+        ("c0_b", "alloc", 0, 1024),
+        ("c1_b", "alloc", 1, 512),
+        ("c2_b", "alloc", 2, 2048),
+        # Round 3: free some, then reallocate
+        ("c0_a", "free", 0, 0),
+        ("c1_a", "free", 1, 0),
+        ("c0_c", "alloc", 0, 2048),  # reuses c0_a's freed space
+        ("c1_c", "alloc", 1, 2048),  # fits in c1_a's freed 4096 gap
+        ("c1_d", "alloc", 1, 1024),  # also fits in remaining c1_a gap
+        # Round 4: more on core 3
+        ("c3_b", "alloc", 3, 512),
+        ("c3_a", "free", 3, 0),
+        ("c3_c", "alloc", 3, 3072),  # reuses c3_a's freed space
+    ]
+
+    tensors = {}  # label → ttnn.Tensor
+    actual = {}
+    mem = None
+
+    for label, action, core_idx, size in script:
+        if action == "alloc":
+            t = _create_single_core_tensor(device, cores[core_idx], size)
+            if mem is None:
+                mem = PerCoreMemMap(t.buffer_address(), size)
+            mem.alloc(label, core_idx, size)
+            actual[label] = t.buffer_address()
+            tensors[label] = t
+        elif action == "free":
+            freed_addr = mem.expected[label]
+            del tensors[label]
+            mem.free(core_idx, freed_addr)
+            del actual[label]
+            del mem.expected[label]
+
+    mem.validate(actual)
+
+
+def _create_lockstep_tensor(device, core, shard_bytes):
+    """Create a single-core HEIGHT_SHARDED L1 tensor with lockstep (default) allocation."""
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
+        [1, shard_bytes],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    data = torch.zeros(1, shard_bytes, dtype=torch.uint8)
+    return ttnn.from_torch(
+        data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+
+def _addr_ranges_overlap(addr_a, size_a, addr_b, size_b):
+    """Check if two address ranges [a, a+size_a) and [b, b+size_b) overlap."""
+    return addr_a < addr_b + size_b and addr_b < addr_a + size_a
+
+
+def test_per_core_and_lockstep_coexist(device):
+    """Interleave per-core and lockstep allocations across multiple cores.
+
+    Verifies:
+    - Per-core and lockstep use different allocator pools (no address reuse)
+    - No address range overlaps between any per-core and lockstep allocation
+    - Freeing per-core doesn't affect lockstep, and vice versa
+    - Both pools can allocate independently after the other has allocated
+    """
+    num_cores = 4
+    cores = [ttnn.CoreCoord(i, 0) for i in range(num_cores)]
+
+    # Track all allocations: (label, addr, size, kind)
+    allocs = []
+    tensors = {}
+
+    # Round 1: per-core allocations on each core (different sizes)
+    pc_sizes = [2048, 4096, 1024, 3072]
+    for i, size in enumerate(pc_sizes):
+        label = f"pc_c{i}_{size}"
+        t = _create_single_core_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Round 2: lockstep allocations on same cores
+    ls_sizes = [1024, 2048, 512, 1024]
+    for i, size in enumerate(ls_sizes):
+        label = f"ls_c{i}_{size}"
+        t = _create_lockstep_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "lockstep"))
+
+    # Round 3: more per-core after lockstep
+    for i, size in enumerate([512, 1024]):
+        label = f"pc2_c{i}_{size}"
+        t = _create_single_core_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Round 4: free some per-core, allocate lockstep in the freed cores
+    del tensors["pc_c0_2048"]
+    del tensors["pc_c1_4096"]
+    ls_after_free_sizes = [2048, 2048]
+    for i, size in enumerate(ls_after_free_sizes):
+        label = f"ls_after_free_c{i}_{size}"
+        t = _create_lockstep_tensor(device, cores[i], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "lockstep"))
+
+    # Round 5: free some lockstep, allocate per-core
+    del tensors["ls_c2_512"]
+    del tensors["ls_c3_1024"]
+    pc_after_free_sizes = [512, 1024]
+    for i, size in enumerate(pc_after_free_sizes):
+        label = f"pc_after_free_c{i+2}_{size}"
+        t = _create_single_core_tensor(device, cores[i + 2], size)
+        tensors[label] = t
+        allocs.append((label, t.buffer_address(), size, "per_core"))
+
+    # Validate: no per-core allocation overlaps with any lockstep allocation on the same core
+    # (Per-core allocs on different cores CAN share addresses — that's the point)
+    # Group by core for overlap checking
+    for i in range(num_cores):
+        core_pc = [(l, a, s) for l, a, s, k in allocs if k == "per_core" and l in tensors and f"_c{i}_" in l]
+        core_ls = [(l, a, s) for l, a, s, k in allocs if k == "lockstep" and l in tensors and f"_c{i}_" in l]
+        for pc_label, pc_addr, pc_size in core_pc:
+            for ls_label, ls_addr, ls_size in core_ls:
+                assert not _addr_ranges_overlap(pc_addr, pc_size, ls_addr, ls_size), (
+                    f"Overlap on core {i}: {pc_label}=[{pc_addr:#x}, +{pc_size}) vs "
+                    f"{ls_label}=[{ls_addr:#x}, +{ls_size})"
+                )
+
+    # Validate: all remaining tensors are still allocated
+    for label, t in tensors.items():
+        assert t.is_allocated(), f"{label} should still be allocated"
+
+
+def test_all_cores_lockstep_then_per_core_then_reverse(device):
+    """Allocate on ALL L1 cores: lockstep first then per-core, then deallocate and reverse order.
+
+    This stresses the dependency-aware path in the bank manager:
+    - Phase 1: lockstep on all cores → per-core on all cores (lockstep first, deps empty initially)
+    - Phase 2: deallocate all → per-core on all cores → lockstep on all cores (deps non-empty for lockstep)
+    Validates no overlaps in either phase.
+    """
+    grid = device.compute_with_storage_grid_size()
+    num_cores = grid.x * grid.y
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+
+    shard_bytes = 2048
+
+    # --- Phase 1: lockstep first, then per-core ---
+    lockstep_tensors = {}
+    per_core_tensors = {}
+
+    # Lockstep on all cores
+    for i, core in enumerate(cores):
+        lockstep_tensors[i] = _create_lockstep_tensor(device, core, shard_bytes)
+
+    # Per-core on all cores
+    for i, core in enumerate(cores):
+        per_core_tensors[i] = _create_single_core_tensor(device, core, shard_bytes)
+
+    # Validate: no overlaps between lockstep and per-core on same core
+    for i in range(num_cores):
+        ls_addr = lockstep_tensors[i].buffer_address()
+        pc_addr = per_core_tensors[i].buffer_address()
+        assert not _addr_ranges_overlap(
+            ls_addr, shard_bytes, pc_addr, shard_bytes
+        ), f"Phase 1 overlap on core {i}: lockstep={ls_addr:#x} per_core={pc_addr:#x}"
+
+    # Deallocate all
+    lockstep_tensors.clear()
+    per_core_tensors.clear()
+
+    # --- Phase 2: per-core first, then lockstep ---
+
+    # Per-core on all cores (varying sizes)
+    pc_sizes = [1024 + (i % 4) * 1024 for i in range(num_cores)]  # 1024, 2048, 3072, 4096, ...
+    for i, core in enumerate(cores):
+        per_core_tensors[i] = _create_single_core_tensor(device, core, pc_sizes[i])
+
+    # Lockstep on all cores — this triggers the dependency-aware path
+    # because per-bank allocators now have allocations
+    for i, core in enumerate(cores):
+        lockstep_tensors[i] = _create_lockstep_tensor(device, core, shard_bytes)
+
+    # Validate: no overlaps
+    for i in range(num_cores):
+        ls_addr = lockstep_tensors[i].buffer_address()
+        pc_addr = per_core_tensors[i].buffer_address()
+        assert not _addr_ranges_overlap(ls_addr, shard_bytes, pc_addr, pc_sizes[i]), (
+            f"Phase 2 overlap on core {i}: lockstep={ls_addr:#x}+{shard_bytes} " f"per_core={pc_addr:#x}+{pc_sizes[i]}"
+        )
+
+    # All tensors still alive
+    for i in range(num_cores):
+        assert lockstep_tensors[i].is_allocated()
+        assert per_core_tensors[i].is_allocated()
+
+
+def test_triangle_allocation_then_uniform_sharded(device):
+    """Triangle per-core allocation on ALL compute cores, then a per-core sharded tensor.
+
+    Phase 1: Create increasing-size per-core tensors (triangle pattern) on every
+    core in the compute grid. Core at flat index i gets (i+1) * TILE_BYTES.
+    This consumes different amounts of L1 per core.
+
+    Phase 2: Allocate one HEIGHT_SHARDED per-core tensor across all cores.
+    Since each core's per-bank allocator has consumed a different amount
+    (the triangle), the resulting per-core addresses should be strictly
+    decreasing with flat index (inverse triangle).
+    """
+    grid = device.compute_with_storage_grid_size()
+    cores = []
+    for y in range(grid.y):
+        for x in range(grid.x):
+            cores.append(ttnn.CoreCoord(x, y))
+    num_cores = len(cores)
+
+    TILE_BYTES = 1024  # above DRAM alignment to avoid min_allocation_size issues
+
+    # Phase 1: Triangle allocation — flat index i gets (i+1) * TILE_BYTES
+    triangle_tensors = {}
+    for i, core in enumerate(cores):
+        size = (i + 1) * TILE_BYTES
+        triangle_tensors[i] = _create_single_core_tensor(device, core, size)
+
+    # Phase 2: Allocate one HEIGHT_SHARDED per-core tensor across all cores
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    shard_bytes = TILE_BYTES
+    shard_spec = ttnn.ShardSpec(core_grid, [1, shard_bytes], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    sharded_data = torch.zeros(num_cores, shard_bytes, dtype=torch.uint8)
+    sharded_tensor = ttnn.from_torch(
+        sharded_data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+    )
+
+    # Verify: per-core addresses form an inverse triangle
+    # Core at flat index 0 consumed least → highest address
+    # Core at flat index N-1 consumed most → lowest address
+    addrs = [sharded_tensor.experimental_per_core_buffer_address(c) for c in cores]
+    for i in range(num_cores - 1):
+        assert addrs[i] > addrs[i + 1], (
+            f"Expected inverse triangle: core {i} ({cores[i].x},{cores[i].y}) addr={addrs[i]:#x} "
+            f"should be > core {i+1} ({cores[i+1].x},{cores[i+1].y}) addr={addrs[i+1]:#x}"
+        )
+
+    # All tensors still alive
+    for i in range(num_cores):
+        assert triangle_tensors[i].is_allocated()
+    assert sharded_tensor.is_allocated()

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -42,6 +42,19 @@ class Allocator;
 class AllocatorImpl;
 class IDevice;
 
+// Forward declarations for friended free functions in the experimental namespace.
+// These are used to access experimental config params, which are not part of the official public API.
+class Buffer;
+class BufferShardingArgs;
+namespace experimental::per_core_allocation {
+bool is_per_core_allocation(const Buffer& buffer);
+DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core);
+const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer);
+void copy_per_core_addresses(Buffer& dst, const Buffer& src);
+BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable);
+bool is_per_core_allocation(const BufferShardingArgs& args);
+}  // namespace experimental::per_core_allocation
+
 struct ShardSpec {
     /* The individual cores the shard grid is mapped to */
     CoreRangeSet grid;
@@ -153,10 +166,18 @@ public:
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 
+    // per_core_allocation is experimental functionality
+    // access is through experimental::per_core_allocation free functions
+    friend BufferShardingArgs& experimental::per_core_allocation::set_per_core_allocation(BufferShardingArgs&, bool);
+    friend bool experimental::per_core_allocation::is_per_core_allocation(const BufferShardingArgs&);
+
 private:
     std::optional<BufferDistributionSpec> buffer_distribution_spec_;
     std::optional<ShardSpecBuffer> shard_spec_;
     TensorMemoryLayout buffer_layout_ = TensorMemoryLayout::INTERLEAVED;
+    // per_core_allocation is experimental functionality
+    // access is through experimental::per_core_allocation free functions
+    bool per_core_allocation_ = false;
 };
 
 bool is_sharded(const TensorMemoryLayout& layout);
@@ -285,7 +306,15 @@ private:
     // Deallocate is allowed to be called multiple times on the same buffer
     void deallocate();
     void deallocate_impl();
+    friend class AllocatorImpl;
     friend void DeallocateBuffer(Buffer& buffer);
+    friend bool experimental::per_core_allocation::is_per_core_allocation(const Buffer&);
+    friend DeviceAddr experimental::per_core_allocation::get_per_core_address(const Buffer&, CoreCoord);
+    friend const std::unordered_map<CoreCoord, DeviceAddr>& experimental::per_core_allocation::get_per_core_addresses(
+        const Buffer&);
+    friend void experimental::per_core_allocation::copy_per_core_addresses(Buffer&, const Buffer&);
+
+    void set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs);
 
     DeviceAddr translate_page_address(DeviceAddr offset, uint32_t bank_id) const;
 
@@ -310,6 +339,10 @@ private:
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
 
     std::optional<BufferDistributionSpec> buffer_distribution_spec_;
+
+    // Per-core allocation state
+    bool per_core_allocation_ = false;
+    std::unordered_map<CoreCoord, DeviceAddr> per_core_addresses_;
 
     // The root buffer is the buffer that owns the underlying device memory.
     // The root buffer is populated only when the buffer was created with a view method.

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/README.md
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/README.md
@@ -1,0 +1,33 @@
+# Per-Core Allocation (Experimental)
+
+This directory contains the experimental per-core L1 allocation API.
+
+## Overview
+
+Standard L1 allocation uses a single "lockstep" allocator: every core that
+holds a shard of a buffer receives the same L1 address.  Per-core allocation
+relaxes this constraint by maintaining independent allocators per bank, so
+each core can receive a different address.
+
+The feature is gated behind `AllocatorMode::HYBRID`, which is enabled by
+setting the environment variable `TT_METAL_ALLOCATOR_MODE_HYBRID=1`.
+
+## Usage
+
+```cpp
+#include <tt-metalium/experimental/per_core_allocation/allocator_mode.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+
+// Enable hybrid allocator mode via env var before device creation:
+//   export TT_METAL_ALLOCATOR_MODE_HYBRID=1
+
+// Query per-core addresses from a buffer
+auto addr = experimental::per_core_allocation::get_per_core_address(buffer, core);
+```
+
+## Why experimental?
+
+Per-core allocation is not yet general-purpose.  It is currently used by
+DeepSeek compressed-tensor inference and has restrictions (L1-only, sharded
+layouts, no buffer views, no trace state serialisation).  Once the feature
+matures it may be promoted into the stable public API.

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/allocator_mode.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/allocator_mode.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::tt_metal {
+
+enum class AllocatorMode {
+    LOCKSTEP,  // Default: single allocator, all cores get the same address
+    HYBRID,    // N+1 allocators: supports both lockstep and per-core addresses
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/buffer.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <unordered_map>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+// Buffer free functions — friended by Buffer to access private per-core state.
+
+bool is_per_core_allocation(const Buffer& buffer);
+DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core);
+const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer);
+void copy_per_core_addresses(Buffer& dst, const Buffer& src);
+
+// BufferShardingArgs free functions.
+
+BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable);
+bool is_per_core_allocation(const BufferShardingArgs& args);
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+
+namespace tt::tt_metal::distributed {
+class MeshBuffer;
+}  // namespace tt::tt_metal::distributed
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+DeviceAddr get_per_core_address(const distributed::MeshBuffer& mesh_buffer, const CoreCoord& core);
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -25,6 +25,14 @@ struct from_json_t;
 
 namespace tt::tt_metal {
 
+// Forward declarations for friended free functions in the experimental namespace.
+// These are used to access experimental config params, which are not part of the official public API.
+class MemoryConfig;
+namespace experimental::per_core_allocation {
+bool is_per_core_allocation(const MemoryConfig& config);
+void set_per_core_allocation(MemoryConfig& config, bool enable);
+}  // namespace experimental::per_core_allocation
+
 class MemoryConfig final {
 public:
     MemoryConfig() = default;  // Interleaved DRAM
@@ -43,6 +51,9 @@ public:
     const std::optional<ShardSpec>& shard_spec() const { return shard_spec_; }
     const std::optional<NdShardSpec>& nd_shard_spec() const { return nd_shard_spec_; }
     bool created_with_nd_shard_spec() const { return created_with_nd_shard_spec_; }
+    // per_core_allocation access is through experimental::per_core_allocation free functions
+    friend bool experimental::per_core_allocation::is_per_core_allocation(const MemoryConfig&);
+    friend void experimental::per_core_allocation::set_per_core_allocation(MemoryConfig&, bool);
 
     MemoryConfig with_shard_spec(std::optional<ShardSpec> shard_spec) const {
         return MemoryConfig(memory_layout_, buffer_type_, std::move(shard_spec));
@@ -81,6 +92,9 @@ private:
     std::optional<ShardSpec> shard_spec_ = std::nullopt;
     std::optional<NdShardSpec> nd_shard_spec_ = std::nullopt;
     bool created_with_nd_shard_spec_ = false;
+    // per_core_allocation is experimental functionality
+    // access is through experimental::per_core_allocation free functions
+    bool per_core_allocation_ = false;
 };
 
 std::ostream& operator<<(std::ostream& os, const MemoryConfig& config);

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -10,8 +10,12 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
 #include "device.hpp"
 #include "mesh_device_impl.hpp"
+
+namespace per_core_allocation = tt::tt_metal::experimental::per_core_allocation;
 
 namespace tt::tt_metal::distributed {
 namespace {
@@ -133,6 +137,14 @@ void MeshBuffer::initialize_device_buffers() {
             device_local_config_.sharding_args,
             device_local_config_.bottom_up,
             /*sub_device_id=*/std::nullopt);  // TODO: sub_device_id is unsupported
+        // For per-core allocation, propagate per-core addresses from the backing buffer.
+        if (per_core_allocation::is_per_core_allocation(*buffer)) {
+            TT_FATAL(
+                std::holds_alternative<OwnedBufferState>(state_),
+                "Per-core allocation is not supported for externally-owned MeshBuffers");
+            auto& owned = std::get<OwnedBufferState>(state_);
+            per_core_allocation::copy_per_core_addresses(*buffer, *owned.backing_buffer);
+        }
         return buffer;
     };
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -402,7 +402,14 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
         std::shared_ptr<MeshDevice>(),
         context_id);
 
-    mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
+    mesh_device->pimpl_->initialize_impl(
+        mesh_device.get(),
+        num_command_queues,
+        l1_small_size,
+        trace_region_size,
+        worker_l1_size,
+        l1_bank_remap,
+        /*minimal=*/false);
 
     // TODO #20966: Remove these calls
     for (auto* device : extract_locals(root_devices)) {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -122,6 +122,32 @@ DeviceAddr AllocatorImpl::allocate_buffer(Buffer* buffer) {
     if (config_->disable_interleaved) {
         TT_FATAL(num_cores.has_value(), "Interleaved allocation is disabled, see validate_num_banks");
     }
+
+    // Per-core allocation path: each core gets an independent address
+    if (buffer->per_core_allocation_) {
+        TT_FATAL(
+            config_->allocator_mode == AllocatorMode::HYBRID,
+            "Per-core allocation requires AllocatorMode::HYBRID when opening the device");
+        TT_FATAL(buffer_type == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+        TT_FATAL(buffer->has_shard_spec(), "per_core_allocation requires a shard_spec with core grid");
+        const auto& grid = buffer->shard_spec().tensor_shard_spec.grid;
+        bool row_major = buffer->shard_spec().tensor_shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+        auto cores = corerange_to_cores(grid, std::nullopt, row_major);
+        TT_FATAL(!cores.empty(), "per_core_allocation: shard grid resolved to zero cores");
+        DeviceAddr alloc_size = buffer->aligned_size_per_bank();
+
+        std::unordered_map<CoreCoord, DeviceAddr> addrs;
+        for (const auto& core : cores) {
+            auto bank_id = logical_core_to_bank_ids_.at(BufferType::L1).at(core).at(0);
+            addrs[core] = l1_manager_->allocate_buffer(
+                alloc_size, page_size, bottom_up, config_->compute_grid, /*num_shards=*/1, AllocatorID{bank_id + 1});
+        }
+        buffer->set_per_core_addresses(std::move(addrs));
+        allocated_buffers_.insert(buffer);
+        return buffer->per_core_addresses_.at(cores[0]);
+    }
+
     switch (buffer_type) {
         case BufferType::DRAM:
             address = dram_manager_->allocate_buffer(size, page_size, bottom_up, config_->compute_grid, num_cores);
@@ -150,6 +176,19 @@ void AllocatorImpl::deallocate_buffer(Buffer* buffer) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto address = buffer->address();
     auto buffer_type = buffer->buffer_type();
+
+    // Per-core deallocation path
+    if (buffer->per_core_allocation_) {
+        TT_FATAL(buffer_type == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+        for (const auto& [core, addr] : buffer->per_core_addresses_) {
+            auto bank_id = logical_core_to_bank_ids_.at(BufferType::L1).at(core).at(0);
+            l1_manager_->deallocate_buffer(addr, AllocatorID{bank_id + 1});
+        }
+        allocated_buffers_.erase(buffer);
+        return;
+    }
+
     switch (buffer_type) {
         case BufferType::DRAM: dram_manager_->deallocate_buffer(address); break;
         case BufferType::L1: l1_manager_->deallocate_buffer(address); break;
@@ -418,6 +457,9 @@ AllocatorImpl::~AllocatorImpl() {
 
 AllocatorState AllocatorImpl::extract_state() const {
     std::lock_guard<std::mutex> lock(mutex_);
+    for (auto* buf : allocated_buffers_) {
+        TT_FATAL(!buf->per_core_allocation_, "extract_state does not yet support per-core L1 allocations");
+    }
 
     std::unordered_map<BufferType, AllocatorState::BufferTypeState> states_per_buffer_type;
 
@@ -448,6 +490,9 @@ AllocatorState AllocatorImpl::extract_state() const {
 
 void AllocatorImpl::override_state(const AllocatorState& state) {
     std::lock_guard<std::mutex> lock(mutex_);
+    for (auto* buf : allocated_buffers_) {
+        TT_FATAL(!buf->per_core_allocation_, "override_state does not yet support per-core L1 allocations");
+    }
 
     // Clear all buffer types
     dram_manager_->deallocate_all();

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include <tt-metalium/experimental/per_core_allocation/allocator_mode.hpp>
 #include <tt-metalium/core_coord.hpp>
 
 namespace tt::tt_metal {
@@ -45,6 +46,7 @@ struct AllocatorConfig {
     CoreRangeSet compute_grid;
     uint32_t l1_alignment = 0;
     bool disable_interleaved = false;
+    AllocatorMode allocator_mode = AllocatorMode::LOCKSTEP;
     void reset();
     ~AllocatorConfig() { reset(); }
 };

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -119,15 +119,38 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
     uint64_t allocatable_l1_size =
         static_cast<uint64_t>(config_->worker_l1_size) - config_->l1_unreserved_base - config_->l1_small_size;
     // Assuming top down allocation for L1 buffers so the allocatable memory space is the top l1_bank_size bytes of L1
-    l1_manager_ = std::make_unique<BankManager>(
-        BufferType::L1,
-        bank_id_to_bank_offset,
-        allocatable_l1_size,
-        interleaved_address_limit,
-        config_->l1_alignment,
-        config_->dram_alignment,
-        config_->l1_unreserved_base,
-        config_->disable_interleaved);
+    if (config_->allocator_mode == AllocatorMode::HYBRID) {
+        // Build per-core dependency graph (N+1 allocators: lockstep + per-bank)
+        using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
+        std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> deps_map;
+        ttsl::SmallVector<AllocatorID> lockstep_deps;
+        for (uint32_t i = 1; i <= num_l1_banks; i++) {
+            lockstep_deps.push_back(AllocatorID{i});
+            deps_map[AllocatorID{i}] = {AllocatorID{0}};
+        }
+        deps_map[AllocatorID{0}] = lockstep_deps;
+        BankManager::AllocatorDependencies l1_deps{deps_map};
+        l1_manager_ = std::make_unique<BankManager>(
+            BufferType::L1,
+            bank_id_to_bank_offset,
+            allocatable_l1_size,
+            interleaved_address_limit,
+            config_->l1_alignment,
+            config_->dram_alignment,
+            config_->l1_unreserved_base,
+            config_->disable_interleaved,
+            l1_deps);
+    } else {
+        l1_manager_ = std::make_unique<BankManager>(
+            BufferType::L1,
+            bank_id_to_bank_offset,
+            allocatable_l1_size,
+            interleaved_address_limit,
+            config_->l1_alignment,
+            config_->dram_alignment,
+            config_->l1_unreserved_base,
+            config_->disable_interleaved);
+    }
     log_debug(
         tt::LogMetal,
         "Configured partition params: worker_l1_size:0x{:X}, "

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -291,7 +291,8 @@ Buffer::Buffer(
     owns_data_(owns_data),
     page_size_(page_size),
     shard_spec_(sharding_args.shard_spec()),
-    buffer_distribution_spec_(sharding_args.buffer_distribution_spec()) {
+    buffer_distribution_spec_(sharding_args.buffer_distribution_spec()),
+    per_core_allocation_(experimental::per_core_allocation::is_per_core_allocation(sharding_args)) {
     TT_FATAL(this->device_ != nullptr, "Device needs to not be null.");
     if (this->sub_device_id_.has_value()) {
         validate_sub_device_id(this->sub_device_id_, this->device_, buffer_type, shard_spec_);
@@ -386,6 +387,8 @@ std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
     if (region.offset == 0 && region.size == size()) {
         return shared_from_this();
     }
+
+    TT_FATAL(!per_core_allocation_, "Buffer::view() with sub-regions is not supported for per-core allocated buffers");
 
     auto buffer = Buffer::create(
         device_,
@@ -564,6 +567,10 @@ DeviceAddr Buffer::aligned_size_per_bank() const {
         is_sharded(this->buffer_layout_) ? this->num_cores().value() : allocator_->get_num_banks(this->buffer_type());
     return tt::tt_metal::detail::calculate_bank_size_spread(
         this->aligned_size(), this->aligned_page_size(), num_banks, this->alignment());
+}
+
+void Buffer::set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs) {
+    per_core_addresses_ = std::move(addrs);
 }
 
 ShardSpecBuffer Buffer::shard_spec() const {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "allocator.hpp"
+#include "common/env_lib.hpp"
 #include <tt_stl/assert.hpp>
 #include "dispatch/command_queue_common.hpp"
 #include "common/core_assignment.hpp"
@@ -152,6 +153,8 @@ std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
         trace_region_size,
         worker_l1_unreserved_start,
         {l1_bank_remap.begin(), l1_bank_remap.end()});
+    config.allocator_mode =
+        tt::parse_env("TT_METAL_ALLOCATOR_MODE_HYBRID", false) ? AllocatorMode::HYBRID : AllocatorMode::LOCKSTEP;
 
     for (const tt::umd::CoreCoord& core : soc_desc.get_cores(CoreType::ETH, CoordSystem::LOGICAL)) {
         this->ethernet_cores_.insert({core.x, core.y});

--- a/tt_metal/impl/per_core_allocation/buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/buffer.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+bool is_per_core_allocation(const Buffer& buffer) { return buffer.per_core_allocation_; }
+
+DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core) {
+    TT_FATAL(
+        buffer.per_core_allocation_, "get_per_core_address() called on buffer without per-core allocation enabled");
+    auto it = buffer.per_core_addresses_.find(core);
+    TT_FATAL(it != buffer.per_core_addresses_.end(), "No per-core address for core ({}, {})", core.x, core.y);
+    return it->second;
+}
+
+const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer) {
+    return buffer.per_core_addresses_;
+}
+
+void copy_per_core_addresses(Buffer& dst, const Buffer& src) {
+    TT_FATAL(
+        dst.per_core_allocation_ && src.per_core_allocation_,
+        "copy_per_core_addresses requires both buffers to use per-core allocation");
+    dst.per_core_addresses_ = src.per_core_addresses_;
+}
+
+BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable) {
+    args.per_core_allocation_ = enable;
+    return args;
+}
+
+bool is_per_core_allocation(const BufferShardingArgs& args) { return args.per_core_allocation_; }
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/per_core_allocation/memory_config.cpp
+++ b/tt_metal/impl/per_core_allocation/memory_config.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+bool is_per_core_allocation(const MemoryConfig& config) { return config.per_core_allocation_; }
+
+void set_per_core_allocation(MemoryConfig& config, bool enable) {
+    if (enable) {
+        TT_FATAL(config.buffer_type_ == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
+        TT_FATAL(config.is_sharded(), "per_core_allocation requires a sharded memory layout");
+        TT_FATAL(!config.created_with_nd_shard_spec_, "per_core_allocation is not supported with NdShardSpec");
+    }
+    config.per_core_allocation_ = enable;
+}
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental::per_core_allocation {
+
+DeviceAddr get_per_core_address(const distributed::MeshBuffer& mesh_buffer, const CoreCoord& core) {
+    auto* buffer = mesh_buffer.get_reference_buffer();
+    TT_FATAL(is_per_core_allocation(*buffer), "Buffer does not use per-core allocation");
+    return get_per_core_address(*buffer, core);
+}
+
+}  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -18,6 +18,9 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device_util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/dispatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/memory_config.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/per_core_allocation/mesh_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_distribution_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer_page_mapping.cpp

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -8,6 +8,8 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
 namespace tt::tt_metal {
 
@@ -227,8 +229,12 @@ BufferShardingArgs TensorLayout::compute_buffer_sharding_args(const tt::tt_metal
             nd_shard_spec->orientation,
             nd_shard_spec->shard_distribution_strategy);
     }
-    return BufferShardingArgs(
-        std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());
+    auto sharding_args =
+        BufferShardingArgs(std::move(distribution_spec), std::move(shard_spec_buffer), memory_config_.memory_layout());
+    if (tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(memory_config_)) {
+        tt::tt_metal::experimental::per_core_allocation::set_per_core_allocation(sharding_args, true);
+    }
+    return sharding_args;
 }
 
 size_t TensorLayout::compute_packed_buffer_size_bytes(const tt::tt_metal::Shape& shape) const {

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
 namespace tt::tt_metal {
 
@@ -250,12 +251,16 @@ MemoryConfig TensorSpec::populate_nd_shard_spec_from_legacy() const {
         nd_shard_spec.shard_distribution_strategy = ShardDistributionStrategy::GRID_2D;
     }
 
-    return MemoryConfig::create_with_prepopulated_shard_specs(
+    auto result = MemoryConfig::create_with_prepopulated_shard_specs(
         mem_config.memory_layout(),
         mem_config.buffer_type(),
         mem_config.shard_spec(),
         std::move(nd_shard_spec),
         mem_config.created_with_nd_shard_spec());
+    if (tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(mem_config)) {
+        tt::tt_metal::experimental::per_core_allocation::set_per_core_allocation(result, true);
+    }
+    return result;
 }
 
 std::optional<MemoryConfig> TensorSpec::populate_legacy_shard_spec_from_nd() const {

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -1,5 +1,8 @@
 set(TT_METAL_PUBLIC_API
     api/tt-metalium/allocator.hpp
+    api/tt-metalium/experimental/per_core_allocation/allocator_mode.hpp
+    api/tt-metalium/experimental/per_core_allocation/buffer.hpp
+    api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
     api/tt-metalium/base_types.hpp
     api/tt-metalium/bfloat16.hpp
     api/tt-metalium/bfloat4.hpp

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -53,6 +53,7 @@
 
 #include <tt-metalium/bfloat4.hpp>
 #include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
 
 #include <tracy/Tracy.hpp>
 
@@ -1320,6 +1321,25 @@ void pytensor_module(nb::module_& mod) {
             .. code-block:: python
 
                 address = tt_tensor.buffer_address()
+
+        )doc")
+        .def(
+            "experimental_per_core_buffer_address",
+            [](const Tensor& self, const CoreCoord& core) -> uint32_t {
+                TT_FATAL(
+                    is_device_tensor(self),
+                    "{} doesn't support experimental_per_core_buffer_address",
+                    self.storage_type());
+                TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
+                return experimental::per_core_allocation::get_per_core_address(self.mesh_buffer(), core);
+            },
+            nb::arg("core"),
+            R"doc(
+            Get the per-core L1 address for a specific core (experimental per-core allocation).
+
+            .. code-block:: python
+
+                address = tt_tensor.experimental_per_core_buffer_address(ttnn.CoreCoord(0, 0))
 
         )doc")
         .def(

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -452,6 +452,13 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             })
         .def("is_sharded", &MemoryConfig::is_sharded, "Whether tensor data is sharded across multiple cores in L1")
         .def(
+            "experimental_set_per_core_allocation",
+            [](MemoryConfig& self, bool enable) {
+                experimental::per_core_allocation::set_per_core_allocation(self, enable);
+            },
+            nb::arg("enable"),
+            "Enable or disable experimental per-core L1 allocation on this MemoryConfig.")
+        .def(
             "with_shard_spec",
             &MemoryConfig::with_shard_spec,
             "Returns a new MemoryConfig with the shard spec set to the given value")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38745?issue=tenstorrent%7Ctt-metal%7C39984)

### Problem description
DeepSeek Blaze requires to use per-core allocation for l1 tensors, especially for Compressed Tensor, it is pre-requisite to have per-core allocator to save memory space. Currently only lock-step is allowed.

### What's changed
First PR to expose per-core allocation flag to Tensor level, propagate down from memory config, to mesh buffer, buffer, allocator, etc. 
```

Python user code                                                                                                                                                                                               
  │                                                                                                                                                                                                            
  │  mem_config = ttnn.MemoryConfig(..., per_core_allocation=True)                                                                                                                                               
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  nanobind (ttnn-nanobind/tensor.cpp)                                                                                                                                                                            
  │                                                                                                                                                                                                              
  │  Constructs MemoryConfig, calls set_per_core_allocation(true)
  │  Validates: L1 only, sharded, no NdShardSpec                                                                                                                                                                 
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  TensorLayout / TensorSpec                                                                                                                                                                                      
  │                                                                                                                                                                                                              
  │  Propagates per_core_allocation flag from MemoryConfig                                                                                                                                                     
  │  onto BufferShardingArgs                                                                                                                                                                                     
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  MeshBuffer::create() (mesh_buffer.cpp)                                                                                                                                                                         
  │                                                                                                                                                                                                              
  │  Creates a backing Buffer with the sharding args                                                                                                                                                             
  │  (this is what triggers actual allocation)                                                                                                                                                                   
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                              
  Buffer::create() → Buffer constructor (buffer.cpp)                                                                                                                                                             
  │                                                                                                                                                                                                              
  │  Stores per_core_allocation_ from BufferShardingArgs
  │  Calls allocate_impl()                                                                                                                                                                                       
  │                                                                                                                                                                                                            
  ▼                                                                                                                                                                                                              
  AllocatorImpl::allocate_buffer() (allocator.cpp)                                                                                                                                                             
  │                                                                                                                                                                                                              
  │  For each core in shard grid:
  │    ├─ Looks up core's L1 bank_id                                                                                                                                                                             
  │    └─ Calls l1_manager_->allocate_buffer() with per-bank AllocatorID                                                                                                                                         
  │       (independent allocation, not lockstep)                                                                                                                                                                 
  │                                                                                                                                                                                                              
  │  Calls buffer->set_per_core_addresses(addrs)  [private, via friend]                                                                                                                                          
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                            
  MeshBuffer::initialize_device_buffers() (mesh_buffer.cpp)                                                                                                                                                      
  │                                                                                                                                                                                                              
  │  Creates device-local Buffers at the backing buffer's address
  │  (no allocation — placed at known address)                                                                                                                                                                   
  │                                                                                                                                                                                                              
  │  Calls buffer->copy_per_core_addresses_from(backing_buffer)  [public]                                                                                                                                        
  │                                                                                                                                                                                                              
  ▼                                                                                                                                                                                                            
  Buffer ready with per-core addresses  
```

AllocatorMode is an enum needs to set at device init (used to not changing current lock step allocation behaviour and only enable per-core/hybrid allocation when flag is turned on.
 
 ```         
AllocatorMode                                                                                                                                                                                                     
  - LOCKSTEP (default): 1 allocator — all cores get the same address for a given allocation. This is the original behavior.                                                                                      
  - HYBRID: N+1 allocators — 1 lockstep allocator (ID 0) + N per-bank allocators (ID 1..N). Supports both lockstep and per-core allocations.                                                                   
                                                                                                                                                                                                                 
  Why it exists                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  The per-core allocation infrastructure always created N+1 allocators, which broke:                                                                                                                             
  - Sub-device shrink_size/reset_size (asserted 1 allocator)                                                                                                                                                   
  - Overlapped allocator tests (address_limit bug in single-allocator path when deps exist but are empty)                                                                                                        
                                                                                                                                                                                                               
  The flag gates N+1 creation so existing behavior is untouched by default.                                                                                                                                      
                                                                                                                                                                                                                 
  Propagation chain                                                                                                                                                                                              
                                                                                                                                                                                                                 
  Python user code                                                                                                                                                                                             
      pytest.mark.use_module_device({"allocator_mode": ttnn.device.AllocatorMode.HYBRID})
          ↓                                                                                                                                                                                                      
  ttnn/ttnn/device.py
      AllocatorMode = ttnn._ttnn.device.AllocatorMode  (re-export)                                                                                                                                               
      CreateDevice(..., allocator_mode=AllocatorMode.LOCKSTEP)                                                                                                                                                   
          ↓                                                                                                                                                                                                      
  ttnn/cpp/ttnn-nanobind/device.cpp                                                                                                                                                                              
      nb::enum_<AllocatorMode>  (nanobind binding)                                                                                                                                                               
      open_device / CreateDevice / CreateDevices bindings accept allocator_mode                                                                                                                                  
          ↓                                                                                                                                                                                                      
  ttnn/core/distributed/api.cpp                                                                                                                                                                                  
      open_mesh_device(..., AllocatorMode allocator_mode)                                                                                                                                                        
          ↓                                                                                                                                                                                                    
  tt_metal/api/tt-metalium/mesh_device.hpp                                                                                                                                                                       
      MeshDevice::create() / create_unit_mesh() / initialize()                                                                                                                                                   
          ↓                                                                                                                                                                                                      
  tt_metal/distributed/mesh_device.cpp                                                                                                                                                                           
      ScopedDevices constructor → experimental::CreateDevices(allocator_mode)                                                                                                                                    
          ↓                                                                                                                                                                                                      
  tt_metal/tt_metal.cpp                                                                                                                                                                                          
      detail::CreateDevices / experimental::CreateDevices                                                                                                                                                        
          ↓                                                                                                                                                                                                      
  tt_metal/impl/context/metal_context.hpp
      initialize_device_manager(allocator_mode)                                                                                                                                                                  
          ↓                                                                                                                                                                                                    
  tt_metal/impl/device/device_manager.cpp                                                                                                                                                                        
      DeviceManager::initialize(allocator_mode) → stores allocator_mode_                                                                                                                                       
          ↓                                                                                                                                                                                                      
  tt_metal/impl/device/device.cpp                                                                                                                                                                              
      Device constructor(allocator_mode)                                                                                                                                                                         
      Device::initialize(allocator_mode)                                                                                                                                                                       
      Device::initialize_allocator(allocator_mode)                                                                                                                                                               
          → sets config.allocator_mode = allocator_mode
          ↓                                                                                                                                                                                                      
  tt_metal/impl/allocator/l1_banking_allocator.cpp                                                                                                                                                             
      if (config.allocator_mode == AllocatorMode::HYBRID) → create N+1 allocators                                                                                                                                
      else → create 1 allocator (no deps)     
```

Following PR will add support to compressed tensor side.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/compressed_tensor6)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/compressed_tensor6)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/compressed_tensor6)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/compressed_tensor6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/compressed_tensor6)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
