### PR TITLE
BUG FIX: Traffic generator pattern kernel logical/physical core mismatch

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -54,9 +54,11 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
 
     auto program = std::make_shared<tt_metal::Program>();
 
-    // Get source fabric node ID from the mesh device (use first device at coord 0,0)
-    FabricNodeId src_fabric_node(MeshId{0}, 0);
-
+    // Use first device
+    auto* src_physical_device = device->get_devices()[0];
+    // Get source fabric node ID from physical first device
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device->id());
     // Target core on remote chip for traffic destination
     CoreCoord remote_logical_core(0, 0);
 

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
 
     // Use first device
     auto* src_physical_device = device->get_devices()[0];
-    // Get source fabric node ID from physical first device
+    // Get source fabric node ID from logical first device
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device->id());
     // Target core on remote chip for traffic destination

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
@@ -118,11 +118,11 @@ protected:
         }
 
         auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        
+
         // Use logical fabric nodes 0 and 1 as neighbors
         FabricNodeId src_node(MeshId{0}, 0);
         FabricNodeId dest_node(MeshId{0}, 1);
-        
+
         // Launch kernel on logical first device
         ChipId src_physical_chip = control_plane.get_physical_chip_id_from_fabric_node_id(src_node);
         mesh_device_ = get_device(src_physical_chip);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
@@ -124,16 +124,14 @@ protected:
         memory_layout_ = allocate_worker_memory();
 
         // Create destination node (second device)
-        FabricNodeId dest_node(MeshId{0}, 1);  // mesh_id=0, device_id=1
+        // Grab the (Mesh, LogicalId) pair from the physical chip
+        auto* dest_physical_device = devices[1]->get_devices()[0];
+        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        FabricNodeId dest_node = control_plane.get_fabric_node_id_from_physical_chip_id(dest_physical_device->id());
 
         // Create and launch program (note: correct argument order)
-        program_ = create_traffic_generator_program(
-            mesh_device_, worker_core, dest_node, memory_layout_);
-
+        program_ = create_traffic_generator_program(mesh_device_, worker_core, dest_node, memory_layout_);
         this->RunProgramNonblocking(mesh_device_, *program_);
-
-        log_info(LogTest, "Traffic generator kernel launched on device {}, core ({},{})",
-                 mesh_device_->id(), worker_core.x, worker_core.y);
     }
 
     WorkerMemoryLayout memory_layout_{};

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
@@ -117,17 +117,18 @@ protected:
             GTEST_SKIP() << "Requires at least 2 devices";
         }
 
-        // Launch kernel on first device
-        mesh_device_ = devices[0];
+        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        
+        // Use logical fabric nodes 0 and 1 as neighbors
+        FabricNodeId src_node(MeshId{0}, 0);
+        FabricNodeId dest_node(MeshId{0}, 1);
+        
+        // Launch kernel on logical first device
+        ChipId src_physical_chip = control_plane.get_physical_chip_id_from_fabric_node_id(src_node);
+        mesh_device_ = get_device(src_physical_chip);
 
         // Allocate memory
         memory_layout_ = allocate_worker_memory();
-
-        // Create destination node (second device)
-        // Grab the (Mesh, LogicalId) pair from the physical chip
-        auto* dest_physical_device = devices[1]->get_devices()[0];
-        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        FabricNodeId dest_node = control_plane.get_fabric_node_id_from_physical_chip_id(dest_physical_device->id());
 
         // Create and launch program (note: correct argument order)
         program_ = create_traffic_generator_program(mesh_device_, worker_core, dest_node, memory_layout_);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
@@ -132,6 +132,13 @@ protected:
         // Create and launch program (note: correct argument order)
         program_ = create_traffic_generator_program(mesh_device_, worker_core, dest_node, memory_layout_);
         this->RunProgramNonblocking(mesh_device_, *program_);
+
+        log_info(
+            LogTest,
+            "Traffic generator kernel launched on device {}, core ({},{})",
+            mesh_device_->id(),
+            worker_core.x,
+            worker_core.y);
     }
 
     WorkerMemoryLayout memory_layout_{};


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40328

### Problem description
Kernel Generator pattern failing test on BH P300

### What's changed
Resolve discrepancy between physical and logical nodes, this caused kernel to be launched without correct configuration of EDM. This caused underflow when performing check of `used_slots` leading to hanging on waiting for free slots on the EDM. 

On two devices example: 
The kernel is launches on physical chip 0, but uses `FabricNodeId(MeshId = 0, ChipId = 0)` (logical node 0) which corresponds to physical chip 1 for setting up fabric connection runtime args. Thus, when the fabric connection check's its channels for `used_slots` the incorrect configuration is used.

This bug is exposed on two device machine solely due to higher chances of it occurring. It was simply not exposed on other machines.

#### Change 
Instead, use the first two **logical** nodes, given they are canonically row-major and will always be beside each other for this test. Using the first two **physical** nodes may not result in their being neighbors. The kernel launch is fixed so the kernel is launched on the logical devices instead of the physical.

### Checklist
Failing same test on main
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=nzhao/traffic-generator-kernel-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:nzhao/traffic-generator-kernel-test)



#### Model tests
N/A