### PR TITLE
SDXL Update accuracy tests

### DIFF
--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 
 from conftest import is_galaxy
-from models.common.utility_functions import is_wormhole_b0
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.stable_diffusion_xl_base.lora.config import TEST_LORA_FILENAME, TEST_LORA_REPO_ID
 from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE, SDXL_L1_SMALL_SIZE_BH
 
@@ -313,14 +313,22 @@ def get_device_name():
 
     num_devices = ttnn.GetNumAvailableDevices()
     if is_galaxy():
+        if is_blackhole():
+            return "bh galaxy"
         return "galaxy"
     elif num_devices == 0:
         return "cpu"
     elif num_devices == 1:
+        if is_blackhole():
+            return "p150"
         return "n150"
     elif num_devices == 2:
+        if is_blackhole():
+            return "p300"
         return "n300"
     elif num_devices == 8:
+        if is_blackhole():
+            return "bh t3k"
         return "t3k"
 
 

--- a/models/demos/stable_diffusion_xl_base/targets/targets.json
+++ b/models/demos/stable_diffusion_xl_base/targets/targets.json
@@ -15,10 +15,6 @@
       "clip_valid_range_full_dataset": [31.68631873, 31.81331801],
       "clip_valid_range_100": [31.70502465208177, 32.094664207879916],
       "fid_valid_range_100": [181.3623, 188.162]
-    },
-    "clip_score_thresholds": {
-      "error": 19,
-      "warning": 25
     }
   },
   "sdxl-512": {
@@ -37,10 +33,6 @@
       "clip_valid_range_full_dataset": [29.38, 31],
       "clip_valid_range_100": [28.5, 30.8],
       "fid_valid_range_100": [195, 233]
-    },
-    "clip_score_thresholds": {
-      "error": 19,
-      "warning": 25
     }
   },
   "sdxl-inpaint-1024": {
@@ -59,10 +51,6 @@
       "clip_valid_range_full_dataset": [31.00179, 31.4179],
       "clip_valid_range_100": [31.0, 31.5],
       "fid_valid_range_100": [183.0, 189.0]
-    },
-    "clip_score_thresholds": {
-      "error": 19.5,
-      "warning": 25
     }
   },
   "sdxl-inpaint-512": {
@@ -81,10 +69,6 @@
       "clip_valid_range_full_dataset": [30, 30.5],
       "clip_valid_range_100": [29.8, 31.4],
       "fid_valid_range_100": [190, 199]
-    },
-    "clip_score_thresholds": {
-      "error": 19.5,
-      "warning": 25
     }
   },
   "sdxl-img2img-1024": {
@@ -135,10 +119,6 @@
       "clip_valid_range_full_dataset": [31.47201, 31.67201],
       "clip_valid_range_100": [31.402317434854226, 31.791956990652366],
       "fid_valid_range_100": [180.87129, 187.87129]
-    },
-    "clip_score_thresholds": {
-      "error": 19.5,
-      "warning": 25
     }
   },
   "sdxl-base-refiner-512": {
@@ -157,10 +137,6 @@
       "clip_valid_range_full_dataset": [29.2, 30],
       "clip_valid_range_100": [28.7, 30.5],
       "fid_valid_range_100": [195, 226]
-    },
-    "clip_score_thresholds": {
-      "error": 19.5,
-      "warning": 25
     }
   },
   "sdxl-lora-1024": {
@@ -179,10 +155,6 @@
       "clip_valid_range_full_dataset": [34.4303, 35.2303],
       "clip_valid_range_100": [34.6343, 35.4343],
       "fid_valid_range_100": [264.3848, 280.3848]
-    },
-    "clip_score_thresholds": {
-      "error": 20,
-      "warning": 28
     }
   },
   "sdxl-lora-512": {
@@ -201,10 +173,6 @@
       "clip_valid_range_full_dataset": [32.8, 33.3],
       "clip_valid_range_100": [33, 34.5],
       "fid_valid_range_100": [285, 296]
-    },
-    "clip_score_thresholds": {
-      "error": 20,
-      "warning": 28
     }
   }
 }

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -18,7 +18,6 @@ from models.demos.stable_diffusion_xl_base.tests.test_common import (
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
     accuracy_assert,
     calculate_accuracy_metrics,
-    check_clip_scores,
     create_report_json,
     save_report_json,
     sdxl_get_prompts,
@@ -218,5 +217,4 @@ def test_accuracy_sdxl(
     save_report_json(report_json, metadata)
     print(json.dumps(report_json, indent=4))
 
-    check_clip_scores(model_name, evaluation_range, prompts, accuracy_metrics["clip_scores"])
     accuracy_assert(metadata, accuracy_metrics)

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -15,7 +15,6 @@ from models.demos.stable_diffusion_xl_base.tests.test_common import SDXL_FABRIC_
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
     accuracy_assert,
     calculate_accuracy_metrics,
-    check_clip_scores,
     create_report_json,
     save_report_json,
 )
@@ -170,7 +169,6 @@ def test_accuracy_sdxl_inpaint(
     save_report_json(report_json, metadata)
     print(json.dumps(report_json, indent=4))
 
-    check_clip_scores(model_name, evaluation_range, prompts, accuracy_metrics["clip_scores"])
     accuracy_assert(metadata, accuracy_metrics)
 
 

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_lora_accuracy.py
@@ -19,7 +19,6 @@ from models.demos.stable_diffusion_xl_base.tests.test_common import (
 from models.demos.stable_diffusion_xl_base.utils.accuracy_utils import (
     accuracy_assert,
     calculate_accuracy_metrics,
-    check_clip_scores,
     create_report_json,
     save_report_json,
     sdxl_get_prompts,
@@ -192,5 +191,4 @@ def test_accuracy_sdxl_lora(
     save_report_json(report_json, metadata)
     print(json.dumps(report_json, indent=4))
 
-    check_clip_scores(model_name, evaluation_range, prompts, accuracy_metrics["clip_scores"])
     accuracy_assert(metadata, accuracy_metrics)

--- a/models/demos/stable_diffusion_xl_base/utils/accuracy_utils.py
+++ b/models/demos/stable_diffusion_xl_base/utils/accuracy_utils.py
@@ -56,35 +56,6 @@ def sdxl_get_prompts(
     return prompts
 
 
-def check_clip_scores(model_name, evaluation_range, prompts, clip_scores):
-    start_from, num_prompts = evaluation_range
-    targets = get_model_targets(model_name)
-    warning_threshold, error_threshold = (
-        targets["clip_score_thresholds"]["warning"],
-        targets["clip_score_thresholds"]["error"],
-    )
-
-    assert len(clip_scores) == num_prompts == len(prompts), f"Expected {num_prompts} CLIP scores and prompts."
-    logger.info(
-        f"CLIP score error threshold: {error_threshold}, warning threshold: {warning_threshold}, for model {model_name}"
-    )
-    num_of_very_low_clip_scores = 0
-    for idx, score in enumerate(clip_scores):
-        if clip_scores[idx] < warning_threshold:
-            if clip_scores[idx] < error_threshold:
-                logger.error(
-                    f"Very low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]},  \
-                        this indicates a fragmented image or noise or prompt mismatch or something else very wrong."
-                )
-                num_of_very_low_clip_scores += 1
-            else:
-                logger.warning(
-                    f"Low CLIP score detected for image {start_from + idx + 1}: {score}, prompt: {prompts[idx]}"
-                )
-
-    assert num_of_very_low_clip_scores == 0, f"Found {num_of_very_low_clip_scores} images with very low CLIP scores"
-
-
 def calculate_accuracy_metrics(images, prompts, coco_statistics_path):
     assert len(images) == len(
         prompts


### PR DESCRIPTION
### Ticket
Improve SDXL accuracy tests: assertions, LoRA, 512 support #39705

### Problem description
- Occasional fails in Shield CI due to low clip scores: [run link](https://github.com/tenstorrent/tt-shield/actions/runs/23386689126/job/68036165183), after PR SDXL lora accuracy 1024x1024 #39632 - accuracy assert is added when clip and fid are out of range, so checking clip scores one by one is unnecessary

- device name is not right in json report when running on blackhole devices

### Checklist
- [ ] [sdxl accuracy, Shield CI](https://github.com/tenstorrent/tt-shield/actions/runs/23500814038)
