### PR TITLE
Fix Inspector null dereference on mock devices

### DIFF
--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -33,7 +33,11 @@ inspector::Data* get_inspector_data() {
 // Inspector is not used on mock devices
 bool Inspector::is_enabled() {
     if (tt::tt_metal::MetalContext::instance_exists(DEFAULT_CONTEXT_ID)) {
-        return tt::tt_metal::MetalContext::instance(DEFAULT_CONTEXT_ID).rtoptions().get_inspector_enabled();
+        auto& ctx = tt::tt_metal::MetalContext::instance(DEFAULT_CONTEXT_ID);
+        if (ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+            return false;
+        }
+        return ctx.rtoptions().get_inspector_enabled();
     }
     return false;
 }
@@ -366,8 +370,11 @@ void Inspector::mesh_workload_set_operation_name_and_parameters(
     if (!is_enabled()) {
         return;
     }
+    auto* data = get_inspector_data();
+    if (!data) {
+        return;
+    }
     try {
-        auto* data = get_inspector_data();
         std::lock_guard<std::mutex> lock(data->mesh_workloads_mutex);
         auto& mesh_workload_data = data->mesh_workloads_data[mesh_workload->get_id()];
         mesh_workload_data.name = std::string(operation_name);


### PR DESCRIPTION
## Ticket: 
https://github.com/tenstorrent/tt-metal/issues/40630

## Problem description:
Inspector::mesh_workload_set_operation_name_and_parameters segfaults on mock devices. Inspector::is_enabled() returns true (because InspectorSettings::enabled defaults to true), but Inspector::initialize() is intentionally skipped for mock devices in MetalContext initialization — leaving inspector_data_ as nullptr. When any TTNN operation (e.g. ttnn::relu via query_op_constraints) triggers an Inspector annotation call, it dereferences the null pointer at data->mesh_workloads_mutex, causing a segfault.

## What's changed:
Inspector::is_enabled() now explicitly checks if the MetalContext is running on a mock device (TargetDevice::Mock) and returns false, preventing any Inspector code paths from executing in mock mode.
Defense-in-depth null check added in mesh_workload_set_operation_name_and_parameters on the get_inspector_data() return value, so even if is_enabled() logic is bypassed in the future, the function safely returns instead of dereferencing a null pointer.
