### PR TITLE
[skip ci]: treat dependency-manifest changes as code-impacting

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -69,6 +69,15 @@ while IFS= read -r FILE; do
             TOOLS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
+        tt_metal/python_env/requirements*.txt|tt_metal/python_env/create_venv.sh)
+            # Runtime dependency changes can alter behavior of tests/tooling
+            # without touching C++/Python source directly.
+            ANY_CODE_CHANGED=true
+            ;;
+        tools/triage/requirements.txt)
+            TOOLS_CHANGED=true
+            ANY_CODE_CHANGED=true
+            ;;
         docs/**|**/*.rst|**/*.md)
             DOCS_CHANGED=true
             if [[ "$FILE" == "README.md" || "$FILE" == "models/README.md" ]]; then


### PR DESCRIPTION
## Summary
- Update `.github/scripts/utils/find-changed-files.sh` to classify runtime dependency manifest updates as `any-code-changed`
- Add explicit handling for:
  - `tt_metal/python_env/requirements*.txt`
  - `tt_metal/python_env/create_venv.sh`
  - `tools/triage/requirements.txt`
- This prevents merge-gate from skipping build/test jobs for dependency-only updates (for example, `tt-smi` version bumps)

## Why
Recent merge-gate behavior showed that dependency-manifest-only updates could be classified as no code change, causing downstream jobs to skip. This change makes dependency updates participate in the same gating path as other code-impacting changes.

## Test plan
- [x] Pre-commit hooks pass for modified shell script
- [x] Verified diff only changes `find-changed-files` classification logic
- [ ] Validate next dependency-manifest PR triggers merge-gate build/test jobs via `any-code-changed=true`

Made with [Cursor](https://cursor.com)