### PR TITLE
Improve print callstack on LW/LLK assert hit

### DIFF
--- a/tools/tests/triage/test_lw_assert_handling.py
+++ b/tools/tests/triage/test_lw_assert_handling.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for callstack_provider and dump_lightweight_asserts helper functions.
+These tests use mocks and temp files—no device or hardware required.
+"""
+
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+import pytest
+
+metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+triage_home = os.path.join(metal_home, "tools", "triage")
+sys.path.insert(0, triage_home)
+
+from dump_lightweight_asserts import extract_assert_code
+from callstack_provider import get_function_die, extract_template_params
+from ttexalens.hardware.risc_debug import CallstackEntry, CallstackEntryVariable
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_die(tag, name=None, parent=None, children=None, attributes=None, value=None, resolved_type=None):
+    """Build a lightweight mock that quacks like an ElfDie."""
+    die = MagicMock()
+    die.tag = tag
+    die.name = name
+    die.parent = parent
+    die.value = value
+    die.attributes = attributes or {}
+    die.resolved_type = resolved_type if resolved_type is not None else die
+
+    child_list = children or []
+    die.iter_children = MagicMock(return_value=iter(child_list))
+    die.get_DIE_from_attribute = MagicMock(return_value=None)
+    return die
+
+
+def _make_variable(die):
+    """Build a CallstackEntryVariable with a mock die and None value."""
+    return CallstackEntryVariable(die=die, value=None)
+
+
+def _make_entry(arguments=None, locals_=None):
+    """Build a CallstackEntry with the given arguments and locals."""
+    return CallstackEntry(
+        pc=0x1000,
+        function_name="test_func",
+        file="test.cpp",
+        line=10,
+        arguments=arguments or [],
+        locals=locals_ or [],
+    )
+
+
+# ===========================================================================
+# extract_assert_code
+# ===========================================================================
+
+
+class TestExtractAssertCode:
+    """Tests for the assert-code extraction logic in dump_lightweight_asserts."""
+
+    def test_single_line_assert(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    ASSERT(x > 0);\n")
+        assert extract_assert_code(str(src), 1, None) == "ASSERT(x > 0)"
+
+    def test_prefixed_assert_single_line(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    LLK_ASSERT(x > 0);\n")
+        assert extract_assert_code(str(src), 1, None) == "LLK_ASSERT(x > 0)"
+
+    def test_prefixed_assert_with_column(self, tmp_path):
+        """LLK_ASSERT at column 5 (1-indexed) must be found despite 'ASSERT(' appearing later."""
+        src = tmp_path / "test.cpp"
+        #                 12345
+        src.write_text("    LLK_ASSERT(x > 0);\n")
+        result = extract_assert_code(str(src), 1, 5)
+        assert result == "LLK_ASSERT(x > 0)"
+
+    def test_multi_line_assert(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    ASSERT(\n" "        x > 0\n" "    );\n")
+        result = extract_assert_code(str(src), 1, None)
+        assert "ASSERT(" in result
+        assert "x > 0" in result
+        assert result.endswith(")")
+
+    def test_multi_line_prefixed_assert(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    LLK_ASSERT(\n" "        (is_configured(a, b)),\n" '        "error");\n')
+        result = extract_assert_code(str(src), 1, 5)
+        assert result.startswith("LLK_ASSERT(")
+        assert "is_configured(a, b)" in result
+        assert result.endswith(")")
+
+    def test_nested_parens_multi_line(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    ASSERT(foo(bar(x),\n" "               baz(y)));\n")
+        result = extract_assert_code(str(src), 1, None)
+        assert result.startswith("ASSERT(")
+        assert "foo(" in result
+        assert "baz(y)" in result
+        assert result.endswith(")")
+
+    def test_none_file(self):
+        assert extract_assert_code(None, 1, None) == "?"
+
+    def test_none_line(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("ASSERT(1);\n")
+        assert extract_assert_code(str(src), None, None) == "?"
+
+    def test_file_not_found(self):
+        assert extract_assert_code("/nonexistent/path.cpp", 1, None) == "?file not found?"
+
+    def test_wrong_line_number(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("ASSERT(1);\n")
+        result = extract_assert_code(str(src), 999, None)
+        assert "wrong line number" in result
+
+    def test_no_assert_on_line(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    int x = 42;\n")
+        result = extract_assert_code(str(src), 1, None)
+        assert "not found" in result
+
+    def test_column_disambiguates_multiple_asserts(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        # Two asserts on one line
+        src.write_text("ASSERT(a); ASSERT(b);\n")
+        # Column 1 (1-indexed) points to the first ASSERT -> selects it
+        assert extract_assert_code(str(src), 1, 1) == "ASSERT(a)"
+        # Column 12 (1-indexed) points to the second ASSERT -> selects it
+        assert extract_assert_code(str(src), 1, 12) == "ASSERT(b)"
+
+    def test_unclosed_assert_no_more_lines(self, tmp_path):
+        src = tmp_path / "test.cpp"
+        src.write_text("    ASSERT(x > 0\n")
+        result = extract_assert_code(str(src), 1, None)
+        assert "closing paren not found" in result
+
+
+# ===========================================================================
+# get_function_die
+# ===========================================================================
+
+
+class TestGetFunctionDie:
+    """Tests for navigating from a CallstackEntry to the parent function die."""
+
+    def test_finds_subprogram_parent(self):
+        func_die = _make_die("DW_TAG_subprogram", name="my_func")
+        param_die = _make_die("DW_TAG_formal_parameter", name="x", parent=func_die)
+        entry = _make_entry(arguments=[_make_variable(param_die)])
+
+        result = get_function_die(entry)
+        assert result is func_die
+
+    def test_walks_through_lexical_block(self):
+        func_die = _make_die("DW_TAG_subprogram", name="my_func")
+        block_die = _make_die("DW_TAG_lexical_block", parent=func_die)
+        var_die = _make_die("DW_TAG_variable", name="tmp", parent=block_die)
+        entry = _make_entry(locals_=[_make_variable(var_die)])
+
+        result = get_function_die(entry)
+        assert result is func_die
+
+    def test_inlined_subroutine_returns_abstract_origin(self):
+        origin_die = _make_die("DW_TAG_subprogram", name="inlined_func")
+        inlined_die = _make_die("DW_TAG_inlined_subroutine")
+        inlined_die.get_DIE_from_attribute = MagicMock(return_value=origin_die)
+        param_die = _make_die("DW_TAG_formal_parameter", name="x", parent=inlined_die)
+        entry = _make_entry(arguments=[_make_variable(param_die)])
+
+        result = get_function_die(entry)
+        assert result is origin_die
+
+    def test_inlined_subroutine_no_abstract_origin_returns_self(self):
+        inlined_die = _make_die("DW_TAG_inlined_subroutine")
+        inlined_die.get_DIE_from_attribute = MagicMock(return_value=None)
+        param_die = _make_die("DW_TAG_formal_parameter", name="x", parent=inlined_die)
+        entry = _make_entry(arguments=[_make_variable(param_die)])
+
+        result = get_function_die(entry)
+        assert result is inlined_die
+
+    def test_empty_entry_returns_none(self):
+        entry = _make_entry()
+        assert get_function_die(entry) is None
+
+    def test_variable_with_no_die_is_skipped(self):
+        var_no_die = MagicMock(spec=CallstackEntryVariable)
+        del var_no_die.die  # getattr(var, "die", None) -> None
+        entry = _make_entry(arguments=[var_no_die])
+        assert get_function_die(entry) is None
+
+    def test_uses_locals_when_no_arguments(self):
+        func_die = _make_die("DW_TAG_subprogram", name="my_func")
+        local_die = _make_die("DW_TAG_variable", name="local_var", parent=func_die)
+        entry = _make_entry(locals_=[_make_variable(local_die)])
+
+        result = get_function_die(entry)
+        assert result is func_die
+
+
+# ===========================================================================
+# extract_template_params
+# ===========================================================================
+
+
+class TestExtractTemplateParams:
+    """Tests for extracting template parameters from a function die."""
+
+    def test_type_param(self):
+        type_die = _make_die("DW_TAG_base_type", name="int")
+        type_die.resolved_type = type_die
+        child = _make_die("DW_TAG_template_type_param", name="T", resolved_type=type_die)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "int")]
+
+    def test_value_param(self):
+        child = _make_die("DW_TAG_template_value_param", name="N", value=42)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("N", "42")]
+
+    def test_value_param_bool_false(self):
+        child = _make_die("DW_TAG_template_value_param", name="flag", value=0)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("flag", "0")]
+
+    def test_mixed_params(self):
+        type_die = _make_die("DW_TAG_base_type", name="float")
+        type_die.resolved_type = type_die
+        type_child = _make_die("DW_TAG_template_type_param", name="T", resolved_type=type_die)
+        value_child = _make_die("DW_TAG_template_value_param", name="N", value=8)
+        func_die = _make_die("DW_TAG_subprogram", children=[type_child, value_child])
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "float"), ("N", "8")]
+
+    def test_no_template_params(self):
+        param_child = _make_die("DW_TAG_formal_parameter", name="x")
+        func_die = _make_die("DW_TAG_subprogram", children=[param_child])
+
+        result = extract_template_params(func_die)
+        assert result == []
+
+    def test_gnu_template_parameter_pack(self):
+        type_die = _make_die("DW_TAG_base_type", name="int")
+        type_die.resolved_type = type_die
+        pack_type = _make_die("DW_TAG_template_type_param", name="T", resolved_type=type_die)
+        pack_value = _make_die("DW_TAG_template_value_param", name="V", value=99)
+        pack = _make_die("DW_TAG_GNU_template_parameter_pack", children=[pack_type, pack_value])
+
+        func_die = _make_die("DW_TAG_subprogram", children=[pack])
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "int"), ("V", "99")]
+
+    def test_specification_redirect(self):
+        type_die = _make_die("DW_TAG_base_type", name="double")
+        type_die.resolved_type = type_die
+        child = _make_die("DW_TAG_template_type_param", name="T", resolved_type=type_die)
+        spec_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        func_die = _make_die("DW_TAG_subprogram", attributes={"DW_AT_specification": True})
+        func_die.get_DIE_from_attribute = MagicMock(return_value=spec_die)
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "double")]
+
+    def test_type_param_none_name_resolved(self):
+        """type_die.name is None -> should fall back to '?'."""
+        type_die = _make_die("DW_TAG_base_type", name=None)
+        type_die.resolved_type = type_die
+        child = _make_die("DW_TAG_template_type_param", name="T", resolved_type=type_die)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "?")]
+
+    def test_value_param_none_value(self):
+        child = _make_die("DW_TAG_template_value_param", name="N", value=None)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("N", "?")]
+
+    def test_type_param_resolved_to_self(self):
+        """When resolved_type is the child itself, treat as unresolvable."""
+        child = _make_die("DW_TAG_template_type_param", name="T")
+        child.resolved_type = child  # self-referencing
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [("T", "?")]
+
+    def test_param_name_is_none(self):
+        child = _make_die("DW_TAG_template_value_param", name=None, value=7)
+        func_die = _make_die("DW_TAG_subprogram", children=[child])
+
+        result = extract_template_params(func_die)
+        assert result == [(None, "7")]

--- a/tools/triage/callstack_provider.py
+++ b/tools/triage/callstack_provider.py
@@ -130,6 +130,54 @@ def get_callstack(
         return KernelCallstackWithMessage(callstack=[], message=str(e))
 
 
+def get_function_die(entry: CallstackEntry):
+    """Navigate from a callstack entry's argument/local dies to the parent function die."""
+    for var in entry.arguments + entry.locals:
+        current = var.die.parent
+        while current is not None:
+            if current.tag == "DW_TAG_subprogram":
+                return current
+            if current.tag == "DW_TAG_inlined_subroutine":
+                abstract_origin = current.get_DIE_from_attribute("DW_AT_abstract_origin")
+                if abstract_origin is not None:
+                    return abstract_origin
+                return current
+            current = current.parent
+    return None
+
+
+def extract_template_params(function_die) -> list[tuple[str | None, str]]:
+    """Extract template parameters (name, display_value) from a function die."""
+    actual_die = function_die
+    if "DW_AT_specification" in actual_die.attributes:
+        spec_die = actual_die.get_DIE_from_attribute("DW_AT_specification")
+        if spec_die is not None:
+            actual_die = spec_die
+
+    template_params = []
+    for child in actual_die.iter_children():
+        if child.tag == "DW_TAG_template_type_param":
+            param_name = child.name
+            type_die = child.resolved_type
+            type_name = type_die.name if type_die and type_die is not child else "?"
+            template_params.append((param_name, type_name))
+        elif child.tag == "DW_TAG_template_value_param":
+            param_name = child.name
+            value = child.value
+            template_params.append((param_name, f"{value}" if value is not None else "?"))
+        elif child.tag == "DW_TAG_GNU_template_parameter_pack":
+            for pack_child in child.iter_children():
+                if pack_child.tag == "DW_TAG_template_type_param":
+                    type_die = pack_child.resolved_type
+                    template_params.append(
+                        (pack_child.name, type_die.name if type_die and type_die is not pack_child else "?")
+                    )
+                elif pack_child.tag == "DW_TAG_template_value_param":
+                    value = pack_child.value
+                    template_params.append((pack_child.name, f"{value}" if value is not None else "?"))
+    return template_params
+
+
 def _format_callstack(callstack: list[CallstackEntry]) -> list[str]:
     """Return string representation of the callstack."""
     frame_number_width = len(str(len(callstack) - 1))

--- a/tools/triage/callstack_provider.py
+++ b/tools/triage/callstack_provider.py
@@ -130,10 +130,15 @@ def get_callstack(
         return KernelCallstackWithMessage(callstack=[], message=str(e))
 
 
-def get_function_die(entry: CallstackEntry):
+def get_function_die(entry: CallstackEntry) -> "ElfDie | None":
     """Navigate from a callstack entry's argument/local dies to the parent function die."""
+    from ttexalens.elf.die import ElfDie
+
     for var in entry.arguments + entry.locals:
-        current = var.die.parent
+        die = getattr(var, "die", None)
+        if die is None:
+            continue
+        current = getattr(die, "parent", None)
         while current is not None:
             if current.tag == "DW_TAG_subprogram":
                 return current
@@ -159,8 +164,8 @@ def extract_template_params(function_die) -> list[tuple[str | None, str]]:
         if child.tag == "DW_TAG_template_type_param":
             param_name = child.name
             type_die = child.resolved_type
-            type_name = type_die.name if type_die and type_die is not child else "?"
-            template_params.append((param_name, type_name))
+            type_name = type_die.name if type_die and type_die is not child else None
+            template_params.append((param_name, type_name or "?"))
         elif child.tag == "DW_TAG_template_value_param":
             param_name = child.name
             value = child.value
@@ -169,9 +174,8 @@ def extract_template_params(function_die) -> list[tuple[str | None, str]]:
             for pack_child in child.iter_children():
                 if pack_child.tag == "DW_TAG_template_type_param":
                     type_die = pack_child.resolved_type
-                    template_params.append(
-                        (pack_child.name, type_die.name if type_die and type_die is not pack_child else "?")
-                    )
+                    type_name = type_die.name if type_die and type_die is not pack_child else None
+                    template_params.append((pack_child.name, type_name or "?"))
                 elif pack_child.tag == "DW_TAG_template_value_param":
                     value = pack_child.value
                     template_params.append((pack_child.name, f"{value}" if value is not None else "?"))

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -23,6 +23,8 @@ from callstack_provider import (
     format_callstack_with_message,
     run as get_callstack_provider,
     CallstackProvider,
+    get_function_die,
+    extract_template_params,
 )
 from run_checks import run as get_run_checks
 from ttexalens.coordinate import OnChipCoordinate
@@ -71,7 +73,14 @@ def extract_assert_code(file: str | None, line: int | None, column: int | None) 
             start_index = -1
             while True:
                 new_index = code_line.find("ASSERT(", start_index + 1)
-                if new_index == -1 or (column is not None and new_index >= column):
+                if new_index == -1:
+                    break
+                # Walk backward to find the actual start of the macro name
+                # (e.g. "LLK_ASSERT(" -> position of 'L', not 'A')
+                macro_start = new_index
+                while macro_start > 0 and (code_line[macro_start - 1].isalnum() or code_line[macro_start - 1] == "_"):
+                    macro_start -= 1
+                if column is not None and macro_start >= column:
                     break
                 start_index = new_index
             if start_index == -1:
@@ -93,7 +102,31 @@ def extract_assert_code(file: str | None, line: int | None, column: int | None) 
                         break
                 i += 1
             if paren_count != 0:
-                return "ASSERT() is multi line. Check the first code line in the stack trace."
+                current_line_idx = line
+                while paren_count > 0 and current_line_idx < len(lines):
+                    next_line = lines[current_line_idx]
+                    code_line += " " + next_line.strip()
+                    for ch in next_line:
+                        if ch == "(":
+                            paren_count += 1
+                        elif ch == ")":
+                            paren_count -= 1
+                            if paren_count == 0:
+                                break
+                    current_line_idx += 1
+                if paren_count != 0:
+                    return "ASSERT() closing paren not found. Check the first code line in the stack trace."
+                # Re-scan the assembled string to find the closing paren position
+                i = open_paren_index + 1
+                scan_count = 1
+                while i < len(code_line):
+                    if code_line[i] == "(":
+                        scan_count += 1
+                    elif code_line[i] == ")":
+                        scan_count -= 1
+                        if scan_count == 0:
+                            break
+                    i += 1
             return code_line[start_index : i + 1].strip()
     except Exception:
         return "?"
@@ -170,20 +203,34 @@ def dump_lightweight_asserts(
                 callstack_data.kernel_callstack_with_message.callstack[0].column,
             )
             arguments_and_locals = ""
-            if len(callstack_data.kernel_callstack_with_message.callstack[0].arguments) > 0:
-                arguments_and_locals += "\nArguments:\n"
-                arguments_and_locals += serialize_variables(
-                    callstack_data.kernel_callstack_with_message.callstack[0].arguments, assert_code
-                )
-                for var in callstack_data.kernel_callstack_with_message.callstack[0].arguments:
+            top_frame = callstack_data.kernel_callstack_with_message.callstack[0]
+            try:
+                function_die = get_function_die(top_frame)
+                if function_die is not None:
+                    template_params = extract_template_params(function_die)
+                    if template_params:
+                        arguments_and_locals += "\nTemplate arguments:\n"
+                        for param_name, param_value in template_params:
+                            display_name = param_name or "?"
+                            if display_name in assert_code:
+                                arguments_and_locals += f"- [info]{display_name}[/] = [command]{param_value}[/]\n"
+                            else:
+                                arguments_and_locals += f"- {display_name} = {param_value}\n"
+                        for param_name, _ in template_params:
+                            if param_name is not None:
+                                assert_code = assert_code.replace(param_name, f"[info]{param_name}[/]")
+            except Exception:
+                pass
+            if len(top_frame.arguments) > 0:
+                arguments_and_locals += "\nRuntime arguments:\n"
+                arguments_and_locals += serialize_variables(top_frame.arguments, assert_code)
+                for var in top_frame.arguments:
                     if var.name is not None:
                         assert_code = assert_code.replace(var.name, f"[info]{var.name}[/]")
-            if len(callstack_data.kernel_callstack_with_message.callstack[0].locals) > 0:
+            if len(top_frame.locals) > 0:
                 arguments_and_locals += "\nLocals:\n"
-                arguments_and_locals += serialize_variables(
-                    callstack_data.kernel_callstack_with_message.callstack[0].locals, assert_code
-                )
-                for var in callstack_data.kernel_callstack_with_message.callstack[0].locals:
+                arguments_and_locals += serialize_variables(top_frame.locals, assert_code)
+                for var in top_frame.locals:
                     if var.name is not None:
                         assert_code = assert_code.replace(var.name, f"[info]{var.name}[/]")
         return LightweightAssertInfo(

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -211,16 +211,21 @@ def dump_lightweight_asserts(
                     if template_params:
                         arguments_and_locals += "\nTemplate arguments:\n"
                         for param_name, param_value in template_params:
-                            display_name = param_name or "?"
-                            if display_name in assert_code:
-                                arguments_and_locals += f"- [info]{display_name}[/] = [command]{param_value}[/]\n"
+                            if param_name and param_name in assert_code:
+                                arguments_and_locals += f"- [info]{param_name}[/] = [command]{param_value}[/]\n"
                             else:
-                                arguments_and_locals += f"- {display_name} = {param_value}\n"
+                                arguments_and_locals += f"- {param_name or '?'} = {param_value}\n"
                         for param_name, _ in template_params:
-                            if param_name is not None:
+                            if param_name:
                                 assert_code = assert_code.replace(param_name, f"[info]{param_name}[/]")
-            except Exception:
-                pass
+            except Exception as e:
+                if os.getenv("TT_TRIAGE_DEBUG_TEMPLATES"):
+                    log_check_risc(
+                        risc_name,
+                        location,
+                        False,
+                        f"[warning]Template arguments unavailable: {e}[/]",
+                    )
             if len(top_frame.arguments) > 0:
                 arguments_and_locals += "\nRuntime arguments:\n"
                 arguments_and_locals += serialize_variables(top_frame.arguments, assert_code)


### PR DESCRIPTION
### Ticket

### Problem description
Currently, when using tt-triage to print callstack of an LW/LLK assert hit, it only prints the first line of assert or sometime assert not found. Also, it does not print template argument values.

### What's changed
With this change, the output of printed stack contains whole assert even when it is multi-line and also it contains both template and runtime arguments. New output looks like this:

dump_lightweight_asserts.py:
┏━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Dev ┃ Loc          ┃ RiscV  ┃ Kernel Name                              ┃ Assert line with callstack                                                                                                                                                                      ┃ Arguments and Locals              ┃
┡━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 0   │ 1-2 (0,0)    │ trisc0 │ bmm_large_block_zm_fused_bias_activation │                                                                                                                                                                                                 │                                   │
│     │              │        │                                          │ LLK_ASSERT(                                                                                                                                                                                     │ Template arguments:               │
│     │              │        │                                          │  (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>( operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)), "")                                    │ - BType = 0                       │
│     │              │        │                                          │                                                                                                                                                                                                 │ - acc_to_dest = 0                 │
│     │              │        │                                          │ #0 0x0000B714 in llk_unpack_A_init<(ckernel::BroadcastType)0, false, (ckernel::EltwiseBinaryReuseDestType)0, true> () at ./tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h 49:5 │ - binary_reuse_dest = 0           │
│     │              │        │                                          │ #1 ckernel::copy_tile_to_dst_init_short () at ./tt_metal/hw/inc/api/compute/tile_move_copy.h 38:5                                                                                               │ - unpack_to_dest = 1              │
│     │              │        │                                          │ #2 ckernel::copy_tile_to_dst_init_short_with_dt () at ./tt_metal/hw/inc/api/compute/tile_move_copy.h 70:32                                                                                      │                                   │
│     │              │        │                                          │ #3 reload_from_cb_to_dst () at ./ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp 91:40                                                      │ Runtime arguments:                │
│     │              │        │                                          │ #4 kernel_main () at ./ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp 264:54                                                               │ - transpose_of_faces = 0          │
│     │              │        │                                          │ #5 run_kernel () at ./tt_metal/hw/ckernels/blackhole/metal/common/chlkc_list.h 38:16                                                                                                            │ - within_face_16x16_transpose = 0 │
│     │              │        │                                          │ #6 _start () at ./tt_metal/hw/firmware/src/tt-1xx/trisck.cc 76:15                                                                                                                               │ - operand = 5                     │
│     │              │        │                                          │ #7 0x0000690C in main () at ./tt_metal/hw/firmware/src/tt-1xx/trisc.cc 216:9                                                                                                                    │                                   │
│     │              │        │                                          │                                                                                                                                                                                                 │ Locals:                           │
│     │              │        │                                          │                                                                                                                                                                                                 │ - operand_id = 5                  │
│     │              │        │                                          │                                                                                                                                                                                                 │ - face_r_dim = 8                  │
│     │              │        │                                          │                                                                                                                                                                                                 │ - num_faces = 1                   │
│     │              │        │                                          │                                                                                                                                                                                                 │ - operand_unpack_src_format = 5   │
│     │              │        │                                          │                                                                                                                                                                                                 │ - operand_unpack_dst_format = 5   │
### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
