### PR TITLE
 Fix missing dfb:: namespace qualifiers in dataflow_buffer.h             

### DIFF
--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -39,7 +39,8 @@ public:
 
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) {
-        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+        dfb::PackedTileCounter packed_tc =
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
@@ -53,7 +54,7 @@ public:
                 ready = true;
                 for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
                     dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                    ASSERT(llk_intf_get_capacity(get_tensix_id(ptc), get_counter_id(ptc)) >= num_entries);
+                    ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
                     // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
                     if (llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
                         ready = false;
@@ -72,7 +73,7 @@ public:
 
     void push_back(uint16_t num_entries) {
         dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = get_counter_id(packed_tc);
+        uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
         ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
         llk_push_tiles(logical_dfb_id_, num_entries);


### PR DESCRIPTION
### Problem description
Fix missing dfb:: namespace qualifiers in dataflow_buffer.h causing compilation failures on quasar (trisc1)

### What's changed
Three symbols in experimental::DataflowBuffer were used without the dfb:: namespace qualifier
                                                                                                                                                                                                                                                                                       
  - PackedTileCounter → dfb::PackedTileCounter                                                                                                                                                                                                                                
  - get_tensix_id(ptc), get_counter_id(ptc) → dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)                                                                                                                                                                               
  - get_counter_id(packed_tc) → dfb::get_counter_id(packed_tc)                                                                                   