### PR TITLE
remove auto-triage of 5s timeout on multi-process tests in tm-fabric-tests

### DIFF
--- a/.github/actions/run-multi-process-tests/action.yml
+++ b/.github/actions/run-multi-process-tests/action.yml
@@ -7,10 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Disable hang detection for multi-process tests
-      if: ${{ inputs.auto-triage == 'false' }}
-      shell: bash
-      run: echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=" >> $GITHUB_ENV
     - name: Run Multi-Process tests
       shell: bash
       env:

--- a/.github/actions/run-multi-process-tests/action.yml
+++ b/.github/actions/run-multi-process-tests/action.yml
@@ -1,8 +1,16 @@
 name: 'Run Multi-Process Tests'
 description: 'Runs multi-process fabric tests with various mesh configurations'
+inputs:
+  auto-triage:
+    description: 'Enable hang detection and auto-triage (disable for multi-process tests where MPI coordination causes false positives)'
+    default: 'false'
 runs:
   using: "composite"
   steps:
+    - name: Disable hang detection for multi-process tests
+      if: ${{ inputs.auto-triage == 'false' }}
+      shell: bash
+      run: echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=" >> $GITHUB_ENV
     - name: Run Multi-Process tests
       shell: bash
       env:

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -181,6 +181,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          auto-triage: false
       - name: Run health tests
         id: cluster-validation
         timeout-minutes: 5

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -202,15 +202,7 @@ jobs:
       - name: Run Multi-Process tests
         if: ${{ !cancelled() && steps.cluster-validation.outcome == 'success' }}
         timeout-minutes: 10
-        run: |
-          python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
-          tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml
-          tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" python3 tests/ttnn/distributed/test_multi_mesh.py
-          tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_mesh_rank_binding.yaml ./build/test/tt_metal/multi_host_socket_tests
-          tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml  ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter="*Socket*"
-          tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
-          tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
-          tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml
+        uses: ./docker-job/.github/actions/run-multi-process-tests
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -181,7 +181,6 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          auto-triage: false
       - name: Run health tests
         id: cluster-validation
         timeout-minutes: 5
@@ -200,6 +199,9 @@ jobs:
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+      - name: Disable auto-triage for multi-process tests
+        if: ${{ !cancelled() && steps.cluster-validation.outcome == 'success' }}
+        run: echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=0" >> $GITHUB_ENV
       - name: Run Multi-Process tests
         if: ${{ !cancelled() && steps.cluster-validation.outcome == 'success' }}
         timeout-minutes: 10

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -181,7 +181,6 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          auto-triage: false
       - name: Run health tests
         id: cluster-validation
         timeout-minutes: 5


### PR DESCRIPTION
It was not meant to be enabled when added to this pipeline (see galaxy-unit-tests where it is not) and was leading to a false positive failure in pipelines

Also for some reason when I added the multi-process tests to the tm-fabric-tests pipeline I did not re-use the action directly - that is also updated now to be directly included.

### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/40098


### Checklist

- [x] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/issue-40098-fabric-multi-process-test-job-failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/issue-40098-fabric-multi-process-test-job-failure)
- [x] [![galaxy-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=snijjar/issue-40098-fabric-multi-process-test-job-failure)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml?query=branch:snijjar/issue-40098-fabric-multi-process-test-job-failure) - o ther failure is on main: https://github.com/tenstorrent/tt-metal/actions/runs/23531540219