### PR TITLE
MoE routing setup refactoring and cleanup

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -221,7 +221,7 @@ def test_forward_pass(
         device_id = row * n_tp_devices
         indices_for_gate[row] = ttnn.to_torch(per_device_topk_indices[device_id]).int()
 
-    expert_offsets, _, cum_sum = get_gate_outputs(
+    expert_offsets, _, _ = get_gate_outputs(
         indices=indices_for_gate,
         dispatch_group_size=n_sp_devices,
         num_routed_experts=n_routed_experts,
@@ -231,7 +231,6 @@ def test_forward_pass(
     )
 
     reference_offsets = expert_offsets.long()
-    reference_totals = cum_sum[-1:].long()
 
     per_device_dispatch_offsets = ttnn.get_device_tensors(dispatch_offsets)
     for device_id in range(len(per_device_dispatch_offsets)):

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -10,6 +10,7 @@ PyTorch reference implementation when dispatching tokens to experts.
 """
 
 import pytest
+import torch
 from loguru import logger
 from tracy import signpost
 
@@ -17,22 +18,22 @@ import ttnn
 
 # from models.demos.deepseek_v3_d_p.reference.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
     compute_constants,
-    create_expert_dispatch_table,
     create_fabric_router_config,
     extract_mesh_config,
     get_gate_outputs,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.moe_gate_prefill2d import MoEGate_prep_dispatch_combine
+from models.demos.deepseek_v3_d_p.tt.moe.moe_gate_prefill2d import MoERoutingSetup
 
 # from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, hidden_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
+    "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
     [
         (3200, 7168, 64, 2, 2),
     ],
@@ -80,7 +81,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 def test_prep_dispatch_combine(
     mesh_device,
     seq_len_per_chip,
-    hidden_dim,
+    emb_dim,
     num_routed_experts,
     num_experts_per_tok,
     capacity_factor,
@@ -96,17 +97,18 @@ def test_prep_dispatch_combine(
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
 
-    logger.info(f"Testing with {mesh_device.shape=}, {num_devices=} {dispatch_group_size=} {num_dispatch_groups=}")
+    logger.debug(f"Testing with {mesh_device.shape=}, {num_devices=} {dispatch_group_size=} {num_dispatch_groups=}")
     ttnn.visualize_mesh_device(mesh_device)
 
     signpost(
-        f"prep dispatch/combine {mesh_device=} {num_devices=} {dispatch_group_size=} {num_dispatch_groups=} {seq_len_per_chip=} {hidden_dim=} {num_routed_experts=} {num_experts_per_tok=} {capacity_factor=} {use_predictable_data=} {num_links=} {topology=}"
+        f"prep dispatch/combine {mesh_device=} {num_devices=} {dispatch_group_size=} {num_dispatch_groups=} {seq_len_per_chip=} {emb_dim=} {num_routed_experts=} {num_experts_per_tok=} {capacity_factor=} {use_predictable_data=} {num_links=} {topology=}"
     )
 
     experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
-        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, capacity_factor
+        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, dispatch_group_size, capacity_factor
     )
-    logger.info(f"{experts_per_chip=}, {metadata_len=}, {max_dispatched_tokens_per_expert=}")
+
+    logger.debug(f"{experts_per_chip=}, {metadata_len=}, {max_dispatched_tokens_per_expert=}")
 
     # Initialize inputs using helper function
     # For 2D mesh, generate different weights per EP rank
@@ -114,25 +116,25 @@ def test_prep_dispatch_combine(
         x, weights, indices = initialize_predictable_test_inputs(
             dispatch_group_size=dispatch_group_size,
             seq_len_per_chip=seq_len_per_chip,
-            hidden_dim=hidden_dim,
+            emb_dim=emb_dim,
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
             num_dispatch_groups=num_dispatch_groups,
         )
-        logger.info("Using PREDICTABLE test data for debugging")
+        logger.debug("Using PREDICTABLE test data for debugging")
     else:
         x, weights, indices = initialize_test_inputs(
             dispatch_group_size=dispatch_group_size,
             seq_len_per_chip=seq_len_per_chip,
-            hidden_dim=hidden_dim,
+            emb_dim=emb_dim,
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
             seed=42,
             num_dispatch_groups=num_dispatch_groups,
         )
-        logger.info("Using RANDOM test data")
+        logger.debug("Using RANDOM test data")
 
     logger.debug(f"Input shapes: {x.shape=}, {weights.shape=}, {indices.shape=}")
 
@@ -148,7 +150,7 @@ def test_prep_dispatch_combine(
     )
 
     # Create expert dispatch table
-    expert_dispatch_table = create_expert_dispatch_table(
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=num_routed_experts,
         dispatch_group_size=dispatch_group_size,
         num_dispatch_groups=num_dispatch_groups,
@@ -170,8 +172,8 @@ def test_prep_dispatch_combine(
         num_experts_per_tok,
     )
 
-    tt_gate_outputs = MoEGate_prep_dispatch_combine(
-        mesh_device=mesh_device, expert_dispatch_table=expert_dispatch_table
+    tt_gate_outputs = MoERoutingSetup(
+        mesh_device=mesh_device, expert_dispatch_table=expert_dispatch_table, num_links=num_links
     )
 
     tt_expert_offsets, tt_expert_token_counts, tt_per_device_expert_counter = tt_gate_outputs(
@@ -183,31 +185,37 @@ def test_prep_dispatch_combine(
         num_experts_per_tok=num_experts_per_tok,
     )
 
-    logger.warning(f"{expert_offsets.shape=}, {expert_token_counts.shape=}, {per_device_expert_counter.shape=}")
-    logger.warning(
-        f"{tt_expert_offsets.shape=}, {tt_expert_token_counts.shape=}, {tt_per_device_expert_counter.shape=}"
-    )
+    # tt_expert_offsets and tt_expert_token_counts are replicated across columns; and sparse across rows;
+    # expert_offsets, and expert_token_counts on torch are dense acrros rows;
 
-    composer = ttnn.create_mesh_composer(
-        mesh_device,
-        ttnn.MeshComposerConfig(
-            dims=[0, -1],
-        ),
-    )
+    # Compose across cols and rows
+    # - Validate replication on cols
+    # - Sparse -> dense on rows to validate everything
+    tt_expert_offsets = ttnn.unsqueeze_to_4D(tt_expert_offsets)
+    tt_expert_token_counts = ttnn.unsqueeze_to_4D(tt_expert_token_counts)
 
-    for name, torch_tensor, tt_tensor in [
-        ("expert_offsets", expert_offsets, tt_expert_offsets),
-        ("expert_token_counts", expert_token_counts, tt_expert_token_counts),
-        ("per_device_expert_counter", per_device_expert_counter, tt_per_device_expert_counter),
-    ]:
-        logger.info(f"Validating {name}...")
-        logger.info(f"{tt_tensor.tensor_topology()=}")
+    composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(dims=[1, 0]))
+    host_expert_offsets = ttnn.to_torch(tt_expert_offsets, mesh_composer=composer)
+    host_expert_token_counts = ttnn.to_torch(tt_expert_token_counts, mesh_composer=composer)
 
-    # tt_tensor.tensor_topology()= (distribution_shape=MeshShape([8, 1]), placements=SmallVector([PlacementShard(0), PlacementReplicate()]),
+    tensors_to_validate = [
+        ("expert_offsets", host_expert_offsets, expert_offsets),
+        ("expert_token_counts", host_expert_token_counts, expert_token_counts),
+    ]
 
-    tt_expert_offsets_per_device = ttnn.get_device_tensors(tt_expert_offsets)
-    for t in tt_expert_offsets_per_device:
-        t = ttnn.to_torch(t)
-        logger.warning(f"{t.shape=}\n{t}")
+    # Validate replication within dispatch groups (across cols)
+    for name, host_tensor, _ in tensors_to_validate:
+        for i in range(num_dispatch_groups):
+            ref = host_tensor[i][0]
+            for j in range(1, dispatch_group_size):
+                if not torch.allclose(host_tensor[i][j], ref, atol=0, rtol=0):
+                    raise AssertionError(
+                        f"Replication mismatch in {name} for dispatch group {i}, row {j}. "
+                        f"Expected {ref}, got {host_tensor[i][j]}"
+                    )
 
-    logger.warning(f"expected {expert_offsets=}")
+    # Validate sparse -> dense across dispatch groups (rows)
+    for name, host_tensor, expected in tensors_to_validate:
+        tt_dense = sum(host_tensor[i][0].int() for i in range(num_dispatch_groups))
+        if not torch.allclose(tt_dense.flatten(), expected.int().flatten(), atol=0, rtol=0):
+            raise AssertionError(f"Sparse->dense mismatch for {name}. Expected {expected}, got {tt_dense}")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -365,7 +365,7 @@ def test_ttnn_dispatch(
     )
 
     # Compute gate outputs (offsets and token counts) before dispatch
-    expert_offsets, expert_token_counts, cum_sum = get_gate_outputs(
+    expert_offsets, expert_token_counts, _ = get_gate_outputs(
         indices,
         dispatch_group_size,
         num_routed_experts,
@@ -400,7 +400,6 @@ def test_ttnn_dispatch(
         logger.debug(f"{torch_metadata[0][0][0][0][0:4]=} | {torch_metadata[0][1][0][0][0:4]=}")
         logger.debug(f"{expert_token_counts.shape=}, {expert_token_counts=}")
         logger.debug(f"{expert_offsets.shape=}, {expert_offsets=}")
-        logger.debug(f"{cum_sum.shape=}, {cum_sum=}")
 
     # Verify dispatched data matches reference (each EP rank against its torch reference)
     buffer_result = validate_dispatch_buffer(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prep_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prep_dispatch_combine.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for TTNN MoE prefill dispatch operation in isolation.
+
+This test verifies that the TTNN dispatch operation produces the same output as the
+PyTorch reference implementation when dispatching tokens to experts.
+"""
+
+import pytest
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+
+# from models.demos.deepseek_v3_d_p.reference.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    compute_constants,
+    create_expert_dispatch_table,
+    create_fabric_router_config,
+    extract_mesh_config,
+    get_gate_outputs,
+    initialize_predictable_test_inputs,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.moe_gate_prefill2d import MoEGate_prep_dispatch_combine
+
+# from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table
+
+
+@pytest.mark.parametrize(
+    "seq_len_per_chip, hidden_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
+    [
+        (3200, 7168, 64, 2, 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8",
+        ),
+        pytest.param(
+            (4, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
+            id="mesh-4x2",
+        ),
+        pytest.param(
+            (2, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
+            id="mesh-2x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("use_predictable_data", [True, False], ids=["predictable", "random"])
+def test_prep_dispatch_combine(
+    mesh_device,
+    seq_len_per_chip,
+    hidden_dim,
+    num_routed_experts,
+    num_experts_per_tok,
+    capacity_factor,
+    num_links,
+    topology,
+    use_predictable_data,
+):
+    """Test TTNN dispatch operation against PyTorch reference."""
+    num_devices = mesh_device.get_num_devices()
+
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    logger.info(f"Testing with {mesh_device.shape=}, {num_devices=} {dispatch_group_size=} {num_dispatch_groups=}")
+    ttnn.visualize_mesh_device(mesh_device)
+
+    signpost(
+        f"prep dispatch/combine {mesh_device=} {num_devices=} {dispatch_group_size=} {num_dispatch_groups=} {seq_len_per_chip=} {hidden_dim=} {num_routed_experts=} {num_experts_per_tok=} {capacity_factor=} {use_predictable_data=} {num_links=} {topology=}"
+    )
+
+    experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
+        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, capacity_factor
+    )
+    logger.info(f"{experts_per_chip=}, {metadata_len=}, {max_dispatched_tokens_per_expert=}")
+
+    # Initialize inputs using helper function
+    # For 2D mesh, generate different weights per EP rank
+    if use_predictable_data:
+        x, weights, indices = initialize_predictable_test_inputs(
+            dispatch_group_size=dispatch_group_size,
+            seq_len_per_chip=seq_len_per_chip,
+            hidden_dim=hidden_dim,
+            num_routed_experts=num_routed_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+            num_dispatch_groups=num_dispatch_groups,
+        )
+        logger.info("Using PREDICTABLE test data for debugging")
+    else:
+        x, weights, indices = initialize_test_inputs(
+            dispatch_group_size=dispatch_group_size,
+            seq_len_per_chip=seq_len_per_chip,
+            hidden_dim=hidden_dim,
+            num_routed_experts=num_routed_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+            seed=42,
+            num_dispatch_groups=num_dispatch_groups,
+        )
+        logger.info("Using RANDOM test data")
+
+    logger.debug(f"Input shapes: {x.shape=}, {weights.shape=}, {indices.shape=}")
+
+    # x and indices: replicated across EP ranks
+    mesh_mapper_replicated = ttnn.ShardTensor2dMesh(
+        mesh_device,
+        mesh_shape=mesh_device.shape,
+        dims=(sp_axis, None),
+    )
+
+    tt_indices = ttnn.from_torch(
+        indices, mesh_mapper=mesh_mapper_replicated, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.uint16
+    )
+
+    # Create expert dispatch table
+    expert_dispatch_table = create_expert_dispatch_table(
+        num_routed_experts=num_routed_experts,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    log_expert_dispatch_table(
+        expert_dispatch_table=expert_dispatch_table,
+        num_dispatch_groups=num_dispatch_groups,
+        dispatch_group_size=dispatch_group_size,
+        num_routed_experts=num_routed_experts,
+    )
+
+    # Compute gate outputs (offsets and token counts) before dispatch
+    expert_offsets, expert_token_counts, cum_sum = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        num_routed_experts,
+        experts_per_chip,
+        seq_len_per_chip,
+        num_experts_per_tok,
+    )
+
+    tt_gate_outputs = MoEGate_prep_dispatch_combine(
+        mesh_device=mesh_device, expert_dispatch_table=expert_dispatch_table
+    )
+
+    tt_expert_offsets, tt_expert_token_counts, tt_cum_sum = tt_gate_outputs(
+        ttnn_top_k_experts_indices=tt_indices,
+        dispatch_group_size=dispatch_group_size,
+        num_routed_experts=num_routed_experts,
+        experts_per_chip=experts_per_chip,
+        seq_len_per_chip=seq_len_per_chip,
+        num_experts_per_tok=num_experts_per_tok,
+    )
+
+    logger.warning(f"{expert_offsets.shape=}, {expert_token_counts.shape=}, {cum_sum.shape=}")
+    logger.warning(f"{tt_expert_offsets.shape=}, {tt_expert_token_counts.shape=}, {tt_cum_sum.shape=}")
+
+    composer = ttnn.create_mesh_composer(
+        mesh_device,
+        ttnn.MeshComposerConfig(
+            dims=[0, -1],
+        ),
+    )
+
+    for name, torch_tensor, tt_tensor in [
+        ("expert_offsets", expert_offsets, tt_expert_offsets),
+        ("expert_token_counts", expert_token_counts, tt_expert_token_counts),
+        ("cum_sum", cum_sum, tt_cum_sum),
+    ]:
+        logger.info(f"Validating {name}...")
+        logger.info(f"{tt_tensor.tensor_topology()=}")
+
+    # tt_tensor.tensor_topology()= (distribution_shape=MeshShape([8, 1]), placements=SmallVector([PlacementShard(0), PlacementReplicate()]),
+
+    tt_expert_offsets_per_device = ttnn.get_device_tensors(tt_expert_offsets)
+    for t in tt_expert_offsets_per_device:
+        t = ttnn.to_torch(t)
+        logger.warning(f"{t.shape=}\n{t}")
+
+    logger.warning(f"expected {expert_offsets=}")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prep_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prep_dispatch_combine.py
@@ -161,7 +161,7 @@ def test_prep_dispatch_combine(
     )
 
     # Compute gate outputs (offsets and token counts) before dispatch
-    expert_offsets, expert_token_counts, cum_sum = get_gate_outputs(
+    expert_offsets, expert_token_counts, per_device_expert_counter = get_gate_outputs(
         indices,
         dispatch_group_size,
         num_routed_experts,
@@ -174,7 +174,7 @@ def test_prep_dispatch_combine(
         mesh_device=mesh_device, expert_dispatch_table=expert_dispatch_table
     )
 
-    tt_expert_offsets, tt_expert_token_counts, tt_cum_sum = tt_gate_outputs(
+    tt_expert_offsets, tt_expert_token_counts, tt_per_device_expert_counter = tt_gate_outputs(
         ttnn_top_k_experts_indices=tt_indices,
         dispatch_group_size=dispatch_group_size,
         num_routed_experts=num_routed_experts,
@@ -183,8 +183,10 @@ def test_prep_dispatch_combine(
         num_experts_per_tok=num_experts_per_tok,
     )
 
-    logger.warning(f"{expert_offsets.shape=}, {expert_token_counts.shape=}, {cum_sum.shape=}")
-    logger.warning(f"{tt_expert_offsets.shape=}, {tt_expert_token_counts.shape=}, {tt_cum_sum.shape=}")
+    logger.warning(f"{expert_offsets.shape=}, {expert_token_counts.shape=}, {per_device_expert_counter.shape=}")
+    logger.warning(
+        f"{tt_expert_offsets.shape=}, {tt_expert_token_counts.shape=}, {tt_per_device_expert_counter.shape=}"
+    )
 
     composer = ttnn.create_mesh_composer(
         mesh_device,
@@ -196,7 +198,7 @@ def test_prep_dispatch_combine(
     for name, torch_tensor, tt_tensor in [
         ("expert_offsets", expert_offsets, tt_expert_offsets),
         ("expert_token_counts", expert_token_counts, tt_expert_token_counts),
-        ("cum_sum", cum_sum, tt_cum_sum),
+        ("per_device_expert_counter", per_device_expert_counter, tt_per_device_expert_counter),
     ]:
         logger.info(f"Validating {name}...")
         logger.info(f"{tt_tensor.tensor_topology()=}")

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
@@ -113,7 +113,7 @@ def test_moe(
     )
 
     # Compute gate outputs
-    expert_offsets, expert_token_counts, cum_sum = get_gate_outputs(
+    expert_offsets, expert_token_counts, _ = get_gate_outputs(
         indices,
         dispatch_group_size,
         num_routed_experts,

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_torch_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_torch_dispatch_combine.py
@@ -89,7 +89,7 @@ def test_torch_dispatch_combine(
     )
 
     # Compute gate outputs before dispatch
-    expert_offsets, expert_token_counts, cum_sum = get_gate_outputs(
+    expert_offsets, expert_token_counts, _ = get_gate_outputs(
         indices,
         dispatch_group_size,
         num_routed_experts,

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -313,7 +313,7 @@ def get_gate_outputs(
     logger.debug(f"  expert_offsets.shape={expert_offsets.shape}")
     logger.debug(f"  expert_token_counts.shape={expert_token_counts.shape}")
     logger.debug(f"  cum_sum.shape={cum_sum.shape}")
-    return expert_offsets, expert_token_counts, cum_sum
+    return expert_offsets, expert_token_counts, cum_sum, expert_counter
 
 
 def compute_constants(

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -288,7 +288,8 @@ def get_gate_outputs(
             Shape: (dispatch_group_size, num_routed_experts)
         expert_token_counts: Total tokens per expert per chip
             Shape: (dispatch_group_size, experts_per_chip)
-        cum_sum: Cumulative sum of token counts across chips
+        expert_counter: Per-chip token counts for each expert (debug only).
+            Shows how many tokens from each chip route to each expert.
             Shape: (dispatch_group_size, num_routed_experts)
     """
     # Count tokens per expert per chip
@@ -312,8 +313,7 @@ def get_gate_outputs(
     logger.debug(f"  expert_counter.shape={expert_counter.shape}")
     logger.debug(f"  expert_offsets.shape={expert_offsets.shape}")
     logger.debug(f"  expert_token_counts.shape={expert_token_counts.shape}")
-    logger.debug(f"  cum_sum.shape={cum_sum.shape}")
-    return expert_offsets, expert_token_counts, cum_sum, expert_counter
+    return expert_offsets, expert_token_counts, expert_counter
 
 
 def compute_constants(

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -11,6 +11,8 @@ from tracy import signpost
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 
+MASKED_BINCOUNT_CORE_COUNT = 64
+
 
 @dataclass
 class MoEGateConfig:
@@ -112,7 +114,7 @@ class MoEGatePrefill(LightweightModule):
         )
 
         self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
-            shape=(config.sp_dim // 64, self.topk),
+            shape=(config.sp_dim // MASKED_BINCOUNT_CORE_COUNT, self.topk),
             core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
             strategy=ttnn.ShardStrategy.HEIGHT,
             use_height_and_width_as_shard_shape=True,
@@ -203,15 +205,12 @@ class MoERoutingSetup(LightweightModule):
         # indices: Expert indices tensor (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
 
         if isinstance(ttnn_top_k_experts_indices, torch.Tensor):
-            # ttnn_top_k_experts_indices.shape
-            # Shape([4096, 8])
-            # ttnn_top_k_experts_indices.tensor_topology()
+            # ttnn_top_k_experts_indices (isl_per_chip, num_experts_per_tok)
             mesh_mapper = ttnn.ShardTensor2dMesh(
                 self.mesh_device,
                 mesh_shape=self.mesh_device.shape,
                 dims=(0, None),  # shard cols; replicate rows
             )
-            # TensorTopology(distribution_shape=MeshShape([4, 2]), placements=SmallVector([PlacementShard(0), PlacementReplicate()]), mesh_coords=MeshCoordinate([0, 0]), MeshCoordinate([0, 1]), MeshCoordinate([1, 0]), MeshCoordinate([1, 1]), MeshCoordinate([2, 0]), MeshCoordinate([2, 1]), MeshCoordinate([3, 0]), MeshCoordinate([3, 1]))
             ttnn_top_k_experts_indices = ttnn.from_torch(
                 ttnn_top_k_experts_indices,
                 device=self.mesh_device,
@@ -230,7 +229,7 @@ class MoERoutingSetup(LightweightModule):
         )
 
         self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
-            shape=(seq_len_per_chip // 64, num_routed_experts),
+            shape=(seq_len_per_chip // MASKED_BINCOUNT_CORE_COUNT, num_routed_experts),
             core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
             strategy=ttnn.ShardStrategy.HEIGHT,
             use_height_and_width_as_shard_shape=True,

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 
 import torch
+from loguru import logger
 from tracy import signpost
 
 import ttnn
@@ -169,3 +170,105 @@ class MoEGatePrefill(LightweightModule):
         signpost(header="moe_gate_calculate_dispatch_offsets")
 
         return (ttnn_scores, ttnn_top_k_experts_indices, logits, dispatch_offsets, total_counts_per_expert)
+
+
+class MoEGate_prep_dispatch_combine(LightweightModule):
+    """MoE gate module from DeepSeek-R1."""
+
+    def __init__(self, mesh_device, expert_dispatch_table):
+        self.mesh_device = mesh_device
+
+        # expert_dispatch_table (Raw table shape: (1, 64))
+        # int value => chip location; -1 not in this group
+        self.experts_in_dispatch_group = ttnn.from_torch(
+            (expert_dispatch_table >= 0).to(torch.uint32),
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+    def forward(
+        self,
+        ttnn_top_k_experts_indices: ttnn.Tensor | torch.Tensor,
+        dispatch_group_size: int,
+        num_routed_experts: int,
+        experts_per_chip: int,
+        seq_len_per_chip: int,
+        num_experts_per_tok: int,
+    ):
+        signpost(header="MoEGate_prep_dispatch_combine")
+        # indices: Expert indices tensor (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
+
+        if isinstance(ttnn_top_k_experts_indices, torch.Tensor):
+            # ttnn_top_k_experts_indices.shape
+            # Shape([4096, 8])
+            # ttnn_top_k_experts_indices.tensor_topology()
+            mesh_mapper = ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                mesh_shape=self.mesh_device.shape,
+                dims=(0, None),  # shard cols; replicate rows
+            )
+            # TensorTopology(distribution_shape=MeshShape([4, 2]), placements=SmallVector([PlacementShard(0), PlacementReplicate()]), mesh_coords=MeshCoordinate([0, 0]), MeshCoordinate([0, 1]), MeshCoordinate([1, 0]), MeshCoordinate([1, 1]), MeshCoordinate([2, 0]), MeshCoordinate([2, 1]), MeshCoordinate([3, 0]), MeshCoordinate([3, 1]))
+            ttnn_top_k_experts_indices = ttnn.from_torch(
+                ttnn_top_k_experts_indices,
+                device=self.mesh_device,
+                dtype=ttnn.uint16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mesh_mapper,
+            )
+        else:
+            ttnn_top_k_experts_indices = ttnn.to_layout(ttnn_top_k_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
+
+        self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
+            shape=(seq_len_per_chip // 64, num_routed_experts),
+            core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        ttnn_top_k_experts_indices = ttnn.to_memory_config(
+            ttnn_top_k_experts_indices, self.expert_index_sharded_mem_config
+        )
+
+        # reference
+        # expert_offsets: Base offset for each expert from each chip
+        #     Shape: (dispatch_group_size, num_routed_experts)
+        # shard (0,None) -> per chip (1,num_routed_experts)
+        # expert_token_counts: Total tokens per expert per chip
+        #     Shape: (dispatch_group_size, experts_per_chip)
+        # cum_sum: Cumulative sum of token counts across chips
+        #     Shape: (dispatch_group_size, num_routed_experts)
+
+        # Torch Input shapes: x.shape=torch.Size([8, 3200, 7168])
+        # Sharded to seq parallel => [1, 3200, 7168] per chip
+        # unsqueeze here for simplicty
+        if len(ttnn_top_k_experts_indices.shape) == 3:
+            ttnn_top_k_experts_indices = ttnn.squeeze(ttnn_top_k_experts_indices, 0)
+        logger.warning(f"{ttnn_top_k_experts_indices.shape=}")
+
+        # expert table (dispatch_groups, routed_experts)
+        # sharded to each dispatch group => (1, routed_experts)
+        # [create_expert_dispatch_table] OUTPUT: table.shape=torch.Size([1, 64])
+        # need to squeeze, as op doesn't support tensor rank 2.
+        logger.error(f"{len(self.experts_in_dispatch_group.shape)}==1?")
+        if len(self.experts_in_dispatch_group.shape) != 1:
+            self.experts_in_dispatch_group = ttnn.squeeze(self.experts_in_dispatch_group, 0)
+        logger.warning(f"{self.experts_in_dispatch_group.shape=}")
+
+        expert_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
+            ttnn_top_k_experts_indices, self.experts_in_dispatch_group, num_routed_experts
+        )
+
+        dispatch_offsets, total_counts_per_expert = ttnn.experimental.deepseek_prefill.offset_cumsum(
+            expert_histograms,
+            cluster_axis=0,
+            num_links=1,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        signpost(header="moe_gate_calculate_dispatch_offsets")
+
+        # return expert_offsets, expert_token_counts, cum_sum
+        # return (ttnn_scores, ttnn_top_k_experts_indices, logits, dispatch_offsets, total_counts_per_expert)
+        return dispatch_offsets, total_counts_per_expert, expert_histograms

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -172,11 +172,12 @@ class MoEGatePrefill(LightweightModule):
         return (ttnn_scores, ttnn_top_k_experts_indices, logits, dispatch_offsets, total_counts_per_expert)
 
 
-class MoEGate_prep_dispatch_combine(LightweightModule):
-    """MoE gate module from DeepSeek-R1."""
+class MoERoutingSetup(LightweightModule):
+    """Prepares routing metadata (offsets, token counts) for MoE dispatch."""
 
-    def __init__(self, mesh_device, expert_dispatch_table):
+    def __init__(self, mesh_device, expert_dispatch_table, num_links=1):
         self.mesh_device = mesh_device
+        self.num_links = num_links
 
         # expert_dispatch_table (Raw table shape: (1, 64))
         # int value => chip location; -1 not in this group
@@ -186,6 +187,7 @@ class MoEGate_prep_dispatch_combine(LightweightModule):
             dtype=ttnn.uint32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_device.shape, dims=(None, 0)),
         )
 
     def forward(
@@ -197,7 +199,7 @@ class MoEGate_prep_dispatch_combine(LightweightModule):
         seq_len_per_chip: int,
         num_experts_per_tok: int,
     ):
-        signpost(header="MoEGate_prep_dispatch_combine")
+        signpost(header="MoERoutingSetup")
         # indices: Expert indices tensor (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
 
         if isinstance(ttnn_top_k_experts_indices, torch.Tensor):
@@ -244,24 +246,24 @@ class MoEGate_prep_dispatch_combine(LightweightModule):
         # shard (0,None) -> per chip (1,num_routed_experts)
         # expert_token_counts: Total tokens per expert per chip
         #     Shape: (dispatch_group_size, experts_per_chip)
-        # cum_sum: Cumulative sum of token counts across chips
-        #     Shape: (dispatch_group_size, num_routed_experts)
 
         # Torch Input shapes: x.shape=torch.Size([8, 3200, 7168])
         # Sharded to seq parallel => [1, 3200, 7168] per chip
-        # unsqueeze here for simplicty
+        # unsqueeze here for simplicity
         if len(ttnn_top_k_experts_indices.shape) == 3:
             ttnn_top_k_experts_indices = ttnn.squeeze(ttnn_top_k_experts_indices, 0)
-        logger.warning(f"{ttnn_top_k_experts_indices.shape=}")
+        logger.debug(f"{ttnn_top_k_experts_indices.shape=}")
 
         # expert table (dispatch_groups, routed_experts)
         # sharded to each dispatch group => (1, routed_experts)
         # [create_expert_dispatch_table] OUTPUT: table.shape=torch.Size([1, 64])
         # need to squeeze, as op doesn't support tensor rank 2.
-        logger.error(f"{len(self.experts_in_dispatch_group.shape)}==1?")
         if len(self.experts_in_dispatch_group.shape) != 1:
+            assert (
+                self.experts_in_dispatch_group.shape[0] == 1
+            ), "Expected first dimension to be 1 after sharding expert dispatch table"
             self.experts_in_dispatch_group = ttnn.squeeze(self.experts_in_dispatch_group, 0)
-        logger.warning(f"{self.experts_in_dispatch_group.shape=}")
+        logger.debug(f"{self.experts_in_dispatch_group.shape=}")
 
         expert_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
             ttnn_top_k_experts_indices, self.experts_in_dispatch_group, num_routed_experts
@@ -270,11 +272,9 @@ class MoEGate_prep_dispatch_combine(LightweightModule):
         dispatch_offsets, total_counts_per_expert = ttnn.experimental.deepseek_prefill.offset_cumsum(
             expert_histograms,
             cluster_axis=0,
-            num_links=1,
+            num_links=self.num_links,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
         signpost(header="moe_gate_calculate_dispatch_offsets")
 
-        # return expert_offsets, expert_token_counts, cum_sum
-        # return (ttnn_scores, ttnn_top_k_experts_indices, logits, dispatch_offsets, total_counts_per_expert)
         return dispatch_offsets, total_counts_per_expert, expert_histograms

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -221,6 +221,12 @@ class MoEGate_prep_dispatch_combine(LightweightModule):
         else:
             ttnn_top_k_experts_indices = ttnn.to_layout(ttnn_top_k_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
 
+        ttnn_top_k_experts_indices = ttnn.pad(
+            ttnn_top_k_experts_indices,
+            padding=((0, 0), (0, num_routed_experts - num_experts_per_tok)),
+            value=257,
+        )
+
         self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
             shape=(seq_len_per_chip // 64, num_routed_experts),
             core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The MoE dispatch preparation code needed cleanup:
- `MoEGate_prep_dispatch_combine` class name was unclear about its purpose
- `get_gate_outputs` returned redundant `cum_sum` (already derived as `expert_token_counts`)
- `num_links` parameter was hardcoded instead of configurable
- Test validation logic had code duplication

### What's changed
**New `MoERoutingSetup` class** (`moe_gate_prefill2d.py`):
- Renamed from `MoEGate_prep_dispatch_combine` to better reflect purpose (prepares routing metadata for dispatch)
- Added configurable `num_links` parameter to constructor
- Computes dispatch offsets and token counts via `masked_bincount` + `offset_cumsum` ops
- Cleaned up: removed dead comments, fixed typos, updated docstring

**API cleanup in `get_gate_outputs`** (`init_helpers.py`):
- Now returns `expert_counter` (useful for debugging) instead of `cum_sum` (redundant)
- Updated all callers across test files

**Test improvements** (`test_moe_routing_setup.py`):
- Renamed from `test_prep_dispatch_combine.py`
- Refactored validation logic to remove duplication
- Validates replication within dispatch groups and sparse->dense correctness

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2603-moe-bridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2603-moe-bridge)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2603-moe-bridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2603-moe-bridge)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2603-moe-bridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2603-moe-bridge)
- [x] New/Existing tests provide coverage for changes

#### Model tests

- [x] [![(T3K) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-moe-bridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2603-moe-bridge) - triggered with `deepseek_prefill` filter
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-moe-bridge)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2603-moe-bridge) - triggered with `deepseek_prefill` filter