### PR TITLE
Bug Fix: Fabric Fused Scatter Write Stateful API

### DIFF
--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -312,10 +312,6 @@ static FORCE_INLINE void populate_unicast_fused_atomic_inc_fields(
             "UnicastFusedAtomicIncUpdateMask requires command_header but std::nullptr_t was provided");
     }
 
-    // Chunk count = 2 unicast write chunks + 1 semaphore increment chunk (constant)
-    packet_header->command_fields.unicast_scatter_write.chunk_count =
-        NOC_SCATTER_WRITE_ATOMIC_INC_FUSED_WRITE_CHUNKS + 1;
-
     if constexpr (has_flag(UpdateMask, UnicastFusedAtomicIncUpdateMask::WriteDstAddr)) {
         auto comps = get_noc_address_components(command_header.noc_address);
         auto noc_addr = safe_get_noc_addr(comps.first.x, comps.first.y, comps.second, edm_to_local_chip_noc);
@@ -349,6 +345,10 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
                 !has_flag(UpdateMask, UnicastFusedScatterWriteAtomicIncUpdateMask::Flush),
             "UnicastFusedScatterWriteAtomicIncUpdateMask requires command_header but std::nullptr_t was provided");
     }
+
+    // Chunk count = 2 unicast write chunks + 1 semaphore increment chunk (constant)
+    packet_header->command_fields.unicast_scatter_write.chunk_count =
+        NOC_SCATTER_WRITE_ATOMIC_INC_FUSED_WRITE_CHUNKS + 1;
 
     // Don't clear destination addresses, since the packet will always have 2 unicast write chunks and 1 semaphore
     // increment chunk.
@@ -395,13 +395,11 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
         for (uint8_t i = 0; i < NOC_SCATTER_WRITE_ATOMIC_INC_FUSED_WRITE_CHUNKS; i++) {
             set_chunk_encoding(chunk_encodings, NocScatterWriteChunkEncoding::CHUNK_ENCODING_UNICAST_WRITE, i);
         }
-        if (command_header.flush) {
-            set_chunk_encoding(
-                chunk_encodings,
-                (command_header.flush ? NocScatterWriteChunkEncoding::CHUNK_ENCODING_SEMINC_FLUSH
-                                      : NocScatterWriteChunkEncoding::CHUNK_ENCODING_SEMINC_NO_FLUSH),
-                NOC_SCATTER_WRITE_ATOMIC_INC_FUSED_WRITE_CHUNKS);
-        }
+        set_chunk_encoding(
+            chunk_encodings,
+            (command_header.flush ? NocScatterWriteChunkEncoding::CHUNK_ENCODING_SEMINC_FLUSH
+                                  : NocScatterWriteChunkEncoding::CHUNK_ENCODING_SEMINC_NO_FLUSH),
+            NOC_SCATTER_WRITE_ATOMIC_INC_FUSED_WRITE_CHUNKS);
         packet_header->command_fields.unicast_scatter_write.chunk_encoding = chunk_encodings;
     }
 


### PR DESCRIPTION
### Ticket

### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/37751 introduced support for a fused scatter write + semaphore inc NoC operation to Fabric. Unfortunately, there was a bug in the stateful API for this operation that caused the operations to hang. 

### What's changed
- Found 2 lines of code in the wrong function, moved them to the right one. 
- Fixed a bug where the `flush` parameter would not be set (left as undefined) if the parameter was set to False (thanks @SeanNijjar for pointing this out in the previous PR).

### Checklist
- [x] Passes Unit testing
- [x] Passes pytest on a Loudbox
- [x] Passes pytest on a 6U galaxy. 
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jhaiTT/fix-fused-scatter-write-stateful-API)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jhaiTT/fix-fused-scatter-write-stateful-API) (https://github.com/tenstorrent/tt-metal/actions/runs/23565166685)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jhaiTT/fix-fused-scatter-write-stateful-API)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jhaiTT/fix-fused-scatter-write-stateful-API) (fails like main)
  - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/23565178129
  - Main: https://github.com/tenstorrent/tt-metal/actions/runs/23599412687
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early (https://github.com/tenstorrent/tt-metal/actions/runs/23565191065)
- [x] TM-Fabric Regression (fails like main)
  - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/23565257263
  - Main: https://github.com/tenstorrent/tt-metal/actions/runs/23598758766
- [x] Merge Gate Regression (https://github.com/tenstorrent/tt-metal/actions/runs/23565317594)