### PR TITLE
#39535: Smaller blocked pack MOP reconfig

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_custom_api.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_io.h"
+#include "llk_outputs.h"
+#include "experimental/llk_pack_custom.h"
+
+/*************************************************************************
+ * LLK PACK CUSTOM API - Lightweight MOP outer-loop patching
+ *************************************************************************/
+
+// WARNING: Experimental API for SDPA optimizations only.
+
+// Lightweight MOP outer-loop patch: only updates mop_cfg[0] (= num_faces * num_tiles).
+// Use ONLY after an initial full llk_pack_mop_config has programmed all 9 MOP registers.
+// Safe when all CBs share the same tile format (same num_faces, face_r_dim, tile_c_dim).
+inline void llk_pack_mop_config_minimal_custom(const std::uint32_t output, std::uint32_t num_tiles) {
+    const std::uint32_t output_id = get_output_id(output);
+    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    _llk_pack_mop_config_minimal_custom_(num_faces, num_tiles);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_custom_api.h
@@ -17,8 +17,8 @@
 // Lightweight MOP outer-loop patch: only updates mop_cfg[0] (= num_faces * num_tiles).
 // Use ONLY after an initial full llk_pack_mop_config has programmed all 9 MOP registers.
 // Safe when all CBs share the same tile format (same num_faces, face_r_dim, tile_c_dim).
-inline void llk_pack_mop_config_minimal_custom(const std::uint32_t output, std::uint32_t num_tiles) {
+inline void llk_pack_set_mop_outer_loop(const std::uint32_t output, std::uint32_t num_tiles) {
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
-    _llk_pack_mop_config_minimal_custom_(num_faces, num_tiles);
+    _llk_pack_set_mop_outer_loop_(num_faces, num_tiles);
 }

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -1,37 +1,9 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include "common_globals.h"
-
-namespace ckernel {
-
-// clang-format off
-/**
- * Initializes the packer for packing multiple contiguous tiles from the destination register bank to L1 memory.
- *
- * Call this function before using `pack_tile`. The function configures the packer
- * to handle the specified number of tiles (typically the full destination bank size).
- *
- * NOTE: This function alters the behavior of the packer only on Blachole.
- * Return value: None
- *
- * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
- * |------------|-----------|---------------------------------------------------|----------|-------------|----------|
- * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
- * | Function   | num_tiles | Number of tiles to configure the packer for       | uint32_t | 1 to 16     | True     |
- */
-// clang-format on
-ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
-// TODO NC: Should be removed as a custom functionality as a part of tt-metal#37671
-#ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
-#else
-    (void)num_tiles;
-    PACK((llk_pack_init<false, false, false>(icb)));
+#if defined(TRISC_PACK) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_pack_custom_api.h"
 #endif
-}
-
-}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#if defined(TRISC_PACK) && defined(ARCH_BLACKHOLE)
-#include "experimental/llk_pack_custom_api.h"
-#endif

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -410,13 +410,13 @@ void salad_correct_fused(
         tile_regs_wait();
         dst_index = 0;
 #ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config_minimal_custom(out_out_cb, cur_cols)));
+        PACK((llk_pack_set_mop_outer_loop(out_out_cb, cur_cols)));
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
             pack_tile<true>(dst_index, out_out_cb, out_tile_index);
             dst_index += cur_cols;
         }
-        PACK((llk_pack_mop_config_minimal_custom(out_out_cb, 1)));
+        PACK((llk_pack_set_mop_outer_loop(out_out_cb, 1)));
 #else
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < cur_cols; j++) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -12,7 +12,6 @@
 
 #ifdef ARCH_BLACKHOLE
 #include "api/compute/experimental/matmul_custom.h"
-#include "api/compute/experimental/pack_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
 // BH has ample code size headroom; allow normal inlining and GCC IPA-CP cloning (no noinline/noclone).
 #define SDPA_NOINLINE
@@ -284,7 +283,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
         // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
 #ifdef ARCH_BLACKHOLE
         if constexpr (blocked_pack) {
-            PACK((llk_pack_mop_config_minimal_custom(reduce_cb, 1)));
+            PACK((llk_pack_mop_config<false, false, false>(reduce_cb, 1)));
         }
 #endif
         dst_index = 0;
@@ -311,7 +310,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
 #ifdef ARCH_BLACKHOLE
     if constexpr (blocked_pack) {
-        PACK((llk_pack_mop_config_minimal_custom(reduce_cb, tiles_per_column)));
+        PACK((llk_pack_mop_config<false, false, false>(reduce_cb, tiles_per_column)));
     }
 #endif
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -695,7 +694,7 @@ static void sdpa_inner_loop_step(
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
 #ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_mop_config_minimal_custom(cb_qkt_im, actual_sbw)));
+    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, actual_sbw)));
 #endif
     cb_wait_front(cb_kt_in, DHt * KT_stride);
 
@@ -799,7 +798,7 @@ static void sdpa_inner_loop_step(
             MaybeDeviceZoneScopedN(profiling_enabled, "Reduce max");
             cb_reserve_back(cur.max, qkt_subblock_h);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config_minimal_custom(cur.max, 1)));
+            PACK((llk_pack_mop_config<false, false, false>(cur.max, 1)));
 #endif
             // Use reduce_trigger to enable early reduce start (before all matmul output is ready).
             // When reduce_trigger=true, the packer signals the unpacker via semaphore after partial output.
@@ -813,7 +812,7 @@ static void sdpa_inner_loop_step(
                 reduce_trigger);
             cb_push_back(cur.max, qkt_subblock_h);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config_minimal_custom(cur.max, actual_sbw)));
+            PACK((llk_pack_mop_config<false, false, false>(cur.max, actual_sbw)));
 #endif
         }
 
@@ -864,7 +863,7 @@ static void sdpa_inner_loop_step(
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
 #ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config_minimal_custom(cb_qkt_im, 1)));
+        PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, 1)));
 #endif
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)@V");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -12,6 +12,7 @@
 
 #ifdef ARCH_BLACKHOLE
 #include "api/compute/experimental/matmul_custom.h"
+#include "api/compute/experimental/pack_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
 // BH has ample code size headroom; allow normal inlining and GCC IPA-CP cloning (no noinline/noclone).
 #define SDPA_NOINLINE
@@ -283,7 +284,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
         // Reduce to reduce_cb: first tile of first kt_subblock overwrites, rest accumulate
 #ifdef ARCH_BLACKHOLE
         if constexpr (blocked_pack) {
-            PACK((llk_pack_mop_config<false, false, false>(reduce_cb, 1)));
+            PACK((llk_pack_mop_config_minimal_custom(reduce_cb, 1)));
         }
 #endif
         dst_index = 0;
@@ -310,7 +311,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
     PACK((llk_pack_relu_config(ReluType::NO_RELU)));
 #ifdef ARCH_BLACKHOLE
     if constexpr (blocked_pack) {
-        PACK((llk_pack_mop_config<false, false, false>(reduce_cb, tiles_per_column)));
+        PACK((llk_pack_mop_config_minimal_custom(reduce_cb, tiles_per_column)));
     }
 #endif
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -410,12 +411,13 @@ void salad_correct_fused(
         tile_regs_wait();
         dst_index = 0;
 #ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(out_out_cb, cur_cols)));
+        PACK((llk_pack_mop_config_minimal_custom(out_out_cb, cur_cols)));
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
             pack_tile<true>(dst_index, out_out_cb, out_tile_index);
             dst_index += cur_cols;
         }
+        PACK((llk_pack_mop_config_minimal_custom(out_out_cb, 1)));
 #else
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < cur_cols; j++) {
@@ -693,7 +695,7 @@ static void sdpa_inner_loop_step(
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
 #ifdef ARCH_BLACKHOLE
-    PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, actual_sbw)));
+    PACK((llk_pack_mop_config_minimal_custom(cb_qkt_im, actual_sbw)));
 #endif
     cb_wait_front(cb_kt_in, DHt * KT_stride);
 
@@ -797,7 +799,7 @@ static void sdpa_inner_loop_step(
             MaybeDeviceZoneScopedN(profiling_enabled, "Reduce max");
             cb_reserve_back(cur.max, qkt_subblock_h);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur.max, 1)));
+            PACK((llk_pack_mop_config_minimal_custom(cur.max, 1)));
 #endif
             // Use reduce_trigger to enable early reduce start (before all matmul output is ready).
             // When reduce_trigger=true, the packer signals the unpacker via semaphore after partial output.
@@ -811,7 +813,7 @@ static void sdpa_inner_loop_step(
                 reduce_trigger);
             cb_push_back(cur.max, qkt_subblock_h);
 #ifdef ARCH_BLACKHOLE
-            PACK((llk_pack_mop_config<false, false, false>(cur.max, actual_sbw)));
+            PACK((llk_pack_mop_config_minimal_custom(cur.max, actual_sbw)));
 #endif
         }
 
@@ -862,7 +864,7 @@ static void sdpa_inner_loop_step(
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
 #ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_mop_config<false, false, false>(cb_qkt_im, 1)));
+        PACK((llk_pack_mop_config_minimal_custom(cb_qkt_im, 1)));
 #endif
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)@V");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -410,13 +410,12 @@ void salad_correct_fused(
         tile_regs_wait();
         dst_index = 0;
 #ifdef ARCH_BLACKHOLE
-        PACK((llk_pack_set_mop_outer_loop(out_out_cb, cur_cols)));
+        PACK((llk_pack_mop_config<false, false, false>(out_out_cb, cur_cols)));
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             uint32_t out_tile_index = (write_row_base + i) * tiles_per_column + col_base;
             pack_tile<true>(dst_index, out_out_cb, out_tile_index);
             dst_index += cur_cols;
         }
-        PACK((llk_pack_set_mop_outer_loop(out_out_cb, 1)));
 #else
         for (uint32_t i = 0; i < tiles_per_row; i++) {
             for (uint32_t j = 0; j < cur_cols; j++) {


### PR DESCRIPTION
### Ticket
#39535 

### Problem description
MOP reprogramming for blocked packing unnecessarily programs all MOP fields while just changing the outer dim.

### What's changed
Made a minimal MOP reprogramming function that just reprograms the outer loop.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
