### PR TITLE
SDXL new expected perf - sanity fix

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -320,7 +320,7 @@ def test_conv2d_auto_sliced_vae_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 3142259  # Measured: 3.19ms for Conv2D VAE auto sliced
+    expected_duration_ns = 3142259  # Measured: 3.14ms for Conv2D VAE auto sliced
 
     # Log the performance result
     print(

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -320,7 +320,7 @@ def test_conv2d_auto_sliced_vae_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 3185244  # Measured: 3.19ms for Conv2D VAE auto sliced
+    expected_duration_ns = 3142259  # Measured: 3.19ms for Conv2D VAE auto sliced
 
     # Log the performance result
     print(


### PR DESCRIPTION
### Problem description
ND passing test in Sanity test (SDXL): `test_conv2d_auto_sliced_vae_performance`

## Analysis
| Statistics           | Value        |
|----------------------|--------------|
| Sanity tests 1033    | 3143273      |
| Sanity tests 1032    | 3146862      |
| Sanity tests 1031    | 3140930      |
| Sanity tests 1024    | 3137395      |
| Sanity tests 1023    | 3144383      |
| Sanity tests 1022    | 3139258      |
| Sanity tests 1018    | 3141278      |
| Sanity tests 1016    | 3144693      |


**New average** : **3142259**
**New upper**:  **3189392.885**
**New lower** : **3095125.115**

## Whats changed:
Updated expected Conv2D VAE auto-sliced device kernel duration to match current measured performance


### Checklist
- [x] [Sanity tests, op tests only](https://github.com/tenstorrent/tt-metal/actions/runs/23506193272) passed ✅