### PR TITLE
Fix MeshBuffer copy/move semantics

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -342,35 +342,6 @@ TEST_F(MeshBufferTestSuite, MoveAssignment) {
     EXPECT_EQ(new_buffer->address(), target_original_address);
 }
 
-TEST_F(MeshBufferTestSuite, MoveConstructorPreservesData) {
-    const DeviceLocalBufferConfig device_local_config{
-        .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
-
-    const ReplicatedBufferConfig buffer_config{.size = 4096};
-    auto original_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
-
-    std::vector<uint32_t> src_vec(1024, 0);
-    std::iota(src_vec.begin(), src_vec.end(), 0);
-
-    for (std::size_t col = 0; col < original_buffer->device()->num_cols(); col++) {
-        for (std::size_t row = 0; row < original_buffer->device()->num_rows(); row++) {
-            WriteShard(mesh_device_->mesh_command_queue(), original_buffer, src_vec, MeshCoordinate(row, col));
-        }
-    }
-
-    MeshBuffer moved_buffer(std::move(*original_buffer));
-
-    auto moved_buffer_ptr = std::shared_ptr<MeshBuffer>(&moved_buffer, [](MeshBuffer*) {});
-
-    for (std::size_t col = 0; col < moved_buffer.device()->num_cols(); col++) {
-        for (std::size_t row = 0; row < moved_buffer.device()->num_rows(); row++) {
-            std::vector<uint32_t> dst_vec = {};
-            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, moved_buffer_ptr, MeshCoordinate(row, col));
-            EXPECT_EQ(dst_vec, src_vec);
-        }
-    }
-}
-
 class DeviceLocalMeshBufferShardingTest
     : public MeshBufferTest2x4,
       public testing::WithParamInterface<

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -18,6 +18,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -45,6 +46,11 @@
 
 namespace tt::tt_metal::distributed::test {
 namespace {
+
+static_assert(!std::is_copy_constructible_v<MeshBuffer>, "MeshBuffer should not be copy constructible");
+static_assert(!std::is_copy_assignable_v<MeshBuffer>, "MeshBuffer should not be copy assignable");
+static_assert(std::is_move_constructible_v<MeshBuffer>, "MeshBuffer should be move constructible");
+static_assert(std::is_move_assignable_v<MeshBuffer>, "MeshBuffer should be move assignable");
 
 using MeshBufferTest2x4 = MeshDevice2x4Fixture;
 using MeshBufferTestSuite = GenericMeshDeviceFixture;
@@ -278,6 +284,91 @@ TEST_F(MeshBufferTest2x4, GetDeviceBuffer) {
     EXPECT_ANY_THROW(replicated_buffer->get_device_buffer(MeshCoordinate{2, 4}));
 
     EXPECT_NO_THROW(replicated_buffer->get_device_buffer(MeshCoordinate{1, 3}));
+}
+
+TEST_F(MeshBufferTestSuite, MoveConstructor) {
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
+
+    const ReplicatedBufferConfig buffer_config{.size = 16 << 10};
+    auto original_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+
+    const auto original_address = original_buffer->address();
+    const auto original_size = original_buffer->size();
+    const auto original_device_local_size = original_buffer->device_local_size();
+
+    EXPECT_TRUE(original_buffer->is_allocated());
+
+    MeshBuffer moved_buffer(std::move(*original_buffer));
+
+    EXPECT_TRUE(moved_buffer.is_allocated());
+    EXPECT_EQ(moved_buffer.address(), original_address);
+    EXPECT_EQ(moved_buffer.size(), original_size);
+    EXPECT_EQ(moved_buffer.device_local_size(), original_device_local_size);
+
+    EXPECT_FALSE(original_buffer->is_allocated());
+}
+
+TEST_F(MeshBufferTestSuite, MoveAssignment) {
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
+
+    const ReplicatedBufferConfig buffer_config{.size = 16 << 10};
+    auto source_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+
+    const auto source_address = source_buffer->address();
+    const auto source_size = source_buffer->size();
+    const auto source_device_local_size = source_buffer->device_local_size();
+
+    EXPECT_TRUE(source_buffer->is_allocated());
+
+    const ReplicatedBufferConfig target_buffer_config{.size = 8 << 10};
+    auto target_buffer = MeshBuffer::create(target_buffer_config, device_local_config, mesh_device_.get());
+    const auto target_original_address = target_buffer->address();
+
+    EXPECT_TRUE(target_buffer->is_allocated());
+    EXPECT_NE(target_buffer->address(), source_address);
+
+    *target_buffer = std::move(*source_buffer);
+
+    EXPECT_TRUE(target_buffer->is_allocated());
+    EXPECT_EQ(target_buffer->address(), source_address);
+    EXPECT_EQ(target_buffer->size(), source_size);
+    EXPECT_EQ(target_buffer->device_local_size(), source_device_local_size);
+
+    EXPECT_FALSE(source_buffer->is_allocated());
+
+    auto new_buffer = MeshBuffer::create(target_buffer_config, device_local_config, mesh_device_.get());
+    EXPECT_EQ(new_buffer->address(), target_original_address);
+}
+
+TEST_F(MeshBufferTestSuite, MoveConstructorPreservesData) {
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
+
+    const ReplicatedBufferConfig buffer_config{.size = 4096};
+    auto original_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+
+    std::vector<uint32_t> src_vec(1024, 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    for (std::size_t col = 0; col < original_buffer->device()->num_cols(); col++) {
+        for (std::size_t row = 0; row < original_buffer->device()->num_rows(); row++) {
+            WriteShard(mesh_device_->mesh_command_queue(), original_buffer, src_vec, MeshCoordinate(row, col));
+        }
+    }
+
+    MeshBuffer moved_buffer(std::move(*original_buffer));
+
+    auto moved_buffer_ptr = std::shared_ptr<MeshBuffer>(&moved_buffer, [](MeshBuffer*) {});
+
+    for (std::size_t col = 0; col < moved_buffer.device()->num_cols(); col++) {
+        for (std::size_t row = 0; row < moved_buffer.device()->num_rows(); row++) {
+            std::vector<uint32_t> dst_vec = {};
+            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, moved_buffer_ptr, MeshCoordinate(row, col));
+            EXPECT_EQ(dst_vec, src_vec);
+        }
+    }
 }
 
 class DeviceLocalMeshBufferShardingTest

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -83,6 +83,8 @@ public:
         std::optional<DeviceAddr> address = std::nullopt);
     ~MeshBuffer();
 
+    // MeshBuffer manages device memory and owns the backing allocation. Copying would create
+    // multiple owners of the same device memory, leading to double-free on destruction.
     MeshBuffer(const MeshBuffer&) = delete;
     MeshBuffer& operator=(const MeshBuffer&) = delete;
     MeshBuffer(MeshBuffer&& other) noexcept;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -83,6 +83,11 @@ public:
         std::optional<DeviceAddr> address = std::nullopt);
     ~MeshBuffer();
 
+    MeshBuffer(const MeshBuffer&) = delete;
+    MeshBuffer& operator=(const MeshBuffer&) = delete;
+    MeshBuffer(MeshBuffer&& other) noexcept;
+    MeshBuffer& operator=(MeshBuffer&& other) noexcept;
+
     // Returns true if the MeshBuffer is allocated. Note that MeshBuffer is created in the allocated state; either the
     // destructor or the `deallocate` method deallocate the MeshBuffer.
     bool is_allocated() const;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -158,7 +158,7 @@ bool MeshBuffer::is_allocated() const {
 MeshBuffer::~MeshBuffer() { deallocate(); }
 
 MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept :
-    config_(std::move(other.config_)),
+    config_(other.config_),
     device_local_config_(std::move(other.device_local_config_)),
     mesh_device_(std::move(other.mesh_device_)),
     address_(other.address_),
@@ -173,7 +173,7 @@ MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept :
 MeshBuffer& MeshBuffer::operator=(MeshBuffer&& other) noexcept {
     if (this != &other) {
         deallocate();
-        config_ = std::move(other.config_);
+        config_ = other.config_;
         device_local_config_ = std::move(other.device_local_config_);
         mesh_device_ = std::move(other.mesh_device_);
         address_ = other.address_;

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -157,6 +157,37 @@ bool MeshBuffer::is_allocated() const {
 
 MeshBuffer::~MeshBuffer() { deallocate(); }
 
+MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept :
+    config_(std::move(other.config_)),
+    device_local_config_(std::move(other.device_local_config_)),
+    mesh_device_(std::move(other.mesh_device_)),
+    address_(other.address_),
+    device_local_size_(other.device_local_size_),
+    buffers_(std::move(other.buffers_)),
+    state_(std::move(other.state_)) {
+    other.state_ = DeallocatedState{};
+    other.address_ = 0;
+    other.device_local_size_ = 0;
+}
+
+MeshBuffer& MeshBuffer::operator=(MeshBuffer&& other) noexcept {
+    if (this != &other) {
+        deallocate();
+        config_ = std::move(other.config_);
+        device_local_config_ = std::move(other.device_local_config_);
+        mesh_device_ = std::move(other.mesh_device_);
+        address_ = other.address_;
+        device_local_size_ = other.device_local_size_;
+        buffers_ = std::move(other.buffers_);
+        state_ = std::move(other.state_);
+
+        other.state_ = DeallocatedState{};
+        other.address_ = 0;
+        other.device_local_size_ = 0;
+    }
+    return *this;
+}
+
 void MeshBuffer::deallocate() {
     auto mesh_device = mesh_device_.lock();
     if (mesh_device) {


### PR DESCRIPTION
### Ticket
No associated issue.

### Problem description
MeshBuffer represents device memory and exhibit RAII semantics on device memory lifetime management. 
MeshBuffer destructor marks the associate device memory as deallocated.

Previously, copy and move operations were implicitly defined, which could lead to incorrect resource management.

An example incorrect usage:
```C++
const MeshBuffer& TrueOwner::get_mesh_buffer();

{
  // A copy happens here without warning.
  MeshBuffer val = TrueOwner::get_mesh_buffer();  
} // val's destructor is called, the copy val destructs the origin MeshBuffer in TrueOwner.
```

### What's changed
- Disabled copy constructor and copy assignment operator
- Implemented move constructor and move assignment operator  
- Moved-from objects transition to `DeallocatedState` to prevent double-free
- Added compile-time `static_assert` checks to verify RAII semantics
- Added 3 runtime tests for move constructor, move assignment, and data preservation after move

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mesh-buffer-raii)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mesh-buffer-raii)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mesh-buffer-raii)
- [x] New/Existing tests provide coverage for changes