### PR TITLE
[skip ci] (triage) Add Cursor CLI smoke test workflow

### DIFF
--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -3,9 +3,13 @@ name: "(triage) Cursor CLI smoke test"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cursor-cli-smoke-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,11 +25,24 @@ jobs:
 
       - name: Install Cursor CLI
         run: |
-          curl https://cursor.com/install -fsS | bash
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
           echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
 
       - name: Run simple Cursor prompt
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
-          agent -p "Reply with exactly: CURSOR_CI_OK"
+          set -euo pipefail
+          output="$(agent -p "Reply with exactly: CURSOR_CI_OK")"
+          echo "Agent output: $output"
+          if [[ "$output" != *"CURSOR_CI_OK"* ]]; then
+            echo "Unexpected agent output; expected CURSOR_CI_OK"
+            exit 1
+          fi

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,0 +1,31 @@
+name: "(triage) Cursor CLI smoke test"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cursor-cli-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure CURSOR_API_KEY is configured
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Install Cursor CLI
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Run simple Cursor prompt
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          agent -p "Reply with exactly: CURSOR_CI_OK"


### PR DESCRIPTION
### Ticket
N/A — experimental CI plumbing for Cursor LLM.

### Problem description
We want to validate running the Cursor CLI / agent from GitHub Actions before building fuller triage automation.

### What's changed
- Added `.github/workflows/triage-ci.yaml`: manual `workflow_dispatch` workflow named `(triage) Cursor CLI smoke test`.
- Installs Cursor CLI via official install script, requires `CURSOR_API_KEY` repo secret, runs a minimal `agent -p` smoke prompt.

**Note:** Configure the `CURSOR_API_KEY` repository secret before running this workflow.

### Checklist

- [ ] New/Existing tests provide coverage for changes — N/A (workflow-only smoke test; run manually from Actions after secret is set).