### PR TITLE
Fix sub_core_grid propagation in where (TSS/TTT/TTS/TST), bitwise_right_shift, and bitwise_and

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -900,3 +900,176 @@ def test_where_tss_subcore_grid(device, shape, sub_core_grid, dtype, scalar_true
         assert_with_pcc(result, golden)
     else:
         assert torch_equal_nan(result, golden)
+
+
+# Tests for INT32/UINT32 predicate with sub_core_grids — exercises the typecast path
+# (INT32/UINT32 predicate is internally typecast to float before the where kernel runs).
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 7, 32, 96]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar_true, scalar_false",
+    [
+        (15.5, 31.2),
+        (0.0, -11.33),
+    ],
+)
+@pytest.mark.parametrize("condition", [1, 0])
+def test_where_tss_int32_predicate_sub_core_grid(device, shape, sub_core_grid, scalar_true, scalar_false, condition):
+    """TSS variant: INT32 predicate, float scalars, sub_core_grids.
+
+    Exercises the internal typecast path where the INT32 predicate is cast to
+    float before the ternary where kernel, with a sub_core_grid restriction.
+    """
+    torch.manual_seed(0)
+
+    C = make_condition_tensor(shape, torch.int32, condition)
+    golden = torch.where(C.bool(), scalar_true, scalar_false)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_result = ttnn.where(ttnn_C, scalar_true, scalar_false, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 7, 32, 96]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar_true, scalar_false",
+    [
+        (15.5, 31.2),
+        (0.0, -11.33),
+    ],
+)
+@pytest.mark.parametrize("condition", [1, 0])
+def test_where_tss_uint32_predicate_sub_core_grid(device, shape, sub_core_grid, scalar_true, scalar_false, condition):
+    """TSS variant: UINT32 predicate, float scalars, sub_core_grids.
+
+    Exercises the internal typecast path where the UINT32 predicate is cast to
+    float before the ternary where kernel, with a sub_core_grid restriction.
+    """
+    torch.manual_seed(0)
+
+    C = make_condition_tensor(shape, torch.int32, condition).abs()
+    golden = torch.where(C.bool(), scalar_true, scalar_false)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.uint32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_result = ttnn.where(ttnn_C, scalar_true, scalar_false, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)
+
+
+@pytest.mark.parametrize(
+    "shape, sub_core_grid",
+    [
+        (
+            torch.Size([1, 2, 32, 960]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 7, 32, 96]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 6)),
+                ]
+            ),
+        ),
+        (
+            torch.Size([1, 1, 32, 128]),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1)),
+                ]
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("condition", [1, 0])
+def test_where_ttt_int32_predicate_sub_core_grid(device, shape, sub_core_grid, condition):
+    """TTT variant: INT32 predicate, float tensors, sub_core_grids.
+
+    Exercises the internal typecast path where the INT32 predicate is cast to
+    float before the ternary where kernel in the tensor-tensor-tensor variant,
+    with a sub_core_grid restriction.
+    """
+    torch.manual_seed(0)
+
+    C = make_condition_tensor(shape, torch.int32, condition)
+    T = torch.randn(shape, dtype=torch.float32)
+    F = torch.ones(shape, dtype=torch.float32) * 10.0
+    golden = torch.where(C.bool(), T, F)
+
+    ttnn_C = ttnn.from_torch(C, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_T = ttnn.from_torch(T, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_F = ttnn.from_torch(F, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_result = ttnn.where(ttnn_C, ttnn_T, ttnn_F, sub_core_grids=sub_core_grid)
+    result = ttnn.to_torch(ttnn_result)
+
+    assert torch_equal_nan(result, golden)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -119,7 +119,7 @@ Tensor invoke_impl(
         condition.logical_shape(), t_true.logical_shape(), t_false.logical_shape());
     bool typecast_needed = ternary_utils::typecast_predicate(predicate, t_true, t_false);
     if (typecast_needed) {
-        condition = ttnn::typecast(predicate, t_true.dtype());
+        condition = ttnn::typecast(predicate, t_true.dtype(), std::nullopt, std::nullopt, sub_core_grids);
     }
 
     if (is_invalid_bcast(broadcast_type)) {
@@ -148,7 +148,7 @@ Tensor invoke_impl(
     Tensor condition = predicate;
     bool typecast_needed = ternary_utils::typecast_predicate(predicate, t_true);
     if (typecast_needed) {
-        condition = ttnn::typecast(predicate, t_true.dtype());
+        condition = ttnn::typecast(predicate, t_true.dtype(), std::nullopt, std::nullopt, sub_core_grids);
     }
 
     return operations::binary::where_operation_with_scalar<operations::binary::BinaryOpType::WHERE_TTS>(
@@ -171,7 +171,7 @@ Tensor invoke_impl(
     Tensor condition = predicate;
     bool typecast_needed = ternary_utils::typecast_predicate(predicate, t_false);
     if (typecast_needed) {
-        condition = ttnn::typecast(predicate, t_false.dtype());
+        condition = ttnn::typecast(predicate, t_false.dtype(), std::nullopt, std::nullopt, sub_core_grids);
     }
 
     return operations::binary::where_operation_with_scalar<operations::binary::BinaryOpType::WHERE_TST>(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -159,7 +159,7 @@ Tensor where_tss(
 
     // Convert input tensor to float32 only if input is INT32/UINT32 and scalars are float
     if ((condition.dtype() == DataType::INT32 || condition.dtype() == DataType::UINT32) && has_float_scalar) {
-        input = ttnn::typecast(condition, DataType::FLOAT32);
+        input = ttnn::typecast(condition, DataType::FLOAT32, std::nullopt, std::nullopt, sub_core_grids);
     }
     UnaryOpType op_type = UnaryOpType::WHERE_TSS;
     auto param = std::visit(


### PR DESCRIPTION
## Summary

Fixes sub_core_grid propagation issues identified in #40383.

### Changes

- **`unary.cpp`**: The internal typecast called inside `ttnn.where_tss` (TSS variant) when the condition tensor is `INT32`/`UINT32` and scalars are float was not forwarding `sub_core_grids`. Fixed by passing the parameter through.
- **`ternary.cpp`**: The internal typecast called in all three `invoke_impl` overloads (TTT, TTS, TST) for `ttnn.where` was not forwarding `sub_core_grids`. Fixed all three.
- **`bitwise_and` / `bitwise_right_shift`**: Already have correct `sub_core_grids` propagation in `binary_composite_op.cpp` — no changes needed.

### Root cause

When `ttnn.where(int32_tensor, float_scalar, float_scalar)` is called, the condition tensor is internally typecast to `FLOAT32` before being passed to the unary kernel. That typecast call at `unary.cpp:162` did not receive or forward `sub_core_grids`, causing the sub-device constraint to be silently dropped.

The same issue existed in the three `invoke_impl` overloads in `ternary.cpp` (TTT, TTS, TST paths), where the predicate tensor is typecast before being forwarded to the ternary kernel.


## CI Runs
| Workflow | Status | Link |
|---|---|---|
| Sanity | ⏳ Running | [23475722248](https://github.com/tenstorrent/tt-metal/actions/runs/23475722248) |
| Blackhole Post-Commit | ⏳ Running | [23475723030](https://github.com/tenstorrent/tt-metal/actions/runs/23475723030) |
| L2 Nightly (eltwise) | ⏳ Running | [23475723826](https://github.com/tenstorrent/tt-metal/actions/runs/23475723826) |