### PR TITLE
Revert tt smi uplift and enable tt triage tests in merge gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -387,7 +387,6 @@ jobs:
       run-metal-cpp-unit-tests: true
 
   triage-tests:
-    if: ${{ false }} # Temporarily disabled in merge gate due to inconsistent failures; tracked in https://github.com/tenstorrent/tt-metal/issues/40659.
     needs: [ build, find-changes ]
     strategy:
       fail-fast: false
@@ -417,14 +416,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, docker-images, code-analysis, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, fabric-unit-tests, fabric-cpu-only-unit-tests]
+    needs: [static-checks, docker-images, code-analysis, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, code-analysis, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, fabric-unit-tests, fabric-cpu-only-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, tt-cnn-unit-tests, ttsim-unit-tests, triage-tests, fabric-unit-tests, fabric-cpu-only-unit-tests"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -28,8 +28,8 @@ chmod +x install.sh
 > TT-Installer automatically installs all latest versions. Wormhole Galaxy (6U) and Blackhole systems require the following versions:
 > | Device               | OS              | Python   | Driver (TT-KMD)    | Firmware (TT-Flash)                        | TT-SMI                | TT-Topology                    |
 > |----------------------|-----------------|----------|--------------------|--------------------------------------------|-----------------------|--------------------------------|
-> | Galaxy               | Ubuntu 22.04    | 3.10     | v2.5.0 or above    | fw_pack-19.2.0.fwbundle (v19.2.0)          | v4.1.2 or above      | N/A                            |
-> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.5.0 or above    | fw_pack-19.2.0.fwbundle (v19.2.0)          | v4.1.2 or above      | N/A                            |
+> | Galaxy               | Ubuntu 22.04    | 3.10     | v2.5.0 or above    | fw_pack-19.2.0.fwbundle (v19.2.0)          | v3.0.38 or above      | N/A                            |
+> | Blackhole            | Ubuntu 22.04    | 3.10     | v2.5.0 or above    | fw_pack-19.2.0.fwbundle (v19.2.0)          | v3.0.38 or above      | N/A                            |
 
 - If required, add the following flags for specifying dependencies versions:
 
@@ -38,7 +38,7 @@ chmod +x install.sh
 
 ```
 ./install.sh \
-  --smi-version=v4.1.2 \
+  --smi-version=v3.0.38 \
   --fw-version=19.2.0 \
   --kmd-version=2.5.0 \
   --install-container-runtime=no

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -5,7 +5,7 @@
 # Make it match pyproject.toml
 loguru==0.6.0
 
-tt-smi==4.1.2; platform_machine == "x86_64"
+tt-smi==4.0.0; platform_machine == "x86_64"
 
 # For github workflow unit test failure annotations
 pytest-github-actions-annotate-failures==0.3.0


### PR DESCRIPTION
### Problem description
Tests for `tt-triage` were not run in uplifting of `tt-smi` which introduced bug
https://github.com/tenstorrent/tt-metal/actions/runs/23510071491

### What's changed

- Revert `tt-smi` uplift
- Enable `tt-triage` tests
