### PR TITLE
[skip ci] Temporarily disable flaky tt-triage tests in merge gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -387,6 +387,7 @@ jobs:
       run-metal-cpp-unit-tests: true
 
   triage-tests:
+    if: ${{ false }} # Temporarily disabled in merge gate due to inconsistent failures; tracked in https://github.com/tenstorrent/tt-metal/issues/40659.
     needs: [ build, find-changes ]
     strategy:
       fail-fast: false
@@ -416,14 +417,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, docker-images, code-analysis, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests]
+    needs: [static-checks, docker-images, code-analysis, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, fabric-unit-tests, fabric-cpu-only-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, code-analysis, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, fabric-unit-tests, fabric-cpu-only-unit-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')


### PR DESCRIPTION
## Summary
- Temporarily disable `triage-tests` in merge gate due to inconsistent failures
- Remove `triage-tests` from merge-gate aggregate `needs` and `optional-jobs` so it no longer blocks merge-gate status
- Link follow-up investigation ticket: https://github.com/tenstorrent/tt-metal/issues/40659

## Test plan
- [x] `Check Yaml` pre-commit hook passes
- [x] `yamllint` pre-commit hook passes
- [ ] Observe next merge-gate runs to confirm `triage-tests` is skipped and no longer participates in aggregate status

Made with [Cursor](https://cursor.com)