### PR TITLE
Updating ccl and model config to be compatible for DUAL + QUAD

### DIFF
--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -41,6 +41,8 @@ def get_num_links(mesh_device, cluster_axis=None):
         "P300": (2, 2),
         "BHGLX": (2, 2),
         "TG": (4, 4),
+        "DUAL": (4, 4),
+        "QUAD": (4, 4),
         "N150x4": (1, 1),
     }
     device_links = link_dict[device_name]

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -4387,6 +4387,8 @@ def determine_device_name(mesh_device):
             4: "N150x4",
             8: "T3K",
             32: "TG",
+            64: "DUAL",
+            128: "QUAD",
         }
     else:
         raise ValueError(f"Unsupported architecture: {arch_name}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40656

### Problem description
The determine_device_name() function is called to identify the hardware configuration. Without these entries, when running on a 128-device QUAD Galaxy setup, it throws: `ValueError: Unsupported number of devices: 128 for wormhole_b0`

The get_num_links() function uses this dictionary to determine how many Ethernet links to use for collective operations (all_gather, reduce_scatter). Without these entries, you get: `KeyError: 'QUAD'`

### What's changed
model_config.py - Recognizes 64/128 device Galaxy configs as "DUAL"/"QUAD"
ccl.py - Provides (4,4) link counts for collective ops on these configs

### Checklist

[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-quad-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-quad-config)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=ds-quad-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:ds-quad-config)
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=ds-quad-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:ds-quad-config)
[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=ds-quad-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:ds-quad-config)