### PR TITLE
[tt-train] Fix ttml binary ops bw broadcasting

### DIFF
--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -5,6 +5,7 @@
 #include "binary_ops.hpp"
 
 #include <memory>
+#include <stdexcept>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
 #include <ttnn/operations/eltwise/binary_backward/binary_backward.hpp>
 #include <ttnn/tensor/tensor.hpp>
@@ -112,10 +113,30 @@ autograd::TensorPtr operator-(const autograd::TensorPtr& a, const autograd::Tens
 
     out->set_value(ttnn::subtract(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
-        tt::tt_metal::MemoryConfig mem_config;
-        // TODO: support broadcasting
-        a->add_grad(out->get_grad());
-        b->add_grad(ttnn::neg(out->get_grad()));
+        if (was_broadcasted(a, out->get_grad())) {
+            a->add_grad(ttnn::moreh_sum(
+                out->get_grad(),
+                get_broadcast_dimensions(a, out->get_grad()),
+                /* keep_dim */ true,
+                /* output_tensor */ std::nullopt,
+                /* memory_config_arg */ std::nullopt,
+                core::ComputeKernelConfig::precise()));
+        } else {
+            a->add_grad(out->get_grad());
+        }
+
+        auto neg_grad = ttnn::neg(out->get_grad());
+        if (was_broadcasted(b, neg_grad)) {
+            b->add_grad(ttnn::moreh_sum(
+                neg_grad,
+                get_broadcast_dimensions(b, neg_grad),
+                /* keep_dim */ true,
+                /* output_tensor */ std::nullopt,
+                /* memory_config_arg */ std::nullopt,
+                core::ComputeKernelConfig::precise()));
+        } else {
+            b->add_grad(neg_grad);
+        }
     };
 
     out->set_node(autograd::add_backward_node(std::move(grad), out, a, b));
@@ -131,8 +152,6 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::Tens
         b->get_value(),
         /* fast_and_approximate_mode*/ true));
     autograd::GradFunction grad = [a, b, out]() {
-        tt::tt_metal::MemoryConfig mem_config;
-        // TODO: support broadcasting (or not)
         auto a_grad = ttnn::multiply(
             out->get_grad(),
             b->get_value(),
@@ -142,8 +161,29 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::Tens
             a->get_value(),
             /* fast_and_approximate_mode*/ true);
 
-        a->add_grad(a_grad);
-        b->add_grad(b_grad);
+        if (was_broadcasted(a, a_grad)) {
+            a->add_grad(ttnn::moreh_sum(
+                a_grad,
+                get_broadcast_dimensions(a, a_grad),
+                /* keep_dim */ true,
+                /* output_tensor */ std::nullopt,
+                /* memory_config_arg */ std::nullopt,
+                core::ComputeKernelConfig::precise()));
+        } else {
+            a->add_grad(a_grad);
+        }
+
+        if (was_broadcasted(b, b_grad)) {
+            b->add_grad(ttnn::moreh_sum(
+                b_grad,
+                get_broadcast_dimensions(b, b_grad),
+                /* keep_dim */ true,
+                /* output_tensor */ std::nullopt,
+                /* memory_config_arg */ std::nullopt,
+                core::ComputeKernelConfig::precise()));
+        } else {
+            b->add_grad(b_grad);
+        }
     };
     out->set_node(autograd::add_backward_node(std::move(grad), out, a, b));
 
@@ -167,6 +207,9 @@ autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::Tens
 
     out->set_value(ttnn::divide(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
+        if (was_broadcasted(a, out->get_grad()) || was_broadcasted(b, out->get_grad())) {
+            throw std::runtime_error("Broadcasting is not supported in the backward pass of operator/");
+        }
         auto res = ttnn::div_bw(out->get_grad(), a->get_value(), b->get_value());
         a->add_grad(res[0].value());
         b->add_grad(res[1].value());

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -19,6 +19,7 @@
 #include "autograd/tensor.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
@@ -30,8 +31,10 @@ namespace {
 bool was_broadcasted(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
     auto input_shape = input->get_value().logical_shape();
     auto grad_shape = grad.logical_shape();
+
+    // Rank mismatch means the input was broadcast with implicit leading 1s.
     if (input_shape.rank() != grad_shape.rank()) {
-        return false;
+        return true;
     }
 
     for (size_t i = 0; i < input_shape.size(); ++i) {
@@ -43,17 +46,41 @@ bool was_broadcasted(const autograd::TensorPtr& input, const ttnn::Tensor& grad)
     return false;
 }
 
-ttsl::SmallVector<int64_t> get_broadcast_dimensions(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
-    ttsl::SmallVector<int64_t> broadcast_dims;
+// Reduce grad along all broadcast dimensions and reshape back to the input's
+// original shape.  Handles both same-rank broadcasting (e.g. [1,1,1,1] vs
+// [1,1,1,4]) and cross-rank broadcasting (e.g. [4] vs [2,1,1,4]) by aligning
+// shapes from the right and left-padding with implicit 1s.
+ttnn::Tensor unbroadcast_grad(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
     auto input_shape = input->get_value().logical_shape();
     auto grad_shape = grad.logical_shape();
-    for (size_t i = 0; i < input_shape.size(); ++i) {
-        if (input_shape[i] != grad_shape[i]) {
+    auto input_rank = input_shape.rank();
+    auto grad_rank = grad_shape.rank();
+    auto max_rank = std::max(input_rank, grad_rank);
+
+    ttsl::SmallVector<int64_t> broadcast_dims;
+    for (size_t i = 0; i < max_rank; ++i) {
+        auto input_dim = (i < max_rank - input_rank) ? 1u : input_shape[i - (max_rank - input_rank)];
+        auto grad_dim = (i < max_rank - grad_rank) ? 1u : grad_shape[i - (max_rank - grad_rank)];
+        if (input_dim != grad_dim) {
             broadcast_dims.push_back(static_cast<int64_t>(i));
         }
     }
 
-    return broadcast_dims;
+    auto reduced = ttnn::moreh_sum(
+        grad,
+        broadcast_dims,
+        /* keep_dim */ true,
+        /* output_tensor */ std::nullopt,
+        /* memory_config_arg */ std::nullopt,
+        core::ComputeKernelConfig::precise());
+
+    // When ranks differ, moreh_sum with keep_dim preserves the grad's rank.
+    // Reshape back to the input's original shape so add_grad doesn't throw.
+    if (input_rank != grad_rank) {
+        reduced = ttnn::reshape(reduced, input_shape);
+    }
+
+    return reduced;
 }
 
 }  // namespace
@@ -80,25 +107,13 @@ autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::Tens
         ttnn::add(a->get_value(), b->get_value(), std::nullopt, std::nullopt, std::nullopt, none, none, none, false));
     autograd::GradFunction grad = [a, b, out]() {
         if (was_broadcasted(a, out->get_grad())) {
-            a->add_grad(ttnn::moreh_sum(
-                out->get_grad(),
-                get_broadcast_dimensions(a, out->get_grad()),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            a->add_grad(unbroadcast_grad(a, out->get_grad()));
         } else {
             a->add_grad(out->get_grad());
         }
 
         if (was_broadcasted(b, out->get_grad())) {
-            b->add_grad(ttnn::moreh_sum(
-                out->get_grad(),
-                get_broadcast_dimensions(b, out->get_grad()),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            b->add_grad(unbroadcast_grad(b, out->get_grad()));
         } else {
             b->add_grad(out->get_grad());
         }
@@ -114,26 +129,14 @@ autograd::TensorPtr operator-(const autograd::TensorPtr& a, const autograd::Tens
     out->set_value(ttnn::subtract(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
         if (was_broadcasted(a, out->get_grad())) {
-            a->add_grad(ttnn::moreh_sum(
-                out->get_grad(),
-                get_broadcast_dimensions(a, out->get_grad()),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            a->add_grad(unbroadcast_grad(a, out->get_grad()));
         } else {
             a->add_grad(out->get_grad());
         }
 
         auto neg_grad = ttnn::neg(out->get_grad());
         if (was_broadcasted(b, neg_grad)) {
-            b->add_grad(ttnn::moreh_sum(
-                neg_grad,
-                get_broadcast_dimensions(b, neg_grad),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            b->add_grad(unbroadcast_grad(b, neg_grad));
         } else {
             b->add_grad(neg_grad);
         }
@@ -162,25 +165,13 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::Tens
             /* fast_and_approximate_mode*/ true);
 
         if (was_broadcasted(a, a_grad)) {
-            a->add_grad(ttnn::moreh_sum(
-                a_grad,
-                get_broadcast_dimensions(a, a_grad),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            a->add_grad(unbroadcast_grad(a, a_grad));
         } else {
             a->add_grad(a_grad);
         }
 
         if (was_broadcasted(b, b_grad)) {
-            b->add_grad(ttnn::moreh_sum(
-                b_grad,
-                get_broadcast_dimensions(b, b_grad),
-                /* keep_dim */ true,
-                /* output_tensor */ std::nullopt,
-                /* memory_config_arg */ std::nullopt,
-                core::ComputeKernelConfig::precise()));
+            b->add_grad(unbroadcast_grad(b, b_grad));
         } else {
             b->add_grad(b_grad);
         }

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -65,6 +65,8 @@ set(SOURCES
     ops/layernorm_bw_fused_op_test.cpp
     ops/layernorm_fw_fused_op_test.cpp
     ops/swiglu_op_test.cpp
+    ops/binary_ops_fw_test.cpp
+    ops/binary_ops_bw_test.cpp
     utils/memory_utils_test.cpp
 )
 

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -89,6 +89,17 @@ set_target_properties(
 target_compile_options(ttml_tests PRIVATE -fPIC)
 target_precompile_headers(ttml_tests REUSE_FROM ttml_pch)
 
+# Suppress false-positive -Wnonnull from xtensor internals on GCC < 13.
+# At -O3, GCC over-inlines xbroadcast::has_linear_assign and wrongly flags std::equal as null.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
+    set_source_files_properties(
+        ops/binary_ops_bw_test.cpp
+        PROPERTIES
+            COMPILE_OPTIONS
+                "-Wno-nonnull"
+    )
+endif()
+
 add_definitions(-DTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data")
 
 # Define the target file location

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "ops/binary_ops.hpp"
+
+namespace ttml::ops::tests {
+
+class BinaryOpsBackwardTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        autograd::ctx().open_device();
+    }
+
+    void TearDown() override {
+        autograd::ctx().reset_graph();
+        autograd::ctx().close_device();
+    }
+};
+
+// ============================================================================
+// Same-shape backward tests
+// ============================================================================
+
+TEST_F(BinaryOpsBackwardTest, AddSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {{{{5.F, 6.F, 7.F, 8.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), /* requires_grad */ true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), /* requires_grad */ true);
+
+    auto out = a + b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a+b)/da = 1, d(a+b)/db = 1
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b)));
+}
+
+TEST_F(BinaryOpsBackwardTest, SubSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {{{{5.F, 6.F, 7.F, 8.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), /* requires_grad */ true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), /* requires_grad */ true);
+
+    auto out = a - b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a-b)/da = 1, d(a-b)/db = -1
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b)));
+}
+
+TEST_F(BinaryOpsBackwardTest, MulSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {{{{4.F, 3.F, 2.F, 1.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), /* requires_grad */ true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), /* requires_grad */ true);
+
+    auto out = a * b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a*b)/da = b, d(a*b)/db = a
+    EXPECT_TRUE(xt::allclose(a_grad, data_b));
+    EXPECT_TRUE(xt::allclose(b_grad, data_a));
+}
+
+TEST_F(BinaryOpsBackwardTest, MulScalar) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), /* requires_grad */ true);
+
+    auto out = a * 3.0F;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+
+    // d(a*c)/da = c
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 3.0F));
+}
+
+TEST_F(BinaryOpsBackwardTest, DivSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{4.F, 6.F, 8.F, 10.F}}}};
+    xt::xarray<float> data_b = {{{{2.F, 3.F, 4.F, 5.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), /* requires_grad */ true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), /* requires_grad */ true);
+
+    auto out = a / b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a/b)/da = 1/b, d(a/b)/db = -a/b^2
+    xt::xarray<float> expected_a_grad = 1.0F / data_b;
+    xt::xarray<float> expected_b_grad = -data_a / (data_b * data_b);
+    EXPECT_TRUE(xt::allclose(a_grad, expected_a_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F));
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F));
+}
+
+// ============================================================================
+// Broadcast backward tests
+// ============================================================================
+
+TEST_F(BinaryOpsBackwardTest, AddBroadcastDim0) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [1, 1, 1, 4] -> b is broadcast along dim 0
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{10.F, 20.F, 30.F, 40.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a + b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // a_grad: same shape as a, all 1s
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // b_grad: summed over dim 0 -> [1,1,1,4], each element = 2 (two batches)
+    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b) * 2.0F));
+}
+
+TEST_F(BinaryOpsBackwardTest, SubBroadcastDim0) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{10.F, 20.F, 30.F, 40.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a - b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // a_grad: all 1s
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // b_grad: summed -1s over dim 0 -> each element = -2
+    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b) * 2.0F));
+}
+
+TEST_F(BinaryOpsBackwardTest, MulBroadcastDim0) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [1, 1, 1, 4]
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{2.F, 2.F, 2.F, 2.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a * b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a*b)/da = b (broadcast) -> each element of a_grad = 2
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 2.0F));
+
+    // d(a*b)/db = a, summed over dim 0 -> [1+5, 2+6, 3+7, 4+8] = [6, 8, 10, 12]
+    xt::xarray<float> expected_b_grad = {{{{6.F, 8.F, 10.F, 12.F}}}};
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+}
+
+TEST_F(BinaryOpsBackwardTest, MulBroadcastDim3) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [1, 1, 1, 4], b: [1, 1, 1, 1] -> b is broadcast along dim 3
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {3.F};
+    data_b.reshape({1, 1, 1, 1});
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a * b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a*b)/da = b (broadcast) -> each element = 3
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 3.0F));
+
+    // d(a*b)/db = a, summed over dim 3 -> [1+2+3+4] = [10]
+    xt::xarray<float> expected_b_grad = {10.F};
+    expected_b_grad.reshape({1, 1, 1, 1});
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+}
+
+TEST_F(BinaryOpsBackwardTest, DivBroadcastThrows) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {4.F, 6.F, 8.F, 10.F, 12.F, 14.F, 16.F, 18.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{2.F, 2.F, 2.F, 2.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a / b;
+    EXPECT_THROW(out->backward(), std::runtime_error);
+}
+
+}  // namespace ttml::ops::tests

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// GCC 12 emits a false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign
+// when std::equal is inlined over empty-vector iterators. Fixed in GCC 13.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
+
 #include <gtest/gtest.h>
 
 #include <stdexcept>

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -171,6 +171,31 @@ TEST_F(BinaryOpsBackwardTest, SubBroadcastDim0) {
     EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b) * 2.0F));
 }
 
+TEST_F(BinaryOpsBackwardTest, SubBroadcastDim3) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [1, 1, 1, 4], b: [1, 1, 1, 1] -> b is broadcast along dim 3
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {3.F};
+    data_b.reshape({1, 1, 1, 1});
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a - b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a-b)/da = 1 -> all ones
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // d(a-b)/db = -1, summed over dim 3 -> [(-1)*4] = [-4]
+    xt::xarray<float> expected_b_grad = {-4.F};
+    expected_b_grad.reshape({1, 1, 1, 1});
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+}
+
 TEST_F(BinaryOpsBackwardTest, MulBroadcastDim0) {
     auto* device = &autograd::ctx().get_device();
     // a: [2, 1, 1, 4], b: [1, 1, 1, 4]
@@ -217,6 +242,80 @@ TEST_F(BinaryOpsBackwardTest, MulBroadcastDim3) {
     // d(a*b)/db = a, summed over dim 3 -> [1+2+3+4] = [10]
     xt::xarray<float> expected_b_grad = {10.F};
     expected_b_grad.reshape({1, 1, 1, 1});
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+}
+
+// ============================================================================
+// Cross-rank broadcast backward tests (input ranks differ)
+// ============================================================================
+
+TEST_F(BinaryOpsBackwardTest, AddBroadcastCrossRank) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {10.F, 20.F, 30.F, 40.F};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a + b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // a_grad: all 1s, shape [2,1,1,4]
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // b_grad: 1s summed over dims 0,1,2 -> each element = 2, shape [4]
+    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b) * 2.0F));
+}
+
+TEST_F(BinaryOpsBackwardTest, SubBroadcastCrossRank) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {10.F, 20.F, 30.F, 40.F};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a - b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // a_grad: all 1s, shape [2,1,1,4]
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // b_grad: -1s summed over dims 0,1,2 -> each element = -2, shape [4]
+    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b) * 2.0F));
+}
+
+TEST_F(BinaryOpsBackwardTest, MulBroadcastCrossRank) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {2.F, 2.F, 2.F, 2.F};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a * b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a*b)/da = b (broadcast) -> each element = 2, shape [2,1,1,4]
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 2.0F));
+
+    // d(a*b)/db = a, summed over dims 0,1,2 -> [1+5, 2+6, 3+7, 4+8] = [6, 8, 10, 12], shape [4]
+    xt::xarray<float> expected_b_grad = {6.F, 8.F, 10.F, 12.F};
     EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
 }
 

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -2,12 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// GCC 12 emits a false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign
-// when std::equal is inlined over empty-vector iterators. Fixed in GCC 13.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13
-#pragma GCC diagnostic ignored "-Wnonnull"
-#endif
-
 #include <gtest/gtest.h>
 
 #include <stdexcept>

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// GCC 12 emits a false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign
+// when std::equal is inlined over empty-vector iterators. Fixed in GCC 13.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
+
 #include <gtest/gtest.h>
 
 #include <stdexcept>
@@ -127,10 +133,8 @@ TEST_F(BinaryOpsBackwardTest, DivSameShape) {
 // ============================================================================
 
 struct BroadcastCase {
-    // Use xarray's native shape type (svector) instead of std::vector to avoid a GCC 12
-    // false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign (fixed in GCC 13).
-    xt::xarray<float>::shape_type a_shape;
-    xt::xarray<float>::shape_type b_shape;
+    std::vector<size_t> a_shape;
+    std::vector<size_t> b_shape;
     std::string name;
 };
 

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -123,15 +123,33 @@ TEST_F(BinaryOpsBackwardTest, DivSameShape) {
 }
 
 // ============================================================================
-// Broadcast backward tests
+// Parametrized broadcast backward tests
 // ============================================================================
 
-TEST_F(BinaryOpsBackwardTest, AddBroadcastDim0) {
+struct BroadcastCase {
+    std::vector<size_t> a_shape;
+    std::vector<size_t> b_shape;
+    std::string name;
+};
+
+void PrintTo(const BroadcastCase& c, std::ostream* os) {
+    *os << c.name;
+}
+
+static std::string BroadcastCaseName(const ::testing::TestParamInfo<BroadcastCase>& info) {
+    return info.param.name;
+}
+
+class AddBroadcastBackwardTest : public BinaryOpsBackwardTest, public ::testing::WithParamInterface<BroadcastCase> {};
+class SubBroadcastBackwardTest : public BinaryOpsBackwardTest, public ::testing::WithParamInterface<BroadcastCase> {};
+class MulBroadcastBackwardTest : public BinaryOpsBackwardTest, public ::testing::WithParamInterface<BroadcastCase> {};
+
+TEST_P(AddBroadcastBackwardTest, GradShapeMatchesInput) {
     auto* device = &autograd::ctx().get_device();
-    // a: [2, 1, 1, 4], b: [1, 1, 1, 4] -> b is broadcast along dim 0
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {{{{10.F, 20.F, 30.F, 40.F}}}};
+    const auto& p = GetParam();
+
+    xt::xarray<float> data_a = xt::ones<float>(p.a_shape) * 5.0F;
+    xt::xarray<float> data_b = xt::ones<float>(p.b_shape) * 3.0F;
 
     auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
     auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
@@ -142,66 +160,51 @@ TEST_F(BinaryOpsBackwardTest, AddBroadcastDim0) {
     auto a_grad = core::to_xtensor(a->get_grad());
     auto b_grad = core::to_xtensor(b->get_grad());
 
-    // a_grad: same shape as a, all 1s
+    // d(a+b)/da = 1
     EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
 
-    // b_grad: summed over dim 0 -> [1,1,1,4], each element = 2 (two batches)
-    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b) * 2.0F));
-}
-
-TEST_F(BinaryOpsBackwardTest, SubBroadcastDim0) {
-    auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {{{{10.F, 20.F, 30.F, 40.F}}}};
-
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
-
-    auto out = a - b;
-    out->backward();
-
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
-
-    // a_grad: all 1s
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-
-    // b_grad: summed -1s over dim 0 -> each element = -2
-    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b) * 2.0F));
-}
-
-TEST_F(BinaryOpsBackwardTest, SubBroadcastDim3) {
-    auto* device = &autograd::ctx().get_device();
-    // a: [1, 1, 1, 4], b: [1, 1, 1, 1] -> b is broadcast along dim 3
-    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
-    xt::xarray<float> data_b = {3.F};
-    data_b.reshape({1, 1, 1, 1});
-
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
-
-    auto out = a - b;
-    out->backward();
-
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
-
-    // d(a-b)/da = 1 -> all ones
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-
-    // d(a-b)/db = -1, summed over dim 3 -> [(-1)*4] = [-4]
-    xt::xarray<float> expected_b_grad = {-4.F};
-    expected_b_grad.reshape({1, 1, 1, 1});
+    // d(a+b)/db = 1, reduced over broadcast dims
+    // Each b element accumulates (a_volume / b_volume) copies of 1
+    auto a_volume = static_cast<float>(data_a.size());
+    auto b_volume = static_cast<float>(data_b.size());
+    xt::xarray<float> expected_b_grad = xt::ones_like(data_b) * (a_volume / b_volume);
     EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
 }
 
-TEST_F(BinaryOpsBackwardTest, MulBroadcastDim0) {
+TEST_P(SubBroadcastBackwardTest, GradShapeMatchesInput) {
     auto* device = &autograd::ctx().get_device();
-    // a: [2, 1, 1, 4], b: [1, 1, 1, 4]
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {{{{2.F, 2.F, 2.F, 2.F}}}};
+    const auto& p = GetParam();
+
+    xt::xarray<float> data_a = xt::ones<float>(p.a_shape) * 5.0F;
+    xt::xarray<float> data_b = xt::ones<float>(p.b_shape) * 3.0F;
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+
+    auto out = a - b;
+    out->backward();
+
+    auto a_grad = core::to_xtensor(a->get_grad());
+    auto b_grad = core::to_xtensor(b->get_grad());
+
+    // d(a-b)/da = 1
+    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+
+    // d(a-b)/db = -1, reduced over broadcast dims
+    auto a_volume = static_cast<float>(data_a.size());
+    auto b_volume = static_cast<float>(data_b.size());
+    xt::xarray<float> expected_b_grad = -xt::ones_like(data_b) * (a_volume / b_volume);
+    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+}
+
+TEST_P(MulBroadcastBackwardTest, GradShapeMatchesInput) {
+    auto* device = &autograd::ctx().get_device();
+    const auto& p = GetParam();
+
+    // Use constant tensors so expected gradients are easy to compute analytically.
+    // a = 3, b = 2 everywhere.
+    xt::xarray<float> data_a = xt::ones<float>(p.a_shape) * 3.0F;
+    xt::xarray<float> data_b = xt::ones<float>(p.b_shape) * 2.0F;
 
     auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
     auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
@@ -212,112 +215,42 @@ TEST_F(BinaryOpsBackwardTest, MulBroadcastDim0) {
     auto a_grad = core::to_xtensor(a->get_grad());
     auto b_grad = core::to_xtensor(b->get_grad());
 
-    // d(a*b)/da = b (broadcast) -> each element of a_grad = 2
+    // d(a*b)/da = b (broadcast) -> each element = 2
     EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 2.0F));
 
-    // d(a*b)/db = a, summed over dim 0 -> [1+5, 2+6, 3+7, 4+8] = [6, 8, 10, 12]
-    xt::xarray<float> expected_b_grad = {{{{6.F, 8.F, 10.F, 12.F}}}};
+    // d(a*b)/db = a, reduced over broadcast dims.
+    // Each b element sees (a_volume / b_volume) copies of a=3, so b_grad = 3 * (a_volume / b_volume).
+    auto a_volume = static_cast<float>(data_a.size());
+    auto b_volume = static_cast<float>(data_b.size());
+    xt::xarray<float> expected_b_grad = xt::ones_like(data_b) * 3.0F * (a_volume / b_volume);
     EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
 }
 
-TEST_F(BinaryOpsBackwardTest, MulBroadcastDim3) {
-    auto* device = &autograd::ctx().get_device();
-    // a: [1, 1, 1, 4], b: [1, 1, 1, 1] -> b is broadcast along dim 3
-    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
-    xt::xarray<float> data_b = {3.F};
-    data_b.reshape({1, 1, 1, 1});
+// Same-rank broadcast: b has a 1 in exactly one dimension
+static const BroadcastCase kSameRankCases[] = {
+    {{2, 1, 1, 4}, {1, 1, 1, 4}, "Dim0"},
+    {{1, 2, 1, 4}, {1, 1, 1, 4}, "Dim1"},
+    {{1, 1, 2, 4}, {1, 1, 1, 4}, "Dim2"},
+    {{1, 1, 1, 4}, {1, 1, 1, 1}, "Dim3"},
+    {{2, 1, 2, 4}, {1, 1, 1, 4}, "Dim0_Dim2"},
+    {{2, 2, 1, 4}, {1, 1, 1, 4}, "Dim0_Dim1"},
+};
 
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
+// Cross-rank broadcast: b has fewer dimensions than a
+static const BroadcastCase kCrossRankCases[] = {
+    {{2, 1, 1, 4}, {4}, "Rank4_vs_Rank1"},
+    {{2, 1, 1, 4}, {1, 4}, "Rank4_vs_Rank2"},
+    {{2, 1, 1, 4}, {1, 1, 4}, "Rank4_vs_Rank3"},
+};
 
-    auto out = a * b;
-    out->backward();
+INSTANTIATE_TEST_SUITE_P(SameRank, AddBroadcastBackwardTest, ::testing::ValuesIn(kSameRankCases), BroadcastCaseName);
+INSTANTIATE_TEST_SUITE_P(CrossRank, AddBroadcastBackwardTest, ::testing::ValuesIn(kCrossRankCases), BroadcastCaseName);
 
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
+INSTANTIATE_TEST_SUITE_P(SameRank, SubBroadcastBackwardTest, ::testing::ValuesIn(kSameRankCases), BroadcastCaseName);
+INSTANTIATE_TEST_SUITE_P(CrossRank, SubBroadcastBackwardTest, ::testing::ValuesIn(kCrossRankCases), BroadcastCaseName);
 
-    // d(a*b)/da = b (broadcast) -> each element = 3
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 3.0F));
-
-    // d(a*b)/db = a, summed over dim 3 -> [1+2+3+4] = [10]
-    xt::xarray<float> expected_b_grad = {10.F};
-    expected_b_grad.reshape({1, 1, 1, 1});
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
-}
-
-// ============================================================================
-// Cross-rank broadcast backward tests (input ranks differ)
-// ============================================================================
-
-TEST_F(BinaryOpsBackwardTest, AddBroadcastCrossRank) {
-    auto* device = &autograd::ctx().get_device();
-    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {10.F, 20.F, 30.F, 40.F};
-
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
-
-    auto out = a + b;
-    out->backward();
-
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
-
-    // a_grad: all 1s, shape [2,1,1,4]
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-
-    // b_grad: 1s summed over dims 0,1,2 -> each element = 2, shape [4]
-    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b) * 2.0F));
-}
-
-TEST_F(BinaryOpsBackwardTest, SubBroadcastCrossRank) {
-    auto* device = &autograd::ctx().get_device();
-    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {10.F, 20.F, 30.F, 40.F};
-
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
-
-    auto out = a - b;
-    out->backward();
-
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
-
-    // a_grad: all 1s, shape [2,1,1,4]
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-
-    // b_grad: -1s summed over dims 0,1,2 -> each element = -2, shape [4]
-    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b) * 2.0F));
-}
-
-TEST_F(BinaryOpsBackwardTest, MulBroadcastCrossRank) {
-    auto* device = &autograd::ctx().get_device();
-    // a: [2, 1, 1, 4], b: [4] -> b is broadcast across ranks
-    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
-    data_a.reshape({2, 1, 1, 4});
-    xt::xarray<float> data_b = {2.F, 2.F, 2.F, 2.F};
-
-    auto a = autograd::create_tensor(core::from_xtensor(data_a, device), true);
-    auto b = autograd::create_tensor(core::from_xtensor(data_b, device), true);
-
-    auto out = a * b;
-    out->backward();
-
-    auto a_grad = core::to_xtensor(a->get_grad());
-    auto b_grad = core::to_xtensor(b->get_grad());
-
-    // d(a*b)/da = b (broadcast) -> each element = 2, shape [2,1,1,4]
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 2.0F));
-
-    // d(a*b)/db = a, summed over dims 0,1,2 -> [1+5, 2+6, 3+7, 4+8] = [6, 8, 10, 12], shape [4]
-    xt::xarray<float> expected_b_grad = {6.F, 8.F, 10.F, 12.F};
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
-}
+INSTANTIATE_TEST_SUITE_P(SameRank, MulBroadcastBackwardTest, ::testing::ValuesIn(kSameRankCases), BroadcastCaseName);
+INSTANTIATE_TEST_SUITE_P(CrossRank, MulBroadcastBackwardTest, ::testing::ValuesIn(kCrossRankCases), BroadcastCaseName);
 
 TEST_F(BinaryOpsBackwardTest, DivBroadcastThrows) {
     auto* device = &autograd::ctx().get_device();

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -2,12 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// GCC 12 emits a false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign
-// when std::equal is inlined over empty-vector iterators. Fixed in GCC 13.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13
-#pragma GCC diagnostic ignored "-Wnonnull"
-#endif
-
 #include <gtest/gtest.h>
 
 #include <stdexcept>
@@ -133,8 +127,10 @@ TEST_F(BinaryOpsBackwardTest, DivSameShape) {
 // ============================================================================
 
 struct BroadcastCase {
-    std::vector<size_t> a_shape;
-    std::vector<size_t> b_shape;
+    // Use xarray's native shape type (svector) instead of std::vector to avoid a GCC 12
+    // false-positive -Wnonnull inside xtensor's xbroadcast::has_linear_assign (fixed in GCC 13).
+    xt::xarray<float>::shape_type a_shape;
+    xt::xarray<float>::shape_type b_shape;
     std::string name;
 };
 

--- a/tt-train/tests/ops/binary_ops_fw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_fw_test.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "ops/binary_ops.hpp"
+
+namespace ttml::ops::tests {
+
+class BinaryOpsForwardTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        autograd::ctx().open_device();
+    }
+
+    void TearDown() override {
+        autograd::ctx().reset_graph();
+        autograd::ctx().close_device();
+    }
+};
+
+TEST_F(BinaryOpsForwardTest, AddSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {{{{5.F, 6.F, 7.F, 8.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a + b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {{{{6.F, 8.F, 10.F, 12.F}}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, AddBroadcast) {
+    auto* device = &autograd::ctx().get_device();
+    // a: [2, 1, 1, 4], b: [1, 1, 1, 4] -> broadcast b along dim 0
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{10.F, 20.F, 30.F, 40.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a + b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {11.F, 22.F, 33.F, 44.F, 15.F, 26.F, 37.F, 48.F};
+    expected.reshape({2, 1, 1, 4});
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, SubSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{5.F, 6.F, 7.F, 8.F}}}};
+    xt::xarray<float> data_b = {{{{1.F, 2.F, 3.F, 4.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a - b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {{{{4.F, 4.F, 4.F, 4.F}}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, SubBroadcast) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {10.F, 20.F, 30.F, 40.F, 50.F, 60.F, 70.F, 80.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{1.F, 2.F, 3.F, 4.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a - b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {9.F, 18.F, 27.F, 36.F, 49.F, 58.F, 67.F, 76.F};
+    expected.reshape({2, 1, 1, 4});
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, MulSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+    xt::xarray<float> data_b = {{{{4.F, 3.F, 2.F, 1.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a * b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {{{{4.F, 6.F, 6.F, 4.F}}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, MulBroadcast) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {1.F, 2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{2.F, 3.F, 4.F, 5.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a * b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {2.F, 6.F, 12.F, 20.F, 10.F, 18.F, 28.F, 40.F};
+    expected.reshape({2, 1, 1, 4});
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, MulScalar) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{1.F, 2.F, 3.F, 4.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+
+    auto out = a * 3.0F;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {{{{3.F, 6.F, 9.F, 12.F}}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, DivSameShape) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {{{{4.F, 6.F, 8.F, 10.F}}}};
+    xt::xarray<float> data_b = {{{{2.F, 3.F, 4.F, 5.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a / b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {{{{2.F, 2.F, 2.F, 2.F}}}};
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+TEST_F(BinaryOpsForwardTest, DivBroadcast) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data_a = {4.F, 6.F, 8.F, 10.F, 12.F, 14.F, 16.F, 18.F};
+    data_a.reshape({2, 1, 1, 4});
+    xt::xarray<float> data_b = {{{{2.F, 2.F, 2.F, 2.F}}}};
+
+    auto a = autograd::create_tensor(core::from_xtensor(data_a, device));
+    auto b = autograd::create_tensor(core::from_xtensor(data_b, device));
+
+    auto out = a / b;
+    auto result = core::to_xtensor(out->get_value());
+
+    xt::xarray<float> expected = {2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F, 9.F};
+    expected.reshape({2, 1, 1, 4});
+    EXPECT_TRUE(xt::allclose(result, expected));
+}
+
+}  // namespace ttml::ops::tests


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/40008

### Problem description

Dimension broadcasting is broken for ttml mul and sub in backward mode.

### What's changed

- Sum gradients in bw of mul and sub on broadcasted dimensions.
- Add tests covering previously broken behavior.

### Checklist

- [x] Nightly tt-metal L2 tests (C++ and Python tt-train tests) https://github.com/tenstorrent/tt-metal/actions/runs/23812854828