### PR TITLE
Use local mesh device count for multihost DeepSeek CCL links

### DIFF
--- a/models/common/modules/tt_ccl.py
+++ b/models/common/modules/tt_ccl.py
@@ -40,6 +40,18 @@ def clear_tt_ccl_cache():
     _tt_ccl_cache.clear()
 
 
+def _get_local_num_devices(mesh_device: ttnn.MeshDevice) -> int:
+    """Return the number of devices visible to the current host process."""
+    if mesh_device is None:
+        raise ValueError("mesh_device is required to determine CCL link counts")
+
+    local_device_ids = mesh_device.get_device_ids()
+    if not local_device_ids:
+        raise ValueError("CCL link detection requires at least one host-local device")
+
+    return len(local_device_ids)
+
+
 # =============================================================================
 # TT_CCL class
 # =============================================================================
@@ -139,13 +151,10 @@ def default_topology(mesh_device: ttnn.MeshDevice) -> Optional[ttnn.Topology]:
 
 
 def _determine_device_name(mesh_device: ttnn.MeshDevice) -> str:
-    """Determine device name based on number of devices and architecture."""
-    num_devices = mesh_device.get_num_devices() if mesh_device else 0
+    """Determine device name for CCL based on the host-local device count."""
+    num_devices = _get_local_num_devices(mesh_device)
     arch_name = ttnn.get_arch_name()
-    dram_grid_size = mesh_device.dram_grid_size() if mesh_device else None
-
-    if num_devices == 0:
-        return "CPU"
+    dram_grid_size = mesh_device.dram_grid_size()
 
     if "blackhole" in arch_name:
         dict_device_names = {
@@ -168,7 +177,7 @@ def _determine_device_name(mesh_device: ttnn.MeshDevice) -> str:
 
     if num_devices in dict_device_names:
         return dict_device_names[num_devices]
-    raise ValueError(f"Unsupported number of devices: {num_devices} for {arch_name}")
+    raise ValueError(f"Unsupported number of local devices: {num_devices} for {arch_name}")
 
 
 def get_num_links(mesh_device: ttnn.MeshDevice, cluster_axis: int | None = None) -> int:
@@ -204,4 +213,4 @@ def get_num_links(mesh_device: ttnn.MeshDevice, cluster_axis: int | None = None)
         return min(device_links)
     if cluster_axis in (0, 1):
         return device_links[cluster_axis]
-    return min(device_links)
+    raise ValueError(f"Unsupported cluster_axis: {cluster_axis}")

--- a/models/common/modules/tt_ccl.py
+++ b/models/common/modules/tt_ccl.py
@@ -40,7 +40,7 @@ def clear_tt_ccl_cache():
     _tt_ccl_cache.clear()
 
 
-def _get_local_num_devices(mesh_device: ttnn.MeshDevice) -> int:
+def _get_local_num_devices(mesh_device: Optional[ttnn.MeshDevice]) -> int:
     """Return the number of devices visible to the current host process."""
     if mesh_device is None:
         raise ValueError("mesh_device is required to determine CCL link counts")

--- a/models/common/modules/tt_ccl.py
+++ b/models/common/modules/tt_ccl.py
@@ -45,7 +45,10 @@ def _get_local_num_devices(mesh_device: Optional[ttnn.MeshDevice]) -> int:
     if mesh_device is None:
         raise ValueError("mesh_device is required to determine CCL link counts")
 
-    local_device_ids = mesh_device.get_device_ids()
+    try:
+        local_device_ids = mesh_device.get_device_ids()
+    except Exception as exc:
+        raise ValueError("CCL link detection requires at least one host-local device") from exc
     if not local_device_ids:
         raise ValueError("CCL link detection requires at least one host-local device")
 

--- a/models/tt_transformers/tests/test_ccl_utils.py
+++ b/models/tt_transformers/tests/test_ccl_utils.py
@@ -27,6 +27,11 @@ class FakeMeshDevice:
         return self._dram_grid_size
 
 
+class FakeMeshDeviceGetDeviceIdsRaises(FakeMeshDevice):
+    def get_device_ids(self):
+        raise RuntimeError("debug assert from get_device_ids")
+
+
 @pytest.mark.parametrize("ccl_module", [tt_transformers_ccl, common_tt_ccl])
 def test_get_num_links_uses_host_local_device_count_for_multihost_wormhole(monkeypatch, ccl_module):
     monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
@@ -50,6 +55,15 @@ def test_get_num_links_rejects_invalid_cluster_axis(monkeypatch, ccl_module):
 def test_get_num_links_requires_local_devices(monkeypatch, ccl_module):
     monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
     mesh_device = FakeMeshDevice(global_num_devices=64, local_device_ids=[])
+
+    with pytest.raises(ValueError, match="requires at least one host-local device"):
+        ccl_module.get_num_links(mesh_device)
+
+
+@pytest.mark.parametrize("ccl_module", [tt_transformers_ccl, common_tt_ccl])
+def test_get_num_links_normalizes_get_device_ids_failures(monkeypatch, ccl_module):
+    monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
+    mesh_device = FakeMeshDeviceGetDeviceIdsRaises(global_num_devices=64, local_device_ids=[])
 
     with pytest.raises(ValueError, match="requires at least one host-local device"):
         ccl_module.get_num_links(mesh_device)

--- a/models/tt_transformers/tests/test_ccl_utils.py
+++ b/models/tt_transformers/tests/test_ccl_utils.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+import ttnn
+from models.common.modules import tt_ccl as common_tt_ccl
+from models.tt_transformers.tt import ccl as tt_transformers_ccl
+
+
+class FakeMeshDevice:
+    def __init__(self, global_num_devices, local_device_ids, dram_grid_x=8):
+        self._global_num_devices = global_num_devices
+        self._local_device_ids = local_device_ids
+        self._dram_grid_size = SimpleNamespace(x=dram_grid_x)
+
+    def get_num_devices(self):
+        return self._global_num_devices
+
+    def get_device_ids(self):
+        return list(self._local_device_ids)
+
+    def dram_grid_size(self):
+        return self._dram_grid_size
+
+
+@pytest.mark.parametrize("ccl_module", [tt_transformers_ccl, common_tt_ccl])
+def test_get_num_links_uses_host_local_device_count_for_multihost_wormhole(monkeypatch, ccl_module):
+    monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
+    mesh_device = FakeMeshDevice(global_num_devices=64, local_device_ids=range(32))
+
+    assert ccl_module.get_num_links(mesh_device, cluster_axis=0) == 4
+    assert ccl_module.get_num_links(mesh_device, cluster_axis=1) == 4
+    assert ccl_module.get_num_links(mesh_device) == 4
+
+
+@pytest.mark.parametrize("ccl_module", [tt_transformers_ccl, common_tt_ccl])
+def test_get_num_links_rejects_invalid_cluster_axis(monkeypatch, ccl_module):
+    monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
+    mesh_device = FakeMeshDevice(global_num_devices=8, local_device_ids=range(8))
+
+    with pytest.raises(ValueError, match="Unsupported cluster_axis: 2"):
+        ccl_module.get_num_links(mesh_device, cluster_axis=2)
+
+
+@pytest.mark.parametrize("ccl_module", [tt_transformers_ccl, common_tt_ccl])
+def test_get_num_links_requires_local_devices(monkeypatch, ccl_module):
+    monkeypatch.setattr(ttnn, "get_arch_name", lambda: "wormhole_b0")
+    mesh_device = FakeMeshDevice(global_num_devices=64, local_device_ids=[])
+
+    with pytest.raises(ValueError, match="requires at least one host-local device"):
+        ccl_module.get_num_links(mesh_device)

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -2,55 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional
-
 import ttnn
-
-
-def _get_local_num_devices(mesh_device: Optional[ttnn.MeshDevice]) -> int:
-    """Return the number of devices visible to the current host process."""
-    if mesh_device is None:
-        raise ValueError("mesh_device is required to determine CCL link counts")
-
-    try:
-        local_device_ids = mesh_device.get_device_ids()
-    except Exception as exc:
-        raise ValueError("CCL link detection requires at least one host-local device") from exc
-    if not local_device_ids:
-        raise ValueError("CCL link detection requires at least one host-local device")
-
-    return len(local_device_ids)
-
-
-def _determine_ccl_device_name(mesh_device):
-    """Determine the CCL device class using the host-local device count."""
-    num_devices = _get_local_num_devices(mesh_device)
-    arch_name = ttnn.get_arch_name()
-    dram_grid_size = mesh_device.dram_grid_size()
-
-    if "blackhole" in arch_name:
-        dict_device_names = {
-            1: "P100" if dram_grid_size and dram_grid_size.x == 7 else "P150",
-            2: "P300",
-            4: "P150x4",
-            8: "P150x8",
-            32: "BHGLX",
-        }
-    elif "wormhole_b0" in arch_name:
-        dict_device_names = {
-            1: "N150",
-            2: "N300",
-            4: "N150x4",
-            8: "T3K",
-            32: "TG",
-        }
-    else:
-        raise ValueError(f"Unsupported architecture: {arch_name}")
-
-    if num_devices in dict_device_names:
-        return dict_device_names[num_devices]
-
-    raise ValueError(f"Unsupported number of local devices: {num_devices} for {arch_name}")
+from models.common.modules.tt_ccl import get_num_links as get_common_num_links
 
 
 def get_num_links(mesh_device, cluster_axis=None):
@@ -74,31 +27,7 @@ def get_num_links(mesh_device, cluster_axis=None):
         >>> num_links = get_num_links(mesh_device)
         >>> num_links_axis0 = get_num_links(mesh_device, cluster_axis=0)
     """
-    # Per-axis link counts as (axis0_links, axis1_links) tuples, classified by
-    # the devices visible to the current host process in multihost runs.
-    device_name = _determine_ccl_device_name(mesh_device)
-    link_dict = {
-        "P100": (0, 0),
-        "P150": (0, 0),
-        "N150": (0, 0),
-        "N300": (1, 1),
-        "T3K": (1, 1),
-        "P150x4": (2, 2),
-        "P150x8": (2, 2),
-        "P300": (2, 2),
-        "BHGLX": (2, 2),
-        "TG": (4, 4),
-        "N150x4": (1, 1),
-    }
-    device_links = link_dict[device_name]
-    # When cluster_axis is None, query links across all axes and return the minimum.
-    if cluster_axis is None:
-        return min(device_links)
-    # For explicit cluster_axis values, return the corresponding axis link count
-    # where 0 -> vertical axis and 1 -> horizontal axis.
-    if cluster_axis in (0, 1):
-        return device_links[cluster_axis]
-    raise ValueError(f"Unsupported cluster_axis: {cluster_axis}")
+    return get_common_num_links(mesh_device, cluster_axis)
 
 
 class TT_CCL:

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -2,15 +2,20 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 import ttnn
 
 
-def _get_local_num_devices(mesh_device):
+def _get_local_num_devices(mesh_device: Optional[ttnn.MeshDevice]) -> int:
     """Return the number of devices visible to the current host process."""
     if mesh_device is None:
         raise ValueError("mesh_device is required to determine CCL link counts")
 
-    local_device_ids = mesh_device.get_device_ids()
+    try:
+        local_device_ids = mesh_device.get_device_ids()
+    except Exception as exc:
+        raise ValueError("CCL link detection requires at least one host-local device") from exc
     if not local_device_ids:
         raise ValueError("CCL link detection requires at least one host-local device")
 

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -3,7 +3,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.tt_transformers.tt.model_config import determine_device_name
+
+
+def _get_local_num_devices(mesh_device):
+    """Return the number of devices visible to the current host process."""
+    if mesh_device is None:
+        raise ValueError("mesh_device is required to determine CCL link counts")
+
+    local_device_ids = mesh_device.get_device_ids()
+    if not local_device_ids:
+        raise ValueError("CCL link detection requires at least one host-local device")
+
+    return len(local_device_ids)
+
+
+def _determine_ccl_device_name(mesh_device):
+    """Determine the CCL device class using the host-local device count."""
+    num_devices = _get_local_num_devices(mesh_device)
+    arch_name = ttnn.get_arch_name()
+    dram_grid_size = mesh_device.dram_grid_size()
+
+    if "blackhole" in arch_name:
+        dict_device_names = {
+            1: "P100" if dram_grid_size and dram_grid_size.x == 7 else "P150",
+            2: "P300",
+            4: "P150x4",
+            8: "P150x8",
+            32: "BHGLX",
+        }
+    elif "wormhole_b0" in arch_name:
+        dict_device_names = {
+            1: "N150",
+            2: "N300",
+            4: "N150x4",
+            8: "T3K",
+            32: "TG",
+        }
+    else:
+        raise ValueError(f"Unsupported architecture: {arch_name}")
+
+    if num_devices in dict_device_names:
+        return dict_device_names[num_devices]
+
+    raise ValueError(f"Unsupported number of local devices: {num_devices} for {arch_name}")
 
 
 def get_num_links(mesh_device, cluster_axis=None):
@@ -27,9 +69,9 @@ def get_num_links(mesh_device, cluster_axis=None):
         >>> num_links = get_num_links(mesh_device)
         >>> num_links_axis0 = get_num_links(mesh_device, cluster_axis=0)
     """
-    # Per-axis link counts as (axis0_links, axis1_links) tuples.
-    # All current WH Galaxies are 6U units with 4 links on both axes.
-    device_name = determine_device_name(mesh_device)
+    # Per-axis link counts as (axis0_links, axis1_links) tuples, classified by
+    # the devices visible to the current host process in multihost runs.
+    device_name = _determine_ccl_device_name(mesh_device)
     link_dict = {
         "P100": (0, 0),
         "P150": (0, 0),
@@ -48,11 +90,10 @@ def get_num_links(mesh_device, cluster_axis=None):
     if cluster_axis is None:
         return min(device_links)
     # For explicit cluster_axis values, return the corresponding axis link count
-    # where 0 -> vertical axis and 1 -> horizontal axis. For any unexpected axis
-    # value, fall back to the minimum across axes as a safe default.
+    # where 0 -> vertical axis and 1 -> horizontal axis.
     if cluster_axis in (0, 1):
         return device_links[cluster_axis]
-    return min(device_links)
+    raise ValueError(f"Unsupported cluster_axis: {cluster_axis}")
 
 
 class TT_CCL:


### PR DESCRIPTION
## Summary
- use the host-local mesh device count from `mesh_device.get_device_ids()` when classifying CCL device/link counts in multihost runs
- normalize `get_device_ids()` failures to the same early `ValueError` used for zero-local-device meshes, and fail early on invalid `cluster_axis`
- deduplicate the local-device/link helper logic by having `models.tt_transformers.tt.ccl.get_num_links()` delegate to `models.common.modules.tt_ccl.get_num_links()`
- add focused coverage for the 64-global / 32-local wormhole case and the early-failure paths

## Issue
Fixes #40680

## Testing
- `python -m compileall models/tt_transformers/tt/ccl.py models/common/modules/tt_ccl.py models/tt_transformers/tests/test_ccl_utils.py`
- direct Python sanity harness covering the 64-global / 32-local case, invalid `cluster_axis`, zero-local-device failure, and normalized `get_device_ids()` exceptions
- [DeepSeek V3 Multi-Host Tests run 23545978596](https://github.com/tenstorrent/tt-metal/actions/runs/23545978596)

## CI Badge
[![DeepSeek V3 Multi-Host Tests (yieldthought/deepseek-local-ccl-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=yieldthought%2Fdeepseek-local-ccl-count)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch%3Ayieldthought%2Fdeepseek-local-ccl-count)
