### PR TITLE
[CI] Add wh_galaxy_perf time budget for models/perf

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -121,6 +121,7 @@ models:
   perf:
     wh_llmbox_perf: 685
     wh_galaxy: 280
+    wh_galaxy_perf: 150
   device_perf:
     wh_n150: 100
     bh_p150: 100


### PR DESCRIPTION
### Ticket
N/A

### Problem description
PR #40384 (`akirby/adding-labels`) changed all Galaxy perf test SKUs from `wh_galaxy` to `wh_galaxy_perf` in `tests/pipeline_reorg/galaxy_perf_tests.yaml` but did not add the corresponding `wh_galaxy_perf` entry under `models: perf:` in `.github/time_budget.yaml`. This causes the `load-test-matrix` validation step to fail on any branch that runs the Galaxy perf pipeline:

```
[ERROR] Configuration FAILED! Could not find a 'time_budget' for Team 'models', Workflow 'perf', SKU 'wh_galaxy_perf' in ./.github/time_budget.yaml.
```

**Failing run**: https://github.com/tenstorrent/tt-metal/actions/runs/23544790218/job/68542961601

### What's changed

1. **`.github/time_budget.yaml`** — Added `wh_galaxy_perf: 150` under `models/perf`. Budget is based on the sum of current test timeouts: 15+15+15+25+20+20+20+15 = 145 min, rounded up to 150.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/galaxy-perf-wh-galaxy-perf-time-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/galaxy-perf-wh-galaxy-perf-time-budget)
- [ ] New/Existing tests provide coverage for changes