### PR TITLE
Remove WH tests from ttsim skip list that pass on BH

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -201,4 +201,3 @@ blackhole:
   - tests/ttnn/unit_tests/operations/reduce/test_moe.py
   - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
   - tests/ttnn/unit_tests/operations/reduce/test_manual_seed.py
-

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -22,6 +22,9 @@ wormhole_b0:
 
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
+  - tests/ttnn/unit_tests/base_functionality/test_expand.py
+  - tests/ttnn/unit_tests/base_functionality/test_roll.py
+  - tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
   - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
 
@@ -31,16 +34,35 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
 
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_relational.py
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_divide.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_mul.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
 
   # Pool tests
@@ -57,6 +79,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
 
   # Matmul tests
+  - tests/ttnn/unit_tests/operations/matmul/test_addmm.py
   - tests/ttnn/unit_tests/operations/matmul/test_matmul.py
   - tests/ttnn/unit_tests/operations/matmul/test_linear.py
 

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -22,9 +22,6 @@ wormhole_b0:
 
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
-  - tests/ttnn/unit_tests/base_functionality/test_expand.py
-  - tests/ttnn/unit_tests/base_functionality/test_roll.py
-  - tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
   - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
 
@@ -34,53 +31,17 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
 
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
   - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_pow.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_relational.py
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_activation.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_composite.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_divide.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_math.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_fill.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_mul.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
 
   # Pool tests
   - tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -96,11 +57,8 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
 
   # Matmul tests
-  - tests/ttnn/unit_tests/operations/matmul/test_addmm.py
   - tests/ttnn/unit_tests/operations/matmul/test_matmul.py
   - tests/ttnn/unit_tests/operations/matmul/test_linear.py
-  - tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
-  - tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
 
   # Fused tests
   - tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -111,9 +69,6 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
   - tests/ttnn/unit_tests/operations/fused/parallel_sequential/
-
-  # Transformers tests
-  - tests/ttnn/unit_tests/operations/transformers/test_transformer.py
 
   # Reduce tests
   - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -49,12 +49,17 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
   - tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_activation.py
   - tests/ttnn/unit_tests/operations/eltwise/test_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_divide.py
   - tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -64,6 +69,11 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
   - tests/ttnn/unit_tests/operations/eltwise/test_mul.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
 
   # Pool tests
   - tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -37,6 +37,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -47,10 +48,9 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -64,14 +64,14 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_divide.py
   - tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
   - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_fill.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
   - tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
   - tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
   - tests/ttnn/unit_tests/operations/eltwise/test_mul.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_fill.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
   - tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
   - tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
 
@@ -102,6 +102,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/fused/test_group_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
   - tests/ttnn/unit_tests/operations/fused/parallel_sequential/
+
 
   # Reduce tests
   - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -200,3 +201,4 @@ blackhole:
   - tests/ttnn/unit_tests/operations/reduce/test_moe.py
   - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
   - tests/ttnn/unit_tests/operations/reduce/test_manual_seed.py
+


### PR DESCRIPTION
### What's changed

Removes tests from the WH ttsim skip list that are already passing on BH (removed in #40319 and #39456). Since BH passes these, WH should too.

*Removed from WH skip list (43 tests):*
- 36 eltwise tests (int32/uint32/fp32/activation/composite/math/etc.)
- 3 matmul tests (addmm, sparse_matmul, matmul_deepseek)
- 3 base_functionality tests (expand, roll, tilize_untilize_2D)
- 1 transformers test (test_transformer)

Typecast tests (test_eltwise_typecast, test_binary_ng_typecast, test_typecast_int) intentionally kept pending tt-llk submodule bump with SFPLOADMACRO typecast fixes.

### Checklist
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/ttsim-skip-list-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/ttsim-skip-list-wh)