### PR TITLE
Optimize utilization of pipeline stages for deepseek prefill

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -14,6 +14,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.pipeline import create_pipeline_configuration_from_num_procs
+from models.demos.deepseek_v3_b1.demo.stage import TOKEN_FIFO_SIZE, TOKEN_PAGE_SIZE_BYTES
 from models.demos.deepseek_v3_b1.demo.weight_provider import (
     CacheWeightProvider,
     StateDictWeightProvider,
@@ -90,6 +91,7 @@ class ModelPipeline:
                 write_fn=self.pipeline.write_token,
                 read_fn=self.pipeline.read_output,
                 batch_size=1,
+                prefill_chunk_size=TOKEN_FIFO_SIZE // TOKEN_PAGE_SIZE_BYTES,
             )
         logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
 

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -28,7 +28,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
 
 # Global constants used by multiple stage kinds (and exported to pipeline/cli)
 TOKEN_PAGE_SIZE_BYTES = 64
-TOKEN_FIFO_SIZE = 1024
+TOKEN_FIFO_SIZE = 4096
 ACTIVATION_DIM = 7168
 ACTIVATION_PAGE_SIZE_BYTES = ACTIVATION_DIM * 2
 ACTIVATION_FIFO_SIZE = ACTIVATION_PAGE_SIZE_BYTES * 1

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -84,6 +84,7 @@ class DeepSeekV3:
         write_fn: Callable[[ttnn.Tensor], None],
         read_fn: Callable[[ttnn.Tensor], None],
         batch_size: int = 1,
+        prefill_chunk_size: int = 64,
     ) -> None:
         """
         Args:
@@ -91,19 +92,22 @@ class DeepSeekV3:
             read_fn: Called with an output tensor; implementation fills it (e.g. Pipeline.read_output).
             batch_size: Batch size B. Current implementation supports only B=1;
                 payload size is B * TOKEN_ID_BYTES (int32).
+            prefill_chunk_size: Max number of tokens to pipeline during prefill. Writes up to this many
+                tokens before draining the corresponding reads. Must match the socket FIFO capacity.
         """
         if batch_size != 1:
             raise ValueError(f"DeepSeekV3 currently supports only batch_size=1, got {batch_size}")
         self._write_fn = write_fn
         self._read_fn = read_fn
         self.batch_size = batch_size
+        self._prefill_chunk_size = prefill_chunk_size
         payload_bytes: int = batch_size * TOKEN_ID_BYTES
         logger.debug(f"Payload bytes: {payload_bytes} bytes")
         self._tensor_size_bytes: int = align_up(payload_bytes, PCIE_PAGE_ALIGNMENT_BYTES)
         self._page_size_datums: int = self._tensor_size_bytes // TOKEN_ID_BYTES
         self._position: int = 0
         self._output_buffer: ttnn.Tensor = create_output_buffer(self._page_size_datums)
-        logger.debug(f"Creating DeepSeekV3 model with batch size {batch_size}")
+        logger.debug(f"Creating DeepSeekV3 model with batch size {batch_size}, prefill_chunk_size {prefill_chunk_size}")
 
     def prefill(self, prompt_tokens: list[ttnn.Tensor]) -> ttnn.Tensor:
         """
@@ -125,11 +129,15 @@ class DeepSeekV3:
             raise ValueError("Expected at least one prompt token")
 
         last_output: ttnn.Tensor | None = None
-        for token in prompt_tokens:
-            self._write_fn(token)
-            self._read_fn(self._output_buffer)
-            last_output = self._output_buffer
-            self._position += 1
+        n = len(prompt_tokens)
+        for start in range(0, n, self._prefill_chunk_size):
+            end = min(start + self._prefill_chunk_size, n)
+            for i in range(start, end):
+                self._write_fn(prompt_tokens[i])
+            for _ in range(start, end):
+                self._read_fn(self._output_buffer)
+                last_output = self._output_buffer
+                self._position += 1
         assert last_output is not None, "Last output tensor is None"
         return last_output
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39881

### Problem description
Currently prefill is done by iterating over prompt-tokens and doing write + read for each. Instead, enough tokens should be written to saturate the pipeline and reads should be pipelined to fully utilize all stages.
Note: this also requires updating TOKEN_FIFO_SIZE to have sufficient capacity (i.e. for TOKEN_PAGE_SIZE_BYTES=64 and 64 stages would need TOKEN_FIFO_SIZE >= 4K).


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ztorlak/optimize-prefill-by-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ztorlak/optimize-prefill-by-decode)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
