### PR TITLE
Fix vadv2 segfault

### DIFF
--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -337,6 +337,8 @@ class TtMSDeformableAttention3D:
         output = multi_scale_deformable_attn(value, spatial_shapes, sampling_locations, attention_weights, self.device)
         ttnn.deallocate(value)
         ttnn.deallocate(sampling_locations)
+        if reference_points.shape[-1] == 2:
+            ttnn.deallocate(sampling_locations_add)
         ttnn.deallocate(attention_weights)
         if not self.batch_first:
             output = ttnn.permute(output, (1, 0, 2))

--- a/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
+++ b/models/experimental/vadv2/tt/tt_spatial_cross_attention.py
@@ -320,7 +320,6 @@ class TtMSDeformableAttention3D:
 
             ttnn.deallocate(reference_xy_reshaped)
             ttnn.deallocate(sampling_locations_reshaped)
-            ttnn.deallocate(sampling_locations_add)
 
             bs, num_query, num_heads, num_levels, num_points, num_Z_anchors, xy = sampling_locations.shape
             assert num_all_points == num_points * num_Z_anchors

--- a/models/experimental/vadv2/tt/tt_temporal_self_attention.py
+++ b/models/experimental/vadv2/tt/tt_temporal_self_attention.py
@@ -157,6 +157,7 @@ class TtTemporalSelfAttention:
             sampling_locations = ttnn.reshape(sampling_locations, sampling_offsets_shape)
             sampling_locations = reference_points + sampling_locations
             ttnn.deallocate(offset_normalizer_xy)
+            ttnn.deallocate(offset_normalizer)
             reference_points = ttnn.reshape(reference_points, reference_points_shape)
         elif reference_points.shape[-1] == 4:
             reference_points_reshape = ttnn.reshape(

--- a/models/experimental/vadv2/tt/tt_temporal_self_attention.py
+++ b/models/experimental/vadv2/tt/tt_temporal_self_attention.py
@@ -137,7 +137,6 @@ class TtTemporalSelfAttention:
             offset_normalizer_xy = ttnn.reshape(
                 offset_normalizer, (1, 1, 1, offset_normalizer.shape[0], 1, offset_normalizer.shape[1])
             )
-            ttnn.deallocate(offset_normalizer)
             sampling_offsets = ttnn.to_layout(sampling_offsets, ttnn.TILE_LAYOUT)
             offset_normalizer_xy = ttnn.to_layout(offset_normalizer_xy, ttnn.TILE_LAYOUT)
 


### PR DESCRIPTION
### Ticket
#39064 broke: [Frequent CI](https://github.com/tenstorrent/tt-metal/actions/runs/23442487598/job/68198473374)

**Verification run:** [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/23464866000/job/68275405738)

### Problem description
The VADv2 model test was segfaulting after commit d6c6a6d12e2 ("Removing sharable ownership to MeshBuffer from Tensor #39064").

Root cause: 
`ttnn.reshape` may return a zero-copy view that shares device memory with the source tensor. 
Calling `ttnn.deallocate()` affects both the target tensor and the source tensor target reshaped from.
A subsequent to_layout call causes a segfault.

Minimal reproducible snippet:
https://github.com/tenstorrent/tt-metal/issues/40547#issuecomment-4114411221

### What's changed
**Short-term fix:** Move `ttnn.deallocate()` calls to after the reshape views are consumed:

1. `tt_temporal_self_attention.py`: Move `ttnn.deallocate(offset_normalizer)` to after `offset_normalizer_xy` is done being used
2. `tt_spatial_cross_attention.py`: Move `ttnn.deallocate(sampling_locations_add)` to after `sampling_locations` is done being used

**Longer-term work needed:**
- Zero copy ops needs to have a more thought out resource allocation semantics. #40547
- `ttnn.deallocate` semantics need clarification around views.
- Operations should validate `is_allocated()` and fail early with clear errors #40550

### Checklist

- **Verification run:** [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/23464866000/job/68275405738)
