### PR TITLE
[skip ci] Reenable fabric test for sp1

### DIFF
--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -57,7 +57,7 @@ jobs:
           spec: |
             allocationType: MGD
             matchLabels:
-              exabox.tenstorrent.com/purpose: ci-quads
+              exabox.tenstorrent.com/purpose: ci-metal
             topologyKeys:
               - exabox.tenstorrent.com/quad-id
             mgd: |-

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -2,7 +2,7 @@ name: "Fabric Test on a BH Quad"
 
 on:
   schedule:
-    - cron: "0 */4 * * *" # Runs every 4 hours
+    - cron: "30 8 * * 1-5" # Runs weekdays at 9:30 AM GMT+1 (8:30 UTC)
   workflow_dispatch:
 
 run-name: Fabric Test on a BH Quad

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -140,7 +140,7 @@ jobs:
             /home/user/tt-metal/build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config /home/user/tt-metal/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_superpod_short_running.yaml
 
       - name: Run Pipeline Test
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: |
           PIPELINE_HOSTS=$(awk '{printf "%s:4,", $1}' /ci/ttrun/hostfile | sed 's/,$//')
           PIPELINE_DIR=/ci/pipeline-${{ github.run_id }}

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -67,9 +67,60 @@ jobs:
         with:
           allocationName: ci-${{ github.run_id }}-metal
 
+  reset:
+    name: Reset cards
+    needs: [build-artifact, create-allocation]
+    runs-on:
+      group: exabox
+      labels: exabox-multihost
+    env:
+      OMPI_MCA_btl_tcp_if_exclude: docker0,lo
+      PRTE_MCA_plm_ssh_args: "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+      PRTE_MCA_plm_ssh_pass_libpath: /opt/openmpi-v5.0.7-ulfm/lib
+      PRTE_MCA_prte_launch_agent: /opt/openmpi-v5.0.7-ulfm/bin/prted
+      PRTE_MCA_prte_default_hostfile: /ci/ttrun/hostfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create environment
+        uses: ./.github/actions/ttop-create-environment
+        timeout-minutes: 5
+        with:
+          environmentName:  ci-${{ github.run_id }}-reset
+          allocationName:  ci-${{ github.run_id }}-metal
+          workerImage: ${{ needs.build-artifact.outputs.dev-docker-image }}
+
+      # We use setup-tt-run just to setup MPI, MGD can be dummy
+      - name: Setup tt-run
+        uses: ./.github/actions/ttop-configure-tt-run
+        timeout-minutes: 5
+        with:
+          directory: /ci/ttrun
+          mgdFile: /tmp/dummy/doesnotexist.textproto
+          copyToWorkers: false
+          ranksData: ${{ needs.create-allocation.outputs.ranksData }}
+
+      - name: Print hostnames
+        working-directory: /tmp
+        run: |
+          mpirun --tag-output --pernode \
+            hostname
+
+      - name: Reset cards
+        working-directory: /tmp
+        run: |
+          mpirun --tag-output --pernode \
+            bash -c 'sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF && sleep 120'
+
+      - name: Delete environment
+        uses: ./.github/actions/ttop-delete-environment
+        with:
+          environmentName:  ci-${{ github.run_id }}-reset
+
   run:
     name: Run test
-    needs: [build-artifact, create-allocation]
+    needs: [build-artifact, create-allocation, reset]
     runs-on:
       group: exabox
       labels: exabox-multihost-with-nfs
@@ -139,7 +190,7 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: [run, create-allocation]
+    needs: [run, reset, create-allocation]
     if: always()
     runs-on:
       group: exabox
@@ -152,6 +203,12 @@ jobs:
         uses: ./.github/actions/ttop-delete-environment
         with:
           environmentName:  ci-${{ github.run_id }}-metal
+
+      # Redundantly try to drop reset env - reset job might have failed
+      - name: Delete reset environment
+        uses: ./.github/actions/ttop-delete-environment
+        with:
+          environmentName:  ci-${{ github.run_id }}-reset
 
       - name: Delete allocation
         uses: ./.github/actions/ttop-delete-allocation

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -118,6 +118,7 @@ jobs:
             bash -c 'sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF && sleep 120'
 
       - name: Delete environment
+        if: always()
         uses: ./.github/actions/ttop-delete-environment
         with:
           environmentName:  ci-${{ github.run_id }}-reset

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -69,9 +69,60 @@ jobs:
         with:
           allocationName: ci-${{ github.run_id }}-metal
 
+  reset:
+    name: Reset cards
+    needs: [build-artifact, create-allocation]
+    runs-on:
+      group: exabox
+      labels: exabox-multihost
+    env:
+      OMPI_MCA_btl_tcp_if_exclude: docker0,lo
+      PRTE_MCA_plm_ssh_args: "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+      PRTE_MCA_plm_ssh_pass_libpath: /opt/openmpi-v5.0.7-ulfm/lib
+      PRTE_MCA_prte_launch_agent: /opt/openmpi-v5.0.7-ulfm/bin/prted
+      PRTE_MCA_prte_default_hostfile: /ci/ttrun-reset/hostfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create environment
+        uses: ./.github/actions/ttop-create-environment
+        timeout-minutes: 5
+        with:
+          environmentName:  ci-${{ github.run_id }}-metal-reset
+          allocationName:  ci-${{ github.run_id }}-metal
+          workerImage: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          sharedVolumeEnabled: 'true'
+
+      - name: Setup tt-run
+        uses: ./.github/actions/ttop-configure-tt-run
+        timeout-minutes: 5
+        with:
+          directory: /ci/ttrun-reset
+          mgd: ${{ needs.create-allocation.outputs.mgd }}
+          copyToWorkers: false
+          ranksData: ${{ needs.create-allocation.outputs.ranksData }}
+
+      - name: Print hostnames
+        working-directory: /tmp
+        run: |
+          mpirun --tag-output --pernode \
+            hostname
+
+      - name: Reset cards
+        working-directory: /tmp
+        run: |
+          mpirun --tag-output --pernode \
+            bash -c 'sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF && sleep 120'
+
+      - name: Delete environment
+        uses: ./.github/actions/ttop-delete-environment
+        with:
+          environmentName:  ci-${{ github.run_id }}-metal-reset
+
   run:
     name: Run test
-    needs: [build-artifact, create-allocation]
+    needs: [build-artifact, reset, create-allocation]
     runs-on:
       group: exabox
       labels: exabox-multihost-with-nfs
@@ -171,6 +222,12 @@ jobs:
         uses: ./.github/actions/ttop-delete-environment
         with:
           environmentName:  ci-${{ github.run_id }}-metal
+
+      # Redundantly try to drop reset env - reset job might have failed
+      - name: Delete reset environment
+        uses: ./.github/actions/ttop-delete-environment
+        with:
+          environmentName:  ci-${{ github.run_id }}-metal-reset
 
       - name: Delete allocation
         uses: ./.github/actions/ttop-delete-allocation

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -2,7 +2,7 @@ name: "Fabric Test on a BH Quad"
 
 on:
   schedule:
-    - cron: "30 8 * * 1-5" # Runs weekdays at 9:30 AM GMT+1 (8:30 UTC)
+    - cron: "0 9 * * 1-5" # Runs weekdays at 10:00 AM GMT+1 (9:00 UTC)
   workflow_dispatch:
 
 run-name: Fabric Test on a BH Quad

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -72,6 +72,7 @@ jobs:
   reset:
     name: Reset cards
     needs: [build-artifact, create-allocation]
+    timeout-minutes: 15
     runs-on:
       group: exabox
       labels: exabox-multihost
@@ -111,6 +112,7 @@ jobs:
 
       - name: Reset cards
         working-directory: /tmp
+        timeout-minutes: 10
         run: |
           mpirun --tag-output --pernode \
             bash -c 'sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF && sleep 120'


### PR DESCRIPTION
### Problem description
Currently we don't have testing for exabox in Metal. We want to change that

### What's changed

- Set cron job to work on working days at 10:00 CET
- Add card reset
- Set allocate sp1 with lable `ci-metal`

### Checklist

- [x] [Fabric Test on a BH Quad](https://github.com/tenstorrent/tt-metal/actions/runs/23539866753/job/68525492083) - CI runs