### PR TITLE
#0: Update kv cache update to use both RISCs

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -255,7 +255,22 @@ void kernel_main() {
         .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
     };
 
-    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
+        .local_cur_pos = 0,
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+        .kv_cache_cur_pos_ready_semaphore_addr =
+            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+    };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -577,22 +592,11 @@ void kernel_main() {
     // Writer args (empty - no-op)
     deepseek_b1_ops::Rope::WriterArgs krope_args{};
 
-    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
-        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
-        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
-        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
-        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-        .kv_cache_cur_pos_ready_semaphore_addr =
-            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1462,12 +1462,12 @@ class AttentionBlock:
             ("krope_Ht", krope_Ht),
         ]
 
-        # KVCacheUpdate CB indices and krope_Wt passed as runtime args (ReaderArgs/WriterArgs/ComputeArgs)
-        kv_cache_brisc_named_compile_time_args = [
+        # KVCacheUpdate compile-time args split across NCRISC (patch + writeback) and BRISC (DRAM read)
+        kv_cache_ncrisc_named_compile_time_args = [
+            ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
             ("krope_output_cb", krope_output_cb),
-            ("kv_cache_output_cb", kv_cache_output_cb),
-            ("kv_cache_input_cb", kv_cache_input_cb),
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
             ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
             ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
@@ -1475,6 +1475,10 @@ class AttentionBlock:
             ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
             ("full_grid_mcast_num_dests", mcast_num_cores - 1),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
+        ]
+        kv_cache_brisc_named_compile_time_args = [
+            ("kv_cache_input_cb", kv_cache_input_cb),
+            ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
         ]
         kv_cache_trisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
@@ -3067,6 +3071,7 @@ class AttentionBlock:
             + kv_rmsnorm_ncrisc_named_compile_time_args
             + dkv_gather_sender_named_compile_time_args
             + krope_ncrisc_named_compile_time_args
+            + kv_cache_ncrisc_named_compile_time_args
             + mla_ncrisc_named_compile_time_args
             + post_sdpa_ncrisc_named_compile_time_args
         )

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -294,7 +294,22 @@ void kernel_main() {
         .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
     };
 
-    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
+        .local_cur_pos = 0,
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+        .kv_cache_cur_pos_ready_semaphore_addr =
+            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+    };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -616,22 +631,11 @@ void kernel_main() {
     // Writer args (empty - no-op)
     deepseek_b1_ops::Rope::WriterArgs krope_args{};
 
-    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
-        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
-        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
-        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
-        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-        .kv_cache_cur_pos_ready_semaphore_addr =
-            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -259,7 +259,22 @@ if constexpr (!Core::skip_ccl) {
         .sin_tensor_address = get_named_compile_time_arg_val("krope_sin_tensor_address"),
         .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address")};
 
-    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(5),
+        .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+        .kv_cache_cur_pos_ready_semaphore_addr =
+            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+    };
 
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -429,22 +444,11 @@ if constexpr (!Core::skip_ccl) {
     // Writer args (empty - no-op)
     deepseek_b1_ops::Rope::WriterArgs krope_args{};
 
-    deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
-        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
-        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
-        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
-        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-        .kv_cache_cur_pos_ready_semaphore_addr =
-            get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1081,14 +1081,12 @@ class PreSDPA:
             ("krope_Ht", krope_Ht),
         ]
 
-        # KVCacheUpdate CB indices and krope_Wt passed as runtime args (ReaderArgs/WriterArgs/ComputeArgs)
+        # KVCacheUpdate compile-time args split across NCRISC (patch + writeback) and BRISC (DRAM read)
         flash_mla_program_config = FlashMLADecode.ProgramConfig()
         device_chunk_size = flash_mla_program_config.device_chunk_size
-        kv_cache_brisc_named_compile_time_args = [
-            ("krope_output_cb", krope_output_cb),
-            ("kv_cache_output_cb", kv_cache_output_cb),
-            ("kv_cache_input_cb", kv_cache_input_cb),
+        kv_cache_ncrisc_named_compile_time_args = [
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
             ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
             ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
@@ -1096,6 +1094,10 @@ class PreSDPA:
             ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
             ("full_grid_mcast_num_dests", mcast_num_cores - 1),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
+        ]
+        kv_cache_brisc_named_compile_time_args = [
+            ("kv_cache_input_cb", kv_cache_input_cb),
+            ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
         ]
         kv_cache_trisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
@@ -2093,6 +2095,7 @@ class PreSDPA:
                     + dkv_gather_sender_named_compile_time_args
                     + krope_ncrisc_named_compile_time_args
                     + krope_ncrisc_addr_args
+                    + kv_cache_ncrisc_named_compile_time_args
                     + kv_cache_sp_named_compile_time_args
                     + mla_ncrisc_named_compile_time_args
                 )

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -3,10 +3,9 @@
 
 // KV Cache Update kernel: uses KVCacheUpdate Op from kv_cache_update.hpp
 //
-// NCRISC (IsNopeCore): Read 16 BFP8 tiles from DRAM into kv_cache_input_cb
-// NCRISC (IsRopeCore): Pop krope_output_cb
-// BRISC (IsNopeCore): Wait on intermed/rmsnorm, push intermed, read output_cb
-// TRISC (IsNopeCore): Untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
+// BRISC: Stream existing KV cache pages from DRAM into kv_cache_input_cb
+// NCRISC: Wait on compute, patch new data, wait on compute, write back to DRAM
+// TRISC: Untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
@@ -19,7 +18,6 @@ struct Core {
 
 void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
-    deepseek_b1_ops::KVCacheUpdate::ReaderArgs args{};
     if (Core::is_nope_core) {
         uint32_t kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb");
         unified_kernels::setup_sharded_buffer(kv_rmsnorm_output_cb, 1);
@@ -28,11 +26,9 @@ void kernel_main() {
         uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
         unified_kernels::setup_sharded_buffer(krope_output_cb, 1);
     }
-#elif defined(COMPILE_FOR_BRISC)
     deepseek_b1_ops::KVCacheUpdate::WriterArgs args{
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,
-        .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
@@ -46,6 +42,13 @@ void kernel_main() {
         .kv_cache_cur_pos_ready_semaphore_addr =
             get_semaphore(get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_id")),
     };
+#elif defined(COMPILE_FOR_BRISC)
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
+        .local_cur_pos = 0,
+        .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+    };
 #elif defined(COMPILE_FOR_TRISC)
     deepseek_b1_ops::KVCacheUpdate::ComputeArgs args{
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
@@ -57,7 +60,7 @@ void kernel_main() {
 #endif
 
     deepseek_b1_ops::KVCacheUpdate::Op<Core::is_nope_core, Core::is_rope_core> op;
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
     {
         uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
         volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
@@ -72,17 +72,12 @@ class KVCacheUpdate:
         full_grid_mcast_end_core = device.worker_core_from_logical_core(full_device_grid.end)
         full_grid_mcast_num_dests = full_device_grid.grid_size().x * full_device_grid.grid_size().y
 
-        # CB indices and krope_Wt passed as named compile-time args; kernel uses get_named_compile_time_arg_val
+        # CB indices passed as named compile-time args; kernel uses get_named_compile_time_arg_val
         ncrisc_named = [
             ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
             ("krope_output_cb", KROPE_OUTPUT_CB),
-        ]
-        brisc_named = [
-            ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
-            ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
             ("kv_cache_intermed_cb", KV_CACHE_INTERMED_CB),
-            ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
-            ("krope_output_cb", KROPE_OUTPUT_CB),
+            ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
             ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
             ("full_grid_mcast_start_x", full_grid_mcast_start_core.x),
             ("full_grid_mcast_start_y", full_grid_mcast_start_core.y),
@@ -90,6 +85,10 @@ class KVCacheUpdate:
             ("full_grid_mcast_end_y", full_grid_mcast_end_core.y),
             ("full_grid_mcast_num_dests", full_grid_mcast_num_dests - 1),
             ("kv_cache_cur_pos_ready_semaphore_id", 0),
+        ]
+        brisc_named = [
+            ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
+            ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
         ]
         trisc_named = [
             ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
@@ -152,7 +151,7 @@ class KVCacheUpdate:
             initial_value=0,
         )
         pos_addr = position_ids_tensor.buffer_address()
-        ncrisc_common_runtime_args = [full_kv_cache_tensor.buffer_address()]
+        ncrisc_common_runtime_args = [full_kv_cache_tensor.buffer_address(), pos_addr]
         brisc_common_runtime_args = [full_kv_cache_tensor.buffer_address(), pos_addr]
 
         kernel_desc = UnifiedKernelDescriptor(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -55,6 +55,7 @@ from models.demos.deepseek_v3_b1.utils import generate_mm_weights
         pytest.param(6644, marks=pytest.mark.skip_post_commit),  # (2,2,1 + partial,1): partial into dev2 (if SP = 4)
         pytest.param(9916, marks=pytest.mark.skip_post_commit),  # (3,2 + partial,2,2): partial into dev1 (if SP = 4)
         pytest.param(11664, marks=pytest.mark.skip_post_commit),  # (3,3,3,2 + partial): partial into dev3 (if SP = 4)
+        pytest.param(8191, marks=pytest.mark.skip_post_commit),  # For benchmarking 8K seq len
     ],
 )  # Must test 128 chunk aligned decode positions, add other tests when causal masks are in for SDPA
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -7,9 +7,9 @@
 
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
-#include "mcast.hpp"
 #elif defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
+#include "mcast.hpp"
 #elif defined(COMPILE_FOR_TRISC)
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/pack_untilize.h"
@@ -25,6 +25,10 @@ namespace deepseek_b1_ops {
 // Computes: Update existing KV Cache with 1x576 new cache
 // assumes one core with 1x512 NOPE cache and 2 cores each with 1x32 ROPE cache
 //
+// BRISC: streams existing KV cache pages from DRAM into kv_cache_input_cb
+// NCRISC: waits on compute (untilize), patches new data, waits on compute
+//         (tilize), writes updated pages back to DRAM, signals cache ready
+// TRISC: untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
 // ============================================================================
 struct KVCacheUpdate {
     // ========================================================================
@@ -32,7 +36,7 @@ struct KVCacheUpdate {
     // (used as template parameters or in constexpr expressions)
     // ========================================================================
 
-    // Reader CTArgs:none needed
+    // Reader CTArgs: none needed
     struct ReaderCTArgs {};
 
     // Writer CTArgs: none needed
@@ -45,11 +49,9 @@ struct KVCacheUpdate {
     // Runtime args structs - different layout per RISC
     // CB indices etc. filled in kernel via get_named_compile_time_arg_val
     // ========================================================================
-    struct ReaderArgs {};
     struct WriterArgs {
         uint32_t kv_cache_buffer_base_addr;
         uint32_t local_cur_pos;
-        uint32_t kv_cache_input_cb;
         uint32_t kv_cache_intermed_cb;
         uint32_t kv_cache_output_cb;
         uint32_t kv_rmsnorm_output_cb;
@@ -62,13 +64,19 @@ struct KVCacheUpdate {
         uint32_t full_grid_mcast_num_dests;
         uint32_t kv_cache_cur_pos_ready_semaphore_addr;
     };
+    struct ReaderArgs {
+        uint32_t kv_cache_buffer_base_addr;
+        uint32_t local_cur_pos;
+        uint32_t kv_cache_input_cb;
+        uint32_t grid_start_y;
+    };
     struct ComputeArgs {
         uint32_t kv_cache_input_cb;
         uint32_t kv_cache_output_cb;
         uint32_t kv_cache_intermed_cb;
     };
 
-    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+    using RTArgs = unified_kernels::SelectByRISCV<WriterArgs, ReaderArgs, ComputeArgs>;
 
     // ========================================================================
     // Op - full KV cache update (owning device)
@@ -79,13 +87,13 @@ struct KVCacheUpdate {
         void operator()([[maybe_unused]] const RTArgs& args) { impl(args); }
 
         void set_local_cur_pos([[maybe_unused]] RTArgs& args, [[maybe_unused]] uint32_t local_cur_pos) {
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
             args.local_cur_pos = local_cur_pos;
 #endif
         }
 
         void signal_cache_ready([[maybe_unused]] const RTArgs& args) {
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC)
             if constexpr (IsRopeCore || IsNopeCore) {
                 static_assert(noc_mode == DM_DYNAMIC_NOC, "KV Cache Update only supports DM_DYNAMIC_NOC");
                 constexpr uint8_t MCAST_NOC = 0;
@@ -106,16 +114,12 @@ struct KVCacheUpdate {
 
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
             if constexpr (IsRopeCore || IsNopeCore) {
-                uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
-                uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
-                uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
-                uint32_t new_cache_cb = IsRopeCore ? args.krope_output_cb : args.kv_rmsnorm_output_cb;
                 constexpr uint32_t PAGE_SIZE = 1088;
                 constexpr uint32_t PAGES_PER_BLOCK = 18;
                 constexpr uint32_t CACHES_PER_BLOCK = 32;
-                constexpr uint32_t nope_num_pages = 16;  // Offset in 1x576 for rope component
+                constexpr uint32_t nope_num_pages = 16;
                 constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
 
                 uint32_t cur_pos = args.local_cur_pos;
@@ -123,17 +127,16 @@ struct KVCacheUpdate {
                 constexpr auto k_args = TensorAccessorArgs<0>();
                 auto kv_tensor_accessor = TensorAccessor(k_args, args.kv_cache_buffer_base_addr, PAGE_SIZE);
 
-                // This op needs to update 18 pages starting from kv_cache_page_id_start
-                // If cur_pos % CACHES_PER_BLOCK != 0, there is an offset into the rows
                 uint32_t kv_cache_page_id_start = cur_pos / CACHES_PER_BLOCK * PAGES_PER_BLOCK;
-                uint32_t offset_in_page = cur_pos % CACHES_PER_BLOCK;
-                uint32_t num_bytes_per_core = IsRopeCore ? 64 : 1024;
-
-                if (IsRopeCore) {
+                if constexpr (IsRopeCore) {
                     uint32_t grid_offset_pages = 1 * (get_absolute_logical_y() - args.grid_start_y);
                     kv_cache_page_id_start += grid_offset_pages;
                     kv_cache_page_id_start += nope_num_pages;
                 }
+
+#if defined(COMPILE_FOR_BRISC)
+                // BRISC: stream existing KV cache pages from DRAM into kv_cache_input_cb
+                uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
 
                 cb_reserve_back(kv_cache_input_cb, kv_cache_num_tiles);
                 uint32_t cb_addr = get_write_ptr(kv_cache_input_cb);
@@ -144,8 +147,15 @@ struct KVCacheUpdate {
                 noc_async_read_barrier();
 
                 cb_push_back(kv_cache_input_cb, kv_cache_num_tiles);
+#elif defined(COMPILE_FOR_NCRISC)
+                // NCRISC: wait on compute, patch new data, wait on compute, write back to DRAM
+                uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
+                uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
+                uint32_t new_cache_cb = IsRopeCore ? args.krope_output_cb : args.kv_rmsnorm_output_cb;
+                uint32_t offset_in_page = cur_pos % CACHES_PER_BLOCK;
+                uint32_t num_bytes_per_core = IsRopeCore ? 64 : 1024;
 
-                // wait for unpacker to untilize
+                // 1. Wait for TRISC to finish untilize into kv_cache_intermed_cb
                 cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles);
 
                 // 2. Wait for new cache data and update into kv_cache_intermed_cb
@@ -153,7 +163,6 @@ struct KVCacheUpdate {
 
                 uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + offset_in_page * num_bytes_per_core;
                 uint32_t new_cache_addr = get_read_ptr(new_cache_cb);
-                // Local copy data from new cache to intermed, 1x512 for nope, 1x64 for rope (1x32 per core)
                 {
                     uint32_t words_per_face = (num_bytes_per_core >> 2);
                     volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(new_cache_addr);
@@ -168,13 +177,14 @@ struct KVCacheUpdate {
                 // 3. Wait for TRISC to finish tilize into kv_cache_output_cb and write out to DRAM
                 cb_wait_front(kv_cache_output_cb, kv_cache_num_tiles);
 
-                cb_addr = get_read_ptr(kv_cache_output_cb);
+                uint32_t cb_addr = get_read_ptr(kv_cache_output_cb);
                 for (uint32_t i = 0; i < kv_cache_num_tiles; i++) {
                     noc_async_write_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
                     cb_addr += kv_tensor_accessor.get_aligned_page_size();
                 }
                 noc_async_write_barrier();
                 cb_pop_front(kv_cache_output_cb, kv_cache_num_tiles);
+#endif
             }
 #elif defined(COMPILE_FOR_TRISC)
             if constexpr (IsNopeCore || IsRopeCore) {
@@ -199,10 +209,10 @@ struct KVCacheUpdate {
                 }
                 pack_untilize_uninit(kv_cache_intermed_cb);
 
-                // Push back to unblock brisc to update kv cache with new data
+                // Push back to unblock ncrisc to update kv cache with new data
                 cb_push_back(kv_cache_intermed_cb, kv_cache_num_tiles);
 
-                // Waits for brisc to push one more "tile"
+                // Waits for ncrisc to push one more "tile"
                 cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
                 cb_reserve_back(kv_cache_output_cb, kv_cache_num_tiles);
 


### PR DESCRIPTION
### Ticket
None

### Problem description
In Deepseek-V3 fused kernel, we want kv cache streaming in FlashMLA to start as early as possible. Currently, kv cache update is using only one RISC and blocking any reading of kv cache in FlashMLA. To enable overlap, we can use BRISC to read out the old kv cache and NCRISC to wait for compute + update/write to kv cache. Later, when we flip FlashMLA to stream kv cache on BRISC, the kv cache streaming will happen as soon as the initial old kv cache is finished streaming.

### What's changed
- BRISC does DRAM read; flash MLA kv cache read can start on same RISC right away
- NCRISC waits for compute, then writes to DRAM

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/main)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/main): https://github.com/tenstorrent/tt-metal/actions/runs/23603327553
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/main)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
