### PR TITLE
[Clean up]: Add existence of tile counter registers and ability to do implicit dfb sync into HAL

### DIFF
--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -318,6 +318,8 @@ private:
     HalTensixHarvestAxis tensix_harvest_axis_{HalTensixHarvestAxis::ROW};
     size_t max_pinned_memory_count_{};
     size_t total_pinned_memory_size_{};
+    bool has_tile_counter_registers_{};
+    bool supports_implicit_dfb_sync_{};
 
     float eps_ = 0.0f;
     float nan_ = 0.0f;
@@ -379,6 +381,8 @@ public:
     }
     uint32_t get_operand_start_stream() const { return operand_start_stream_; }
     bool has_stream_registers() const { return has_stream_registers_; }
+    bool has_tile_counter_registers() const { return has_tile_counter_registers_; }
+    bool supports_implicit_dfb_sync() const { return supports_implicit_dfb_sync_; }
 
     float get_eps() const { return eps_; }
     float get_nan() const { return nan_; }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -393,6 +393,8 @@ void Hal::initialize_bh(bool enable_2_erisc_mode, std::uint32_t profiler_dram_ba
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
+    this->has_tile_counter_registers_ = false;
+    this->supports_implicit_dfb_sync_ = false;
 
     this->eps_ = EPS_BH;
     this->nan_ = NAN_BH;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -343,6 +343,8 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled, std::uint32_t profiler_
     this->eth_fw_is_cooperative_ = true;
     this->virtualized_core_types_ = {dev_msgs::AddressableCoreType::TENSIX, dev_msgs::AddressableCoreType::ETH};
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
+    this->has_tile_counter_registers_ = false;
+    this->supports_implicit_dfb_sync_ = false;
 
     this->eps_ = EPS_WHB0;
     this->nan_ = NAN_WHB0;

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -472,6 +472,8 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
         dev_msgs::AddressableCoreType::PCIE,
         dev_msgs::AddressableCoreType::DRAM};
     this->tensix_harvest_axis_ = static_cast<HalTensixHarvestAxis>(tensix_harvest_axis);
+    this->has_tile_counter_registers_ = true;
+    this->supports_implicit_dfb_sync_ = true;
 
     this->eps_ = EPS_QA;
     this->nan_ = NAN_QA;


### PR DESCRIPTION
### What's changed
Add arch specific features related to DFBs into the HAL. This will be used to enable DFBs on WH/BH

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-hal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-hal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-hal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-hal)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
