### PR TITLE
[Feature] Add support for DRAM-backed command queues for fast dispatch on MMIO devices

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -300,12 +300,22 @@ TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
 
         std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
 
-        tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
-            cq_zeros.data(),
-            (cq_size - cq_start),
-            get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
-            mmio_device_id,
-            channel);
+        if (local_device->sysmem_manager().is_dram_backed()) {
+            tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
+                cq_zeros.data(),
+                (cq_size - cq_start),
+                local_device->id(),
+                local_device->sysmem_manager().get_dram_region_channel(),
+                local_device->sysmem_manager().get_dram_region_base_addr() +
+                    get_absolute_cq_offset(channel, 0, cq_size) + cq_start);
+        } else {
+            tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+                cq_zeros.data(),
+                (cq_size - cq_start),
+                get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
+                mmio_device_id,
+                channel);
+        }
     }
 
     // Create src vector

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "dispatch/system_memory_manager.hpp"
+#include "allocator/allocator.hpp"
 
 #include "tt_metal/test_utils/stimulus.hpp"
 
@@ -301,11 +302,13 @@ TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
         std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
 
         if (local_device->sysmem_manager().is_dram_backed()) {
+            const uint32_t dram_channel = local_device->allocator_impl()->get_dram_channel_from_bank_id(
+                local_device->sysmem_manager().get_dram_region_bank_id());
             tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
                 cq_zeros.data(),
                 (cq_size - cq_start),
                 local_device->id(),
-                local_device->sysmem_manager().get_dram_region_channel(),
+                dram_channel,
                 local_device->sysmem_manager().get_dram_region_base_addr() +
                     get_absolute_cq_offset(channel, 0, cq_size) + cq_start);
         } else {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
+#include "allocator/allocator.hpp"
 #include "dispatch/system_memory_manager.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
@@ -302,11 +303,13 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     auto device_coord = distributed::MeshCoordinate(0, 0);
     std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
     if (device->sysmem_manager().is_dram_backed()) {
+        const uint32_t dram_channel =
+            device->allocator_impl()->get_dram_channel_from_bank_id(device->sysmem_manager().get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
             cq_zeros.data(),
             (cq_size - cq_start),
             device->id(),
-            device->sysmem_manager().get_dram_region_channel(),
+            dram_channel,
             device->sysmem_manager().get_dram_region_base_addr() + get_absolute_cq_offset(channel, 0, cq_size) +
                 cq_start);
     } else {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -782,7 +782,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
-            .num_pages = 256, .page_size = max_prefetch_command_size + 2048, .buftype = BufferType::DRAM};
+            .num_pages = 1024, .page_size = max_prefetch_command_size + 2048, .buftype = BufferType::DRAM};
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             mesh_device, mesh_device->mesh_command_queue(), config);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -301,12 +301,22 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     auto device_coord = distributed::MeshCoordinate(0, 0);
     std::vector<uint32_t> cq_zeros((cq_size - cq_start) / sizeof(uint32_t), 0);
-    tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
-        cq_zeros.data(),
-        (cq_size - cq_start),
-        get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
-        mmio_device_id,
-        channel);
+    if (device->sysmem_manager().is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
+            cq_zeros.data(),
+            (cq_size - cq_start),
+            device->id(),
+            device->sysmem_manager().get_dram_region_channel(),
+            device->sysmem_manager().get_dram_region_base_addr() + get_absolute_cq_offset(channel, 0, cq_size) +
+                cq_start);
+    } else {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+            cq_zeros.data(),
+            (cq_size - cq_start),
+            get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
+            mmio_device_id,
+            channel);
+    }
 
     for (const bool cq_write : {true, false}) {
         for (const bool cq_read : {true, false}) {
@@ -769,7 +779,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
-            .num_pages = 1024, .page_size = max_prefetch_command_size + 2048, .buftype = BufferType::DRAM};
+            .num_pages = 256, .page_size = max_prefetch_command_size + 2048, .buftype = BufferType::DRAM};
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             mesh_device, mesh_device->mesh_command_queue(), config);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -7,17 +7,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
-#include <future>
-#include <initializer_list>
 #include <memory>
-#include <thread>
-#include <variant>
 #include <vector>
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
+#include "allocator/allocator.hpp"
 #include "command_queue_fixture.hpp"
 #include <tt-metalium/device.hpp>
+#include "device/device_manager.hpp"
 #include "impl/dispatch/dispatch_settings.hpp"
 #include "impl/dispatch/system_memory_manager.hpp"
 #include "gtest/gtest.h"
@@ -38,8 +36,12 @@ void read_completion_queue_event_id(
     const SystemMemoryManager& sysmem, ChipId mmio_device_id, uint16_t channel, uint32_t byte_addr, uint32_t& out) {
     auto& cluster = MetalContext::instance().get_cluster();
     if (sysmem.is_dram_backed()) {
-        cluster.read_dram_vec(
-            &out, sizeof(uint32_t), sysmem.get_device_id(), sysmem.get_dram_region_channel(), byte_addr);
+        const uint32_t dram_channel = MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(sysmem.get_device_id())
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem.get_dram_region_bank_id());
+        cluster.read_dram_vec(&out, sizeof(uint32_t), sysmem.get_device_id(), dram_channel, byte_addr);
     } else {
         cluster.read_sysmem(&out, sizeof(uint32_t), byte_addr, mmio_device_id, channel);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -109,7 +109,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
 TEST_F(UnitMeshCQEventFixture, TestEventsEnqueueRecordEventIssueQueueWrap) {
     auto mesh_device = this->devices_[0];
     auto& cq = mesh_device->mesh_command_queue();
-    const size_t num_events = 100;  // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
+    const size_t num_events = 100000;  // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
     uint32_t cmds_issued_per_cq = 0;
 
     auto start = std::chrono::system_clock::now();

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -34,6 +34,17 @@ constexpr uint32_t completion_queue_page_size = DispatchSettings::TRANSFER_PAGE_
 
 enum class DataMovementMode : uint8_t { WRITE = 0, READ = 1 };
 
+void read_completion_queue_event_id(
+    const SystemMemoryManager& sysmem, ChipId mmio_device_id, uint16_t channel, uint32_t byte_addr, uint32_t& out) {
+    auto& cluster = MetalContext::instance().get_cluster();
+    if (sysmem.is_dram_backed()) {
+        cluster.read_dram_vec(
+            &out, sizeof(uint32_t), sysmem.get_device_id(), sysmem.get_dram_region_channel(), byte_addr);
+    } else {
+        cluster.read_sysmem(&out, sizeof(uint32_t), byte_addr, mmio_device_id, channel);
+    }
+}
+
 TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInOrder) {
     size_t num_buffers = 100;
     uint32_t page_size = 2048;
@@ -76,8 +87,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
             for (size_t i = 0; i < num_buffers; i++) {
                 uint32_t host_addr =
                     last_read_address + (i * completion_queue_page_size) + completion_queue_event_offset;
-                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                    &event, 4, host_addr, mmio_device_id, channel);
+                read_completion_queue_event_id(device->sysmem_manager(), mmio_device_id, channel, host_addr, event);
                 EXPECT_EQ(event, ++expected_event_id);  // Event ids start at 1
             }
         } else if (data_movement_mode == DataMovementMode::READ) {
@@ -85,8 +95,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
                 // Extra entry in the completion queue is from the buffer read data.
                 uint32_t host_addr =
                     completion_queue_base + ((2 * i + 1) * completion_queue_page_size) + completion_queue_event_offset;
-                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                    &event, 4, host_addr, mmio_device_id, channel);
+                read_completion_queue_event_id(device->sysmem_manager(), mmio_device_id, channel, host_addr, event);
                 EXPECT_EQ(event, ++expected_event_id);  // Event ids start at 1
                 last_read_address = host_addr - completion_queue_event_offset + completion_queue_page_size;
             }
@@ -98,7 +107,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
 TEST_F(UnitMeshCQEventFixture, TestEventsEnqueueRecordEventIssueQueueWrap) {
     auto mesh_device = this->devices_[0];
     auto& cq = mesh_device->mesh_command_queue();
-    const size_t num_events = 100000;  // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
+    const size_t num_events = 100;  // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
     uint32_t cmds_issued_per_cq = 0;
 
     auto start = std::chrono::system_clock::now();
@@ -269,8 +278,7 @@ TEST_F(UnitMeshCQEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) 
     uint32_t event_id;
     for (size_t i = 0; i < num_buffers * num_events_per_cq; i++) {
         uint32_t host_addr = completion_queue_base + (i * completion_queue_page_size) + completion_queue_event_offset;
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            &event_id, 4, host_addr, mmio_device_id, channel);
+        read_completion_queue_event_id(device->sysmem_manager(), mmio_device_id, channel, host_addr, event_id);
         EXPECT_EQ(event_id, ++expected_event_id);
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -22,12 +22,12 @@ static constexpr uint32_t default_l1_alignment = 16;
 
 TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
     const auto unsupported_core = CoreType::ARC;
-    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, default_l1_alignment), std::runtime_error);
+    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, false, default_l1_alignment), std::runtime_error);
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
     DispatchSettings settings_2 = settings;  // Copy
     EXPECT_EQ(settings, settings_2);
     settings_2.dispatch_size_ += 1;
@@ -39,7 +39,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
@@ -49,7 +49,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchSettings::prefetch_q_entry_type);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
@@ -59,7 +59,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
@@ -70,7 +70,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_pages_, expected_page_count);

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -537,8 +537,6 @@ get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_
     } else {
         noc_addr = l1_bank_to_noc_xy[noc][bank_id];
     }
-    DPRINT << "get_noc_addr_from_bank_id: noc_addr=" << noc_addr << " bank_address_offset=" << bank_address_offset
-           << ENDL();
     return (noc_addr << NOC_ADDR_COORD_SHIFT) | (bank_address_offset);
 }
 

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -537,6 +537,8 @@ get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_
     } else {
         noc_addr = l1_bank_to_noc_xy[noc][bank_id];
     }
+    DPRINT << "get_noc_addr_from_bank_id: noc_addr=" << noc_addr << " bank_address_offset=" << bank_address_offset
+           << ENDL();
     return (noc_addr << NOC_ADDR_COORD_SHIFT) | (bank_address_offset);
 }
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1588,7 +1588,12 @@ void read_completion_queue(
     if (sysmem_manager.is_dram_backed()) {
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()
-            .read_dram_vec(dst, size_bytes, device_id, 0, completion_q_read_ptr + completion_q_data_offset);
+            .read_dram_vec(
+                dst,
+                size_bytes,
+                device_id,
+                sysmem_manager.get_dram_region_channel(),
+                completion_q_read_ptr + completion_q_data_offset);
     } else {
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1577,6 +1577,28 @@ std::shared_ptr<tt::tt_metal::CompletionReaderVariant> generate_interleaved_buff
         dispatch_params.total_pages_read);
 }
 
+void read_completion_queue(
+    void* dst,
+    uint32_t size_bytes,
+    ChipId device_id,
+    uint16_t channel,
+    uint32_t cq_id,
+    uint32_t completion_q_read_ptr,
+    uint32_t completion_q_data_offset,
+    const SystemMemoryManager& sysmem_manager) {
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().read_dram_vec(
+            dst,
+            size_bytes,
+            device_id,
+            0,
+            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_read_ptr + completion_q_data_offset);
+    } else {
+        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().read_sysmem(
+            dst, size_bytes, completion_q_read_ptr + completion_q_data_offset, device_id, channel);
+    }
+}
+
 void copy_completion_queue_data_into_user_space(
     const ReadBufferDescriptor& read_buffer_descriptor,
     ChipId mmio_device_id,
@@ -1635,14 +1657,15 @@ void copy_completion_queue_data_into_user_space(
             void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {
                 uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
-                tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
-                    .get_cluster()
-                    .read_sysmem(
-                        contiguous_dst,
-                        data_bytes_xfered,
-                        completion_q_read_ptr + offset_in_completion_q_data,
-                        mmio_device_id,
-                        channel);
+                read_completion_queue(
+                    contiguous_dst,
+                    data_bytes_xfered,
+                    mmio_device_id,
+                    channel,
+                    cq_id,
+                    completion_q_read_ptr,
+                    offset_in_completion_q_data,
+                    sysmem_manager);
                 contig_dst_offset += data_bytes_xfered;
                 offset_in_completion_q_data = 0;
             } else {
@@ -1686,14 +1709,15 @@ void copy_completion_queue_data_into_user_space(
                         num_bytes_to_copy = page_size;
                     }
 
-                    tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
-                        .get_cluster()
-                        .read_sysmem(
-                            (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
-                            num_bytes_to_copy,
-                            completion_q_read_ptr + src_offset_bytes,
-                            mmio_device_id,
-                            channel);
+                    read_completion_queue(
+                        (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
+                        num_bytes_to_copy,
+                        mmio_device_id,
+                        channel,
+                        cq_id,
+                        completion_q_read_ptr,
+                        src_offset_bytes,
+                        sysmem_manager);
 
                     src_offset_bytes += src_offset_increment;
                     dst_offset_bytes += num_bytes_to_copy;
@@ -1761,14 +1785,15 @@ void copy_completion_queue_data_into_user_space(
                     }
                 }
 
-                tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
-                    .get_cluster()
-                    .read_sysmem(
-                        (char*)(uint64_t(dst) + dst_offset_bytes),
-                        num_bytes_to_copy,
-                        completion_q_read_ptr + src_offset_bytes,
-                        mmio_device_id,
-                        channel);
+                read_completion_queue(
+                    (char*)(uint64_t(dst) + dst_offset_bytes),
+                    num_bytes_to_copy,
+                    mmio_device_id,
+                    channel,
+                    cq_id,
+                    completion_q_read_ptr,
+                    src_offset_bytes,
+                    sysmem_manager);
 
                 src_offset_bytes += src_offset_increment;
             }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -12,8 +12,10 @@
 #include <utility>
 
 #include <tt_stl/assert.hpp>
+#include "allocator/allocator.hpp"
 #include "buffer_types.hpp"
 #include "dispatch.hpp"
+#include "device/device_manager.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
@@ -1586,14 +1588,14 @@ void read_completion_queue(
     uint32_t completion_q_data_offset,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
+        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+                                          .device_manager()
+                                          ->get_active_device(device_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()
-            .read_dram_vec(
-                dst,
-                size_bytes,
-                device_id,
-                sysmem_manager.get_dram_region_channel(),
-                completion_q_read_ptr + completion_q_data_offset);
+            .read_dram_vec(dst, size_bytes, device_id, dram_channel, completion_q_read_ptr + completion_q_data_offset);
     } else {
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1582,20 +1582,17 @@ void read_completion_queue(
     uint32_t size_bytes,
     ChipId device_id,
     uint16_t channel,
-    uint32_t cq_id,
     uint32_t completion_q_read_ptr,
     uint32_t completion_q_data_offset,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().read_dram_vec(
-            dst,
-            size_bytes,
-            device_id,
-            0,
-            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_read_ptr + completion_q_data_offset);
+        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+            .get_cluster()
+            .read_dram_vec(dst, size_bytes, device_id, 0, completion_q_read_ptr + completion_q_data_offset);
     } else {
-        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().read_sysmem(
-            dst, size_bytes, completion_q_read_ptr + completion_q_data_offset, device_id, channel);
+        tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+            .get_cluster()
+            .read_sysmem(dst, size_bytes, completion_q_read_ptr + completion_q_data_offset, device_id, channel);
     }
 }
 
@@ -1662,7 +1659,6 @@ void copy_completion_queue_data_into_user_space(
                     data_bytes_xfered,
                     mmio_device_id,
                     channel,
-                    cq_id,
                     completion_q_read_ptr,
                     offset_in_completion_q_data,
                     sysmem_manager);
@@ -1714,7 +1710,6 @@ void copy_completion_queue_data_into_user_space(
                         num_bytes_to_copy,
                         mmio_device_id,
                         channel,
-                        cq_id,
                         completion_q_read_ptr,
                         src_offset_bytes,
                         sysmem_manager);
@@ -1790,7 +1785,6 @@ void copy_completion_queue_data_into_user_space(
                     num_bytes_to_copy,
                     mmio_device_id,
                     channel,
-                    cq_id,
                     completion_q_read_ptr,
                     src_offset_bytes,
                     sysmem_manager);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -224,10 +224,10 @@ void MetalContext::initialize(
         dispatch_core_config_, num_hw_cqs, MetalEnvAccessor(*this->env_).impl());
     dispatch_query_manager_ =
         std::make_unique<DispatchQueryManager>(*this->env_, *dispatch_core_manager_, dispatch_core_config_, num_hw_cqs);
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal(), is_galaxy_cluster);
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs, hal(), is_galaxy_cluster);
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<DispatchMemMap>(
+        CoreType::WORKER, num_hw_cqs, hal(), is_galaxy_cluster, rtoptions().get_dram_backed_cq());
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<DispatchMemMap>(
+        CoreType::ETH, num_hw_cqs, hal(), is_galaxy_cluster, rtoptions().get_dram_backed_cq());
     // Initialize debug servers. Attaching individual devices done below
     rtoptions().resolve_fabric_node_ids_to_chip_ids(this->get_control_plane());
     rtoptions().resolve_mesh_coords_to_chip_ids(this->get_system_mesh());

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -139,7 +139,8 @@ void MetalEnvImpl::initialize_base_objects() {
         platform_arch,
         is_base_routing_fw_enabled,
         this->rtoptions_->get_enable_2_erisc_mode(),
-        get_profiler_dram_bank_size_for_hal_allocation(*this->rtoptions_));
+        get_profiler_dram_bank_size_for_hal_allocation(*this->rtoptions_),
+        this->rtoptions_->get_dram_backed_cq());
 
     this->rtoptions_->ParseAllFeatureEnv(*hal_);
     this->cluster_->set_hal(hal_.get());

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -197,7 +197,11 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
                 // Reset the host manager's pointer for this command queue
                 this->sysmem_manager_->reset(cq_id);
 
-                const uint32_t cq_offset = get_absolute_cq_offset(channel, cq_id, cq_size);
+                const uint32_t cq_offset =
+                    this->sysmem_manager_->is_dram_backed()
+                        ? get_absolute_cq_offset(
+                              channel, cq_id, cq_size, this->sysmem_manager_->get_dram_region_base_addr())
+                        : get_absolute_cq_offset(channel, cq_id, cq_size);
 
                 pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
                 pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
@@ -208,11 +212,7 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
 
                 if (this->sysmem_manager_->is_dram_backed()) {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
-                        pointers.data(),
-                        pointers.size() * sizeof(uint32_t),
-                        this->id(),
-                        0,
-                        this->sysmem_manager_->get_dram_region_start_addr(cq_id));
+                        pointers.data(), pointers.size() * sizeof(uint32_t), this->id(), 0, cq_offset);
                 } else {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                         pointers.data(),

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -197,25 +197,30 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
                 // Reset the host manager's pointer for this command queue
                 this->sysmem_manager_->reset(cq_id);
 
-                pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] =
-                    (cq_start + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
-                pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] =
-                    (cq_start + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
-                pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] =
-                    (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) +
-                     get_absolute_cq_offset(channel, cq_id, cq_size)) >>
-                    4;
-                pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] =
-                    (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) +
-                     get_absolute_cq_offset(channel, cq_id, cq_size)) >>
-                    4;
+                const uint32_t cq_offset = get_absolute_cq_offset(channel, cq_id, cq_size);
 
-                MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
-                    pointers.data(),
-                    pointers.size() * sizeof(uint32_t),
-                    get_absolute_cq_offset(channel, cq_id, cq_size),
-                    mmio_device_id,
-                    get_umd_channel(channel));
+                pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] =
+                    (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
+                pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] =
+                    (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
+
+                if (this->sysmem_manager_->is_dram_backed()) {
+                    MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
+                        pointers.data(),
+                        pointers.size() * sizeof(uint32_t),
+                        this->id(),
+                        0,
+                        this->sysmem_manager_->get_dram_region_start_addr(cq_id));
+                } else {
+                    MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
+                        pointers.data(),
+                        pointers.size() * sizeof(uint32_t),
+                        cq_offset,
+                        mmio_device_id,
+                        get_umd_channel(channel));
+                }
             }
         }
     }

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -187,7 +187,8 @@ void read_completion_queue(
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(dst, size_bytes, device_id, 0, addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            dst, size_bytes, device_id, sysmem_manager.get_dram_region_channel(), addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -4,7 +4,9 @@
 
 #include "dispatch.hpp"
 #include <cstdint>
+#include "allocator/allocator.hpp"
 #include "context/context_types.hpp"
+#include "device/device_manager.hpp"
 #include "dispatch/device_command.hpp"
 #include "dispatch/device_command_calculator.hpp"
 #include "dispatch/system_memory_manager.hpp"
@@ -187,8 +189,13 @@ void read_completion_queue(
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
+        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(device_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, sysmem_manager.get_dram_region_channel(), addr);
+            dst, size_bytes, device_id, dram_channel, addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -184,12 +184,10 @@ void read_completion_queue(
     uint32_t size_bytes,
     ChipId device_id,
     uint16_t channel,
-    uint32_t cq_id,
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(dst, size_bytes, device_id, 0, addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }
@@ -236,7 +234,6 @@ void read_core_data_from_completion_queue(
             num_bytes_to_copy,
             mmio_device_id,
             channel,
-            cq_id,
             completion_q_read_ptr + completion_queue_read_offset,
             sysmem_manager);
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -179,6 +179,22 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, dispatch_params.cq_id);
 }
 
+void read_completion_queue(
+    void* dst,
+    uint32_t size_bytes,
+    ChipId device_id,
+    uint16_t channel,
+    uint32_t cq_id,
+    uint32_t addr,
+    const SystemMemoryManager& sysmem_manager) {
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            dst, size_bytes, device_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + addr);
+    } else {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
+    }
+}
+
 void read_core_data_from_completion_queue(
     const ReadCoreDataDescriptor& read_descriptor,
     ChipId mmio_device_id,
@@ -215,12 +231,14 @@ void read_core_data_from_completion_queue(
         const uint32_t num_bytes_to_copy = std::min(
             num_bytes_to_read - num_bytes_read, num_bytes_available_in_completion_queue - completion_queue_read_offset);
 
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+        read_completion_queue(
             (char*)(uint64_t(read_descriptor.dst) + num_bytes_read),
             num_bytes_to_copy,
-            completion_q_read_ptr + completion_queue_read_offset,
             mmio_device_id,
-            channel);
+            channel,
+            cq_id,
+            completion_q_read_ptr + completion_queue_read_offset,
+            sysmem_manager);
 
         num_bytes_read += num_bytes_to_copy;
         const uint32_t num_pages_read =

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -68,9 +68,17 @@ void DispatchKernelInitializer::init(
 
     bool is_galaxy_cluster = descriptor_->cluster().is_galaxy_cluster();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
-        CoreType::WORKER, descriptor_->num_cqs(), descriptor_->hal(), is_galaxy_cluster);
+        CoreType::WORKER,
+        descriptor_->num_cqs(),
+        descriptor_->hal(),
+        is_galaxy_cluster,
+        descriptor_->rtoptions().get_dram_backed_cq());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
-        CoreType::ETH, descriptor_->num_cqs(), descriptor_->hal(), is_galaxy_cluster);
+        CoreType::ETH,
+        descriptor_->num_cqs(),
+        descriptor_->hal(),
+        is_galaxy_cluster,
+        descriptor_->rtoptions().get_dram_backed_cq());
 
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "command_queue_common.hpp"
+#include "device/device_manager.hpp"
+#include "dispatch/system_memory_manager.hpp"
 #include "dispatch_settings.hpp"
 
 #include "impl/context/metal_context.hpp"
@@ -25,18 +27,27 @@ uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_siz
 
 template <bool addr_16B>
 uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t recv;
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-    uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     uint32_t issue_q_rd_ptr =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-        &recv,
-        sizeof(uint32_t),
-        issue_q_rd_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
-        mmio_device_id,
-        channel);
+    const SystemMemoryManager& sysmem_manager =
+        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+    uint32_t recv;
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            &recv, sizeof(uint32_t), chip_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + issue_q_rd_ptr);
+    } else {
+        ChipId mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+            &recv,
+            sizeof(uint32_t),
+            issue_q_rd_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
+            mmio_device_id,
+            channel);
+    }
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -48,13 +59,22 @@ template uint32_t get_cq_issue_rd_ptr<false>(ChipId chip_id, uint8_t cq_id, uint
 
 template <bool addr_16B>
 uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t recv;
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
     uint32_t issue_q_wr_ptr =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-        &recv, sizeof(uint32_t), issue_q_wr_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
+    const SystemMemoryManager& sysmem_manager =
+        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+    uint32_t recv;
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            &recv, sizeof(uint32_t), chip_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + issue_q_wr_ptr);
+    } else {
+        ChipId mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+            &recv, sizeof(uint32_t), issue_q_wr_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
+    }
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -66,18 +86,31 @@ template uint32_t get_cq_issue_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint
 
 template <bool addr_16B>
 uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t recv;
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-    uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     uint32_t completion_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_WR);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-        &recv,
-        sizeof(uint32_t),
-        completion_q_wr_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
-        mmio_device_id,
-        channel);
+    const SystemMemoryManager& sysmem_manager =
+        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+    uint32_t recv;
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            &recv,
+            sizeof(uint32_t),
+            chip_id,
+            0,
+            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_wr_ptr);
+    } else {
+        ChipId mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+            &recv,
+            sizeof(uint32_t),
+            completion_q_wr_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
+            mmio_device_id,
+            channel);
+    }
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -89,13 +122,30 @@ template uint32_t get_cq_completion_wr_ptr<false>(ChipId chip_id, uint8_t cq_id,
 
 template <bool addr_16B>
 inline uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t recv;
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
     uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_RD);
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-        &recv, sizeof(uint32_t), completion_q_rd_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
+    const SystemMemoryManager& sysmem_manager =
+        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+    uint32_t recv;
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            &recv,
+            sizeof(uint32_t),
+            chip_id,
+            0,
+            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_rd_ptr);
+    } else {
+        ChipId mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+            &recv,
+            sizeof(uint32_t),
+            completion_q_rd_ptr + get_relative_cq_offset(cq_id, cq_size),
+            mmio_device_id,
+            channel);
+    }
     if constexpr (!addr_16B) {
         return recv << 4;
     }

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -37,7 +37,7 @@ uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
             &recv,
             sizeof(uint32_t),
             chip_id,
-            0,
+            sysmem_manager.get_dram_region_channel(),
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_rd_ptr);
     } else {
         ChipId mmio_device_id =
@@ -73,7 +73,7 @@ uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
             &recv,
             sizeof(uint32_t),
             chip_id,
-            0,
+            sysmem_manager.get_dram_region_channel(),
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_wr_ptr);
     } else {
         ChipId mmio_device_id =
@@ -104,7 +104,7 @@ uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
             &recv,
             sizeof(uint32_t),
             chip_id,
-            0,
+            sysmem_manager.get_dram_region_channel(),
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_wr_ptr);
     } else {
         ChipId mmio_device_id =
@@ -140,7 +140,7 @@ inline uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t
             &recv,
             sizeof(uint32_t),
             chip_id,
-            0,
+            sysmem_manager.get_dram_region_channel(),
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_rd_ptr);
     } else {
         ChipId mmio_device_id =

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "command_queue_common.hpp"
+#include "allocator/allocator.hpp"
 #include "device/device_manager.hpp"
 #include "dispatch/system_memory_manager.hpp"
 #include "dispatch_settings.hpp"
@@ -25,33 +26,48 @@ uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_siz
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }
 
+// Device-written pointers live at an offset within the hugepage that includes the device channel offset, while
+// host-written pointers do not
+template <bool include_device_channel_offset>
+uint32_t read_cq_host_ptr(
+    const SystemMemoryManager& sysmem_manager,
+    ChipId chip_id,
+    uint8_t cq_id,
+    uint32_t cq_size,
+    uint32_t host_addr_offset) {
+    uint32_t recv;
+    if (sysmem_manager.is_dram_backed()) {
+        const uint32_t dram_channel = MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(chip_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        MetalContext::instance().get_cluster().read_dram_vec(
+            &recv,
+            sizeof(uint32_t),
+            chip_id,
+            dram_channel,
+            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + host_addr_offset);
+    } else {
+        ChipId mmio_device_id = MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        uint32_t sysmem_offset = host_addr_offset + get_relative_cq_offset(cq_id, cq_size);
+        if constexpr (include_device_channel_offset) {
+            sysmem_offset += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+        }
+        MetalContext::instance().get_cluster().read_sysmem(
+            &recv, sizeof(uint32_t), sysmem_offset, mmio_device_id, channel);
+    }
+    return recv;
+}
+
 template <bool addr_16B>
 uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t issue_q_rd_ptr =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv;
-    if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv,
-            sizeof(uint32_t),
-            chip_id,
-            sysmem_manager.get_dram_region_channel(),
-            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_rd_ptr);
-    } else {
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-        uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            &recv,
-            sizeof(uint32_t),
-            issue_q_rd_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
-            mmio_device_id,
-            channel);
-    }
+    uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -67,22 +83,7 @@ uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv;
-    if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv,
-            sizeof(uint32_t),
-            chip_id,
-            sysmem_manager.get_dram_region_channel(),
-            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_wr_ptr);
-    } else {
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            &recv, sizeof(uint32_t), issue_q_wr_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
-    }
+    uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -98,27 +99,7 @@ uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
         CommandQueueHostAddrType::COMPLETION_Q_WR);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv;
-    if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv,
-            sizeof(uint32_t),
-            chip_id,
-            sysmem_manager.get_dram_region_channel(),
-            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_wr_ptr);
-    } else {
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-        uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            &recv,
-            sizeof(uint32_t),
-            completion_q_wr_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
-            mmio_device_id,
-            channel);
-    }
+    uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -129,31 +110,12 @@ template uint32_t get_cq_completion_wr_ptr<true>(ChipId chip_id, uint8_t cq_id, 
 template uint32_t get_cq_completion_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-inline uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_RD);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv;
-    if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv,
-            sizeof(uint32_t),
-            chip_id,
-            sysmem_manager.get_dram_region_channel(),
-            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_rd_ptr);
-    } else {
-        ChipId mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            &recv,
-            sizeof(uint32_t),
-            completion_q_rd_ptr + get_relative_cq_offset(cq_id, cq_size),
-            mmio_device_id,
-            channel);
-    }
+    uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
@@ -196,7 +158,10 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
     return progress;
 }
 
-uint32_t calculate_expected_workers_to_finish(const tt::tt_metal::IDevice* device, const SubDeviceId& sub_device_id, tt::tt_metal::HalProgrammableCoreType core_type) {
+uint32_t calculate_expected_workers_to_finish(
+    const tt::tt_metal::IDevice* device,
+    const SubDeviceId& sub_device_id,
+    tt::tt_metal::HalProgrammableCoreType core_type) {
     // Sub Device manager state must be correct (from device init)
     // If core type is active ethernet, it does not include fabric routers which were created using slow dispatch
     // Not managed by fast dispatch

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -20,8 +20,8 @@ uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id 
 
 uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
 
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size) {
-    return (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
+uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t base) {
+    return base + (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }
 
@@ -34,7 +34,11 @@ uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
     if (sysmem_manager.is_dram_backed()) {
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv, sizeof(uint32_t), chip_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + issue_q_rd_ptr);
+            &recv,
+            sizeof(uint32_t),
+            chip_id,
+            0,
+            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_rd_ptr);
     } else {
         ChipId mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
@@ -66,7 +70,11 @@ uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
     if (sysmem_manager.is_dram_backed()) {
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            &recv, sizeof(uint32_t), chip_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + issue_q_wr_ptr);
+            &recv,
+            sizeof(uint32_t),
+            chip_id,
+            0,
+            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + issue_q_wr_ptr);
     } else {
         ChipId mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
@@ -97,7 +105,7 @@ uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
             sizeof(uint32_t),
             chip_id,
             0,
-            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_wr_ptr);
+            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_wr_ptr);
     } else {
         ChipId mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
@@ -133,7 +141,7 @@ inline uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t
             sizeof(uint32_t),
             chip_id,
             0,
-            sysmem_manager.get_dram_region_start_addr(cq_id) + completion_q_rd_ptr);
+            sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + completion_q_rd_ptr);
     } else {
         ChipId mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -56,7 +56,7 @@ uint16_t get_umd_channel(uint16_t channel);
 /// @param cq_id uint8_t ID the command queue
 /// @param cq_size uint32_t size of the command queue
 /// @return uint32_t absolute offset
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t base = 0);
 
 // mostly used in debug_tools
 template <bool addr_16B>

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -15,7 +15,9 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include "allocator/allocator.hpp"
 #include "command_queue_common.hpp"
+#include "device/device_manager.hpp"
 #include "dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include "host_api.hpp"
@@ -51,7 +53,12 @@ void read_cq_memory_for_dump(
     const SystemMemoryManager& sysmem_manager) {
     auto& cluster = MetalContext::instance().get_cluster();
     if (sysmem_manager.is_dram_backed()) {
-        cluster.read_dram_vec(dst, size_bytes, mmio_device_id, 0, byte_addr);
+        const uint32_t dram_channel = MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(mmio_device_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        cluster.read_dram_vec(dst, size_bytes, mmio_device_id, dram_channel, byte_addr);
     } else {
         cluster.read_sysmem(dst, size_bytes, byte_addr, mmio_device_id, channel);
     }

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -42,6 +42,21 @@ T val(T v) {
 }
 }  // namespace
 
+void read_cq_memory_for_dump(
+    void* dst,
+    uint32_t size_bytes,
+    uint64_t byte_addr,
+    ChipId mmio_device_id,
+    uint16_t channel,
+    const SystemMemoryManager& sysmem_manager) {
+    auto& cluster = MetalContext::instance().get_cluster();
+    if (sysmem_manager.is_dram_backed()) {
+        cluster.read_dram_vec(dst, size_bytes, mmio_device_id, 0, byte_addr);
+    } else {
+        cluster.read_sysmem(dst, size_bytes, byte_addr, mmio_device_id, channel);
+    }
+}
+
 void match_device_program_data_with_host_program_data(const char* host_file, const char* device_file) {
     std::ifstream host_dispatch_dump_file;
     std::ifstream device_dispatch_dump_file;
@@ -360,8 +375,7 @@ void dump_completion_queue_entries(
     print_progress_bar(0.0, true);
     for (uint32_t page_offset = 0; page_offset < completion_q_bytes;) {  // page_offset increment at end of loop
         uint32_t page_addr = base_addr + page_offset;
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            read_data.data(), read_data.size(), page_addr, mmio_device_id, channel);
+        read_cq_memory_for_dump(read_data.data(), read_data.size(), page_addr, mmio_device_id, channel, sysmem_manager);
 
         // Check if this page starts with a valid command id
         CQDispatchCmd* cmd = (CQDispatchCmd*)read_data.data();
@@ -457,8 +471,8 @@ void dump_issue_queue_entries(
     uint32_t first_page_addr = issue_q_base_addr - (issue_q_base_addr % DispatchSettings::TRANSFER_PAGE_SIZE);
     uint32_t end_of_curr_page =
         first_page_addr + DispatchSettings::TRANSFER_PAGE_SIZE - 1;  // To track offset of latest page read out
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-        read_data.data(), read_data.size(), first_page_addr, mmio_device_id, channel);
+    read_cq_memory_for_dump(
+        read_data.data(), read_data.size(), first_page_addr, mmio_device_id, channel, sysmem_manager);
     const auto& hal = MetalContext::instance().hal();
     for (uint32_t offset = 0; offset < issue_q_bytes;) {  // offset increments at end of loop
         uint32_t curr_addr = issue_q_base_addr + offset;
@@ -467,8 +481,8 @@ void dump_issue_queue_entries(
         // Check if we need to read a new page
         if (curr_addr > end_of_curr_page) {
             uint32_t page_base = curr_addr - (curr_addr % DispatchSettings::TRANSFER_PAGE_SIZE);
-            tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                read_data.data(), read_data.size(), page_base, mmio_device_id, channel);
+            read_cq_memory_for_dump(
+                read_data.data(), read_data.size(), page_base, mmio_device_id, channel, sysmem_manager);
             end_of_curr_page = page_base + DispatchSettings::TRANSFER_PAGE_SIZE - 1;
         }
 
@@ -524,8 +538,8 @@ void dump_issue_queue_entries(
                     if (dispatch_curr_addr > end_of_curr_page) {
                         uint32_t page_base =
                             dispatch_curr_addr - (dispatch_curr_addr % DispatchSettings::TRANSFER_PAGE_SIZE);
-                        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-                            read_data.data(), read_data.size(), page_base, mmio_device_id, channel);
+                        read_cq_memory_for_dump(
+                            read_data.data(), read_data.size(), page_base, mmio_device_id, channel, sysmem_manager);
                         end_of_curr_page = page_base + DispatchSettings::TRANSFER_PAGE_SIZE - 1;
                     }
 
@@ -628,8 +642,7 @@ void dump_command_queue_raw_data(
         print_progress_bar(((float)page_offset / bytes_to_read) + 0.005);
 
         // Print in 16B per line
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
-            read_data.data(), read_data.size(), page_addr, mmio_device_id, channel);
+        read_cq_memory_for_dump(read_data.data(), read_data.size(), page_addr, mmio_device_id, channel, sysmem_manager);
         TT_ASSERT(read_data.size() % 16 == 0);
         for (uint32_t line_offset = 0; line_offset < read_data.size(); line_offset += 16) {
             uint32_t line_addr = page_addr + line_offset;

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -15,8 +15,10 @@
 
 namespace tt::tt_metal {
 
-DispatchMemMap::DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster) :
-    settings(DispatchSettings(num_hw_cqs, core_type, is_galaxy_cluster, hal.get_alignment(HalMemType::L1))),
+DispatchMemMap::DispatchMemMap(
+    const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster, bool are_cqs_dram_backed) :
+    settings(DispatchSettings(
+        num_hw_cqs, core_type, is_galaxy_cluster, are_cqs_dram_backed, hal.get_alignment(HalMemType::L1))),
     host_alignment_(hal.get_alignment(HalMemType::HOST)),
     l1_alignment_(hal.get_alignment(HalMemType::L1)),
     noc_overlay_start_addr_(hal.get_noc_overlay_start_addr()),

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -31,7 +31,12 @@ public:
     DispatchMemMap(const DispatchMemMap&) = delete;
     DispatchMemMap(DispatchMemMap&& other) noexcept = delete;
     // Create a DispatchMemMap
-    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster);
+    DispatchMemMap(
+        const CoreType& core_type,
+        uint32_t num_hw_cqs,
+        const Hal& hal,
+        bool is_galaxy_cluster,
+        bool are_cqs_dram_backed);
 
     uint32_t prefetch_q_entries() const;
 

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -25,7 +25,11 @@ class Hal;
 class DispatchSettings {
 public:
     explicit DispatchSettings(
-        uint32_t num_hw_cqs, const CoreType& core_type, bool is_galaxy_cluster, uint32_t l1_alignment);
+        uint32_t num_hw_cqs,
+        const CoreType& core_type,
+        bool is_galaxy_cluster,
+        bool are_cqs_dram_backed,
+        uint32_t l1_alignment);
 
     bool operator==(const DispatchSettings& other) const;
 
@@ -157,7 +161,8 @@ public:
     CoreType core_type_{0};  // Which core this settings is for
 
 private:
-    void init_worker_defaults(uint32_t num_hw_cqs, bool is_galaxy_cluster, uint32_t l1_alignment);
+    void init_worker_defaults(
+        uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment);
     void init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment);
 };
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -102,9 +102,11 @@ void DispatchKernel::GenerateStaticConfigs() {
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
-                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
-                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr =
+            device_->sysmem_manager().is_dram_backed()
+                ? get_absolute_cq_offset(
+                      channel, cq_id_, cq_size, device_->sysmem_manager().get_dram_region_base_addr())
+                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
@@ -153,9 +155,11 @@ void DispatchKernel::GenerateStaticConfigs() {
         channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
-                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
-                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr =
+            device_->sysmem_manager().is_dram_backed()
+                ? get_absolute_cq_offset(
+                      channel, cq_id_, cq_size, device_->sysmem_manager().get_dram_region_base_addr())
+                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
@@ -555,8 +559,9 @@ void DispatchKernel::CreateKernel() {
     if (device_->sysmem_manager().is_dram_backed()) {
         const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
         CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
-        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_core.x);
-        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_core.y);
+        auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
+        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
+        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
     }
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -557,13 +557,9 @@ void DispatchKernel::CreateKernel() {
             defines["FABRIC_2D"] = "1";
         }
     }
-    // if (device_->sysmem_manager().is_dram_backed()) {
-    //     const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
-    //     CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
-    //     auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
-    //     defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
-    //     defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
-    // }
+    if (device_->sysmem_manager().is_dram_backed()) {
+        defines["DRAM_BACKED_CQ_BANK_ID"] = std::to_string(device_->sysmem_manager().get_dram_region_bank_id());
+    }
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));
     defines["OFFSETOF_TO_DEV_ID"] = std::to_string(static_config_.offsetof_to_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -102,7 +102,9 @@ void DispatchKernel::GenerateStaticConfigs() {
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
+                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
+                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
@@ -151,7 +153,9 @@ void DispatchKernel::GenerateStaticConfigs() {
         channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
+                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
+                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
@@ -475,6 +479,7 @@ void DispatchKernel::CreateKernel() {
         {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dependent_config_.upstream_dispatch_cb_sem_id.value())},
         {"DISPATCH_CB_BLOCKS", std::to_string(static_config_.dispatch_cb_blocks.value())},
         {"UPSTREAM_SYNC_SEM", std::to_string(dependent_config_.upstream_sync_sem.value())},
+        {"IS_CQ_DRAM_BACKED", std::to_string(device_->sysmem_manager().is_dram_backed())},
         {"COMMAND_QUEUE_BASE_ADDR", std::to_string(static_config_.command_queue_base_addr.value())},
         {"COMPLETION_QUEUE_BASE_ADDR", std::to_string(static_config_.completion_queue_base_addr.value())},
         {"COMPLETION_QUEUE_SIZE", std::to_string(static_config_.completion_queue_size.value())},
@@ -546,6 +551,12 @@ void DispatchKernel::CreateKernel() {
         if (static_config_.is_2d_fabric.value_or(false)) {
             defines["FABRIC_2D"] = "1";
         }
+    }
+    if (device_->sysmem_manager().is_dram_backed()) {
+        const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
+        CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
+        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_core.x);
+        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_core.y);
     }
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -465,8 +465,6 @@ void DispatchKernel::CreateKernel() {
     auto downstream_s_virtual_noc_coords =
         device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_s_virtual_core);
 
-    log_info(tt::LogMetal, "completion queue base addr: {}", static_config_.completion_queue_base_addr.value());
-
     std::map<std::string, std::string> defines = {
         {"MY_NOC_X", std::to_string(my_virtual_noc_coords.x)},
         {"MY_NOC_Y", std::to_string(my_virtual_noc_coords.y)},

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -5,6 +5,7 @@
 #include "dispatch.hpp"
 
 #include <host_api.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
 #include <map>
 #include <string>
@@ -464,6 +465,8 @@ void DispatchKernel::CreateKernel() {
     auto downstream_s_virtual_noc_coords =
         device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_s_virtual_core);
 
+    log_info(tt::LogMetal, "completion queue base addr: {}", static_config_.completion_queue_base_addr.value());
+
     std::map<std::string, std::string> defines = {
         {"MY_NOC_X", std::to_string(my_virtual_noc_coords.x)},
         {"MY_NOC_Y", std::to_string(my_virtual_noc_coords.y)},
@@ -556,13 +559,13 @@ void DispatchKernel::CreateKernel() {
             defines["FABRIC_2D"] = "1";
         }
     }
-    if (device_->sysmem_manager().is_dram_backed()) {
-        const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
-        CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
-        auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
-        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
-        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
-    }
+    // if (device_->sysmem_manager().is_dram_backed()) {
+    //     const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
+    //     CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
+    //     auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
+    //     defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
+    //     defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
+    // }
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));
     defines["OFFSETOF_TO_DEV_ID"] = std::to_string(static_config_.offsetof_to_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -118,9 +118,17 @@ public:
         get_reads_dispatch_cores_(get_reads_dispatch_cores) {
         bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
         dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
-            CoreType::WORKER, descriptor.num_cqs(), descriptor.hal(), is_galaxy_cluster);
+            CoreType::WORKER,
+            descriptor.num_cqs(),
+            descriptor.hal(),
+            is_galaxy_cluster,
+            descriptor.rtoptions().get_dram_backed_cq());
         dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
-            CoreType::ETH, descriptor.num_cqs(), descriptor.hal(), is_galaxy_cluster);
+            CoreType::ETH,
+            descriptor.num_cqs(),
+            descriptor.hal(),
+            is_galaxy_cluster,
+            descriptor.rtoptions().get_dram_backed_cq());
     }
     virtual ~FDKernel() = default;
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -585,8 +585,12 @@ void PrefetchKernel::ConfigureCore() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
         uint32_t prefetch_q_pcie_rd_ptr =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_PCIE_RD);
-        std::vector<uint32_t> prefetch_q_pcie_rd_ptr_addr_data = {
-            get_absolute_cq_offset(channel, cq_id_, cq_size) + cq_start};
+        const uint32_t command_queue_start_addr =
+            device_->sysmem_manager().is_dram_backed()
+                ? get_absolute_cq_offset(
+                      channel, cq_id_, cq_size, device_->sysmem_manager().get_dram_region_base_addr())
+                : get_absolute_cq_offset(channel, cq_id_, cq_size);
+        std::vector<uint32_t> prefetch_q_pcie_rd_ptr_addr_data = {command_queue_start_addr + cq_start};
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_rd_ptr, prefetch_q_rd_ptr_addr_data, GetCoreType());
         detail::WriteToDeviceL1(
             device_, logical_core_, prefetch_q_pcie_rd_ptr, prefetch_q_pcie_rd_ptr_addr_data, GetCoreType());

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -99,7 +99,9 @@ void PrefetchKernel::GenerateStaticConfigs() {
         bool is_mock = descriptor_.cluster().get_target_device_type() == tt::TargetDevice::Mock;
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = is_mock ? 0x10000 : device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
+                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
+                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = is_mock ? 0x10000 : device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -155,7 +157,9 @@ void PrefetchKernel::GenerateStaticConfigs() {
         channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
+                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
+                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -467,6 +471,7 @@ void PrefetchKernel::CreateKernel() {
         {"DOWNSTREAM_CB_PAGES", std::to_string(dependent_config_.downstream_cb_pages.value())},
         {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(static_config_.my_downstream_cb_sem_id.value())},
         {"DOWNSTREAM_CB_SEM_ID", std::to_string(dependent_config_.downstream_cb_sem_id.value())},
+        {"IS_CQ_DRAM_BACKED", std::to_string(device_->sysmem_manager().is_dram_backed())},
         {"PCIE_BASE", std::to_string(static_config_.pcie_base.value())},
         {"PCIE_SIZE", std::to_string(static_config_.pcie_size.value())},
         {"PREFETCH_Q_BASE", std::to_string(static_config_.prefetch_q_base.value())},

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -99,9 +99,11 @@ void PrefetchKernel::GenerateStaticConfigs() {
         bool is_mock = descriptor_.cluster().get_target_device_type() == tt::TargetDevice::Mock;
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = is_mock ? 0x10000 : device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
-                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
-                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr =
+            device_->sysmem_manager().is_dram_backed()
+                ? get_absolute_cq_offset(
+                      channel, cq_id_, cq_size, device_->sysmem_manager().get_dram_region_base_addr())
+                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = is_mock ? 0x10000 : device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -157,9 +159,11 @@ void PrefetchKernel::GenerateStaticConfigs() {
         channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = device_->sysmem_manager().is_dram_backed()
-                                                ? device_->sysmem_manager().get_dram_region_start_addr(cq_id_)
-                                                : get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr =
+            device_->sysmem_manager().is_dram_backed()
+                ? get_absolute_cq_offset(
+                      channel, cq_id_, cq_size, device_->sysmem_manager().get_dram_region_base_addr())
+                : get_absolute_cq_offset(channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -539,6 +543,14 @@ void PrefetchKernel::CreateKernel() {
         if (static_config_.is_2d_fabric.value_or(false)) {
             defines["FABRIC_2D"] = "1";
         }
+    }
+
+    if (device_->sysmem_manager().is_dram_backed()) {
+        const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
+        CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
+        auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
+        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
+        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
     }
 
     // Runtime args offsets

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -545,13 +545,13 @@ void PrefetchKernel::CreateKernel() {
         }
     }
 
-    if (device_->sysmem_manager().is_dram_backed()) {
-        const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
-        CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
-        auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
-        defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
-        defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
-    }
+    // if (device_->sysmem_manager().is_dram_backed()) {
+    //     const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
+    //     CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
+    //     auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
+    //     defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
+    //     defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
+    // }
 
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -545,13 +545,9 @@ void PrefetchKernel::CreateKernel() {
         }
     }
 
-    // if (device_->sysmem_manager().is_dram_backed()) {
-    //     const auto& soc_descriptor = descriptor_.cluster().get_soc_desc(device_id_);
-    //     CoreCoord dram_core = soc_descriptor.get_preferred_worker_core_for_dram_view(0, tt_metal::NOC::NOC_0);
-    //     auto dram_noc_coords = device_->virtual_noc0_coordinate(0, dram_core);
-    //     defines["CQ_DRAM_NOC_X"] = std::to_string(dram_noc_coords.x);
-    //     defines["CQ_DRAM_NOC_Y"] = std::to_string(dram_noc_coords.y);
-    // }
+    if (device_->sysmem_manager().is_dram_backed()) {
+        defines["DRAM_BACKED_CQ_BANK_ID"] = std::to_string(device_->sysmem_manager().get_dram_region_bank_id());
+    }
 
     // Runtime args offsets
     defines["OFFSETOF_MY_DEV_ID"] = std::to_string(static_config_.offsetof_my_dev_id.value_or(0));

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -104,8 +104,7 @@ constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBOR
 constexpr uint8_t my_noc_index = NOC_INDEX;
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-constexpr uint64_t pcie_noc_xy =
-    uint64_t(NOC_XY_ENCODING(NOC_X_PHYS_COORD(CQ_DRAM_NOC_X), NOC_Y_PHYS_COORD(CQ_DRAM_NOC_Y))) << NOC_ADDR_LOCAL_BITS;
+constexpr uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
 #else
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -103,9 +103,7 @@ constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X
 constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
 constexpr uint8_t my_noc_index = NOC_INDEX;
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
-#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-constexpr uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
-#else
+#if !defined(IS_CQ_DRAM_BACKED) || IS_CQ_DRAM_BACKED == 0
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
 #endif
@@ -262,7 +260,13 @@ void notify_host_of_completion_queue_write_pointer() {
     volatile tt_l1_ptr uint32_t* completion_wr_ptr_addr = get_cq_completion_write_ptr();
     completion_wr_ptr_addr[0] = completion_wr_ptr_and_toggle;
 #if defined(FABRIC_RELAY)
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+#endif
+    DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
+           << " completion_queue_write_ptr_addr=" << completion_queue_write_ptr_addr << ENDL();
     noc_async_write(dev_completion_q_wr_ptr, pcie_noc_xy | completion_queue_write_ptr_addr, 4);
+    DPRINT << "noc_async_write done" << ENDL();
 #else
     cq_noc_async_write_with_state<CQ_NOC_SnDL>(dev_completion_q_wr_ptr, completion_queue_write_ptr_addr, 4);
 #endif
@@ -296,7 +300,12 @@ void process_write_host_h() {
     // DPRINT << "process_write_host_h: " << length << ENDL();
     uint32_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+#endif
+    DPRINT << "cq_dispatch: cq_noc_async_write_init_state: pcie_noc_xy=" << pcie_noc_xy << ENDL();
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
+    DPRINT << "cq_dispatch: cq_noc_async_write_init_state done" << ENDL();
 #endif
     constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     if (is_event) {
@@ -318,7 +327,14 @@ void process_write_host_h() {
             if (completion_queue_write_addr + xfer_size > completion_queue_end_addr) {
                 uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
 #if defined(FABRIC_RELAY)
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+                uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+#endif
+                DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
+                       << " completion_queue_write_addr=" << completion_queue_write_addr
+                       << " last_chunk_size=" << last_chunk_size << ENDL();
                 noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
+                DPRINT << "cq_dispatch: noc_async_write done" << ENDL();
 #else
                 cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
                 uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
@@ -331,7 +347,14 @@ void process_write_host_h() {
                 xfer_size -= last_chunk_size;
             }
 #if defined(FABRIC_RELAY)
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+            uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+#endif
+            DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
+                   << " completion_queue_write_addr=" << completion_queue_write_addr << " xfer_size=" << xfer_size
+                   << ENDL();
             noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
+            DPRINT << "noc_async_write done" << ENDL();
 #else
             cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
             // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -263,10 +263,7 @@ void notify_host_of_completion_queue_write_pointer() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
     uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-    DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
-           << " completion_queue_write_ptr_addr=" << completion_queue_write_ptr_addr << ENDL();
     noc_async_write(dev_completion_q_wr_ptr, pcie_noc_xy | completion_queue_write_ptr_addr, 4);
-    DPRINT << "noc_async_write done" << ENDL();
 #else
     cq_noc_async_write_with_state<CQ_NOC_SnDL>(dev_completion_q_wr_ptr, completion_queue_write_ptr_addr, 4);
 #endif
@@ -303,9 +300,7 @@ void process_write_host_h() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
     uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-    DPRINT << "cq_dispatch: cq_noc_async_write_init_state: pcie_noc_xy=" << pcie_noc_xy << ENDL();
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
-    DPRINT << "cq_dispatch: cq_noc_async_write_init_state done" << ENDL();
 #endif
     constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     if (is_event) {
@@ -330,11 +325,7 @@ void process_write_host_h() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
                 uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-                DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
-                       << " completion_queue_write_addr=" << completion_queue_write_addr
-                       << " last_chunk_size=" << last_chunk_size << ENDL();
                 noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
-                DPRINT << "cq_dispatch: noc_async_write done" << ENDL();
 #else
                 cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, last_chunk_size);
                 uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
@@ -350,11 +341,7 @@ void process_write_host_h() {
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
             uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-            DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
-                   << " completion_queue_write_addr=" << completion_queue_write_addr << " xfer_size=" << xfer_size
-                   << ENDL();
             noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
-            DPRINT << "noc_async_write done" << ENDL();
 #else
             cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
             // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -261,7 +261,7 @@ void notify_host_of_completion_queue_write_pointer() {
     completion_wr_ptr_addr[0] = completion_wr_ptr_and_toggle;
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
     DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
            << " completion_queue_write_ptr_addr=" << completion_queue_write_ptr_addr << ENDL();
@@ -301,7 +301,7 @@ void process_write_host_h() {
     uint32_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
     DPRINT << "cq_dispatch: cq_noc_async_write_init_state: pcie_noc_xy=" << pcie_noc_xy << ENDL();
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
@@ -328,7 +328,7 @@ void process_write_host_h() {
                 uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-                uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+                uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
                 DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
                        << " completion_queue_write_addr=" << completion_queue_write_addr
@@ -348,7 +348,7 @@ void process_write_host_h() {
             }
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-            uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+            uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
             DPRINT << "cq_dispatch: noc_async_write: pcie_noc_xy=" << pcie_noc_xy
                    << " completion_queue_write_addr=" << completion_queue_write_addr << " xfer_size=" << xfer_size

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -103,8 +103,13 @@ constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X
 constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
 constexpr uint8_t my_noc_index = NOC_INDEX;
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+constexpr uint64_t pcie_noc_xy =
+    uint64_t(NOC_XY_ENCODING(NOC_X_PHYS_COORD(CQ_DRAM_NOC_X), NOC_Y_PHYS_COORD(CQ_DRAM_NOC_Y))) << NOC_ADDR_LOCAL_BITS;
+#else
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
+#endif
 constexpr uint32_t dispatch_cb_page_size = 1 << dispatch_cb_log_page_size;
 
 constexpr uint32_t completion_queue_end_addr = completion_queue_base_addr + completion_queue_size;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -41,6 +41,8 @@ union CQPrefetchHToPrefetchDHeader {
 };
 static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
 
+#define ENABLE_PREFETCH_DPRINTS 0
+
 using prefetch_q_entry_type = uint16_t;
 
 // Use named defines instead of get_compile_time_arg_val indices
@@ -143,9 +145,7 @@ constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UP
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
 constexpr uint32_t dispatch_s_noc_xy =
     uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
-#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-constexpr uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
-#else
+#if !defined(IS_CQ_DRAM_BACKED) || IS_CQ_DRAM_BACKED == 0
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
 #endif
@@ -380,6 +380,11 @@ FORCE_INLINE uint32_t read_from_pcie(
 #endif
         pcie_read_ptr = pcie_base;
     }
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+    DPRINT << "cq_prefetch: pcie_noc_xy=" << pcie_noc_xy << ENDL();
+    DPRINT << "cq_prefetch: pcie_read_ptr=" << pcie_read_ptr << ENDL();
+#endif
 
     const uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
     const uint32_t dst_addr = fence + preamble_size;
@@ -391,6 +396,7 @@ FORCE_INLINE uint32_t read_from_pcie(
     DPRINT << "cq_prefetch: noc_async_read: host_src_addr=" << host_src_addr << " dst_addr=" << dst_addr
            << " size=" << size << ENDL();
     noc_async_read(host_src_addr, dst_addr, size);
+    DPRINT << "noc_async_read done" << ENDL();
     // Avoid leaking this trid to unrelated reads.
     noc_async_read_set_trid(0U);
     pending_read_size = needed_bytes;
@@ -526,6 +532,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
 
         // Local helper for reading the current prefetch_q entry.
         uint32_t prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
+        DPRINT << "fetch_q_get_cmds: prefetch_q_rd_ptr_local=" << prefetch_q_rd_ptr_local << ENDL();
         uint32_t fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
         bool stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0U;
 
@@ -1568,6 +1575,8 @@ uint32_t process_exec_buf_cmd(
     exec_buf_state.prefetch_length = 0;
     uint32_t cmd_ptr = cmddat_q_base;
 
+    DPRINT << "process_exec_buf_cmd: start" << ENDL();
+
     bool done = false;
     while (!done) {
         paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
@@ -1998,13 +2007,13 @@ bool process_cmd(
             break;
 
         default:
-            //  DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " " <<
-            //                           cmddat_q_base << ENDL();
-            //  DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
-            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
-            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
-            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
-            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+4) << ENDL();
+            DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " "
+                   << cmddat_q_base << ENDL();
+            DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
+            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
+            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 2) << ENDL();
+            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 3) << ENDL();
+            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 4) << ENDL();
             WAYPOINT("!CMD");
             ASSERT(0);
     }
@@ -2398,6 +2407,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
 }
 
 void kernel_main_h() {
+    DPRINT << "kernel_main_h: start" << ENDL();
     uint32_t cmd_ptr = cmddat_q_base;
     uint32_t fence = cmddat_q_base;
     bool done = false;
@@ -2544,6 +2554,8 @@ void kernel_main_hd() {
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
+
+    DPRINT << "kernel_main_hd: start" << ENDL();
 
     while (!done) {
         DeviceZoneScopedN("CQ-PREFETCH");

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -144,8 +144,7 @@ constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X
 constexpr uint32_t dispatch_s_noc_xy =
     uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-constexpr uint64_t pcie_noc_xy =
-    uint64_t(NOC_XY_ENCODING(NOC_X_PHYS_COORD(CQ_DRAM_NOC_X), NOC_Y_PHYS_COORD(CQ_DRAM_NOC_Y))) << NOC_ADDR_LOCAL_BITS;
+constexpr uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
 #else
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
@@ -389,6 +388,8 @@ FORCE_INLINE uint32_t read_from_pcie(
            << " dst_addr=" << dst_addr << " size=" << size << ENDL();
 #endif
     noc_async_read_set_trid(trid);
+    DPRINT << "cq_prefetch: noc_async_read: host_src_addr=" << host_src_addr << " dst_addr=" << dst_addr
+           << " size=" << size << ENDL();
     noc_async_read(host_src_addr, dst_addr, size);
     // Avoid leaking this trid to unrelated reads.
     noc_async_read_set_trid(0U);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -381,7 +381,7 @@ FORCE_INLINE uint32_t read_from_pcie(
         pcie_read_ptr = pcie_base;
     }
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(0, 0);
+    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
     DPRINT << "cq_prefetch: pcie_noc_xy=" << pcie_noc_xy << ENDL();
     DPRINT << "cq_prefetch: pcie_read_ptr=" << pcie_read_ptr << ENDL();
 #endif

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -41,8 +41,6 @@ union CQPrefetchHToPrefetchDHeader {
 };
 static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
 
-#define ENABLE_PREFETCH_DPRINTS 0
-
 using prefetch_q_entry_type = uint16_t;
 
 // Use named defines instead of get_compile_time_arg_val indices
@@ -382,8 +380,6 @@ FORCE_INLINE uint32_t read_from_pcie(
     }
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
     uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
-    DPRINT << "cq_prefetch: pcie_noc_xy=" << pcie_noc_xy << ENDL();
-    DPRINT << "cq_prefetch: pcie_read_ptr=" << pcie_read_ptr << ENDL();
 #endif
 
     const uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
@@ -393,10 +389,7 @@ FORCE_INLINE uint32_t read_from_pcie(
            << " dst_addr=" << dst_addr << " size=" << size << ENDL();
 #endif
     noc_async_read_set_trid(trid);
-    DPRINT << "cq_prefetch: noc_async_read: host_src_addr=" << host_src_addr << " dst_addr=" << dst_addr
-           << " size=" << size << ENDL();
     noc_async_read(host_src_addr, dst_addr, size);
-    DPRINT << "noc_async_read done" << ENDL();
     // Avoid leaking this trid to unrelated reads.
     noc_async_read_set_trid(0U);
     pending_read_size = needed_bytes;
@@ -532,7 +525,6 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
 
         // Local helper for reading the current prefetch_q entry.
         uint32_t prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
-        DPRINT << "fetch_q_get_cmds: prefetch_q_rd_ptr_local=" << prefetch_q_rd_ptr_local << ENDL();
         uint32_t fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
         bool stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0U;
 
@@ -1575,8 +1567,6 @@ uint32_t process_exec_buf_cmd(
     exec_buf_state.prefetch_length = 0;
     uint32_t cmd_ptr = cmddat_q_base;
 
-    DPRINT << "process_exec_buf_cmd: start" << ENDL();
-
     bool done = false;
     while (!done) {
         paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
@@ -2007,13 +1997,13 @@ bool process_cmd(
             break;
 
         default:
-            DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " "
-                   << cmddat_q_base << ENDL();
-            DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 2) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 3) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 4) << ENDL();
+            // DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " "
+            //        << cmddat_q_base << ENDL();
+            // DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
+            // DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
+            // DPRINT << HEX() << *((uint32_t*)cmd_ptr + 2) << ENDL();
+            // DPRINT << HEX() << *((uint32_t*)cmd_ptr + 3) << ENDL();
+            // DPRINT << HEX() << *((uint32_t*)cmd_ptr + 4) << ENDL();
             WAYPOINT("!CMD");
             ASSERT(0);
     }
@@ -2407,7 +2397,6 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
 }
 
 void kernel_main_h() {
-    DPRINT << "kernel_main_h: start" << ENDL();
     uint32_t cmd_ptr = cmddat_q_base;
     uint32_t fence = cmddat_q_base;
     bool done = false;
@@ -2554,8 +2543,6 @@ void kernel_main_hd() {
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
-
-    DPRINT << "kernel_main_hd: start" << ENDL();
 
     while (!done) {
         DeviceZoneScopedN("CQ-PREFETCH");

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -143,8 +143,13 @@ constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UP
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
 constexpr uint32_t dispatch_s_noc_xy =
     uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+constexpr uint64_t pcie_noc_xy =
+    uint64_t(NOC_XY_ENCODING(NOC_X_PHYS_COORD(CQ_DRAM_NOC_X), NOC_Y_PHYS_COORD(CQ_DRAM_NOC_Y))) << NOC_ADDR_LOCAL_BITS;
+#else
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
+#endif
 constexpr uint32_t downstream_cb_page_size = 1 << downstream_cb_log_page_size;
 constexpr uint32_t dispatch_s_cb_page_size = 1 << dispatch_s_cb_log_page_size;
 constexpr uint32_t downstream_cb_end = downstream_cb_base + (1 << downstream_cb_log_page_size) * downstream_cb_pages;

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -11,7 +11,7 @@
 namespace tt::tt_metal {
 
 SystemMemoryCQInterface::SystemMemoryCQInterface(
-    uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment) :
+    uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment, uint32_t base) :
     cq_start(cq_start),
     command_completion_region_size(
         (((cq_size - cq_start) / DispatchSettings::TRANSFER_PAGE_SIZE) / 4) * DispatchSettings::TRANSFER_PAGE_SIZE),
@@ -19,8 +19,8 @@ SystemMemoryCQInterface::SystemMemoryCQInterface(
     id(cq_id),
     issue_fifo_size(command_issue_region_size >> 4),
     issue_fifo_limit(
-        ((cq_start + this->command_issue_region_size) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4),
-    offset(get_absolute_cq_offset(channel, cq_id, cq_size)),
+        ((cq_start + this->command_issue_region_size) + get_absolute_cq_offset(channel, cq_id, cq_size, base)) >> 4),
+    offset(get_absolute_cq_offset(channel, cq_id, cq_size, base)),
     completion_fifo_size(command_completion_region_size >> 4),
     completion_fifo_limit(issue_fifo_limit + completion_fifo_size) {
     TT_ASSERT(

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -11,7 +11,7 @@
 namespace tt::tt_metal {
 
 SystemMemoryCQInterface::SystemMemoryCQInterface(
-    uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment, uint32_t base) :
+    uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t alignment, uint32_t base) :
     cq_start(cq_start),
     command_completion_region_size(
         (((cq_size - cq_start) / DispatchSettings::TRANSFER_PAGE_SIZE) / 4) * DispatchSettings::TRANSFER_PAGE_SIZE),
@@ -24,10 +24,9 @@ SystemMemoryCQInterface::SystemMemoryCQInterface(
     completion_fifo_size(command_completion_region_size >> 4),
     completion_fifo_limit(issue_fifo_limit + completion_fifo_size) {
     TT_ASSERT(
-        this->command_completion_region_size % host_alignment == 0 and
-            this->command_issue_region_size % host_alignment == 0,
+        this->command_completion_region_size % alignment == 0 and this->command_issue_region_size % alignment == 0,
         "Issue queue and completion queue need to be {}B aligned!",
-        host_alignment);
+        alignment);
     TT_ASSERT(this->issue_fifo_limit != 0, "Cannot have a 0 fifo limit");
     // Currently read / write pointers on host and device assumes contiguous ranges for each channel
     // Device needs absolute offset of a hugepage to access the region of sysmem that holds a particular command

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
@@ -15,7 +15,12 @@ struct SystemMemoryCQInterface {
     // completion region Equation for issue fifo size is | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
     SystemMemoryCQInterface(
-        uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t host_alignment);
+        uint16_t channel,
+        uint8_t cq_id,
+        uint32_t cq_size,
+        uint32_t cq_start,
+        uint32_t host_alignment,
+        uint32_t base = 0);
 
     // Percentage of the command queue that is dedicated for issuing commands. Issue queue size is rounded to be 32B
     // aligned and remaining space is dedicated for completion queue Smaller issue queues can lead to more stalls for

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
@@ -15,12 +15,7 @@ struct SystemMemoryCQInterface {
     // completion region Equation for issue fifo size is | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
     SystemMemoryCQInterface(
-        uint16_t channel,
-        uint8_t cq_id,
-        uint32_t cq_size,
-        uint32_t cq_start,
-        uint32_t host_alignment,
-        uint32_t base = 0);
+        uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start, uint32_t alignment, uint32_t base = 0);
 
     // Percentage of the command queue that is dedicated for issuing commands. Issue queue size is rounded to be 32B
     // aligned and remaining space is dedicated for completion queue Smaller issue queues can lead to more stalls for

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -394,6 +394,7 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
     if (this->bypass_enable) {
         return this->bypass_buffer_write_offset;
     }
+    log_info(tt::LogMetal, "issue_queue_write_ptr: {}", this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4);
     return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
 }
 
@@ -401,6 +402,7 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
     if (is_mock_device()) {
         return 0;
     }
+    log_info(tt::LogMetal, "completion_queue_read_ptr: {}", this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4);
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
@@ -533,7 +535,7 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 
     if (use_dram_for_cq_storage()) {
         MetalContext::instance().get_cluster().write_dram_vec(
-            this->cq_sysmem_start + cq_interface.offset + cq_interface.cq_start,
+            this->cq_sysmem_start + (cq_interface.offset - this->channel_offset) + cq_interface.cq_start,
             this->get_issue_queue_size(cq_id),
             this->device_id,
             0,

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -402,7 +402,6 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
     if (is_mock_device()) {
         return 0;
     }
-    // log_info(tt::LogMetal, "completion_queue_read_ptr: {}", this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4);
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -21,6 +21,7 @@
 #include "dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include "memcpy.hpp"
+#include "allocator/allocator.hpp"
 #include "command_queue_common.hpp"
 #include "system_memory_cq_interface.hpp"
 #include <tt-logger/tt-logger.hpp>
@@ -131,18 +132,23 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         return;
     }
 
-    if (use_dram_for_cq_storage()) {
-        this->cq_size = 1 << 28;  // 256 MB
+    if (is_dram_backed()) {
+        const uint32_t dram_backed_command_queues_size =
+            MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
+        TT_ASSERT(dram_backed_command_queues_size > 0);
+        TT_FATAL(
+            (dram_backed_command_queues_size % num_hw_cqs) == 0,
+            "Size of DRAM region reserved for command queues {}B is not divisible by number of command queues {}",
+            dram_backed_command_queues_size,
+            num_hw_cqs);
+        this->cq_size = dram_backed_command_queues_size / num_hw_cqs;
         TT_ASSERT((this->cq_size % MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
-        IDevice* device = MetalContext::instance().device_manager()->get_active_device(this->device_id);
+        const IDevice* device = MetalContext::instance().device_manager()->get_active_device(this->device_id);
         TT_FATAL(device->is_mmio_capable(), "Device {} is not an MMIO device", this->device_id);
-        this->dram_region_buffer =
-            Buffer::create(device, this->cq_size * num_hw_cqs, this->cq_size * num_hw_cqs, BufferType::DRAM);
-        this->dram_region_staging_buffer = std::make_unique<char[]>(this->cq_size * num_hw_cqs);
+        this->dram_region_staging_buffer = std::make_unique<char[]>(dram_backed_command_queues_size);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
-        this->channel_offset =
-            this->dram_region_buffer
-                ->address();  // change this to 0 and instead modify individual functions to subtract buf addr
+        this->channel_offset = this->get_dram_region_base_addr();  // change this to 0 and instead modify individual
+                                                                   // functions to subtract buf addr
         this->init_dispatch_core_interfaces(num_hw_cqs, 0);
         return;
     }
@@ -212,7 +218,7 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
         const uint32_t alignment = ctx.hal().get_alignment(HalMemType::HOST);
-        const uint32_t base = use_dram_for_cq_storage() ? this->get_dram_region_base_addr() : 0;
+        const uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
         this->cq_interfaces.push_back(
             SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment, base));
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
@@ -238,10 +244,6 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
 bool SystemMemoryManager::is_mock_device() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().get_target_device_type() ==
            tt::TargetDevice::Mock;
-}
-
-bool SystemMemoryManager::use_dram_for_cq_storage() const {
-    return tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_dram_backed_cq();
 }
 
 uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
@@ -394,7 +396,7 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
     if (this->bypass_enable) {
         return this->bypass_buffer_write_offset;
     }
-    log_info(tt::LogMetal, "issue_queue_write_ptr: {}", this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4);
+    // log_info(tt::LogMetal, "issue_queue_write_ptr: {}", this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4);
     return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
 }
 
@@ -402,17 +404,17 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
     if (is_mock_device()) {
         return 0;
     }
-    log_info(tt::LogMetal, "completion_queue_read_ptr: {}", this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4);
+    // log_info(tt::LogMetal, "completion_queue_read_ptr: {}", this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4);
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
 void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
-    if (use_dram_for_cq_storage()) {
+    if (is_dram_backed()) {
         MetalContext::instance().get_cluster().read_dram_vec(
             this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset),
             this->get_completion_queue_size(cq_id),
             this->device_id,
-            0,
+            this->get_dram_region_channel(),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
                 cq_interfaces[cq_id].cq_start + cq_interfaces[cq_id].command_issue_region_size);
     }
@@ -501,7 +503,7 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 
     if (this->bypass_enable) {
         std::copy((uint8_t*)data, (uint8_t*)data + size_in_bytes, (uint8_t*)this->bypass_buffer.data() + write_ptr);
-    } else if (use_dram_for_cq_storage()) {
+    } else if (is_dram_backed()) {
         memcpy(user_scratchspace, data, size_in_bytes);
     } else {
         memcpy_to_device(user_scratchspace, data, size_in_bytes);
@@ -533,18 +535,18 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         cq_interface.issue_fifo_wr_ptr += push_size_16B;
     }
 
-    if (use_dram_for_cq_storage()) {
+    if (is_dram_backed()) {
         MetalContext::instance().get_cluster().write_dram_vec(
             this->cq_sysmem_start + (cq_interface.offset - this->channel_offset) + cq_interface.cq_start,
             this->get_issue_queue_size(cq_id),
             this->device_id,
-            0,
+            this->get_dram_region_channel(),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + cq_interface.cq_start);
         MetalContext::instance().get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
             sizeof(uint32_t),
             this->device_id,
-            0,
+            this->get_dram_region_channel(),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + issue_q_wr_ptr);
         return;
     }
@@ -572,12 +574,12 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     const uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_RD);
 
-    if (use_dram_for_cq_storage()) {
+    if (is_dram_backed()) {
         MetalContext::instance().get_cluster().write_dram_vec(
             &read_ptr_and_toggle,
             sizeof(uint32_t),
             this->device_id,
-            0,
+            this->get_dram_region_channel(),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
         return;
     }
@@ -775,11 +777,22 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
 }
 
-bool SystemMemoryManager::is_dram_backed() const { return this->dram_region_buffer != nullptr; }
+bool SystemMemoryManager::is_dram_backed() const {
+    return tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_dram_backed_cq();
+}
 
 uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
-    return this->dram_region_buffer->address();
+    return tt::tt_metal::MetalContext::instance(this->context_id)
+        .hal()
+        .get_dev_addr(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
+}
+
+uint32_t SystemMemoryManager::get_dram_region_channel() const {
+    TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
+    const IDevice* device =
+        MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
+    return device->allocator_impl()->get_dram_channel_from_bank_id(0);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -147,8 +147,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         TT_FATAL(device->is_mmio_capable(), "Device {} is not an MMIO device", this->device_id);
         this->dram_region_staging_buffer = std::make_unique<char[]>(dram_backed_command_queues_size);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
-        this->channel_offset = this->get_dram_region_base_addr();  // change this to 0 and instead modify individual
-                                                                   // functions to subtract buf addr
+        this->channel_offset = 0;
         this->init_dispatch_core_interfaces(num_hw_cqs, 0);
         return;
     }
@@ -396,7 +395,6 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
     if (this->bypass_enable) {
         return this->bypass_buffer_write_offset;
     }
-    // log_info(tt::LogMetal, "issue_queue_write_ptr: {}", this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4);
     return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
 }
 
@@ -415,12 +413,15 @@ void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
         const uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         MetalContext::instance().get_cluster().read_dram_vec(
-            this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset),
+            this->cq_sysmem_start +
+                (this->get_issue_queue_limit(cq_id) - this->get_dram_region_base_addr() - this->channel_offset),
             this->get_completion_queue_size(cq_id),
             this->device_id,
             dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
                 cq_interfaces[cq_id].cq_start + cq_interfaces[cq_id].command_issue_region_size);
+        return (void*)(this->cq_sysmem_start +
+                       (this->get_issue_queue_limit(cq_id) - this->get_dram_region_base_addr() - this->channel_offset));
     }
     // The completion queue follows issue queue in contiguous memory
     // get_issue_queue_limit() returns absolute device address where the issue queue ends.
@@ -484,7 +485,13 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     //  so channel offset needs to be subtracted to get address relative to channel
     // TODO: Reconsider offset sysmem offset calculations based on
     // https://github.com/tenstorrent/tt-metal/issues/4757
-    void* issue_q_region = this->cq_sysmem_start + (issue_q_write_ptr - this->channel_offset);
+    void* issue_q_region = nullptr;
+    if (is_dram_backed()) {
+        issue_q_region =
+            this->cq_sysmem_start + (issue_q_write_ptr - this->get_dram_region_base_addr() - this->channel_offset);
+    } else {
+        issue_q_region = this->cq_sysmem_start + (issue_q_write_ptr - this->channel_offset);
+    }
 
     return issue_q_region;
 }
@@ -503,13 +510,15 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
     //  so channel offset needs to be subtracted to get address relative to channel
     // TODO: Reconsider offset sysmem offset calculations based on
     // https://github.com/tenstorrent/tt-metal/issues/4757
-    void* user_scratchspace = this->cq_sysmem_start + (write_ptr - this->channel_offset);
 
     if (this->bypass_enable) {
         std::copy((uint8_t*)data, (uint8_t*)data + size_in_bytes, (uint8_t*)this->bypass_buffer.data() + write_ptr);
     } else if (is_dram_backed()) {
+        void* user_scratchspace =
+            this->cq_sysmem_start + (write_ptr - this->get_dram_region_base_addr() - this->channel_offset);
         memcpy(user_scratchspace, data, size_in_bytes);
     } else {
+        void* user_scratchspace = this->cq_sysmem_start + (write_ptr - this->channel_offset);
         memcpy_to_device(user_scratchspace, data, size_in_bytes);
     }
 }
@@ -545,7 +554,8 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         const uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         MetalContext::instance().get_cluster().write_dram_vec(
-            this->cq_sysmem_start + (cq_interface.offset - this->channel_offset) + cq_interface.cq_start,
+            this->cq_sysmem_start + (cq_interface.offset - this->get_dram_region_base_addr() - this->channel_offset) +
+                cq_interface.cq_start,
             this->get_issue_queue_size(cq_id),
             this->device_id,
             dram_channel,

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -135,6 +135,11 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
 
     if (is_dram_backed()) {
+        log_warning(
+            tt::LogMetal,
+            "DRAM-backed CQs are enabled; this feature is intended for niche use-cases such as simulator "
+            "environments, may not work in all configurations, and will result in significantly slower fast dispatch "
+            "performance due to DRAM read/write latency replacing direct host memory access.");
         const uint32_t dram_backed_command_queues_size =
             ctx.hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
         TT_ASSERT(dram_backed_command_queues_size > 0);

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -118,13 +118,13 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->prefetch_q_writers.reserve(num_hw_cqs);
     this->completion_q_writers.reserve(num_hw_cqs);
 
-    uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
     if (is_mock_device()) {
         this->cq_size = 65536;
         this->cq_sysmem_start = nullptr;
         this->channel_offset = 0;
         this->cq_to_event.resize(num_hw_cqs, 0);
         this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
+        const uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0, alignment);
         }
@@ -216,10 +216,10 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
         this->completion_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(tt_cxy_pair(
             completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
-        const uint32_t alignment = ctx.hal().get_alignment(HalMemType::HOST);
+        const uint32_t alignment =
+            is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
         const uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
-        this->cq_interfaces.push_back(
-            SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment, base));
+        this->cq_interfaces.emplace_back(channel, cq_id, this->cq_size, cq_start, alignment, base);
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
         // PREFETCH_MAX_OUTSTANDING_PCIE_READS to allow us to start writing to issue queue
@@ -466,12 +466,13 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
     const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-    if (issue_q_write_ptr + align(
-                                cmd_size_B,
-                                tt::tt_metal::MetalContext::instance(this->context_id)
-                                    .hal()
-                                    .get_alignment(tt::tt_metal::HalMemType::HOST)) >  // use dram alignment if needed
-        command_issue_limit) {
+    const uint32_t alignment =
+        is_dram_backed()
+            ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
+            : tt::tt_metal::MetalContext::instance(this->context_id)
+                  .hal()
+                  .get_alignment(tt::tt_metal::HalMemType::HOST);
+    if (issue_q_write_ptr + align(cmd_size_B, alignment) > command_issue_limit) {
         this->wrap_issue_queue_wr_ptr(cq_id);
         issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
     }
@@ -535,8 +536,13 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    // All data needs to be PCIE_ALIGNMENT aligned
-    uint32_t push_size_16B = align(push_size_B, ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
+    const uint32_t alignment =
+        is_dram_backed()
+            ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
+            : tt::tt_metal::MetalContext::instance(this->context_id)
+                  .hal()
+                  .get_alignment(tt::tt_metal::HalMemType::HOST);
+    const uint32_t push_size_16B = align(push_size_B, alignment) >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     uint32_t issue_q_wr_ptr = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -140,7 +140,9 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
             Buffer::create(device, this->cq_size * num_hw_cqs, this->cq_size * num_hw_cqs, BufferType::DRAM);
         this->dram_region_staging_buffer = std::make_unique<char[]>(this->cq_size * num_hw_cqs);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
-        this->channel_offset = 0;
+        this->channel_offset =
+            this->dram_region_buffer
+                ->address();  // change this to 0 and instead modify individual functions to subtract buf addr
         this->init_dispatch_core_interfaces(num_hw_cqs, 0);
         return;
     }
@@ -210,7 +212,9 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
         const uint32_t alignment = ctx.hal().get_alignment(HalMemType::HOST);
-        this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment));
+        const uint32_t base = use_dram_for_cq_storage() ? this->get_dram_region_base_addr() : 0;
+        this->cq_interfaces.push_back(
+            SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment, base));
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
         // PREFETCH_MAX_OUTSTANDING_PCIE_READS to allow us to start writing to issue queue
@@ -407,8 +411,8 @@ void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
             this->get_completion_queue_size(cq_id),
             this->device_id,
             0,
-            this->get_dram_region_start_addr(cq_id) + cq_interfaces[cq_id].cq_start +
-                cq_interfaces[cq_id].command_issue_region_size);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
+                cq_interfaces[cq_id].cq_start + cq_interfaces[cq_id].command_issue_region_size);
     }
     // The completion queue follows issue queue in contiguous memory
     // get_issue_queue_limit() returns absolute device address where the issue queue ends.
@@ -533,13 +537,13 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
             this->get_issue_queue_size(cq_id),
             this->device_id,
             0,
-            this->get_dram_region_start_addr(cq_id) + cq_interface.cq_start);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + cq_interface.cq_start);
         MetalContext::instance().get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
             sizeof(uint32_t),
             this->device_id,
             0,
-            this->get_dram_region_start_addr(cq_id) + issue_q_wr_ptr);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + issue_q_wr_ptr);
         return;
     }
 
@@ -572,7 +576,7 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
             sizeof(uint32_t),
             this->device_id,
             0,
-            this->get_dram_region_start_addr(cq_id) + completion_q_rd_ptr);
+            this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
         return;
     }
 
@@ -771,9 +775,9 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
 
 bool SystemMemoryManager::is_dram_backed() const { return this->dram_region_buffer != nullptr; }
 
-uint32_t SystemMemoryManager::get_dram_region_start_addr(uint8_t cq_id) const {
+uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
-    return this->dram_region_buffer->address() + get_relative_cq_offset(cq_id, this->cq_size);
+    return this->dram_region_buffer->address();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -132,9 +132,11 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         return;
     }
 
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+
     if (is_dram_backed()) {
         const uint32_t dram_backed_command_queues_size =
-            MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
+            ctx.hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
         TT_ASSERT(dram_backed_command_queues_size > 0);
         TT_FATAL(
             (dram_backed_command_queues_size % num_hw_cqs) == 0,
@@ -142,8 +144,8 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
             dram_backed_command_queues_size,
             num_hw_cqs);
         this->cq_size = dram_backed_command_queues_size / num_hw_cqs;
-        TT_ASSERT((this->cq_size % MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
-        const IDevice* device = MetalContext::instance().device_manager()->get_active_device(this->device_id);
+        TT_ASSERT((this->cq_size % ctx.hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
+        const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         TT_FATAL(device->is_mmio_capable(), "Device {} is not an MMIO device", this->device_id);
         this->dram_region_staging_buffer = std::make_unique<char[]>(dram_backed_command_queues_size);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
@@ -153,7 +155,6 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     }
 
     // Real hardware initialization below
-    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(device_id);
     uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
     char* hugepage_start = static_cast<char*>(ctx.get_cluster().host_dma_address(0, mmio_device_id, channel));
@@ -407,11 +408,11 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
 
 void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
     if (is_dram_backed()) {
-        const IDevice* device =
-            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
+        auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
+        const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         const uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
-        MetalContext::instance().get_cluster().read_dram_vec(
+        ctx.get_cluster().read_dram_vec(
             this->cq_sysmem_start +
                 (this->get_issue_queue_limit(cq_id) - this->get_dram_region_base_addr() - this->channel_offset),
             this->get_completion_queue_size(cq_id),
@@ -554,18 +555,17 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     if (is_dram_backed()) {
-        const IDevice* device =
-            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
+        const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         const uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
-        MetalContext::instance().get_cluster().write_dram_vec(
+        ctx.get_cluster().write_dram_vec(
             this->cq_sysmem_start + (cq_interface.offset - this->get_dram_region_base_addr() - this->channel_offset) +
                 cq_interface.cq_start,
             this->get_issue_queue_size(cq_id),
             this->device_id,
             dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + cq_interface.cq_start);
-        MetalContext::instance().get_cluster().write_dram_vec(
+        ctx.get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
             sizeof(uint32_t),
             this->device_id,
@@ -594,13 +594,13 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
     this->completion_q_writers[cq_id].write(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
-    const uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-        CommandQueueHostAddrType::COMPLETION_Q_RD);
+    auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
+    const uint32_t completion_q_rd_ptr =
+        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
-        const IDevice* device =
-            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
-        MetalContext::instance().get_cluster().write_dram_vec(
+        const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
+        ctx.get_cluster().write_dram_vec(
             &read_ptr_and_toggle,
             sizeof(uint32_t),
             this->device_id,
@@ -610,7 +610,6 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     }
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
-    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
     uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
     ctx.get_cluster().write_sysmem(

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -34,6 +34,7 @@
 #include <impl/debug/inspector/inspector.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <impl/device/device_manager.hpp>
 
 namespace tt::tt_metal {
 
@@ -130,6 +131,20 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         return;
     }
 
+    if (use_dram_for_cq_storage()) {
+        this->cq_size = 1 << 28;  // 256 MB
+        TT_ASSERT((this->cq_size % MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
+        IDevice* device = MetalContext::instance().device_manager()->get_active_device(this->device_id);
+        TT_FATAL(device->is_mmio_capable(), "Device {} is not an MMIO device", this->device_id);
+        this->dram_region_buffer =
+            Buffer::create(device, this->cq_size * num_hw_cqs, this->cq_size * num_hw_cqs, BufferType::DRAM);
+        this->dram_region_staging_buffer = std::make_unique<char[]>(this->cq_size * num_hw_cqs);
+        this->cq_sysmem_start = this->dram_region_staging_buffer.get();
+        this->channel_offset = 0;
+        this->init_dispatch_core_interfaces(num_hw_cqs, 0);
+        return;
+    }
+
     // Real hardware initialization below
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(device_id);
@@ -154,21 +169,29 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
-    uint32_t completion_q_rd_ptr =
-        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    uint32_t prefetch_q_base =
-        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
-    uint32_t cq_start = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+    this->init_dispatch_core_interfaces(num_hw_cqs, channel);
+}
+
+void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint16_t channel) {
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+    const CoreType core_type =
+        ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    const uint32_t completion_q_rd_ptr = ctx.dispatch_mem_map().get_device_command_queue_addr(
+        CommandQueueDeviceAddrType::COMPLETION_Q_RD);
+    const uint32_t prefetch_q_base = ctx.dispatch_mem_map().get_device_command_queue_addr(
+        CommandQueueDeviceAddrType::UNRESERVED);
+    const uint32_t cq_start =
+        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-        tt_cxy_pair prefetcher_core = ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+        tt_cxy_pair prefetcher_core =
+            ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
         auto prefetcher_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
             prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
         this->prefetch_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
-            ctx.get_dispatch_core_manager().completion_queue_writer_core(device_id, channel, cq_id);
+            ctx.get_dispatch_core_manager().completion_queue_writer_core(this->device_id, channel, cq_id);
         auto completion_queue_writer_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
             completion_queue_writer_core.chip,
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
@@ -186,6 +209,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         this->completion_q_writers.emplace_back(ctx.get_cluster().get_static_tlb_writer(tt_cxy_pair(
             completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
+        const uint32_t alignment = ctx.hal().get_alignment(HalMemType::HOST);
         this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size, cq_start, alignment));
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
@@ -210,6 +234,10 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
 bool SystemMemoryManager::is_mock_device() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().get_target_device_type() ==
            tt::TargetDevice::Mock;
+}
+
+bool SystemMemoryManager::use_dram_for_cq_storage() const {
+    return tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_dram_backed_cq();
 }
 
 uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
@@ -373,6 +401,15 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
 }
 
 void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
+    if (use_dram_for_cq_storage()) {
+        MetalContext::instance().get_cluster().read_dram_vec(
+            this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset),
+            this->get_completion_queue_size(cq_id),
+            this->device_id,
+            0,
+            this->get_dram_region_start_addr(cq_id) + cq_interfaces[cq_id].cq_start +
+                cq_interfaces[cq_id].command_issue_region_size);
+    }
     // The completion queue follows issue queue in contiguous memory
     // get_issue_queue_limit() returns absolute device address where the issue queue ends.
     // We subtract channel_offset (absolute device channel base) to get relative offset,
@@ -420,7 +457,7 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
                                 cmd_size_B,
                                 tt::tt_metal::MetalContext::instance(this->context_id)
                                     .hal()
-                                    .get_alignment(tt::tt_metal::HalMemType::HOST)) >
+                                    .get_alignment(tt::tt_metal::HalMemType::HOST)) >  // use dram alignment if needed
         command_issue_limit) {
         this->wrap_issue_queue_wr_ptr(cq_id);
         issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
@@ -458,6 +495,8 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 
     if (this->bypass_enable) {
         std::copy((uint8_t*)data, (uint8_t*)data + size_in_bytes, (uint8_t*)this->bypass_buffer.data() + write_ptr);
+    } else if (use_dram_for_cq_storage()) {
+        memcpy(user_scratchspace, data, size_in_bytes);
     } else {
         memcpy_to_device(user_scratchspace, data, size_in_bytes);
     }
@@ -488,6 +527,22 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         cq_interface.issue_fifo_wr_ptr += push_size_16B;
     }
 
+    if (use_dram_for_cq_storage()) {
+        MetalContext::instance().get_cluster().write_dram_vec(
+            this->cq_sysmem_start + cq_interface.offset + cq_interface.cq_start,
+            this->get_issue_queue_size(cq_id),
+            this->device_id,
+            0,
+            this->get_dram_region_start_addr(cq_id) + cq_interface.cq_start);
+        MetalContext::instance().get_cluster().write_dram_vec(
+            &cq_interface.issue_fifo_wr_ptr,
+            sizeof(uint32_t),
+            this->device_id,
+            0,
+            this->get_dram_region_start_addr(cq_id) + issue_q_wr_ptr);
+        return;
+    }
+
     // Also store this data in hugepages, so if a hang happens we can see what was written by host.
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
     uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
@@ -508,13 +563,23 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
 
     uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
     this->completion_q_writers[cq_id].write(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
+    const uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
+        CommandQueueHostAddrType::COMPLETION_Q_RD);
+
+    if (use_dram_for_cq_storage()) {
+        MetalContext::instance().get_cluster().write_dram_vec(
+            &read_ptr_and_toggle,
+            sizeof(uint32_t),
+            this->device_id,
+            0,
+            this->get_dram_region_start_addr(cq_id) + completion_q_rd_ptr);
+        return;
+    }
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
     uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
-    uint32_t completion_q_rd_ptr =
-        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
     ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
         sizeof(uint32_t),
@@ -702,6 +767,13 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     }
     this->prefetch_q_writers[cq_id].write(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
     this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
+}
+
+bool SystemMemoryManager::is_dram_backed() const { return this->dram_region_buffer != nullptr; }
+
+uint32_t SystemMemoryManager::get_dram_region_start_addr(uint8_t cq_id) const {
+    TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
+    return this->dram_region_buffer->address() + get_relative_cq_offset(cq_id, this->cq_size);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -410,11 +410,15 @@ uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id)
 
 void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
     if (is_dram_backed()) {
+        const IDevice* device =
+            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
+        const uint32_t dram_channel =
+            device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         MetalContext::instance().get_cluster().read_dram_vec(
             this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset),
             this->get_completion_queue_size(cq_id),
             this->device_id,
-            this->get_dram_region_channel(),
+            dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
                 cq_interfaces[cq_id].cq_start + cq_interfaces[cq_id].command_issue_region_size);
     }
@@ -536,17 +540,21 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     if (is_dram_backed()) {
+        const IDevice* device =
+            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
+        const uint32_t dram_channel =
+            device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         MetalContext::instance().get_cluster().write_dram_vec(
             this->cq_sysmem_start + (cq_interface.offset - this->channel_offset) + cq_interface.cq_start,
             this->get_issue_queue_size(cq_id),
             this->device_id,
-            this->get_dram_region_channel(),
+            dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + cq_interface.cq_start);
         MetalContext::instance().get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
             sizeof(uint32_t),
             this->device_id,
-            this->get_dram_region_channel(),
+            dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + issue_q_wr_ptr);
         return;
     }
@@ -575,11 +583,13 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
         CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
+        const IDevice* device =
+            MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
         MetalContext::instance().get_cluster().write_dram_vec(
             &read_ptr_and_toggle,
             sizeof(uint32_t),
             this->device_id,
-            this->get_dram_region_channel(),
+            device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id()),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
         return;
     }
@@ -788,11 +798,9 @@ uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
         .get_dev_addr(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
 }
 
-uint32_t SystemMemoryManager::get_dram_region_channel() const {
+uint32_t SystemMemoryManager::get_dram_region_bank_id() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
-    const IDevice* device =
-        MetalContext::instance(this->context_id).device_manager()->get_active_device(this->device_id);
-    return device->allocator_impl()->get_dram_channel_from_bank_id(0);
+    return 0;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -11,7 +11,6 @@
 #include <umd/device/types/xy_pair.hpp>           // for tt_cxy_pair
 #include <atomic>
 #include <cstdint>
-#include <functional>
 #include <mutex>
 #include <vector>
 #include "impl/context/context_types.hpp"
@@ -105,10 +104,10 @@ public:
 
     uint32_t get_dram_region_base_addr() const;
 
+    uint32_t get_dram_region_channel() const;
+
 private:
     bool is_mock_device() const;
-
-    bool use_dram_for_cq_storage() const;
 
     void init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint16_t channel);
 
@@ -133,7 +132,7 @@ private:
     uint32_t bypass_buffer_write_offset = 0;
 
     std::unique_ptr<char[]> dram_region_staging_buffer;
-    std::shared_ptr<Buffer> dram_region_buffer;
+    // std::shared_ptr<Buffer> dram_region_buffer;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -104,7 +104,7 @@ public:
 
     uint32_t get_dram_region_base_addr() const;
 
-    uint32_t get_dram_region_channel() const;
+    uint32_t get_dram_region_bank_id() const;
 
 private:
     bool is_mock_device() const;

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -20,6 +20,8 @@ using ChipId = int;
 
 namespace tt::tt_metal {
 
+class Buffer;
+
 class SystemMemoryManager {
 public:
     // Create a SystemMemoryManager for accessing system memory accessible by the given device
@@ -99,8 +101,16 @@ public:
     void set_current_and_last_completed_event(
         uint8_t cq_id, uint32_t current_event_id, uint32_t last_completed_event_id);
 
+    bool is_dram_backed() const;
+
+    uint32_t get_dram_region_start_addr(uint8_t cq_id) const;
+
 private:
     bool is_mock_device() const;
+
+    bool use_dram_for_cq_storage() const;
+
+    void init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint16_t channel);
 
     ContextId context_id;
     ChipId device_id = 0;
@@ -121,6 +131,9 @@ private:
     bool bypass_enable = false;
     std::vector<uint32_t> bypass_buffer;
     uint32_t bypass_buffer_write_offset = 0;
+
+    std::unique_ptr<char[]> dram_region_staging_buffer;
+    std::shared_ptr<Buffer> dram_region_buffer;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -103,7 +103,7 @@ public:
 
     bool is_dram_backed() const;
 
-    uint32_t get_dram_region_start_addr(uint8_t cq_id) const;
+    uint32_t get_dram_region_base_addr() const;
 
 private:
     bool is_mock_device() const;

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -132,7 +132,6 @@ private:
     uint32_t bypass_buffer_write_offset = 0;
 
     std::unique_ptr<char[]> dram_region_staging_buffer;
-    // std::shared_ptr<Buffer> dram_region_buffer;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -777,8 +777,14 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
                     CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT);
                 // Initialize completion queue write pointer and read pointer copy
                 uint32_t issue_queue_size = device->sysmem_manager().get_issue_queue_size(cq_id);
-                uint32_t completion_queue_start_addr =
-                    cq_start + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);
+                uint32_t completion_queue_start_addr;
+                if (device->sysmem_manager().is_dram_backed()) {
+                    completion_queue_start_addr =
+                        device->sysmem_manager().get_dram_region_start_addr(cq_id) + cq_start + issue_queue_size;
+                } else {
+                    completion_queue_start_addr =
+                        cq_start + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);
+                }
                 uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
                 std::vector<uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
                 detail::WriteToDeviceL1(

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -407,10 +407,18 @@ DispatchTopology::DispatchTopology(
     get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
     bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs(), descriptor_.hal(), is_galaxy_cluster);
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs(), descriptor_.hal(), is_galaxy_cluster);
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<DispatchMemMap>(
+        CoreType::WORKER,
+        descriptor_.num_cqs(),
+        descriptor_.hal(),
+        is_galaxy_cluster,
+        descriptor_.rtoptions().get_dram_backed_cq());
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<DispatchMemMap>(
+        CoreType::ETH,
+        descriptor_.num_cqs(),
+        descriptor_.hal(),
+        is_galaxy_cluster,
+        descriptor_.rtoptions().get_dram_backed_cq());
 }
 
 DispatchTopology::~DispatchTopology() { reset(); }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -780,7 +780,9 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
                 uint32_t completion_queue_start_addr;
                 if (device->sysmem_manager().is_dram_backed()) {
                     completion_queue_start_addr =
-                        device->sysmem_manager().get_dram_region_start_addr(cq_id) + cq_start + issue_queue_size;
+                        cq_start + issue_queue_size +
+                        get_absolute_cq_offset(
+                            channel, cq_id, cq_size, device->sysmem_manager().get_dram_region_base_addr());
                 } else {
                     completion_queue_start_addr =
                         cq_start + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -34,9 +34,15 @@ static_assert(
     "Fix the value in dispatch_settings.hpp");
 
 DispatchSettings::DispatchSettings(
-    uint32_t num_hw_cqs, const CoreType& core_type, bool is_galaxy_cluster, uint32_t l1_alignment) {
+    uint32_t num_hw_cqs,
+    const CoreType& core_type,
+    bool is_galaxy_cluster,
+    bool are_cqs_dram_backed,
+    uint32_t l1_alignment) {
     switch (core_type) {
-        case CoreType::WORKER: init_worker_defaults(num_hw_cqs, is_galaxy_cluster, l1_alignment); break;
+        case CoreType::WORKER:
+            init_worker_defaults(num_hw_cqs, is_galaxy_cluster, are_cqs_dram_backed, l1_alignment);
+            break;
         case CoreType::ETH: init_eth_defaults(num_hw_cqs, l1_alignment); break;
         default: TT_THROW("init_defaults not implemented for core type {}", enchantum::to_string(core_type));
     }
@@ -44,12 +50,15 @@ DispatchSettings::DispatchSettings(
     this->num_hw_cqs_ = num_hw_cqs;
 }
 
-void DispatchSettings::init_worker_defaults(uint32_t num_hw_cqs, bool is_galaxy_cluster, uint32_t l1_alignment) {
+void DispatchSettings::init_worker_defaults(
+    uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment) {
     uint32_t prefetch_q_entries;
-    if (is_galaxy_cluster) {
+    if (are_cqs_dram_backed) {
+        prefetch_q_entries = 256;
+    } else if (is_galaxy_cluster) {
         prefetch_q_entries = 1532 / num_hw_cqs;
     } else {
-        prefetch_q_entries = 256;
+        prefetch_q_entries = 1534;
     }
 
     this->num_hw_cqs(num_hw_cqs)

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -49,7 +49,7 @@ void DispatchSettings::init_worker_defaults(uint32_t num_hw_cqs, bool is_galaxy_
     if (is_galaxy_cluster) {
         prefetch_q_entries = 1532 / num_hw_cqs;
     } else {
-        prefetch_q_entries = 1534;
+        prefetch_q_entries = 256;
     }
 
     this->num_hw_cqs(num_hw_cqs)

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -188,7 +188,8 @@ void read_completion_queue(
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(dst, size_bytes, device_id, 0, addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            dst, size_bytes, device_id, sysmem_manager.get_dram_region_channel(), addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -185,12 +185,10 @@ void read_completion_queue(
     uint32_t size_bytes,
     ChipId device_id,
     uint16_t channel,
-    uint32_t cq_id,
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(dst, size_bytes, device_id, 0, addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }
@@ -219,7 +217,6 @@ void read_events_from_completion_queue(
         sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE,
         mmio_device_id,
         channel,
-        cq_id,
         read_ptr,
         sysmem_manager);
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -10,8 +10,10 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include "allocator/allocator.hpp"
 #include "core_coord.hpp"
 #include "device.hpp"
+#include "device/device_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/command_queue_common.hpp"
@@ -188,8 +190,13 @@ void read_completion_queue(
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
+        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(device_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, sysmem_manager.get_dram_region_channel(), addr);
+            dst, size_bytes, device_id, dram_channel, addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -180,6 +180,22 @@ void issue_wait_for_event_commands(
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, cq_id);
 }
 
+void read_completion_queue(
+    void* dst,
+    uint32_t size_bytes,
+    ChipId device_id,
+    uint16_t channel,
+    uint32_t cq_id,
+    uint32_t addr,
+    const SystemMemoryManager& sysmem_manager) {
+    if (sysmem_manager.is_dram_backed()) {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
+            dst, size_bytes, device_id, 0, sysmem_manager.get_dram_region_start_addr(cq_id) + addr);
+    } else {
+        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
+    }
+}
+
 void read_events_from_completion_queue(
     ReadEventDescriptor& event_descriptor,
     ChipId mmio_device_id,
@@ -198,12 +214,14 @@ void read_events_from_completion_queue(
     uint32_t read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
     thread_local static std::vector<uint32_t> dispatch_cmd_and_event(
         (sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE) / sizeof(uint32_t));
-    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+    read_completion_queue(
         dispatch_cmd_and_event.data(),
         sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE,
-        read_ptr,
         mmio_device_id,
-        channel);
+        channel,
+        cq_id,
+        read_ptr,
+        sysmem_manager);
 
     CQDispatchCmd* dispatch_cmd = reinterpret_cast<CQDispatchCmd*>(dispatch_cmd_and_event.data());
     uint32_t expected_padding_value = HugepageDeviceCommand::random_padding_value();

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -35,16 +35,19 @@ Hal::Hal(
     tt::ARCH arch,
     bool is_base_routing_fw_enabled,
     bool enable_2_erisc_mode,
-    uint32_t profiler_dram_bank_size_per_risc_bytes) :
+    uint32_t profiler_dram_bank_size_per_risc_bytes,
+    bool enable_dram_backed_cq) :
     arch_(arch) {
     switch (this->arch_) {
         case tt::ARCH::WORMHOLE_B0:
-            initialize_wh(is_base_routing_fw_enabled, profiler_dram_bank_size_per_risc_bytes);
+            initialize_wh(is_base_routing_fw_enabled, profiler_dram_bank_size_per_risc_bytes, enable_dram_backed_cq);
             break;
 
-        case tt::ARCH::QUASAR: initialize_qa(profiler_dram_bank_size_per_risc_bytes); break;
+        case tt::ARCH::QUASAR: initialize_qa(profiler_dram_bank_size_per_risc_bytes, enable_dram_backed_cq); break;
 
-        case tt::ARCH::BLACKHOLE: initialize_bh(enable_2_erisc_mode, profiler_dram_bank_size_per_risc_bytes); break;
+        case tt::ARCH::BLACKHOLE:
+            initialize_bh(enable_2_erisc_mode, profiler_dram_bank_size_per_risc_bytes, enable_dram_backed_cq);
+            break;
 
         default: /*TT_THROW("Unsupported arch for HAL")*/; break;
     }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -55,7 +55,13 @@ std::ostream& operator<<(std::ostream&, const HalProcessorIdentifier&);
 bool operator<(const HalProcessorIdentifier&, const HalProcessorIdentifier&);
 bool operator==(const HalProcessorIdentifier&, const HalProcessorIdentifier&);
 
-enum class HalDramMemAddrType : uint8_t { BARRIER = 0, PROFILER = 1, UNRESERVED = 2, COUNT = 3 };
+enum class HalDramMemAddrType : uint8_t {
+    BARRIER = 0,
+    PROFILER = 1,
+    DRAM_BACKED_COMMAND_QUEUES = 2,
+    UNRESERVED = 3,
+    COUNT = 4
+};
 
 enum class HalTensixHarvestAxis : uint8_t { ROW = 0x1, COL = 0x2 };
 
@@ -325,9 +331,11 @@ private:
     float nan_ = 0.0f;
     float inf_ = 0.0f;
 
-    void initialize_wh(bool is_base_routing_fw_enabled, uint32_t profiler_dram_bank_size_per_risc_bytes);
-    void initialize_bh(bool enable_2_erisc_mode, uint32_t profiler_dram_bank_size_per_risc_bytes);
-    void initialize_qa(uint32_t profiler_dram_bank_size_per_risc_bytes);
+    void initialize_wh(
+        bool is_base_routing_fw_enabled, uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq);
+    void initialize_bh(
+        bool enable_2_erisc_mode, uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq);
+    void initialize_qa(uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq);
 
     // Functions where implementation varies by architecture
     RelocateFunc relocate_func_;
@@ -352,7 +360,8 @@ public:
     Hal(tt::ARCH arch,
         bool is_base_routing_fw_enabled,
         bool enable_2_erisc_mode,
-        uint32_t profiler_dram_bank_size_per_risc_bytes);
+        uint32_t profiler_dram_bank_size_per_risc_bytes,
+        bool enable_dram_backed_cq);
 
     tt::ARCH get_arch() const { return arch_; }
 

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -56,11 +56,21 @@ constexpr static std::uint32_t get_dram_profiler_size(
 #endif
 }
 
-constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size) {
+constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t dram_profiler_size) {
     return DRAM_PROFILER_BASE + dram_profiler_size;
 }
-constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size) {
-    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size);
+
+constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
+    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+                                 : 0;
+}
+
+constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return get_dram_backed_command_queues_base(dram_profiler_size) +
+           get_dram_backed_command_queues_size(enable_dram_backed_cq);
+}
+constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
 }
 
 static constexpr float EPS_BH = 1.19209e-7f;
@@ -251,7 +261,8 @@ public:
     }
 };
 
-void Hal::initialize_bh(bool enable_2_erisc_mode, std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
+void Hal::initialize_bh(
+    bool enable_2_erisc_mode, std::uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq) {
     using namespace blackhole;
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(
@@ -275,10 +286,14 @@ void Hal::initialize_bh(bool enable_2_erisc_mode, std::uint32_t profiler_dram_ba
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = DRAM_PROFILER_BASE;
     const std::uint32_t dram_profiler_size = get_dram_profiler_size(profiler_dram_bank_size_per_risc_bytes);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = dram_profiler_size;
+    this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_base(dram_profiler_size);
+    this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_size(enable_dram_backed_cq);
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_base(dram_profiler_size);
+        get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_size(dram_profiler_size);
+        get_dram_unreserved_size(dram_profiler_size, enable_dram_backed_cq);
 
     this->mem_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::L1)] = L1_ALIGNMENT;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -54,11 +54,19 @@ constexpr static std::uint32_t get_dram_profiler_size(
 #endif
 }
 
-constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size) {
+constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t dram_profiler_size) {
     return DRAM_PROFILER_BASE + dram_profiler_size;
 }
-constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size) {
-    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size);
+constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
+    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+                                 : 0;
+}
+constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return get_dram_backed_command_queues_base(dram_profiler_size) +
+           get_dram_backed_command_queues_size(enable_dram_backed_cq);
+}
+constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
 }
 
 static constexpr float EPS_WHB0 = 1.19209e-7f;
@@ -212,7 +220,8 @@ public:
     bool firmware_is_kernel_object(const Params&) const override { return false; }
 };
 
-void Hal::initialize_wh(bool is_base_routing_fw_enabled, std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
+void Hal::initialize_wh(
+    bool is_base_routing_fw_enabled, std::uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq) {
     using namespace wormhole;
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(
@@ -236,10 +245,14 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled, std::uint32_t profiler_
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = DRAM_PROFILER_BASE;
     const std::uint32_t dram_profiler_size = get_dram_profiler_size(profiler_dram_bank_size_per_risc_bytes);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = dram_profiler_size;
+    this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_base(dram_profiler_size);
+    this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_size(enable_dram_backed_cq);
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_base(dram_profiler_size);
+        get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_size(dram_profiler_size);
+        get_dram_unreserved_size(dram_profiler_size, enable_dram_backed_cq);
 
     this->mem_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::L1)] = L1_ALIGNMENT;

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -50,11 +50,21 @@ constexpr static std::uint32_t get_dram_profiler_size(
 #endif
 }
 
-constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size) {
+constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t dram_profiler_size) {
     return DRAM_PROFILER_BASE + dram_profiler_size;
 }
-constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size) {
-    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size);
+
+constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
+    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+                                 : 0;
+}
+
+constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return get_dram_backed_command_queues_base(dram_profiler_size) +
+           get_dram_backed_command_queues_size(enable_dram_backed_cq);
+}
+constexpr static std::uint32_t get_dram_unreserved_size(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {
+    return MEM_DRAM_SIZE - get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
 }
 
 static constexpr float EPS_QA = 1.19209e-7f;  // TODO: verify
@@ -343,7 +353,7 @@ public:
     }
 };
 
-void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
+void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bool enable_dram_backed_cq) {
     using namespace quasar;
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(
@@ -367,10 +377,14 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = DRAM_PROFILER_BASE;
     const std::uint32_t dram_profiler_size = get_dram_profiler_size(profiler_dram_bank_size_per_risc_bytes);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::PROFILER)] = dram_profiler_size;
+    this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_base(dram_profiler_size);
+    this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES)] =
+        get_dram_backed_command_queues_size(enable_dram_backed_cq);
     this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_base(dram_profiler_size);
+        get_dram_unreserved_base(dram_profiler_size, enable_dram_backed_cq);
     this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::UNRESERVED)] =
-        get_dram_unreserved_size(dram_profiler_size);
+        get_dram_unreserved_size(dram_profiler_size, enable_dram_backed_cq);
 
     this->mem_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
     this->mem_alignments_[static_cast<std::size_t>(HalMemType::L1)] = L1_ALIGNMENT;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -105,6 +105,7 @@ enum class EnvVarID {
     TT_METAL_USE_MGD_2_0,                      // Use mesh graph descriptor 2.0
     TT_METAL_FORCE_JIT_COMPILE,                // Force JIT compilation
     TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
+    TT_METAL_DRAM_BACKED_CQ,                   // Store command queues in device DRAM
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -687,6 +688,12 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: 0 (use SFPLOADMACRO instructions)
         // Usage: export TT_METAL_DISABLE_SFPLOADMACRO=1
         case EnvVarID::TT_METAL_DISABLE_SFPLOADMACRO: this->disable_sfploadmacro = is_env_enabled(value); break;
+
+        // TT_METAL_DRAM_BACKED_CQ
+        // Store command queues in device DRAM.
+        // Default: false (use hugepages)
+        // Usage: export TT_METAL_DRAM_BACKED_CQ=1
+        case EnvVarID::TT_METAL_DRAM_BACKED_CQ: this->dram_backed_cq = is_env_enabled(value); break;
 
         // ========================================
         // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -315,6 +315,9 @@ class RunTimeOptions {
     // Force JIT compile even if dependencies are up to date
     bool force_jit_compile = false;
 
+    // Store command queues in device DRAM
+    bool dram_backed_cq = false;
+
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
 
@@ -733,6 +736,8 @@ public:
     void set_force_jit_compile(bool enable) { force_jit_compile = enable; }
 
     bool get_numa_based_affinity() const { return numa_based_affinity; }
+
+    bool get_dram_backed_cq() const { return dram_backed_cq; }
 
     std::optional<uint32_t> get_fabric_router_sync_timeout_ms() const { return fabric_router_sync_timeout_ms; }
 

--- a/tt_metal/tools/precompile_fw/precompile_fw.cpp
+++ b/tt_metal/tools/precompile_fw/precompile_fw.cpp
@@ -56,6 +56,8 @@ void enumerate_jit_device_configs(
     // Only support compiling 2-ERISC mode for Blackhole.
     const bool enable_2_erisc_mode = (arch == tt::ARCH::BLACKHOLE);
 
+    const bool enable_dram_backed_cq = false;
+
     // FIXME: hardcoded based on UMD values
     static const std::unordered_map<tt::ARCH, uint32_t> num_dram_banks_map = {
         {tt::ARCH::WORMHOLE_B0, 12},
@@ -123,7 +125,11 @@ void enumerate_jit_device_configs(
                     for (const auto& dram_harvesting_count : dram_harvesting_cfgs) {
                         const uint32_t num_dram_banks = num_dram_banks_map.at(arch) - dram_harvesting_count;
                         tt::tt_metal::Hal hal(
-                            arch, routing_fw_enabled, enable_2_erisc_mode, profiler_dram_bank_size_per_risc_bytes);
+                            arch,
+                            routing_fw_enabled,
+                            enable_2_erisc_mode,
+                            profiler_dram_bank_size_per_risc_bytes,
+                            enable_dram_backed_cq);
                         JitDeviceConfig jit_device_config = {
                             .hal = &hal,
                             .arch = arch,


### PR DESCRIPTION
This PR adds support for storing fast dispatch CQs in device DRAM instead of host hugepages. When enabled via `TT_METAL_DRAM_BACKED_CQ=1`, a 256 MB region is reserved in DRAM bank 0 for command queues. The host writes commands to a local staging buffer, then flushes to DRAM via `write_dram_vec`. On device, the prefetcher and dispatcher kernels use NOC DRAM reads/writes (via `get_noc_addr_from_bank_id`) instead of PCIe encoding to access the CQ memory.

Fast dispatch performance with DRAM-backed CQs is significantly slower due to DRAM read/write latency replacing direct host memory access. This feature is currently limited to MMIO-capable devices and has been tested by running a subset of existing fast dispatch tests with DRAM-backed CQs enabled.

DRAM-backed CQs are needed to support fast dispatch in Quasar emulation devices.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/simulator_fd_dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/simulator_fd_dram)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/simulator_fd_dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/simulator_fd_dram)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/simulator_fd_dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/simulator_fd_dram)
- [x] Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
