### PR TITLE
Fixing the workflow failure due to the missing skus key

### DIFF
--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -4,10 +4,9 @@
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run (env vars must be inlined).
 #   test_type: Test type identifier for filtering (workflow_dispatch test-type selection).
-#   sku: Machine type to target (e.g. wh_galaxy, bh_galaxy).
+#   skus: A mapping of SKU names to their configuration (each SKU has timeout in minutes).
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   timeout: The maximum allowed runtime for this job in minutes.
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -15,7 +14,8 @@
 - name: "(Galaxy) DeepSeek Prefill module tests"
   cmd: export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG && uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt && pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
   test_type: module
-  sku: bh_galaxy
+  skus:
+    bh_galaxy:
+      timeout: 30
   owner_id: U08RL15T4N8
   team: models
-  timeout: 30


### PR DESCRIPTION
### Ticket
[DS Prefill :: Fix galaxy pipeline #40570
](https://github.com/tenstorrent/tt-metal/issues/40570)
### Problem description
The galaxy_deepseek_prefill_tests.yaml test definition used a flat sku/timeout format that doesn't match the nested skus schema expected by verify_time_budget.py, causing the workflow to fail:

> Verifying that timeouts defined in tests.yaml are within the allowed limits...
Loading time budgets from: ./.github/time_budget.yaml
Loading tests from: ./tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
--- Summing Test Timeouts per Team and SKU ---
Error: R] Validation FAILED! Test '(Galaxy) DeepSeek Prefill module tests' is missing mandatory keys: skus.
Missing keys in ./tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml. Please fix the entries above.
Error: Process completed with exit code 1.

### What's changed
Converted sku and timeout top-level keys to the required nested skus dictionary format (matching other test files like galaxy_demo_tests.yaml)

### Checklist

- [ ] [Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/23489765709)
- [x] [Galaxy DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/23488857515)
