### PR TITLE
[CI] Fix to parse board type from boards section in generating tray mapping

### DIFF
--- a/.github/scripts/utils/generate_tray_mapping.py
+++ b/.github/scripts/utils/generate_tray_mapping.py
@@ -76,8 +76,21 @@ def parse_cluster_descriptor(yaml_path: str) -> tuple[str, dict[int, int], dict[
         else:
             chip_to_bus_id[int(chip_id)] = int(bus_id_val, 16)
 
-    # Parse chip_to_boardtype: {chip_id: "ubb"} - keys can be int or str
-    chip_to_boardtype: dict[int, str] = {int(k): v for k, v in data.get("chip_to_boardtype", {}).items()}
+    # Parse chip_to_boardtype from boards section.
+    # UMD serializes board type per board: boards: [[{board_id:}, {board_type:}, {chips:}], ...]
+    chip_to_boardtype: dict[int, str] = {}
+    for board_entry in data.get("boards", []):
+        board_type = None
+        chip_ids: list[int] = []
+        for item in board_entry:
+            if isinstance(item, dict):
+                if "board_type" in item:
+                    board_type = str(item["board_type"]).lower()
+                elif "chips" in item:
+                    chip_ids = [int(c) for c in item["chips"]]
+        if board_type:
+            for chip_id in chip_ids:
+                chip_to_boardtype[chip_id] = board_type
 
     return arch, chips_with_mmio, chip_to_bus_id, chip_to_boardtype
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Failed an isolation CI: https://github.com/tenstorrent/tt-metal/actions/runs/23416306939

UMD commit 013ab63b removed `chip_to_boardtype` from cluster descriptor serialization, the CI is failing in UMD due to this change. Board type is now only available in the boards section.

### What's changed
Update `parse_cluster_descriptor` to build `chip_to_boardtype` from the boards section instead, fixing empty device_mapping on Galaxy systems.

Passed this CI: https://github.com/tenstorrent/tt-metal/actions/runs/23469940411/job/68290738179

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-isolation-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-isolation-ci)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-isolation-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-isolation-ci)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-isolation-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-isolation-ci)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early