### PR TITLE
Prefetch-batch DRAM reads in ring attention all-gather reader

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -26,6 +26,55 @@ constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
 constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
 constexpr bool fuse_op = get_compile_time_arg_val(10);
 
+// Prefetch: batch multiple packets of DRAM reads before a single barrier.
+// This keeps more reads in flight across interleaved DRAM banks, hiding latency.
+// CB depth must be >= 2 * PREFETCH_PACKETS * packet_size_in_pages (see program_factory cb_num_pages).
+constexpr uint32_t PREFETCH_PACKETS = 4;
+
+// Batch-read tiles into the output CB with DRAM prefetch and FIFO wrapping.
+// get_noc_addr_and_advance is called once per tile-group read; it returns the source
+// NoC address and may perform per-tile side effects (e.g. row-stride tracking).
+//
+// Manual ring-buffer wrapping: batched reads may write across the FIFO boundary, which
+// bypasses the CB's normal contiguous-write assumption (see cb_push_back). This is safe because
+// noc_async_read targets raw L1 addresses and cb_push_back is called per-packet
+// (packet_size_in_pages always divides cb_num_pages evenly).
+template <typename AddrFn>
+FORCE_INLINE void prefetch_batch_read_tiles(
+    uint32_t& tiles_read,
+    uint32_t tiles_to_read,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    AddrFn&& get_noc_addr_and_advance) {
+    constexpr uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
+    while (tiles_read < tiles_to_read) {
+        uint32_t remaining_tiles = tiles_to_read - tiles_read;
+        uint32_t remaining_packets = (remaining_tiles + packet_size_in_pages - 1) / packet_size_in_pages;
+        uint32_t batch_packets = std::min(remaining_packets, PREFETCH_PACKETS);
+        uint32_t batch_pages = batch_packets * packet_size_in_pages;
+
+        cb_reserve_back(cb_output_id, batch_pages);
+        uint32_t l1_write_addr = get_write_ptr(cb_output_id);
+
+        for (uint32_t p = 0; p < batch_packets; p++) {
+            uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+            for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
+                if (l1_write_addr >= cb_fifo_limit) {
+                    l1_write_addr -= cb_fifo_size;
+                }
+                noc_async_read(get_noc_addr_and_advance(tiles_read), l1_write_addr, input_tensor_page_size);
+                l1_write_addr += payload_size_bytes;
+                tiles_read += contig_pages_advanced;
+            }
+            l1_write_addr += (packet_size_in_pages - num_pages_to_read) * input_tensor_page_size;
+        }
+        noc_async_read_barrier();
+        for (uint32_t p = 0; p < batch_packets; p++) {
+            cb_push_back(cb_output_id, packet_size_in_pages);
+        }
+    }
+}
+
 void kernel_main() {
     constexpr uint32_t page_size_base_idx = 11;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
@@ -72,29 +121,19 @@ void kernel_main() {
         op_signaler = OpSignaler(arg_idx);
     }
 
-    const uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
-    // Push out our local slice
+    const uint32_t cb_fifo_limit = get_local_cb_interface(cb_output_id).fifo_limit;
+    const uint32_t cb_fifo_size = get_local_cb_interface(cb_output_id).fifo_size;
 
+    // Push out our local slice
     uint32_t output_tile_id_start = 0;
     // Read local slice to our buffers, before sending them over
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
         uint32_t tiles_read = input_tile_id_start[input_idx];
         uint32_t tiles_to_read = input_tile_id_end[input_idx];
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-            while (tiles_read < tiles_to_read) {
-                uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                cb_reserve_back(cb_output_id, packet_size_in_pages);
-                const uint32_t l1_write_addr_base = get_write_ptr(cb_output_id);
-                uint32_t l1_write_addr = l1_write_addr_base;
-                for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                    auto read_addr = input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tiles_read);
-                    noc_async_read(read_addr, l1_write_addr, input_tensor_page_size);
-                    l1_write_addr += payload_size_bytes;
-                    tiles_read += contig_pages_advanced;
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_output_id, packet_size_in_pages);
-            }
+            prefetch_batch_read_tiles(tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t tr) {
+                return input_tensor_addrgens[input_idx].get_noc_addr(output_tile_id_start + tr);
+            });
             tiles_read = input_tile_id_start[input_idx];
             tiles_to_read = input_tile_id_end[input_idx];
             output_tile_id_start += input_tensor_Wt[input_idx] * input_tensor_Ht[input_idx];
@@ -175,26 +214,17 @@ void kernel_main() {
                         actual_sender_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
                 }
                 for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-                    while (tiles_read < tiles_to_read) {
-                        uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);  // 2
-                        cb_reserve_back(cb_output_id, packet_size_in_pages);
-                        size_t l1_write_addr = get_write_ptr(cb_output_id);
-                        for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                            auto read_addr = output_tensor_addrgens[input_idx].get_noc_addr(
+                    prefetch_batch_read_tiles(
+                        tiles_read, tiles_to_read, cb_fifo_limit, cb_fifo_size, [&](uint32_t /* tiles_read */) {
+                            auto addr = output_tensor_addrgens[input_idx].get_noc_addr(
                                 output_tile_id_start + row_offset + pages_read_in_row);
-                            noc_async_read(read_addr, l1_write_addr, input_tensor_page_size);
-                            l1_write_addr += payload_size_bytes;
-                            tiles_read += contig_pages_advanced;
-
                             pages_read_in_row++;
                             if (pages_read_in_row >= slice_Wt) {
                                 row_offset += stride_Wt;
                                 pages_read_in_row = 0;
                             }
-                        }
-                        noc_async_read_barrier();
-                        cb_push_back(cb_output_id, packet_size_in_pages);
-                    }
+                            return addr;
+                        });
                     pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
                     row_offset =
                         (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -217,7 +217,9 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     const uint32_t max_scatter_write_pages = 2;
     const uint32_t num_pages_per_packet =
         std::min((uint32_t)(packet_size_bytes / l1_scratch_cb_page_size_bytes), max_scatter_write_pages);
-    const uint32_t cb_num_pages = 3 * num_pages_per_packet;  // triple buffering
+    // Must be >= 2 * PREFETCH_PACKETS(=4) * num_pages_per_packet for deadlock-free double-buffering
+    // (see PREFETCH_PACKETS in ring_attention_all_gather_reader.cpp).
+    const uint32_t cb_num_pages = 8 * num_pages_per_packet;
     const tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor[0].dtype());
 
     // CBs for transferring data between sender_reader and sender_writer


### PR DESCRIPTION
## Summary

- Batch 4 packets (8 tile reads) per `noc_async_read_barrier` in the CCL reader kernel via a `prefetch_batch_read_tiles()` template helper, keeping more reads in flight across interleaved DRAM banks
- Manual L1 ring-buffer wrapping lets the writer's per-packet pop protocol stay unchanged; host-side CB depth increased from 3x to 8x (6→16 pages, +20 KB per CCL core)
- Measured on BH 4-chip ring (WAN 2.2 shapes): math utilization recovers from ~50% back to ~65% (PCC 0.9997, unchanged)

## Test plan
- [ ] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=pjosipovic%2Fring_attention_ccl_dram_reads)](https://github.com/tenstorrent/tt-metal/actions/runs/23485013026)
- [ ] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=pjosipovic%2Fring_attention_ccl_dram_reads)](https://github.com/tenstorrent/tt-metal/actions/runs/23484968842)
- [ ] [![(T3K) T3000 fast tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-fast-tests.yaml/badge.svg?branch=pjosipovic%2Fring_attention_ccl_dram_reads)](https://github.com/tenstorrent/tt-metal/actions/runs/23484963472)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Fring_attention_ccl_dram_reads)](https://github.com/tenstorrent/tt-metal/actions/runs/23484956346)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic%2Fring_attention_ccl_dram_reads)](https://github.com/tenstorrent/tt-metal/actions/runs/23484952057)

🤖 Generated with [Claude Code](https://claude.com/claude-code)