### PR TITLE
Fix how sanity and nightly work with ttsim-integration-tests

### DIFF
--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -170,6 +170,7 @@ jobs:
       platform: "Ubuntu 24.04"
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' }}
+      enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       schedule-runs-all-tests: false
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -118,6 +118,7 @@ jobs:
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}
+      packages-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.packages-artifact-name }}
 
   blackhole-nightly-debug-ubuntu-22:
     name: blackhole nightly debug run (Ubuntu 22.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})
@@ -156,6 +157,7 @@ jobs:
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.wheel-artifact-name }}
+      packages-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.packages-artifact-name }}
 
   blackhole-nightly-debug-ubuntu-24:
     name: blackhole nightly debug run (Ubuntu 24.04${{ needs.determine-debug-flags.outputs.enable-watcher == 'true' && ' with watcher' || '' }}${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' && ' with LLK asserts' || '' }})

--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -154,6 +154,7 @@ jobs:
       run-profiler-regression: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-t3000-apc-fast-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-ttsim-integration-tests: false # ttsim requires gcc-12 which is not available on Ubuntu 24.04
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-24.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-24.outputs.wheel-artifact-name }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -53,6 +53,11 @@ on:
         type: boolean
         default: true
         description: "Run ops unit tests"
+      run-ttsim-integration-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run TTSim integration tests"
       enable-watcher:
         required: false
         type: boolean
@@ -89,6 +94,11 @@ on:
         type: string
         default: ""
         description: "Pre-built wheel artifact name (skips build if provided)"
+      packages-artifact-name:
+        required: false
+        type: string
+        default: ""
+        description: "Pre-built packages artifact name (for ttsim tests)"
   workflow_dispatch:
     inputs:
       with-retries:
@@ -148,6 +158,11 @@ on:
         default: true
         type: boolean
         description: "Run ops unit tests"
+      run-ttsim-integration-tests:
+        required: false
+        default: true
+        type: boolean
+        description: "Run TTSim integration tests"
       enable-watcher:
         required: false
         default: false
@@ -231,7 +246,7 @@ jobs:
             echo "ci-test-docker-image=${{ inputs.dev-docker-image }}" >> "$GITHUB_OUTPUT"
             echo "build-artifact-name=${{ inputs.build-artifact-name }}" >> "$GITHUB_OUTPUT"
             echo "wheel-artifact-name=${{ inputs.wheel-artifact-name }}" >> "$GITHUB_OUTPUT"
-            echo "packages-artifact-name=" >> "$GITHUB_OUTPUT"
+            echo "packages-artifact-name=${{ inputs.packages-artifact-name }}" >> "$GITHUB_OUTPUT"
           else
             echo "dev-docker-image=${{ needs.build-artifact.outputs.dev-docker-image }}" >> "$GITHUB_OUTPUT"
             echo "basic-dev-docker-image=${{ needs.build-artifact.outputs.basic-dev-docker-image }}" >> "$GITHUB_OUTPUT"
@@ -252,6 +267,7 @@ jobs:
       run-profiler-regression: ${{ steps.set-run-profiler-regression.outputs.should-run }}
       t3000-apc-fast-tests: ${{ steps.set-t3000-apc-fast-tests.outputs.should-run }}
       ops-unit-tests: ${{ steps.set-ops-unit-tests.outputs.should-run }}
+      ttsim-integration-tests: ${{ steps.set-ttsim-integration-tests.outputs.should-run }}
     steps:
       - id: set-ttnn-unit-tests
         run: |
@@ -271,6 +287,9 @@ jobs:
       - id: set-ops-unit-tests
         run: |
           echo "should-run=${{ github.event_name == 'push' || inputs.run-ops-unit-tests }}" >> "$GITHUB_OUTPUT"
+      - id: set-ttsim-integration-tests
+        run: |
+          echo "should-run=${{ github.event_name == 'push' || inputs.run-ttsim-integration-tests }}" >> "$GITHUB_OUTPUT"
 
   # TTNN FD Unit tests
   ttnn-unit-tests:
@@ -393,8 +412,8 @@ jobs:
       ref: ${{ inputs.ref || github.sha }}
 
   ttsim-integration-tests:
-    needs: [resolve-artifacts]
-    if: ${{ always() && !cancelled() && needs.resolve-artifacts.result == 'success' }}
+    needs: [resolve-artifacts, tests-to-run]
+    if: ${{ always() && !cancelled() && needs.tests-to-run.outputs.ttsim-integration-tests == 'true' }}
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml


### PR DESCRIPTION
### Ticket

### Problem description
Currently, ttsim-integration-tests must be ran as part of Sanity.
Also, in Sanity tests nightly debug run, this group of test always fail.

### What's changed
Added checkbox for ttsim-integration-tests so these tests become optional in Sanity.
Fixed how nightly propagates artifact to Sanity when running ttsim-integration-tests.
1. On Ubuntu 22.04 these tests will be ran
2. On Ubuntu 24.04 these tests can't be ran due to gcc version mismatch - ttsim requires gcc12 while Ubuntu 24.04 is not containing that version. Due to this mismatch, these tests are disabled for now, until fixed.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
- [x] [![Sanity tests nightly debug run](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-debug.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests-debug.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_sanity_ttsim_integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_sanity_ttsim_integration)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
