### PR TITLE
Fix NeighborPad multihost crash: remove illegal remote device pointer…

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -177,8 +177,9 @@ void kernel_main() {
             }
         } else {
             // W barrier: 1-hop unicast to immediate W neighbor only.
-            // neighbor_sem_noc0_x/y and barrier_sem_noc0_x/y are pre-computed
-            // using the NEIGHBOR device's worker_core_from_logical_core().
+            // neighbor_sem_noc0_x/y and barrier_sem_noc0_x/y are NOC coords of the local
+            // device's worker cores. Since NOC coords are not chip-dependent, these are
+            // valid targets on the neighbor device as well.
             if (!is_last_chip) {
                 auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -373,12 +373,10 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             is_last_w_device);
 
         // W fabric core coordinates (placed after H fabric cores in first row)
-        // Use per-device core mapping to get correct NOC coords for this device's harvesting.
-        auto* local_device = mesh_device->get_device(mesh_coordinate);
         for (uint32_t i = 0; i < num_w_fabric_cores; i++) {
             CoreCoord wc = {num_h_fabric_cores + i, 0};
             w_fabric_logical_cores.push_back(wc);
-            w_fabric_virtual_cores.push_back(local_device->worker_core_from_logical_core(wc));
+            w_fabric_virtual_cores.push_back(mesh_device->worker_core_from_logical_core(wc));
         }
         w_fabric_core_range =
             CoreRangeSet(CoreRange({num_h_fabric_cores, 0}, {num_h_fabric_cores + num_w_fabric_cores - 1, 0}));
@@ -798,19 +796,6 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 w_reader_rt_args.push_back(w_direction);                                         // direction
                 SetRuntimeArgs(program, w_reader_kernel_id, {w_core}, w_reader_rt_args);
 
-                // Compute neighbor device NOC coords for W writer targets.
-                // W-axis devices span different UBBs with potentially different core harvesting,
-                // so we must use the NEIGHBOR device's worker_core_from_logical_core().
-                const auto& w_neighbor_coord = w_direction ? w_backward_coord : w_forward_coord;
-                CoreCoord w_neighbor_same_virtual = w_virtual_core;  // default: local (won't be used if no neighbor)
-                CoreCoord w_neighbor_opp_virtual = w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)];
-                if (w_neighbor_coord.has_value()) {
-                    auto* w_neighbor_dev = mesh_device->get_device(w_neighbor_coord.value());
-                    w_neighbor_same_virtual = w_neighbor_dev->worker_core_from_logical_core(w_core);
-                    CoreCoord opp_logical = w_fabric_logical_cores[(w_link * 2) + (1 - w_direction)];
-                    w_neighbor_opp_virtual = w_neighbor_dev->worker_core_from_logical_core(opp_logical);
-                }
-
                 // W writer runtime args (addresses in CRTAs, not here)
                 std::vector<uint32_t> w_writer_rt_args = {
                     w_link_start * output_num_sticks_per_halo_dim,  // outer_dim_offset_start_id (per-link)
@@ -820,13 +805,13 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                     w_link_count,                                   // outer_dim_size (per-link)
                     w_direction ? operation_attributes.pad2_right : operation_attributes.pad2_left,  // padding
                     operation_attributes.pad2_left,                                                  // padding_left
-                    1,                          // num_sticks_to_read
-                    1,                          // num_sticks_per_halo_dim
-                    w_neighbor_same_virtual.x,  // neighbor_sem_noc0_x (NEIGHBOR device coords!)
-                    w_neighbor_same_virtual.y,  // neighbor_sem_noc0_y (NEIGHBOR device coords!)
-                    true,                       // use_barrier_semaphore (W writers: W-axis startup barrier)
-                    w_neighbor_opp_virtual.x,   // barrier_sem_noc0_x (opp W dir, NEIGHBOR device coords!)
-                    w_neighbor_opp_virtual.y};  // barrier_sem_noc0_y (opp W dir, NEIGHBOR device coords!)
+                    1,                 // num_sticks_to_read
+                    1,                 // num_sticks_per_halo_dim
+                    w_virtual_core.x,  // neighbor_sem_noc0_x
+                    w_virtual_core.y,  // neighbor_sem_noc0_y
+                    true,              // use_barrier_semaphore (W writers: W-axis startup barrier)
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,   // barrier_sem_noc0_x (opp W dir)
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y};  // barrier_sem_noc0_y (opp W dir)
                 // No Phase 2 signal targets (W writers ARE Phase 2)
                 // sem_addr omitted — kernel reads barrier_sem from CRTA[3]
                 constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;


### PR DESCRIPTION
### Ticket
Partial revert of #40154

### Problem description
PR #40154 updated the NeighborPad program factory to use `mesh_device->get_device(neighbor_coord)` when computing NOC coordinates, with the intention of accounting for per-device core harvesting on the neighbor chip. However, this pattern doesn't work in multi-host mesh configurations where the neighbor device lives on a different MPI rank — `get_device()` is only valid for devices local to the current rank.

It turns out the neighbor device lookup wasn't needed anyway: NOC coordinates are not chip-dependent, so the same logical core maps to the same NOC x/y regardless of which device you ask. The local device's core mapping produces identical results.

### What's changed
- Remove the `mesh_device->get_device(w_neighbor_coord)` calls introduced in #40154 for computing W-writer runtime arg NOC coordinates, replacing them with local virtual core coordinates (`w_virtual_core` and `w_fabric_virtual_cores`).
- Switch the W fabric core mapping from `local_device->worker_core_from_logical_core()` to `mesh_device->worker_core_from_logical_core()`, removing the need for a per-device pointer.
- Update a stale comment in `minimal_default_writer.cpp` that described `neighbor_sem_noc0_x/y` and `barrier_sem_noc0_x/y` as being pre-computed using the neighbor device's core mapping.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:neighbor_pad_multihost)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:neighbor_pad_multihost)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:neighbor_pad_multihost)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### CI runs

- [(T3K) T3000 integration tests — wan2.2](https://github.com/tenstorrent/tt-metal/actions/runs/23510116791)
- [(Galaxy) integration tests — wan22](https://github.com/tenstorrent/tt-metal/actions/runs/23510120454)
- [(T3K) T3000 fast tests](https://github.com/tenstorrent/tt-metal/actions/runs/23510147178)
- [(WH Galaxy) Quick](https://github.com/tenstorrent/tt-metal/actions/runs/23510147103)

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:neighbor_pad_multihost)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:neighbor_pad_multihost)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=neighbor_pad_multihost)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:neighbor_pad_multihost)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs