### PR TITLE
Follow-up fix galaxy demo pipeline

### DIFF
--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -14,8 +14,9 @@ Usage:
 enabled_skus is a comma-separated list, or the literal ALL_SKUS_IN_TESTS to enable every SKU
 key that appears under any test entry's skus mapping in the tests YAML.
 
-Example:
+Examples:
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml
+    python prepare_test_matrix.py tests/pipeline_reorg/galaxy_demo_tests.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml
 """
 
 import yaml

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -11,6 +11,9 @@ This script:
 Usage:
     python prepare_test_matrix.py <tests_yaml_path> <enabled_skus> <sku_config_yaml_path>
 
+enabled_skus is a comma-separated list, or the literal ALL_SKUS_IN_TESTS to enable every SKU
+key that appears under any test entry's skus mapping in the tests YAML.
+
 Example:
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml
 """
@@ -19,6 +22,18 @@ import yaml
 import json
 import sys
 import os
+
+ALL_SKUS_IN_TESTS = "ALL_SKUS_IN_TESTS"
+
+
+def collect_skus_from_tests(tests):
+    """Return sorted unique SKU names referenced in tests' skus mappings."""
+    names = set()
+    for test in tests:
+        test_skus = test.get("skus")
+        if isinstance(test_skus, dict):
+            names.update(test_skus.keys())
+    return sorted(names)
 
 
 def parse_enabled_skus(enabled_skus_str):
@@ -180,6 +195,7 @@ def build_test_matrix(tests, enabled_skus, sku_config):
 def main():
     if len(sys.argv) != 4:
         print("Usage: python prepare_test_matrix.py <tests_yaml_path> <enabled_skus> <sku_config_yaml_path>")
+        print("  enabled_skus: comma-separated list, or ALL_SKUS_IN_TESTS")
         print(
             'Example: python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml'
         )
@@ -193,15 +209,19 @@ def main():
     print(f"Loading SKU config from: {sku_config_path}")
     print(f"Enabled SKUs: '{enabled_skus_str}'")
 
-    # Parse enabled SKUs
-    enabled_skus = parse_enabled_skus(enabled_skus_str)
-    print(f"Parsed enabled SKUs: {enabled_skus}")
-
-    # Load configurations
     sku_config = load_sku_config(sku_config_path)
     tests = load_tests(tests_yaml_path)
 
-    # Build filtered matrix
+    if enabled_skus_str.strip().upper() == ALL_SKUS_IN_TESTS:
+        enabled_skus = collect_skus_from_tests(tests)
+        print(f"Resolved {ALL_SKUS_IN_TESTS} to: {enabled_skus}")
+        if not enabled_skus:
+            print("::error::No SKU keys found under skus in the tests YAML.")
+            sys.exit(1)
+    else:
+        enabled_skus = parse_enabled_skus(enabled_skus_str)
+        print(f"Parsed enabled SKUs: {enabled_skus}")
+
     filtered_matrix = build_test_matrix(tests, enabled_skus, sku_config)
 
     # Output as JSON

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -129,7 +129,8 @@ models:
   demo:
     wh_llmbox_perf: 1090
     wh_llmbox_perf_release: 1090
-    wh_galaxy: 287
+    wh_galaxy: 247
+    wh_galaxy_perf: 40
     wh_galaxy_release: 345
     bh_galaxy: 30
     wh_n150: 500

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -12,9 +12,6 @@ on:
       build-artifact-name:
         required: true
         type: string
-      enabled-skus:
-        required: true
-        type: string
       model:
         required: false
         type: string
@@ -48,12 +45,12 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
             "demo"
-      - name: Build unified test matrix based on enabled SKUs
+      - name: Build test matrix (all SKUs listed in tests YAML)
         id: build-matrix
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
+            ALL_SKUS_IN_TESTS \
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -77,5 +77,5 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
-      enabled-skus: wh_galaxy_perf
+      enabled-skus: wh_galaxy,wh_galaxy_perf
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -77,5 +77,4 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
-      enabled-skus: wh_galaxy,wh_galaxy_perf
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -245,7 +245,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-demo || 'all' }}
   galaxy-model-perf-tests:
     if: ${{ needs.determine-tests.outputs.run-model-perf == 'true' }}


### PR DESCRIPTION
Galaxy demo was updated to use two different types of galaxies based on test requirement (weka and non weka, aka perf and functional) in https://github.com/tenstorrent/tt-metal/pull/40384. Due to (my) previous subpar design decisions, `enabled-skus` input into test matrix generation was hardcoded to one type of galaxy instead of both, resulting in galaxy demo not running all tests by default. This PR addresses the root cause by removing the dependency on `enabled-skus`. 

Testing:

- [x] Galaxy demo https://github.com/tenstorrent/tt-metal/actions/runs/23512328887