### PR TITLE
Fix Qwen3-VL wrapped vision output reconstruction

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -111,7 +111,7 @@ models:
     wh_n300: 30
     wh_galaxy: 30
   unit:
-    wh_llmbox: 315
+    wh_llmbox: 320
     wh_llmbox_perf: 60
     wh_n150: 30
     wh_n300: 30

--- a/models/demos/qwen3_vl/tests/test_wrapped_model.py
+++ b/models/demos/qwen3_vl/tests/test_wrapped_model.py
@@ -75,13 +75,12 @@ def test_wrapped_vision_model_inference(
     reference_output, deepstack_visual_embeds = reference_model(pt_pixel_values, image_grid_thw)
     tt_output, tt_deepstack_visual_embeds = torch_model(pt_pixel_values, image_grid_thw)
 
-    # Convert ttnn tensor to torch, concatenating replicated outputs along dim 0
+    # Reassemble the hidden dimension that was mesh-partitioned by the wrapper.
     tt_output_torch = ttnn.to_torch(
         tt_output,
-        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
+        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1),
     )
-    # Take only the first device's output (the rest are duplicates due to replication)
-    tt_output_torch = tt_output_torch[: reference_output.shape[0], :]
+    assert tt_output_torch.shape == reference_output.shape
 
     # Compare outputs
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -165,7 +165,7 @@
   cmd: run_t3000_qwen3_vl_unit_tests
   skus:
     wh_llmbox:
-      timeout: 10
+      timeout: 15
   owner_id: U08H31YMN4Q # Sanjay Sanjay
   team: models
   model-name: qwen3_vl


### PR DESCRIPTION
### Ticket
N/A

### Problem description
qwen3-vl has been failing the T3K Unit test pipeline:  https://github.com/tenstorrent/tt-metal/actions/runs/23442449880. The failed runs showed timeouts but there is a deeper issue.

`test_wrapped_vision_model_inference` was rebuilding the wrapped vision output by concatenating mesh shards along the batch dimension and then slicing away duplicated rows. The wrapped output is now partitioned across the hidden dimension (after this optimization PR: https://github.com/tenstorrent/tt-metal/pull/39993), so the test needs to be updated to reconstruct the output accordingly.

### What's changed
- switch `ttnn.ConcatMeshToTensor` from `dim=0` to `dim=1` when converting the wrapped output back to torch
- remove the row-slicing workaround that assumed replicated outputs
- assert that the reconstructed tensor shape matches the PyTorch reference before running the PCC comparison

### Checklist
- [x] t3k unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/23452422531