### PR TITLE
[Clean up]: Remove quasar specific attributes from CB interface

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -40,7 +40,7 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
  */
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    // Use fifo_rd_tile_idx: number of tiles the read pointer has advanced from DFB base
+    // Number of tiles the read pointer has advanced from DFB base
     const std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + tile_index;
 
     WAYPOINT("UPAW");

--- a/tt_metal/hw/inc/internal/circular_buffer_init.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_init.h
@@ -66,14 +66,6 @@ FORCE_INLINE void setup_local_cb_read_write_interfaces(
             if (init_wr_tile_ptr) {
                 local_interface.fifo_wr_tile_ptr = 0;
             }
-#ifdef ARCH_QUASAR
-            if (read) {
-                local_interface.fifo_rd_tile_idx = 0;
-            }
-            if (write) {
-                local_interface.fifo_wr_tile_idx = 0;
-            }
-#endif
             cb_id++;
         } else {
             circular_buffer_config_addr += UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
@@ -106,14 +98,6 @@ FORCE_INLINE void setup_local_cb_read_write_interfaces(
         ".if %[init_wr_tile_ptr]\n\t"
         "    sw zero, %[off_fifo_tile_wr_ptr](%[liptr])\n\t"  // local_interface.fifo_wr_tile_ptr = 0;
         ".endif\n\t"
-#ifdef ARCH_QUASAR
-        ".if %[read]\n\t"
-        "    sw zero, %[off_fifo_rd_tile_idx](%[liptr])\n\t"  // local_interface.fifo_rd_tile_idx = 0;
-        ".endif\n\t"
-        ".if %[write]\n\t"
-        "    sw zero, %[off_fifo_wr_tile_idx](%[liptr])\n\t"  // local_interface.fifo_wr_tile_idx = 0;
-        ".endif\n\t"
-#endif
         // Advance to next cb config.
         "    addi %[cbconfig], %[cbconfig], %[circular_buffer_byte_size]\n\t"
 
@@ -171,10 +155,6 @@ FORCE_INLINE void setup_local_cb_read_write_interfaces(
           [off_fifo_wr_ptr] "i"(offsetof(LocalCBInterface, fifo_wr_ptr)),
           [off_tiles_acked] "i"(offsetof(LocalCBInterface, tiles_acked_received_init)),
           [off_fifo_tile_wr_ptr] "i"(offsetof(LocalCBInterface, fifo_wr_tile_ptr)),
-#ifdef ARCH_QUASAR
-          [off_fifo_rd_tile_idx] "i"(offsetof(LocalCBInterface, fifo_rd_tile_idx)),
-          [off_fifo_wr_tile_idx] "i"(offsetof(LocalCBInterface, fifo_wr_tile_idx)),
-#endif
           [local_cb_interface_size] "i"(sizeof(CBInterface)),
           [circular_buffer_byte_size] "i"(UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t)),
           [read] "i"(read ? 1 : 0),

--- a/tt_metal/hw/inc/internal/circular_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_interface.h
@@ -81,12 +81,6 @@ struct LocalCBInterface {
 
     // used by packer for in-order packing
     uint32_t fifo_wr_tile_ptr;
-
-#ifdef ARCH_QUASAR
-    // Quasar only: Tile indices tracking how many tiles from CB base the rd/wr pointers are
-    uint32_t fifo_rd_tile_idx;
-    uint32_t fifo_wr_tile_idx;
-#endif
 };
 
 struct CBInterface {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
CBs shouldn't have Quasar specific attributes 

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/qsr-cb-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/qsr-cb-clean)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/qsr-cb-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/qsr-cb-clean)
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early