### PR TITLE
Increase t3k_dits_tests timeout from 15 to 20 minutes

### DIFF
--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -183,7 +183,7 @@
   cmd: run_t3000_tt_dit_tests
   skus:
     wh_llmbox:
-      timeout: 15
+      timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
   model-name: dits


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40617

### Problem description
The `t3k_dits_tests` job has been intermittently timing out at 15 minutes since #38690 added UMT5 encoder tests on Feb 28. The added tests consume ~4 minutes, leaving only ~20 seconds of headroom in the 15-minute budget. Normal run-to-run variance (~±20s) determines pass/fail.

The step ran in **13m 42s** when #38690 merged, but subsequent runs on main show the budget is chronically tight:

- **Last pass** (Mar 20 14:50 UTC, `37b8ea33`): step took **14m 41s** — 19 seconds to spare
- **First fail** (Mar 20 17:15 UTC, `2ffa6a8de3`): step took **15m 0s** — hit timeout exactly

No single commit between those two runs caused a regression. The 10 commits in between (`0116f2ce65`, `27720a7ea0`, etc.) don't affect the dit test suite's runtime. The failures are caused by the tight budget plus normal CI variance.

Since Mar 20, the job fails ~95% of runs, with occasional passes when variance is favorable.

**Failing run**: https://github.com/tenstorrent/tt-metal/actions/runs/23494845765/job/68374489642

Timing breakdown from failing run logs:

| Test | Duration |
|------|----------|
| `test_timestep_encoding` | ~15s |
| `test_wan_time_text_image_embedding` | ~32s |
| `test_t5_encoder` | ~34s |
| `test_umt5_embeddings` | ~82s |
| `test_umt5_encoder` | ~164s |
| `test_clip_encoder` (×2) | ~38s |
| `test_sd35_vae_vae_decoder` | ~91s |
| `test_transformer` (flux1) | ~76s |
| `test_wan_decoder` | ~102s |
| `test_wan_transformer_model` | ~79s |
| `test_mochi_transformer_model` | ~61s |
| `test_tt_resblock_forward` | **timed out** |
| **Total (before last test)** | **~13.9 min** |

### What's changed

1. **`tests/pipeline_reorg/t3k_unit_tests.yaml`** — Increase `t3k_dits_tests` timeout from 15 to 20 minutes, providing ~5 minutes of headroom instead of ~20 seconds.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/fix-t3k-dits-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/fix-t3k-dits-timeout)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/fix-t3k-dits-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/fix-t3k-dits-timeout)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/fix-t3k-dits-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/fix-t3k-dits-timeout)
  - [ ] [T3K dits unit tests](<run-url>)