### PR TITLE
dev: add pre-push hook to detect merge pollution and oversized branch diffs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,3 +96,12 @@ repos:
       language: system
       pass_filenames: false
       files: ^tests/tt_metal/tt_metal/perf_microbenchmark/routing/golden/.*bandwidth.*\.csv$
+- repo: local
+  hooks:
+    - id: check-push-sanity
+      name: Check push sanity (merge pollution / large diff)
+      entry: scripts/check_push_sanity.sh
+      language: script
+      stages: [pre-push]
+      always_run: true
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,8 +100,8 @@ repos:
   hooks:
     - id: check-push-sanity
       name: Check push sanity (merge pollution / large diff)
-      entry: scripts/check_push_sanity.sh
-      language: script
+      entry: bash scripts/check_push_sanity.sh
+      language: system
       stages: [pre-push]
       always_run: true
       pass_filenames: false

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -371,6 +371,7 @@ fi
 if [ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ]; then
     echo "Generating git hooks"
     pre-commit install
+    pre-commit install --hook-type pre-push
     # Note: do NOT add `pre-commit install --hook-type commit-msg` here unless
     # .pre-commit-config.yaml contains hooks with `stages: [commit-msg]`.
     # Without matching hooks, the commit-msg invocation runs the default-stage

--- a/scripts/check_push_sanity.sh
+++ b/scripts/check_push_sanity.sh
@@ -6,7 +6,6 @@
 set -euo pipefail
 
 REMOTE="${1:-origin}"
-BRANCH="${2:-HEAD}"
 
 # Colors
 RED='\033[0;31m'
@@ -14,49 +13,75 @@ YELLOW='\033[1;33m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-MERGE_BASE=$(git merge-base "${REMOTE}/main" HEAD 2>/dev/null) || {
-    echo -e "${YELLOW}[pre-push] Could not determine merge base with ${REMOTE}/main — skipping checks.${NC}"
-    exit 0
-}
+# Collect local SHAs being pushed from pre-push stdin (local_ref local_sha remote_ref remote_sha).
+# If nothing is read (e.g., script run manually), fall back to checking HEAD.
+LOCAL_SHAS=()
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Ignore delete refs (all-zero SHA) and empty lines.
+    if [ -n "${local_sha:-}" ] && [ "$local_sha" != "0000000000000000000000000000000000000000" ]; then
+        LOCAL_SHAS+=("$local_sha")
+    fi
+done || true
+
+if [ "${#LOCAL_SHAS[@]}" -eq 0 ]; then
+    LOCAL_SHAS=("HEAD")
+fi
 
 EXIT_CODE=0
 
-# --- Check 1: Merge commits in branch history (HARD BLOCK) ---
-MERGE_COMMITS=$(git log "${MERGE_BASE}..HEAD" --merges --oneline 2>/dev/null)
-if [ -n "$MERGE_COMMITS" ]; then
-    echo -e "${RED}[pre-push] ERROR: Your branch contains merge commits:${NC}"
-    echo "$MERGE_COMMITS"
-    echo ""
-    echo -e "${RED}Merge commits are banned in tt-metal (see CONTRIBUTING.md).${NC}"
-    echo -e "${RED}Fix with: git rebase origin/main${NC}"
-    echo -e "${RED}Push aborted.${NC}"
-    EXIT_CODE=1
-fi
+run_checks_for_sha() {
+    local TARGET_SHA="$1"
 
-# --- Check 2: Files changed vs main ---
-FILE_COUNT=$(git diff --name-only "${MERGE_BASE}..HEAD" | wc -l | tr -d ' ')
-if [ "$FILE_COUNT" -gt 200 ]; then
-    echo -e "${RED}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main.${NC}"
-    echo -e "${RED}This likely indicates merge pollution (accidental 'git merge main' instead of 'git rebase main').${NC}"
-    echo -e "${RED}Check with: git log --oneline ${REMOTE}/main..HEAD${NC}"
-    echo -e "${RED}If intentional, push with: git push --no-verify${NC}"
-    echo ""
-elif [ "$FILE_COUNT" -gt 50 ]; then
-    echo -e "${YELLOW}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main.${NC}"
-    echo -e "${YELLOW}If you ran 'git merge main', consider 'git rebase main' instead.${NC}"
-    echo ""
-fi
+    local MERGE_BASE
+    MERGE_BASE=$(git merge-base "${REMOTE}/main" "$TARGET_SHA" 2>/dev/null) || {
+        echo -e "${YELLOW}[pre-push] Could not determine merge base with ${REMOTE}/main for ${TARGET_SHA} — skipping checks for this ref.${NC}"
+        return 0
+    }
 
-# --- Check 3: Commit count ---
-COMMIT_COUNT=$(git rev-list --count "${MERGE_BASE}..HEAD" 2>/dev/null)
-if [ "$COMMIT_COUNT" -gt 30 ]; then
-    echo -e "${YELLOW}[pre-push] WARNING: Your branch has ${COMMIT_COUNT} commits ahead of main.${NC}"
-    echo -e "${YELLOW}Consider squashing or reviewing before pushing.${NC}"
-    echo ""
-fi
+    # --- Check 1: Merge commits in branch history (HARD BLOCK) ---
+    local MERGE_COMMITS
+    MERGE_COMMITS=$(git log "${MERGE_BASE}..${TARGET_SHA}" --merges --oneline 2>/dev/null)
+    if [ -n "$MERGE_COMMITS" ]; then
+        echo -e "${RED}[pre-push] ERROR: Your branch contains merge commits (up to ${TARGET_SHA}):${NC}"
+        echo "$MERGE_COMMITS"
+        echo ""
+        echo -e "${RED}Merge commits are banned in tt-metal (see CONTRIBUTING.md).${NC}"
+        echo -e "${RED}Fix with: git rebase ${REMOTE}/main${NC}"
+        echo -e "${RED}Push aborted.${NC}"
+        EXIT_CODE=1
+    fi
 
-if [ "$EXIT_CODE" -eq 0 ] && [ "$FILE_COUNT" -le 50 ]; then
-    echo -e "${GREEN}[pre-push] ✓ Sanity checks passed (${FILE_COUNT} files, ${COMMIT_COUNT} commits).${NC}"
-fi
+    # --- Check 2: Files changed vs main ---
+    local FILE_COUNT
+    FILE_COUNT=$(git diff --name-only "${MERGE_BASE}..${TARGET_SHA}" | wc -l | tr -d ' ')
+    if [ "$FILE_COUNT" -gt 200 ]; then
+        echo -e "${RED}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main (up to ${TARGET_SHA}).${NC}"
+        echo -e "${RED}This likely indicates merge pollution (accidental 'git merge main' instead of 'git rebase main').${NC}"
+        echo -e "${RED}Check with: git log --oneline ${REMOTE}/main..${TARGET_SHA}${NC}"
+        echo -e "${RED}If intentional, push with: git push --no-verify${NC}"
+        echo ""
+    elif [ "$FILE_COUNT" -gt 50 ]; then
+        echo -e "${YELLOW}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main (up to ${TARGET_SHA}).${NC}"
+        echo -e "${YELLOW}If you ran 'git merge main', consider 'git rebase ${REMOTE}/main' instead.${NC}"
+        echo ""
+    fi
+
+    # --- Check 3: Commit count ---
+    local COMMIT_COUNT
+    COMMIT_COUNT=$(git rev-list --count "${MERGE_BASE}..${TARGET_SHA}" 2>/dev/null)
+    if [ "$COMMIT_COUNT" -gt 30 ]; then
+        echo -e "${YELLOW}[pre-push] WARNING: Your branch has ${COMMIT_COUNT} commits ahead of main (up to ${TARGET_SHA}).${NC}"
+        echo -e "${YELLOW}Consider squashing or reviewing before pushing.${NC}"
+        echo ""
+    fi
+
+    if [ "$EXIT_CODE" -eq 0 ] && [ "$FILE_COUNT" -le 50 ]; then
+        echo -e "${GREEN}[pre-push] ✓ Sanity checks passed (${FILE_COUNT} files, ${COMMIT_COUNT} commits) for ${TARGET_SHA}.${NC}"
+    fi
+}
+
+for sha in "${LOCAL_SHAS[@]}"; do
+    run_checks_for_sha "$sha"
+done
 
 exit $EXIT_CODE

--- a/scripts/check_push_sanity.sh
+++ b/scripts/check_push_sanity.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check_push_sanity.sh — Pre-push sanity checks for tt-metal
+# Detects merge pollution (merge commits absorbed into branch) and large diffs
+# that indicate an improper rebase.
+
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+BRANCH="${2:-HEAD}"
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+MERGE_BASE=$(git merge-base "${REMOTE}/main" HEAD 2>/dev/null) || {
+    echo -e "${YELLOW}[pre-push] Could not determine merge base with ${REMOTE}/main — skipping checks.${NC}"
+    exit 0
+}
+
+EXIT_CODE=0
+
+# --- Check 1: Merge commits in branch history (HARD BLOCK) ---
+MERGE_COMMITS=$(git log "${MERGE_BASE}..HEAD" --merges --oneline 2>/dev/null)
+if [ -n "$MERGE_COMMITS" ]; then
+    echo -e "${RED}[pre-push] ERROR: Your branch contains merge commits:${NC}"
+    echo "$MERGE_COMMITS"
+    echo ""
+    echo -e "${RED}Merge commits are banned in tt-metal (see CONTRIBUTING.md).${NC}"
+    echo -e "${RED}Fix with: git rebase origin/main${NC}"
+    echo -e "${RED}Push aborted.${NC}"
+    EXIT_CODE=1
+fi
+
+# --- Check 2: Files changed vs main ---
+FILE_COUNT=$(git diff --name-only "${MERGE_BASE}..HEAD" | wc -l | tr -d ' ')
+if [ "$FILE_COUNT" -gt 200 ]; then
+    echo -e "${RED}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main.${NC}"
+    echo -e "${RED}This likely indicates merge pollution (accidental 'git merge main' instead of 'git rebase main').${NC}"
+    echo -e "${RED}Check with: git log --oneline ${REMOTE}/main..HEAD${NC}"
+    echo -e "${RED}If intentional, push with: git push --no-verify${NC}"
+    echo ""
+elif [ "$FILE_COUNT" -gt 50 ]; then
+    echo -e "${YELLOW}[pre-push] WARNING: Your branch changes ${FILE_COUNT} files vs main.${NC}"
+    echo -e "${YELLOW}If you ran 'git merge main', consider 'git rebase main' instead.${NC}"
+    echo ""
+fi
+
+# --- Check 3: Commit count ---
+COMMIT_COUNT=$(git rev-list --count "${MERGE_BASE}..HEAD" 2>/dev/null)
+if [ "$COMMIT_COUNT" -gt 30 ]; then
+    echo -e "${YELLOW}[pre-push] WARNING: Your branch has ${COMMIT_COUNT} commits ahead of main.${NC}"
+    echo -e "${YELLOW}Consider squashing or reviewing before pushing.${NC}"
+    echo ""
+fi
+
+if [ "$EXIT_CODE" -eq 0 ] && [ "$FILE_COUNT" -le 50 ]; then
+    echo -e "${GREEN}[pre-push] ✓ Sanity checks passed (${FILE_COUNT} files, ${COMMIT_COUNT} commits).${NC}"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds a pre-push git hook that catches merge pollution before it reaches GitHub.

### Problem

Developers occasionally run `git merge main` instead of `git rebase main` to sync their branch. This absorbs all of main's commit history into the feature branch, resulting in PRs with hundreds of unrelated files changed (e.g. #40300 had 1,850 files changed / 207 commits). These PRs are impossible to review and pollute CI.

CONTRIBUTING.md already bans merge commits and requires rebase, but there is no local enforcement — developers only discover the issue after pushing.

### Solution

A `pre-push` hook (`scripts/check_push_sanity.sh`) that runs automatically before every push:

| Check | Threshold | Action |
|---|---|---|
| Merge commits in branch history | Any | Hard block — policy violation, CI rejects these anyway |
| Files changed vs `origin/main` | > 50 | Warn with rebase suggestion |
| Files changed vs `origin/main` | > 200 | Strong warning, suggests `--no-verify` if intentional |
| Commits on branch | > 30 | Warn, suggest squashing |

### Changes

- `scripts/check_push_sanity.sh` — new hook script
- `.pre-commit-config.yaml` — adds `check-push-sanity` hook with `stages: [pre-push]`
- `create_venv.sh` — adds `pre-commit install --hook-type pre-push` so the hook is auto-installed

### Usage

Developers who have already run `create_venv.sh` need to run once:
```bash
pre-commit install --hook-type pre-push
```

New developers get it automatically via `create_venv.sh`.
