### PR TITLE
Minor optimizations to create_q_heads and all_reduce_receiver

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
@@ -20,7 +20,7 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Initializes the only the unpacker for the tilize operation.
+ * Initializes only the unpacker for the tilize operation.
  *
  * Return value: None
  *

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +6,6 @@
 
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
-#include "api/compute/tilize.h"
 #ifdef TRISC_MATH
 #include "llk_math_unary_datacopy_api.h"
 #include "llk_math_reduce_api.h"
@@ -38,17 +37,16 @@ ALWI void tilize_init_unpack(uint32_t icb, uint32_t block, uint32_t call_line = 
 
 // clang-format off
 /**
- * Performs the tilize operation on a block.
+ * Performs the tilize operation on a block. num_chunks * chunk must be equal to the block size.
  *
  * Return value: None
  *
  * | Param Type | Name             | Description                              | Type     | Valid Range | Required |
  * |----------- |------------------|------------------------------------------|----------|-------------|----------|
  * | Function   | icb              | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
- * | Function   | block            | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | num_chunks       | Number of chunks to work on              | uint32_t | > 0         | True     |
+ * | Function   | chunk            | Size of each chunk to work on            | uint32_t | > 0         | True     |
  * | Function   | ocb              | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
- * | Function   | input_tile_index | Index of the input tile in the icb       | uint32_t | >= 0        | False    |
- * | Function   | output_tile_index| Index of the output tile in the ocb      | uint32_t | >= 0        | False    |
  */
 // clang-format on
 ALWI void tilize_block_custom(uint32_t icb, uint32_t num_chunks, uint32_t chunk, uint32_t ocb) {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common.h"
+#include "api/compute/sentinel/compute_kernel_sentinel.h"
+#include "api/compute/tilize.h"
+#ifdef TRISC_MATH
+#include "llk_math_unary_datacopy_api.h"
+#include "llk_math_reduce_api.h"
+#include "llk_math_matmul_api.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "llk_unpack_tilize_api.h"
+#include "llk_unpack_common_api.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Initializes the only the unpacker for the tilize operation.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                                   | Type     | Valid Range | Required |
+ * |----------- |--------|-----------------------------------------------|----------|-------------|----------|
+ * | Function   | icb    | Input circular buffer identifier              | uint32_t | 0 to 31     | True     |
+ * | Function   | block  | Size of tile block to work on                 | uint32_t | > 0         | True     |
+ */
+// clang-format on
+ALWI void tilize_init_unpack(uint32_t icb, uint32_t block, uint32_t call_line = __builtin_LINE()) {
+    state_configure<Operand::SRCA>(icb, call_line);
+    UNPACK((llk_unpack_tilize_init(icb, block)));
+}
+
+// clang-format off
+/**
+ * Performs the tilize operation on a block.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name             | Description                              | Type     | Valid Range | Required |
+ * |----------- |------------------|------------------------------------------|----------|-------------|----------|
+ * | Function   | icb              | Input circular buffer identifier         | uint32_t | 0 to 31     | True     |
+ * | Function   | block            | Size of tile block to work on            | uint32_t | > 0         | True     |
+ * | Function   | ocb              | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
+ * | Function   | input_tile_index | Index of the input tile in the icb       | uint32_t | >= 0        | False    |
+ * | Function   | output_tile_index| Index of the output tile in the ocb      | uint32_t | >= 0        | False    |
+ */
+// clang-format on
+ALWI void tilize_block_custom(uint32_t icb, uint32_t num_chunks, uint32_t chunk, uint32_t ocb) {
+    UNPACK((llk_unpack_tilize_block(icb, num_chunks * chunk, 0)));
+
+    // Acquire dst
+    MATH((llk_math_wait_for_dest_available()));
+    for (uint32_t c = 0; c < num_chunks; c++) {
+        uint32_t dst_index = c * chunk;
+        PACK((t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU)));
+        for (uint32_t t = 0; t < chunk; t++) {
+            // Datacopy
+            MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+                dst_index + t /*dst index*/)));
+            PACK((llk_pack<DST_ACCUM_MODE>(dst_index + t /*tile index*/, ocb)));
+        }
+        PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
+        MATH((t6_semaphore_post<p_stall::MATH>(semaphore::FPU_SFPU)));
+    }
+    PACK((llk_packer_wait_for_math_done()));
+    // Release dest
+    MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
+    PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_create_q_heads.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_create_q_heads.py
@@ -38,8 +38,6 @@ Per-receiver data layout (8 heads per receiver):
 @pytest.mark.parametrize(
     "qnope_shard_shape, qrope_shard_shape, noc",
     [
-        ((1, 512), (2, 64), ttnn.NOC.NOC_0),  # Force NOC0
-        ((1, 512), (2, 64), ttnn.NOC.NOC_1),  # Force NOC1
         ((1, 512), (2, 64), None),  # Auto NOC routing - selects best single NOC
     ],
 )

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
@@ -111,43 +111,38 @@ struct AllReduceReceiver {
 #if defined(COMPILE_FOR_TRISC)
         template <bool AcquireRegs>
         static FORCE_INLINE void batched_add(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out, uint32_t num_tiles) {
-            // constexpr uint32_t max_dst_tiles = 4;
-            // uint32_t num_batches = (num_tiles + max_dst_tiles - 1) / max_dst_tiles;
+            constexpr uint32_t max_dst_tiles = 4;
+            uint32_t num_batches = (num_tiles + max_dst_tiles - 1) / max_dst_tiles;
+
+            // For safety
+            MATH((t6_semaphore_wait_on_max<p_stall::STALL_MATH>(semaphore::FPU_SFPU)));
 
             cb_wait_front(cb_a, num_tiles);
             cb_wait_front(cb_b, num_tiles);
             cb_reserve_back(cb_out, num_tiles);
 
-            // Original code for reference
-            // TODO: Restore the pack overlap with math for better performance
-            // for (uint32_t batch = 0; batch < num_batches; ++batch) {
-            //     uint32_t start_tile = batch * max_dst_tiles;
-            //     uint32_t batch_size = (start_tile + max_dst_tiles <= num_tiles)
-            //                               ? max_dst_tiles
-            //                               : (num_tiles - start_tile);
-
-            //     tile_regs_acquire();
-            //     for (uint32_t i = 0; i < batch_size; ++i) {
-            //         add_tiles(cb_a, cb_b, start_tile + i, start_tile + i, i);
-            //     }
-            //     tile_regs_commit();
-
-            //     tile_regs_wait();
-            //     for (uint32_t i = 0; i < batch_size; ++i) {
-            //         pack_tile(i, cb_out, start_tile + i);
-            //     }
-            //     tile_regs_release();
-            // }
             if constexpr (AcquireRegs) {
                 tile_regs_acquire();
             }
-            for (uint32_t i = 0; i < num_tiles; i++) {
-                add_tiles(cb_a, cb_b, i, i, i);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            for (uint32_t i = 0; i < num_tiles; i++) {
-                pack_tile(i, cb_out, i);
+            for (uint32_t batch = 0; batch < num_batches; ++batch) {
+                uint32_t start_tile = batch * max_dst_tiles;
+                uint32_t batch_size =
+                    (start_tile + max_dst_tiles <= num_tiles) ? max_dst_tiles : (num_tiles - start_tile);
+                if (batch == num_batches - 1) {
+                    tile_regs_wait();
+                } else {
+                    PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
+                }
+                for (uint32_t i = 0; i < batch_size; ++i) {
+                    add_tiles(cb_a, cb_b, start_tile + i, start_tile + i, start_tile + i);
+                    pack_tile(start_tile + i, cb_out);
+                }
+                if (batch == num_batches - 1) {
+                    tile_regs_commit();
+                } else {
+                    PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));
+                    MATH((t6_semaphore_post<p_stall::MATH>(semaphore::FPU_SFPU)));
+                }
             }
             tile_regs_release();
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
@@ -12,6 +12,7 @@
 
 #if defined(COMPILE_FOR_TRISC)
 #include "api/compute/tilize.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack_untilize.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
@@ -159,6 +160,14 @@ struct CreateQHeads {
             // Select the appropriate CB
             uint32_t src_cb = is_qnope_core ? args.qnope_cb : args.qrope_cb;
 
+            // Get target NOC coordinates based on row (unpacked from uint32)
+            uint32_t packed_coords = args.target_noc_coords[my_row];
+            uint32_t target_noc_x = packed_coords & 0xFFFF;          // Lower 16 bits
+            uint32_t target_noc_y = (packed_coords >> 16) & 0xFFFF;  // Upper 16 bits
+
+            const uint64_t dst_noc_coord = get_noc_addr(target_noc_x, target_noc_y, 0);
+            constexpr uint32_t half_qnope_data_size_bytes = CTArgs::qnope_data_size_bytes / 2;
+
             // Setup sharded input buffer if needed (standalone op)
             if constexpr (setup_sharded_input) {
                 unified_kernels::setup_sharded_buffer(src_cb, args.src_num_pages);
@@ -169,14 +178,6 @@ struct CreateQHeads {
 
             // Get source address from CB
             uint32_t src_addr = get_read_ptr(src_cb);
-
-            // Get target NOC coordinates based on row (unpacked from uint32)
-            uint32_t packed_coords = args.target_noc_coords[my_row];
-            uint32_t target_noc_x = packed_coords & 0xFFFF;          // Lower 16 bits
-            uint32_t target_noc_y = (packed_coords >> 16) & 0xFFFF;  // Upper 16 bits
-
-            const uint64_t dst_noc_coord = get_noc_addr(target_noc_x, target_noc_y, 0);
-            constexpr uint32_t half_qnope_data_size_bytes = CTArgs::qnope_data_size_bytes / 2;
 
             if (is_qnope_core) {
                 // QNOPE core: Split 512 elements into two 256-element halves for tilization
@@ -270,33 +271,35 @@ struct CreateQHeads {
             //
             // Each phase does: wait→reserve→tilize→push→pop
             // This ensures proper hardware state between tilize_block calls.
-
+            constexpr uint32_t nope_num_chunks = 2;
+            uint32_t nope_chunk = args.nope_tiles / nope_num_chunks;
             reconfig_data_format_srca<false, true>(args.receiver_in_cb);
             pack_reconfig_data_format<true>(args.out_cb);
             tilize_init(args.receiver_in_cb, args.nope_tiles, args.out_cb);
+            // For safety
+            MATH((t6_semaphore_wait_on_max<p_stall::STALL_MATH>(semaphore::FPU_SFPU)));
 
             // Phase 1: Tilize first NOPE block [8, 256] → 8 tiles
             cb_wait_front(args.receiver_in_cb, args.nope_tiles);
             cb_reserve_back(args.out_cb, args.nope_tiles);
-            tilize_block(args.receiver_in_cb, args.nope_tiles, args.out_cb);
+            tilize_block_custom(args.receiver_in_cb, nope_num_chunks, nope_chunk, args.out_cb);
             cb_push_back(args.out_cb, args.nope_tiles);
             cb_pop_front(args.receiver_in_cb, args.nope_tiles);
 
             // Phase 2: Tilize second NOPE block [8, 256] → 8 tiles
             cb_wait_front(args.receiver_in_cb, args.nope_tiles);
             cb_reserve_back(args.out_cb, args.nope_tiles);
-            tilize_block(args.receiver_in_cb, args.nope_tiles, args.out_cb);
+            tilize_block_custom(args.receiver_in_cb, nope_num_chunks, nope_chunk, args.out_cb);
             cb_push_back(args.out_cb, args.nope_tiles);
             cb_pop_front(args.receiver_in_cb, args.nope_tiles);
 
             // Phase 3: Tilize ROPE block [8, 64] → 2 tiles
             // Must re-init tilize for different block width (2 tiles vs 8 tiles)
-            tilize_uninit(args.receiver_in_cb, args.out_cb);
-            tilize_init(args.receiver_in_cb, args.rope_tiles, args.out_cb);
+            tilize_init_unpack(args.receiver_in_cb, args.rope_tiles);
 
             cb_wait_front(args.receiver_in_cb, args.rope_tiles);
             cb_reserve_back(args.out_cb, args.rope_tiles);
-            tilize_block(args.receiver_in_cb, args.rope_tiles, args.out_cb);
+            tilize_block_custom(args.receiver_in_cb, args.rope_tiles, 1, args.out_cb);
             cb_push_back(args.out_cb, args.rope_tiles);
             cb_pop_front(args.receiver_in_cb, args.rope_tiles);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38716

### Problem description
create_q_heads was doing a full tilize uninit and reinit for switching between a block size of 8 and 2, but this is unnecessary. We only need to reconfigure unpack since only unpack init depends on block size.
The standard tilize_block is also suboptimal since it does dest bank flipping per tile. We can better optimize by not doing full flipping, and aggregating some number of tiles before signalling pack to get better utilization.

all_reduce_receiver had a regression introduced when we enabled deterministic output across devices as we removed the math/pack overlap.

### What's changed
Switch to only reconfiguring unpack when moving between nope tilize and rope tilize.
Use a granularity of 4 tiles when tilizing when signalling between math/pack.
Restore the math/pack overlap in all_reduce_receiver at 4 tile granularity.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/optimizations)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/optimizations)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/optimizations)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
