### PR TITLE
Disable Optimized Deepseek Tilize Test for Dual and Quad

### DIFF
--- a/models/demos/deepseek_v3/tests/unit/test_deepseek_moe_post_combine_tilize.py
+++ b/models/demos/deepseek_v3/tests/unit/test_deepseek_moe_post_combine_tilize.py
@@ -9,7 +9,7 @@ import ttnn
 from models.common.utility_functions import comp_pcc
 
 
-@pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
+@pytest.mark.requires_device(["TG"])
 @pytest.mark.parametrize("iterations", [10])
 @pytest.mark.parametrize(
     "device_params",


### PR DESCRIPTION
### What's changed
Test only needs to be run on TG

### Checklist
- Deepseek single glx: https://github.com/tenstorrent/tt-metal/actions/runs/23492518577
- Deepseek dual: https://github.com/tenstorrent/tt-metal/actions/runs/23492529590

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/disable-tilize-for-dual)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/disable-tilize-for-dual)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
