### PR TITLE
[skip ci] Add publish-artifact option to build-artifact.yaml for workflow dispatch

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -223,6 +223,11 @@ on:
         description: >-
           Git fetch depth for the checkout step. Must be large enough to
           include all tags and history needed for `git describe`.
+      publish-artifact:
+        required: false
+        type: boolean
+        default: true
+        description: "Make resulting artifact available in the workflow"
 
 jobs:
   # =============================================================================


### PR DESCRIPTION
### Ticket
None

### Problem description
When running build-artifact using workflow dispatch, the tarball is not uploaded by default because there's no `inputs.publish-artifact` exposed (needed for artifact reuse on tt-blaze)

### What's changed
Add `inputs.publish-artifact` to workflow dispatch 

### Checklist

- [x] Build artifact: https://github.com/tenstorrent/tt-metal/actions/runs/23462715732

