### PR TITLE
[skip ci] Remove tt-smi reset noise from validation logs

### DIFF
--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -182,23 +182,35 @@ run_board_reset() {
         --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
         --tag-output \
         bash -c 'tt-smi -glx_reset > /dev/null 2>&1; echo "RESET_EXIT_CODE=$?"' > "$output_file"
+    mpirun_exit_code=$?
+
+   # Check if mpirun failed
+    if [[ $mpirun_exit_code -ne 0 ]]; then
+        echo "ERROR: mpirun failed with exit code $mpirun_exit_code" >&2
+        rm -f "$output_file"
+        return 1  # Signal mpirun infrastructure failure
+    fi
 
     # Parse and display results, collect failures
-    local rank=0
     local failed_hosts=()
     while IFS= read -r line; do
         if [[ $line =~ ^\[([0-9]+),([0-9]+)\]\<stdout\>:RESET_EXIT_CODE=([0-9]+)$ ]]; then
             local job_id="${BASH_REMATCH[1]}"
             local mpi_rank="${BASH_REMATCH[2]}"
             local exit_code="${BASH_REMATCH[3]}"
-            local hostname="${host_array[$rank]}"
-            if [[ $exit_code -eq 0 ]]; then
-                echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset completed successfully" >&2
+
+            # Use mpi_rank to index host_array
+            if [[ $mpi_rank -lt ${#host_array[@]} ]]; then
+                local hostname="${host_array[$mpi_rank]}"
+                if [[ $exit_code -eq 0 ]]; then
+                    echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset completed successfully" >&2
+                else
+                    echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset failed | Exit code: $exit_code" >&2
+                    failed_hosts+=("$hostname")
+                fi
             else
-                echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset failed | Exit code: $exit_code" >&2
-                failed_hosts+=("$hostname")
+                echo "Warning: MPI rank $mpi_rank exceeds host array size ${#host_array[@]}" >&2
             fi
-            ((rank++))
         fi
     done < "$output_file"
     rm -f "$output_file"
@@ -206,6 +218,7 @@ run_board_reset() {
     # Return comma-separated list of failed hosts (to stdout only)
     local IFS=','
     echo "${failed_hosts[*]}"
+    return 0  # Success
 }
 
 
@@ -242,6 +255,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
         # Run initial reset and capture failures
         RESET_OUTPUT_FILE="$OUTPUT_DIR/reset_output_iter_${i}_$$"
         FAILED_HOSTS_STR=$(run_board_reset "$HOSTS" "$RESET_OUTPUT_FILE" "")
+        MPI_EXIT_CODE=$?
 
         # Retry only failed hosts if any
         if [[ -n "$FAILED_HOSTS_STR" ]]; then
@@ -250,15 +264,22 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
             RESET_RETRY_OUTPUT_FILE="$OUTPUT_DIR/reset_retry_output_iter_${i}_$$"
 
-            # Run retry (discard return value)
+            # Run retry and capture exit code (discard stdout)
             run_board_reset "$FAILED_HOSTS_STR" "$RESET_RETRY_OUTPUT_FILE" "Retry: " > /dev/null
+            MPI_EXIT_CODE=$?
         fi
 
-        sleep 5
+        # Only run validation if retry was successful (or no retry needed)
+        if [[ $MPI_EXIT_CODE -eq 0 ]]; then
+            sleep 5
 
-        echo ""
-        echo "Running cluster validation..."
-        run_cluster_validation
+            echo ""
+            echo "Running cluster validation..."
+            run_cluster_validation
+        else
+            echo "Skipping validation due to mpirun failure"
+        fi
+
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -167,6 +167,48 @@ run_cluster_validation() {
     fi
 }
 
+# Function to run reset on hosts and return hosts that failed reset
+# Args: host_list (comma-separated), output_file, message_prefix
+run_board_reset() {
+    local host_list="$1"
+    local output_file="$2"
+    local msg_prefix="$3"
+
+    # Convert host list to array
+    IFS=',' read -ra host_array <<< "$host_list"
+
+    # Run reset
+    mpirun --host "$host_list" \
+        --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
+        --tag-output \
+        bash -c 'tt-smi -glx_reset > /dev/null 2>&1; echo "RESET_EXIT_CODE=$?"' > "$output_file"
+
+    # Parse and display results, collect failures
+    local rank=0
+    local failed_hosts=()
+    while IFS= read -r line; do
+        if [[ $line =~ ^\[([0-9]+),([0-9]+)\]\<stdout\>:RESET_EXIT_CODE=([0-9]+)$ ]]; then
+            local job_id="${BASH_REMATCH[1]}"
+            local mpi_rank="${BASH_REMATCH[2]}"
+            local exit_code="${BASH_REMATCH[3]}"
+            local hostname="${host_array[$rank]}"
+            if [[ $exit_code -eq 0 ]]; then
+                echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset completed successfully" >&2
+            else
+                echo "[$job_id,$mpi_rank]$hostname: ${msg_prefix}Reset failed | Exit code: $exit_code" >&2
+                failed_hosts+=("$hostname")
+            fi
+            ((rank++))
+        fi
+    done < "$output_file"
+    rm -f "$output_file"
+
+    # Return comma-separated list of failed hosts (to stdout only)
+    local IFS=','
+    echo "${failed_hosts[*]}"
+}
+
+
 echo "Using hosts: $HOSTS"
 echo "Using docker image: $DOCKER_IMAGE"
 if [[ -n "$FACTORY_DESCRIPTOR_PATH" ]]; then
@@ -195,8 +237,22 @@ for ((i=1; i<=ITERATIONS; i++)); do
         echo "=========================================="
         echo ""
 
-        echo "Running tt-smi -glx_reset..."
-        mpirun --host "$HOSTS" --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
+        echo "Running tt-smi -glx_reset (this may take a few minutes)..."
+
+        # Run initial reset and capture failures
+        RESET_OUTPUT_FILE="$OUTPUT_DIR/reset_output_iter_${i}_$$"
+        FAILED_HOSTS_STR=$(run_board_reset "$HOSTS" "$RESET_OUTPUT_FILE" "")
+
+        # Retry only failed hosts if any
+        if [[ -n "$FAILED_HOSTS_STR" ]]; then
+            echo ""
+            echo "Retrying reset for failed hosts: $FAILED_HOSTS_STR"
+
+            RESET_RETRY_OUTPUT_FILE="$OUTPUT_DIR/reset_retry_output_iter_${i}_$$"
+
+            # Run retry (discard return value)
+            run_board_reset "$FAILED_HOSTS_STR" "$RESET_RETRY_OUTPUT_FILE" "Retry: " > /dev/null
+        fi
 
         sleep 5
 


### PR DESCRIPTION
### Ticket
[DCAMP-159](https://tenstorrent.atlassian.net/browse/DCAMP-159)
Parent: [DCAMP-146](https://tenstorrent.atlassian.net/browse/DCAMP-146)

### Problem description
run_validation.sh captured all tt-smi -glx_reset output in the generated logs, adding too much noise to the logs and causing files to become too large particularly when hosts are slow to reset (logs could show something from 1,000 to 500,000 lines of reset noise depending on board's status)

### What's changed
- Suppressed tt-smi progress updates during reset
- Display only start/completion reset messages
- Added reset status tracking per host
- Implemented automatic retry reset for failed hosts -> clear logging with retry messages
- Display MPI rank alongside hostnames to help with debugging 

New output example (with retry):
```
Iteration: 1
Timestamp: Tue Mar 24 18:57:31 UTC 2026
==========================================

Running tt-smi -glx_reset (this may take a few minutes)...
[1,0]wh-glx-110-a06u02: Reset completed successfully
[1,2]wh-glx-110-a06u08: Reset completed successfully
[1,1]wh-glx-110-a06u14: Reset completed successfully
[1,3]wh-glx-110-a07u02: Reset completed successfully
[1,4]wh-glx-110-a07u14: Reset failed | Exit code: 1

Retrying reset for failed hosts: wh-glx-110-a07u14
[wh-glx-110-a07u14] Retry: Reset completed successfully

Running cluster validation...
```