### PR TITLE
Fix Llama regression due to bounding box core selection error in Ring Matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1931,8 +1931,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     }
     for (const auto& cr : subdevice_cores.ranges()) {
         auto intersection = non_idle_cores.intersection(cr);
-        for (const auto& ir : intersection.ranges()) {
-            non_idle_cores_vec.push_back(ir);
+        if (intersection.empty()) {
+            continue;
+        }
+        bool is_rectangular = cr.end_coord.x > cr.start_coord.x && cr.end_coord.y > cr.start_coord.y;
+        if (is_rectangular) {
+            non_idle_cores_vec.push_back(intersection.bounding_box());
+        } else {
+            for (const auto& ir : intersection.ranges()) {
+                non_idle_cores_vec.push_back(ir);
+            }
         }
     }
     all_cores = CoreRangeSet(non_idle_cores_vec);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40614

### Problem description
Llama regressed because bounding box logic was wrong.
When prefetcher integration PR was introduced we enabled the ability for sub device core ranges that are non-rectangular (row core strips) to act as matmul cores

For llama the matmul cores intersection with the sub device core range is NOT same as the bounding box core range and llama GLX relies on the bounding box for all matmul cores. so we should check that if the sub device core range set forms  a rectangular so that we use the full bounding box when possible. If it doesnt we just use the intersections. 

### What's changed
- described above

### Checklist
- [ ] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23503262641)
- [ ] [Llama demo](https://github.com/tenstorrent/tt-metal/actions/runs/23503130314)
- [ ] [BH demo](https://github.com/tenstorrent/tt-metal/actions/runs/23503120649)
- [ ] [BH unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/23503197315)