### PR TITLE
Manual uplift llk submodule

### DIFF
--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -82,7 +82,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
     // Get DRAM usage
     auto dram_usage = ttml::utils::MemoryUsageTracker::get_dram_usage();
 
-    size_t binary_size = 16384;  // Size of DRAM buffer used for matmul program
+    size_t binary_size = 18432;          // Size of DRAM buffer used for matmul program
     size_t expected_size = binary_size;  // Allocated left over is program cache
     size_t expected_peak_size = tensor1_size + tensor2_size + result_size + expected_size;
     // LLK_ASSERTs add constant DRAM overhead (one page) due to additional assertion code
@@ -187,12 +187,12 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
     expected_peak_size += compute_tensor_size(mul_result) + 10240;
     expected_peak_size += compute_tensor_size(matmul_result) + 18432;
     expected_peak_size +=
-        compute_tensor_size(sdpa_result->get_value()) + 243712;  // All the intermediate tensors / activations
+        compute_tensor_size(sdpa_result->get_value()) + 239616;  // All the intermediate tensors / activations
 
     // LLK_ASSERTs add constant DRAM overhead due to additional assertion code
     // in unpacker/packer configurations that invoke functions exclusively used for assertions.
     if (ttml::core::is_llk_assert_enabled()) {
-        expected_peak_size += 22528;  // Additional program cache overhead
+        expected_peak_size += 16384;  // Additional program cache overhead
     }
 
     expected_size = expected_peak_size;
@@ -402,15 +402,17 @@ TEST_F(MemoryUtilsTest, SnapshotFeature) {
     size_t peak_2 = 86016, alloc_2 = 86016, dealloc_2 = 20480;
     size_t peak_3 = 272384, alloc_3 = 280576, dealloc_3 = 18432;
     if (ttml::core::is_llk_assert_enabled()) {
-        peak_1 = 36864;
-        alloc_1 = 36864;
-        dealloc_1 = 12288;
-        peak_2 = 90112;
-        alloc_2 = 90112;
-        dealloc_2 = 24576;
-        peak_3 = 276480;
-        alloc_3 = 284672;
-        dealloc_3 = 22528;
+        constexpr size_t llk_assert_overhead = 2048;
+        constexpr size_t llk_assert_overhead_matmul = 4096;
+        peak_1 += llk_assert_overhead;
+        alloc_1 += llk_assert_overhead;
+        dealloc_1 += llk_assert_overhead;
+        peak_2 += llk_assert_overhead_matmul;
+        alloc_2 += llk_assert_overhead_matmul;
+        dealloc_2 += llk_assert_overhead_matmul;
+        peak_3 += llk_assert_overhead;
+        alloc_3 += llk_assert_overhead;
+        dealloc_3 += llk_assert_overhead;
     }
 
     // Snapshot 1: Add operation

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -41,7 +41,7 @@ inline void llk_unpack_AB(
     std::uint32_t address_b = base_address_b + offset_address_b;
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[operandB_id],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -41,7 +41,7 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[operandB_id],
@@ -92,7 +92,7 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandB_id],
             unpack_dst_format[operandB_id],
             unpack_src_format[operandA_id],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -83,7 +83,7 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
-    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+    LLK_ASSERT((are_unpackers_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
         unpack_src_format[operandA_id],
         unpack_dst_format[operandA_id],
         unpack_src_format[get_operand_id(operandB)],
@@ -130,7 +130,7 @@ inline void llk_unpack_tilizeA_B(
     const std::uint32_t offset_address_b = tile_index_b * get_local_cb_interface(operandB_id).fifo_page_size;
     const std::uint32_t address_b = base_address_b + offset_address_b;
 
-    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+    LLK_ASSERT((are_unpackers_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
         unpack_src_format[operandA_id],
         unpack_dst_format[operandA_id],
         unpack_src_format[operandB_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -41,7 +41,7 @@ inline void llk_unpack_AB(
     std::uint32_t address_b = base_address_b + offset_address_b;
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[operandB_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -41,7 +41,7 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[operandB_id],
@@ -91,7 +91,7 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly(
+        (are_unpackers_AB_configured_correctly(
             unpack_src_format[operandB_id],
             unpack_dst_format[operandB_id],
             unpack_src_format[operandA_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -95,7 +95,7 @@ inline void llk_unpack_tilizeA_B_init(
     const bool narrow_tile = get_operand_narrow_tile(operandA_id);
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+        (are_unpackers_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[get_operand_id(operandB)],
@@ -140,7 +140,7 @@ inline void llk_unpack_tilizeA_B(
     std::uint32_t address_b = base_address_b + offset_address_b;
 
     LLK_ASSERT(
-        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+        (are_unpackers_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
             unpack_src_format[operandA_id],
             unpack_dst_format[operandA_id],
             unpack_src_format[operandB_id],


### PR DESCRIPTION
### Ticket

### Problem description
Next LLK submodule uplift brings changes in memory_utils_tests.cpp
Also, changes in the name of function. New name is are_unpackers_AB_configured_correctly.

### What's changed
Uplift LLK submodule and add fixes needed to maintain green Sanity and function name consistency.
PR which impacts memory_utils_tests.cpp checks on all code paths:
https://github.com/tenstorrent/tt-llk/pull/1502
In this PR, some variables are now part of all code paths which was enough for memory usage increase.

PR which impacts memory_utils_tests.cpp when LLK_ASSERTS are enabled:
https://github.com/tenstorrent/tt-llk/pull/1520
It reduce code size overhead when LLK_ASSERTS are enabled.

Info related to which LLK changes are added can be found in this auto-generated PR:
https://github.com/tenstorrent/tt-metal/pull/40522

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
 - [x] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
 - [x] [![Fast dispatch frequent tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-frequent-tests.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-frequent-tests.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/manual_uplift_llk_submodule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/manual_uplift_llk_submodule)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
