### PR TITLE
Revert "Removing sharable ownership to MeshBuffer from Tensor (#39064)"

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -125,15 +125,18 @@ TEST_F(MeshTensorTest, Lifecycle) {
 
     EXPECT_TRUE(input_tensor.is_allocated());
 
-    EXPECT_NO_THROW({ input_tensor.mesh_buffer(); });
+    const auto* device_storage = &input_tensor.device_storage();
+
+    ASSERT_NE(device_storage, nullptr);
+    EXPECT_NE(device_storage->mesh_buffer, nullptr);
 
     // Buffer address is the same across all device buffers.
     const auto& view = mesh_device_->get_view();
-    const auto buffer_address = input_tensor.mesh_buffer().address();
+    const auto buffer_address = device_storage->mesh_buffer->address();
 
     for (auto* device : view.get_devices()) {
         auto coordinate = view.find_device(device->id());
-        auto* buffer = input_tensor.mesh_buffer().get_device_buffer(coordinate);
+        auto* buffer = device_storage->mesh_buffer->get_device_buffer(coordinate);
 
         ASSERT_NE(buffer, nullptr);
         EXPECT_TRUE(buffer->is_allocated());
@@ -142,7 +145,6 @@ TEST_F(MeshTensorTest, Lifecycle) {
 
     input_tensor.deallocate();
     EXPECT_FALSE(input_tensor.is_allocated());
-    EXPECT_THROW({ input_tensor.mesh_buffer(); }, std::runtime_error);
 }
 
 TEST_F(MeshTensorTest, ToDeviceMemoryConfigOverride) {
@@ -185,7 +187,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
         TensorTopology::create_fully_replicated_tensor_topology(mesh_device_->shape()));
 
     const auto& device_storage = device_tensor.device_storage();
-    EXPECT_NO_THROW({ device_storage.get_mesh_buffer(); });
+    EXPECT_NE(device_storage.mesh_buffer, nullptr);
     EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
 
     // Read the tensor back, and compare it with input data.
@@ -211,7 +213,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
 
     Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get());
     const auto& device_storage = device_tensor.device_storage();
-    EXPECT_NO_THROW({ device_storage.get_mesh_buffer(); });
+    EXPECT_NE(device_storage.mesh_buffer, nullptr);
     EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
 
     // Validate each tensor shard.
@@ -220,7 +222,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
     EXPECT_THAT(device_tensors, SizeIs(mesh_device_->num_devices()));
     for (const auto& tensor_shard : device_tensors) {
         const auto& shard_storage = tensor_shard.device_storage();
-        EXPECT_NO_THROW({ shard_storage.get_mesh_buffer(); });
+        EXPECT_NE(shard_storage.mesh_buffer, nullptr);
         EXPECT_THAT(shard_storage.coords, SizeIs(1));
         device_shard_coords.push_back(shard_storage.coords.front());
         EXPECT_THAT(tensor_shard.to_vector<float>(), Pointwise(FloatEq(), host_data));
@@ -275,7 +277,7 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
         std::vector<Tensor>{device_tensors1[6], device_tensors1[4], device_tensors1[2], device_tensors1[0]}, shard_dim);
 
     const auto& partial_device_storage = partial_tensor.device_storage();
-    EXPECT_NO_THROW({ partial_device_storage.get_mesh_buffer(); });
+    EXPECT_NE(partial_device_storage.mesh_buffer, nullptr);
 
     EXPECT_EQ(partial_tensor.tensor_topology().distribution_shape(), MeshShape(4));
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -136,20 +136,18 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
     std::vector<uint16_t> empty_data(volume);
     auto tensor = Tensor::from_vector(empty_data, tensor_spec, device_);
 
-    const auto& buffer = tensor.mesh_buffer();
+    const auto& storage = tensor.device_storage();
+    auto buffer = storage.get_mesh_buffer();
 
-    // TODO(#38691): Clean this up after we provide non-shared-ptr overloads for these methods.
-    const auto& shared_mesh_buffer = tensor.device_storage().get_mesh_buffer_leak_ownership();
-
-    size_t region_size = buffer.page_size();
-    while (buffer.size() % (region_size * 2) == 0) {
+    size_t region_size = buffer->page_size();
+    while (buffer->size() % (region_size * 2) == 0) {
         region_size *= 2;
     }
 
     std::vector<uint16_t> partial_readback_data(tensor_data.size());
     std::vector<uint16_t> full_readback_data(tensor_data.size());
 
-    for (size_t region = 0; region < buffer.size() / region_size; region++) {
+    for (size_t region = 0; region < buffer->size() / region_size; region++) {
         size_t region_offset = region * region_size;
         auto buffer_region = BufferRegion{region_offset, region_size};
         auto write_shard_data_transfer =
@@ -160,13 +158,13 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
             distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}
                 .host_data(reinterpret_cast<std::byte*>(partial_readback_data.data()) + region_offset)
                 .region(buffer_region);
-        device_->mesh_command_queue().enqueue_write_shards(shared_mesh_buffer, {write_shard_data_transfer}, true);
-        device_->mesh_command_queue().enqueue_read_shards({read_shard_data_transfer}, shared_mesh_buffer, true);
+        device_->mesh_command_queue().enqueue_write_shards(buffer, {write_shard_data_transfer}, true);
+        device_->mesh_command_queue().enqueue_read_shards({read_shard_data_transfer}, buffer, true);
     }
     EXPECT_EQ(tensor_data, partial_readback_data);
 
     distributed::ReadShard(
-        device_->mesh_command_queue(), full_readback_data, shared_mesh_buffer, distributed::MeshCoordinate(0, 0), true);
+        device_->mesh_command_queue(), full_readback_data, buffer, distributed::MeshCoordinate(0, 0), true);
     EXPECT_EQ(tensor_data, full_readback_data);
 }
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -66,9 +66,9 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
     }
 
     // Verify all tensors are at the same address
-    auto reference_address = unit_tensors[0].mesh_buffer().address();
+    auto reference_address = unit_tensors[0].mesh_buffer()->address();
     for (size_t i = 1; i < unit_tensors.size(); i++) {
-        EXPECT_EQ(unit_tensors[i].mesh_buffer().address(), reference_address);
+        EXPECT_EQ(unit_tensors[i].mesh_buffer()->address(), reference_address);
     }
 
     // Test aggregate
@@ -79,7 +79,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
     EXPECT_EQ(aggregated_tensor.logical_shape(), shape);
     EXPECT_EQ(aggregated_tensor.dtype(), dtype);
     EXPECT_EQ(aggregated_tensor.layout(), layout);
-    EXPECT_EQ(aggregated_tensor.mesh_buffer().address(), reference_address);
+    EXPECT_EQ(aggregated_tensor.mesh_buffer()->address(), reference_address);
 
     // Test disaggregate
     auto disaggregated_tensors = disaggregate(aggregated_tensor);
@@ -92,7 +92,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
         EXPECT_EQ(tensor.logical_shape(), shape);
         EXPECT_EQ(tensor.dtype(), dtype);
         EXPECT_EQ(tensor.layout(), layout);
-        EXPECT_EQ(tensor.mesh_buffer().address(), reference_address);
+        EXPECT_EQ(tensor.mesh_buffer()->address(), reference_address);
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
@@ -563,7 +563,8 @@ inline void log_gcores_info(
 inline tt::tt_metal::experimental::udm::MeshTensorBuilder create_tensor_builder(const ttnn::Tensor& tensor) {
     // Extract MeshBuffer from the distributed tensor
     TT_FATAL(is_device_tensor(tensor), "Tensor must be on device");
-    TT_FATAL(tensor.is_allocated(), "Tensor must be allocated");
+    const auto& device_storage = tensor.device_storage();
+    TT_FATAL(device_storage.mesh_buffer != nullptr, "Tensor must have a MeshBuffer");
 
     // Extract distribution info from tensor topology
     const auto& topology = tensor.tensor_topology();
@@ -587,7 +588,7 @@ inline tt::tt_metal::experimental::udm::MeshTensorBuilder create_tensor_builder(
     }
 
     return tt::tt_metal::experimental::udm::MeshTensorBuilder(
-        tensor.mesh_buffer(), tensor_shape_in_pages, distribution_shape, shard_dims);
+        *device_storage.mesh_buffer, tensor_shape_in_pages, distribution_shape, shard_dims);
 }
 
 /**

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_program_factory.cpp
@@ -45,6 +45,16 @@ RingSDPABwKVProgramFactory::cached_mesh_workload_t RingSDPABwKVProgramFactory::c
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t> shared_vars;
 
+    // Get mesh buffers
+    auto grad_output_mesh_buffer = grad_output.mesh_buffer();
+    auto attn_output_mesh_buffer = attn_output.mesh_buffer();
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+    auto grad_key_mesh_buffer = grad_key.mesh_buffer();
+    auto grad_value_mesh_buffer = grad_value.mesh_buffer();
+
     for (const auto& mesh_coord : ttnn::MeshCoordinateRange(mesh_shape)) {
         uint32_t device_ring_id = mesh_coord[ring_axis];
 
@@ -55,21 +65,52 @@ RingSDPABwKVProgramFactory::cached_mesh_workload_t RingSDPABwKVProgramFactory::c
             continue;
         }
 
+        // Create DeviceStorage objects
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{mesh_coord};
+        tt::tt_metal::DeviceStorage grad_output_storage(grad_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage attn_output_storage(attn_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_key_storage(grad_key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_value_storage(grad_value_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(mesh_shape.dims());
+        for (size_t i = 0; i < mesh_shape.dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto grad_output_tensor =
+            ttnn::Tensor(std::move(grad_output_storage), grad_output.tensor_spec(), tensor_topology);
+        auto attn_output_tensor =
+            ttnn::Tensor(std::move(attn_output_storage), attn_output.tensor_spec(), tensor_topology);
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+        auto grad_key_tensor = ttnn::Tensor(std::move(grad_key_storage), grad_key.tensor_spec(), tensor_topology);
+        auto grad_value_tensor = ttnn::Tensor(std::move(grad_value_storage), grad_value.tensor_spec(), tensor_topology);
+
         // Create SDPA backward KV with mask_type (no explicit mask tensor needed)
         sdpa_kv::operation_attributes_t sdpa_attrs{.mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_kv::tensor_args_t sdpa_tensor_args{
-            .grad_output = grad_output,
-            .attn_output = attn_output,
-            .query = query,
-            .key = key,
-            .value = value,
+            .grad_output = grad_output_tensor,
+            .attn_output = attn_output_tensor,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .attn_mask = std::nullopt,  // No explicit mask - using mask_type
-            .intermediates = intermediates,
-            .preallocated_grad_key = grad_key,
-            .preallocated_grad_value = grad_value};
+            .intermediates = intermediates_tensor,
+            .preallocated_grad_key = grad_key_tensor,
+            .preallocated_grad_value = grad_value_tensor};
 
-        sdpa_kv::tensor_return_value_t sdpa_return_value{grad_key, grad_value};
+        sdpa_kv::tensor_return_value_t sdpa_return_value{grad_key_tensor, grad_value_tensor};
 
         auto cached_program =
             sdpa_bw::device::SDPABackwardKVProgramFactory::create(sdpa_attrs, sdpa_tensor_args, sdpa_return_value);
@@ -118,6 +159,16 @@ void RingSDPABwKVProgramFactory::override_runtime_arguments(
     const auto mask_type = operation_attributes.mask_type;
     const auto ring_direction = operation_attributes.ring_direction;
 
+    // Get mesh buffers
+    auto grad_output_mesh_buffer = grad_output.mesh_buffer();
+    auto attn_output_mesh_buffer = attn_output.mesh_buffer();
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+    auto grad_key_mesh_buffer = grad_key.mesh_buffer();
+    auto grad_value_mesh_buffer = grad_value.mesh_buffer();
+
     for (auto& [coord_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coord_range);
         const auto& start_coord = coord_range.start_coord();
@@ -127,21 +178,52 @@ void RingSDPABwKVProgramFactory::override_runtime_arguments(
         auto [should_execute, effective_mask_type] =
             get_device_execution_info(device_ring_id, step, ring_size, mask_type, ring_direction);
 
+        // Create DeviceStorage objects for this coordinate
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{start_coord};
+        tt::tt_metal::DeviceStorage grad_output_storage(grad_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage attn_output_storage(attn_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_key_storage(grad_key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_value_storage(grad_value_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(mesh_shape.dims());
+        for (size_t i = 0; i < mesh_shape.dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto grad_output_tensor =
+            ttnn::Tensor(std::move(grad_output_storage), grad_output.tensor_spec(), tensor_topology);
+        auto attn_output_tensor =
+            ttnn::Tensor(std::move(attn_output_storage), attn_output.tensor_spec(), tensor_topology);
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+        auto grad_key_tensor = ttnn::Tensor(std::move(grad_key_storage), grad_key.tensor_spec(), tensor_topology);
+        auto grad_value_tensor = ttnn::Tensor(std::move(grad_value_storage), grad_value.tensor_spec(), tensor_topology);
+
         // Create SDPA attributes and tensor args
         sdpa_kv::operation_attributes_t sdpa_attrs{.mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_kv::tensor_args_t sdpa_tensor_args{
-            .grad_output = grad_output,
-            .attn_output = attn_output,
-            .query = query,
-            .key = key,
-            .value = value,
+            .grad_output = grad_output_tensor,
+            .attn_output = attn_output_tensor,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .attn_mask = std::nullopt,
-            .intermediates = intermediates,
-            .preallocated_grad_key = grad_key,
-            .preallocated_grad_value = grad_value};
+            .intermediates = intermediates_tensor,
+            .preallocated_grad_key = grad_key_tensor,
+            .preallocated_grad_value = grad_value_tensor};
 
-        sdpa_kv::tensor_return_value_t sdpa_return_value{grad_key, grad_value};
+        sdpa_kv::tensor_return_value_t sdpa_return_value{grad_key_tensor, grad_value_tensor};
 
         // Convert our shared_variables to SDPA's shared_variables type
         sdpa_bw::device::SDPABackwardKVProgramFactory::shared_variables_t sdpa_shared_vars{

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_program_factory.cpp
@@ -45,6 +45,15 @@ RingSDPABwQProgramFactory::cached_mesh_workload_t RingSDPABwQProgramFactory::cre
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t> shared_vars;
 
+    // Get mesh buffers
+    auto grad_output_mesh_buffer = grad_output.mesh_buffer();
+    auto attn_output_mesh_buffer = attn_output.mesh_buffer();
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+    auto grad_query_mesh_buffer = grad_query.mesh_buffer();
+
     for (const auto& mesh_coord : ttnn::MeshCoordinateRange(mesh_shape)) {
         uint32_t device_ring_id = mesh_coord[ring_axis];
 
@@ -55,20 +64,47 @@ RingSDPABwQProgramFactory::cached_mesh_workload_t RingSDPABwQProgramFactory::cre
             continue;
         }
 
+        // Create DeviceStorage objects
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{mesh_coord};
+        tt::tt_metal::DeviceStorage grad_output_storage(grad_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage attn_output_storage(attn_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_query_storage(grad_query_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(
+            mesh_shape.dims(), ttnn::distributed::MeshMapperConfig::Replicate{});
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto grad_output_tensor =
+            ttnn::Tensor(std::move(grad_output_storage), grad_output.tensor_spec(), tensor_topology);
+        auto attn_output_tensor =
+            ttnn::Tensor(std::move(attn_output_storage), attn_output.tensor_spec(), tensor_topology);
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+        auto grad_query_tensor = ttnn::Tensor(std::move(grad_query_storage), grad_query.tensor_spec(), tensor_topology);
+
         // Create SDPA backward Q with mask_type (no explicit mask tensor needed)
         sdpa_q::operation_attributes_t sdpa_attrs{.mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_q::tensor_args_t sdpa_tensor_args{
-            .grad_output = grad_output,
-            .attn_output = attn_output,
-            .query = query,
-            .key = key,
-            .value = value,
+            .grad_output = grad_output_tensor,
+            .attn_output = attn_output_tensor,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .attn_mask = std::nullopt,  // No explicit mask - using mask_type
-            .intermediates = intermediates,
-            .preallocated_grad_query = grad_query};
+            .intermediates = intermediates_tensor,
+            .preallocated_grad_query = grad_query_tensor};
 
-        sdpa_q::tensor_return_value_t sdpa_return_value{grad_query};
+        sdpa_q::tensor_return_value_t sdpa_return_value{grad_query_tensor};
 
         auto cached_program =
             sdpa_bw::device::SDPABackwardQProgramFactory::create(sdpa_attrs, sdpa_tensor_args, sdpa_return_value);
@@ -116,6 +152,15 @@ void RingSDPABwQProgramFactory::override_runtime_arguments(
     const auto mask_type = operation_attributes.mask_type;
     const auto ring_direction = operation_attributes.ring_direction;
 
+    // Get mesh buffers
+    auto grad_output_mesh_buffer = grad_output.mesh_buffer();
+    auto attn_output_mesh_buffer = attn_output.mesh_buffer();
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+    auto grad_query_mesh_buffer = grad_query.mesh_buffer();
+
     for (auto& [coord_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coord_range);
         const auto& start_coord = coord_range.start_coord();
@@ -126,20 +171,49 @@ void RingSDPABwQProgramFactory::override_runtime_arguments(
             get_device_execution_info(device_ring_id, step, ring_size, mask_type, ring_direction);
         (void)should_execute;  // Already filtered in create_mesh_workload
 
+        // Create DeviceStorage objects for this coordinate
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{start_coord};
+        tt::tt_metal::DeviceStorage grad_output_storage(grad_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage attn_output_storage(attn_output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage grad_query_storage(grad_query_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(mesh_shape.dims());
+        for (size_t i = 0; i < mesh_shape.dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto grad_output_tensor =
+            ttnn::Tensor(std::move(grad_output_storage), grad_output.tensor_spec(), tensor_topology);
+        auto attn_output_tensor =
+            ttnn::Tensor(std::move(attn_output_storage), attn_output.tensor_spec(), tensor_topology);
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+        auto grad_query_tensor = ttnn::Tensor(std::move(grad_query_storage), grad_query.tensor_spec(), tensor_topology);
+
         // Create SDPA attributes and tensor args
         sdpa_q::operation_attributes_t sdpa_attrs{.mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_q::tensor_args_t sdpa_tensor_args{
-            .grad_output = grad_output,
-            .attn_output = attn_output,
-            .query = query,
-            .key = key,
-            .value = value,
+            .grad_output = grad_output_tensor,
+            .attn_output = attn_output_tensor,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .attn_mask = std::nullopt,
-            .intermediates = intermediates,
-            .preallocated_grad_query = grad_query};
+            .intermediates = intermediates_tensor,
+            .preallocated_grad_query = grad_query_tensor};
 
-        sdpa_q::tensor_return_value_t sdpa_return_value{grad_query};
+        sdpa_q::tensor_return_value_t sdpa_return_value{grad_query_tensor};
 
         // Convert our shared_variables to SDPA's shared_variables type
         sdpa_bw::device::SDPABackwardQProgramFactory::shared_variables_t sdpa_shared_vars{

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_program_factory.cpp
@@ -87,6 +87,13 @@ RingSDPAFwProgramFactory::cached_mesh_workload_t RingSDPAFwProgramFactory::creat
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t> shared_vars;
 
+    // Get mesh buffers
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto output_mesh_buffer = output.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+
     // Iterate over all device coordinates in the mesh
     for (const auto& mesh_coord : ttnn::MeshCoordinateRange(mesh_shape)) {
         uint32_t device_ring_id = mesh_coord[ring_axis];
@@ -99,20 +106,43 @@ RingSDPAFwProgramFactory::cached_mesh_workload_t RingSDPAFwProgramFactory::creat
             continue;
         }
 
+        // Create DeviceStorage objects for this coordinate
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{mesh_coord};
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage output_storage(output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology for single device
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(mesh_shape.dims());
+        for (size_t i = 0; i < mesh_shape.dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto output_tensor = ttnn::Tensor(std::move(output_storage), output.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+
         // Create SDPA forward operation with the effective mask type
         // No explicit mask tensor needed - SDPA kernel generates causal mask internally
         sdpa_fw::device::operation_attributes_t sdpa_attrs{
             .return_intermediates = true, .mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_fw::device::tensor_args_t sdpa_tensor_args{
-            .query = query,
-            .key = key,
-            .value = value,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .mask = std::nullopt,  // No explicit mask - use mask_type
-            .preallocated_intermediate = intermediates,
-            .preallocated_output = output};
+            .preallocated_intermediate = intermediates_tensor,
+            .preallocated_output = output_tensor};
 
-        sdpa_fw::device::tensor_return_value_t sdpa_return_value{output, intermediates};
+        sdpa_fw::device::tensor_return_value_t sdpa_return_value{output_tensor, intermediates_tensor};
 
         // Create the program
         auto cached_program =
@@ -160,6 +190,13 @@ void RingSDPAFwProgramFactory::override_runtime_arguments(
     const auto mask_type = operation_attributes.mask_type;
     const auto ring_direction = operation_attributes.ring_direction;
 
+    // Get mesh buffers
+    auto query_mesh_buffer = query.mesh_buffer();
+    auto key_mesh_buffer = key.mesh_buffer();
+    auto value_mesh_buffer = value.mesh_buffer();
+    auto output_mesh_buffer = output.mesh_buffer();
+    auto intermediates_mesh_buffer = intermediates.mesh_buffer();
+
     // Iterate over cached programs and update runtime arguments
     for (auto& [coord_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coord_range);
@@ -173,20 +210,43 @@ void RingSDPAFwProgramFactory::override_runtime_arguments(
             get_device_execution_info(device_ring_id, step, ring_size, mask_type, ring_direction);
         (void)should_execute;  // Already filtered in create_mesh_workload
 
+        // Create DeviceStorage objects for this coordinate
+        std::vector<tt::tt_metal::distributed::MeshCoordinate> single_coord_vec{start_coord};
+        tt::tt_metal::DeviceStorage query_storage(query_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage key_storage(key_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage value_storage(value_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage output_storage(output_mesh_buffer, single_coord_vec);
+        tt::tt_metal::DeviceStorage intermediates_storage(intermediates_mesh_buffer, single_coord_vec);
+
+        // Create TensorTopology
+        ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements(mesh_shape.dims());
+        for (size_t i = 0; i < mesh_shape.dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tt::tt_metal::TensorTopology tensor_topology{mesh_shape, placements, single_coord_vec};
+
+        // Create single-device tensors
+        auto query_tensor = ttnn::Tensor(std::move(query_storage), query.tensor_spec(), tensor_topology);
+        auto key_tensor = ttnn::Tensor(std::move(key_storage), key.tensor_spec(), tensor_topology);
+        auto value_tensor = ttnn::Tensor(std::move(value_storage), value.tensor_spec(), tensor_topology);
+        auto output_tensor = ttnn::Tensor(std::move(output_storage), output.tensor_spec(), tensor_topology);
+        auto intermediates_tensor =
+            ttnn::Tensor(std::move(intermediates_storage), intermediates.tensor_spec(), tensor_topology);
+
         // Create SDPA attributes and tensor args
         std::optional<ttnn::Tensor> mask_opt = std::nullopt;
         sdpa_fw::operation_attributes_t sdpa_attrs{
             .return_intermediates = true, .mask_type = effective_mask_type, .dropout_probability = 0.0F};
 
         sdpa_fw::tensor_args_t sdpa_tensor_args{
-            .query = query,
-            .key = key,
-            .value = value,
+            .query = query_tensor,
+            .key = key_tensor,
+            .value = value_tensor,
             .mask = mask_opt,
-            .preallocated_intermediate = intermediates,
-            .preallocated_output = output};
+            .preallocated_intermediate = intermediates_tensor,
+            .preallocated_output = output_tensor};
 
-        sdpa_fw::tensor_return_value_t sdpa_return_value{output, intermediates};
+        sdpa_fw::tensor_return_value_t sdpa_return_value{output_tensor, intermediates_tensor};
 
         // Convert our shared_variables to SDPA's shared_variables type
         sdpa_fw::SDPAForwardProgramFactory::shared_variables_t sdpa_shared_vars{

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -60,8 +60,7 @@ TensorReturnValue filter_tensor_shards(
             }
 
             // Create new storage with filtered coords, sharing the mesh_buffer
-            tt::tt_metal::DeviceStorage new_storage(
-                old_storage.get_mesh_buffer_leak_ownership(), std::move(filtered_coords));
+            tt::tt_metal::DeviceStorage new_storage(old_storage.mesh_buffer, std::move(filtered_coords));
 
             // Return new tensor with new storage
             return Tensor(std::move(new_storage), tensor.tensor_spec(), tensor.tensor_topology());

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -57,13 +57,10 @@ private:
 
 struct DeviceStorage {
     std::vector<distributed::MeshCoordinate> coords;
-
-private:
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
     // Workaround for managing view MeshBuffer; expected to be refactored in #38093
     std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
 
-public:
     DeviceStorage() = default;
     DeviceStorage(
         std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
@@ -71,13 +68,9 @@ public:
         std::shared_ptr<distributed::MeshBuffer> root_buffer_ = nullptr);
 
     Buffer* get_buffer() const;
-    const distributed::MeshBuffer& get_mesh_buffer() const;
-
-    // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
-    bool is_sole_owner_of_device_memory() const;
+    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
 
     // Begin internal functions:
-    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
     //
     // These functions allows the use of the get_mesh_buffer as a view.
     // These are considered internal functions and are not part of the public API.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -250,7 +250,7 @@ public:
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.
-    const distributed::MeshBuffer& mesh_buffer() const;
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer() const;
 
     // Returns the device the tensor is allocated on.
     // Throws if the tensor is not allocated on a device.

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -75,7 +75,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
     }
     if (is_device_tensor(tensor)) {
         const auto& device_storage = tensor.device_storage();
-        if (const auto& mesh_buffer = device_storage.get_mesh_buffer_leak_ownership(); mesh_buffer != nullptr) {
+        if (auto mesh_buffer = device_storage.mesh_buffer; mesh_buffer != nullptr) {
             std::vector<ttnn::Tensor> tensors;
             tensors.reserve(device_storage.coords.size());
             for (const auto& coord : device_storage.coords) {
@@ -120,7 +120,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
             shard.tensor_spec() == reference_shard.tensor_spec(), "All tensor shards must have the same tensor spec");
     }
 
-    auto mesh_buffer = reference_shard.device_storage().get_mesh_buffer_leak_ownership();
+    auto mesh_buffer = reference_shard.device_storage().mesh_buffer;
     TT_FATAL(
         mesh_buffer != nullptr,
         "Error aggregating multichip tensors: tensors shards must be allocated on a mesh buffer.");
@@ -128,7 +128,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
     for (const auto& shard : tensor_shards) {
         const auto& shard_storage = shard.device_storage();
         TT_FATAL(
-            shard_storage.get_mesh_buffer_leak_ownership() == mesh_buffer,
+            shard_storage.mesh_buffer == mesh_buffer,
             "Error aggregating multichip tensors: tensor shards must be allocated on the same mesh buffer. "
             "Consider moving tensors to host, aggregating, and re-uploading on device storage.");
         for (const auto& coord : shard_storage.coords) {

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -545,24 +545,30 @@ void GraphProcessor::track_function_end(const std::any& output_tensors) {
 node_id GraphProcessor::add_tensor(const Tensor& t) {
     tt::tt_metal::Buffer* buffer = nullptr;
     nlohmann::json device_tensors_json = nlohmann::json::array();
-    if (is_device_tensor(t) && t.is_allocated()) {
-        const auto& mesh_buffer = t.mesh_buffer();
+    if (is_device_tensor(t)) {
+        const auto& storage = t.device_storage();
+        if (storage.mesh_buffer) {
+            // `t.buffers()` returns a reference buffer allocated on first device in a mesh.
+            // It has an ID different from the "backing" buffer that was used to perform the allocation.
+            // To deduplicate an entry for this buffer, captured during its allocation, use the "backing"
+            // buffer.
+            buffer = storage.mesh_buffer->get_backing_buffer();
 
-        // `t.buffers()` returns a reference buffer allocated on first device in a mesh.
-        // It has an ID different from the "backing" buffer that was used to perform the allocation.
-        // To deduplicate an entry for this buffer, captured during its allocation, use the "backing"
-        // buffer.
-        buffer = mesh_buffer.get_backing_buffer();
-
-        // For multi-device tensors, capture per-device addresses and mesh device IDs
-        for (const auto& coord : t.device_storage().coords) {
-            auto* device_buffer = mesh_buffer.get_device_buffer(coord);
-            if (device_buffer != nullptr) {
-                device_tensors_json.push_back(
-                    {{"device_id", device_buffer->device()->id()},
-                     {kMeshDeviceId, buffer != nullptr ? buffer->device()->id() : device_buffer->device()->id()},
-                     {"address", device_buffer->address()}});
+            // For multi-device tensors, capture per-device addresses and mesh device IDs
+            if (storage.mesh_buffer->is_allocated()) {
+                for (const auto& coord : storage.coords) {
+                    auto* device_buffer = storage.mesh_buffer->get_device_buffer(coord);
+                    if (device_buffer != nullptr) {
+                        device_tensors_json.push_back(
+                            {{"device_id", device_buffer->device()->id()},
+                             {kMeshDeviceId,
+                              buffer != nullptr ? buffer->device()->id() : device_buffer->device()->id()},
+                             {"address", device_buffer->address()}});
+                    }
+                }
             }
+        } else {
+            buffer = t.buffer();
         }
     }
 
@@ -603,12 +609,7 @@ node_id GraphProcessor::add_tensor(const Tensor& t) {
         .stacking_level = stacking_level});
 
     if (buffer == nullptr) {
-        switch (t.storage_type()) {
-            case StorageType::DEVICE:
-                log_debug(tt::LogAlways, "Tensor does not have buffer (on device but deallocated)");
-                break;
-            case StorageType::HOST: log_debug(tt::LogAlways, "Tensor does not have buffer (on host)"); break;
-        }
+        log_debug(tt::LogAlways, "Tensor doesn't have buffer, but storage is {}", t.storage_type());
     } else {
         node_id buffer_node_id = add_buffer(buffer);
         graph[buffer_node_id].connections.push_back(tensor_counter);

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
-#include <functional>
-#include <unordered_set>
 #include <vector>
 
 #include <ttnn/tensor/layout/layout.hpp>
@@ -59,14 +57,7 @@ Buffer* DeviceStorage::get_buffer() const {
     TT_THROW("Buffer is not allocated");
 }
 
-const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
-    return *mesh_buffer;
-}
-
-bool DeviceStorage::is_sole_owner_of_device_memory() const { return mesh_buffer.use_count() == 1; }
-
-std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
+std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer() const {
     TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
     return mesh_buffer;
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -116,8 +116,8 @@ Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology ten
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
         std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
-    if (device_storage().is_allocated()) {
-        mesh_device_ = device_storage().get_device();
+    if (auto buffer = device_storage().mesh_buffer; buffer != nullptr) {
+        mesh_device_ = buffer->device();
     }
 }
 
@@ -529,7 +529,7 @@ void memcpy(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(dst)
             .region(region)};
-    queue.enqueue_read_shards(shard_data_transfers, src.device_storage().get_mesh_buffer_leak_ownership(), blocking);
+    queue.enqueue_read_shards(shard_data_transfers, src.mesh_buffer(), blocking);
 }
 
 void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
@@ -548,7 +548,7 @@ void memcpy(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(const_cast<void*>(src))
             .region(region)};
-    queue.enqueue_write_shards(dst.device_storage().get_mesh_buffer_leak_ownership(), shard_data_transfers, false);
+    queue.enqueue_write_shards(dst.mesh_buffer(), shard_data_transfers, false);
 }
 
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
@@ -641,7 +641,7 @@ distributed::MeshDevice* Tensor::device() const {
     return nullptr;
 }
 
-const distributed::MeshBuffer& Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }
+std::shared_ptr<distributed::MeshBuffer> Tensor::mesh_buffer() const { return device_storage().get_mesh_buffer(); }
 
 const MemoryConfig& Tensor::memory_config() const { return tensor_spec().tensor_layout().get_memory_config(); }
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -472,12 +472,12 @@ std::string to_string_impl(const Tensor& tensor) {
 
     const auto& storage = tensor.device_storage();
     auto cpu_tensor = tensor.cpu();
-    if (!storage.is_allocated()) {
+    if (storage.mesh_buffer == nullptr) {
         // Use owned buffer path above.
         return to_string_impl<T>(cpu_tensor);
     }
 
-    auto* mesh_device = storage.get_device();
+    auto* mesh_device = storage.mesh_buffer->device();
     // TODO: Uncomment after the distributed tensors migration to tt-metal is complete.
     // if (mesh_device->num_devices() == 1) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));
@@ -539,7 +539,7 @@ HostBuffer allocate_host_buffer(const TensorSpec& tensor_spec) {
 Tensor to_host(const Tensor& tensor, bool blocking, std::optional<tt::tt_metal::QueueId> cq_id) {
     TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
     const auto& storage = tensor.device_storage();
-    const auto& mesh_buffer = storage.get_mesh_buffer_leak_ownership();
+    const auto& mesh_buffer = storage.mesh_buffer;
     distributed::MeshDevice* device = mesh_buffer->device();
 
     auto cq_id_int = tt::tt_metal::raw_optional(cq_id);
@@ -672,7 +672,7 @@ void copy_to_host(
         "Host tensor has different page config");
 
     const auto& device_storage = device_tensor.device_storage();
-    const auto& mesh_buffer = device_storage.get_mesh_buffer_leak_ownership();
+    const auto& mesh_buffer = device_storage.mesh_buffer;
     distributed::MeshDevice* device = mesh_buffer->device();
 
     auto cq_id_int = tt::tt_metal::raw_optional(cq_id);
@@ -725,8 +725,7 @@ void copy_to_host(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(dst)
             .region(region)};
-    queue.enqueue_read_shards(
-        shard_data_transfers, device_tensor.device_storage().get_mesh_buffer_leak_ownership(), blocking);
+    queue.enqueue_read_shards(shard_data_transfers, device_tensor.mesh_buffer(), blocking);
 }
 
 void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optional<tt::tt_metal::QueueId> cq_id) {
@@ -740,7 +739,7 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
         host_tensor.tensor_spec().page_config() == device_tensor.tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
+    auto mesh_buffer = device_tensor.device_storage().mesh_buffer;
 
     auto [mesh_storage, topology] = to_device_mesh_buffer(
         host_tensor.host_storage(), mesh_buffer, device_tensor.tensor_spec(), host_tensor.tensor_topology(), cq_id);
@@ -759,8 +758,7 @@ void copy_to_device(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(const_cast<std::byte*>(src))
             .region(region)};
-    queue.enqueue_write_shards(
-        device_tensor.device_storage().get_mesh_buffer_leak_ownership(), shard_data_transfers, false);
+    queue.enqueue_write_shards(device_tensor.mesh_buffer(), shard_data_transfers, false);
 }
 
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -323,7 +323,7 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                 tt::tt_metal::BufferDistributionSpec new_buffer_dist_spec = tt::tt_metal::BufferDistributionSpec(
                     tensor_shape_pages, shard_shape_pages, new_shard_spec.grid, new_shard_spec.orientation);
 
-                auto device_local_config = device_storage.get_mesh_buffer().device_local_config();
+                auto device_local_config = device_storage.mesh_buffer->device_local_config();
                 auto& sharding_args = device_local_config.sharding_args;
                 tt::tt_metal::BufferShardingArgs new_sharding_args(
                     new_buffer_dist_spec, new_shard_spec_buffer, sharding_args.buffer_layout());
@@ -335,10 +335,10 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                     .bottom_up = device_local_config.bottom_up};
 
                 auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-                    device_storage.get_mesh_buffer().global_config(),
+                    device_storage.mesh_buffer->global_config(),
                     new_device_config,
-                    device_storage.get_device(),
-                    device_storage.get_mesh_buffer().address());
+                    device_storage.mesh_buffer->device(),
+                    device_storage.mesh_buffer->address());
                 tt::tt_metal::DeviceStorage view_storage(
                     view_mesh_buffer, device_storage.coords, device_storage.get_root_mesh_buffer());
 

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -27,8 +27,9 @@ std::string to_string(const tt::tt_metal::Tensor& tensor) {
     }
 
     if (is_device_tensor(tensor)) {
-        if (tensor.is_allocated()) {
-            auto* mesh_device = tensor.device();
+        const auto& storage = tensor.device_storage();
+        if (storage.mesh_buffer != nullptr) {
+            auto* mesh_device = storage.mesh_buffer->device();
 
             if (mesh_device->num_devices() == 1) {
                 auto cpu_tensor = tensor.cpu();

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -67,11 +67,11 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
 
     // Validate all tensor specs and mesh buffer addresses are the same.
     const auto& reference_spec = tensors[0].tensor_spec();
-    auto reference_address = tensors[0].mesh_buffer().address();
+    auto reference_address = tensors[0].mesh_buffer()->address();
     for (size_t i = 1; i < tensors.size(); i++) {
         TT_FATAL(tensors[i].tensor_spec() == reference_spec, "All tensors must have the same TensorSpec");
         TT_FATAL(
-            tensors[i].mesh_buffer().address() == reference_address, "All mesh buffers must be at the same address");
+            tensors[i].mesh_buffer()->address() == reference_address, "All mesh buffers must be at the same address");
     }
 
     synchronize_parent_allocator_with_submeshes(parent_mesh.get());
@@ -79,7 +79,10 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     // Create a new mesh tensor for parent mesh.
     const auto& reference_buffer = tensors[0].mesh_buffer();
     auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-        reference_buffer.global_config(), reference_buffer.device_local_config(), parent_mesh.get(), reference_address);
+        reference_buffer->global_config(),
+        reference_buffer->device_local_config(),
+        parent_mesh.get(),
+        reference_address);
 
     std::vector<tt::tt_metal::distributed::MeshCoordinate> coords;
     coords.reserve(parent_mesh->shape().mesh_size());
@@ -120,7 +123,7 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
     }
 
     const auto& input_mesh_buffer = tensor.mesh_buffer();
-    const auto input_address = input_mesh_buffer.address();
+    const auto input_address = input_mesh_buffer->address();
     const auto& reference_spec = tensor.tensor_spec();
 
     // For all unit meshes, create individual mesh buffers with the same address.
@@ -131,7 +134,7 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
             submesh->get_active_sub_device_manager_id() == submesh->get_default_sub_device_manager_id(),
             "Cannot disaggregate tensor when submesh has non-default sub-device manager");
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-            input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
+            input_mesh_buffer->global_config(), input_mesh_buffer->device_local_config(), submesh.get(), input_address);
 
         DeviceStorage device_storage(
             std::move(mesh_buffer),

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1309,8 +1309,9 @@ void pytensor_module(nb::module_& mod) {
             "buffer_address",
             [](const Tensor& self) -> uint32_t {
                 TT_FATAL(is_device_tensor(self), "{} doesn't support buffer_address method", self.storage_type());
-                TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
-                return self.mesh_buffer().address();
+                const auto& storage = self.device_storage();
+                TT_FATAL(storage.mesh_buffer != nullptr, "Tensor is not allocated.");
+                return storage.mesh_buffer->address();
             },
             R"doc(
             Get the address of the underlying buffer.

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -17,18 +17,30 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 
+bool can_deallocate(const Tensor& input_tensor) {
+    if (is_cpu_tensor(input_tensor)) {
+        return false;
+    }
+    return input_tensor.device_storage().mesh_buffer.use_count() == 1;
+}
+
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     const auto& input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 
-    // TODO(#38697): Migrate to Tensor::deallocate(/* force = */ false)
-    if (not input_tensor.device_storage().is_sole_owner_of_device_memory()) {
+    if (not can_deallocate(input_tensor)) {
         // TODO: Should this throw error?
         return input_tensor;
     }
-    input_tensor.device_storage().get_mesh_buffer_leak_ownership()->deallocate();
+    // Special handling for Mesh vs single device. Needs to be consolidated after full
+    // migration
+    if (input_tensor.device_storage().mesh_buffer) {
+        input_tensor.device_storage().mesh_buffer->deallocate();
+    } else {
+        DeallocateBuffer(*input_tensor.buffer());
+    }
 
     if (mem_config) {
         output_tensor_spec = output_tensor_spec.with_memory_config(*mem_config);
@@ -98,10 +110,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Expected input tensor to be sharded");
     [[maybe_unused]] auto input_address = input_tensor.buffer()->address();
-    auto shard_spec = input_tensor.shard_spec().value();
-
-    // TODO(#38697): Migrate to Tensor::deallocate(/* forced = */ false)
-    if (not input_tensor.device_storage().is_sole_owner_of_device_memory()) {
+    if (not can_deallocate(input_tensor)) {
         TT_FATAL(
             false,
             "Expect input tensor to be deallocated after move op. Cannot deallocate before there is probably "
@@ -109,7 +118,15 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         // TODO: Should this throw error?
         return {input_tensor};
     }
-    input_tensor.device_storage().get_mesh_buffer_leak_ownership()->deallocate();
+    auto shard_spec = input_tensor.shard_spec().value();
+    // Special handling for Mesh vs single device. Needs to be consolidated after full
+    // migration
+
+    if (input_tensor.device_storage().mesh_buffer) {
+        input_tensor.device_storage().mesh_buffer->deallocate();
+    } else {
+        DeallocateBuffer(*input_tensor.buffer());
+    }
 
     auto output_tensor_spec = input_tensor.tensor_spec();
     if (mem_config) {

--- a/ttnn/examples/lab_eltwise_binary/lab_eltwise_binary.cpp
+++ b/ttnn/examples/lab_eltwise_binary/lab_eltwise_binary.cpp
@@ -205,12 +205,12 @@ void eltwise_add_tensix(
     // future).
     create_cb(prog_state.program, prog_state.core, tiles_per_cb_output, tt::CBIndex::c_16);
 
-    // Get MeshBuffers from tensors. Mesh buffers hold info about how tensor data is distributed
+    // Get MeshBuffer pointers from tensors. Mesh buffers hold info about how tensor data is distributed
     // across physical DRAM banks (at least for our case when data is stored in DRAM).
     // Programmer doesn't need to understand the internals, but needs to pass this info to the kernels.
-    const auto& src0_mesh_buffer = src0_tensor.mesh_buffer();
-    const auto& src1_mesh_buffer = src1_tensor.mesh_buffer();
-    const auto& dst_mesh_buffer = dst_tensor.mesh_buffer();
+    auto src0_mesh_buffer = src0_tensor.mesh_buffer();
+    auto src1_mesh_buffer = src1_tensor.mesh_buffer();
+    auto dst_mesh_buffer = dst_tensor.mesh_buffer();
 
     // Create the reader, writer and compute kernels. The kernels do the following:
     // * Reader: Reads data from the DRAM buffer and pushes it into the circular buffer.
@@ -223,8 +223,8 @@ void eltwise_add_tensix(
     std::vector<uint32_t> reader_compile_time_args;
     // TensorAccessorArgs just extracts data distribution details from MeshBuffer object into
     // the vector of uint32_t so it can be pushed into compile-time arguments.
-    TensorAccessorArgs(src0_mesh_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(src1_mesh_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src0_mesh_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_mesh_buffer).append_to(reader_compile_time_args);
 
     // There are two data movement RISCV processors in each Tensix core:
     // DataMovementProcessor::RISCV_0 and DataMovementProcessor::RISCV_1, corresponding to
@@ -242,7 +242,7 @@ void eltwise_add_tensix(
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(dst_mesh_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*dst_mesh_buffer).append_to(writer_compile_time_args);
     KernelHandle writer_id = tt_metal::CreateKernel(
         prog_state.program,
         OVERRIDE_KERNEL_PREFIX "ttnn/examples/lab_eltwise_binary/kernels/dataflow/write_tiles.cpp",
@@ -266,9 +266,9 @@ void eltwise_add_tensix(
         tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
 
     // Set the runtime arguments for the kernels.
-    uint32_t src0_addr = src0_mesh_buffer.address();
-    uint32_t src1_addr = src1_mesh_buffer.address();
-    uint32_t dst_addr = dst_mesh_buffer.address();
+    uint32_t src0_addr = src0_mesh_buffer->address();
+    uint32_t src1_addr = src1_mesh_buffer->address();
+    uint32_t dst_addr = dst_mesh_buffer->address();
     tt_metal::SetRuntimeArgs(prog_state.program, reader_id, prog_state.core, {src0_addr, src1_addr, n_tiles});
     tt_metal::SetRuntimeArgs(prog_state.program, writer_id, prog_state.core, {dst_addr, n_tiles});
 

--- a/ttnn/examples/lab_multicast/lab_multicast.cpp
+++ b/ttnn/examples/lab_multicast/lab_multicast.cpp
@@ -249,10 +249,10 @@ void multicast_tensor_tensix(
     // Create output tensor on device (no initialization needed - kernels will write into it).
     Tensor dst_tensor = create_device_tensor(output_spec, prog_state.mesh_device.get());
 
-    // Get MeshBuffers from tensors. Mesh buffers hold info about how tensor data is distributed
+    // Get MeshBuffer pointers from tensors. Mesh buffers hold info about how tensor data is distributed
     // across physical DRAM banks.
-    const auto& src_mesh_buffer = src_tensor.mesh_buffer();
-    const auto& dst_mesh_buffer = dst_tensor.mesh_buffer();
+    auto src_mesh_buffer = src_tensor.mesh_buffer();
+    auto dst_mesh_buffer = dst_tensor.mesh_buffer();
 
     ////////// TENSIX CORE SETUP //////////
     // Define logical sender core and receiver core range (for kernel creation on the host).
@@ -293,7 +293,7 @@ void multicast_tensor_tensix(
     // TensorAccessorArgs extracts data distribution details from MeshBuffer so kernels
     // don't need to deal with low-level details like bank IDs.
     std::vector<uint32_t> mcast_sender_compile_args;
-    TensorAccessorArgs(src_mesh_buffer).append_to(mcast_sender_compile_args);
+    TensorAccessorArgs(*src_mesh_buffer).append_to(mcast_sender_compile_args);
     DataMovementConfig mcast_sender_config = {
         .processor = DataMovementProcessor::RISCV_0,
         .noc = NOC::RISCV_0_default,
@@ -304,7 +304,7 @@ void multicast_tensor_tensix(
         .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
 
     std::vector<uint32_t> write_tiles_compile_args;
-    TensorAccessorArgs(dst_mesh_buffer).append_to(write_tiles_compile_args);
+    TensorAccessorArgs(*dst_mesh_buffer).append_to(write_tiles_compile_args);
     DataMovementConfig write_tiles_config = {
         .processor = DataMovementProcessor::RISCV_1,
         .noc = NOC::RISCV_1_default,
@@ -362,7 +362,7 @@ void multicast_tensor_tensix(
          static_cast<uint32_t>(receiver_cores_device.end_coord.y),
          receivers_ready_semaphore,
          tile_sent_semaphore,
-         src_mesh_buffer.address(),
+         src_mesh_buffer->address(),
          n_tiles,
          num_dests});
 
@@ -387,7 +387,7 @@ void multicast_tensor_tensix(
             prog_state.program,
             write_tiles_id,
             core,
-            {dst_mesh_buffer.address(), n_tiles, static_cast<uint32_t>(receiver_idx)});
+            {dst_mesh_buffer->address(), n_tiles, static_cast<uint32_t>(receiver_idx)});
         receiver_idx++;
     }
 


### PR DESCRIPTION
This reverts commit d6c6a6d12e2a4ac32a591916eb50c714e455ef18.

This commit causes segmentation fault issues on multiple models on Galaxy machines. For example:

Llama 3.3 70B: https://github.com/tenstorrent/tt-metal/actions/runs/23466923295/job/68281801941
Qwen3-32B: https://github.com/tenstorrent/tt-metal/actions/runs/23466923295/job/68281801939

This could also happen on other models as well but further investigations would be needed. Because of that reason the best idea is to revert it back.

Tests ran:

T3K: https://github.com/tenstorrent/tt-metal/actions/runs/23548869923

Galaxy: https://github.com/tenstorrent/tt-metal/actions/runs/23548903373