### PR TITLE
[QSR] Add transpose_wh compute api and tests

### DIFF
--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
             .noc = NOC::RISCV_1_default,
             .compile_args = reader_compile_time_args});
 
-    std::vector<uint32_t> writer_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     tt::tt_metal::TensorAccessorArgs(output_buf).append_to(writer_compile_time_args);
     auto unary_writer_kernel = CreateKernel(
         *program,

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -112,7 +112,7 @@ std::vector<std::shared_ptr<Program>> create_eltwise_bin_programs(
                 .noc = tt_metal::NOC::RISCV_1_default,
                 .compile_args = reader_compile_time_args});
 
-        std::vector<uint32_t> writer_compile_time_args;
+        std::vector<uint32_t> writer_compile_time_args = {ouput_cb_index};
         tt::tt_metal::TensorAccessorArgs(output_bufs.front()).append_to(writer_compile_time_args);
         auto unary_writer_kernel = tt_metal::CreateKernel(
             program,

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -172,7 +172,7 @@ std::pair<KernelHandle, KernelHandle> add_reader_writer_kernels(
                         .defines = reader_defines});
             }
 
-            std::vector<uint32_t> writer_compile_args = {};
+            std::vector<uint32_t> writer_compile_args = {tt::CBIndex::c_16};
             tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_args);
 
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
@@ -235,7 +235,7 @@ std::pair<KernelHandle, KernelHandle> add_reader_writer_kernels(
                         .compile_args = reader_compile_args});
             }
 
-            std::vector<uint32_t> writer_compile_args = {};
+            std::vector<uint32_t> writer_compile_args = {tt::CBIndex::c_16};
             tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_args);
 
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -130,7 +130,8 @@ std::pair<KernelHandle, KernelHandle> add_reader_writer_kernels(
     const CoreCoord& logical_core,
     const ReduceConfig& test_config,
     const std::shared_ptr<distributed::MeshBuffer>& src_dram_buffer,
-    const std::shared_ptr<distributed::MeshBuffer>& dst_dram_buffer) {
+    const std::shared_ptr<distributed::MeshBuffer>& dst_dram_buffer,
+    uint32_t dst_buffer_id) {
     uint32_t tile_H = test_config.tile_shape.get_tile_shape()[0], tile_W = test_config.tile_shape.get_tile_shape()[1];
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1] * test_config.shape[0];
     uint32_t N = test_config.shape[0] * test_config.shape[1];
@@ -172,7 +173,7 @@ std::pair<KernelHandle, KernelHandle> add_reader_writer_kernels(
                         .defines = reader_defines});
             }
 
-            std::vector<uint32_t> writer_compile_args = {tt::CBIndex::c_16};
+            std::vector<uint32_t> writer_compile_args = {dst_buffer_id};
             tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_args);
 
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
@@ -235,7 +236,7 @@ std::pair<KernelHandle, KernelHandle> add_reader_writer_kernels(
                         .compile_args = reader_compile_args});
             }
 
-            std::vector<uint32_t> writer_compile_args = {tt::CBIndex::c_16};
+            std::vector<uint32_t> writer_compile_args = {dst_buffer_id};
             tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_args);
 
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
@@ -451,7 +452,12 @@ void run_single_core_reduce_program(
         tt_metal::CreateCircularBuffer(program_, core, cb_temp_reduce_tile_config);
     }
 
-    auto [reader_kernel, writer_kernel] = add_reader_writer_kernels(workload, device_range, core, test_config, src_dram_buffer, dst_dram_buffer);
+    const uint32_t dst_buffer_id = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR
+                                       ? dst_dfb
+                                       : static_cast<uint32_t>(tt::CBIndex::c_16);
+
+    auto [reader_kernel, writer_kernel] = add_reader_writer_kernels(
+        workload, device_range, core, test_config, src_dram_buffer, dst_dram_buffer, dst_buffer_id);
 
     vector<uint32_t> compute_kernel_args = {
         uint(Ht),

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -179,6 +179,8 @@ void run_single_core_transpose(
     }
 
     std::vector<uint32_t> reader_cta;
+    reader_cta.push_back(
+        MetalContext::instance().get_cluster().arch() == ARCH::QUASAR ? dfb_src0 : static_cast<uint32_t>(tt::CBIndex::c_0));
     tt::tt_metal::TensorAccessorArgs(src_dram_buffer).append_to(reader_cta);
     std::vector<uint32_t> writer_cta;
     writer_cta.push_back(
@@ -198,7 +200,6 @@ void run_single_core_transpose(
     KernelHandle unary_writer_kernel;
     KernelHandle compute_kernel;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-        reader_cta.push_back(dfb_src0);
         unary_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
@@ -267,7 +268,7 @@ void run_single_core_transpose(
             Ht,
             Wt,
             Ht * Wt,
-            0 /* no scaler */
+            (uint32_t)0  // unused scaler slot kept for compat
         });
 
     tt_metal::SetRuntimeArgs(

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -181,6 +181,9 @@ void run_single_core_transpose(
     std::vector<uint32_t> reader_cta;
     tt::tt_metal::TensorAccessorArgs(src_dram_buffer).append_to(reader_cta);
     std::vector<uint32_t> writer_cta;
+    writer_cta.push_back(
+        MetalContext::instance().get_cluster().arch() == ARCH::QUASAR ? dfb_output
+                                                                      : static_cast<uint32_t>(tt::CBIndex::c_16));
     tt::tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_cta);
 
     vector<uint32_t> compute_kernel_args = {uint(Ht * Wt * NC)};
@@ -203,7 +206,6 @@ void run_single_core_transpose(
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
                 .num_threads_per_cluster = 1, .compile_args = reader_cta});
 
-        writer_cta.push_back(dfb_output);
         unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
@@ -36,6 +37,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -132,43 +134,54 @@ void run_single_core_transpose(
     std::shared_ptr<tt_metal::Buffer> dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    uint32_t src0_cb_index = 0;
     uint32_t num_buffer_tiles = 32;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(
-            num_buffer_tiles * test_config.single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, test_config.single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
-
-    uint32_t ouput_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_buffer_tiles = 32;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_buffer_tiles * test_config.single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(ouput_cb_index, test_config.single_tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+
+    uint32_t dfb_src0 = 0;
+    uint32_t dfb_output = 0;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        tt::tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
+            .entry_size = test_config.single_tile_size,
+            .num_entries = num_buffer_tiles,
+            .num_producers = 1,
+            .pap = tt::tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .num_consumers = 1,
+            .cap = tt::tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b};
+
+        tt::tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
+            .entry_size = test_config.single_tile_size,
+            .num_entries = num_output_buffer_tiles,
+            .num_producers = 1,
+            .pap = tt::tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .num_consumers = 1,
+            .cap = tt::tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b};
+
+        dfb_src0 = tt::tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_src0_config);
+        dfb_output = tt::tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_output_config);
+    } else {
+        uint32_t src0_cb_index = 0;
+        tt_metal::CircularBufferConfig cb_src0_config =
+            tt_metal::CircularBufferConfig(
+                num_buffer_tiles * test_config.single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src0_cb_index, test_config.single_tile_size);
+        tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+
+        uint32_t ouput_cb_index = tt::CBIndex::c_16;
+        tt_metal::CircularBufferConfig cb_output_config =
+            tt_metal::CircularBufferConfig(
+                num_output_buffer_tiles * test_config.single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(ouput_cb_index, test_config.single_tile_size);
+        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+    }
 
     std::vector<uint32_t> reader_cta;
     tt::tt_metal::TensorAccessorArgs(src_dram_buffer).append_to(reader_cta);
-    auto unary_reader_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = reader_cta});
-
     std::vector<uint32_t> writer_cta;
     tt::tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_cta);
-    auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = writer_cta});
 
     vector<uint32_t> compute_kernel_args = {uint(Ht * Wt * NC)};
 
@@ -178,12 +191,66 @@ void run_single_core_transpose(
         defines["SHORT_INIT"] = "1";
     }
 
-    tt_metal::CreateKernel(
-        program_,
-        test_config.transpose_dest ? "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh_dest.cpp"
-                                   : "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp",
-        core,
-        tt_metal::ComputeConfig{.compile_args = compute_kernel_args, .defines = defines});
+    KernelHandle unary_reader_kernel;
+    KernelHandle unary_writer_kernel;
+    KernelHandle compute_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        reader_cta.push_back(dfb_src0);
+        unary_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = reader_cta});
+
+        writer_cta.push_back(dfb_output);
+        unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .compile_args = writer_cta});
+
+        compute_kernel_args.push_back(dfb_src0);
+        compute_kernel_args.push_back(dfb_output);
+        compute_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            test_config.transpose_dest ? "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh_dest.cpp"
+                                       : "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = 1, .compile_args = compute_kernel_args, .defines = defines});
+
+        tt::tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, dfb_src0, unary_reader_kernel, compute_kernel);
+        tt::tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, dfb_output, compute_kernel, unary_writer_kernel);
+    } else {
+        unary_reader_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_1_default,
+                .compile_args = reader_cta});
+
+        unary_writer_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = writer_cta});
+
+        compute_kernel = tt_metal::CreateKernel(
+            program_,
+            test_config.transpose_dest ? "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh_dest.cpp"
+                                       : "tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp",
+            core,
+            tt_metal::ComputeConfig{.compile_args = compute_kernel_args, .defines = defines});
+    }
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -212,8 +279,11 @@ void run_single_core_transpose(
     vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100.0f, 0x1234);
     tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    auto blocking = device->arch() == ARCH::QUASAR;
+    distributed::EnqueueMeshWorkload(cq, workload, blocking);
+    if (not blocking) {
+        distributed::Finish(cq);
+    }
 
     std::vector<uint32_t> result_vec;
     tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
@@ -248,6 +318,9 @@ TEST_F(MeshDeviceFixture, TensixComputeTransposeWHShortInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixComputeTransposeWHDest) {
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "TensixComputeTransposeWHDest not implemented for Quasar yet";
+    }
     unit_tests::compute::transpose::TransposeConfig test_config = {
         .short_init = false,
         .transpose_dest = true,

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -208,6 +208,9 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
+    if (multibank) {
+        writer_compile_time_args.emplace_back(tt::CBIndex::c_16);
+    }
     TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_time_args);
     auto unary_writer_kernel = CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -98,6 +98,9 @@ void run_eltwise_binary_test(
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
+    if (multibank) {
+        writer_compile_time_args.emplace_back(ouput_cb_index);
+    }
     TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_time_args);
     auto unary_writer_kernel = CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -466,7 +466,7 @@ bool test_interleaved_l1_datacopy(
             .noc = tt_metal::NOC::RISCV_1_default,
             .compile_args = reader_compile_time_args});
 
-    std::vector<uint32_t> writer_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16};
     tt::tt_metal::TensorAccessorArgs(dst).append_to(writer_compile_time_args);
     auto unary_writer_kernel = tt_metal::CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
@@ -6,11 +6,28 @@
 
 #include "api/compute/transpose_wh.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 
 void kernel_main() {
     uint32_t NHtWt = get_compile_time_arg_val(0);
 
+#ifdef ARCH_QUASAR
+    constexpr uint32_t dfb_in_id = get_compile_time_arg_val(1);
+    constexpr uint32_t dfb_out_id = get_compile_time_arg_val(2);
+    experimental::DataflowBuffer dfb_in(dfb_in_id);
+    experimental::DataflowBuffer dfb_out(dfb_out_id);
+
+#ifndef SHORT_INIT
+    transpose_wh_init(dfb_in.get_id(), dfb_out.get_id());
+#else
+    unary_op_init_common(dfb_in.get_id(), dfb_out.get_id());
+    transpose_wh_init_short(dfb_in.get_id());
+#endif
+#else
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb16(tt::CBIndex::c_16);
 
@@ -20,12 +37,28 @@ void kernel_main() {
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     transpose_wh_init_short(tt::CBIndex::c_0);
 #endif
+#endif
 
     // transpose a row-major block:
     // - assumes the tiles come in in column major order from reader
     // - uses reader_unary_transpose_wh
     // - transpose_wh each tile
     for (uint32_t n = 0; n < NHtWt; n++) {
+#ifdef ARCH_QUASAR
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
+
+        tile_regs_acquire();
+        transpose_wh_tile(dfb_in.get_id(), 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb_out.get_id());
+        tile_regs_release();
+
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
+#else
         cb0.wait_front(1);
         cb16.reserve_back(1);
 
@@ -39,5 +72,6 @@ void kernel_main() {
 
         cb16.push_back(1);
         cb0.pop_front(1);
+#endif
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
@@ -21,15 +21,13 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(5);
     uint32_t Wt = get_arg_val<uint32_t>(6);
     uint32_t HtWt = get_arg_val<uint32_t>(7);
-    uint32_t scaler = get_arg_val<uint32_t>(8);
 
-    constexpr auto src_args = TensorAccessorArgs<0>();
+    constexpr uint32_t in_id = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
 #ifdef ARCH_QUASAR
-    constexpr uint32_t dfb_in_id = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
-    experimental::DataflowBuffer dfb_in(dfb_in_id);
+    experimental::DataflowBuffer dfb_in(in_id);
 #else
-    constexpr uint32_t cb_id_in0 = 0;
-    experimental::CircularBuffer cb(cb_id_in0);
+    experimental::CircularBuffer cb(in_id);
 #endif
 
     experimental::Noc noc;
@@ -40,31 +38,6 @@ void kernel_main() {
     uint32_t tile_bytes = dfb_in.get_entry_size();
 #else
     uint32_t tile_bytes = cb.get_tile_size();
-#endif
-
-#ifndef ARCH_QUASAR
-    if (scaler != 0) {
-        union {
-            float f;
-            uint32_t u;
-        } u;
-        u.u = scaler;
-        // DPRINT << "TWH Scaler = " << F32(u.f) << ENDL();
-        constexpr uint32_t cb_in_2 = 2;
-        experimental::CircularBuffer cb2(cb_in_2);
-        cb2.reserve_back(1);
-        auto ptr = reinterpret_cast<uint16_t*>(cb2.get_write_ptr());
-        for (int j = 0; j < 1024; j++) {
-            ptr[j] = uint16_t(0);
-        }
-
-        for (int k = 0; k < 4; k++) {
-            for (int j = 0; j < 16; j++) {
-                ptr[k * 256 + j] = uint16_t(u.u >> 16);
-            }
-        }
-        cb2.push_back(1);
-    }
 #endif
 
     uint32_t i_tile_N = 0;  // first tile in current batch

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
@@ -4,7 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 #include "experimental/noc.h"
 #include "experimental/tensor.h"
 
@@ -19,15 +23,26 @@ void kernel_main() {
     uint32_t HtWt = get_arg_val<uint32_t>(7);
     uint32_t scaler = get_arg_val<uint32_t>(8);
 
+    constexpr auto src_args = TensorAccessorArgs<0>();
+#ifdef ARCH_QUASAR
+    constexpr uint32_t dfb_in_id = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
+    experimental::DataflowBuffer dfb_in(dfb_in_id);
+#else
     constexpr uint32_t cb_id_in0 = 0;
+    experimental::CircularBuffer cb(cb_id_in0);
+#endif
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb(cb_id_in0);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
+#ifdef ARCH_QUASAR
+    uint32_t tile_bytes = dfb_in.get_entry_size();
+#else
     uint32_t tile_bytes = cb.get_tile_size();
+#endif
 
+#ifndef ARCH_QUASAR
     if (scaler != 0) {
         union {
             float f;
@@ -50,11 +65,11 @@ void kernel_main() {
         }
         cb2.push_back(1);
     }
+#endif
 
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    constexpr auto src_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(src_args, src_addr, tile_bytes);
 
     // this reader will read a NHW tensor in NWH order
@@ -62,12 +77,21 @@ void kernel_main() {
         i_tile = i_tile_N;
         for (uint32_t w = 0; w < Wt; w++) {
             for (uint32_t h = 0; h < Ht; h++) {
+#ifdef ARCH_QUASAR
+                dfb_in.reserve_back(onetile);
+
+                noc.async_read(s, dfb_in, tile_bytes, {.page_id = i_tile}, {});
+                noc.async_read_barrier();
+
+                dfb_in.push_back(onetile);
+#else
                 cb.reserve_back(onetile);
 
                 noc.async_read(s, cb, tile_bytes, {.page_id = i_tile}, {});
                 noc.async_read_barrier();
 
                 cb.push_back(onetile);
+#endif
                 i_tile += Wt;  // stride in H
             }  // Ht
             i_tile -= HtWt;  // go back to H=0

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 #include "experimental/noc.h"
 #include "experimental/tensor.h"
 #ifdef ARCH_QUASAR
@@ -15,16 +19,16 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(2); // Index 2 to match with regular writer_unary
 
     constexpr uint32_t onetile = 1;
+    constexpr auto dst_args = TensorAccessorArgs<0>();
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb_out(2);
-    const uint32_t tile_bytes = dfb_out.get_entry_size();
+    constexpr uint32_t dfb_out_id = get_compile_time_arg_val(dst_args.next_compile_time_args_offset());
+    experimental::DataflowBuffer dfb_out(dfb_out_id);
+    uint32_t tile_bytes = dfb_out.get_entry_size();
 #else
     constexpr uint32_t cb_id_out0 = 16;
-    const uint32_t tile_bytes = get_tile_size(cb_id_out0);
     experimental::CircularBuffer cb(cb_id_out0);
+    uint32_t tile_bytes = get_tile_size(cb_id_out0);
 #endif
-
-    constexpr auto dst_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     experimental::Noc noc;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
@@ -19,13 +19,13 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(2); // Index 2 to match with regular writer_unary
 
     constexpr uint32_t onetile = 1;
-    constexpr auto dst_args = TensorAccessorArgs<0>();
+    constexpr uint32_t out_id = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 #ifdef ARCH_QUASAR
-    constexpr uint32_t dfb_out_id = get_compile_time_arg_val(dst_args.next_compile_time_args_offset());
-    experimental::DataflowBuffer dfb_out(dfb_out_id);
+    experimental::DataflowBuffer dfb_out(out_id);
     uint32_t tile_bytes = dfb_out.get_entry_size();
 #else
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t cb_id_out0 = out_id;
     experimental::CircularBuffer cb(cb_id_out0);
     uint32_t tile_bytes = get_tile_size(cb_id_out0);
 #endif

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -95,6 +95,9 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
+    if (multibank) {
+        writer_compile_time_args.emplace_back(tt::CBIndex::c_16);
+    }
     TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_time_args);
     auto unary_writer_kernel = CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
@@ -180,6 +180,9 @@ TEST_F(MeshDeviceSingleCardFixture, UntilizeEltwiseBinary) {
                 .compile_args = reader_compile_time_args});
 
         std::vector<uint32_t> writer_compile_time_args;
+        if (multibank) {
+            writer_compile_time_args.emplace_back(ouput_cb_index);
+        }
         tt::tt_metal::TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_time_args);
         auto unary_writer_kernel = tt_metal::CreateKernel(
             program,

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -9,7 +9,9 @@
 #ifdef TRISC_MATH
 #include "llk_math_common_api.h"
 #include "llk_math_unary_datacopy_api.h"
+#ifndef ARCH_QUASAR
 #include "llk_math_transpose_dest_api.h"
+#endif
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_common_api.h"

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -34,6 +34,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
+#ifndef ARCH_QUASAR
     if (is_int32) {
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
@@ -47,11 +48,25 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+#else
+    ASSERT(!is_int32);  // transpose dest not implemented for Quasar yet
+    UNPACK((llk_unpack_hw_configure(icb)));
+    UNPACK((llk_unpack_A_init<true /*transpose*/, DST_ACCUM_MODE>(icb)));
+
+    MATH((llk_math_eltwise_unary_datacopy_init<ckernel::DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
+    MATH((llk_math_pack_sync_init()));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
+#endif
 #endif
 
+#ifndef ARCH_QUASAR
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+#else
+    PACK((llk_pack_hw_configure(ocb)));
+    PACK((llk_pack_init(ocb)));
+#endif
 }
 
 /**
@@ -64,6 +79,7 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
+#ifndef ARCH_QUASAR
     if (is_int32) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
@@ -73,6 +89,11 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }
+#else
+    ASSERT(!is_int32);  // transpose dest not implemented for Quasar yet
+    UNPACK((llk_unpack_A_init<true /*transpose*/, DST_ACCUM_MODE>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<ckernel::DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
+#endif
 
 #endif
 }
@@ -100,6 +121,7 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
 
+#ifndef ARCH_QUASAR
     if (is_int32) {
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
@@ -110,6 +132,11 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false>(icb, itile)));
         MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst, icb)));
     }
+#else
+    ASSERT(!is_int32);  // transpose dest not implemented for Quasar yet
+    UNPACK((llk_unpack_A(icb, itile)));
+    MATH((llk_math_eltwise_unary_datacopy(idst, icb)));
+#endif
 #endif
 }
 

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
             .noc = tt_metal::NOC::RISCV_1_default,
             .compile_args = reader_compile_time_args});
 
-    std::vector<uint32_t> writer_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
     tt::tt_metal::TensorAccessorArgs(output_buf).append_to(writer_compile_time_args);
     auto unary_writer_kernel = tt_metal::CreateKernel(
         *program,


### PR DESCRIPTION
### Ticket
None

### Problem description
Bring up transpose_wh compute api 

### What's changed
Added transpose_wh compute api implementation for Quasar. Int32 paths are missing since transpose dest is not yet implemented for Quasar.
Modified test_transpose.cpp to test Quasar as well. 
Test passes dfb ids as compile time args for Quasar. This is done to avoid clashing with other tests that use the same reader/writer kernels. For instance, test_reduce.cpp has 2 input dfbs (id 0 and 1) and uses the same writer and there dfb_out will have id=2. On the other hand transpose has 1 input dfb id=0 and one output dfb with id=1. Due to this hardcoding one value is for the output dfb id is problematic.
Changed other tests that use the same reader/writer as transpose to pass cb/dfb id as compile time args to this reader and this writer.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/qsr_transpose)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/qsr_transpose)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/qsr_transpose)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/qsr_transpose)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/qsr_transpose)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/qsr_transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/qsr_transpose)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
