### PR TITLE
Add native padding support for generic tiled reductions

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -537,6 +537,72 @@ def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+def _run_torch_reduce(op_name, torch_input_tensor, dim, keepdim):
+    if op_name == "sum":
+        return torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+    if op_name == "mean":
+        return torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim)
+    if op_name == "max":
+        if isinstance(dim, list):
+            return torch.amax(torch_input_tensor, dim=dim, keepdim=keepdim)
+        return torch.max(torch_input_tensor, dim=dim, keepdim=keepdim).values
+    if op_name == "min":
+        if isinstance(dim, list):
+            return torch.amin(torch_input_tensor, dim=dim, keepdim=keepdim)
+        return torch.min(torch_input_tensor, dim=dim, keepdim=keepdim).values
+    raise ValueError(f"Unsupported reduction op: {op_name}")
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "op_name, pad_value",
+    [("sum", 42.0), ("mean", 42.0), ("max", 10000.0)],
+)
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        ((2, 37, 41), -1, True),
+        ((2, 37, 41), -2, True),
+        ((2, 37, 41), [-2, -1], True),
+        ((32, 6, 7), -3, True),
+    ],
+)
+def test_reduce_with_padding(device, dtype, op_name, pad_value, input_shape, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch_input_tensor = torch_random(input_shape, -1, 1, dtype=torch_dtype)
+    torch_output_tensor = _run_torch_reduce(op_name, torch_input_tensor, dim, keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    ttnn.fill_implicit_tile_padding(input_tensor, pad_value)
+
+    output_tensor = getattr(ttnn, op_name)(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim", [-1, -2, [-2, -1], -3])
+def test_min_reduce_with_padding_uses_fallback(device, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch_random((32, 6, 7), -1, 1, dtype=torch.bfloat16)
+    torch_output_tensor = _run_torch_reduce("min", torch_input_tensor, dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(input_tensor, -10000.0)
+
+    output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=True)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
 def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
     torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
     batch_size, in_c, in_h, in_w = input_shape

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
@@ -15,7 +15,7 @@ The ReduceDeviceOperation uses 3 ProgramFactory variants:
 compute_program_hash() includes:
   math_op, dim, scaler, output_mem_config, output_dtype, compute_kernel_config,
   sub_core_grids, negate, program_factory.index(), input dtype,
-  input memory_config, input padded_shape.
+  input memory_config, input logical_shape, input padded_shape.
 
 override_runtime_arguments() only updates buffer addresses — shape/work distribution
 changes require separate cache entries (padded_shape is in hash).
@@ -143,6 +143,22 @@ def test_reduce_cache_miss_different_shapes(device, isolate_program_cache):
     assert_with_pcc(torch_ref1, tt_out1, 0.999)
 
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, [1, 1, 64, 64], dim=-1, dtype=ttnn.bfloat16)
+    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+
+    assert device.num_program_cache_entries() == 2
+
+
+def test_reduce_cache_miss_same_padded_shape_different_logical_shape(device, isolate_program_cache):
+    """Different logical shapes that share a padded shape still need separate cache entries.
+
+    Native reduce padding bakes the logical tail sizes into reader compile-time args.
+    Reusing a program across the same padded tile shape but different logical shapes
+    would apply the wrong terminal-tile masking.
+    """
+    torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, [1, 1, 9, 9], dim=-1, dtype=ttnn.bfloat16)
+    assert_with_pcc(torch_ref1, tt_out1, 0.999)
+
+    torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, [1, 1, 37, 9], dim=-1, dtype=ttnn.bfloat16)
     assert_with_pcc(torch_ref2, tt_out2, 0.999)
 
     assert device.num_program_cache_entries() == 2

--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
@@ -5,6 +5,35 @@
 #pragma once
 
 #include <tt-metalium/constants.hpp>
+#include "api/numeric/bfloat16.h"
+#include "api/numeric/float32.h"
+
+enum class NeutralPolicy : uint32_t {
+    Zero = 0,
+    NegInf = 1,
+    PosInf = 2,
+};
+
+template <DataFormat data_format, NeutralPolicy policy>
+constexpr auto get_neutral_value() {
+    if constexpr (data_format == DataFormat::Float32) {
+        if constexpr (policy == NeutralPolicy::NegInf) {
+            return NEG_INF_FLOAT32;
+        } else if constexpr (policy == NeutralPolicy::PosInf) {
+            return POS_INF_FLOAT32;
+        } else {
+            return static_cast<uint32_t>(0);
+        }
+    } else {
+        if constexpr (policy == NeutralPolicy::NegInf) {
+            return NEG_INF_BFLOAT16;
+        } else if constexpr (policy == NeutralPolicy::PosInf) {
+            return POS_INF_BFLOAT16;
+        } else {
+            return static_cast<uint16_t>(0);
+        }
+    }
+}
 
 /**
  * @brief Pads a face within a tile.
@@ -200,5 +229,47 @@ void pad_last_transposed_ktile(uint32_t l1_write_addr_in0) {
     } else if constexpr (in0_data_format == DataFormat::Float16_b) {
         fill_pad_tile<uint16_t, /*num_elements_unpadded_w=*/TILE_WIDTH, in0_last_ktile_h>(
             l1_write_addr_in0, /*pad_value=*/0);
+    }
+}
+
+template <DataFormat data_format, uint32_t last_tile_w, NeutralPolicy policy>
+void pad_last_wtile(uint32_t l1_write_addr) {
+    using namespace tt::constants;
+    if constexpr (data_format == DataFormat::Float32) {
+        constexpr uint32_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint32_t, last_tile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(l1_write_addr, fill_value);
+    } else if constexpr (data_format == DataFormat::Float16_b) {
+        constexpr uint16_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint16_t, last_tile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(l1_write_addr, fill_value);
+    }
+}
+
+template <DataFormat data_format, uint32_t last_tile_h, NeutralPolicy policy>
+void pad_last_htile(uint32_t l1_write_addr) {
+    using namespace tt::constants;
+    if constexpr (data_format == DataFormat::Float32) {
+        constexpr uint32_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint32_t, /*num_elements_unpadded_w=*/TILE_WIDTH, last_tile_h>(l1_write_addr, fill_value);
+    } else if constexpr (data_format == DataFormat::Float16_b) {
+        constexpr uint16_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint16_t, /*num_elements_unpadded_w=*/TILE_WIDTH, last_tile_h>(l1_write_addr, fill_value);
+    }
+}
+
+template <uint32_t in_df, uint32_t last_w, NeutralPolicy policy>
+void apply_width_padding(uint32_t l1_write_addr) {
+    if constexpr (in_df == static_cast<uint32_t>(DataFormat::Float32)) {
+        pad_last_wtile<DataFormat::Float32, last_w, policy>(l1_write_addr);
+    } else if constexpr (in_df == static_cast<uint32_t>(DataFormat::Float16_b)) {
+        pad_last_wtile<DataFormat::Float16_b, last_w, policy>(l1_write_addr);
+    }
+}
+
+template <uint32_t in_df, uint32_t last_h, NeutralPolicy policy>
+void apply_height_padding(uint32_t l1_write_addr) {
+    if constexpr (in_df == static_cast<uint32_t>(DataFormat::Float32)) {
+        pad_last_htile<DataFormat::Float32, last_h, policy>(l1_write_addr);
+    } else if constexpr (in_df == static_cast<uint32_t>(DataFormat::Float16_b)) {
+        pad_last_htile<DataFormat::Float16_b, last_h, policy>(l1_write_addr);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace tt::tt_metal {
@@ -23,3 +25,23 @@ tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const tt::tt_metal::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
 }  // namespace ttnn::prim
+
+namespace ttnn::operations::reduction {
+
+inline uint32_t get_neutral_policy(tt::tt_metal::ReduceOpMath math_op) {
+    switch (math_op) {
+        case tt::tt_metal::ReduceOpMath::MAX: return 1;
+        case tt::tt_metal::ReduceOpMath::MIN: return 2;
+        default: return 0;
+    }
+}
+
+inline bool supports_native_reduce_padding(const tt::tt_metal::DataType dtype, const bool negate) {
+    return !negate && (dtype == tt::tt_metal::DataType::FLOAT32 || dtype == tt::tt_metal::DataType::BFLOAT16);
+}
+
+inline bool supports_native_reduce_padding(const tt::DataFormat data_format, const bool negate) {
+    return !negate && (data_format == tt::DataFormat::Float32 || data_format == tt::DataFormat::Float16_b);
+}
+
+}  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -12,13 +12,21 @@
 #else
 #include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
 #endif
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
     constexpr uint32_t scaler = get_compile_time_arg_val(0);
-    constexpr auto tensor_args = TensorAccessorArgs<1>();
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t Ht = get_compile_time_arg_val(2);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(3);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(4);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(5);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(6);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
+    constexpr auto tensor_args = TensorAccessorArgs<7>();
 
     constexpr uint32_t cb_id_in2 = 2;
 #ifndef REDUCE_ROW_SUM_VIA_MM
@@ -37,11 +45,32 @@ void kernel_main() {
     experimental::Noc noc;
     experimental::CircularBuffer cb_in0(cb_id_in0);
 
+    uint32_t current_row = start_id / Wt;
+    uint32_t current_col = start_id % Wt;
+
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         cb_in0.reserve_back(onetile);
         noc.async_read(tensor_accessor, cb_in0, tile_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
+
+        if constexpr (LAST_W > 0) {
+            if (current_col == Wt - 1) {
+                apply_width_padding<IN_DF, LAST_W, NEUTRAL>(cb_in0.get_write_ptr());
+            }
+        }
+        if constexpr (LAST_H > 0) {
+            if ((current_row % Ht) == Ht - 1) {
+                apply_height_padding<IN_DF, LAST_H, NEUTRAL>(cb_in0.get_write_ptr());
+            }
+        }
+
         cb_in0.push_back(onetile);
+
+        current_col++;
+        if (current_col == Wt) {
+            current_col = 0;
+            current_row++;
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -8,6 +8,7 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/endpoints.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -16,13 +17,20 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(3);
     uint32_t row_size_bytes = get_arg_val<uint32_t>(4);
     uint32_t batch_size_bytes = get_arg_val<uint32_t>(5);
+    uint32_t is_last_w_padded = get_arg_val<uint32_t>(6);
+    uint32_t is_last_h_padded = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(2);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(3);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(4);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(5);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
 
 #ifdef REDUCE_SCALER
-    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
-    uint32_t scalar = get_arg_val<uint32_t>(6);
+    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(6);
+    uint32_t scalar = get_arg_val<uint32_t>(8);
     generate_reduce_scaler(cb_id_in2, scalar);
 #endif
 
@@ -54,6 +62,18 @@ void kernel_main() {
                     {.offset_bytes = 0});
                 curr_l1_addr += row_size_bytes;
                 noc.async_read_barrier();
+
+                if constexpr (LAST_W > 0) {
+                    if (is_last_w_padded && (i == Wt - 1)) {
+                        apply_width_padding<IN_DF, LAST_W, NEUTRAL>(cb_in0.get_write_ptr());
+                    }
+                }
+                if constexpr (LAST_H > 0) {
+                    if (is_last_h_padded && (j == Ht - 1)) {
+                        apply_height_padding<IN_DF, LAST_H, NEUTRAL>(cb_in0.get_write_ptr());
+                    }
+                }
+
                 cb_in0.push_back(onetile);
             }
             col_l1_addr += tile_bytes;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -8,6 +8,7 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -20,6 +21,11 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t HtWt = get_compile_time_arg_val(2);
     constexpr uint32_t row_chunk = get_compile_time_arg_val(3);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(4);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(5);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(6);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(7);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
@@ -27,10 +33,10 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
-    constexpr uint32_t scalar = get_compile_time_arg_val(4);
+    constexpr uint32_t scalar = get_compile_time_arg_val(8);
     generate_reduce_scaler(cb_id_in2, scalar);
 
-    constexpr auto tensor_args = TensorAccessorArgs<5>();
+    constexpr auto tensor_args = TensorAccessorArgs<9>();
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     experimental::Noc noc;
@@ -67,6 +73,18 @@ void kernel_main() {
                 cb_in0.reserve_back(onetile);
                 noc.async_read(tensor_accessor, cb_in0, tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
                 noc.async_read_barrier();
+
+                if constexpr (LAST_W > 0) {
+                    if (w == Wt - 1) {
+                        apply_width_padding<IN_DF, LAST_W, NEUTRAL>(cb_in0.get_write_ptr());
+                    }
+                }
+                if constexpr (LAST_H > 0) {
+                    if (j == Ht - 1) {
+                        apply_height_padding<IN_DF, LAST_H, NEUTRAL>(cb_in0.get_write_ptr());
+                    }
+                }
+
                 cb_in0.push_back(onetile);
 
                 ++w;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -100,6 +100,7 @@ ttsl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
         program_factory.index(),
         tensor_args.dtype(),
         tensor_args.memory_config(),
+        tensor_args.logical_shape(),
         tensor_args.padded_shape());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_op_multi_core_h_program_factory.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -26,6 +27,9 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
     uint32_t HtWt = Ht * Wt;
+    const auto& logical_shape = a.logical_shape();
+    uint32_t last_w = 0;
+    uint32_t last_h = 0;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
@@ -34,10 +38,15 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    if (ttnn::operations::reduction::supports_native_reduce_padding(src0_cb_data_format, operation_attributes.negate)) {
+        last_w = logical_shape[3] % tile_width;
+        last_h = logical_shape[2] % tile_height;
+    }
     tt::DataFormat scaler_cb_data_format = DataFormat::Float16_b;
     uint32_t scaler_single_tile_size = tt::tile_size(scaler_cb_data_format);
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+    uint32_t neutral_policy = ttnn::operations::reduction::get_neutral_policy(operation_attributes.math_op);
 
     tt_metal::IDevice* device = a.device();
 
@@ -142,7 +151,14 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     }
 
     if (use_width_sharding) {
-        std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index};
+        std::vector<uint32_t> reader_compile_time_args = {
+            src0_cb_index,
+            src1_cb_index,
+            static_cast<uint32_t>(src0_cb_data_format),
+            last_w,
+            last_h,
+            neutral_policy,
+            scaler_cb_index};
         std::map<std::string, std::string> reader_defines;
         reader_defines["REDUCE_SCALER"] = "1";
         reader_kernel_id = tt_metal::CreateKernel(
@@ -152,7 +168,16 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             all_cores,
             tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, chunk_size, packed_scaler_value};
+        std::vector<uint32_t> reader_compile_time_args = {
+            Ht,
+            Wt,
+            HtWt,
+            chunk_size,
+            static_cast<uint32_t>(src0_cb_data_format),
+            last_w,
+            last_h,
+            neutral_policy,
+            packed_scaler_value};
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
         reader_kernel_id = tt_metal::CreateKernel(
@@ -244,9 +269,22 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         uint32_t shard_Wt = num_cols_per_core_group_1 / NC;
         uint32_t shard_row_size = shard_Wt * src0_single_tile_size;
         uint32_t shard_batch_size = shard_row_size * Ht;
-        std::vector<uint32_t> reader_rt_args = {
-            num_cols_per_core_group_1 * Ht, shard_Wt, Ht, NC, shard_row_size, shard_batch_size, packed_scaler_value};
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores, reader_rt_args);
+        const bool row_major = a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+        const auto shard_cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+        for (const auto& core : shard_cores) {
+            const bool core_has_last_width_shard = last_w > 0 && core == shard_cores.back();
+            std::vector<uint32_t> reader_rt_args = {
+                num_cols_per_core_group_1 * Ht,
+                shard_Wt,
+                Ht,
+                NC,
+                shard_row_size,
+                shard_batch_size,
+                static_cast<uint32_t>(core_has_last_width_shard),
+                static_cast<uint32_t>(last_h > 0),
+                packed_scaler_value};
+            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+        }
 
         std::vector<uint32_t> writer_rt_args = {num_cols_per_core_group_1};
         tt_metal::SetRuntimeArgs(program, writer_kernel_id, all_cores, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_op_multi_core_w_program_factory.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -24,13 +25,21 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
+    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const auto& logical_shape = a.logical_shape();
+    uint32_t last_w = 0;
+    uint32_t last_h = 0;
+    if (ttnn::operations::reduction::supports_native_reduce_padding(src0_cb_data_format, operation_attributes.negate)) {
+        last_w = logical_shape[3] % tile_width;
+        last_h = logical_shape[2] % tile_height;
+    }
+    uint32_t neutral_policy = ttnn::operations::reduction::get_neutral_policy(operation_attributes.math_op);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
 
     // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
@@ -79,7 +88,14 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
     tt_metal::Buffer* src_buffer = a.buffer();
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args = {
+        packed_scaler_value,
+        Wt,
+        Ht,
+        static_cast<uint32_t>(src0_cb_data_format),
+        last_w,
+        last_h,
+        neutral_policy};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
     tt_metal::Buffer* dst_buffer = output.buffer();
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_op_single_core_hw_program_factory.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -29,6 +30,9 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
     float scaler = std::sqrt(operation_attributes.scaler);
+    const auto& logical_shape = a.logical_shape();
+    uint32_t last_w = 0;
+    uint32_t last_h = 0;
 
     uint32_t num_tensor_tiles = NC * H * W / tile_hw;
 
@@ -43,12 +47,17 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
+    if (ttnn::operations::reduction::supports_native_reduce_padding(src0_cb_data_format, operation_attributes.negate)) {
+        last_w = logical_shape[3] % tile_width;
+        last_h = logical_shape[2] % tile_height;
+    }
 
     // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
     tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t scaler_single_tile_size = tt::tile_size(scaler_cb_data_format);
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+    uint32_t neutral_policy = ttnn::operations::reduction::get_neutral_policy(operation_attributes.math_op);
 
     tt_metal::Buffer* src0_buffer = a.buffer();
 
@@ -78,7 +87,14 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     bfloat16 bfloat_scaler_value = bfloat16::truncate(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args = {
+        packed_scaler_value,
+        Wt,
+        Ht,
+        static_cast<uint32_t>(src0_cb_data_format),
+        last_w,
+        last_h,
+        neutral_policy};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -336,6 +337,12 @@ bool call_fast_nc(DataType dtype) {
     return dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B;
 }
 
+template <reduction_common::ReduceType reduce_type>
+constexpr bool supports_native_reduce_padding_for_type() {
+    return reduce_type == reduction_common::ReduceType::Sum || reduce_type == reduction_common::ReduceType::Mean ||
+           reduce_type == reduction_common::ReduceType::Max;
+}
+
 Tensor non_height_width_reduce(
     const ttnn::Tensor& input_tensor,
     ttnn::SmallVector<int> dims,
@@ -370,13 +377,25 @@ Tensor reduce(
     ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
     float pad_value = get_pad_value(reduce_type);
     bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
-    auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
-    // TODO: generalize to support all types, parameters, and formats. Issue #18566
     ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
-    if (call_fast_nc<reduce_type>(input_tensor.dtype())) {
-        auto dims = split_height_width_dims(dim, input_tensor);
+    if (call_fast_nc<reduce_type>(input_tensor_arg.dtype())) {
+        auto dims = split_height_width_dims(dim, input_tensor_arg);
         non_height_width_dims = dims.first;
         height_width_dims = dims.second;
+    }
+
+    const bool uses_fast_nc_non_hw_dims =
+        call_fast_nc<reduce_type>(input_tensor_arg.dtype()) && !non_height_width_dims.empty();
+    const bool use_native_padding =
+        is_tiled && supports_native_reduce_padding_for_type<reduce_type>() &&
+        ttnn::operations::reduction::supports_native_reduce_padding(input_tensor_arg.dtype(), /*negate=*/false) &&
+        !uses_fast_nc_non_hw_dims;
+    auto input_tensor = use_native_padding ? input_tensor_arg
+                                           : (is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value)
+                                                       : input_tensor_arg);
+
+    // TODO: generalize to support all types, parameters, and formats. Issue #18566
+    if (call_fast_nc<reduce_type>(input_tensor.dtype())) {
 
         if (!non_height_width_dims.empty()) {
             auto rank = input_tensor_arg.logical_shape().rank();


### PR DESCRIPTION
## Summary

Add native reader-side tile padding for generic tiled `sum`/`mean`/`max` reductions on `float32` and `bfloat16`. Fix reduction program-cache hashing so tensors with the same padded shape but different logical shape no longer collide.

## Design notes

- Reuse the shared `ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp` helper; no reduction-local copy.
- Derive tile dimensions from the tensor spec rather than assuming compile-time constants.
- `min` and `BFLOAT8_B` remain on the existing fallback path.
- `fast_reduce_nc` sum path is unchanged.
- No extra `fill_implicit_tile_padding` calls around transpose - transpose still relies on `pad_value`; reduce readers handle terminal-tile native padding.

## Tests

```bash
./build_metal.sh --without-distributed
```

Unit tests (`tests/ttnn/unit_tests/operations/reduce/`):

| File |
|---|
| `test_max.py` |
| `test_reduction.py` |
| `test_reduction_h_interleaved.py` |
| `test_reduction_mean.py` |
| `test_reduction_min.py` |
| `test_reduction_on_batch.py` |
| `test_reduction_program_cache.py` |
| `test_row_major_reduce.py` |
| `test_sum.py` |

Nightly tests (`tests/ttnn/nightly/unit_tests/operations/reduction/`):

| File |
|---|
| `test_min_max.py` |
| `test_reduce.py` |
| `test_sum.py` |

Tracy trace collected via `test_reduction.py::test_reduce_with_padding`.

Pre-commit hooks were also run on the changed files and passed.

Closes #25549.
