### PR TITLE
Fix test_umt5_embeddings HF download failure when local_files_only=True on non-local path

### DIFF
--- a/models/tt_dit/tests/encoders/umt5/test_umt5.py
+++ b/models/tt_dit/tests/encoders/umt5/test_umt5.py
@@ -97,7 +97,7 @@ def test_umt5_embeddings(
     else:
         model_name_checkpoint = f"Wan-AI/Wan2.2-T2V-A14B-Diffusers"
         hf_model = UMT5EncoderModel.from_pretrained(
-            model_name_checkpoint, subfolder="text_encoder", local_files_only=True
+            model_name_checkpoint, subfolder="text_encoder", local_files_only=False
         )
 
     hf_model.eval()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40598

### Problem description
`test_umt5_embeddings` fails on Galaxy CI with:
```
OSError: We couldn't connect to 'https://huggingface.co' to load the files, and couldn't find them in the cached files.
```

The non-local code path (`local=False`) was incorrectly setting `local_files_only=True` when loading the UMT5 model from Hugging Face. When the cached weights were not present, the test failed because it could not download them.

**Failing run**: https://github.com/tenstorrent/tt-metal/actions/runs/23472123126/job/68297403585

### What's changed

1. **`models/tt_dit/tests/encoders/umt5/test_umt5.py`** — Set `local_files_only=False` in the non-local (`else`) branch of `test_umt5_embeddings` so the test can download weights from Hugging Face when they are not cached.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/fix-umt5-local-files-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/fix-umt5-local-files-only)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-umt5-local-files-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-umt5-local-files-only)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/fix-umt5-local-files-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/fix-umt5-local-files-only)
  - [ ] [Galaxy wan22 integration](<run-url>)

Made with [Cursor](https://cursor.com)