### PR TITLE
[skip ci] Add stress test for P150 in upstream tests workflow

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -408,6 +408,12 @@ jobs:
         run: |
           docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent \
             ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+      - name: Run stress test (P150 only)
+        if: ${{ matrix.bh-card == 'P150' }}
+        timeout-minutes: 30
+        run: |
+          docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent \
+            ${{ needs.get-image-tags.outputs.bh-image-tag }} blackhole_ttnn_stress_tests
   calculate-to-publish:
     if: ${{ !cancelled() }}
     needs:


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/metal-internal-workflows/issues/998

### Problem description
Stress test on p150 is delivered to syseng so we should test it on upstream CI

### What's changed
Run in on p150

### Checklist

- [ ] Upstream P150: https://github.com/tenstorrent/tt-metal/actions/runs/23509719872/job/68429380514
