### PR TITLE
#40167: fix bias related values in matmul kernel

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -246,23 +246,6 @@ def test_matmul_2d_interleaved_sharded_dtype_bias_sweep(
     """
     expected_pcc = 0.99
 
-    if has_bias and batch == 1:
-        # Low PCC (in0, in1, bias) dtype combos: ttnn.linear runs but gives very low PCC. See issue #40167.
-        skip_configs = {
-            (ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32),
-            (ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.float32),
-            (ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat16),
-            (ttnn.float32, ttnn.bfloat16, ttnn.float32),
-            (ttnn.float32, ttnn.bfloat8_b, ttnn.float32),
-            (ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat16),
-            (ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32),
-        }
-        if (in0_dtype, in1_dtype, bias_dtype) in skip_configs:
-            pytest.skip(
-                f"Issue #40167: Low PCC dtype combination for ttnn.Linear "
-                f"(in0={in0_dtype}, in1={in1_dtype}, bias={bias_dtype})"
-            )
-
     _run_matmul_2d_interleaved_in0_sharded_in1(
         device=device,
         batch=batch,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -456,16 +456,21 @@ void kernel_main() {
                                 current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
 
                             if (i == 0) {
-                                in3_base_addr += dram_tensor_start_offset;
+                                // dram_tensor_start_offset is in in1 tile bytes; convert to
+                                // bias tile bytes since bias_dtype may differ from in1_dtype.
+                                in3_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                 bias_single_tile_size_bytes;
                             }
 
                             noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
 
                             uint32_t l1_read_addr_in3 = 0;
                             uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3) + l1_write_addr_in3_offset;
+                            // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
+                            // by in1_single_tile_size_bytes (not bias) to get the tile count.
                             uint32_t in3_block_w_dram =
                                 in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
-                                bias_single_tile_size_bytes;
+                                in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
                                 noc_async_read_one_packet_with_state<true, true>(
@@ -474,8 +479,8 @@ void kernel_main() {
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;
                             }
-                            l1_write_addr_in3_offset +=
-                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index];
+                            // Advance L1 offset in bias tile bytes, not in1 stride bytes.
+                            l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
                             next_bank_id_and_dram_stride_index += 2;
                         }
                         noc_async_read_barrier();


### PR DESCRIPTION
### Ticket
Link to Github Issue #40167

### Problem description
A subset of pytests to test more corner cases for a new matmul variant were failing and had to be skipped. This was related to bias related information not being set up properly.

### What's changed
- update the code to save the correction information
- remove the skips

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-40167_linear_reader)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-40167_linear_reader)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-40167_linear_reader)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-40167_linear_reader)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-40167_linear_reader)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-40167_linear_reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-40167_linear_reader)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
