### PR TITLE
[QSR] Datacopy block and pack block compute api and tests

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -316,6 +316,10 @@ TEST_F(MeshDeviceFixture, TensixComputeCopyBlockMultiple) {
 TEST_F(MeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
     for (bool fp32_dest_acc_en : {true, false}) {
         for (bool dst_full_sync_en : {true, false}) {
+            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR && fp32_dest_acc_en &&
+                !dst_full_sync_en) {
+                continue;
+            }
             log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
             unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
                 .num_tiles = 8,

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -208,6 +208,10 @@ void run_single_core_copy_block_matmul_partials(
                 .dst_full_sync_en = test_config.dst_full_sync_en,
                 .compile_args = compute_kernel_args,
                 .defines = defines});
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, src0_dfb, unary_reader_kernel, compute_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, dst_dfb, compute_kernel, unary_writer_kernel);
     } else {
         compute_kernel = tt_metal::CreateKernel(
             program_,

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -101,10 +101,8 @@ void run_single_core_copy_block_matmul_partials(
         tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
             .entry_size = single_tile_size,
             .num_entries = num_input_tiles,
-            .producer_risc_mask = 0x1,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -115,10 +113,8 @@ void run_single_core_copy_block_matmul_partials(
         tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
             .entry_size = single_tile_size,
             .num_entries = num_output_tiles,
-            .producer_risc_mask = 0x100,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x2,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -309,6 +305,9 @@ TEST_F(MeshDeviceFixture, TensixComputeCopyBlockMultiple) {
                 .dst_full_sync_en = dst_full_sync_en};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
                 this->devices_.at(0), test_config);
+            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -318,6 +317,7 @@ TEST_F(MeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
         for (bool dst_full_sync_en : {true, false}) {
             if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR && fp32_dest_acc_en &&
                 !dst_full_sync_en) {
+                // TODO (#40827): AM; Remove when correct 32bit dest address is used
                 continue;
             }
             log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
@@ -330,6 +330,9 @@ TEST_F(MeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
                 .dst_full_sync_en = dst_full_sync_en};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
                 this->devices_.at(0), test_config);
+            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -29,6 +29,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -87,68 +89,136 @@ void run_single_core_copy_block_matmul_partials(
     auto dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    uint32_t src0_cb_index = test_config.src0_cb_index;
     uint32_t num_input_tiles = test_config.reader_ublock;
-
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, single_tile_size);
-
-    if (test_config.fp32_dest_acc_en) {
-        cb_src0_config = tt_metal::CircularBufferConfig(
-                             num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float32}})
-                             .set_page_size(src0_cb_index, single_tile_size);
-    }
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
-
-    uint32_t ouput_cb_index = test_config.ouput_cb_index;
     uint32_t num_output_tiles = test_config.writer_ublock;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(ouput_cb_index, single_tile_size);
-    if (test_config.fp32_dest_acc_en) {
-        cb_output_config = tt_metal::CircularBufferConfig(
-                               num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float32}})
-                               .set_page_size(ouput_cb_index, single_tile_size);
+
+    uint32_t input_id = 0;
+    uint32_t output_id = 0;
+
+    uint32_t src0_dfb = 0;
+    uint32_t dst_dfb = 0;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        tt_metal::experimental::dfb::DataflowBufferConfig dfb_src0_config = {
+            .entry_size = single_tile_size,
+            .num_entries = num_input_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = test_config.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b};
+        src0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_src0_config);
+        input_id = src0_dfb;
+
+        tt_metal::experimental::dfb::DataflowBufferConfig dfb_output_config = {
+            .entry_size = single_tile_size,
+            .num_entries = num_output_tiles,
+            .producer_risc_mask = 0x100,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x2,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = test_config.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
+        };
+        dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, core, dfb_output_config);
+        output_id = dst_dfb;
+    } else {
+        uint32_t src0_cb_index = test_config.src0_cb_index;
+        input_id = src0_cb_index;
+        tt_metal::CircularBufferConfig cb_src0_config =
+            tt_metal::CircularBufferConfig(
+                num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src0_cb_index, single_tile_size);
+
+        if (test_config.fp32_dest_acc_en) {
+            cb_src0_config = tt_metal::CircularBufferConfig(
+                                 num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float32}})
+                                 .set_page_size(src0_cb_index, single_tile_size);
+        }
+        tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+
+        uint32_t ouput_cb_index = test_config.ouput_cb_index;
+        output_id = ouput_cb_index;
+        tt_metal::CircularBufferConfig cb_output_config =
+            tt_metal::CircularBufferConfig(
+                num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(ouput_cb_index, single_tile_size);
+        if (test_config.fp32_dest_acc_en) {
+            cb_output_config = tt_metal::CircularBufferConfig(
+                                   num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float32}})
+                                   .set_page_size(ouput_cb_index, single_tile_size);
+        }
+        tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
     }
-    tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
 
-    auto unary_reader_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+    KernelHandle unary_reader_kernel;
+    KernelHandle unary_writer_kernel;
+    KernelHandle compute_kernel;
 
-    auto unary_writer_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        unary_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+
+        unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+    } else {
+        unary_reader_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+        unary_writer_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
+            core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+    }
 
     vector<uint32_t> compute_kernel_args = {
         uint(num_tiles),                   // total tiles to transfer
         uint(test_config.compute_ublock),  // tiles to transfer in a single iteration/copy_block call
-        uint(src0_cb_index),               // Input CB idx
-        uint(ouput_cb_index)               // Output CB idx
+        uint(input_id),                    // Input CB idx or DFB id
+        uint(output_id)                    // Output CB idx or DFB id
     };
 
     std::map<std::string, std::string> defines;
     if (test_config.fp32_dest_acc_en) {
         defines["DST_ACCUM_MODE"] = "1";
     }
-    tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
-        core,
-        tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
-            .dst_full_sync_en = test_config.dst_full_sync_en,
-            .compile_args = compute_kernel_args,
-            .defines = defines});
-
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        compute_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
+            core,
+            tt_metal::experimental::quasar::QuasarComputeConfig{
+                .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
+                .dst_full_sync_en = test_config.dst_full_sync_en,
+                .compile_args = compute_kernel_args,
+                .defines = defines});
+    } else {
+        compute_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
+            core,
+            tt_metal::ComputeConfig{
+                .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
+                .dst_full_sync_en = test_config.dst_full_sync_en,
+                .compile_args = compute_kernel_args,
+                .defines = defines});
+    }
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
@@ -171,7 +241,7 @@ void run_single_core_copy_block_matmul_partials(
         {dram_buffer_src_addr,
          (uint32_t)0,  // dram bank id
          num_tiles,
-         src0_cb_index,
+         input_id,
          test_config.reader_ublock,
          false});
 
@@ -182,12 +252,15 @@ void run_single_core_copy_block_matmul_partials(
         {dram_buffer_dst_addr,
          (uint32_t)0,  // dram bank id
          num_tiles,
-         ouput_cb_index,
+         output_id,
          test_config.writer_ublock,
          false});
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    auto blocking = device->arch() == ARCH::QUASAR;
+    distributed::EnqueueMeshWorkload(cq, workload, blocking);
+    if (not blocking) {
+        distributed::Finish(cq);
+    }
 
     std::vector<uint32_t> result_vec_bf16;
     tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec_bf16);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -3,28 +3,64 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_binary.h"
+// #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
+// #include "api/compute/compute_kernel_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 
 void kernel_main() {
     constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t num_single_transfer = get_compile_time_arg_val(1);
+#ifdef ARCH_QUASAR
+    constexpr uint32_t in_dfb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t out_dfb_id = get_compile_time_arg_val(3);
+#else
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
+#endif
 
     constexpr uint32_t outer_loop = num_tiles / num_single_transfer;
 
-    unary_op_init_common(in_cb_id, out_cb_id);
-
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb_in(in_dfb_id);
+    experimental::DataflowBuffer dfb_out(out_dfb_id);
+    unary_op_init_common(dfb_in.get_id(), dfb_out.get_id());
+#else
     experimental::CircularBuffer cb_in(in_cb_id);
     experimental::CircularBuffer cb_out(out_cb_id);
+    unary_op_init_common(in_cb_id, out_cb_id);
+#endif
 
     // Run the outer loop
     for (uint32_t b = 0; b < outer_loop; ++b) {
+#ifdef ARCH_QUASAR
+        // Wait for num_single_transfer tiles to be available in dfb_in
+        dfb_in.wait_front(num_single_transfer);
+        // Acquire DEST reg for MATH/PACK
+        acquire_dst();
+        // Reserve dfb_out space for num_single_transfer tiles
+        dfb_out.reserve_back(num_single_transfer);
+
+        // Copy num_single_transfer tiles from dfb_in to DEST
+        for (uint32_t i = 0; i < num_single_transfer; ++i) {
+            copy_block_matmul_partials(dfb_in.get_id(), i, i, 1);
+        }
+        // Pack num_single_transfer tiles to dfb_out
+        pack_tile_block(0, dfb_out.get_id(), num_single_transfer);
+
+        // Release DEST reg marking compute/pack complete
+        release_dst();
+        // Move rd ptr from dfb_in by num_single_transfer places
+        dfb_in.pop_front(num_single_transfer);
+        // Move wr prt from dfb_out by num_single_transfer places
+        dfb_out.push_back(num_single_transfer);
+#else
         // Wait for num_single_transfer tiles to be available in in_cb
         cb_in.wait_front(num_single_transfer);
         // Acquire DEST reg for MATH/PACK
@@ -45,5 +81,6 @@ void kernel_main() {
         cb_in.pop_front(num_single_transfer);
         // Move wr prt from out_cb by num_single_transfer places
         cb_out.push_back(num_single_transfer);
+#endif
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -34,8 +34,8 @@ void kernel_main() {
     for (uint32_t b = 0; b < outer_loop; ++b) {
 #ifdef ARCH_QUASAR
         dfb_in.wait_front(num_single_transfer);
-        acquire_dst();
         dfb_out.reserve_back(num_single_transfer);
+        acquire_dst();
 
         for (uint32_t i = 0; i < num_single_transfer; ++i) {
             copy_block_matmul_partials(dfb_in.get_id(), i, i, 1);
@@ -49,10 +49,10 @@ void kernel_main() {
 #else
         // Wait for num_single_transfer tiles to be available in in_cb
         cb_in.wait_front(num_single_transfer);
-        // Acquire DEST reg for MATH/PACK
-        acquire_dst();
         // Reserve out_cb space for num_single_transfer tiles
         cb_out.reserve_back(num_single_transfer);
+        // Acquire DEST reg for MATH/PACK
+        acquire_dst();
 
         // Copy num_single_transfer tiles from in_cb to DEST
         for (uint32_t i = 0; i < num_single_transfer; ++i) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -17,19 +17,14 @@
 void kernel_main() {
     constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t num_single_transfer = get_compile_time_arg_val(1);
-#ifdef ARCH_QUASAR
-    constexpr uint32_t in_dfb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t out_dfb_id = get_compile_time_arg_val(3);
-#else
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
-#endif
 
     constexpr uint32_t outer_loop = num_tiles / num_single_transfer;
 
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb_in(in_dfb_id);
-    experimental::DataflowBuffer dfb_out(out_dfb_id);
+    experimental::DataflowBuffer dfb_in(in_cb_id);
+    experimental::DataflowBuffer dfb_out(out_cb_id);
     unary_op_init_common(dfb_in.get_id(), dfb_out.get_id());
 #else
     experimental::CircularBuffer cb_in(in_cb_id);
@@ -40,25 +35,18 @@ void kernel_main() {
     // Run the outer loop
     for (uint32_t b = 0; b < outer_loop; ++b) {
 #ifdef ARCH_QUASAR
-        // Wait for num_single_transfer tiles to be available in dfb_in
         dfb_in.wait_front(num_single_transfer);
-        // Acquire DEST reg for MATH/PACK
         acquire_dst();
-        // Reserve dfb_out space for num_single_transfer tiles
         dfb_out.reserve_back(num_single_transfer);
 
-        // Copy num_single_transfer tiles from dfb_in to DEST
         for (uint32_t i = 0; i < num_single_transfer; ++i) {
             copy_block_matmul_partials(dfb_in.get_id(), i, i, 1);
         }
-        // Pack num_single_transfer tiles to dfb_out
+
         pack_tile_block(0, dfb_out.get_id(), num_single_transfer);
 
-        // Release DEST reg marking compute/pack complete
         release_dst();
-        // Move rd ptr from dfb_in by num_single_transfer places
         dfb_in.pop_front(num_single_transfer);
-        // Move wr prt from dfb_out by num_single_transfer places
         dfb_out.push_back(num_single_transfer);
 #else
         // Wait for num_single_transfer tiles to be available in in_cb

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-// #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/pack.h"
-// #include "api/compute/compute_kernel_api.h"
 #ifdef ARCH_QUASAR
 #include "experimental/dataflow_buffer.h"
 #else

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
 
@@ -11,18 +15,36 @@ void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
     uint32_t src_dram_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+#ifdef ARCH_QUASAR
+    uint32_t dfb_id_in0 = get_arg_val<uint32_t>(3);
+#else
     uint32_t cb_id_in0 = get_arg_val<uint32_t>(3);
+#endif
     uint32_t ublock_size_tiles = get_arg_val<uint32_t>(4);
     bool reader_only = get_arg_val<uint32_t>(5);
 
     experimental::Noc noc;
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_src;
-    experimental::CircularBuffer cb(cb_id_in0);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb(dfb_id_in0);
+    uint32_t ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+#else
+    experimental::CircularBuffer cb(cb_id_in0);
     uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+#endif
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(src_dram_bank_id, src_addr);
+#ifdef ARCH_QUASAR
+        if (reader_only == false) {
+            dfb.reserve_back(ublock_size_tiles);
+        }
+        noc.async_read(dram_src, dfb, ublock_size_bytes, {.bank_id = src_dram_bank_id, .addr = src_addr}, {});
+        noc.async_read_barrier();
+        if (reader_only == false) {
+            dfb.push_back(ublock_size_tiles);
+        }
+#else
         if (reader_only == false) {
             cb.reserve_back(ublock_size_tiles);
         }
@@ -31,6 +53,7 @@ void kernel_main() {
         if (reader_only == false) {
             cb.push_back(ublock_size_tiles);
         }
+#endif
         src_addr += ublock_size_bytes;
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
@@ -15,11 +15,7 @@ void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
     uint32_t src_dram_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
-#ifdef ARCH_QUASAR
-    uint32_t dfb_id_in0 = get_arg_val<uint32_t>(3);
-#else
     uint32_t cb_id_in0 = get_arg_val<uint32_t>(3);
-#endif
     uint32_t ublock_size_tiles = get_arg_val<uint32_t>(4);
     bool reader_only = get_arg_val<uint32_t>(5);
 
@@ -27,7 +23,7 @@ void kernel_main() {
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_src;
 
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb(dfb_id_in0);
+    experimental::DataflowBuffer dfb(cb_id_in0);
     uint32_t ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
 #else
     experimental::CircularBuffer cb(cb_id_in0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
@@ -14,16 +14,12 @@ void kernel_main() {
     uint32_t dst_addr  = get_arg_val<uint32_t>(0);
     uint32_t dst_dram_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
-#ifdef ARCH_QUASAR
-    uint32_t dfb_id_out0 = get_arg_val<uint32_t>(3);
-#else
     uint32_t cb_id_out0 = get_arg_val<uint32_t>(3);
-#endif
     uint32_t ublock_size_tiles = get_arg_val<uint32_t>(4);
     bool writer_only = get_arg_val<uint32_t>(5);
 
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb(dfb_id_out0);
+    experimental::DataflowBuffer dfb(cb_id_out0);
     uint32_t ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
 #else
     experimental::CircularBuffer cb(cb_id_out0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
@@ -3,24 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 #include "experimental/endpoints.h"
 
 void kernel_main() {
     uint32_t dst_addr  = get_arg_val<uint32_t>(0);
     uint32_t dst_dram_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+#ifdef ARCH_QUASAR
+    uint32_t dfb_id_out0 = get_arg_val<uint32_t>(3);
+#else
     uint32_t cb_id_out0 = get_arg_val<uint32_t>(3);
+#endif
     uint32_t ublock_size_tiles = get_arg_val<uint32_t>(4);
     bool writer_only = get_arg_val<uint32_t>(5);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb(dfb_id_out0);
+    uint32_t ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+#else
     experimental::CircularBuffer cb(cb_id_out0);
+    uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+#endif
     experimental::Noc noc;
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_dst;
 
-    uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
-
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#ifdef ARCH_QUASAR
+        if (writer_only == false) {
+            dfb.wait_front(ublock_size_tiles);
+        }
+        noc.async_write(dfb, dram_dst, ublock_size_bytes, {}, {.bank_id = dst_dram_bank_id, .addr = dst_addr});
+
+        noc.async_write_barrier();
+        if (writer_only == false) {
+            dfb.pop_front(ublock_size_tiles);
+        }
+#else
         if (writer_only == false) {
             cb.wait_front(ublock_size_tiles);
         }
@@ -30,6 +53,7 @@ void kernel_main() {
         if (writer_only == false) {
             cb.pop_front(ublock_size_tiles);
         }
+#endif
         dst_addr += ublock_size_bytes;
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -15,7 +15,7 @@
  *
  * @brief Initialize eltwise unary datacopy operations
  *
- * @tparam DATA_COPY_TYPE sets which src register to copy from, values = <A2D, B2D>
+ * @tparam type sets which src register to copy from, values = <A2D, B2D>
  * @tparam IS_32b_DEST_EN set if math destination register is set to Float32/Int32 mode
  * @param operand: The input operand circular buffer
  * This function prepares the math hardware to copy a specified number of rows
@@ -31,8 +31,10 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
 }
 
 /**
+ * @brief Performs an eltwise unary datacopy for a single tile.
  *
- * @brief Perform an eltwise unary datacopy operation
+ * @param dst_index Tile index into the destination register.
+ * @param operand The input operand logical dataflow buffer id.
  *
  * @param dst_index: Tile index into the destination register
  * @param operand: The input operand circular buffer
@@ -45,4 +47,27 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     _llk_math_eltwise_unary_datacopy_(num_faces * face_r_dim, dst_index);
+}
+
+/**
+ * @brief Performs an eltwise unary datacopy for a block of tiles.
+ *
+ * @param start_dst_index Starting tile index in the destination register.
+ * @param ntiles Number of tiles to copy to the destination register.
+ * @param operand The input operand logical dataflow buffer id.
+ *
+ * This function copies a contiguous block of tiles
+ * from the srcA or srcB register to the destination register.
+ */
+inline void llk_math_eltwise_unary_datacopy_block(
+    const std::uint32_t start_dst_index, const std::uint32_t ntiles, const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+
+    for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
+        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+
+        _llk_math_eltwise_unary_datacopy_(num_faces * face_r_dim, dst_index);
+    }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -66,8 +66,6 @@ inline void llk_math_eltwise_unary_datacopy_block(
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
 
     for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
-
         _llk_math_eltwise_unary_datacopy_(num_faces * face_r_dim, dst_index);
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -104,15 +104,6 @@ inline void llk_pack_block(
     std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(pack_output);
 
-    LLK_ASSERT(
-        (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-            pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(pack_output))),
-        "");
-    LLK_ASSERT(
-        ((start_tile_index + ntiles - 1) <
-         get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
-        "");
-
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t l1_tile_index =
             get_output_tile_index<false /* out_of_order_output */, false /* untilize */>(output_id, output_tile_index);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -95,18 +95,17 @@ inline void llk_pack(
  * @param start_tile_index Starting destination register tile index to pack out from
  * @param pack_output Logical output dataflow buffer id
  * @param ntiles Number of consecutive tiles to pack
- * @param output_tile_index Starting output tile index to pack out to in L1 memory
  *
  * Packs ntiles tiles starting at start_tile_index from the destination register into the L1
  * output buffer identified by pack_output starting from output_tile_index
  */
-inline void llk_pack_block(
-    std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
+// TODO: AM; Optimize block calls by using ntiles per pack, issue #40798
+inline void llk_pack_block(std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles) {
     std::uint8_t output_id = get_output_id(pack_output);
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
-        std::uint32_t l1_tile_index =
-            get_output_tile_index<false /* out_of_order_output */, false /* untilize */>(output_id, output_tile_index);
+        std::uint32_t l1_tile_index = get_output_tile_index<false /* out_of_order_output */, false /* untilize */>(
+            output_id, 0 /* output_tile_index */);
 
         _llk_pack_<p_pacr::PACK0>(tile_index, l1_tile_index);
     }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -39,7 +39,7 @@ inline void llk_pack_init(const std::uint32_t pack_output) {
  * @brief Gets the output L1 tile index where the tile will be packed out to, determined by out_of_order_output
  *
  * @tparam out_of_order_output: Set true to write the output tile to the tile index specified by
- * the user in `output_tile_index`, set false for pack to operqate sequentially: write to the next tile index
+ * the user in `output_tile_index`, set false for pack to operate sequentially: write to the next tile index
  * starting from index 0, and ignore the `output_tile_index` parameter
  * @tparam untilize: Selects pack or pack untilizem
  * @param output_id The output circular buffer identifier
@@ -87,6 +87,38 @@ inline void llk_pack(
     const std::uint32_t l1_tile_index = get_output_tile_index<out_of_order_output, false>(output_id, output_tile_index);
 
     _llk_pack_<p_pacr::PACK0>(tile_index, l1_tile_index);
+}
+
+/**
+ * @brief Packs a block of destination tiles into the specified output buffer
+ *
+ * @param start_tile_index Starting destination register tile index to pack out from
+ * @param pack_output Logical output dataflow buffer id
+ * @param ntiles Number of consecutive tiles to pack
+ * @param output_tile_index Starting output tile index to pack out to in L1 memory
+ *
+ * Packs ntiles tiles starting at start_tile_index from the destination register into the L1
+ * output buffer identified by pack_output starting from output_tile_index
+ */
+inline void llk_pack_block(
+    std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
+    std::uint8_t output_id = get_output_id(pack_output);
+
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+            pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(pack_output))),
+        "");
+    LLK_ASSERT(
+        ((start_tile_index + ntiles - 1) <
+         get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "");
+
+    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+        std::uint32_t l1_tile_index =
+            get_output_tile_index<false /* out_of_order_output */, false /* untilize */>(output_id, output_tile_index);
+
+        _llk_pack_<p_pacr::PACK0>(tile_index, l1_tile_index);
+    }
 }
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -58,6 +58,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
  * The tiles are read from the operand buffer starting at start_tile_index
  * and unpacked into srcA one tile at a time.
  */
+// TODO: AM; Optimize block calls by using ntiles per unpack, issue #40798
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
     const std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -47,3 +47,26 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);
     WAYPOINT("UPAD");
 }
+
+/**
+ * @brief Unpacks a contiguous block of tiles with unpacker0.
+ *
+ * @param operand The logical dataflow buffer id.
+ * @param start_tile_index The starting tile index within the input buffer.
+ * @param ntiles The number of consecutive tiles to unpack.
+ *
+ * The tiles are read from the operand buffer starting at start_tile_index
+ * and unpacked into srcA one tile at a time.
+ */
+inline void llk_unpack_A_block(
+    const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + start_tile_index;
+
+    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+        WAYPOINT("UPAW");
+        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);
+        l1_tile_index += 1;
+        WAYPOINT("UPAD");
+    }
+}

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -101,7 +101,9 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
 ALWI void pack_tile_block(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
 #ifndef ARCH_QUASAR
     PACK((llk_matmul_pack<DST_ACCUM_MODE, false, false>(ifrom_dst, icb, ntiles)));
-#endif  // TODO: AM; add Quasar implementation
+#else
+    PACK((llk_pack_block(ifrom_dst, icb, ntiles)));
+#endif
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -111,7 +111,10 @@ ALWI void copy_block_matmul_partials(
         in_cb_id, start_in_tile_index, ntiles)));
     MATH((llk_math_eltwise_unary_datacopy_block<A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
         start_dst_tile_index, ntiles, in_cb_id)));
-#endif  // TODO: AM; add Quasar implementation
+#else
+    UNPACK((llk_unpack_A_block(in_cb_id, start_in_tile_index, ntiles)));
+    MATH((llk_math_eltwise_unary_datacopy_block(start_dst_tile_index, ntiles, in_cb_id)));
+#endif
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Added pack block and datacopy block compute and llk api.
Expanded test_copy_block_matmul_partials.cpp to test Quasar pack_tile_block and copy_block_matmul_partials.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/qsr_matmul_partials)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/qsr_matmul_partials)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/qsr_matmul_partials)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/qsr_matmul_partials)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/qsr_matmul_partials)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/qsr_matmul_partials)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/qsr_matmul_partials)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
