### PR TITLE
[tt-triage] Use --use_luwen for tt-smi -r in triage tests

### DIFF
--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -124,7 +124,7 @@ def cause_hang_with_app(request):
 
         # Reset the device state after the hang if set in environment
         if os.environ.get("TT_METAL_RESET_DEVICE_AFTER_HANG", "0") == "1":
-            subprocess.run(["tt-smi", "-r"], check=True)
+            subprocess.run(["tt-smi", "-r", "--use_luwen"], check=True)
 
 
 @pytest.mark.parametrize(

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -124,7 +124,7 @@ def cause_hang_with_app(request):
 
         # Reset the device state after the hang if set in environment
         if os.environ.get("TT_METAL_RESET_DEVICE_AFTER_HANG", "0") == "1":
-            subprocess.run(["tt-smi", "-r", "--use_luwen"], check=True)
+            subprocess.run(["tt-smi", "--use_luwen", "-r"], check=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change adds `--use_luwen` in resets between triage tests in CI which are currently disabled due to braking bump of `tt-smi` to 4.1.2 breaking them and causing merge gate deterministically failing 100% of the time. This is a mitigation due to a mismatch in umd versions in `tt-smi` and `tt-exalens` which cause this issue.