### PR TITLE
Fix profiler zone source location file corruption

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -244,7 +244,22 @@ void populateZoneSrcLocations(
         std::getline(ss, source_file, ',');
         std::getline(ss, line_num_str, ',');
 
-        tracy::MarkerDetails details(zone_name, source_file, std::stoull(line_num_str));
+        if (line_num_str.empty()) {
+            log_warning(tt::LogMetal, "Skipping malformed zone source location entry: {}", zone_src_location);
+            continue;
+        }
+        uint64_t line_num = 0;
+        try {
+            line_num = std::stoull(line_num_str);
+        } catch (const std::exception& e) {
+            log_warning(
+                tt::LogMetal,
+                "Skipping zone source location with invalid line number '{}': {}",
+                line_num_str,
+                e.what());
+            continue;
+        }
+        tracy::MarkerDetails details(zone_name, source_file, line_num);
 
         auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
         if (ret.second && push_new) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -254,7 +254,8 @@ void populateZoneSrcLocations(
         } catch (const std::exception& e) {
             log_warning(
                 tt::LogMetal,
-                "Skipping zone source location with invalid line number '{}': {}",
+                "Skipping zone source location entry '{}' with invalid line number '{}': {}",
+                zone_src_location,
                 line_num_str,
                 e.what());
             continue;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -660,6 +661,10 @@ void JitBuildState::weaken(const string& out_dir) const {
 void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const {
     // ZoneScoped;
     static std::atomic<bool> new_log = true;
+    // Mutex to serialize concurrent writes to the shared zone src locations log file.
+    // Multiple kernels are compiled in parallel; without serialization their grep outputs
+    // interleave in the file, producing corrupted lines that fail to parse.
+    static std::mutex zone_log_mutex;
     if (env_.get_rtoptions().get_profiler_enabled()) {
         if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
             std::remove(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG.c_str());
@@ -670,6 +675,7 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
         }
 
         auto cmd = fmt::format("grep KERNEL_PROFILER {}*.o.log", out_dir);
+        std::lock_guard<std::mutex> lk(zone_log_mutex);
         tt::jit_build::utils::run_command(
             cmd, tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, env_.get_rtoptions().get_dump_build_commands());
     }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -666,6 +666,7 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
     // interleave in the file, producing corrupted lines that fail to parse.
     static std::mutex zone_log_mutex;
     if (env_.get_rtoptions().get_profiler_enabled()) {
+        std::lock_guard<std::mutex> lk(zone_log_mutex);
         if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
             std::remove(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG.c_str());
         }
@@ -675,7 +676,6 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
         }
 
         auto cmd = fmt::format("grep KERNEL_PROFILER {}*.o.log", out_dir);
-        std::lock_guard<std::mutex> lk(zone_log_mutex);
         tt::jit_build::utils::run_command(
             cmd, tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, env_.get_rtoptions().get_dump_build_commands());
     }

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -11,6 +11,8 @@
 #include <reflect>
 #include <set>
 #include <stack>
+#include <string_view>
+#include <unordered_set>
 
 #include <enchantum/enchantum.hpp>
 #include <fmt/format.h>
@@ -232,6 +234,11 @@ inline void tracy_frame() {
 
 #if defined(TRACY_ENABLE)
 static inline json get_kernels_json(ChipId device_id, const Program& program) {
+    // Deduplicate by source file: ops with per-core compile-time args produce one
+    // Kernel object per core (all sharing the same source), which would otherwise
+    // emit hundreds of identical entries and blow past Tracy's 64KiB message limit.
+    std::unordered_set<std::string_view> seenComputeSources;
+    std::unordered_set<std::string_view> seenDMSources;
     std::vector<json> computeKernels;
     std::vector<json> datamovementKernels;
 
@@ -530,9 +537,29 @@ inline std::string op_meta_data_serialized_json(
             cached_ops.at(device_id).emplace(program_hash, short_str);
         }
 
+        // Tracy hard limit is uint16_t::max bytes including null terminator.
+        // The message is wrapped in backticks which serve as the CSV quotechar.
+        // If the message is truncated by tracy_message(), the closing backtick is
+        // lost, causing the CSV reader to absorb subsequent rows into this field.
+        // Build with pretty JSON first, then compact, then drop kernel_info to fit.
+        constexpr size_t tracy_limit = std::numeric_limits<uint16_t>::max() - 1;
         auto msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(4));
-        if (msg.size() >= std::numeric_limits<uint16_t>::max()) {
+        if (msg.size() > tracy_limit) {
             msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
+        }
+        if (msg.size() > tracy_limit) {
+            // kernel_info is the largest field. Drop it to fit within the limit;
+            // process_ops_logs.py guards all kernel_info accesses with "if in".
+            j.erase("kernel_info");
+            msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
+            log_warning(
+                tt::LogMetal,
+                "Tracy op profiler message for op '{}' (call {}, device {}) exceeded the {} byte limit even after "
+                "compacting JSON. kernel_info was dropped from the perf report for this op.",
+                j.value("op_code", "?"),
+                operation_id,
+                device_id,
+                tracy_limit);
         }
         return msg;
     }

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -237,8 +237,6 @@ static inline json get_kernels_json(ChipId device_id, const Program& program) {
     // Deduplicate by source file: ops with per-core compile-time args produce one
     // Kernel object per core (all sharing the same source), which would otherwise
     // emit hundreds of identical entries and blow past Tracy's 64KiB message limit.
-    std::unordered_set<std::string_view> seenComputeSources;
-    std::unordered_set<std::string_view> seenDMSources;
     std::vector<json> computeKernels;
     std::vector<json> datamovementKernels;
 
@@ -548,18 +546,20 @@ inline std::string op_meta_data_serialized_json(
             msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
         }
         if (msg.size() > tracy_limit) {
-            // kernel_info is the largest field. Drop it to fit within the limit;
-            // process_ops_logs.py guards all kernel_info accesses with "if in".
             j.erase("kernel_info");
             msg = fmt::format("{}{} ->\n{}`", short_str, operation_id, j.dump(-1));
+        }
+        if (msg.size() > tracy_limit) {
             log_warning(
                 tt::LogMetal,
                 "Tracy op profiler message for op '{}' (call {}, device {}) exceeded the {} byte limit even after "
-                "compacting JSON. kernel_info was dropped from the perf report for this op.",
+                "dropping kernel_info ({} bytes). Message discarded.",
                 j.value("op_code", "?"),
                 operation_id,
                 device_id,
-                tracy_limit);
+                tracy_limit,
+                msg.size());
+            return {};
         }
         return msg;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40666

### Problem description
Zone source location is corrupted on some runs


### What's changed
Lock the zone source location file on threaded jit compiles.

Catch corrupted zone source data and drop it instead of crashing.

### Checklist

https://github.com/tenstorrent/tt-metal/actions/runs/23519312907