### PR TITLE
#38901: update group_norm to device 2.0 api

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -209,7 +209,7 @@ def test_block_sharded_group_norm_negative_mask_sdxl_performance():
     # Extract the device kernel duration result
     device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
 
-    expected_duration_ns = 564334  # Measured: ~564μs for GroupNorm SDXL negative mask
+    expected_duration_ns = 549179  # Measured: ~549μs for GroupNorm SDXL negative mask
 
     # Log the performance result
     print(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/matmul.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     // clang-format off
@@ -53,12 +54,12 @@ void kernel_main() {
     //       Local Reduce:
     //           First we apply an input mask
     //           This is where we sum up our core's subtensor
-    //           After summing up, we pass our scalar tile to cb_ex_partial
+    //           After summing up, we pass our scalar tile to cb_ex_partial_id
     //           The reader kernels then aggregate all of the local scalars into a single tile
     //       Global Reduce:
-    //           This single tile (cb_ex_external) is a tile that contains each partial reduce from all the other cores
+    //           This single tile (cb_ex_external_id) is a tile that contains each partial reduce from all the other cores
     //           Only the core designated as the sender reduces this tile to produce the global scalar reduce value.
-    //           It's reader core the sends this data out to all other cores as cb_ex_global
+    //           It's reader core the sends this data out to all other cores as cb_ex_global_id
     //
     //     Variance Calc: ∑(x-E[x])^2
     //     This follows the same pattern as the average calculation
@@ -66,15 +67,15 @@ void kernel_main() {
     //           First we subtract each value from our core's subtensor by the average value
     //           We next apply our input mask to zero our the values we wish to ignore
     //           Next we square our residuals to obtain the squared residuals
-    //           After summing up, we pass our scalar tile to cb_ex2_partial
+    //           After summing up, we pass our scalar tile to cb_ex2_partial_id
     //           The reader kernels then aggregate all of the local scalars into a single tile
     //       Global Reduce:
-    //           This single tile (cb_ex_external) is a tile that contains each partial reduce from all the other cores
+    //           This single tile (cb_ex_external_id) is a tile that contains each partial reduce from all the other cores
     //           Only the core designated as the sender reduces this tile to produce the global scalar reduce value.
-    //           It's reader core the sends this data out to all other cores as cb_ex2_global
+    //           It's reader core the sends this data out to all other cores as cb_ex2_global_id
     //
-    //     cb_ex2pe Calculation:
-    //       First we add cb_ex2_global with cb_eps
+    //     cb_ex2pe_id Calculation:
+    //       First we add cb_ex2_global_id with cb_eps_id
     //       Then we take the sqrt
     //       Lastly we take the reciprocal and he have the denominator of our calculation
     //     Final Val Calc:
@@ -135,40 +136,40 @@ void kernel_main() {
     constexpr uint32_t scaler0 = 0;
 
     // input cbs
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in = tt::CBIndex::c_29;
-    constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
-    constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_29;
+    constexpr uint32_t cb_scaler_id = tt::CBIndex::c_2;
+    constexpr uint32_t cb_scaler_global_id = tt::CBIndex::c_4;
+    constexpr uint32_t cb_eps_id = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_28;
 
     // interm cbs
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_x = tt::CBIndex::c_24;
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_25;
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex2_partial = tt::CBIndex::c_21;
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;
-    constexpr uint32_t cb_ex2 = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
-    constexpr uint32_t cb_ex2_global = tt::CBIndex::c_14;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_24;
+    constexpr uint32_t cb_xmm_id = tt::CBIndex::c_25;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
+    constexpr uint32_t cb_ex_external_id = tt::CBIndex::c_10;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;
+    constexpr uint32_t cb_ex2pe_id = tt::CBIndex::c_27;
 
     // interm cbs reuse
-    constexpr uint32_t cb_fusion = cb_xmm;
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
-    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
+    constexpr uint32_t cb_fusion_id = cb_xmm_id;
+    constexpr uint32_t cb_reread_out_id = tt::CBIndex::c_23;
+    constexpr uint32_t cb_reread_write_out_id = tt::CBIndex::c_22;
 
     // output cb
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta) ? cb_out0 : cb_reread_write_out;
+    constexpr uint32_t cb_out_id = (do_gamma or do_beta) ? cb_out0_id : cb_reread_write_out_id;
 #endif
 
     // tile offset
@@ -190,50 +191,74 @@ void kernel_main() {
     constexpr uint32_t data_per_core_N_per_group = (per_core_N * tile_width / group);
 
 #ifdef UNTILIZE_OUT
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
-    constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma
-                                   : do_beta                  ? cb_outbeta
-                                                              : cb_reread_write_out;
-    constexpr int cb_untilize_out =
+    constexpr int cb_outgamma_id = cb_in_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_reread_write_out_id;
+    constexpr int cb_outbeta_id = do_gamma ? cb_out_id : cb_in_id;
+    constexpr int cb_untilize_in_id = (do_gamma and not do_beta) ? cb_outgamma_id
+                                      : do_beta                  ? cb_outbeta_id
+                                                                 : cb_reread_write_out_id;
+    constexpr int cb_untilize_out_id =
 #ifdef READER_REPACK
-        cb_repack_out;
+        cb_repack_out_id;
 #else
-        cb_out0;
+        cb_out0_id;
 #endif
 #else
-    constexpr int cb_outgamma = do_beta ? cb_in : cb_out0;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
-    constexpr int cb_outbeta = cb_out0;
+    constexpr int cb_outgamma_id = do_beta ? cb_in_id : cb_out0_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_reread_write_out_id;
+    constexpr int cb_outbeta_id = cb_out0_id;
 #endif
+
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_eps(cb_eps_id);
+    experimental::CircularBuffer cb_ex(cb_ex_id);
+    experimental::CircularBuffer cb_ex2(cb_ex2_id);
+    experimental::CircularBuffer cb_ex2_global(cb_ex2_global_id);
+    experimental::CircularBuffer cb_ex2_partial(cb_ex2_partial_id);
+    experimental::CircularBuffer cb_ex2pe(cb_ex2pe_id);
+    experimental::CircularBuffer cb_ex_external(cb_ex_external_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_in(cb_in_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_inbeta(cb_inbeta_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_outbeta(cb_outbeta_id);
+    experimental::CircularBuffer cb_outgamma(cb_outgamma_id);
+    experimental::CircularBuffer cb_reread_out(cb_reread_out_id);
+    experimental::CircularBuffer cb_reread_write_out(cb_reread_write_out_id);
+    experimental::CircularBuffer cb_scaler(cb_scaler_id);
+    experimental::CircularBuffer cb_scaler_global(cb_scaler_global_id);
+    experimental::CircularBuffer cb_x(cb_x_id);
+    experimental::CircularBuffer cb_xmm(cb_xmm_id);
 
 // tilize input from RM to tile layout
 #ifdef TILIZE_IN
-    binary_op_init_common(cb_in0, cb_in0, cb_in);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in_id);
 // Tilize in0 -> in (row-major to tiled)
 #ifdef READER_REPACK
-    constexpr uint32_t cb_in_rm = cb_repack;
+    constexpr uint32_t cb_in_rm_id = cb_repack_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #else
-    constexpr uint32_t cb_in_rm = cb_in0;
+    constexpr uint32_t cb_in_rm_id = cb_in0_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::NoWait,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #endif
-    cb_wait_front(cb_in, per_core_MN);
+    cb_in.wait_front(per_core_MN);
 #else
-    binary_op_init_common(cb_in0, cb_input_mask, cb_x);
+    binary_op_init_common(cb_in0_id, cb_input_mask_id, cb_x_id);
 #endif
 
     index_b_offset = 0;
@@ -271,7 +296,7 @@ void kernel_main() {
         for (uint32_t g = 0; g < group; ++g) {
             // Start Average Calc
             // Start Local Reduce
-            cb_wait_front(cb_input_mask, block_w);
+            cb_input_mask.wait_front(block_w);
             for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
                 uint32_t out_block_h_actual, out_block_hw_actual;
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
@@ -281,13 +306,13 @@ void kernel_main() {
                     out_block_h_actual = out_block_h_normal;
                     out_block_hw_actual = out_block_hw_normal;
                 }
-                cb_wait_front(cb_in0, out_block_hw_normal);
+                cb_in0.wait_front(out_block_hw_normal);
 
                 index_h_offset = 0;
-                reconfig_data_format_srcb(cb_in0, cb_input_mask);
+                reconfig_data_format_srcb(cb_in0_id, cb_input_mask_id);
                 // mask input
-                mul_tiles_init(cb_in0, cb_input_mask);
-                cb_reserve_back(cb_x, out_block_hw_normal);
+                mul_tiles_init(cb_in0_id, cb_input_mask_id);
+                cb_x.reserve_back(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
@@ -296,15 +321,15 @@ void kernel_main() {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset;
                             uint32_t index_mask = w + index_subblock_w_offset;
 #ifdef TILIZE_IN
-                        mul_tiles(cb_in, cb_input_mask, index, index_mask, w);
+                            mul_tiles(cb_in_id, cb_input_mask_id, index, index_mask, w);
 #else
-                            mul_tiles(cb_in0, cb_input_mask, index, index_mask, w);
+                            mul_tiles(cb_in0_id, cb_input_mask_id, index, index_mask, w);
 #endif
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; ++i) {
-                            pack_tile(i, cb_x);
+                            pack_tile(i, cb_x_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
@@ -312,62 +337,63 @@ void kernel_main() {
                     index_h_offset += block_w;
                 }
 #ifdef TILIZE_IN
-                cb_pop_front(cb_in, out_block_hw_actual);
+                cb_in.pop_front(out_block_hw_actual);
 #else
-                cb_pop_front(cb_in0, out_block_hw_normal);
+                cb_in0.pop_front(out_block_hw_normal);
 #endif
-                cb_push_back(cb_x, out_block_hw_normal);
-                reconfig_data_format_srcb(cb_input_mask, cb_scaler);
+                cb_x.push_back(out_block_hw_normal);
+                reconfig_data_format_srcb(cb_input_mask_id, cb_scaler_id);
 
                 // Partial/E[x]
                 index_h_offset = 0;
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x, cb_scaler, cb_ex_partial);
-                cb_reserve_back(cb_ex_partial, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x_id, cb_scaler_id, cb_ex_partial_id);
+                cb_ex_partial.reserve_back(1);
                 tile_regs_acquire();
-                cb_wait_front(cb_scaler, 1);
-                cb_wait_front(cb_x, out_block_hw_normal);
+                cb_scaler.wait_front(1);
+                cb_x.wait_front(out_block_hw_normal);
 
                 for (uint32_t h = 0; h < out_block_h_actual; ++h) {
                     for (uint32_t w = 0; w < block_w; ++w) {
                         uint32_t index = index_h_offset + w;
-                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x, cb_scaler, index, scaler0, dst0);
+                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_x_id, cb_scaler_id, index, scaler0, dst0);
                     }
                     index_h_offset += block_w;
                 }
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex_partial);
+                pack_tile(dst0, cb_ex_partial_id);
                 tile_regs_release();
-                cb_pop_front(cb_x, out_block_hw_normal);
-                cb_push_back(cb_ex_partial, 1);
+                cb_x.pop_front(out_block_hw_normal);
+                cb_ex_partial.push_back(1);
                 reduce_uninit<FP32_DEST_ACC>();
 
-                cb_wait_front(cb_ex_partial, 1);
+                cb_ex_partial.wait_front(1);
             }
             // End Local Redcue
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
-                cb_reserve_back(cb_ex_global, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, cb_ex_global_id);
+                cb_ex_global.reserve_back(1);
                 if (num_cores_per_mcast_group > 1) {
-                    cb_reserve_back(cb_ex, 1);
+                    cb_ex.reserve_back(1);
                 }
                 tile_regs_acquire();
-                cb_wait_front(cb_scaler_global, 1);
-                cb_wait_front(cb_ex_external, cb_ex_external_tiles_required);
+                cb_scaler_global.wait_front(1);
+                cb_ex_external.wait_front(cb_ex_external_tiles_required);
                 for (uint32_t external_i = 0; external_i < cb_ex_external_tiles_required; external_i++) {
                     reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
-                        cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
+                        cb_ex_external_id, cb_scaler_global_id, external_i, scaler0, dst0);
                 }
-                cb_pop_front(cb_ex_external, cb_ex_external_tiles_required);
+                cb_ex_external.pop_front(cb_ex_external_tiles_required);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex_global);
+                pack_tile(dst0, cb_ex_global_id);
                 tile_regs_release();
                 reduce_uninit<FP32_DEST_ACC>();
-                cb_push_back(cb_ex_global, 1);
+                cb_ex_global.push_back(1);
                 if (num_cores_per_mcast_group > 1) {
-                    cb_push_back(cb_ex, 1);
+                    cb_ex.push_back(1);
                 }
             }
             // End Global Reduce
@@ -385,40 +411,40 @@ void kernel_main() {
                     out_block_hw_actual = out_block_hw_normal;
                 }
 
-                cb_wait_front(cb_in0, out_block_hw_normal);
+                cb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
-                sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
+                sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
 
-                cb_reserve_back(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_ex_global, 1);
+                cb_xmm.reserve_back(out_block_hw_normal);
+                cb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
                             uint32_t index = w + index_subblock_w_offset;
-                            sub_tiles_bcast_scalar(cb_in0, cb_ex_global, index, 0, w);
+                            sub_tiles_bcast_scalar(cb_in0_id, cb_ex_global_id, index, 0, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
+                            pack_tile(i, cb_xmm_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
-                    cb_pop_front(cb_in0, block_w);
+                    cb_in0.pop_front(block_w);
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_in0, out_block_hw_normal - out_block_hw_last);
+                    cb_in0.pop_front(out_block_hw_normal - out_block_hw_last);
                 }
-                cb_push_back(cb_xmm, out_block_hw_normal);
+                cb_xmm.push_back(out_block_hw_normal);
 
                 // zero out the garbage values by mult mask again
-                reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-                mul_tiles_init(cb_xmm, cb_input_mask);
-                cb_reserve_back(cb_x, out_block_hw_normal);
-                cb_wait_front(cb_xmm, out_block_hw_normal);
+                reconfig_data_format_srcb(cb_ex_global_id, cb_input_mask_id);
+                mul_tiles_init(cb_xmm_id, cb_input_mask_id);
+                cb_x.reserve_back(out_block_hw_normal);
+                cb_xmm.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
@@ -426,119 +452,121 @@ void kernel_main() {
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset;
                             uint32_t index_mask = index;
-                            mul_tiles(cb_xmm, cb_input_mask, index, index_mask, w);
+                            mul_tiles(cb_xmm_id, cb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; ++i) {
-                            pack_tile(i, cb_x);
+                            pack_tile(i, cb_x_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
-                    cb_pop_front(cb_xmm, block_w);
+                    cb_xmm.pop_front(block_w);
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_xmm, out_block_hw_normal - out_block_hw_last);
+                    cb_xmm.pop_front(out_block_hw_normal - out_block_hw_last);
                 }
-                cb_push_back(cb_x, out_block_hw_normal);
+                cb_x.push_back(out_block_hw_normal);
 
-                reconfig_data_format_srcb(cb_input_mask, cb_x);
+                reconfig_data_format_srcb(cb_input_mask_id, cb_x_id);
                 // (x - E[x])^2
                 index_h_offset = 0;
-                mul_tiles_init(cb_x, cb_x);
-                cb_reserve_back(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_x, out_block_hw_normal);
+                mul_tiles_init(cb_x_id, cb_x_id);
+                cb_xmm.reserve_back(out_block_hw_normal);
+                cb_x.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset;
-                            mul_tiles(cb_x, cb_x, index, index, w);
+                            mul_tiles(cb_x_id, cb_x_id, index, index, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
+                            pack_tile(i, cb_xmm_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
                     index_h_offset += block_w;
                 }
-                cb_pop_front(cb_x, out_block_hw_normal);
-                cb_push_back(cb_xmm, out_block_hw_normal);
+                cb_x.pop_front(out_block_hw_normal);
+                cb_xmm.push_back(out_block_hw_normal);
 
                 // Partial-Var(x)
                 index_h_offset = 0;
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_xmm, cb_scaler, cb_ex2_partial);
-                cb_reserve_back(cb_ex2_partial, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_xmm_id, cb_scaler_id, cb_ex2_partial_id);
+                cb_ex2_partial.reserve_back(1);
                 tile_regs_acquire();
-                cb_wait_front(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_scaler, 1);  // TODO DELETE THIS
+                cb_xmm.wait_front(out_block_hw_normal);
+                cb_scaler.wait_front(1);  // TODO DELETE THIS
                 for (uint32_t h = 0; h < out_block_h_actual; ++h) {
                     for (uint32_t w = 0; w < block_w; ++w) {
                         uint32_t index = index_h_offset + w;
-                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_xmm, cb_scaler, index, scaler0, dst0);
+                        reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                            cb_xmm_id, cb_scaler_id, index, scaler0, dst0);
                     }
                     index_h_offset += block_w;
                 }
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex2_partial);
+                pack_tile(dst0, cb_ex2_partial_id);
                 tile_regs_release();
-                cb_push_back(cb_ex2_partial, 1);
-                cb_pop_front(cb_xmm, out_block_hw_normal);
+                cb_ex2_partial.push_back(1);
+                cb_xmm.pop_front(out_block_hw_normal);
                 reduce_uninit<FP32_DEST_ACC>();
             }
             // End Local Reduce
             // Start Global Reduce
             if constexpr (is_mcast_sender) {
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex2_global);
-                cb_reserve_back(cb_ex2_global, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, cb_ex2_global_id);
+                cb_ex2_global.reserve_back(1);
                 if (num_cores_per_mcast_group > 1) {
-                    cb_reserve_back(cb_ex2, 1);
+                    cb_ex2.reserve_back(1);
                 }
                 tile_regs_acquire();
-                cb_wait_front(cb_scaler_global, 1);
-                cb_wait_front(cb_ex_external, cb_ex_external_tiles_required);  // TODO DELETE THIS AND ADD POP
+                cb_scaler_global.wait_front(1);
+                cb_ex_external.wait_front(cb_ex_external_tiles_required);  // TODO DELETE THIS AND ADD POP
                 for (uint32_t external_i = 0; external_i < cb_ex_external_tiles_required; external_i++) {
                     reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
-                        cb_ex_external, cb_scaler_global, external_i, scaler0, dst0);
+                        cb_ex_external_id, cb_scaler_global_id, external_i, scaler0, dst0);
                 }
-                cb_pop_front(cb_ex_external, cb_ex_external_tiles_required);
+                cb_ex_external.pop_front(cb_ex_external_tiles_required);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex2_global);
+                pack_tile(dst0, cb_ex2_global_id);
                 tile_regs_release();
                 reduce_uninit<FP32_DEST_ACC>();
-                cb_push_back(cb_ex2_global, 1);
+                cb_ex2_global.push_back(1);
                 if (num_cores_per_mcast_group > 1) {
-                    cb_push_back(cb_ex2, 1);
+                    cb_ex2.push_back(1);
                 }
             }
             // End Global Reduce
 
             // Start Variance Calc
             //  global reduce results
-            cb_wait_front(cb_eps, 1);
-            cb_wait_front(cb_ex2_global, 1);
-            cb_reserve_back(cb_ex2pe, 1);
+            cb_eps.wait_front(1);
+            cb_ex2_global.wait_front(1);
+            cb_ex2pe.reserve_back(1);
             // (Var + eps)
             tile_regs_acquire();
-            add_tiles_init(cb_ex2_global, cb_eps);
-            add_tiles(cb_ex2_global, cb_eps, 0, 0, dst0);
+            add_tiles_init(cb_ex2_global_id, cb_eps_id);
+            add_tiles(cb_ex2_global_id, cb_eps_id, 0, 0, dst0);
             tile_regs_wait();
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
-            cb_pop_front(cb_ex2_global, 1);
+            cb_ex2pe.push_back(1);
+            cb_ex2_global.pop_front(1);
             // End Variance Calc
 
             bool start_copy_or_add = copy_or_add;
@@ -557,39 +585,39 @@ void kernel_main() {
                     out_block_hw_actual = out_block_hw_normal;
                 }
 
-                cb_wait_front(cb_in0, out_block_hw_normal);
+                cb_in0.wait_front(out_block_hw_normal);
                 // x - E[x]
-                sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-                cb_reserve_back(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_ex_global, 1);
+                sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
+                cb_xmm.reserve_back(out_block_hw_normal);
+                cb_ex_global.wait_front(1);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
                             uint32_t index = w + index_subblock_w_offset;
-                            sub_tiles_bcast_scalar(cb_in0, cb_ex_global, index, 0, w);
+                            sub_tiles_bcast_scalar(cb_in0_id, cb_ex_global_id, index, 0, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
+                            pack_tile(i, cb_xmm_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
-                    cb_pop_front(cb_in0, block_w);
+                    cb_in0.pop_front(block_w);
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_in0, out_block_hw_normal - out_block_hw_last);
+                    cb_in0.pop_front(out_block_hw_normal - out_block_hw_last);
                 }
-                cb_push_back(cb_xmm, out_block_hw_normal);
+                cb_xmm.push_back(out_block_hw_normal);
 
                 // zero out the garbage values by mult mask again
-                reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-                mul_tiles_init(cb_xmm, cb_input_mask);
-                cb_reserve_back(cb_x, out_block_hw_normal);
-                cb_wait_front(cb_xmm, out_block_hw_normal);
+                reconfig_data_format_srcb(cb_ex_global_id, cb_input_mask_id);
+                mul_tiles_init(cb_xmm_id, cb_input_mask_id);
+                cb_x.reserve_back(out_block_hw_normal);
+                cb_xmm.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
@@ -597,51 +625,51 @@ void kernel_main() {
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset;
                             uint32_t index_mask = index;
-                            mul_tiles(cb_xmm, cb_input_mask, index, index_mask, w);
+                            mul_tiles(cb_xmm_id, cb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; ++i) {
-                            pack_tile(i, cb_x);
+                            pack_tile(i, cb_x_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
-                    cb_pop_front(cb_xmm, block_w);
+                    cb_xmm.pop_front(block_w);
                 }
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
-                    cb_pop_front(cb_xmm, out_block_hw_normal - out_block_hw_last);
+                    cb_xmm.pop_front(out_block_hw_normal - out_block_hw_last);
                 }
-                cb_push_back(cb_x, out_block_hw_normal);
-                reconfig_data_format_srcb(cb_input_mask, cb_x);
+                cb_x.push_back(out_block_hw_normal);
+                reconfig_data_format_srcb(cb_input_mask_id, cb_x_id);
 
                 // (x - Ex) * 1/[sqrt(Var + eps)]
                 index_h_offset = 0;
-                mul_tiles_bcast_scalar_init_short(cb_x, cb_ex2pe);
-                cb_reserve_back(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_ex2pe, 1);
-                cb_wait_front(cb_x, out_block_hw_normal);
+                mul_tiles_bcast_scalar_init_short(cb_x_id, cb_ex2pe_id);
+                cb_xmm.reserve_back(out_block_hw_normal);
+                cb_ex2pe.wait_front(1);
+                cb_x.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; j++) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; w++) {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset;
-                            mul_tiles_bcast_scalar(cb_x, cb_ex2pe, index, 0, w);
+                            mul_tiles_bcast_scalar(cb_x_id, cb_ex2pe_id, index, 0, w);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
                         for (uint32_t i = 0; i < subblock_w; i++) {
-                            pack_tile(i, cb_xmm);
+                            pack_tile(i, cb_xmm_id);
                         }
                         tile_regs_release();
                         index_subblock_w_offset += subblock_w;
                     }
                     index_h_offset += block_w;
                 }
-                cb_pop_front(cb_x, out_block_hw_normal);
-                cb_push_back(cb_xmm, out_block_hw_normal);
-                cb_wait_front(cb_xmm, out_block_hw_normal);
+                cb_x.pop_front(out_block_hw_normal);
+                cb_xmm.push_back(out_block_hw_normal);
+                cb_xmm.wait_front(out_block_hw_normal);
 
                 copy_or_add = start_copy_or_add;
                 group_reset_index = start_group_reset_index;
@@ -650,16 +678,16 @@ void kernel_main() {
                 // add or copy with previous output results
                 uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
-                cb_wait_front(cb_reread_out, out_block_hw_normal);
-                cb_reserve_back(cb_reread_write_out, out_block_hw_normal);
+                cb_reread_out.wait_front(out_block_hw_normal);
+                cb_reread_write_out.reserve_back(out_block_hw_normal);
                 for (uint32_t w = 0; w < block_w_curr; ++w) {
                     uint32_t index_h_offset = 0;
                     uint32_t index_h1_offset = 0;
 
                     if (copy_or_add == true) {
-                        copy_tile_init(cb_xmm);
+                        copy_tile_init(cb_xmm_id);
                     } else {
-                        add_tiles_init(cb_reread_out, cb_xmm);
+                        add_tiles_init(cb_reread_out_id, cb_xmm_id);
                     }
 
                     for (uint32_t i = 0; i < out_block_h_actual; ++i) {
@@ -668,13 +696,13 @@ void kernel_main() {
                         uint32_t index_xmm = w + index_h1_offset;
 
                         if (copy_or_add == true) {
-                            copy_tile(cb_xmm, index_xmm, dst0);
+                            copy_tile(cb_xmm_id, index_xmm, dst0);
                         } else {
-                            add_tiles(cb_reread_out, cb_xmm, index_reread_out, index_xmm, dst0);
+                            add_tiles(cb_reread_out_id, cb_xmm_id, index_reread_out, index_xmm, dst0);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile<true>(dst0, cb_reread_write_out, index_reread_out);
+                        pack_tile<true>(dst0, cb_reread_write_out_id, index_reread_out);
                         tile_regs_release();
 
                         index_h_offset += block_w_curr;
@@ -703,74 +731,74 @@ void kernel_main() {
                         (((w + index_g_offset) + 1) * tile_width) > ((g + 1) * data_per_core_N_per_group);
                     apply_gamma_beta[w] = !is_past_end_of_group;
                 }
-                cb_pop_front(cb_xmm, out_block_hw_normal);
-                cb_pop_front(cb_reread_out, out_block_hw_normal);
-                cb_push_back(cb_reread_write_out, out_block_hw_normal);
+                cb_xmm.pop_front(out_block_hw_normal);
+                cb_reread_out.pop_front(out_block_hw_normal);
+                cb_reread_write_out.push_back(out_block_hw_normal);
 
                 // Start Optional Gamma:
                 if constexpr (do_gamma) {
                     index_h_offset = 0;
-                    cb_reserve_back(cb_outgamma, out_block_hw_normal);
-                    cb_wait_front(cb_gamma, per_core_N);
-                    cb_wait_front(cb_reread_write_out, out_block_hw_normal);
+                    cb_outgamma.reserve_back(out_block_hw_normal);
+                    cb_gamma.wait_front(per_core_N);
+                    cb_reread_write_out.wait_front(out_block_hw_normal);
                     for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
-                                mul_bcast_rows_init_short(cb_reread_write_out, cb_gamma);
+                                mul_bcast_rows_init_short(cb_reread_write_out_id, cb_gamma_id);
                             } else {
-                                copy_tile_init(cb_reread_write_out);
+                                copy_tile_init(cb_reread_write_out_id);
                             }
                             tile_regs_acquire();
                             uint32_t index = j + index_h_offset;
                             uint32_t index_gamma = j + index_g_offset;
                             if (apply_gamma_beta[j]) {
-                                mul_tiles_bcast_rows(cb_reread_write_out, cb_gamma, index, index_gamma, dst0);
+                                mul_tiles_bcast_rows(cb_reread_write_out_id, cb_gamma_id, index, index_gamma, dst0);
                             } else {
-                                copy_tile(cb_reread_write_out, index, dst0);
+                                copy_tile(cb_reread_write_out_id, index, dst0);
                             }
                             tile_regs_commit();
                             tile_regs_wait();
-                            pack_tile(dst0, cb_outgamma);
+                            pack_tile(dst0, cb_outgamma_id);
                             tile_regs_release();
                         }
                         index_h_offset += block_w_curr;
                     }
-                    cb_push_back(cb_outgamma, out_block_hw_normal);
-                    cb_pop_front(cb_reread_write_out, out_block_hw_normal);
-                    cb_wait_front(cb_outgamma, out_block_hw_normal);
+                    cb_outgamma.push_back(out_block_hw_normal);
+                    cb_reread_write_out.pop_front(out_block_hw_normal);
+                    cb_outgamma.wait_front(out_block_hw_normal);
                 }
                 // End Optional Gamma
                 //
                 // Start Optional Beta
                 if constexpr (do_beta) {
                     index_h_offset = 0;
-                    cb_reserve_back(cb_outbeta, out_block_hw_normal);
-                    cb_wait_front(cb_beta, per_core_N);
+                    cb_outbeta.reserve_back(out_block_hw_normal);
+                    cb_beta.wait_front(per_core_N);
                     for (uint32_t i = 0; i < out_block_h_actual; ++i) {
                         for (uint32_t j = 0; j < block_w_curr; ++j) {
                             if (apply_gamma_beta[j]) {
-                                add_bcast_rows_init_short(cb_inbeta, cb_beta);
+                                add_bcast_rows_init_short(cb_inbeta_id, cb_beta_id);
                             } else {
-                                copy_tile_init(cb_inbeta);
+                                copy_tile_init(cb_inbeta_id);
                             }
                             tile_regs_acquire();
                             uint32_t index = j + index_h_offset;
                             uint32_t index_beta = j + index_g_offset;
                             if (apply_gamma_beta[j]) {
-                                add_tiles_bcast_rows(cb_inbeta, cb_beta, index, index_beta, dst0);
+                                add_tiles_bcast_rows(cb_inbeta_id, cb_beta_id, index, index_beta, dst0);
                             } else {
-                                copy_tile(cb_inbeta, index, dst0);
+                                copy_tile(cb_inbeta_id, index, dst0);
                             }
                             tile_regs_commit();
                             tile_regs_wait();
-                            pack_tile(dst0, cb_outbeta);
+                            pack_tile(dst0, cb_outbeta_id);
                             tile_regs_release();
                         }
                         index_h_offset += block_w_curr;
                     }
-                    cb_push_back(cb_outbeta, out_block_hw_normal);
-                    cb_pop_front(cb_inbeta, out_block_hw_normal);
-                    cb_wait_front(cb_outbeta, out_block_hw_normal);
+                    cb_outbeta.push_back(out_block_hw_normal);
+                    cb_inbeta.pop_front(out_block_hw_normal);
+                    cb_outbeta.wait_front(out_block_hw_normal);
                 }
                 // End Optional Beta
 
@@ -778,8 +806,8 @@ void kernel_main() {
                 // untilize - DEST capacity auto-detected
                 compute_kernel_lib::untilize<
                     per_core_N,
-                    cb_untilize_in,
-                    cb_untilize_out,
+                    cb_untilize_in_id,
+                    cb_untilize_out_id,
                     compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
                     compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
                     compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
@@ -816,9 +844,9 @@ void kernel_main() {
                     index_g_offset += block_w_minus_two;
                 }
             }
-            cb_pop_front(cb_ex_global, 1);
-            cb_pop_front(cb_ex2pe, 1);
-            cb_pop_front(cb_input_mask, block_w);
+            cb_ex_global.pop_front(1);
+            cb_ex2pe.pop_front(1);
+            cb_input_mask.pop_front(block_w);
         }
         // End Group Loop
         index_b_offset += num_tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
     //       Global Reduce:
     //           This single tile (cb_ex_external_id) is a tile that contains each partial reduce from all the other cores
     //           Only the core designated as the sender reduces this tile to produce the global scalar reduce value.
-    //           It's reader core the sends this data out to all other cores as cb_ex_global_id
+    //           The reader core then sends this data out to all other cores as cb_ex_global_id
     //
     //     Variance Calc: ∑(x-E[x])^2
     //     This follows the same pattern as the average calculation
@@ -72,7 +72,7 @@ void kernel_main() {
     //       Global Reduce:
     //           This single tile (cb_ex_external_id) is a tile that contains each partial reduce from all the other cores
     //           Only the core designated as the sender reduces this tile to produce the global scalar reduce value.
-    //           It's reader core the sends this data out to all other cores as cb_ex2_global_id
+    //           The reader core then sends this data out to all other cores as cb_ex2_global_id
     //
     //     cb_ex2pe_id Calculation:
     //       First we add cb_ex2_global_id with cb_eps_id

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/matmul.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 // SPLIT REDUCE across Cores
 void kernel_main() {
@@ -66,35 +67,35 @@ void kernel_main() {
     constexpr uint32_t scaler0 = 0;
 
     // input cbs
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in = tt::CBIndex::c_1;
-    constexpr uint32_t cb_scaler = tt::CBIndex::c_2;
-    constexpr uint32_t cb_scaler_global = tt::CBIndex::c_4;
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_scaler_id = tt::CBIndex::c_2;
+    constexpr uint32_t cb_scaler_global_id = tt::CBIndex::c_4;
+    constexpr uint32_t cb_eps_id = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_7;
 
     // interm cbs
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_x = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;
-    constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
-    constexpr uint32_t cb_ex_global = num_cores_per_mcast_group == 1 ? cb_ex_partial : tt::CBIndex::c_15;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_17;
-    constexpr uint32_t cb_ones = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_13;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex_external_id = tt::CBIndex::c_10;
+    constexpr uint32_t cb_ex_global_id = num_cores_per_mcast_group == 1 ? cb_ex_partial_id : tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex2pe_id = tt::CBIndex::c_17;
+    constexpr uint32_t cb_ones_id = tt::CBIndex::c_26;
 
     // output cb
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
     // not used in cases of negative mask
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta)
-                                    ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in : cb_out0)
-                                    : cb_out0;
+    constexpr uint32_t cb_out_id =
+        (do_gamma or do_beta) ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in_id : cb_out0_id)
+                              : cb_out0_id;
 #endif
 
     // tile offset
@@ -116,36 +117,36 @@ void kernel_main() {
 
 #ifdef UNTILIZE_OUT
 #ifndef FUSE_NEGATIVE_MASK
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
-    constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma : do_beta ? cb_outbeta : cb_out;
-    constexpr int cb_untilize_out =
+    constexpr int cb_outgamma_id = cb_in_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_out_id;
+    constexpr int cb_outbeta_id = do_gamma ? cb_out_id : cb_in_id;
+    constexpr int cb_untilize_in_id = (do_gamma and not do_beta) ? cb_outgamma_id : do_beta ? cb_outbeta_id : cb_out_id;
+    constexpr int cb_untilize_out_id =
 #ifdef READER_REPACK
-        cb_repack_out;
+        cb_repack_out_id;
 #else
-        cb_out0;
+        cb_out0_id;
 #endif
 #else
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = cb_in;
-    constexpr int cb_outbeta = cb_in;
-    constexpr int cb_untilize_in = cb_in;
-    constexpr int cb_untilize_out =
+    constexpr int cb_outgamma_id = cb_in_id;
+    constexpr int cb_inbeta_id = cb_in_id;
+    constexpr int cb_outbeta_id = cb_in_id;
+    constexpr int cb_untilize_in_id = cb_in_id;
+    constexpr int cb_untilize_out_id =
 #ifdef READER_REPACK
-        cb_repack_out;
+        cb_repack_out_id;
 #else
-        cb_out0;
+        cb_out0_id;
 #endif
 #endif
 #else
-    constexpr int cb_outgamma = do_beta ? cb_in : cb_out0;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_out;
-    constexpr int cb_outbeta = cb_out0;
+    constexpr int cb_outgamma_id = do_beta ? cb_in_id : cb_out0_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_out_id;
+    constexpr int cb_outbeta_id = cb_out0_id;
 #endif
 
     // Used in cases of negative mask provided
-    constexpr uint32_t cb_in_negative_mask = tt::CBIndex::c_14;
+    constexpr uint32_t cb_in_negative_mask_id = tt::CBIndex::c_14;
 
 #ifdef FUSE_NEGATIVE_MASK
     constexpr bool use_negative_mask = true;
@@ -153,32 +154,52 @@ void kernel_main() {
     constexpr bool use_negative_mask = false;
 #endif
 
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_eps(cb_eps_id);
+    experimental::CircularBuffer cb_ex(cb_ex_id);
+    experimental::CircularBuffer cb_ex2pe(cb_ex2pe_id);
+    experimental::CircularBuffer cb_ex_external(cb_ex_external_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_in(cb_in_id);
+    experimental::CircularBuffer cb_in_negative_mask(cb_in_negative_mask_id);
+    experimental::CircularBuffer cb_inbeta(cb_inbeta_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_ones(cb_ones_id);
+    experimental::CircularBuffer cb_out(cb_out_id);
+    experimental::CircularBuffer cb_outbeta(cb_outbeta_id);
+    experimental::CircularBuffer cb_outgamma(cb_outgamma_id);
+    experimental::CircularBuffer cb_scaler(cb_scaler_id);
+    experimental::CircularBuffer cb_scaler_global(cb_scaler_global_id);
+    experimental::CircularBuffer cb_x(cb_x_id);
+
 // tilize input from RM to tile layout
 #ifdef TILIZE_IN
-    binary_op_init_common(cb_in0, cb_in0, cb_in);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in_id);
 // Tilize in0 -> in (row-major to tiled)
 #ifdef READER_REPACK
-    constexpr uint32_t cb_in_rm = cb_repack;
+    constexpr uint32_t cb_in_rm_id = cb_repack_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #else
-    constexpr uint32_t cb_in_rm = cb_in0;
+    constexpr uint32_t cb_in_rm_id = cb_in0_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::NoWait,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #endif
-    cb_wait_front(cb_in, per_core_MN);
+    cb_in.wait_front(per_core_MN);
 #else
-    binary_op_init_common(cb_in0, cb_input_mask, cb_x);
+    binary_op_init_common(cb_in0_id, cb_input_mask_id, cb_x_id);
 #endif
 
     index_b_offset = 0;
@@ -188,10 +209,10 @@ void kernel_main() {
         for (uint32_t g = 0; g < group; ++g) {
             // mask input
             index_h_offset = index_b_offset + index_g_offset;
-            reconfig_data_format_srcb(cb_in0, cb_input_mask);
-            mul_tiles_init(cb_in0, cb_input_mask);
-            cb_reserve_back(cb_x, block_hw);
-            cb_wait_front(cb_input_mask, block_w);
+            reconfig_data_format_srcb(cb_in0_id, cb_input_mask_id);
+            mul_tiles_init(cb_in0_id, cb_input_mask_id);
+            cb_x.reserve_back(block_hw);
+            cb_input_mask.wait_front(block_w);
             for (uint32_t i = 0; i < block_h; ++i) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; ++j) {
@@ -200,31 +221,31 @@ void kernel_main() {
                         uint32_t index = w + index_subblock_w_offset + index_h_offset;
                         uint32_t index_mask = w + index_subblock_w_offset;
 #ifdef TILIZE_IN
-                        mul_tiles(cb_in, cb_input_mask, index, index_mask, w);
+                        mul_tiles(cb_in_id, cb_input_mask_id, index, index_mask, w);
 #else
-                        mul_tiles(cb_in0, cb_input_mask, index, index_mask, w);
+                        mul_tiles(cb_in0_id, cb_input_mask_id, index, index_mask, w);
 #endif
                     }
                     tile_regs_commit();
                     tile_regs_wait();
                     for (uint32_t i = 0; i < subblock_w; ++i) {
-                        pack_tile(i, cb_x);
+                        pack_tile(i, cb_x_id);
                     }
                     tile_regs_release();
                     index_subblock_w_offset += subblock_w;
                 }
                 index_h_offset += per_core_N;
             }
-            cb_push_back(cb_x, block_hw);
-            reconfig_data_format_srcb(cb_input_mask, cb_ones);
+            cb_x.push_back(block_hw);
+            reconfig_data_format_srcb(cb_input_mask_id, cb_ones_id);
 
             // Partial-E[x]
             index_h_offset = 0;
-            mul_tiles_init(cb_x, cb_ones);
-            cb_reserve_back(cb_ex2pe, 1);
+            mul_tiles_init(cb_x_id, cb_ones_id);
+            cb_ex2pe.reserve_back(1);
             tile_regs_acquire();
-            cb_wait_front(cb_x, block_hw);
-            cb_wait_front(cb_ones, 1);
+            cb_x.wait_front(block_hw);
+            cb_ones.wait_front(1);
 
             index_h_offset = 0;
             // Accomulate into dest directly by using mul_tiles (tile * 1 is accomulated into dest at the moment)
@@ -232,76 +253,78 @@ void kernel_main() {
             for (uint32_t h = 0; h < block_h; ++h) {
                 for (uint32_t w = 0; w < block_w; ++w) {
                     uint32_t index = index_h_offset + w;
-                    mul_tiles(cb_x, cb_ones, index, 0, dst0);
+                    mul_tiles(cb_x_id, cb_ones_id, index, 0, dst0);
                 }
                 index_h_offset += block_w;
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
+            cb_ex2pe.push_back(1);
             tile_regs_acquire();
-            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, cb_ex_partial);
-            cb_reserve_back(cb_ex_partial, 1);
-            cb_wait_front(cb_scaler, 1);
-            cb_wait_front(cb_ex2pe, 1);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id);
+            cb_ex_partial.reserve_back(1);
+            cb_scaler.wait_front(1);
+            cb_ex2pe.wait_front(1);
             // reduce only one final tile
-            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
-            cb_pop_front(cb_ex2pe, 1);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe_id, cb_scaler_id, 0, scaler0, dst0);
+            cb_ex2pe.pop_front(1);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex_partial);
+            pack_tile(dst0, cb_ex_partial_id);
             tile_regs_release();
-            cb_push_back(cb_ex_partial, 1);
+            cb_ex_partial.push_back(1);
             reduce_uninit<FP32_DEST_ACC>();
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
-                cb_reserve_back(cb_ex_global, 1);
-                cb_reserve_back(cb_ex, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, cb_ex_global_id);
+                cb_ex_global.reserve_back(1);
+                cb_ex.reserve_back(1);
                 tile_regs_acquire();
-                cb_wait_front(cb_scaler_global, 1);
-                cb_wait_front(cb_ex_external, 1);
-                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
-                cb_pop_front(cb_ex_external, 1);
+                cb_scaler_global.wait_front(1);
+                cb_ex_external.wait_front(1);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, 0, scaler0, dst0);
+                cb_ex_external.pop_front(1);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex_global);
+                pack_tile(dst0, cb_ex_global_id);
                 tile_regs_release();
                 reduce_uninit<FP32_DEST_ACC>();
-                cb_push_back(cb_ex_global, 1);
-                cb_push_back(cb_ex, 1);
+                cb_ex_global.push_back(1);
+                cb_ex.push_back(1);
             }
             // x - E[x]
-            sub_tiles_bcast_scalar_init_short(cb_x, cb_ex_global);
+            sub_tiles_bcast_scalar_init_short(cb_x_id, cb_ex_global_id);
 
-            cb_wait_front(cb_ex_global, 1);
+            cb_ex_global.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; j++) {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; w++) {
                         uint32_t index = w + index_subblock_w_offset;
-                        sub_tiles_bcast_scalar(cb_x, cb_ex_global, index, 0, w);
+                        sub_tiles_bcast_scalar(cb_x_id, cb_ex_global_id, index, 0, w);
                     }
                     tile_regs_commit();
-                    cb_pop_front(cb_x, subblock_w);
-                    cb_reserve_back(cb_x, subblock_w);
+                    cb_x.pop_front(subblock_w);
+                    cb_x.reserve_back(subblock_w);
                     tile_regs_wait();
                     for (uint32_t k = 0; k < subblock_w; k++) {
-                        pack_tile(k, cb_x);
+                        pack_tile(k, cb_x_id);
                     }
-                    cb_push_back(cb_x, subblock_w);
+                    cb_x.push_back(subblock_w);
                     tile_regs_release();
-                    cb_wait_front(cb_x, block_hw);
+                    cb_x.wait_front(block_hw);
                 }
             }
-            cb_pop_front(cb_ex_global, 1);
+            cb_ex_global.pop_front(1);
 
-            reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-            mul_tiles_init(cb_x, cb_input_mask);
-            cb_wait_front(cb_x, block_hw);
+            reconfig_data_format_srcb(cb_ex_global_id, cb_input_mask_id);
+            mul_tiles_init(cb_x_id, cb_input_mask_id);
+            cb_x.wait_front(block_hw);
 
             for (uint32_t i = 0; i < block_h; i++) {
                 index_subblock_w_offset = 0;
@@ -310,38 +333,38 @@ void kernel_main() {
                     for (uint32_t w = 0; w < subblock_w; ++w) {
                         uint32_t index = w + index_subblock_w_offset;
                         uint32_t index_mask = index;
-                        mul_tiles(cb_x, cb_input_mask, index, index_mask, w);
+                        mul_tiles(cb_x_id, cb_input_mask_id, index, index_mask, w);
                     }
                     tile_regs_commit();
 
-                    cb_pop_front(cb_x, subblock_w);
-                    cb_reserve_back(cb_x, subblock_w);
+                    cb_x.pop_front(subblock_w);
+                    cb_x.reserve_back(subblock_w);
 
                     tile_regs_wait();
                     for (uint32_t i = 0; i < subblock_w; ++i) {
-                        pack_tile(i, cb_x);
+                        pack_tile(i, cb_x_id);
                     }
-                    cb_push_back(cb_x, subblock_w);
+                    cb_x.push_back(subblock_w);
                     tile_regs_release();
                 }
             }
-            cb_pop_front(cb_input_mask, block_w);
-            reconfig_data_format_srcb(cb_input_mask, cb_x);
+            cb_input_mask.pop_front(block_w);
+            reconfig_data_format_srcb(cb_input_mask_id, cb_x_id);
 
             // (x - E[x])^2
             index_h_offset = 0;
-            mul_tiles_init(cb_x, cb_x);
-            cb_wait_front(cb_x, block_hw);
+            mul_tiles_init(cb_x_id, cb_x_id);
+            cb_x.wait_front(block_hw);
 
             tile_regs_acquire();
-            cb_reserve_back(cb_ex2pe, 1);
+            cb_ex2pe.reserve_back(1);
 
             for (uint32_t i = 0; i < block_h; i++) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; j++) {
                     for (uint32_t w = 0; w < subblock_w; w++) {
                         uint32_t index = w + index_subblock_w_offset + index_h_offset;
-                        mul_tiles(cb_x, cb_x, index, index, dst0);
+                        mul_tiles(cb_x_id, cb_x_id, index, index, dst0);
                     }
 
                     index_subblock_w_offset += subblock_w;
@@ -350,91 +373,93 @@ void kernel_main() {
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
+            cb_ex2pe.push_back(1);
 
-            cb_reserve_back(cb_ex_partial, 1);
-            cb_wait_front(cb_scaler, 1);
-            cb_wait_front(cb_ex2pe, 1);
+            cb_ex_partial.reserve_back(1);
+            cb_scaler.wait_front(1);
+            cb_ex2pe.wait_front(1);
 
-            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, cb_ex_partial);
+            reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe_id, cb_scaler_id, cb_ex_partial_id);
 
             tile_regs_acquire();
-            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe, cb_scaler, 0, scaler0, dst0);
+            reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex2pe_id, cb_scaler_id, 0, scaler0, dst0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex_partial);
+            pack_tile(dst0, cb_ex_partial_id);
             tile_regs_release();
-            cb_push_back(cb_ex_partial, 1);
+            cb_ex_partial.push_back(1);
 
             reduce_uninit<FP32_DEST_ACC>();
 
-            cb_pop_front(cb_ex2pe, 1);
-            cb_wait_front(cb_ex_partial, 1);
+            cb_ex2pe.pop_front(1);
+            cb_ex_partial.wait_front(1);
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, cb_ex_global);
-                cb_reserve_back(cb_ex_global, 1);
-                cb_reserve_back(cb_ex, 1);
+                reduce_init<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, cb_ex_global_id);
+                cb_ex_global.reserve_back(1);
+                cb_ex.reserve_back(1);
                 tile_regs_acquire();
-                cb_wait_front(cb_scaler_global, 1);
-                cb_wait_front(cb_ex_external, 1);
-                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
-                cb_pop_front(cb_ex_external, 1);
+                cb_scaler_global.wait_front(1);
+                cb_ex_external.wait_front(1);
+                reduce_tile<REDUCE_OP, REDUCE_DIM, FP32_DEST_ACC>(
+                    cb_ex_external_id, cb_scaler_global_id, 0, scaler0, dst0);
+                cb_ex_external.pop_front(1);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(dst0, cb_ex_global);
+                pack_tile(dst0, cb_ex_global_id);
                 tile_regs_release();
                 reduce_uninit<FP32_DEST_ACC>();
-                cb_push_back(cb_ex_global, 1);
-                cb_push_back(cb_ex, 1);
+                cb_ex_global.push_back(1);
+                cb_ex.push_back(1);
             }
 
             // global reduce results
 
-            cb_wait_front(cb_eps, 1);
-            cb_wait_front(cb_ex_global, 1);
-            cb_reserve_back(cb_ex2pe, 1);
+            cb_eps.wait_front(1);
+            cb_ex_global.wait_front(1);
+            cb_ex2pe.reserve_back(1);
 
             // (Var + eps)
             tile_regs_acquire();
-            add_tiles_init(cb_ex_global, cb_eps);
-            add_tiles(cb_ex_global, cb_eps, 0, 0, dst0);
+            add_tiles_init(cb_ex_global_id, cb_eps_id);
+            add_tiles(cb_ex_global_id, cb_eps_id, 0, 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
-            cb_push_back(cb_ex2pe, 1);
-            cb_pop_front(cb_ex_global, 1);
+            cb_ex2pe.push_back(1);
+            cb_ex_global.pop_front(1);
             //  (x - Ex) * 1/[sqrt(Var + eps)]
             index_h_offset = 0;
-            mul_tiles_bcast_scalar_init_short(cb_x, cb_ex2pe);
+            mul_tiles_bcast_scalar_init_short(cb_x_id, cb_ex2pe_id);
 
-            cb_wait_front(cb_ex2pe, 1);
+            cb_ex2pe.wait_front(1);
             for (uint32_t i = 0; i < block_h; i++) {
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; j++) {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; w++) {
                         uint32_t index = w + index_subblock_w_offset;
-                        mul_tiles_bcast_scalar(cb_x, cb_ex2pe, index, 0, w);
+                        mul_tiles_bcast_scalar(cb_x_id, cb_ex2pe_id, index, 0, w);
                     }
                     tile_regs_commit();
-                    cb_pop_front(cb_x, subblock_w);
-                    cb_reserve_back(cb_x, subblock_w);
+                    cb_x.pop_front(subblock_w);
+                    cb_x.reserve_back(subblock_w);
                     tile_regs_wait();
                     for (uint32_t i = 0; i < subblock_w; i++) {
-                        pack_tile(i, cb_x);
+                        pack_tile(i, cb_x_id);
                     }
-                    cb_push_back(cb_x, subblock_w);
+                    cb_x.push_back(subblock_w);
                     tile_regs_release();
                 }
             }
-            cb_pop_front(cb_ex2pe, 1);
-            cb_wait_front(cb_x, block_hw);
+            cb_ex2pe.pop_front(1);
+            cb_x.wait_front(block_hw);
             //  add or copy with previous output results
             uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
@@ -446,9 +471,9 @@ void kernel_main() {
                     uint32_t index_h1_offset = 0;
 
                     if (copy_or_add == true) {
-                        copy_tile_init(cb_x);
+                        copy_tile_init(cb_x_id);
                     } else {
-                        add_tiles_init(cb_out, cb_x);
+                        add_tiles_init(cb_out_id, cb_x_id);
                     }
 
                     for (uint32_t i = 0; i < block_h; ++i) {
@@ -457,13 +482,13 @@ void kernel_main() {
                         uint32_t index = w + index_h_offset;
 
                         if (copy_or_add == true) {
-                            copy_tile(cb_x, index_x, dst0);
+                            copy_tile(cb_x_id, index_x, dst0);
                         } else {
-                            add_tiles(cb_out, cb_x, index, index_x, dst0);
+                            add_tiles(cb_out_id, cb_x_id, index, index_x, dst0);
                         }
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile<true>(dst0, cb_out, index);
+                        pack_tile<true>(dst0, cb_out_id, index);
                         tile_regs_release();
 
                         index_h_offset += per_core_N;
@@ -490,9 +515,9 @@ void kernel_main() {
                 }
             } else {
                 // zero out values in cb_tilized_in input by multiplying with negative mask for the current group
-                cb_wait_front(cb_in_negative_mask, block_w);
-                reconfig_data_format_srcb(cb_x, cb_in_negative_mask);
-                mul_tiles_init(cb_in, cb_in_negative_mask);
+                cb_in_negative_mask.wait_front(block_w);
+                reconfig_data_format_srcb(cb_x_id, cb_in_negative_mask_id);
+                mul_tiles_init(cb_in_id, cb_in_negative_mask_id);
 
                 for (uint32_t w = 0; w < block_w_curr; w++) {
                     index_h_offset = index_b_offset + index_g_offset;
@@ -503,21 +528,21 @@ void kernel_main() {
                         uint32_t index_in = w + index_h_offset;
                         uint32_t index_mask = w;
 
-                        mul_tiles(cb_in, cb_in_negative_mask, index_in, index_mask, dst0);
+                        mul_tiles(cb_in_id, cb_in_negative_mask_id, index_in, index_mask, dst0);
                         tile_regs_commit();
 
                         tile_regs_wait();
-                        pack_tile<true>(dst0, cb_in, index_in);
+                        pack_tile<true>(dst0, cb_in_id, index_in);
                         tile_regs_release();
 
                         index_h_offset += per_core_N;
                     }
                 }
 
-                reconfig_data_format_srcb(cb_in_negative_mask, cb_x);
-                add_tiles_init(cb_in, cb_x);
-                // data in cb_x has valid data only for current group
-                // cb_in has cleared data for that group
+                reconfig_data_format_srcb(cb_in_negative_mask_id, cb_x_id);
+                add_tiles_init(cb_in_id, cb_x_id);
+                // data in cb_x_id has valid data only for current group
+                // cb_in_id has cleared data for that group
                 // just add them together
                 for (uint32_t w = 0; w < block_w_curr; ++w) {
                     index_h_offset = index_b_offset + index_g_offset;
@@ -528,20 +553,20 @@ void kernel_main() {
                         uint32_t index_x = w + index_h1_offset;
                         uint32_t index = w + index_h_offset;
 
-                        add_tiles(cb_in, cb_x, index, index_x, dst0);
+                        add_tiles(cb_in_id, cb_x_id, index, index_x, dst0);
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile<true>(dst0, cb_in, index);
+                        pack_tile<true>(dst0, cb_in_id, index);
                         tile_regs_release();
 
                         index_h_offset += per_core_N;
                         index_h1_offset += block_w;
                     }
                 }
-                cb_pop_front(cb_in_negative_mask, block_w);
+                cb_in_negative_mask.pop_front(block_w);
             }
 
-            cb_pop_front(cb_x, block_hw);
+            cb_x.pop_front(block_hw);
 
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
                 if (row_offset == tile_width) {
@@ -578,51 +603,51 @@ void kernel_main() {
     }
 
     if constexpr (use_negative_mask == false) {
-        cb_push_back(cb_out, per_core_MN);
-        cb_pop_front(cb_in, per_core_MN);
+        cb_out.push_back(per_core_MN);
+        cb_in.pop_front(per_core_MN);
 
     } else {
-        // nothing, for the negative mask implementation, cb_in is the only cb in use, and it already has the data
+        // nothing, for the negative mask implementation, cb_in_id is the only cb in use, and it already has the data
         // required for the rest of kernel.
     }
 
     if constexpr (do_gamma) {
         index_h_offset = 0;
         if constexpr (use_negative_mask == false) {
-            mul_bcast_rows_init_short(cb_out, cb_gamma);
-            cb_reserve_back(cb_outgamma, per_core_MN);
-            cb_wait_front(cb_gamma, per_core_N);
+            mul_bcast_rows_init_short(cb_out_id, cb_gamma_id);
+            cb_outgamma.reserve_back(per_core_MN);
+            cb_gamma.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
                 for (uint32_t j = 0; j < per_core_N; ++j) {
                     tile_regs_acquire();
                     uint32_t index = j + index_h_offset;
-                    mul_tiles_bcast_rows(cb_out, cb_gamma, index, j, dst0);
+                    mul_tiles_bcast_rows(cb_out_id, cb_gamma_id, index, j, dst0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(dst0, cb_outgamma);
+                    pack_tile(dst0, cb_outgamma_id);
                     tile_regs_release();
                 }
                 index_h_offset += per_core_N;
             }
 
-            cb_push_back(cb_outgamma, per_core_MN);
-            cb_pop_front(cb_out, per_core_MN);
-            cb_wait_front(cb_outgamma, per_core_MN);
+            cb_outgamma.push_back(per_core_MN);
+            cb_out.pop_front(per_core_MN);
+            cb_outgamma.wait_front(per_core_MN);
         } else {
             // cb in has data required for gamma, so we do it inplace
-            mul_bcast_rows_init_short(cb_in, cb_gamma);
-            cb_wait_front(cb_gamma, per_core_N);
-            cb_wait_front(cb_in, per_core_MN);
+            mul_bcast_rows_init_short(cb_in_id, cb_gamma_id);
+            cb_gamma.wait_front(per_core_N);
+            cb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {
                 for (uint32_t j = 0; j < per_core_N; j++) {
                     tile_regs_acquire();
-                    mul_tiles_bcast_rows(cb_in, cb_gamma, 0, j, dst0);
+                    mul_tiles_bcast_rows(cb_in_id, cb_gamma_id, 0, j, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_in, 1);
-                    cb_reserve_back(cb_in, 1);
+                    cb_in.pop_front(1);
+                    cb_in.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_in);
-                    cb_push_back(cb_in, 1);
+                    pack_tile(dst0, cb_in_id);
+                    cb_in.push_back(1);
                     tile_regs_release();
                 }
             }
@@ -632,39 +657,39 @@ void kernel_main() {
     if constexpr (do_beta) {
         if constexpr (use_negative_mask == false) {
             index_h_offset = 0;
-            add_bcast_rows_init_short(cb_inbeta, cb_beta);
-            cb_reserve_back(cb_outbeta, per_core_MN);
-            cb_wait_front(cb_beta, per_core_N);
+            add_bcast_rows_init_short(cb_inbeta_id, cb_beta_id);
+            cb_outbeta.reserve_back(per_core_MN);
+            cb_beta.wait_front(per_core_N);
             for (uint32_t i = 0; i < per_core_M; ++i) {
                 for (uint32_t j = 0; j < per_core_N; ++j) {
                     tile_regs_acquire();
                     uint32_t index = j + index_h_offset;
-                    add_tiles_bcast_rows(cb_inbeta, cb_beta, index, j, dst0);
+                    add_tiles_bcast_rows(cb_inbeta_id, cb_beta_id, index, j, dst0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(dst0, cb_outbeta);
+                    pack_tile(dst0, cb_outbeta_id);
                     tile_regs_release();
                 }
                 index_h_offset += per_core_N;
             }
-            cb_push_back(cb_outbeta, per_core_MN);
-            cb_pop_front(cb_inbeta, per_core_MN);
-            cb_wait_front(cb_outbeta, per_core_MN);
+            cb_outbeta.push_back(per_core_MN);
+            cb_inbeta.pop_front(per_core_MN);
+            cb_outbeta.wait_front(per_core_MN);
         } else {
-            // cb_in has data required for beta, so we do it inplace
-            add_bcast_rows_init_short(cb_in, cb_beta);
-            cb_wait_front(cb_beta, per_core_N);
-            cb_wait_front(cb_in, per_core_MN);
+            // cb_in_id has data required for beta, so we do it inplace
+            add_bcast_rows_init_short(cb_in_id, cb_beta_id);
+            cb_beta.wait_front(per_core_N);
+            cb_in.wait_front(per_core_MN);
             for (uint32_t i = 0; i < per_core_M; i++) {
                 for (uint32_t j = 0; j < per_core_N; j++) {
                     tile_regs_acquire();
-                    add_tiles_bcast_rows(cb_in, cb_beta, 0, j, dst0);
+                    add_tiles_bcast_rows(cb_in_id, cb_beta_id, 0, j, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_in, 1);
-                    cb_reserve_back(cb_in, 1);
+                    cb_in.pop_front(1);
+                    cb_in.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_in);
-                    cb_push_back(cb_in, 1);
+                    pack_tile(dst0, cb_in_id);
+                    cb_in.push_back(1);
                     tile_regs_release();
                 }
             }
@@ -675,8 +700,8 @@ void kernel_main() {
     // untilize - DEST capacity auto-detected
     compute_kernel_lib::untilize<
         per_core_N,
-        cb_untilize_in,
-        cb_untilize_out,
+        cb_untilize_in_id,
+        cb_untilize_out_id,
         compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
         compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -23,6 +23,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 #include "ttnn/operations/normalization/kernel_util/compute/memory.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     /*
@@ -64,14 +65,14 @@ void kernel_main() {
      *   Statistics Aggregation:
      *       Local aggregation per core:
      *           Convert accumulated M2 to variance using welford_finalize_to_face()
-     *           Store per-group statistics in cb_ex_partial for inter-core communication
+     *           Store per-group statistics in cb_ex_partial_id for inter-core communication
      *       Global reduction across cores:
-     *           Reader kernels aggregate local statistics from all cores into cb_ex_global
+     *           Reader kernels aggregate local statistics from all cores into cb_ex_global_id
      *           Designated sender core produces final global mean and variance per group
      *   Normalization Factor Calculation:
      *       Add epsilon to variance: Var + eps
      *       Compute reciprocal square root: 1/sqrt(Var + eps)
-     *       Store normalization factor in cb_ex2pe for use in final calculation
+     *       Store normalization factor in cb_ex2pe_id for use in final calculation
      *   Final Normalization:
      *       Center inputs: x - μ (mean subtraction)
      *       Apply input mask to handle padding/ignored elements
@@ -120,79 +121,92 @@ void kernel_main() {
     constexpr uint32_t mean_dst = 1;
 
     // input cbs
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in = tt::CBIndex::c_29;
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
-    constexpr uint32_t cb_reciprocals = tt::CBIndex::c_18;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_29;
+    constexpr uint32_t cb_eps_id = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_28;
+    constexpr uint32_t cb_reciprocals_id = tt::CBIndex::c_18;
 
     // interm cbs
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_x = tt::CBIndex::c_24;
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_25;
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_27;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_24;
+    constexpr uint32_t cb_xmm_id = tt::CBIndex::c_25;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex2pe_id = tt::CBIndex::c_27;
 
     // interm cbs reuse
-    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
+    constexpr uint32_t cb_reread_write_out_id = tt::CBIndex::c_22;
 
     // output cb
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta) ? cb_out0 : cb_reread_write_out;
+    constexpr uint32_t cb_out_id = (do_gamma or do_beta) ? cb_out0_id : cb_reread_write_out_id;
 #endif
 
 #ifdef UNTILIZE_OUT
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
-    constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma
-                                   : do_beta                  ? cb_outbeta
-                                                              : cb_reread_write_out;
-    constexpr int cb_untilize_out =
+    constexpr int cb_outgamma_id = cb_in_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_reread_write_out_id;
+    constexpr int cb_outbeta_id = do_gamma ? cb_out_id : cb_in_id;
+    constexpr int cb_untilize_in_id = (do_gamma and not do_beta) ? cb_outgamma_id
+                                      : do_beta                  ? cb_outbeta_id
+                                                                 : cb_reread_write_out_id;
+    constexpr int cb_untilize_out_id =
 #ifdef READER_REPACK
-        cb_repack_out;
+        cb_repack_out_id;
 #else
-        cb_out0;
+        cb_out0_id;
 #endif
 #else
-    constexpr int cb_outgamma = do_beta ? cb_in : cb_out0;
-    constexpr int cb_inbeta = do_gamma ? cb_outgamma : cb_reread_write_out;
-    constexpr int cb_outbeta = cb_out0;
+    constexpr int cb_outgamma_id = do_beta ? cb_in_id : cb_out0_id;
+    constexpr int cb_inbeta_id = do_gamma ? cb_outgamma_id : cb_reread_write_out_id;
+    constexpr int cb_outbeta_id = cb_out0_id;
 #endif
+
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_eps(cb_eps_id);
+    experimental::CircularBuffer cb_ex2pe(cb_ex2pe_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_in(cb_in_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_out(cb_out_id);
+    experimental::CircularBuffer cb_x(cb_x_id);
+    experimental::CircularBuffer cb_xmm(cb_xmm_id);
 
 // tilize input from RM to tile layout
 #ifdef TILIZE_IN
-    binary_op_init_common(cb_in0, cb_in0, cb_in);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in_id);
 // Tilize in0 -> in (row-major to tiled)
 #ifdef READER_REPACK
-    constexpr uint32_t cb_in_rm = cb_repack;
+    constexpr uint32_t cb_in_rm_id = cb_repack_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #else
-    constexpr uint32_t cb_in_rm = cb_in0;
+    constexpr uint32_t cb_in_rm_id = cb_in0_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::NoWait,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #endif
-    cb_wait_front(cb_in, per_core_MN);
+    cb_in.wait_front(per_core_MN);
 #else
-    binary_op_init_common(cb_in0, cb_in0, cb_in0);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in0_id);
 #endif
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
@@ -213,20 +227,20 @@ void kernel_main() {
     // Get pointer to the reciprocal LUT
     using recip_lut_t = std::array<uint32_t, reciprocal_size>;
     auto p_reciprocal =
-        norm::kernel_util::compute::memory::get_pointer_to_cb_data<recip_lut_t>(cb_reciprocals, /*tile_idx=*/0);
+        norm::kernel_util::compute::memory::get_pointer_to_cb_data<recip_lut_t>(cb_reciprocals_id, /*tile_idx=*/0);
 
-    cb_wait_front(cb_eps, 1);
-    cb_wait_front(cb_input_mask, num_tiles_input_mask);
+    cb_eps.wait_front(1);
+    cb_input_mask.wait_front(num_tiles_input_mask);
 
     if constexpr (do_gamma) {
-        cb_wait_front(cb_gamma, per_core_N);
+        cb_gamma.wait_front(per_core_N);
     }
     if constexpr (do_beta) {
-        cb_wait_front(cb_beta, per_core_N);
+        cb_beta.wait_front(per_core_N);
     }
 
     for (uint32_t b = 0; b < num_batches; ++b) {
-        cb_reserve_back(cb_ex_partial, 2);
+        cb_ex_partial.reserve_back(2);
         tile_regs_acquire();
         welford_init();
 
@@ -261,13 +275,13 @@ void kernel_main() {
                 uint32_t curr_xy_coord = block_xy_coord;
 
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_wait_front(cb_in0, 1);
+                    cb_in0.wait_front(1);
 #ifdef TILIZE_IN
-                    transpose_wh_init_short(cb_in);
-                    transpose_wh_tile(cb_in, 0, input_dst);
+                    transpose_wh_init_short(cb_in_id);
+                    transpose_wh_tile(cb_in_id, 0, input_dst);
 #else
-                    transpose_wh_init_short(cb_in0);
-                    transpose_wh_tile(cb_in0, 0, input_dst);
+                    transpose_wh_init_short(cb_in0_id);
+                    transpose_wh_tile(cb_in0_id, 0, input_dst);
 #endif
 
                     uint32_t group_offset = 0;
@@ -306,7 +320,7 @@ void kernel_main() {
                             break;
                         }
                     }
-                    cb_pop_front(cb_in0, 1);
+                    cb_in0.pop_front(1);
                 }
                 block_xy_coord += num_channels_per_group;
             }
@@ -321,34 +335,34 @@ void kernel_main() {
 
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile_block(mean_dst, cb_ex_partial, 2);
+        pack_tile_block(mean_dst, cb_ex_partial_id, 2);
         tile_regs_release();
-        cb_push_back(cb_ex_partial, 2);
+        cb_ex_partial.push_back(2);
         // End Statistics Aggregation
 
         // Start Normalization Factor Calculation
-        // Wait for final welford values in cb_ex_global
-        cb_wait_front(cb_ex_global, 2 * num_groups);
-        cb_reserve_back(cb_ex2pe, num_groups);
+        // Wait for final welford values in cb_ex_global_id
+        cb_ex_global.wait_front(2 * num_groups);
+        cb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
-        add_tiles_init(cb_ex_global, cb_eps);
-        reconfig_data_format_srcb(cb_eps);
+        add_tiles_init(cb_ex_global_id, cb_eps_id);
+        reconfig_data_format_srcb(cb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
-            add_tiles(cb_ex_global, cb_eps, 1 + (g << 1), 0, dst0);
+            add_tiles(cb_ex_global_id, cb_eps_id, 1 + (g << 1), 0, dst0);
 
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
         }
-        cb_push_back(cb_ex2pe, num_groups);
+        cb_ex2pe.push_back(num_groups);
         // End Normalization Factor Calculation
 
-        cb_wait_front(cb_ex2pe, num_groups);
+        cb_ex2pe.wait_front(num_groups);
 
         // Start Final Normalization
         for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
@@ -376,84 +390,84 @@ void kernel_main() {
                 uint32_t block_w_index = 0;
 
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_wait_front(cb_in0, 1);
+                    cb_in0.wait_front(1);
 
                     uint32_t group_offset = 0;
                     for (uint32_t g = min_group; g < num_groups; ++g) {
-                        cb_reserve_back(cb_xmm, 2);
+                        cb_xmm.reserve_back(2);
 
                         // // Now let us do the actual computation for the current group here
                         // // a. x-u
-                        sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-                        reconfig_data_format_srcb(cb_eps, cb_ex_global);
+                        sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
+                        reconfig_data_format_srcb(cb_eps_id, cb_ex_global_id);
 
                         tile_regs_acquire();
-                        sub_tiles_bcast_scalar(cb_in0, cb_ex_global, 0, 0 + (g << 1), dst0);
+                        sub_tiles_bcast_scalar(cb_in0_id, cb_ex_global_id, 0, 0 + (g << 1), dst0);
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile(dst0, cb_xmm);
+                        pack_tile(dst0, cb_xmm_id);
                         tile_regs_release();
 
                         // // b. 1/[sqrt(Var + eps)] * mask
                         const uint32_t mask_offset = g * block_w;
                         const uint32_t mask_index = mask_offset + block_w_index;
 
-                        mul_tiles_bcast_scalar_init_short(cb_input_mask, cb_ex2pe);
-                        reconfig_data_format_srcb(cb_ex_global, cb_ex2pe);
+                        mul_tiles_bcast_scalar_init_short(cb_input_mask_id, cb_ex2pe_id);
+                        reconfig_data_format_srcb(cb_ex_global_id, cb_ex2pe_id);
                         tile_regs_acquire();
-                        mul_tiles_bcast_scalar(cb_input_mask, cb_ex2pe, mask_index, g, dst0);
+                        mul_tiles_bcast_scalar(cb_input_mask_id, cb_ex2pe_id, mask_index, g, dst0);
                         tile_regs_commit();
                         tile_regs_wait();
-                        pack_tile(dst0, cb_xmm);
+                        pack_tile(dst0, cb_xmm_id);
                         tile_regs_release();
-                        cb_push_back(cb_xmm, 2);
+                        cb_xmm.push_back(2);
 
                         // // c. a * b
-                        cb_wait_front(cb_xmm, 2);
-                        mul_tiles_init(cb_xmm, cb_xmm);
-                        reconfig_data_format_srcb(cb_ex2pe, cb_xmm);
+                        cb_xmm.wait_front(2);
+                        mul_tiles_init(cb_xmm_id, cb_xmm_id);
+                        reconfig_data_format_srcb(cb_ex2pe_id, cb_xmm_id);
                         tile_regs_acquire();
-                        mul_tiles(cb_xmm, cb_xmm, 0, 1, dst0);
+                        mul_tiles(cb_xmm_id, cb_xmm_id, 0, 1, dst0);
                         tile_regs_commit();
-                        cb_pop_front(cb_xmm, 2);
-                        cb_reserve_back(cb_xmm, 1);
+                        cb_xmm.pop_front(2);
+                        cb_xmm.reserve_back(1);
                         tile_regs_wait();
-                        pack_tile(dst0, cb_xmm);
+                        pack_tile(dst0, cb_xmm_id);
                         tile_regs_release();
-                        cb_push_back(cb_xmm, 1);
+                        cb_xmm.push_back(1);
 
-                        // // d. Add to cb_xmm (accumulate results)
+                        // // d. Add to cb_xmm_id (accumulate results)
                         // // First we get the result in dst0
                         if (group_offset == 0) {
                             // When group_offset is 0, this is the first group for this tile,
-                            // so we can copy the results to cb_x without needing to add them
-                            copy_tile_init(cb_xmm);
+                            // so we can copy the results to cb_x_id without needing to add them
+                            copy_tile_init(cb_xmm_id);
 
-                            cb_wait_front(cb_xmm, 1);
+                            cb_xmm.wait_front(1);
                             tile_regs_acquire();
-                            copy_tile(cb_xmm, 0, dst0);
+                            copy_tile(cb_xmm_id, 0, dst0);
                             tile_regs_commit();
-                            cb_pop_front(cb_xmm, 1);
+                            cb_xmm.pop_front(1);
                         } else {
                             // This is not the first group for this tile, so we need to add
-                            // the results over what is already in cb_x
-                            add_tiles_init(cb_x, cb_xmm);
+                            // the results over what is already in cb_x_id
+                            add_tiles_init(cb_x_id, cb_xmm_id);
 
-                            cb_wait_front(cb_xmm, 1);
-                            cb_wait_front(cb_x, 1);
+                            cb_xmm.wait_front(1);
+                            cb_x.wait_front(1);
                             tile_regs_acquire();
-                            add_tiles(cb_x, cb_xmm, 0, 0, dst0);
+                            add_tiles(cb_x_id, cb_xmm_id, 0, 0, dst0);
                             tile_regs_commit();
-                            cb_pop_front(cb_xmm, 1);
-                            cb_pop_front(cb_x, 1);
+                            cb_xmm.pop_front(1);
+                            cb_x.pop_front(1);
                         }
 
-                        // Then we pack the result into cb_x
-                        cb_reserve_back(cb_x, 1);
+                        // Then we pack the result into cb_x_id
+                        cb_x.reserve_back(1);
                         tile_regs_wait();
-                        pack_tile(dst0, cb_x);
+                        pack_tile(dst0, cb_x_id);
                         tile_regs_release();
-                        cb_push_back(cb_x, 1);
+                        cb_x.push_back(1);
 
                         uint32_t cols_available = tile_width - group_offset;
                         uint32_t cols_consumed = std::min(cols_available, channels_left);
@@ -482,54 +496,54 @@ void kernel_main() {
                             break;
                         }
                     }
-                    cb_pop_front(cb_in0, 1);
+                    cb_in0.pop_front(1);
 
                     if constexpr (do_gamma) {
-                        mul_bcast_rows_init_short(cb_x, cb_gamma);
-                        reconfig_data_format_srcb(cb_xmm, cb_gamma);
+                        mul_bcast_rows_init_short(cb_x_id, cb_gamma_id);
+                        reconfig_data_format_srcb(cb_xmm_id, cb_gamma_id);
 
-                        cb_wait_front(cb_x, 1);
+                        cb_x.wait_front(1);
                         tile_regs_acquire();
-                        mul_tiles_bcast_rows(cb_x, cb_gamma, 0, nt, dst0);
+                        mul_tiles_bcast_rows(cb_x_id, cb_gamma_id, 0, nt, dst0);
                         tile_regs_commit();
-                        cb_pop_front(cb_x, 1);
-                        cb_reserve_back(cb_x, 1);
+                        cb_x.pop_front(1);
+                        cb_x.reserve_back(1);
                         tile_regs_wait();
-                        pack_tile(dst0, cb_x);
+                        pack_tile(dst0, cb_x_id);
                         tile_regs_release();
-                        cb_push_back(cb_x, 1);
+                        cb_x.push_back(1);
                     }
 
                     if constexpr (do_beta) {
-                        add_bcast_rows_init_short(cb_x, cb_beta);
-                        reconfig_data_format_srcb(do_gamma ? cb_gamma : cb_xmm, cb_beta);
+                        add_bcast_rows_init_short(cb_x_id, cb_beta_id);
+                        reconfig_data_format_srcb(do_gamma ? cb_gamma_id : cb_xmm_id, cb_beta_id);
 
-                        cb_wait_front(cb_x, 1);
+                        cb_x.wait_front(1);
                         tile_regs_acquire();
-                        add_tiles_bcast_rows(cb_x, cb_beta, 0, nt, dst0);
+                        add_tiles_bcast_rows(cb_x_id, cb_beta_id, 0, nt, dst0);
                         tile_regs_commit();
-                        cb_pop_front(cb_x, 1);
-                        cb_reserve_back(cb_x, 1);
+                        cb_x.pop_front(1);
+                        cb_x.reserve_back(1);
                         tile_regs_wait();
-                        pack_tile(dst0, cb_x);
+                        pack_tile(dst0, cb_x_id);
                         tile_regs_release();
-                        cb_push_back(cb_x, 1);
+                        cb_x.push_back(1);
                     }
 
                     // Write out the final output
-                    copy_tile_init(cb_x);
-                    reconfig_data_format_srcb(do_beta ? cb_beta : cb_xmm, cb_x);
+                    copy_tile_init(cb_x_id);
+                    reconfig_data_format_srcb(do_beta ? cb_beta_id : cb_xmm_id, cb_x_id);
 
-                    cb_wait_front(cb_x, 1);
+                    cb_x.wait_front(1);
                     tile_regs_acquire();
-                    copy_tile(cb_x, 0, dst0);
+                    copy_tile(cb_x_id, 0, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_x, 1);
-                    cb_reserve_back(cb_out, 1);
+                    cb_x.pop_front(1);
+                    cb_out.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_out);
+                    pack_tile(dst0, cb_out_id);
                     tile_regs_release();
-                    cb_push_back(cb_out, 1);
+                    cb_out.push_back(1);
                 }
             }
 
@@ -537,8 +551,8 @@ void kernel_main() {
             // untilize - DEST capacity auto-detected
             compute_kernel_lib::untilize<
                 per_core_N,
-                cb_untilize_in,
-                cb_untilize_out,
+                cb_untilize_in_id,
+                cb_untilize_out_id,
                 compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
                 compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
                 compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
@@ -546,18 +560,18 @@ void kernel_main() {
         }
         // End Final Normalization
 
-        cb_pop_front(cb_ex_global, 2 * num_groups);
-        cb_pop_front(cb_ex2pe, num_groups);
+        cb_ex_global.pop_front(2 * num_groups);
+        cb_ex2pe.pop_front(num_groups);
     }
 
-    cb_pop_front(cb_eps, 1);
-    cb_pop_front(cb_input_mask, num_tiles_input_mask);
+    cb_eps.pop_front(1);
+    cb_input_mask.pop_front(num_tiles_input_mask);
 
-    // Pop all the cb_beta and cb_gamma if used
+    // Pop all the cb_beta_id and cb_gamma_id if used
     if constexpr (do_beta) {
-        cb_pop_front(cb_beta, per_core_N);
+        cb_beta.pop_front(per_core_N);
     }
     if constexpr (do_gamma) {
-        cb_pop_front(cb_gamma, per_core_N);
+        cb_gamma.pop_front(per_core_N);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -22,6 +22,7 @@
 #include "api/compute/welford.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t do_gamma = get_compile_time_arg_val(1);
@@ -48,92 +49,103 @@ void kernel_main() {
     constexpr uint32_t mean_dst = 1;
 
     // input cbs
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in = tt::CBIndex::c_1;
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_eps_id = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_7;
 
     // interm cbs
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_x = tt::CBIndex::c_13;
-    constexpr uint32_t cb_xmm = tt::CBIndex::c_2;
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
-    constexpr uint32_t cb_ex2pe = tt::CBIndex::c_17;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_13;
+    constexpr uint32_t cb_xmm_id = tt::CBIndex::c_2;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex2pe_id = tt::CBIndex::c_17;
 
     // output cb
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (do_gamma or do_beta)
-                                    ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in : cb_out0)
-                                    : cb_out0;
+    constexpr uint32_t cb_out_id =
+        (do_gamma or do_beta) ? (((do_gamma and not do_beta) or (not do_gamma and do_beta)) ? cb_in_id : cb_out0_id)
+                              : cb_out0_id;
 #endif
 
 #ifdef UNTILIZE_OUT
-    constexpr int cb_outgamma = cb_in;
-    constexpr int cb_outbeta = do_gamma ? cb_out : cb_in;
-    constexpr int cb_untilize_in = (do_gamma and not do_beta) ? cb_outgamma : do_beta ? cb_outbeta : cb_out;
-    constexpr int cb_untilize_out =
+    constexpr int cb_outgamma_id = cb_in_id;
+    constexpr int cb_outbeta_id = do_gamma ? cb_out_id : cb_in_id;
+    constexpr int cb_untilize_in_id = (do_gamma and not do_beta) ? cb_outgamma_id : do_beta ? cb_outbeta_id : cb_out_id;
+    constexpr int cb_untilize_out_id =
 #ifdef READER_REPACK
-        cb_repack_out;
+        cb_repack_out_id;
 #else
-        cb_out0;
+        cb_out0_id;
 #endif
 #else
-    constexpr int cb_outgamma = do_beta ? cb_in : cb_out0;
-    constexpr int cb_outbeta = cb_out0;
+    constexpr int cb_outgamma_id = do_beta ? cb_in_id : cb_out0_id;
+    constexpr int cb_outbeta_id = cb_out0_id;
 #endif
+
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_eps(cb_eps_id);
+    experimental::CircularBuffer cb_ex2pe(cb_ex2pe_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_in(cb_in_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_x(cb_x_id);
+    experimental::CircularBuffer cb_xmm(cb_xmm_id);
 
 // tilize input from RM to tile layout
 #ifdef TILIZE_IN
-    binary_op_init_common(cb_in0, cb_in0, cb_in);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in_id);
 // Tilize in0 -> in (row-major to tiled)
 #ifdef READER_REPACK
-    constexpr uint32_t cb_in_rm = cb_repack;
+    constexpr uint32_t cb_in_rm_id = cb_repack_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #else
-    constexpr uint32_t cb_in_rm = cb_in0;
+    constexpr uint32_t cb_in_rm_id = cb_in0_id;
     compute_kernel_lib::tilize<
         per_core_N,
-        cb_in_rm,
-        cb_in,
+        cb_in_rm_id,
+        cb_in_id,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::NoWait,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);
 #endif
-    cb_wait_front(cb_in, per_core_MN);
+    cb_in.wait_front(per_core_MN);
 #else
-    binary_op_init_common(cb_in0, cb_in0, cb_in0);
+    binary_op_init_common(cb_in0_id, cb_in0_id, cb_in0_id);
 #endif
 
     // Sharded v2 does not use reciprocal lookup table, so we pass an empty array
     constexpr std::array<uint32_t, 0> empty_reciprocal_lut{};
 
-    cb_wait_front(cb_eps, 1);
-    cb_wait_front(cb_input_mask, num_tiles_input_mask);
+    cb_eps.wait_front(1);
+    cb_input_mask.wait_front(num_tiles_input_mask);
 
     if constexpr (do_gamma) {
-        cb_wait_front(cb_gamma, per_core_N);
+        cb_gamma.wait_front(per_core_N);
     }
     if constexpr (do_beta) {
-        cb_wait_front(cb_beta, per_core_N);
+        cb_beta.wait_front(per_core_N);
     }
 
     for (uint32_t b = 0; b < num_batches; ++b) {
         uint32_t tile_id = b * block_hw;
-        cb_reserve_back(cb_ex_partial, 2);
-        transpose_wh_init(cb_in0, cb_ex_partial);
+        cb_ex_partial.reserve_back(2);
+        transpose_wh_init(cb_in0_id, cb_ex_partial_id);
         tile_regs_acquire();
         welford_init();
 
@@ -163,11 +175,11 @@ void kernel_main() {
 
             for (uint32_t nt = 0; nt < per_core_N; ++nt) {
 #ifdef TILIZE_IN
-                transpose_wh_init_short(cb_in);
-                transpose_wh_tile(cb_in, tile_id, input_dst);
+                transpose_wh_init_short(cb_in_id);
+                transpose_wh_tile(cb_in_id, tile_id, input_dst);
 #else
-                transpose_wh_init_short(cb_in0);
-                transpose_wh_tile(cb_in0, tile_id, input_dst);
+                transpose_wh_init_short(cb_in0_id);
+                transpose_wh_tile(cb_in0_id, tile_id, input_dst);
 #endif
 
                 uint32_t group_offset = 0;
@@ -217,33 +229,33 @@ void kernel_main() {
 
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile_block(mean_dst, cb_ex_partial, 2);
+        pack_tile_block(mean_dst, cb_ex_partial_id, 2);
         tile_regs_release();
-        cb_push_back(cb_ex_partial, 2);
+        cb_ex_partial.push_back(2);
 
         // Start Variance Calc
-        // Wait for final welford values in cb_ex_global
-        cb_wait_front(cb_ex_global, 2 * num_groups);
-        cb_reserve_back(cb_ex2pe, num_groups);
+        // Wait for final welford values in cb_ex_global_id
+        cb_ex_global.wait_front(2 * num_groups);
+        cb_ex2pe.reserve_back(num_groups);
         // (Var + eps)
-        add_tiles_init(cb_ex_global, cb_eps);
-        reconfig_data_format_srcb(cb_eps);
+        add_tiles_init(cb_ex_global_id, cb_eps_id);
+        reconfig_data_format_srcb(cb_eps_id);
         for (uint32_t g = 0; g < num_groups; ++g) {
             tile_regs_acquire();
-            add_tiles(cb_ex_global, cb_eps, 1 + (g << 1), 0, dst0);
+            add_tiles(cb_ex_global_id, cb_eps_id, 1 + (g << 1), 0, dst0);
 
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_ex2pe);
+            pack_tile(dst0, cb_ex2pe_id);
             tile_regs_release();
         }
-        cb_push_back(cb_ex2pe, num_groups);
+        cb_ex2pe.push_back(num_groups);
         // End Variance Calc
 
-        cb_wait_front(cb_ex2pe, num_groups);
+        cb_ex2pe.wait_front(num_groups);
 
         // Start Final Val Calc
         tile_id = b * block_hw;
@@ -268,85 +280,85 @@ void kernel_main() {
             for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                 uint32_t group_offset = 0;
                 for (uint32_t g = min_group; g < num_groups; ++g) {
-                    cb_reserve_back(cb_xmm, 2);
+                    cb_xmm.reserve_back(2);
 
                     // // Now let us do the actual computation for the current group here
                     // // a. x-u
-                    sub_tiles_bcast_scalar_init_short(cb_in0, cb_ex_global);
-                    reconfig_data_format(cb_in0, cb_ex_global);
+                    sub_tiles_bcast_scalar_init_short(cb_in0_id, cb_ex_global_id);
+                    reconfig_data_format(cb_in0_id, cb_ex_global_id);
 
                     tile_regs_acquire();
 #ifdef TILIZE_IN
-                    sub_tiles_bcast_scalar(cb_in, cb_ex_global, tile_id, 0 + (g << 1), dst0);
+                    sub_tiles_bcast_scalar(cb_in_id, cb_ex_global_id, tile_id, 0 + (g << 1), dst0);
 #else
-                    sub_tiles_bcast_scalar(cb_in0, cb_ex_global, tile_id, 0 + (g << 1), dst0);
+                    sub_tiles_bcast_scalar(cb_in0_id, cb_ex_global_id, tile_id, 0 + (g << 1), dst0);
 #endif
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(dst0, cb_xmm);
+                    pack_tile(dst0, cb_xmm_id);
                     tile_regs_release();
 
                     // // b. 1/[sqrt(Var + eps)] * mask
                     const uint32_t mask_offset = g * block_w;
                     const uint32_t mask_index = mask_offset + block_w_index;
 
-                    mul_tiles_bcast_scalar_init_short(cb_input_mask, cb_ex2pe);
-                    reconfig_data_format(cb_in0, cb_input_mask, cb_ex_global, cb_ex2pe);
+                    mul_tiles_bcast_scalar_init_short(cb_input_mask_id, cb_ex2pe_id);
+                    reconfig_data_format(cb_in0_id, cb_input_mask_id, cb_ex_global_id, cb_ex2pe_id);
                     tile_regs_acquire();
-                    mul_tiles_bcast_scalar(cb_input_mask, cb_ex2pe, mask_index, g, dst0);
+                    mul_tiles_bcast_scalar(cb_input_mask_id, cb_ex2pe_id, mask_index, g, dst0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(dst0, cb_xmm);
+                    pack_tile(dst0, cb_xmm_id);
                     tile_regs_release();
-                    cb_push_back(cb_xmm, 2);
+                    cb_xmm.push_back(2);
 
                     // // c. a * b
-                    cb_wait_front(cb_xmm, 2);
-                    mul_tiles_init(cb_xmm, cb_xmm);
-                    reconfig_data_format(cb_input_mask, cb_xmm, cb_ex2pe, cb_xmm);
+                    cb_xmm.wait_front(2);
+                    mul_tiles_init(cb_xmm_id, cb_xmm_id);
+                    reconfig_data_format(cb_input_mask_id, cb_xmm_id, cb_ex2pe_id, cb_xmm_id);
                     tile_regs_acquire();
-                    mul_tiles(cb_xmm, cb_xmm, 0, 1, dst0);
+                    mul_tiles(cb_xmm_id, cb_xmm_id, 0, 1, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_xmm, 2);
-                    cb_reserve_back(cb_xmm, 1);
+                    cb_xmm.pop_front(2);
+                    cb_xmm.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_xmm);
+                    pack_tile(dst0, cb_xmm_id);
                     tile_regs_release();
-                    cb_push_back(cb_xmm, 1);
+                    cb_xmm.push_back(1);
 
-                    // // d. Add to cb_xmm (accumulate results)
+                    // // d. Add to cb_xmm_id (accumulate results)
                     // // First we get the result in dst0
                     if (group_offset == 0) {
                         // When group_offset is 0, this is the first group for this tile,
-                        // so we can copy the results to cb_x without needing to add them
-                        copy_tile_init(cb_xmm);
+                        // so we can copy the results to cb_x_id without needing to add them
+                        copy_tile_init(cb_xmm_id);
 
-                        cb_wait_front(cb_xmm, 1);
+                        cb_xmm.wait_front(1);
                         tile_regs_acquire();
-                        copy_tile(cb_xmm, 0, dst0);
+                        copy_tile(cb_xmm_id, 0, dst0);
                         tile_regs_commit();
-                        cb_pop_front(cb_xmm, 1);
+                        cb_xmm.pop_front(1);
                     } else {
                         // This is not the first group for this tile, so we need to add
-                        // the results over what is already in cb_x
-                        reconfig_data_format_srca(cb_xmm, cb_x);
-                        add_tiles_init(cb_x, cb_xmm);
+                        // the results over what is already in cb_x_id
+                        reconfig_data_format_srca(cb_xmm_id, cb_x_id);
+                        add_tiles_init(cb_x_id, cb_xmm_id);
 
-                        cb_wait_front(cb_xmm, 1);
-                        cb_wait_front(cb_x, 1);
+                        cb_xmm.wait_front(1);
+                        cb_x.wait_front(1);
                         tile_regs_acquire();
-                        add_tiles(cb_x, cb_xmm, 0, 0, dst0);
+                        add_tiles(cb_x_id, cb_xmm_id, 0, 0, dst0);
                         tile_regs_commit();
-                        cb_pop_front(cb_xmm, 1);
-                        cb_pop_front(cb_x, 1);
+                        cb_xmm.pop_front(1);
+                        cb_x.pop_front(1);
                     }
 
-                    // Then we pack the result into cb_x
-                    cb_reserve_back(cb_x, 1);
+                    // Then we pack the result into cb_x_id
+                    cb_x.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_x);
+                    pack_tile(dst0, cb_x_id);
                     tile_regs_release();
-                    cb_push_back(cb_x, 1);
+                    cb_x.push_back(1);
 
                     uint32_t cols_available = tile_width - group_offset;
                     uint32_t cols_consumed = std::min(cols_available, channels_left);
@@ -378,80 +390,81 @@ void kernel_main() {
                 ++tile_id;
 
                 if constexpr (do_gamma) {
-                    mul_bcast_rows_init_short(cb_x, cb_gamma);
-                    reconfig_data_format_srcb(cb_xmm, cb_gamma);
+                    mul_bcast_rows_init_short(cb_x_id, cb_gamma_id);
+                    reconfig_data_format_srcb(cb_xmm_id, cb_gamma_id);
 
-                    cb_wait_front(cb_x, 1);
+                    cb_x.wait_front(1);
                     tile_regs_acquire();
-                    mul_tiles_bcast_rows(cb_x, cb_gamma, 0, nt, dst0);
+                    mul_tiles_bcast_rows(cb_x_id, cb_gamma_id, 0, nt, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_x, 1);
-                    cb_reserve_back(cb_x, 1);
+                    cb_x.pop_front(1);
+                    cb_x.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_x);
+                    pack_tile(dst0, cb_x_id);
                     tile_regs_release();
-                    cb_push_back(cb_x, 1);
+                    cb_x.push_back(1);
                 }
 
                 if constexpr (do_beta) {
-                    add_bcast_rows_init_short(cb_x, cb_beta);
-                    reconfig_data_format_srcb(do_gamma ? cb_gamma : cb_xmm, cb_beta);
+                    add_bcast_rows_init_short(cb_x_id, cb_beta_id);
+                    reconfig_data_format_srcb(do_gamma ? cb_gamma_id : cb_xmm_id, cb_beta_id);
 
-                    cb_wait_front(cb_x, 1);
+                    cb_x.wait_front(1);
                     tile_regs_acquire();
-                    add_tiles_bcast_rows(cb_x, cb_beta, 0, nt, dst0);
+                    add_tiles_bcast_rows(cb_x_id, cb_beta_id, 0, nt, dst0);
                     tile_regs_commit();
-                    cb_pop_front(cb_x, 1);
-                    cb_reserve_back(cb_x, 1);
+                    cb_x.pop_front(1);
+                    cb_x.reserve_back(1);
                     tile_regs_wait();
-                    pack_tile(dst0, cb_x);
+                    pack_tile(dst0, cb_x_id);
                     tile_regs_release();
-                    cb_push_back(cb_x, 1);
+                    cb_x.push_back(1);
                 }
 
                 // Write out the final output
-                copy_tile_init(cb_x);
-                reconfig_data_format_srcb(do_beta ? cb_beta : cb_xmm, cb_x);
+                copy_tile_init(cb_x_id);
+                reconfig_data_format_srcb(do_beta ? cb_beta_id : cb_xmm_id, cb_x_id);
 
-                cb_wait_front(cb_x, 1);
+                cb_x.wait_front(1);
                 tile_regs_acquire();
-                copy_tile(cb_x, 0, dst0);
+                copy_tile(cb_x_id, 0, dst0);
                 tile_regs_commit();
-                cb_pop_front(cb_x, 1);
+                cb_x.pop_front(1);
 #ifdef UNTILIZE_OUT
-                auto write_cb = cb_untilize_in;
+                auto write_cb_id = cb_untilize_in_id;
 #else
-                auto write_cb = cb_out0;
+                auto write_cb_id = cb_out0_id;
 #endif
-                cb_reserve_back(write_cb, 1);
+                experimental::CircularBuffer write_cb(write_cb_id);
+                write_cb.reserve_back(1);
                 tile_regs_wait();
-                pack_tile(dst0, write_cb);
+                pack_tile(dst0, write_cb_id);
                 tile_regs_release();
-                cb_push_back(write_cb, 1);
+                write_cb.push_back(1);
             }
         }
 
-        cb_pop_front(cb_ex_global, 2 * num_groups);
-        cb_pop_front(cb_ex2pe, num_groups);
+        cb_ex_global.pop_front(2 * num_groups);
+        cb_ex2pe.pop_front(num_groups);
     }
 
-    cb_pop_front(cb_eps, 1);
-    cb_pop_front(cb_input_mask, num_tiles_input_mask);
+    cb_eps.pop_front(1);
+    cb_input_mask.pop_front(num_tiles_input_mask);
 
-    // Pop all the cb_beta and cb_gamma if used
+    // Pop all the cb_beta_id and cb_gamma_id if used
     if constexpr (do_beta) {
-        cb_pop_front(cb_beta, per_core_N);
+        cb_beta.pop_front(per_core_N);
     }
     if constexpr (do_gamma) {
-        cb_pop_front(cb_gamma, per_core_N);
+        cb_gamma.pop_front(per_core_N);
     }
 
 #ifdef UNTILIZE_OUT
     // untilize - DEST capacity auto-detected
     compute_kernel_lib::untilize<
         per_core_N,
-        cb_untilize_in,
-        cb_untilize_out,
+        cb_untilize_in_id,
+        cb_untilize_out_id,
         compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::untilize_config::WaitMode::WaitUpfront,
         compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_M);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -110,10 +110,10 @@ void kernel_main() {
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(5);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;  // E[x] partial reduce
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;    // E[x] partial reduce
     constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;  // E[x] partial reduce
-    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;// E[x] partial reduce
-    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;// E[x] global reduce
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;            // E[x] partial reduce
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;    // E[x] global reduce
     constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
     constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;
     constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -110,10 +110,10 @@ void kernel_main() {
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(5);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;
-    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
-    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;  // E[x] partial reduce
+    constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;  // E[x] partial reduce
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;// E[x] partial reduce
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;// E[x] global reduce
     constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
     constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;
     constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -9,6 +9,8 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
 #include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // clang-format off
@@ -139,13 +141,14 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack), per_core_N_bytes, {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0}, {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -201,11 +204,13 @@ void kernel_main() {
                     cb_in0.reserve_back(out_block_hw_normal);
                     for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                         for (uint32_t nt = 0; nt < block_w; nt++) {
-                            noc_async_read_tile(
-                                start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt + index_b_offset +
-                                    index_g_offset,
+                            noc.async_read(
                                 src_a,
-                                l1_write_addr);
+                                experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                                src0_tile_bytes,
+                                {.page_id = start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt + index_b_offset +
+                                    index_g_offset},
+                                {});
                             l1_write_addr += src0_tile_bytes;
                             noc.async_read_barrier();
                         }
@@ -244,11 +249,13 @@ void kernel_main() {
 
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                noc_async_read_tile(
-                                    out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset,
+                                noc.async_read(
                                     dst_a,
-                                    l1_write_addr);
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                                    single_tile_size_bytes,
+                                    {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                        index_b_offset + index_g_offset},
+                                    {});
                                 l1_write_addr += dst_tile_bytes;
                                 noc.async_read_barrier();
                             }
@@ -311,10 +318,11 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack), per_core_N_bytes, {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0}, {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -114,9 +114,9 @@ void kernel_main() {
     constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;  // E[x] partial reduce
     constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;            // E[x] partial reduce
     constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;    // E[x] global reduce
-    constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;
-    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;          // E[x]^2 partial reduce
+    constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;   // E[x]^2 global reduce
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;           // input cb
     constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
     constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
     constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // clang-format off
@@ -56,8 +60,9 @@ void kernel_main() {
     //          Third Read of data:
     //
     //      // clang-format on
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
+
+    constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
+    constexpr uint32_t reduce_sender_semaphore_id = get_named_compile_time_arg_val("reduce_sender_semaphore_id");
 
     constexpr uint32_t num_batch_group = get_named_compile_time_arg_val("num_batch_group");
     constexpr uint32_t num_batches = get_named_compile_time_arg_val("num_batches");
@@ -103,43 +108,48 @@ void kernel_main() {
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(5);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;  // E[x] partial reduce
-    constexpr uint32_t cb_ex2_partial = tt::CBIndex::c_21;  // E[x] partial reduce
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;          // E[x] partial reduce
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_ex2 = tt::CBIndex::c_13;        // E[x]^2 partial reduce
-    constexpr uint32_t cb_ex2_global = tt::CBIndex::c_14;  // E[x]^2 global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // input cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_x = tt::CBIndex::c_24;
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
+    constexpr uint32_t cb_ex2_global_id = tt::CBIndex::c_14;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_24;
+    constexpr uint32_t cb_reread_out_id = tt::CBIndex::c_23;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);  // tile size
-    const DataFormat out_data_format = get_dataformat(cb_out0);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex2_partial(cb_ex2_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_ex2_global(cb_ex2_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
+    experimental::CircularBuffer cb_reread_out(cb_reread_out_id);
 
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    const DataFormat out_data_format = get_dataformat(cb_out0_id);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
@@ -152,7 +162,7 @@ void kernel_main() {
     const uint32_t num_reads_of_input = 3;
     if constexpr (block_h % num_out_blocks != 0) {
         extra_out_block = true;
-	uint32_t residual = block_h - (num_out_blocks * out_block_h_normal);
+        uint32_t residual = block_h - (num_out_blocks * out_block_h_normal);
         num_out_blocks_padded += (residual / out_block_h_normal + 1);
         out_block_h_last = residual % out_block_h_normal;
         out_block_hw_last = out_block_h_last * block_w;
@@ -184,11 +194,11 @@ void kernel_main() {
                         out_block_hw_actual = out_block_hw_normal;
                     }
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
-                    const uint32_t src0_tile_bytes = get_tile_size(cb_in0);
+                    const uint32_t src0_tile_bytes = get_tile_size(cb_in0_id);
                     const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
                     uint32_t l1_write_addr;
-                    l1_write_addr = get_write_ptr(cb_in0);
-                    cb_reserve_back(cb_in0, out_block_hw_normal);
+                    l1_write_addr = cb_in0.get_write_ptr();
+                    cb_in0.reserve_back(out_block_hw_normal);
                     for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                         for (uint32_t nt = 0; nt < block_w; nt++) {
                             noc_async_read_tile(
@@ -197,40 +207,40 @@ void kernel_main() {
                                 src_a,
                                 l1_write_addr);
                             l1_write_addr += src0_tile_bytes;
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                         }
                     }
-                    cb_push_back(cb_in0, out_block_hw_normal);
+                    cb_in0.push_back(out_block_hw_normal);
 
 #endif
                     if (cur_read_iteration == 0 || cur_read_iteration == 1) {
                         //Section for waiting for local reduce to be pushed to a cb_ex_partial
-                        noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+                        reduce_sender_sem.set(INVALID);
                         if (cur_read_iteration == 0) {
                             //Wait for local avg calculation
-                            cb_wait_front(cb_ex_partial, 1);
+                            cb_ex_partial.wait_front(1);
                         } else {
                             //Wait for local variance calculation
-                            cb_wait_front(cb_ex2_partial, 1);
+                            cb_ex2_partial.wait_front(1);
                         }
-                        noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+                        reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
 
-                        noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+                        reduce_sender_sem.wait(VALID);
                         if (cur_read_iteration == 0) {
-                            cb_pop_front(cb_ex_partial, 1);
+                            cb_ex_partial.pop_front(1);
                         } else {
-                            cb_pop_front(cb_ex2_partial, 1);
+                            cb_ex2_partial.pop_front(1);
                         }
                     } else if (cur_read_iteration == 2) {
+                        // add or copy with previous output results
                         const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
 
-                        // add or copy with previous output results
                         uint32_t block_w_curr = index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
-                        const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out);
+                        const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out_id);
                         uint32_t l1_write_addr;
-                        l1_write_addr = get_write_ptr(cb_reread_out);
-                        cb_reserve_back(cb_reread_out, out_block_hw_normal);
+                        l1_write_addr = cb_reread_out.get_write_ptr();
+                        cb_reread_out.reserve_back(out_block_hw_normal);
 
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w_curr; nt++) {
@@ -240,25 +250,25 @@ void kernel_main() {
                                     dst_a,
                                     l1_write_addr);
                                 l1_write_addr += dst_tile_bytes;
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
                             }
                         }
-                        cb_push_back(cb_reread_out, out_block_hw_normal);
+                        cb_reread_out.push_back(out_block_hw_normal);
                     }
                     out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
                 }
 
                 if (cur_read_iteration == 0 || cur_read_iteration == 1) {
-                    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-                    uint32_t cb_mcast_receive;
+                    reduce_sender_sem.set(INVALID);
                     if (cur_read_iteration == 0) {
-                        cb_mcast_receive = cb_ex_global;
+                        cb_ex_global.reserve_back(1);
+                        reduce_sender_sem.wait(VALID);
+                        cb_ex_global.push_back(1);
                     } else if (cur_read_iteration == 1) {
-                        cb_mcast_receive = cb_ex2_global;
+                        cb_ex2_global.reserve_back(1);
+                        reduce_sender_sem.wait(VALID);
+                        cb_ex2_global.push_back(1);
                     }
-                    cb_reserve_back(cb_mcast_receive, 1);
-                    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-                    cb_push_back(cb_mcast_receive, 1);
                 }
             }
 
@@ -292,23 +302,23 @@ void kernel_main() {
                     index_g_offset += block_w_minus_two;
                 }
             }
-        }  // End Group Loop:
+        }
         index_b_offset += num_tiles_per_batch;
-    }  // End Batch Loop:
+    }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -5,11 +5,14 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
+    constexpr uint32_t reduce_sender_semaphore_id = get_compile_time_arg_val(1);
 
     constexpr uint32_t num_batch_group = get_compile_time_arg_val(2);
 
@@ -22,67 +25,68 @@ void kernel_main() {
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(1);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;  // E[x] partial reduce
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;          // E[x] partial reduce
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);  // tile size
-    const DataFormat data_format = get_dataformat(cb_ex_partial);          // data format
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
 
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    const DataFormat data_format = get_dataformat(cb_ex_partial_id);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
     for (uint32_t i = 0; i < num_batch_group; ++i) {
         for (uint32_t j = 0; j < 2; ++j) {
-            // wait for local data ready
-            cb_wait_front(cb_ex_partial, 1);
-            noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-            cb_reserve_back(cb_ex_global, 1);
-            noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-            cb_push_back(cb_ex_global, 1);
-            cb_pop_front(cb_ex_partial, 1);
+            cb_ex_partial.wait_front(1);
+            reduce_sender_sem.set(INVALID);
+            cb_ex_global.reserve_back(1);
+            reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
+            reduce_sender_sem.wait(VALID);
+            cb_ex_global.push_back(1);
+            cb_ex_partial.pop_front(1);
         }
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -8,6 +8,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 // split REDUCE across cores
 void kernel_main() {
@@ -48,13 +50,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -79,10 +87,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // clang-format off
@@ -56,8 +60,9 @@ void kernel_main() {
     //          Third Read of data:
     //
     //      // clang-format on
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
+
+    constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
+    constexpr uint32_t reduce_sender_semaphore_id = get_named_compile_time_arg_val("reduce_sender_semaphore_id");
 
     constexpr uint32_t num_mcast_cores = get_named_compile_time_arg_val("num_cores_per_mcast_group");
     constexpr uint32_t num_batch_group = get_named_compile_time_arg_val("num_batch_group");
@@ -122,7 +127,6 @@ void kernel_main() {
     uint32_t mcast_last_group_dest_noc_start_y;
     uint32_t mcast_last_group_dest_noc_end_x;
     uint32_t mcast_last_group_dest_noc_end_y;
-    // volatile tt_l1_ptr uint32_t * noc_coord;
     tt_l1_ptr uint32_t* noc_coord_x;
     tt_l1_ptr uint32_t* noc_coord_y;
 
@@ -131,9 +135,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_last_group;
 
     // noc addrs for first and last groups
-    uint64_t reduce_sender_first_group_semaphore_noc_addr;
     uint64_t multicast_first_group_data_noc;
-    uint64_t reduce_sender_last_group_semaphore_noc_addr;
     uint64_t multicast_last_group_data_noc;
 
     if (has_mcast_first_group and has_mcast_last_group) {
@@ -177,24 +179,10 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_mcast_cores));
     }
 
-    const uint64_t reduce_sender_semaphore_noc_addr = get_noc_multicast_addr(
-        mcast_dest_noc_start_x,
-        mcast_dest_noc_start_y,
-        mcast_dest_noc_end_x,
-        mcast_dest_noc_end_y,
-        reduce_sender_semaphore_addr);
-
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
 
     if (has_mcast_first_group) {
-        reduce_sender_first_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_first_group_data_noc = get_noc_multicast_addr(
             mcast_first_group_dest_noc_start_x,
             mcast_first_group_dest_noc_start_y,
@@ -203,13 +191,6 @@ void kernel_main() {
             0);
     }
     if (has_mcast_last_group) {
-        reduce_sender_last_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_last_group_data_noc = get_noc_multicast_addr(
             mcast_last_group_dest_noc_start_x,
             mcast_last_group_dest_noc_start_y,
@@ -218,41 +199,51 @@ void kernel_main() {
             0);
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    *reduce_sender_semaphore_addr_ptr = VALID;
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    reduce_sender_sem.set(VALID);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex2_partial = tt::CBIndex::c_21;
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;
-    constexpr uint32_t cb_ex2 = tt::CBIndex::c_13;
-    constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;  // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_x = tt::CBIndex::c_24;
-    constexpr uint32_t cb_reread_out = tt::CBIndex::c_23;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex2_partial_id = tt::CBIndex::c_21;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex2_id = tt::CBIndex::c_13;
+    constexpr uint32_t cb_ex_external_id = tt::CBIndex::c_10;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
+    constexpr uint32_t cb_x_id = tt::CBIndex::c_24;
+    constexpr uint32_t cb_reread_out_id = tt::CBIndex::c_23;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
-    const DataFormat out_data_format = get_dataformat(cb_out0);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex2_partial(cb_ex2_partial_id);
+    experimental::CircularBuffer cb_ex(cb_ex_id);
+    experimental::CircularBuffer cb_ex2(cb_ex2_id);
+    experimental::CircularBuffer cb_ex_external(cb_ex_external_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
+    experimental::CircularBuffer cb_reread_out(cb_reread_out_id);
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    const DataFormat out_data_format = get_dataformat(cb_out0_id);
     const uint32_t num_bytes_read = datum_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
@@ -265,7 +256,7 @@ void kernel_main() {
     const uint32_t num_reads_of_input = 3;
     if constexpr (block_h % num_out_blocks != 0) {
         extra_out_block = true;
-	uint32_t residual = block_h - (num_out_blocks * out_block_h_normal);
+        uint32_t residual = block_h - (num_out_blocks * out_block_h_normal);
         num_out_blocks_padded += (residual / out_block_h_normal + 1);
         out_block_h_last = residual % out_block_h_normal;
         out_block_hw_last = out_block_h_last * block_w;
@@ -281,16 +272,16 @@ void kernel_main() {
             row_offset = num_cols_per_group;
 
             for (uint32_t m = 0; m < num_groups; ++m) {
-            //The following loop is for the 3 passes of input tensor required for GroupNorm
-            //First Pass: Calculates average value
-            //Second Pass: Calculates the Variance value
-            //Third Pass: Calculates final value
-            //Definition: num_read_of_input = 3
+                //The following loop is for the 3 passes of input tensor required for GroupNorm
+                //First Pass: Calculates average value
+                //Second Pass: Calculates the Variance value
+                //Third Pass: Calculates final value
+                //Definition: num_read_of_input = 3
                 for (uint32_t cur_read_iteration = 0; cur_read_iteration < num_reads_of_input; ++cur_read_iteration) {
                     uint32_t out_block_start_id_offset = 0;
-                    uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external);
+                    uint32_t l1_write_addr_external = cb_ex_external.get_write_ptr();
                     uint32_t cb_ex_external_bytes_written = 0;
-                    cb_reserve_back(cb_ex_external, cb_ex_external_tiles_required);
+                    cb_ex_external.reserve_back(cb_ex_external_tiles_required);
                     for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
                         uint32_t out_block_h_actual, out_block_hw_actual;
                         if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
@@ -302,11 +293,11 @@ void kernel_main() {
                         }
 
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
-                        const uint32_t src0_tile_bytes = get_tile_size(cb_in0);
+                        const uint32_t src0_tile_bytes = get_tile_size(cb_in0_id);
                         const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
                         uint32_t l1_write_addr;
-                        l1_write_addr = get_write_ptr(cb_in0);
-                        cb_reserve_back(cb_in0, out_block_hw_normal);
+                        l1_write_addr = cb_in0.get_write_ptr();
+                        cb_in0.reserve_back(out_block_hw_normal);
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w; nt++) {
                                 noc_async_read_tile(
@@ -315,37 +306,36 @@ void kernel_main() {
                                     src_a,
                                     l1_write_addr);
                                 l1_write_addr += src0_tile_bytes;
-                                noc_async_read_barrier();
+                                noc.async_read_barrier();
                             }
                         }
-                        cb_push_back(cb_in0, out_block_hw_normal);
+                        cb_in0.push_back(out_block_hw_normal);
 #endif
                         if (cur_read_iteration== 0 || cur_read_iteration== 1) {
-                            // wait for local data ready
                             if (cur_read_iteration== 0) {
-                                cb_wait_front(cb_ex_partial, 1);
+                                cb_ex_partial.wait_front(1);
                             } else {
-                                cb_wait_front(cb_ex2_partial, 1);
+                                cb_ex2_partial.wait_front(1);
                             }
 
                             // read self Ex partial - on the first iteration, read a full tile for overwriting
                             // garbage in L1, on subsequent just treat it as another core
                             uint32_t l1_read_addr_ex_par =
-                                cur_read_iteration== 0 ? get_read_ptr(cb_ex_partial) : get_read_ptr(cb_ex2_partial);
+                                cur_read_iteration== 0 ? cb_ex_partial.get_read_ptr() : cb_ex2_partial.get_read_ptr();
                             uint64_t noc_addr_ex_par =
                                 get_noc_addr(noc_coord_x[0], noc_coord_y[0], l1_read_addr_ex_par);
                             uint32_t read_size = (cb_ex_external_bytes_written % single_tile_size_bytes > 0)
                                                      ? num_bytes_read
                                                      : single_tile_size_bytes;
-			    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, read_size);
+                            noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, read_size);
                             l1_write_addr_external += 16;
                             cb_ex_external_bytes_written += 16;
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             if constexpr (num_mcast_cores > 1) {
                                 // wait for all other cores data ready
-                                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-                                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+                                reduce_receiver_sem.wait(num_mcast_cores - 1);
+                                reduce_receiver_sem.set(0);
 
                                 // read data from other cores
                                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
@@ -354,32 +344,41 @@ void kernel_main() {
                                     noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
                                     l1_write_addr_external += 16;
                                     cb_ex_external_bytes_written += 16;
-                                    noc_async_read_barrier();
+                                    noc.async_read_barrier();
                                 }
                             }
                             if (cur_read_iteration== 0) {
-                                cb_pop_front(cb_ex_partial, 1);
+                                cb_ex_partial.pop_front(1);
                             } else {
-                                cb_pop_front(cb_ex2_partial, 1);
+                                cb_ex2_partial.pop_front(1);
                             }
 
                             if constexpr (num_mcast_cores > 1) {
-                                noc_semaphore_set_multicast(
-                                    reduce_sender_semaphore_addr,
-                                    reduce_sender_semaphore_noc_addr,
+                                reduce_sender_sem.set_multicast(
+                                    noc,
+                                    mcast_dest_noc_start_x,
+                                    mcast_dest_noc_start_y,
+                                    mcast_dest_noc_end_x,
+                                    mcast_dest_noc_end_y,
                                     num_mcast_cores_mid_group,
                                     false);
                                 if (has_mcast_first_group) {
-                                    noc_semaphore_set_multicast(
-                                        reduce_sender_semaphore_addr,
-                                        reduce_sender_first_group_semaphore_noc_addr,
+                                    reduce_sender_sem.set_multicast(
+                                        noc,
+                                        mcast_first_group_dest_noc_start_x,
+                                        mcast_first_group_dest_noc_start_y,
+                                        mcast_first_group_dest_noc_end_x,
+                                        mcast_first_group_dest_noc_end_y,
                                         num_mcast_cores_first_group,
                                         false);
                                 }
                                 if (has_mcast_last_group) {
-                                    noc_semaphore_set_multicast(
-                                        reduce_sender_semaphore_addr,
-                                        reduce_sender_last_group_semaphore_noc_addr,
+                                    reduce_sender_sem.set_multicast(
+                                        noc,
+                                        mcast_last_group_dest_noc_start_x,
+                                        mcast_last_group_dest_noc_start_y,
+                                        mcast_last_group_dest_noc_end_x,
+                                        mcast_last_group_dest_noc_end_y,
                                         num_mcast_cores_last_group,
                                         false);
                                 }
@@ -391,10 +390,10 @@ void kernel_main() {
                             uint32_t block_w_curr =
                                 index_g_offset == (per_core_N - block_w_last) ? block_w_last : block_w;
 
-                            const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out);
+                            const uint32_t dst_tile_bytes = get_tile_size(cb_reread_out_id);
                             uint32_t l1_write_addr;
-                            l1_write_addr = get_write_ptr(cb_reread_out);
-                            cb_reserve_back(cb_reread_out, out_block_hw_normal);
+                            l1_write_addr = cb_reread_out.get_write_ptr();
+                            cb_reread_out.reserve_back(out_block_hw_normal);
 
                             for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                                 for (uint32_t nt = 0; nt < block_w_curr; nt++) {
@@ -404,38 +403,38 @@ void kernel_main() {
                                         dst_a,
                                         l1_write_addr);
                                     l1_write_addr += dst_tile_bytes;
-                                    noc_async_read_barrier();
+                                    noc.async_read_barrier();
                                 }
                             }
-                            cb_push_back(cb_reread_out, out_block_hw_normal);
+                            cb_reread_out.push_back(out_block_hw_normal);
                         }
                         out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
                     }
                     if (cur_read_iteration== 0 || cur_read_iteration == 1) {
-                        cb_push_back(cb_ex_external, cb_ex_external_tiles_required);
+                        cb_ex_external.push_back(cb_ex_external_tiles_required);
 
                         if constexpr (num_mcast_cores > 1) {
-                            uint32_t cb_mcast;
+                            uint32_t l1_read_addr_ex;
                             if (cur_read_iteration== 0) {
-                                cb_mcast = cb_ex;
-                            } else if (cur_read_iteration== 1) {
-                                cb_mcast = cb_ex2;
+                                cb_ex.wait_front(1);
+                                l1_read_addr_ex = cb_ex.get_read_ptr();
+                            } else {
+                                cb_ex2.wait_front(1);
+                                l1_read_addr_ex = cb_ex2.get_read_ptr();
                             }
 
-                            // global reduce
-                            cb_wait_front(cb_mcast, 1);
-
-                            // mcast to other cores
-                            uint32_t l1_read_addr_ex = get_read_ptr(cb_mcast);
                             noc_async_write_multicast(
                                 l1_read_addr_ex,
                                 multicast_data_noc | l1_read_addr_ex,
                                 num_bytes_read,
                                 num_mcast_cores_mid_group,
                                 true);
-                            noc_semaphore_set_multicast(
-                                reduce_sender_semaphore_addr,
-                                reduce_sender_semaphore_noc_addr,
+                            reduce_sender_sem.set_multicast(
+                                noc,
+                                mcast_dest_noc_start_x,
+                                mcast_dest_noc_start_y,
+                                mcast_dest_noc_end_x,
+                                mcast_dest_noc_end_y,
                                 num_mcast_cores_mid_group,
                                 false);
 
@@ -446,9 +445,12 @@ void kernel_main() {
                                     num_bytes_read,
                                     num_mcast_cores_first_group,
                                     true);
-                                noc_semaphore_set_multicast(
-                                    reduce_sender_semaphore_addr,
-                                    reduce_sender_first_group_semaphore_noc_addr,
+                                reduce_sender_sem.set_multicast(
+                                    noc,
+                                    mcast_first_group_dest_noc_start_x,
+                                    mcast_first_group_dest_noc_start_y,
+                                    mcast_first_group_dest_noc_end_x,
+                                    mcast_first_group_dest_noc_end_y,
                                     num_mcast_cores_first_group,
                                     false);
                             }
@@ -460,14 +462,21 @@ void kernel_main() {
                                     num_bytes_read,
                                     num_mcast_cores_last_group,
                                     true);
-                                noc_semaphore_set_multicast(
-                                    reduce_sender_semaphore_addr,
-                                    reduce_sender_last_group_semaphore_noc_addr,
+                                reduce_sender_sem.set_multicast(
+                                    noc,
+                                    mcast_last_group_dest_noc_start_x,
+                                    mcast_last_group_dest_noc_start_y,
+                                    mcast_last_group_dest_noc_end_x,
+                                    mcast_last_group_dest_noc_end_y,
                                     num_mcast_cores_last_group,
                                     false);
                             }
-                            noc_async_write_barrier();
-                            cb_pop_front(cb_mcast, 1);
+                            noc.async_write_barrier();
+                            if (cur_read_iteration == 0) {
+                                cb_ex.pop_front(1);
+                            } else {
+                                cb_ex2.pop_front(1);
+                            }
                         }
                     }
                 }
@@ -506,18 +515,18 @@ void kernel_main() {
         }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -9,6 +9,8 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
 #include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // clang-format off
@@ -134,9 +136,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_first_group;
     uint32_t num_mcast_cores_last_group;
 
-    // noc addrs for first and last groups
-    uint64_t multicast_first_group_data_noc;
-    uint64_t multicast_last_group_data_noc;
+    // first and last group mcast coordinates passed directly in async_write_multicast calls below
 
     if (has_mcast_first_group and has_mcast_last_group) {
         mcast_first_group_dest_noc_start_x = get_arg_val<uint32_t>(12);
@@ -179,26 +179,6 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_mcast_cores));
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    if (has_mcast_first_group) {
-        multicast_first_group_data_noc = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            0);
-    }
-    if (has_mcast_last_group) {
-        multicast_last_group_data_noc = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            0);
-    }
-
     experimental::Noc noc;
     experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
     experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
@@ -233,13 +213,14 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack), per_core_N_bytes, {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0}, {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -300,11 +281,13 @@ void kernel_main() {
                         cb_in0.reserve_back(out_block_hw_normal);
                         for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                             for (uint32_t nt = 0; nt < block_w; nt++) {
-                                noc_async_read_tile(
-                                    start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                        index_b_offset + index_g_offset,
+                                noc.async_read(
                                     src_a,
-                                    l1_write_addr);
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                                    src0_tile_bytes,
+                                    {.page_id = start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                        index_b_offset + index_g_offset},
+                                    {});
                                 l1_write_addr += src0_tile_bytes;
                                 noc.async_read_barrier();
                             }
@@ -322,12 +305,11 @@ void kernel_main() {
                             // garbage in L1, on subsequent just treat it as another core
                             uint32_t l1_read_addr_ex_par =
                                 cur_read_iteration== 0 ? cb_ex_partial.get_read_ptr() : cb_ex2_partial.get_read_ptr();
-                            uint64_t noc_addr_ex_par =
-                                get_noc_addr(noc_coord_x[0], noc_coord_y[0], l1_read_addr_ex_par);
+                            experimental::UnicastEndpoint remote_ep;
                             uint32_t read_size = (cb_ex_external_bytes_written % single_tile_size_bytes > 0)
                                                      ? num_bytes_read
                                                      : single_tile_size_bytes;
-                            noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, read_size);
+                            noc.async_read(remote_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_external), read_size, {.noc_x = noc_coord_x[0], .noc_y = noc_coord_y[0], .addr = l1_read_addr_ex_par}, {});
                             l1_write_addr_external += 16;
                             cb_ex_external_bytes_written += 16;
                             noc.async_read_barrier();
@@ -339,9 +321,8 @@ void kernel_main() {
 
                                 // read data from other cores
                                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
-                                    uint64_t noc_addr_ex_par =
-                                        get_noc_addr(noc_coord_x[i + 1], noc_coord_y[i + 1], l1_read_addr_ex_par);
-                                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
+                                    experimental::UnicastEndpoint remote_ep;
+                                    noc.async_read(remote_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_external), num_bytes_read, {.noc_x = noc_coord_x[i + 1], .noc_y = noc_coord_y[i + 1], .addr = l1_read_addr_ex_par}, {});
                                     l1_write_addr_external += 16;
                                     cb_ex_external_bytes_written += 16;
                                     noc.async_read_barrier();
@@ -397,11 +378,13 @@ void kernel_main() {
 
                             for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                                 for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                                    noc_async_read_tile(
-                                        out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                            index_b_offset + index_g_offset,
+                                    noc.async_read(
                                         dst_a,
-                                        l1_write_addr);
+                                        experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                                        single_tile_size_bytes,
+                                        {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                            index_b_offset + index_g_offset},
+                                        {});
                                     l1_write_addr += dst_tile_bytes;
                                     noc.async_read_barrier();
                                 }
@@ -423,11 +406,14 @@ void kernel_main() {
                                 l1_read_addr_ex = cb_ex2.get_read_ptr();
                             }
 
-                            noc_async_write_multicast(
-                                l1_read_addr_ex,
-                                multicast_data_noc | l1_read_addr_ex,
+                            experimental::MulticastEndpoint mcast_dst;
+                            noc.async_write_multicast(
+                                experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                                mcast_dst,
                                 num_bytes_read,
                                 num_mcast_cores_mid_group,
+                                {},
+                                {.noc_x_start = mcast_dest_noc_start_x, .noc_y_start = mcast_dest_noc_start_y, .noc_x_end = mcast_dest_noc_end_x, .noc_y_end = mcast_dest_noc_end_y, .addr = l1_read_addr_ex},
                                 true);
                             reduce_sender_sem.set_multicast(
                                 noc,
@@ -439,11 +425,14 @@ void kernel_main() {
                                 false);
 
                             if (has_mcast_first_group) {
-                                noc_async_write_multicast(
-                                    l1_read_addr_ex,
-                                    multicast_first_group_data_noc | l1_read_addr_ex,
+                                experimental::MulticastEndpoint mcast_first_dst;
+                                noc.async_write_multicast(
+                                    experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                                    mcast_first_dst,
                                     num_bytes_read,
                                     num_mcast_cores_first_group,
+                                    {},
+                                    {.noc_x_start = mcast_first_group_dest_noc_start_x, .noc_y_start = mcast_first_group_dest_noc_start_y, .noc_x_end = mcast_first_group_dest_noc_end_x, .noc_y_end = mcast_first_group_dest_noc_end_y, .addr = l1_read_addr_ex},
                                     true);
                                 reduce_sender_sem.set_multicast(
                                     noc,
@@ -456,11 +445,14 @@ void kernel_main() {
                             }
 
                             if (has_mcast_last_group) {
-                                noc_async_write_multicast(
-                                    l1_read_addr_ex,
-                                    multicast_last_group_data_noc | l1_read_addr_ex,
+                                experimental::MulticastEndpoint mcast_last_dst;
+                                noc.async_write_multicast(
+                                    experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                                    mcast_last_dst,
                                     num_bytes_read,
                                     num_mcast_cores_last_group,
+                                    {},
+                                    {.noc_x_start = mcast_last_group_dest_noc_start_x, .noc_y_start = mcast_last_group_dest_noc_start_y, .noc_x_end = mcast_last_group_dest_noc_end_x, .noc_y_end = mcast_last_group_dest_noc_end_y, .addr = l1_read_addr_ex},
                                     true);
                                 reduce_sender_sem.set_multicast(
                                     noc,
@@ -519,10 +511,11 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(self_ep, experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack), per_core_N_bytes, {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0}, {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -8,6 +8,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 // split REDUCE across cores
 void kernel_main() {
@@ -51,9 +53,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_first_group;
     uint32_t num_mcast_cores_last_group;
 
-    // noc addrs for first and last groups
-    uint64_t multicast_first_group_data_noc;
-    uint64_t multicast_last_group_data_noc;
+    // first and last group mcast coordinates passed directly in async_write_multicast calls below
 
     if (has_mcast_first_group and has_mcast_last_group) {
         mcast_first_group_dest_noc_start_x = get_arg_val<uint32_t>(7);
@@ -96,26 +96,6 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_mcast_cores));
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    if (has_mcast_first_group) {
-        multicast_first_group_data_noc = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            0);
-    }
-    if (has_mcast_last_group) {
-        multicast_last_group_data_noc = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            0);
-    }
-
     experimental::Noc noc;
     experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
     experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
@@ -143,13 +123,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -164,8 +150,13 @@ void kernel_main() {
 
                 uint32_t l1_read_addr_ex_par = cb_ex_partial.get_read_ptr();
                 uint32_t l1_write_addr_external = cb_ex_external.get_write_ptr();
-                uint64_t noc_addr_ex_par = get_noc_addr(noc_coord_x[0], noc_coord_y[0], l1_read_addr_ex_par);
-                noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                experimental::UnicastEndpoint remote_ep;
+                noc.async_read(
+                    remote_ep,
+                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_external),
+                    single_tile_size_bytes,
+                    {.noc_x = noc_coord_x[0], .noc_y = noc_coord_y[0], .addr = l1_read_addr_ex_par},
+                    {});
                 l1_write_addr_external += 16;
                 noc.async_read_barrier();
 
@@ -174,9 +165,13 @@ void kernel_main() {
 
                 cb_ex_external.reserve_back(1);
                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
-                    uint64_t noc_addr_ex_par =
-                        get_noc_addr(noc_coord_x[i + 1], noc_coord_y[i + 1], l1_read_addr_ex_par);
-                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
+                    experimental::UnicastEndpoint remote_ep;
+                    noc.async_read(
+                        remote_ep,
+                        experimental::CoreLocalMem<uint32_t>(l1_write_addr_external),
+                        num_bytes_read,
+                        {.noc_x = noc_coord_x[i + 1], .noc_y = noc_coord_y[i + 1], .addr = l1_read_addr_ex_par},
+                        {});
                     l1_write_addr_external += 16;
                     noc.async_read_barrier();
                 }
@@ -186,11 +181,18 @@ void kernel_main() {
                 cb_ex_partial.pop_front(1);
 
                 uint32_t l1_read_addr_ex = cb_ex.get_read_ptr();
-                noc_async_write_multicast(
-                    l1_read_addr_ex,
-                    multicast_data_noc | l1_read_addr_ex,
+                experimental::MulticastEndpoint mcast_dst;
+                noc.async_write_multicast(
+                    experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                    mcast_dst,
                     num_bytes_read,
                     num_mcast_cores_mid_group,
+                    {},
+                    {.noc_x_start = mcast_dest_noc_start_x,
+                     .noc_y_start = mcast_dest_noc_start_y,
+                     .noc_x_end = mcast_dest_noc_end_x,
+                     .noc_y_end = mcast_dest_noc_end_y,
+                     .addr = l1_read_addr_ex},
                     true);
                 reduce_sender_sem.set_multicast(
                     noc,
@@ -202,11 +204,17 @@ void kernel_main() {
                     false);
 
                 if (has_mcast_first_group) {
-                    noc_async_write_multicast(
-                        l1_read_addr_ex,
-                        multicast_first_group_data_noc | l1_read_addr_ex,
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                        mcast_dst,
                         num_bytes_read,
                         num_mcast_cores_first_group,
+                        {},
+                        {.noc_x_start = mcast_first_group_dest_noc_start_x,
+                         .noc_y_start = mcast_first_group_dest_noc_start_y,
+                         .noc_x_end = mcast_first_group_dest_noc_end_x,
+                         .noc_y_end = mcast_first_group_dest_noc_end_y,
+                         .addr = l1_read_addr_ex},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -219,11 +227,17 @@ void kernel_main() {
                 }
 
                 if (has_mcast_last_group) {
-                    noc_async_write_multicast(
-                        l1_read_addr_ex,
-                        multicast_last_group_data_noc | l1_read_addr_ex,
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(l1_read_addr_ex),
+                        mcast_dst,
                         num_bytes_read,
                         num_mcast_cores_last_group,
+                        {},
+                        {.noc_x_start = mcast_last_group_dest_noc_start_x,
+                         .noc_y_start = mcast_last_group_dest_noc_start_y,
+                         .noc_x_end = mcast_last_group_dest_noc_end_x,
+                         .noc_y_end = mcast_last_group_dest_noc_end_y,
+                         .addr = l1_read_addr_ex},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -245,10 +259,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -149,6 +149,7 @@ void kernel_main() {
                 cb_ex_partial.wait_front(1);
 
                 uint32_t l1_read_addr_ex_par = cb_ex_partial.get_read_ptr();
+                cb_ex_external.reserve_back(1);
                 uint32_t l1_write_addr_external = cb_ex_external.get_write_ptr();
                 experimental::UnicastEndpoint remote_ep;
                 noc.async_read(
@@ -162,8 +163,6 @@ void kernel_main() {
 
                 reduce_receiver_sem.wait(num_mcast_cores - 1);
                 reduce_receiver_sem.set(0);
-
-                cb_ex_external.reserve_back(1);
                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
                     experimental::UnicastEndpoint remote_ep;
                     noc.async_read(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -5,11 +5,14 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 // split REDUCE across cores
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
+    constexpr uint32_t reduce_sender_semaphore_id = get_compile_time_arg_val(1);
 
     constexpr uint32_t num_mcast_cores = get_compile_time_arg_val(2);
     constexpr uint32_t num_batch_group = get_compile_time_arg_val(3);
@@ -41,7 +44,6 @@ void kernel_main() {
     uint32_t mcast_last_group_dest_noc_start_y;
     uint32_t mcast_last_group_dest_noc_end_x;
     uint32_t mcast_last_group_dest_noc_end_y;
-    // volatile tt_l1_ptr uint32_t * noc_coord;
     tt_l1_ptr uint32_t* noc_coord_x;
     tt_l1_ptr uint32_t* noc_coord_y;
 
@@ -50,9 +52,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_last_group;
 
     // noc addrs for first and last groups
-    uint64_t reduce_sender_first_group_semaphore_noc_addr;
     uint64_t multicast_first_group_data_noc;
-    uint64_t reduce_sender_last_group_semaphore_noc_addr;
     uint64_t multicast_last_group_data_noc;
 
     if (has_mcast_first_group and has_mcast_last_group) {
@@ -96,24 +96,10 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_mcast_cores));
     }
 
-    const uint64_t reduce_sender_semaphore_noc_addr = get_noc_multicast_addr(
-        mcast_dest_noc_start_x,
-        mcast_dest_noc_start_y,
-        mcast_dest_noc_end_x,
-        mcast_dest_noc_end_y,
-        reduce_sender_semaphore_addr);
-
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
 
     if (has_mcast_first_group) {
-        reduce_sender_first_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_first_group_data_noc = get_noc_multicast_addr(
             mcast_first_group_dest_noc_start_x,
             mcast_first_group_dest_noc_start_y,
@@ -122,13 +108,6 @@ void kernel_main() {
             0);
     }
     if (has_mcast_last_group) {
-        reduce_sender_last_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_last_group_data_noc = get_noc_multicast_addr(
             mcast_last_group_dest_noc_start_x,
             mcast_last_group_dest_noc_start_y,
@@ -137,89 +116,90 @@ void kernel_main() {
             0);
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    *reduce_sender_semaphore_addr_ptr = VALID;
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    reduce_sender_sem.set(VALID);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex = tt::CBIndex::c_9;
-    constexpr uint32_t cb_ex_external = tt::CBIndex::c_10;
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;  // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_id = tt::CBIndex::c_9;
+    constexpr uint32_t cb_ex_external_id = tt::CBIndex::c_10;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
-    const DataFormat data_format = get_dataformat(cb_ex_partial);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex(cb_ex_id);
+    experimental::CircularBuffer cb_ex_external(cb_ex_external_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    const DataFormat data_format = get_dataformat(cb_ex_partial_id);
     const uint32_t num_bytes_read = datum_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
-
-    uint32_t l1_read_addr_ex_par = get_read_ptr(cb_ex_partial);
-    volatile tt_l1_ptr uint16_t* rptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_read_addr_ex_par);
-
-    uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external);
-    volatile tt_l1_ptr uint16_t* wptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_external);
 
     if constexpr (num_mcast_cores > 1) {
         for (uint32_t m = 0; m < num_batch_group; ++m) {
             for (uint32_t n = 0; n < 2; ++n) {
-                // wait for local data ready
-                cb_wait_front(cb_ex_partial, 1);
+                cb_ex_partial.wait_front(1);
 
-                // read self Ex partial - read a full tile for overwriting garbabge in L1
-                uint32_t l1_read_addr_ex_par = get_read_ptr(cb_ex_partial);
-                uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external);
+                uint32_t l1_read_addr_ex_par = cb_ex_partial.get_read_ptr();
+                uint32_t l1_write_addr_external = cb_ex_external.get_write_ptr();
                 uint64_t noc_addr_ex_par = get_noc_addr(noc_coord_x[0], noc_coord_y[0], l1_read_addr_ex_par);
                 noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += 16;
-                noc_async_read_barrier();
+                noc.async_read_barrier();
 
-                // wait for all other cores data ready
-                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+                reduce_receiver_sem.wait(num_mcast_cores - 1);
+                reduce_receiver_sem.set(0);
 
-                // read data from other cores
-                cb_reserve_back(cb_ex_external, 1);
+                cb_ex_external.reserve_back(1);
                 for (uint32_t i = 0; i < num_mcast_cores - 1; ++i) {
                     uint64_t noc_addr_ex_par =
                         get_noc_addr(noc_coord_x[i + 1], noc_coord_y[i + 1], l1_read_addr_ex_par);
                     noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, num_bytes_read);
                     l1_write_addr_external += 16;
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
-                cb_push_back(cb_ex_external, 1);
+                cb_ex_external.push_back(1);
 
-                // global reduce
-                cb_wait_front(cb_ex, 1);
-                cb_pop_front(cb_ex_partial, 1);
+                cb_ex.wait_front(1);
+                cb_ex_partial.pop_front(1);
 
-                // mcast to other cores
-                uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
+                uint32_t l1_read_addr_ex = cb_ex.get_read_ptr();
                 noc_async_write_multicast(
                     l1_read_addr_ex,
                     multicast_data_noc | l1_read_addr_ex,
                     num_bytes_read,
                     num_mcast_cores_mid_group,
                     true);
-                noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    num_mcast_cores_mid_group,
+                    false);
 
                 if (has_mcast_first_group) {
                     noc_async_write_multicast(
@@ -228,9 +208,12 @@ void kernel_main() {
                         num_bytes_read,
                         num_mcast_cores_first_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_first_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_first_group_dest_noc_start_x,
+                        mcast_first_group_dest_noc_start_y,
+                        mcast_first_group_dest_noc_end_x,
+                        mcast_first_group_dest_noc_end_y,
                         num_mcast_cores_first_group,
                         false);
                 }
@@ -242,31 +225,34 @@ void kernel_main() {
                         num_bytes_read,
                         num_mcast_cores_last_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_last_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_last_group_dest_noc_start_x,
+                        mcast_last_group_dest_noc_start_y,
+                        mcast_last_group_dest_noc_end_x,
+                        mcast_last_group_dest_noc_end_y,
                         num_mcast_cores_last_group,
                         false);
                 }
-                noc_async_write_barrier();
-                cb_pop_front(cb_ex, 1);
+                noc.async_write_barrier();
+                cb_ex.pop_front(1);
             }
         }
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -10,6 +10,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
@@ -74,13 +76,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -119,7 +127,12 @@ void kernel_main() {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                     cb_in0.reserve_back(1);
                     const uint32_t l1_write_addr = cb_in0.get_write_ptr();
-                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc.async_read(
+                        src_a,
+                        experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                        src0_tile_bytes,
+                        {.page_id = start_id + index_b_offset + mt_offset + nt},
+                        {});
                     noc.async_read_barrier();
                     cb_in0.push_back(1);
                 }
@@ -183,7 +196,12 @@ void kernel_main() {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                     cb_in0.reserve_back(1);
                     const uint32_t l1_write_addr = cb_in0.get_write_ptr();
-                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc.async_read(
+                        src_a,
+                        experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                        src0_tile_bytes,
+                        {.page_id = start_id + index_b_offset + mt_offset + nt},
+                        {});
                     noc.async_read_barrier();
                     cb_in0.push_back(1);
                 }
@@ -199,10 +217,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -12,6 +12,7 @@
 #include "experimental/noc_semaphore.h"
 #include "experimental/endpoints.h"
 #include "experimental/core_local_mem.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -7,10 +7,13 @@
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
 #include "noc_parameters.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
+    constexpr uint32_t reduce_sender_semaphore_id = get_named_compile_time_arg_val("reduce_sender_semaphore_id");
 
     constexpr uint32_t num_batch_group = get_named_compile_time_arg_val("num_batch_group");
     constexpr uint32_t num_batches = get_named_compile_time_arg_val("num_batches");
@@ -41,20 +44,26 @@ void kernel_main() {
 
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(5);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(6);
-    const auto reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    const auto reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
-    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
+
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0_id);
 
     // This is the stride between two consecutive local means/variances in the cb_ex_partial
     constexpr uint32_t local_stride = 2;
@@ -64,18 +73,18 @@ void kernel_main() {
     const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    const uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
@@ -108,23 +117,23 @@ void kernel_main() {
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
             for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_reserve_back(cb_in0, 1);
-                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(1);
+                    const uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, 1);
+                    noc.async_read_barrier();
+                    cb_in0.push_back(1);
                 }
                 mt_offset += num_channels_tiles;
             }
 #endif
         }
 
-        cb_wait_front(cb_ex_partial, 2);
-        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        cb_ex_partial.wait_front(2);
+        auto local_means_ptr = cb_ex_partial.get_read_ptr();
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        cb_reserve_back(cb_ex_global, 2 * num_groups);
-        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        cb_ex_global.reserve_back(2 * num_groups);
+        auto global_means_ptr = cb_ex_global.get_write_ptr();
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
@@ -144,11 +153,11 @@ void kernel_main() {
             p_global_vars[0] = local_result.variance;
 
             // Signal to sender that our partial data is ready
-            noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+            reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
 
             // Wait for sender to signal that it has sent the global data
-            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-            noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+            reduce_sender_sem.wait(VALID);
+            reduce_sender_sem.set(INVALID);
 
             local_means_ptr += local_stride_per_group;
             local_vars_ptr += local_stride_per_group;
@@ -156,8 +165,8 @@ void kernel_main() {
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
 
-        cb_pop_front(cb_ex_partial, 2);
-        cb_push_back(cb_ex_global, 2 * num_groups);
+        cb_ex_partial.pop_front(2);
+        cb_ex_global.push_back(2 * num_groups);
 
         mt_offset = 0;
         for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
@@ -172,11 +181,11 @@ void kernel_main() {
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
             for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_reserve_back(cb_in0, 1);
-                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(1);
+                    const uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, 1);
+                    noc.async_read_barrier();
+                    cb_in0.push_back(1);
                 }
                 mt_offset += num_channels_tiles;
             }
@@ -186,18 +195,18 @@ void kernel_main() {
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        const uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -6,10 +6,13 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
+    constexpr uint32_t reduce_sender_semaphore_id = get_compile_time_arg_val(1);
 
     constexpr uint32_t num_batches = get_compile_time_arg_val(2);
 
@@ -27,20 +30,24 @@ void kernel_main() {
     const uint32_t mcast_sender_noc_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_sender_noc_y = get_arg_val<uint32_t>(1);
 
-    auto reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(mcast_sender_noc_x, mcast_sender_noc_y, reduce_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;  // E[x] partial reduce
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
 
     // This is the stride between two consecutive local means/variances in the cb_ex_partial
     constexpr uint32_t local_stride = 2;
@@ -48,31 +55,30 @@ void kernel_main() {
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
     for (uint32_t i = 0; i < num_batches; ++i) {
         // Read mean and variance arrays from cb_ex_partial, then combine using Welford
-
         // wait for local data ready
-        cb_wait_front(cb_ex_partial, 2);
-        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        cb_ex_partial.wait_front(2);
+        auto local_means_ptr = cb_ex_partial.get_read_ptr();
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        cb_reserve_back(cb_ex_global, 2 * num_groups);
-        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        cb_ex_global.reserve_back(2 * num_groups);
+        auto global_means_ptr = cb_ex_global.get_write_ptr();
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
@@ -89,11 +95,11 @@ void kernel_main() {
             p_global_vars[0] = local_result.variance;
 
             // Signal to sender that our partial data is ready
-            noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+            reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);
 
             // Wait for sender to signal that it has sent the global data
-            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-            noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+            reduce_sender_sem.wait(VALID);
+            reduce_sender_sem.set(INVALID);
 
             local_means_ptr += local_stride_per_group;
             local_vars_ptr += local_stride_per_group;
@@ -101,23 +107,23 @@ void kernel_main() {
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
 
-        cb_pop_front(cb_ex_partial, 2);
-        cb_push_back(cb_ex_global, 2 * num_groups);
+        cb_ex_partial.pop_front(2);
+        cb_ex_global.push_back(2 * num_groups);
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -9,6 +9,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
@@ -56,13 +58,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -116,10 +124,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -12,6 +12,7 @@
 #include "experimental/noc_semaphore.h"
 #include "experimental/endpoints.h"
 #include "experimental/core_local_mem.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -7,10 +7,13 @@
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
 #include "noc_parameters.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_receiver_semaphore_id"));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reduce_sender_semaphore_id"));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
+    constexpr uint32_t reduce_sender_semaphore_id = get_named_compile_time_arg_val("reduce_sender_semaphore_id");
 
     constexpr uint32_t num_mcast_cores = get_named_compile_time_arg_val("num_cores_per_mcast_group");
     constexpr uint32_t num_batch_group = get_named_compile_time_arg_val("num_batch_group");
@@ -69,9 +72,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_last_group;
 
     // noc addrs for first and last groups
-    uint64_t reduce_sender_first_group_semaphore_noc_addr;
     uint64_t multicast_first_group_data_noc;
-    uint64_t reduce_sender_last_group_semaphore_noc_addr;
     uint64_t multicast_last_group_data_noc;
 
     if (has_mcast_first_group and has_mcast_last_group) {
@@ -115,24 +116,10 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_mcast_cores));
     }
 
-    const uint64_t reduce_sender_semaphore_noc_addr = get_noc_multicast_addr(
-        mcast_dest_noc_start_x,
-        mcast_dest_noc_start_y,
-        mcast_dest_noc_end_x,
-        mcast_dest_noc_end_y,
-        reduce_sender_semaphore_addr);
-
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
 
     if (has_mcast_first_group) {
-        reduce_sender_first_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_first_group_data_noc = get_noc_multicast_addr(
             mcast_first_group_dest_noc_start_x,
             mcast_first_group_dest_noc_start_y,
@@ -141,13 +128,6 @@ void kernel_main() {
             0);
     }
     if (has_mcast_last_group) {
-        reduce_sender_last_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_last_group_data_noc = get_noc_multicast_addr(
             mcast_last_group_dest_noc_start_x,
             mcast_last_group_dest_noc_start_y,
@@ -156,23 +136,28 @@ void kernel_main() {
             0);
     }
 
-    const auto reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    *reduce_sender_semaphore_addr_ptr = VALID;
-    const auto reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    reduce_sender_sem.set(VALID);
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_repack = tt::CBIndex::c_26;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_31;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_26;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_31;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
-    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0);
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
 
-    // This is the stride between two consecutive local means/variances in the cb_ex_partial
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
+    constexpr uint32_t src0_tile_bytes = get_tile_size(cb_in0_id);
+
     constexpr uint32_t local_stride = 2;
     constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
     constexpr uint32_t single_row_size_bytes = single_tile_size_bytes / tile_height;
@@ -181,18 +166,18 @@ void kernel_main() {
     const auto src_a = TensorAccessor(src0_args, src_addr, src0_tile_bytes);
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    const uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
@@ -225,23 +210,23 @@ void kernel_main() {
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
             for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_reserve_back(cb_in0, 1);
-                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(1);
+                    const uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, 1);
+                    noc.async_read_barrier();
+                    cb_in0.push_back(1);
                 }
                 mt_offset += num_channels_tiles;
             }
 #endif
         }
 
-        cb_wait_front(cb_ex_partial, 2);
-        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        cb_ex_partial.wait_front(2);
+        auto local_means_ptr = cb_ex_partial.get_read_ptr();
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        cb_reserve_back(cb_ex_global, 2 * num_groups);
-        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        cb_ex_global.reserve_back(2 * num_groups);
+        auto global_means_ptr = cb_ex_global.get_write_ptr();
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
@@ -262,8 +247,8 @@ void kernel_main() {
 
             if constexpr (num_mcast_cores > 1) {
                 // Wait until all other cores have signaled that their partial data is ready
-                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+                reduce_receiver_sem.wait(num_mcast_cores - 1);
+                reduce_receiver_sem.set(0);
 
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
                     uint64_t noc_means_addr = get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_means_ptr);
@@ -275,7 +260,7 @@ void kernel_main() {
                     noc_async_read_one_packet(
                         noc_vars_addr, global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES, NOC_L1_READ_ALIGNMENT_BYTES);
                 }
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             }
 
             // Read mean and variance arrays from cb_ex_global, then combine using Welford
@@ -295,8 +280,14 @@ void kernel_main() {
                     2 * single_tile_size_bytes,
                     num_mcast_cores_mid_group,
                     true);
-                noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    num_mcast_cores_mid_group,
+                    false);
 
                 if (has_mcast_first_group) {
                     noc_async_write_multicast(
@@ -305,9 +296,12 @@ void kernel_main() {
                         2 * single_tile_size_bytes,
                         num_mcast_cores_first_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_first_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_first_group_dest_noc_start_x,
+                        mcast_first_group_dest_noc_start_y,
+                        mcast_first_group_dest_noc_end_x,
+                        mcast_first_group_dest_noc_end_y,
                         num_mcast_cores_first_group,
                         false);
                 }
@@ -319,13 +313,16 @@ void kernel_main() {
                         2 * single_tile_size_bytes,
                         num_mcast_cores_last_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_last_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_last_group_dest_noc_start_x,
+                        mcast_last_group_dest_noc_start_y,
+                        mcast_last_group_dest_noc_end_x,
+                        mcast_last_group_dest_noc_end_y,
                         num_mcast_cores_last_group,
                         false);
                 }
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
 
             local_means_ptr += local_stride_per_group;
@@ -334,8 +331,8 @@ void kernel_main() {
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
 
-        cb_pop_front(cb_ex_partial, 2);
-        cb_push_back(cb_ex_global, 2 * num_groups);
+        cb_ex_partial.pop_front(2);
+        cb_ex_global.push_back(2 * num_groups);
 
         mt_offset = 0;
         for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
@@ -350,11 +347,11 @@ void kernel_main() {
 #if !defined(READER_REPACK) or !defined(TILIZE_IN)
             for (uint32_t mt = 0; mt < out_block_h_actual; ++mt) {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_reserve_back(cb_in0, 1);
-                    const uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(1);
+                    const uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, 1);
+                    noc.async_read_barrier();
+                    cb_in0.push_back(1);
                 }
                 mt_offset += num_channels_tiles;
             }
@@ -364,18 +361,18 @@ void kernel_main() {
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        const uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_gn.cpp
@@ -10,6 +10,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_named_compile_time_arg_val("reduce_receiver_semaphore_id");
@@ -71,9 +73,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_first_group;
     uint32_t num_mcast_cores_last_group;
 
-    // noc addrs for first and last groups
-    uint64_t multicast_first_group_data_noc;
-    uint64_t multicast_last_group_data_noc;
+    // first and last group mcast coordinates passed directly in async_write_multicast calls below
 
     if (has_mcast_first_group and has_mcast_last_group) {
         mcast_first_group_dest_noc_start_x = get_arg_val<uint32_t>(12);
@@ -116,26 +116,6 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_mcast_cores));
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    if (has_mcast_first_group) {
-        multicast_first_group_data_noc = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            0);
-    }
-    if (has_mcast_last_group) {
-        multicast_last_group_data_noc = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            0);
-    }
-
     experimental::Noc noc;
     experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
     experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
@@ -167,13 +147,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -212,7 +198,12 @@ void kernel_main() {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                     cb_in0.reserve_back(1);
                     const uint32_t l1_write_addr = cb_in0.get_write_ptr();
-                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc.async_read(
+                        src_a,
+                        experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                        src0_tile_bytes,
+                        {.page_id = start_id + index_b_offset + mt_offset + nt},
+                        {});
                     noc.async_read_barrier();
                     cb_in0.push_back(1);
                 }
@@ -251,14 +242,19 @@ void kernel_main() {
                 reduce_receiver_sem.set(0);
 
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
-                    uint64_t noc_means_addr = get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_means_ptr);
-                    uint64_t noc_vars_addr = get_noc_addr(noc_coord_x[i], noc_coord_y[i], global_vars_ptr);
-                    noc_async_read_one_packet(
-                        noc_means_addr,
-                        global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES,
-                        NOC_L1_READ_ALIGNMENT_BYTES);
-                    noc_async_read_one_packet(
-                        noc_vars_addr, global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES, NOC_L1_READ_ALIGNMENT_BYTES);
+                    experimental::UnicastEndpoint remote_ep;
+                    noc.async_read(
+                        remote_ep,
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
+                        NOC_L1_READ_ALIGNMENT_BYTES,
+                        {.noc_x = noc_coord_x[i], .noc_y = noc_coord_y[i], .addr = global_means_ptr},
+                        {});
+                    noc.async_read(
+                        remote_ep,
+                        experimental::CoreLocalMem<uint32_t>(global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
+                        NOC_L1_READ_ALIGNMENT_BYTES,
+                        {.noc_x = noc_coord_x[i], .noc_y = noc_coord_y[i], .addr = global_vars_ptr},
+                        {});
                 }
                 noc.async_read_barrier();
             }
@@ -274,11 +270,18 @@ void kernel_main() {
 
             if constexpr (num_mcast_cores > 1) {
                 // mcast to other cores
-                noc_async_write_multicast(
-                    global_means_ptr,
-                    multicast_data_noc | global_means_ptr,
+                experimental::MulticastEndpoint mcast_dst;
+                noc.async_write_multicast(
+                    experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                    mcast_dst,
                     2 * single_tile_size_bytes,
                     num_mcast_cores_mid_group,
+                    {},
+                    {.noc_x_start = mcast_dest_noc_start_x,
+                     .noc_y_start = mcast_dest_noc_start_y,
+                     .noc_x_end = mcast_dest_noc_end_x,
+                     .noc_y_end = mcast_dest_noc_end_y,
+                     .addr = global_means_ptr},
                     true);
                 reduce_sender_sem.set_multicast(
                     noc,
@@ -290,11 +293,18 @@ void kernel_main() {
                     false);
 
                 if (has_mcast_first_group) {
-                    noc_async_write_multicast(
-                        global_means_ptr,
-                        multicast_first_group_data_noc | global_means_ptr,
+                    experimental::MulticastEndpoint mcast_first_group_dst;
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                        mcast_first_group_dst,
                         2 * single_tile_size_bytes,
                         num_mcast_cores_first_group,
+                        {},
+                        {.noc_x_start = mcast_first_group_dest_noc_start_x,
+                         .noc_y_start = mcast_first_group_dest_noc_start_y,
+                         .noc_x_end = mcast_first_group_dest_noc_end_x,
+                         .noc_y_end = mcast_first_group_dest_noc_end_y,
+                         .addr = global_means_ptr},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -307,11 +317,18 @@ void kernel_main() {
                 }
 
                 if (has_mcast_last_group) {
-                    noc_async_write_multicast(
-                        global_means_ptr,
-                        multicast_last_group_data_noc | global_means_ptr,
+                    experimental::MulticastEndpoint mcast_last_group_dst;
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                        mcast_last_group_dst,
                         2 * single_tile_size_bytes,
                         num_mcast_cores_last_group,
+                        {},
+                        {.noc_x_start = mcast_last_group_dest_noc_start_x,
+                         .noc_y_start = mcast_last_group_dest_noc_start_y,
+                         .noc_x_end = mcast_last_group_dest_noc_end_x,
+                         .noc_y_end = mcast_last_group_dest_noc_end_y,
+                         .addr = global_means_ptr},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -349,7 +366,12 @@ void kernel_main() {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                     cb_in0.reserve_back(1);
                     const uint32_t l1_write_addr = cb_in0.get_write_ptr();
-                    noc_async_read_tile(start_id + index_b_offset + mt_offset + nt, src_a, l1_write_addr);
+                    noc.async_read(
+                        src_a,
+                        experimental::CoreLocalMem<uint32_t>(l1_write_addr),
+                        src0_tile_bytes,
+                        {.page_id = start_id + index_b_offset + mt_offset + nt},
+                        {});
                     noc.async_read_barrier();
                     cb_in0.push_back(1);
                 }
@@ -365,10 +387,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -9,6 +9,8 @@
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
@@ -56,9 +58,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_first_group;
     uint32_t num_mcast_cores_last_group;
 
-    // noc addrs for first and last groups
-    uint64_t multicast_first_group_data_noc;
-    uint64_t multicast_last_group_data_noc;
+    // first and last group noc addrs are specified inline via coordinates in multicast write calls
 
     if (has_mcast_first_group and has_mcast_last_group) {
         mcast_first_group_dest_noc_start_x = get_arg_val<uint32_t>(7);
@@ -104,23 +104,6 @@ void kernel_main() {
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
 
-    if (has_mcast_first_group) {
-        multicast_first_group_data_noc = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            0);
-    }
-    if (has_mcast_last_group) {
-        multicast_last_group_data_noc = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            0);
-    }
-
     experimental::Noc noc;
     experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
     experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
@@ -149,13 +132,19 @@ void kernel_main() {
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
-    uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+    uint32_t src_addr_in0 = in0_l1_read_addr;
+    experimental::UnicastEndpoint self_ep;
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack.reserve_back(per_core_N);
         uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
         noc.async_read_barrier();
@@ -217,11 +206,18 @@ void kernel_main() {
 
             // mcast to other cores
             if constexpr (num_mcast_cores > 1) {
-                noc_async_write_multicast(
-                    global_means_ptr,
-                    multicast_data_noc | global_means_ptr,
+                experimental::MulticastEndpoint mcast_dst;
+                noc.async_write_multicast(
+                    experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                    mcast_dst,
                     2 * single_tile_size_bytes,
                     num_mcast_cores_mid_group,
+                    {},
+                    {.noc_x_start = mcast_dest_noc_start_x,
+                     .noc_y_start = mcast_dest_noc_start_y,
+                     .noc_x_end = mcast_dest_noc_end_x,
+                     .noc_y_end = mcast_dest_noc_end_y,
+                     .addr = global_means_ptr},
                     true);
                 reduce_sender_sem.set_multicast(
                     noc,
@@ -233,11 +229,17 @@ void kernel_main() {
                     false);
 
                 if (has_mcast_first_group) {
-                    noc_async_write_multicast(
-                        global_means_ptr,
-                        multicast_first_group_data_noc | global_means_ptr,
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                        mcast_dst,
                         2 * single_tile_size_bytes,
                         num_mcast_cores_first_group,
+                        {},
+                        {.noc_x_start = mcast_first_group_dest_noc_start_x,
+                         .noc_y_start = mcast_first_group_dest_noc_start_y,
+                         .noc_x_end = mcast_first_group_dest_noc_end_x,
+                         .noc_y_end = mcast_first_group_dest_noc_end_y,
+                         .addr = global_means_ptr},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -250,11 +252,17 @@ void kernel_main() {
                 }
 
                 if (has_mcast_last_group) {
-                    noc_async_write_multicast(
-                        global_means_ptr,
-                        multicast_last_group_data_noc | global_means_ptr,
+                    noc.async_write_multicast(
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr),
+                        mcast_dst,
                         2 * single_tile_size_bytes,
                         num_mcast_cores_last_group,
+                        {},
+                        {.noc_x_start = mcast_last_group_dest_noc_start_x,
+                         .noc_y_start = mcast_last_group_dest_noc_start_y,
+                         .noc_x_end = mcast_last_group_dest_noc_end_x,
+                         .noc_y_end = mcast_last_group_dest_noc_end_y,
+                         .addr = global_means_ptr},
                         true);
                     reduce_sender_sem.set_multicast(
                         noc,
@@ -282,10 +290,16 @@ void kernel_main() {
     for (uint32_t m = 0; m < per_core_M; ++m) {
         cb_repack_out.wait_front(per_core_N);
         uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
-        uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
+        uint32_t src_addr_in0 = in0_l1_read_addr;
+        experimental::UnicastEndpoint self_ep;
         for (uint32_t i = 0; i < tile_height; ++i) {
-            noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
-            noc_addr_in0 += per_core_N_bytes_with_stride;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_repack),
+                per_core_N_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = src_addr_in0},
+                {});
+            src_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -155,7 +155,7 @@ void kernel_main() {
     for (uint32_t m = 0; m < num_batches; ++m) {
         // Read mean and variance arrays from cb_ex_partial, then combine using Welford
 
-        // wait for local data readykj
+        // wait for local data ready
         cb_ex_partial.wait_front(2);
         auto local_means_ptr = cb_ex_partial.get_read_ptr();
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -6,10 +6,13 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t reduce_receiver_semaphore_id = get_compile_time_arg_val(0);
+    constexpr uint32_t reduce_sender_semaphore_id = get_compile_time_arg_val(1);
 
     constexpr uint32_t num_mcast_cores = get_compile_time_arg_val(2);
     constexpr uint32_t num_batches = get_compile_time_arg_val(3);
@@ -54,9 +57,7 @@ void kernel_main() {
     uint32_t num_mcast_cores_last_group;
 
     // noc addrs for first and last groups
-    uint64_t reduce_sender_first_group_semaphore_noc_addr;
     uint64_t multicast_first_group_data_noc;
-    uint64_t reduce_sender_last_group_semaphore_noc_addr;
     uint64_t multicast_last_group_data_noc;
 
     if (has_mcast_first_group and has_mcast_last_group) {
@@ -100,24 +101,10 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_mcast_cores));
     }
 
-    const uint64_t reduce_sender_semaphore_noc_addr = get_noc_multicast_addr(
-        mcast_dest_noc_start_x,
-        mcast_dest_noc_start_y,
-        mcast_dest_noc_end_x,
-        mcast_dest_noc_end_y,
-        reduce_sender_semaphore_addr);
-
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
 
     if (has_mcast_first_group) {
-        reduce_sender_first_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_first_group_dest_noc_start_x,
-            mcast_first_group_dest_noc_start_y,
-            mcast_first_group_dest_noc_end_x,
-            mcast_first_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_first_group_data_noc = get_noc_multicast_addr(
             mcast_first_group_dest_noc_start_x,
             mcast_first_group_dest_noc_start_y,
@@ -126,13 +113,6 @@ void kernel_main() {
             0);
     }
     if (has_mcast_last_group) {
-        reduce_sender_last_group_semaphore_noc_addr = get_noc_multicast_addr(
-            mcast_last_group_dest_noc_start_x,
-            mcast_last_group_dest_noc_start_y,
-            mcast_last_group_dest_noc_end_x,
-            mcast_last_group_dest_noc_end_y,
-            reduce_sender_semaphore_addr);
-
         multicast_last_group_data_noc = get_noc_multicast_addr(
             mcast_last_group_dest_noc_start_x,
             mcast_last_group_dest_noc_start_y,
@@ -141,21 +121,26 @@ void kernel_main() {
             0);
     }
 
-    auto reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, VALID);
+    experimental::Noc noc;
+    experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    reduce_sender_sem.set(VALID);
 
-    auto reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    constexpr uint32_t cb_ex_partial_id = tt::CBIndex::c_8;
+    constexpr uint32_t cb_ex_global_id = tt::CBIndex::c_15;
+    constexpr uint32_t cb_in0_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_repack_id = tt::CBIndex::c_11;
+    constexpr uint32_t cb_repack_out_id = tt::CBIndex::c_12;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 
-    constexpr uint32_t cb_ex_partial = tt::CBIndex::c_8;
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;  // E[x] global reduce
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;         // sharded cb
-    constexpr uint32_t cb_repack = tt::CBIndex::c_11;
-    constexpr uint32_t cb_repack_out = tt::CBIndex::c_12;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    experimental::CircularBuffer cb_ex_partial(cb_ex_partial_id);
+    experimental::CircularBuffer cb_ex_global(cb_ex_global_id);
+    experimental::CircularBuffer cb_in0(cb_in0_id);
+    experimental::CircularBuffer cb_repack(cb_repack_id);
+    experimental::CircularBuffer cb_repack_out(cb_repack_out_id);
+    experimental::CircularBuffer cb_out0(cb_out0_id);
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial);
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial_id);
     // This is the stride between two consecutive local means/variances in the cb_ex_partial
     constexpr uint32_t local_stride = 2;
     constexpr uint32_t global_stride = NOC_L1_READ_ALIGNMENT_BYTES / 2;
@@ -163,31 +148,31 @@ void kernel_main() {
     constexpr uint32_t local_stride_per_group = local_stride * single_row_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
-    uint32_t in0_l1_read_addr = get_read_ptr(cb_in0);
+    uint32_t in0_l1_read_addr = cb_in0.get_read_ptr();
     uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_reserve_back(cb_repack, per_core_N);
-        uint32_t l1_write_addr_repack = get_write_ptr(cb_repack);
+        cb_repack.reserve_back(per_core_N);
+        uint32_t l1_write_addr_repack = cb_repack.get_write_ptr();
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes;
             l1_write_addr_repack += per_core_N_bytes_with_stride;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_repack, per_core_N);
+        noc.async_read_barrier();
+        cb_repack.push_back(per_core_N);
     }
 #endif
 
     for (uint32_t m = 0; m < num_batches; ++m) {
         // Read mean and variance arrays from cb_ex_partial, then combine using Welford
 
-        // wait for local data ready
-        cb_wait_front(cb_ex_partial, 2);
-        auto local_means_ptr = get_read_ptr(cb_ex_partial);
+        // wait for local data readykj
+        cb_ex_partial.wait_front(2);
+        auto local_means_ptr = cb_ex_partial.get_read_ptr();
         auto local_vars_ptr = local_means_ptr + single_tile_size_bytes;
 
-        cb_reserve_back(cb_ex_global, 2 * num_groups);
-        auto global_means_ptr = get_write_ptr(cb_ex_global);
+        cb_ex_global.reserve_back(2 * num_groups);
+        auto global_means_ptr = cb_ex_global.get_write_ptr();
         auto global_vars_ptr = global_means_ptr + single_tile_size_bytes;
 
         for (uint32_t m = 0; m < num_groups; ++m) {
@@ -205,8 +190,8 @@ void kernel_main() {
 
             if constexpr (num_mcast_cores > 1) {
                 // wait for all other cores data ready
-                noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_mcast_cores - 1);
-                noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+                reduce_receiver_sem.wait(num_mcast_cores - 1);
+                reduce_receiver_sem.set(0);
 
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
                     noc_async_read_one_packet(
@@ -218,7 +203,7 @@ void kernel_main() {
                         global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES,
                         NOC_L1_READ_ALIGNMENT_BYTES);
                 }
-                noc_async_read_barrier();
+                noc.async_read_barrier();
             }
 
             // Read mean and variance arrays from cb_ex_global, then combine using Welford
@@ -238,8 +223,14 @@ void kernel_main() {
                     2 * single_tile_size_bytes,
                     num_mcast_cores_mid_group,
                     true);
-                noc_semaphore_set_multicast(
-                    reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_mcast_cores_mid_group, false);
+                reduce_sender_sem.set_multicast(
+                    noc,
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    num_mcast_cores_mid_group,
+                    false);
 
                 if (has_mcast_first_group) {
                     noc_async_write_multicast(
@@ -248,9 +239,12 @@ void kernel_main() {
                         2 * single_tile_size_bytes,
                         num_mcast_cores_first_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_first_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_first_group_dest_noc_start_x,
+                        mcast_first_group_dest_noc_start_y,
+                        mcast_first_group_dest_noc_end_x,
+                        mcast_first_group_dest_noc_end_y,
                         num_mcast_cores_first_group,
                         false);
                 }
@@ -262,13 +256,16 @@ void kernel_main() {
                         2 * single_tile_size_bytes,
                         num_mcast_cores_last_group,
                         true);
-                    noc_semaphore_set_multicast(
-                        reduce_sender_semaphore_addr,
-                        reduce_sender_last_group_semaphore_noc_addr,
+                    reduce_sender_sem.set_multicast(
+                        noc,
+                        mcast_last_group_dest_noc_start_x,
+                        mcast_last_group_dest_noc_start_y,
+                        mcast_last_group_dest_noc_end_x,
+                        mcast_last_group_dest_noc_end_y,
                         num_mcast_cores_last_group,
                         false);
                 }
-                noc_async_write_barrier();
+                noc.async_write_barrier();
             }
 
             local_means_ptr += local_stride_per_group;
@@ -276,23 +273,23 @@ void kernel_main() {
             global_means_ptr += 2 * single_tile_size_bytes;
             global_vars_ptr += 2 * single_tile_size_bytes;
         }
-        cb_pop_front(cb_ex_partial, 2);
-        cb_push_back(cb_ex_global, 2 * num_groups);
+        cb_ex_partial.pop_front(2);
+        cb_ex_global.push_back(2 * num_groups);
     }
 
 #if defined(READER_REPACK) and defined(UNTILIZE_OUT)
-    uint32_t l1_write_addr_repack = get_write_ptr(cb_out0);
+    uint32_t l1_write_addr_repack = cb_out0.get_write_ptr();
     for (uint32_t m = 0; m < per_core_M; ++m) {
-        cb_wait_front(cb_repack_out, per_core_N);
-        uint32_t in0_l1_read_addr = get_read_ptr(cb_repack_out);
+        cb_repack_out.wait_front(per_core_N);
+        uint32_t in0_l1_read_addr = cb_repack_out.get_read_ptr();
         uint64_t noc_addr_in0 = get_noc_addr(in0_l1_read_addr);
         for (uint32_t i = 0; i < tile_height; ++i) {
             noc_async_read(noc_addr_in0, l1_write_addr_repack, per_core_N_bytes);
             noc_addr_in0 += per_core_N_bytes_with_stride;
             l1_write_addr_repack += per_core_N_bytes;
         }
-        noc_async_read_barrier();
-        cb_pop_front(cb_repack_out, per_core_N);
+        noc.async_read_barrier();
+        cb_repack_out.pop_front(per_core_N);
     }
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -114,7 +114,12 @@ void kernel_main() {
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {
         for (uint32_t j = 0; j < block_w; ++j) {
-            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+            noc.async_read(
+                mask,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                input_mask_single_tile_size_bytes,
+                {.page_id = input_mask_tile_id},
+                {});
             input_mask_tile_id += 1;
             noc.async_read_barrier();
             l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
@@ -142,9 +147,8 @@ void kernel_main() {
         // Read the first 64 bytes of the tile into the first face
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
+            noc.async_read(
+                gamma, experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma), 64, {.page_id = tile_id}, {});
             l1_write_addr_gamma += gamma_tile_bytes;
         }
         noc.async_read_barrier();
@@ -152,9 +156,14 @@ void kernel_main() {
         // Copy the second set of 32 bytes into the second face
         l1_write_addr_gamma = base_l1_write_addr_gamma;
 
+        experimental::UnicastEndpoint self_ep_gamma;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
-            noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
+            noc.async_read(
+                self_ep_gamma,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
+                32,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
+                {});
             l1_write_addr_gamma += gamma_tile_bytes;
         }
 
@@ -176,8 +185,8 @@ void kernel_main() {
         // Read the first 64 bytes of the tile into the first face
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
-            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
+            noc.async_read(
+                beta, experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta), 64, {.page_id = tile_id}, {});
             l1_write_addr_beta += beta_tile_bytes;
         }
         noc.async_read_barrier();
@@ -185,9 +194,14 @@ void kernel_main() {
         // Copy the second set of 32 bytes into the second face
         l1_write_addr_beta = base_l1_write_addr_beta;
 
+        experimental::UnicastEndpoint self_ep_beta;
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-            uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
-            noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
+            noc.async_read(
+                self_ep_beta,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
+                32,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
+                {});
             l1_write_addr_beta += beta_tile_bytes;
         }
 
@@ -215,8 +229,12 @@ void kernel_main() {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
                     cb_out.wait_front(1);
                     const uint32_t l1_read_addr = cb_out.get_read_ptr();
-                    noc_async_write_tile(
-                        out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
+                    noc.async_write(
+                        experimental::CoreLocalMem<uint32_t>(l1_read_addr),
+                        dst_a,
+                        single_tile_size_bytes,
+                        {},
+                        {.page_id = out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt});
                     noc.async_write_barrier();
                     cb_out.pop_front(1);
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -7,6 +7,11 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -62,24 +67,29 @@ void kernel_main() {
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(10);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(11);
 
-    constexpr uint32_t cb_eps = tt::CBIndex::c_3;
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
-    constexpr uint32_t cb_in = tt::CBIndex::c_29;
+    constexpr uint32_t cb_eps_id = tt::CBIndex::c_3;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_28;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_29;
 
-    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_reread_write_out_id = tt::CBIndex::c_22;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (fuse_gamma or fuse_beta) ? cb_out0 : cb_reread_write_out;
+    constexpr uint32_t cb_out_id = (fuse_gamma or fuse_beta) ? cb_out0_id : cb_reread_write_out_id;
 #endif
 
-    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_out);
-    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_out(cb_out_id);
 
-    // input mask
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_out_id);
+    constexpr uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask_id);
+
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
@@ -97,28 +107,28 @@ void kernel_main() {
     }
 
     // Send eps, mask, gamma, and beta to the compute kernel
-    generate_bcast_col_scalar(cb_eps, eps_val);
+    generate_bcast_col_scalar(cb_eps_id, eps_val);
 
-    cb_reserve_back(cb_input_mask, block_w * num_groups_per_core);
-    uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+    cb_input_mask.reserve_back(block_w * num_groups_per_core);
+    uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {
         for (uint32_t j = 0; j < block_w; ++j) {
             noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
             input_mask_tile_id += 1;
-            noc_async_read_barrier();
+            noc.async_read_barrier();
             l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
         }
     }
-    cb_push_back(cb_input_mask, block_w * num_groups_per_core);
+    cb_input_mask.push_back(block_w * num_groups_per_core);
 
     if constexpr (fuse_gamma) {
-        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);
         const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
 
-        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+        cb_gamma.reserve_back(num_cols_tile_gamma_beta);
 
-        const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+        const uint32_t base_l1_write_addr_gamma = cb_gamma.get_write_ptr();
         uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
 
         // We want this data to appear as the first row of the tile.
@@ -137,7 +147,7 @@ void kernel_main() {
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // Copy the second set of 32 bytes into the second face
         l1_write_addr_gamma = base_l1_write_addr_gamma;
@@ -148,20 +158,19 @@ void kernel_main() {
             l1_write_addr_gamma += gamma_tile_bytes;
         }
 
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+        noc.async_read_barrier();
+        cb_gamma.push_back(num_cols_tile_gamma_beta);
     }
 
     if constexpr (fuse_beta) {
         // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
         // Then copy the second set of 32 bytes into the second face
-
-        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta_id);
         const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
 
-        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+        cb_beta.reserve_back(num_cols_tile_gamma_beta);
 
-        const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+        const uint32_t base_l1_write_addr_beta = cb_beta.get_write_ptr();
         uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
 
         // Read the first 64 bytes of the tile into the first face
@@ -171,7 +180,7 @@ void kernel_main() {
             noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
             l1_write_addr_beta += beta_tile_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // Copy the second set of 32 bytes into the second face
         l1_write_addr_beta = base_l1_write_addr_beta;
@@ -182,8 +191,8 @@ void kernel_main() {
             l1_write_addr_beta += beta_tile_bytes;
         }
 
-        noc_async_read_barrier();
-        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+        noc.async_read_barrier();
+        cb_beta.push_back(num_cols_tile_gamma_beta);
     }
 
     const auto dst_a = TensorAccessor(out_args, out_addr, single_tile_size_bytes);
@@ -204,12 +213,12 @@ void kernel_main() {
             uint32_t mt_offset = 0;
             for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                 for (uint32_t nt = 0; nt < per_core_N; ++nt) {
-                    cb_wait_front(cb_out, 1);
-                    const uint32_t l1_read_addr = get_read_ptr(cb_out);
+                    cb_out.wait_front(1);
+                    const uint32_t l1_read_addr = cb_out.get_read_ptr();
                     noc_async_write_tile(
                         out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_out, 1);
+                    noc.async_write_barrier();
+                    cb_out.pop_front(1);
                 }
                 mt_offset += num_channels_tiles;
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -69,7 +69,12 @@ void kernel_main() {
         cb_input_mask.reserve_back(block_w);
         uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
         for (uint32_t j = 0; j < block_w; ++j) {
-            noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+            noc.async_read(
+                mask,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                input_mask_single_tile_size_bytes,
+                {.page_id = input_mask_tile_id},
+                {});
             l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
             input_mask_tile_id += 1;
         }
@@ -96,20 +101,39 @@ void kernel_main() {
         // to L1
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
 
             // Read the first 64 bytes of the tile into the first face
 #ifdef ARCH_BLACKHOLE
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, NOC_DRAM_READ_ALIGNMENT_BYTES);
-            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + gamma_face_w_bytes);
+            noc.async_read(
+                gamma,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma),
+                gamma_face_w_bytes * 2,
+                {.page_id = tile_id},
+                {});
             noc.async_read_barrier();
-#else
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, gamma_face_w_bytes);
-            gamma_noc_addr += gamma_face_w_bytes;
-#endif
-
             // Copy the second set of 32 bytes into the second face
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma + gamma_face_bytes, gamma_face_w_bytes);
+            experimental::UnicastEndpoint self_ep;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + gamma_face_bytes),
+                gamma_face_w_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + gamma_face_w_bytes},
+                {});
+#else
+            noc.async_read(
+                gamma,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma),
+                gamma_face_w_bytes,
+                {.page_id = tile_id},
+                {});
+            // Copy the second set of 32 bytes into the second face
+            noc.async_read(
+                gamma,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + gamma_face_bytes),
+                gamma_face_w_bytes,
+                {.page_id = tile_id, .offset_bytes = gamma_face_w_bytes},
+                {});
+#endif
             l1_write_addr_gamma += gamma_tile_bytes;
         }
         noc.async_read_barrier();
@@ -130,20 +154,39 @@ void kernel_main() {
 
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
-            uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
 
             // Read the first 64 bytes of the tile into the first face
 #ifdef ARCH_BLACKHOLE
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, NOC_DRAM_READ_ALIGNMENT_BYTES);
-            beta_noc_addr = get_noc_addr(l1_write_addr_beta + beta_face_w_bytes);
+            noc.async_read(
+                beta,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta),
+                beta_face_w_bytes * 2,
+                {.page_id = tile_id},
+                {});
             noc.async_read_barrier();
-#else
-            noc_async_read(beta_noc_addr, l1_write_addr_beta, beta_face_w_bytes);
-            beta_noc_addr += beta_face_w_bytes;
-#endif
-
             // Copy the second set of 32 bytes into the second face
-            noc_async_read(beta_noc_addr, l1_write_addr_beta + beta_face_bytes, beta_face_w_bytes);
+            experimental::UnicastEndpoint self_ep;
+            noc.async_read(
+                self_ep,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + beta_face_bytes),
+                beta_face_w_bytes,
+                {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + beta_face_w_bytes},
+                {});
+#else
+            noc.async_read(
+                beta,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta),
+                beta_face_w_bytes,
+                {.page_id = tile_id},
+                {});
+            // Copy the second set of 32 bytes into the second face
+            noc.async_read(
+                beta,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + beta_face_bytes),
+                beta_face_w_bytes,
+                {.page_id = tile_id, .offset_bytes = beta_face_w_bytes},
+                {});
+#endif
             l1_write_addr_beta += beta_tile_bytes;
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -7,6 +7,11 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr uint32_t TILE_HW = TILE_HW_VAL;
@@ -39,16 +44,20 @@ void kernel_main() {
     const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(8);
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(9);
 
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
-    constexpr uint32_t cb_ones = tt::CBIndex::c_26;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_7;
+    constexpr uint32_t cb_ones_id = tt::CBIndex::c_26;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
 
-    // input mask
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma_id);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask_id);
+
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
     constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
@@ -57,26 +66,26 @@ void kernel_main() {
 
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-        cb_reserve_back(cb_input_mask, block_w);
-        uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+        cb_input_mask.reserve_back(block_w);
+        uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
         for (uint32_t j = 0; j < block_w; ++j) {
             noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
             l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
             input_mask_tile_id += 1;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_input_mask, block_w);
+        noc.async_read_barrier();
+        cb_input_mask.push_back(block_w);
     }
 
     if constexpr (fuse_gamma) {
-        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+        constexpr uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);
         constexpr uint32_t gamma_element_bytes = gamma_tile_bytes / TILE_HW;
         constexpr uint32_t gamma_face_bytes = gamma_element_bytes * tt::constants::FACE_HW;
         constexpr uint32_t gamma_face_w_bytes = gamma_element_bytes * tt::constants::FACE_WIDTH;
         const auto gamma = TensorAccessor(gamma_args, gamma_addr, size);
 
-        cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
-        auto l1_write_addr_gamma = get_write_ptr(cb_gamma);
+        cb_gamma.reserve_back(num_cols_tile_gamma_beta);
+        auto l1_write_addr_gamma = cb_gamma.get_write_ptr();
 
         // We want this data to appear as the first row of the tile.
         // This is 32B at the start of the first face, 32B at the start of the second face
@@ -85,7 +94,6 @@ void kernel_main() {
         // Then later, copy the second set of 32 bytes into the start of the second face
         // L1-L1 NOC transactions only need 16 byte alignment on BH, so this is legal after data is loaded
         // to L1
-
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
             uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
@@ -94,7 +102,7 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma, NOC_DRAM_READ_ALIGNMENT_BYTES);
             gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + gamma_face_w_bytes);
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 #else
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma, gamma_face_w_bytes);
             gamma_noc_addr += gamma_face_w_bytes;
@@ -104,22 +112,21 @@ void kernel_main() {
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma + gamma_face_bytes, gamma_face_w_bytes);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+        noc.async_read_barrier();
+        cb_gamma.push_back(num_cols_tile_gamma_beta);
     }
 
     if constexpr (fuse_beta) {
         // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
         // Then copy the second set of 32 bytes into the second face
-
-        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+        constexpr uint32_t beta_tile_bytes = get_tile_size(cb_beta_id);
         constexpr uint32_t beta_element_bytes = beta_tile_bytes / TILE_HW;
         constexpr uint32_t beta_face_bytes = beta_element_bytes * tt::constants::FACE_HW;
         constexpr uint32_t beta_face_w_bytes = beta_element_bytes * tt::constants::FACE_WIDTH;
         const auto beta = TensorAccessor(beta_args, beta_addr, size);
 
-        cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
-        auto l1_write_addr_beta = get_write_ptr(cb_beta);
+        cb_beta.reserve_back(num_cols_tile_gamma_beta);
+        auto l1_write_addr_beta = cb_beta.get_write_ptr();
 
         for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
             uint32_t tile_id = beta_tile_start_id + w;
@@ -129,7 +136,7 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
             noc_async_read(beta_noc_addr, l1_write_addr_beta, NOC_DRAM_READ_ALIGNMENT_BYTES);
             beta_noc_addr = get_noc_addr(l1_write_addr_beta + beta_face_w_bytes);
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 #else
             noc_async_read(beta_noc_addr, l1_write_addr_beta, beta_face_w_bytes);
             beta_noc_addr += beta_face_w_bytes;
@@ -139,7 +146,7 @@ void kernel_main() {
             noc_async_read(beta_noc_addr, l1_write_addr_beta + beta_face_bytes, beta_face_w_bytes);
             l1_write_addr_beta += beta_tile_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+        noc.async_read_barrier();
+        cb_beta.push_back(num_cols_tile_gamma_beta);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -118,7 +118,12 @@ void kernel_main() {
             cb_input_mask.reserve_back(block_w);
             uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
-                noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+                noc.async_read(
+                    mask,
+                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                    input_mask_single_tile_size_bytes,
+                    {.page_id = input_mask_tile_id},
+                    {});
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
@@ -162,9 +167,12 @@ void kernel_main() {
                     // Read the first 64 bytes of the tile into the first face
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = gamma_tile_start_id + w;
-                        uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
+                        noc.async_read(
+                            gamma,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma),
+                            64,
+                            {.page_id = tile_id},
+                            {});
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -172,9 +180,14 @@ void kernel_main() {
                     // Copy the second set of 32 bytes into the second face
                     l1_write_addr_gamma = base_l1_write_addr_gamma;
 
+                    experimental::UnicastEndpoint self_ep_gamma;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_gamma + 32);
-                        noc_async_read(noc_read_addr, l1_write_addr_gamma + 512, 32);
+                        noc.async_read(
+                            self_ep_gamma,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
+                            32,
+                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
+                            {});
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
 
@@ -196,8 +209,12 @@ void kernel_main() {
                     // Read the first 64 bytes of the tile into the first face
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = beta_tile_start_id + w;
-                        uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
+                        noc.async_read(
+                            beta,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta),
+                            64,
+                            {.page_id = tile_id},
+                            {});
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -205,9 +222,14 @@ void kernel_main() {
                     // Copy the second set of 32 bytes into the second face
                     l1_write_addr_beta = base_l1_write_addr_beta;
 
+                    experimental::UnicastEndpoint self_ep_beta;
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
-                        uint64_t noc_read_addr = get_noc_addr(l1_write_addr_beta + 32);
-                        noc_async_read(noc_read_addr, l1_write_addr_beta + 512, 32);
+                        noc.async_read(
+                            self_ep_beta,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
+                            32,
+                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
+                            {});
                         l1_write_addr_beta += beta_tile_bytes;
                     }
 
@@ -239,11 +261,13 @@ void kernel_main() {
                         // Checks, only relevant to the last group, that we are not indexing out of bounds
                         // for the cases where our last group does not span the length of our max tile span for a group
                         if ((index_g_offset + nt) < row_tile_max_index) {
-                            noc_async_write_tile(
-                                out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
-                                    index_b_offset + index_g_offset,
+                            noc.async_write(
+                                experimental::CoreLocalMem<uint32_t>(l1_read_addr),
                                 dst_a,
-                                l1_read_addr);
+                                single_tile_size_bytes,
+                                {},
+                                {.page_id = out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                            index_b_offset + index_g_offset});
                         }
                         l1_read_addr += single_tile_size_bytes;
                     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -7,6 +7,11 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr bool is_mcast_sender = get_named_compile_time_arg_val("is_mcast_sender") == 1;
@@ -63,23 +68,28 @@ void kernel_main() {
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(10);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(11);
 
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_28;
-    constexpr uint32_t cb_in = tt::CBIndex::c_29;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_28;
+    constexpr uint32_t cb_in_id = tt::CBIndex::c_29;
 
-    constexpr uint32_t cb_reread_write_out = tt::CBIndex::c_22;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_reread_write_out_id = tt::CBIndex::c_22;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
 #ifdef UNTILIZE_OUT
-    constexpr uint32_t cb_out = tt::CBIndex::c_30;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_30;
 #else
-    constexpr uint32_t cb_out = (fuse_gamma or fuse_beta) ? cb_out0 : cb_reread_write_out;
+    constexpr uint32_t cb_out_id = (fuse_gamma or fuse_beta) ? cb_out0_id : cb_reread_write_out_id;
 #endif
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_out);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_out(cb_out_id);
 
-    // input mask
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_out_id);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask_id);
+
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
     constexpr uint32_t out_block_h_normal = block_h / num_out_blocks;
@@ -105,15 +115,15 @@ void kernel_main() {
         row_offset = num_cols_per_group;
 
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-            cb_reserve_back(cb_input_mask, block_w);
-            uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+            cb_input_mask.reserve_back(block_w);
+            uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_input_mask, block_w);
+            noc.async_read_barrier();
+            cb_input_mask.push_back(block_w);
 
             if (i == 0 and b == 0) {
                 if constexpr (!use_welford) {
@@ -133,12 +143,12 @@ void kernel_main() {
                 generate_bcast_col_scalar(eps_cb_id, eps);
 
                 if constexpr (fuse_gamma) {
-                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr, page_size);
 
-                    cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
+                    cb_gamma.reserve_back(num_cols_tile_gamma_beta);
 
-                    const uint32_t base_l1_write_addr_gamma = get_write_ptr(cb_gamma);
+                    const uint32_t base_l1_write_addr_gamma = cb_gamma.get_write_ptr();
                     uint32_t l1_write_addr_gamma = base_l1_write_addr_gamma;
 
                     // We want this data to appear as the first row of the tile.
@@ -157,7 +167,7 @@ void kernel_main() {
                         noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 64);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
 
                     // Copy the second set of 32 bytes into the second face
                     l1_write_addr_gamma = base_l1_write_addr_gamma;
@@ -168,20 +178,19 @@ void kernel_main() {
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+                    noc.async_read_barrier();
+                    cb_gamma.push_back(num_cols_tile_gamma_beta);
                 }
 
                 if constexpr (fuse_beta) {
                     // Just like gamma, we read at a 64 byte granularity for Blackhole NOC compatibility
                     // Then copy the second set of 32 bytes into the second face
-
-                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta_id);
                     const auto beta = TensorAccessor(beta_args, beta_addr, page_size);
 
-                    cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+                    cb_beta.reserve_back(num_cols_tile_gamma_beta);
 
-                    const uint32_t base_l1_write_addr_beta = get_write_ptr(cb_beta);
+                    const uint32_t base_l1_write_addr_beta = cb_beta.get_write_ptr();
                     uint32_t l1_write_addr_beta = base_l1_write_addr_beta;
 
                     // Read the first 64 bytes of the tile into the first face
@@ -191,7 +200,7 @@ void kernel_main() {
                         noc_async_read(beta_noc_addr, l1_write_addr_beta, 64);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
 
                     // Copy the second set of 32 bytes into the second face
                     l1_write_addr_beta = base_l1_write_addr_beta;
@@ -202,8 +211,8 @@ void kernel_main() {
                         l1_write_addr_beta += beta_tile_bytes;
                     }
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+                    noc.async_read_barrier();
+                    cb_beta.push_back(num_cols_tile_gamma_beta);
                 }
             }
 
@@ -222,8 +231,8 @@ void kernel_main() {
                     out_block_h_actual = out_block_h_normal;
                     out_block_hw_actual = out_block_hw_normal;
                 }
-                cb_wait_front(cb_out, out_block_hw_normal);
-                uint32_t l1_read_addr = get_read_ptr(cb_out);
+                cb_out.wait_front(out_block_hw_normal);
+                uint32_t l1_read_addr = cb_out.get_read_ptr();
 
                 for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                     for (uint32_t nt = 0; nt < block_w_curr; nt++) {
@@ -238,11 +247,10 @@ void kernel_main() {
                         }
                         l1_read_addr += single_tile_size_bytes;
                     }
-                    // l1_read_addr += (single_tile_size_bytes * (block_w-block_w_curr));
                 }
                 out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
-                noc_async_write_barrier();
-                cb_pop_front(cb_out, out_block_hw_normal);
+                noc.async_write_barrier();
+                cb_out.pop_front(out_block_hw_normal);
             }
 
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -126,7 +126,7 @@ void kernel_main() {
                 const uint32_t scalar_w = get_arg_val<uint32_t>(1);
                 generate_reduce_scaler(cb_in_2, scalar_w);
 
-                constexpr uint32_t ones = 0x3F803F80;
+                constexpr uint32_t ones = 0x3F803F80;  // 2 packed bfloat16 into 1 uint32_t of value 1.0
                 generate_tile_with_packed_bfloat16_values(cb_ones_id, ones);
 
                 if constexpr (is_mcast_sender) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -7,14 +7,20 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
+#include "experimental/tensor.h"
 
 void generate_tile_with_packed_bfloat16_values(uint32_t cb_id, uint32_t packed_bf16_value) {
-    cb_reserve_back(cb_id, 1);
-    uint32_t* ptr = reinterpret_cast<uint32_t*>(get_write_ptr(cb_id));
+    experimental::CircularBuffer cb(cb_id);
+    cb.reserve_back(1);
+    uint32_t* ptr = reinterpret_cast<uint32_t*>(cb.get_write_ptr());
     for (uint32_t i = 0; i < 512U; ++i) {
         *ptr++ = packed_bf16_value;
     }
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 void kernel_main() {
@@ -23,7 +29,6 @@ void kernel_main() {
     constexpr bool fuse_beta = get_compile_time_arg_val(2) == 1;
 
     // Used only if negative mask is passed in kernel, i.e. if define FUSE_NEGATIVE_MASK is defined
-
     constexpr uint32_t num_cols_tile_gamma_beta = get_compile_time_arg_val(3);
 
     constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
@@ -50,22 +55,27 @@ void kernel_main() {
     const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(8);
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(9);
 
-    constexpr uint32_t cb_gamma = tt::CBIndex::c_5;
-    constexpr uint32_t cb_beta = tt::CBIndex::c_6;
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
-    constexpr uint32_t cb_input_mask = tt::CBIndex::c_7;
-    constexpr uint32_t cb_ones = tt::CBIndex::c_26;
+    constexpr uint32_t cb_gamma_id = tt::CBIndex::c_5;
+    constexpr uint32_t cb_beta_id = tt::CBIndex::c_6;
+    constexpr uint32_t cb_out0_id = tt::CBIndex::c_16;
+    constexpr uint32_t cb_input_mask_id = tt::CBIndex::c_7;
+    constexpr uint32_t cb_ones_id = tt::CBIndex::c_26;
 
-    // constexpr uint32_t block_w = 4;
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_gamma(cb_gamma_id);
+    experimental::CircularBuffer cb_beta(cb_beta_id);
+    experimental::CircularBuffer cb_input_mask(cb_input_mask_id);
 
-    // input mask
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_gamma_id);
+    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(cb_input_mask_id);
+
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr, input_mask_single_tile_size_bytes);
 
 #if defined(FUSE_NEGATIVE_MASK)
-    constexpr uint32_t cb_input_negative_mask = tt::CBIndex::c_14;
-    const uint32_t input_negative_mask_single_tile_size_bytes = get_tile_size(cb_input_negative_mask);
+    constexpr uint32_t cb_input_negative_mask_id = tt::CBIndex::c_14;
+    const uint32_t input_negative_mask_single_tile_size_bytes = get_tile_size(cb_input_negative_mask_id);
+
+    experimental::CircularBuffer cb_input_negative_mask(cb_input_negative_mask_id);
 
     constexpr auto negative_mask_args = TensorAccessorArgs<input_mask_args.next_compile_time_args_offset()>();
     const auto negative_mask_tensor_accessor =
@@ -79,27 +89,27 @@ void kernel_main() {
         uint32_t input_negative_mask_tile_id = input_mask_tile_start_id;
 #endif
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-            cb_reserve_back(cb_input_mask, block_w);
-            uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
+            cb_input_mask.reserve_back(block_w);
+            uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_input_mask, block_w);
+            noc.async_read_barrier();
+            cb_input_mask.push_back(block_w);
 
 #if defined(FUSE_NEGATIVE_MASK)
-            cb_reserve_back(cb_input_negative_mask, block_w);
-            uint32_t l1_write_addr_input_negative_mask = get_write_ptr(cb_input_negative_mask);
+            cb_input_negative_mask.reserve_back(block_w);
+            uint32_t l1_write_addr_input_negative_mask = cb_input_negative_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc_async_read_tile(
                     input_negative_mask_tile_id, negative_mask_tensor_accessor, l1_write_addr_input_negative_mask);
                 l1_write_addr_input_negative_mask += input_negative_mask_single_tile_size_bytes;
                 input_negative_mask_tile_id += 1;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_input_negative_mask, block_w);
+            noc.async_read_barrier();
+            cb_input_negative_mask.push_back(block_w);
 #endif
 
             if (i == 0 and b == 0) {
@@ -107,8 +117,8 @@ void kernel_main() {
                 const uint32_t scalar_w = get_arg_val<uint32_t>(1);
                 generate_reduce_scaler(cb_in_2, scalar_w);
 
-                constexpr uint32_t ones = 0x3F803F80;  // 2 packed bfloat16 into 1 uint32_t of value 1.0
-                generate_tile_with_packed_bfloat16_values(cb_ones, ones);
+                constexpr uint32_t ones = 0x3F803F80;
+                generate_tile_with_packed_bfloat16_values(cb_ones_id, ones);
 
                 if constexpr (is_mcast_sender) {
                     constexpr uint32_t cb_in_4 = tt::CBIndex::c_4;
@@ -121,18 +131,18 @@ void kernel_main() {
                 generate_bcast_col_scalar(eps_cb_id, eps);
 
                 if constexpr (fuse_gamma) {
-                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+                    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr, size);
 
-                    cb_reserve_back(cb_gamma, num_cols_tile_gamma_beta);
-                    uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
+                    cb_gamma.reserve_back(num_cols_tile_gamma_beta);
+                    uint32_t l1_write_addr_gamma = cb_gamma.get_write_ptr();
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = gamma_tile_start_id + w;
                         uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
 #ifdef ARCH_BLACKHOLE
                         noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32 * 2);
                         gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + 32);
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #else
                         noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
                         gamma_noc_addr += 32;
@@ -140,23 +150,23 @@ void kernel_main() {
                         noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_gamma, num_cols_tile_gamma_beta);
+                    noc.async_read_barrier();
+                    cb_gamma.push_back(num_cols_tile_gamma_beta);
                 }
 
                 if constexpr (fuse_beta) {
-                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+                    const uint32_t beta_tile_bytes = get_tile_size(cb_beta_id);
                     const auto beta = TensorAccessor(beta_args, beta_addr, size);
 
-                    uint32_t l1_write_addr_beta = get_write_ptr(cb_beta);
-                    cb_reserve_back(cb_beta, num_cols_tile_gamma_beta);
+                    uint32_t l1_write_addr_beta = cb_beta.get_write_ptr();
+                    cb_beta.reserve_back(num_cols_tile_gamma_beta);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = beta_tile_start_id + w;
                         uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
 #ifdef ARCH_BLACKHOLE
                         noc_async_read(beta_noc_addr, l1_write_addr_beta, 32 * 2);
                         beta_noc_addr = get_noc_addr(l1_write_addr_beta + 32);
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #else
                         noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
                         beta_noc_addr += 32;
@@ -164,8 +174,8 @@ void kernel_main() {
                         noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_beta, num_cols_tile_gamma_beta);
+                    noc.async_read_barrier();
+                    cb_beta.push_back(num_cols_tile_gamma_beta);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -16,7 +16,7 @@
 void generate_tile_with_packed_bfloat16_values(uint32_t cb_id, uint32_t packed_bf16_value) {
     experimental::CircularBuffer cb(cb_id);
     cb.reserve_back(1);
-    uint32_t* ptr = reinterpret_cast<uint32_t*>(cb.get_write_ptr());
+    experimental::CoreLocalMem<uint32_t> ptr(cb.get_write_ptr());
     for (uint32_t i = 0; i < 512U; ++i) {
         *ptr++ = packed_bf16_value;
     }
@@ -92,7 +92,12 @@ void kernel_main() {
             cb_input_mask.reserve_back(block_w);
             uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
-                noc_async_read_tile(input_mask_tile_id, mask, l1_write_addr_input_mask);
+                noc.async_read(
+                    mask,
+                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                    input_mask_single_tile_size_bytes,
+                    {.page_id = input_mask_tile_id},
+                    {});
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
@@ -103,8 +108,12 @@ void kernel_main() {
             cb_input_negative_mask.reserve_back(block_w);
             uint32_t l1_write_addr_input_negative_mask = cb_input_negative_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
-                noc_async_read_tile(
-                    input_negative_mask_tile_id, negative_mask_tensor_accessor, l1_write_addr_input_negative_mask);
+                noc.async_read(
+                    negative_mask_tensor_accessor,
+                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_input_negative_mask),
+                    input_negative_mask_single_tile_size_bytes,
+                    {.page_id = input_negative_mask_tile_id},
+                    {});
                 l1_write_addr_input_negative_mask += input_negative_mask_single_tile_size_bytes;
                 input_negative_mask_tile_id += 1;
             }
@@ -138,16 +147,35 @@ void kernel_main() {
                     uint32_t l1_write_addr_gamma = cb_gamma.get_write_ptr();
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = gamma_tile_start_id + w;
-                        uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
 #ifdef ARCH_BLACKHOLE
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32 * 2);
-                        gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + 32);
+                        noc.async_read(
+                            gamma,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma),
+                            32 * 2,
+                            {.page_id = tile_id},
+                            {});
                         noc.async_read_barrier();
+                        experimental::UnicastEndpoint self_ep;
+                        noc.async_read(
+                            self_ep,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
+                            32,
+                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_gamma + 32},
+                            {});
 #else
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma, 32);
-                        gamma_noc_addr += 32;
+                        noc.async_read(
+                            gamma,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma),
+                            32,
+                            {.page_id = tile_id},
+                            {});
+                        noc.async_read(
+                            gamma,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_gamma + 512),
+                            32,
+                            {.page_id = tile_id, .offset_bytes = 32},
+                            {});
 #endif
-                        noc_async_read(gamma_noc_addr, l1_write_addr_gamma + 512, 32);
                         l1_write_addr_gamma += gamma_tile_bytes;
                     }
                     noc.async_read_barrier();
@@ -162,16 +190,35 @@ void kernel_main() {
                     cb_beta.reserve_back(num_cols_tile_gamma_beta);
                     for (uint32_t w = 0; w < num_cols_tile_gamma_beta; w++) {
                         uint32_t tile_id = beta_tile_start_id + w;
-                        uint64_t beta_noc_addr = get_noc_addr(tile_id, beta);
 #ifdef ARCH_BLACKHOLE
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 32 * 2);
-                        beta_noc_addr = get_noc_addr(l1_write_addr_beta + 32);
+                        noc.async_read(
+                            beta,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta),
+                            32 * 2,
+                            {.page_id = tile_id},
+                            {});
                         noc.async_read_barrier();
+                        experimental::UnicastEndpoint self_ep;
+                        noc.async_read(
+                            self_ep,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
+                            32,
+                            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = l1_write_addr_beta + 32},
+                            {});
 #else
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta, 32);
-                        beta_noc_addr += 32;
+                        noc.async_read(
+                            beta,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta),
+                            32,
+                            {.page_id = tile_id},
+                            {});
+                        noc.async_read(
+                            beta,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_beta + 512),
+                            32,
+                            {.page_id = tile_id, .offset_bytes = 32},
+                            {});
 #endif
-                        noc_async_read(beta_noc_addr, l1_write_addr_beta + 512, 32);
                         l1_write_addr_beta += beta_tile_bytes;
                     }
                     noc.async_read_barrier();


### PR DESCRIPTION
### Ticket
Link to Github Issue #38901

### Problem description
A new device 2.0 api is available

### What's changed
- Use the new api for ttnn.group_norm kernels
- Update perf threshold for a specific group norm perf test since perf improved just over 2% and acceptable range is 1.5%

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-38901_gn_m20)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38901_gn_m20)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38901_gn_m20)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38901_gn_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38901_gn_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38901_gn_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38901_gn_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
