### PR TITLE
attention_softmax_ argument mismatch error

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -16,7 +16,8 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
-#include <nanobind/stl/variant.h>
+// Added for the nanobind includes and types -- see the comments in the decorators.hpp
+#include "ttnn/decorators.hpp"
 
 namespace ttnn {
 

--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -16,6 +16,7 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/variant.h>
 
 namespace ttnn {
 

--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -17,7 +17,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 // Added for the nanobind includes and types -- see the comments in the decorators.hpp
-#include "ttnn/decorators.hpp"
+#include "ttnn-nanobind/decorators.hpp"
 
 namespace ttnn {
 


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/40411

### Problem description

`attention_softmax_` argument mismatch error

### What's changed

Add missing variant type caster in the bind function header to provide the proper type caster to the nanobind wrappers. 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=martemov/ttnn.transformer.attention_softmax_-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:martemov/ttnn.transformer.attention_softmax_-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
