### PR TITLE
Change row fast dispatch to col dispatch for deepseek

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -121,6 +121,7 @@ def mesh_device(request, device_params):
             return system_name_to_mesh_shape(system_name.upper())
 
     mesh_shape = get_mesh_shape(requested_system_name)
+    device_params.setdefault("dispatch_core_axis", ttnn.DispatchCoreAxis.COL)
     updated_device_params = get_updated_device_params(device_params)
 
     fabric_config = updated_device_params.pop("fabric_config", None)

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -470,6 +470,8 @@ def run_demo(
     fabric_config = get_fabric_config()
     logger.info(f"Setting fabric config to {fabric_config} for demo run")
     ttnn.set_fabric_config(fabric_config, ttnn.FabricReliabilityMode.RELAXED_INIT)
+    dispatch_core_config = ttnn.DispatchCoreConfig(type=ttnn.DispatchCoreType.WORKER, axis=ttnn.DispatchCoreAxis.COL)
+    logger.info("Setting dispatch core axis to ttnn.DispatchCoreAxis.COL")
 
     logger.info(f"Opening mesh device with shape {mesh_shape}")
     if enable_trace:
@@ -489,9 +491,11 @@ def run_demo(
         if enable_mtp:
             trace_region_size = max(trace_region_size, 134_217_728)
         logger.info(f"Trace region size set to {trace_region_size}")
-        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, trace_region_size=trace_region_size)
+        mesh_device = ttnn.open_mesh_device(
+            mesh_shape=mesh_shape, trace_region_size=trace_region_size, dispatch_core_config=dispatch_core_config
+        )
     else:
-        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, dispatch_core_config=dispatch_core_config)
 
     # Load tokenizer only for full-model mode; in random-weights mode we synthesize token ids
     tokenizer = None

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,7 +40,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        pytest.param(10386.34, 191.52, 10048.04, 0.03, id="decode_e2e_perf"),
+        pytest.param(10235.49, 172.68, 10408.17, 0.03, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -121,6 +121,7 @@ def run_test_forward_pass_decoder2d(
         input_cache, tuple(mesh_device.shape), paged_config, user_id
     )
 
+    is_real_weights = module_path is not None
     # Set up model config
     weight_config = get_test_weight_config(
         DecoderBlockClass,
@@ -130,7 +131,7 @@ def run_test_forward_pass_decoder2d(
         mesh_device,
         force_recalculate_weight_config,
         test_name="test_decoder_block",
-        real_weights=module_path is not None,
+        real_weights=is_real_weights,
         layer_id=module_path,
     )
     model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device, fabric_config)
@@ -186,8 +187,12 @@ def run_test_forward_pass_decoder2d(
         tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape)
     )
 
+    if is_real_weights:
+        required_pcc = 0.9899
+    else:
+        required_pcc = 0.988
     # Check output PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.9899)
+    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=required_pcc)
 
 
 TEST_CASES, TEST_IDS = build_test_cases_and_ids(

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -26,8 +26,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
-pytestmark = pytest.mark.t3k_compat
-
 
 # TODO: Doesn't work on multi-host - we should figure out why
 @pytest.mark.requires_device(["TG"])

--- a/models/demos/deepseek_v3/tests/unit/test_interleaved_to_sharded.py
+++ b/models/demos/deepseek_v3/tests/unit/test_interleaved_to_sharded.py
@@ -16,7 +16,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
             memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             buffer_type=ttnn.BufferType.L1,
             shard_spec=ttnn.ShardSpec(
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
                 (32, 64),
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
@@ -30,7 +30,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
             memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             buffer_type=ttnn.BufferType.L1,
             shard_spec=ttnn.ShardSpec(
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
                 (32, 64),
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
@@ -72,7 +72,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
             memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             buffer_type=ttnn.BufferType.L1,
             shard_spec=ttnn.ShardSpec(
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 8))}),
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 9))}),
                 (32, 576),
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
@@ -86,7 +86,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
             memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             buffer_type=ttnn.BufferType.L1,
             shard_spec=ttnn.ShardSpec(
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7))}),
                 (32, 128),
                 ttnn.ShardOrientation.ROW_MAJOR,
             ),
@@ -100,7 +100,7 @@ DEEPSEEK_MEM_CONFIG_SHAPE_DTYPE_MEM_CONFIG = [
             ttnn.BufferType.L1,
             ttnn.NdShardSpec(
                 (32, 128),
-                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7))}),
                 ttnn.ShardOrientation.ROW_MAJOR,
                 ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
             ),

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -256,7 +256,15 @@ def test_matmul_dram_sharded_single_device(
 )
 @pytest.mark.parametrize("enable_trace", [False, True])
 @pytest.mark.parametrize(
-    "device_params", [{"trace_region_size": 90112, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+            "trace_region_size": 90112,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        }
+    ],
+    indirect=True,
 )
 def test_matmul_dram_sharded_mesh_device(
     mesh_device,

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -259,7 +259,7 @@ def test_matmul_dram_sharded_single_device(
     "device_params",
     [
         {
-            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,  # TODO: Remove this once we have a fix for issue #40860
             "trace_region_size": 90112,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }

--- a/models/demos/deepseek_v3/tests/unit/test_sharded_to_interleaved.py
+++ b/models/demos/deepseek_v3/tests/unit/test_sharded_to_interleaved.py
@@ -13,10 +13,10 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "shape, shard_type, cores, out_mem_config",
     [
-        # kv_nope -> L1 interleaved (mla1d.py _fwd_decode_norm_and_rope): width sharded 8x2 [32,32]
-        ([1, 1, 32, 512], "W", (8, 2), ttnn.L1_MEMORY_CONFIG),
-        # q_rope -> L1 interleaved (mla1d.py _fwd_decode_q_rope_nope): height sharded 8x4 [32,64]
-        ([1, 32, 16, 64], "H", (8, 4), ttnn.L1_MEMORY_CONFIG),
+        # kv_nope -> L1 interleaved (mla1d.py _fwd_decode_norm_and_rope): width sharded 2x8 [32,32]
+        ([1, 1, 32, 512], "W", (2, 8), ttnn.L1_MEMORY_CONFIG),
+        # q_rope -> L1 interleaved (mla1d.py _fwd_decode_q_rope_nope): height sharded 4x8 [32,64]
+        ([1, 32, 16, 64], "H", (4, 8), ttnn.L1_MEMORY_CONFIG),
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -669,7 +669,7 @@ class MLA1D(AbstractModule):
         qkv_a_n = q_lora_rank + kv_lora_rank + qk_rope_head_dim  # 2112
         qkv_a_n_padded = pad_n_to_dram_banks(qkv_a_n, tile_size=32, num_dram_banks=num_dram_banks)  # 2304
         qkv_a_in0_core_grid = ttnn.CoreGrid(y=1, x=7)
-        qkv_a_out_core_grid = ttnn.CoreGrid(y=1, x=8)
+        qkv_a_out_core_grid = ttnn.CoreGrid(y=8, x=1)
 
         # Program config for qkv_a
         qkv_a_num_in0_cores = qkv_a_in0_core_grid.x * qkv_a_in0_core_grid.y
@@ -710,8 +710,8 @@ class MLA1D(AbstractModule):
         wq_b_n_padded = pad_n_to_dram_banks(
             wq_b_n, tile_size=32, num_dram_banks=num_dram_banks
         )  # 3072 (already aligned)
-        wq_b_in0_core_grid = ttnn.CoreGrid(y=2, x=8)
-        wq_b_out_core_grid = ttnn.CoreGrid(y=2, x=8)
+        wq_b_in0_core_grid = ttnn.CoreGrid(y=8, x=2)
+        wq_b_out_core_grid = ttnn.CoreGrid(y=8, x=2)
 
         # Program config for wq_b
         wq_b_num_in0_cores = wq_b_in0_core_grid.x * wq_b_in0_core_grid.y
@@ -872,7 +872,7 @@ class MLA1D(AbstractModule):
         wo_k = num_heads * v_head_dim  # 16384
         wo_n = dim // mesh_device.shape[1]  # 896
         wo_n_padded = pad_n_to_dram_banks(wo_n, tile_size=32, num_dram_banks=num_dram_banks)  # 1152
-        wo_in0_core_grid = ttnn.CoreGrid(y=2, x=8)
+        wo_in0_core_grid = ttnn.CoreGrid(y=8, x=2)
         wo_out_core_grid = ttnn.CoreGrid(y=2, x=6)
 
         # Program config for wo

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -1072,15 +1072,6 @@ class MLA1D(AbstractModule):
             out_dim=1,
         )
 
-        wq_a2a_reshard_out_mem_config = ttnn.create_sharded_memory_config(
-            shape=(USERS_PER_ROW, num_heads, kv_lora_rank + qk_rope_head_dim),
-            core_grid=ttnn.CoreGrid(y=8, x=8),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-        )
-        wq_a2a_reshard_config = ReshardConfig(
-            memory_config=wq_a2a_reshard_out_mem_config,
-        )  # 1,4,128,576, height sharded 8x8 [32,576]
-
         # Slice configs for fused wq_kv_a output: [q_lora_rank | kv_lora_rank | qk_rope_head_dim]
         # Q and KV nope use non-overlapping core grids, but keep this decode path
         # on the pre-40275 merged-descriptor dispatch as a temporary workaround.
@@ -1168,7 +1159,6 @@ class MLA1D(AbstractModule):
             "kv_nope_slice_decode": kv_nope_slice_config,
             "kv_rope_slice_decode": kv_rope_slice_config,
             "wq_a2a_decode": wq_a2a_config,
-            "wq_a2a_reshard_decode": wq_a2a_reshard_config,
             "flash_mla_a2a_decode": flash_mla_a2a_config,
             "wo_ag_decode": wo_ag_config,
             "mesh_device": mesh_device,

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -66,7 +66,7 @@ def pad_batch_to_dram_banks(batch, num_banks=12):
     return ((batch + num_banks - 1) // num_banks) * num_banks
 
 
-def build_prefill_matmul_program_config(seq_len, k, n, batch=1, tile_h=32, tile_w=32):
+def build_prefill_matmul_program_config(seq_len, k, n, batch=1, tile_h=32, tile_w=32, *, mesh_device: ttnn.Device):
     """Build MatmulMultiCoreReuseMultiCastProgramConfig for prefill matmuls.
 
     Handles both unbatched (batch=1, fuse_batch=True) and batched (batch>1, fuse_batch=False)
@@ -79,6 +79,7 @@ def build_prefill_matmul_program_config(seq_len, k, n, batch=1, tile_h=32, tile_
         batch: Batch dimension (1 for unbatched, >1 for batched)
         tile_h: Tile height (default 32)
         tile_w: Tile width (default 32)
+        mesh_device: Device (or mesh) used for the tests - needed to retrieve the core grid
 
     Returns:
         MatmulMultiCoreReuseMultiCastProgramConfig
@@ -87,15 +88,17 @@ def build_prefill_matmul_program_config(seq_len, k, n, batch=1, tile_h=32, tile_
     K_tiles = even_int_div(k, tile_w)
     N_tiles = even_int_div(n, tile_w)
 
+    compute_grid = mesh_device.compute_with_storage_grid_size()
+
     # grid_x splits N dimension; grid_y splits M dimension
     grid_x = 1
-    for x in range(min(8, N_tiles), 0, -1):
+    for x in range(min(compute_grid.x, N_tiles), 0, -1):
         if N_tiles % x == 0:
             grid_x = x
             break
 
     grid_y = 1
-    for y in range(min(8, M_tiles), 0, -1):
+    for y in range(min(compute_grid.y, M_tiles), 0, -1):
         if M_tiles % y == 0:
             grid_y = y
             break
@@ -1666,7 +1669,7 @@ class MLA1D(AbstractModule):
         # Q path: norm + wq_b (interleaved in0 + DRAM WIDTH sharded in1)
         tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
         wq_b_program_config = build_prefill_matmul_program_config(
-            seq_len, k=q_lora_rank, n=num_heads_local * qk_head_dim
+            seq_len, k=q_lora_rank, n=num_heads_local * qk_head_dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
         )
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"], program_config=wq_b_program_config)
 
@@ -1682,7 +1685,11 @@ class MLA1D(AbstractModule):
         num_heads_local_padded = pad_batch_to_dram_banks(num_heads_local)
 
         wkv_b1_program_config = build_prefill_matmul_program_config(
-            seq_len, k=qk_nope_head_dim, n=kv_lora_rank, batch=num_heads_local_padded
+            seq_len,
+            k=qk_nope_head_dim,
+            n=kv_lora_rank,
+            batch=num_heads_local_padded,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
         )
         tt_q_nope = ttnn.linear(
             tt_q_nope, **cfg["wkv_b1"], program_config=wkv_b1_program_config
@@ -1764,7 +1771,11 @@ class MLA1D(AbstractModule):
         num_heads_padded = pad_batch_to_dram_banks(num_heads)
 
         wkv_b2_program_config = build_prefill_matmul_program_config(
-            seq_len, k=kv_lora_rank, n=v_head_dim, batch=num_heads_padded
+            seq_len,
+            k=kv_lora_rank,
+            n=v_head_dim,
+            batch=num_heads_padded,
+            mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY],
         )
         v_out = ttnn.linear(
             v_out, **cfg["wkv_b2"], program_config=wkv_b2_program_config
@@ -1795,7 +1806,9 @@ class MLA1D(AbstractModule):
                 # Pad the sequence dimension (dim=1)
                 v_out = ttnn.pad(v_out, padding=((0, 0), (0, padded_seq_len - seq_len), (0, 0), (0, 0)), value=0.0)
 
-            wo_chunk_program_config = build_prefill_matmul_program_config(SEQ_LEN_CHUNK_SIZE, k=wo_k, n=dim)
+            wo_chunk_program_config = build_prefill_matmul_program_config(
+                SEQ_LEN_CHUNK_SIZE, k=wo_k, n=dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
+            )
 
             output_chunks = []
             hidden_dim = num_heads * v_head_dim
@@ -1823,7 +1836,9 @@ class MLA1D(AbstractModule):
         else:
             # For non-chunked case: [1, seq_len, num_heads, v_head_dim] -> [1, 1, seq_len, hidden_dim]
             v_out = ttnn.reshape(v_out, (1, 1, seq_len, num_heads * v_head_dim))
-            wo_program_config = build_prefill_matmul_program_config(seq_len, k=wo_k, n=dim)
+            wo_program_config = build_prefill_matmul_program_config(
+                seq_len, k=wo_k, n=dim, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
+            )
             out = ttnn.linear(v_out, **cfg["wo"], program_config=wo_program_config)  # [1, 1, seq_len, dim]
             ttnn.deallocate(v_out)
 
@@ -2201,7 +2216,9 @@ class MLA1D(AbstractModule):
         # Fused wq_kv_a matmul (interleaved in0 + DRAM WIDTH sharded in1)
         dim = x.shape[3]
         qkv_a_n = q_lora_rank + kv_lora_rank + qk_rope_head_dim
-        wq_kv_a_program_config = build_prefill_matmul_program_config(seq_len, k=dim, n=qkv_a_n)
+        wq_kv_a_program_config = build_prefill_matmul_program_config(
+            seq_len, k=dim, n=qkv_a_n, mesh_device=cfg[MESH_DEVICE_STATE_DICT_KEY]
+        )
         tt_q_kv = ttnn.linear(x, **cfg["wq_kv_a"], program_config=wq_kv_a_program_config)
 
         # AR using AG + local reduce (since sub-tile RS not supported for new shapes)

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -166,9 +166,10 @@ class MLP(AbstractModule):
         Returns:
             ModelPrefillConfig containing operator configurations for prefill mode
         """
+        grid_size = mesh_device.compute_with_storage_grid_size()
         matmul_core_grid_size = ttnn.CoreCoord(
-            mesh_device.core_grid.x,
-            mesh_device.core_grid.y,
+            grid_size.x,
+            grid_size.y,
         )  # NOTE: we might modify this later during optimization stage
 
         # Calculate device metrics
@@ -239,7 +240,8 @@ class MLP(AbstractModule):
 
         # Calculate device metrics
         _, mesh_width = mesh_device.shape
-        max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
+        grid_size = mesh_device.compute_with_storage_grid_size()
+        max_num_cores = grid_size.x * grid_size.y
         input_num_cores = input_num_cores or max(
             get_activation_sharding_core_counts_for_dram_matmul(dim, max_num_cores)
         )
@@ -343,7 +345,7 @@ class MLP(AbstractModule):
             ),
             core_grid=ttnn.num_cores_to_corerangeset(
                 activation_sharding_num_cores,
-                ttnn.CoreCoord(mesh_device.core_grid.x, mesh_device.core_grid.y),
+                mesh_device.compute_with_storage_grid_size(),
                 row_wise=True,
             ),
             strategy=ttnn.TensorMemoryLayout.WIDTH_SHARDED,

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -1115,6 +1115,7 @@ def test_matmul_batched_dram_sharded_program_cache(device, batch, m, k, n):
 )
 @pytest.mark.parametrize("seq_len", [128])  # Longer sequence lengths are 1024, 4096, 8192, 32768, 131072
 @skip_for_blackhole("Deepseek tests target Wormhole")
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 def test_prefill_mm_interleaved_sharded(device, test_case, seq_len):
     """
     Tests the MLA prefill matmuls with in0 DRAM interleaved and in1 DRAM sharded.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40423

### Description
This PR switches DeepSeek V3 execution to use column (COL) dispatch core axis instead of row dispatch, and updates DeepSeek model/test configuration to use the device’s compute-with-storage grid size when deriving core-grid-related parameters.

Changes:

Default DeepSeek V3 tests and demo runs to DispatchCoreAxis.COL via dispatch_core_config / device_params.
Replace uses of mesh_device.core_grid with mesh_device.compute_with_storage_grid_size() in DeepSeek V3 MLP/MLA configuration logic.
Update DeepSeek V3 decode demo performance expected thresholds.

TG All Tests ✅  https://github.com/tenstorrent/tt-metal/actions/runs/23616038621
Dual Module Tests ✅  https://github.com/tenstorrent/tt-metal/actions/runs/23569759412/job/68630288235
Dual Demo CI ✅  https://github.com/tenstorrent/tt-metal/actions/runs/23612995407