### PR TITLE
Changing MoeGate in Deepseek_v3 prefill to use a dispatch table for masked bincount instead of 0/1 mask

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -14,7 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, extract_mesh_config
 
 
 def torch_masked_bincount(
@@ -72,13 +72,11 @@ def torch_masked_bincount(
     ],
     indirect=["mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("mask_all_present", [True, False], ids=["all_present", "sparse_mask"])
 def test_masked_bincount(
     mesh_device,
     sp_dim,
     topk,
     n_routed_experts,
-    mask_all_present,
 ):
     """Test ttnn.masked_bincount against PyTorch reference on each device."""
     mesh_config = extract_mesh_config(mesh_device)
@@ -88,7 +86,7 @@ def test_masked_bincount(
 
     logger.info(
         f"Testing masked_bincount: {mesh_device.shape=}, {sp_dim=}, {topk=}, "
-        f"{n_routed_experts=}, {mask_all_present=}, {num_dispatch_groups=}"
+        f"{n_routed_experts=}, {num_dispatch_groups=}"
     )
     ttnn.visualize_mesh_device(mesh_device)
 
@@ -99,14 +97,11 @@ def test_masked_bincount(
     indices = torch.randint(0, n_routed_experts, (total_sp, topk), dtype=torch.int32)
 
     # Expert dispatch table: maps expert_id -> chip_id (>= 0) or -1 (absent)
-    dispatch_table = create_expert_dispatch_table(
+    dispatch_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=n_routed_experts,
         dispatch_group_size=dispatch_group_size,
         num_dispatch_groups=num_dispatch_groups,
     )
-    if not mask_all_present:
-        absent = torch.randint(0, 2, (n_routed_experts,)).bool()
-        dispatch_table[:, absent] = -1
 
     # Compute torch reference per (dispatch_group, chip) pair
     # torch_histograms[group][chip] = histogram for that group/chip combination
@@ -144,27 +139,18 @@ def test_masked_bincount(
     )
     tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
 
-    if num_dispatch_groups == 1:
-        tt_dispatch_table = ttnn.from_torch(
-            dispatch_table[0],
-            device=mesh_device,
-            dtype=ttnn.int32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-    else:
-        tt_dispatch_table = ttnn.from_torch(
-            dispatch_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device,
-                mesh_shape=mesh_device.shape,
-                dims=(None, 0),
-            ),
-        )
+    tt_dispatch_table = ttnn.from_torch(
+        dispatch_table,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            mesh_shape=mesh_device.shape,
+            dims=(None, 0),
+        ),
+    )
 
     # Run ttnn op
     tt_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
@@ -183,8 +169,6 @@ def test_masked_bincount(
         col = device_id % n_cols
         chip_idx = row if sp_axis == 0 else col
         group_idx = col if sp_axis == 0 else row
-        if num_dispatch_groups == 1:
-            group_idx = 0
         ref_hist = torch_histograms[(group_idx, chip_idx)]
 
         matches = torch.equal(tt_hist[:n_routed_experts], ref_hist)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -167,11 +167,10 @@ def test_masked_bincount(
     for device_id in range(len(device_tensors)):
         tt_hist = ttnn.to_torch(device_tensors[device_id]).flatten().to(torch.int32)
 
-        row = device_id // n_cols
-        col = device_id % n_cols
-        chip_idx = row if sp_axis == 0 else col
-        group_idx = col if sp_axis == 0 else row
-        ref_hist = torch_histograms[(group_idx, chip_idx)]
+        row_idx = device_id // n_cols
+        group_idx = device_id % n_cols
+
+        ref_hist = torch_histograms[(group_idx, row_idx)]
 
         matches = torch.equal(tt_hist[:n_routed_experts], ref_hist)
         if not matches:

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -144,12 +144,11 @@ def test_masked_bincount(
     )
     tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
 
-    # Dispatch table -> UINT32 for kernel (-1 in int32 becomes 0xFFFFFFFF in uint32)
     if num_dispatch_groups == 1:
         tt_dispatch_table = ttnn.from_torch(
             dispatch_table[0],
             device=mesh_device,
-            dtype=ttnn.uint32,
+            dtype=ttnn.int32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
@@ -157,7 +156,7 @@ def test_masked_bincount(
         tt_dispatch_table = ttnn.from_torch(
             dispatch_table,
             device=mesh_device,
-            dtype=ttnn.uint32,
+            dtype=ttnn.int32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -84,6 +84,8 @@ def test_masked_bincount(
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
 
+    assert sp_axis == 0
+
     logger.info(
         f"Testing masked_bincount: {mesh_device.shape=}, {sp_dim=}, {topk=}, "
         f"{n_routed_experts=}, {num_dispatch_groups=}"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -14,23 +14,25 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, extract_mesh_config
 
 
-def torch_masked_bincount(indices: torch.Tensor, expert_mask: torch.Tensor, n_routed_experts: int) -> torch.Tensor:
+def torch_masked_bincount(
+    indices: torch.Tensor, expert_dispatch_table: torch.Tensor, n_routed_experts: int
+) -> torch.Tensor:
     """
-    Reference implementation: count expert occurrences masked by expert_mask.
+    Reference implementation: count expert occurrences masked by expert_dispatch_table.
 
     Args:
         indices: [sp_dim, topk] int tensor of expert indices.
-        expert_mask: [n_routed_experts] int tensor (nonzero = present).
+        expert_dispatch_table: [n_routed_experts] int32 tensor (>= 0 = present, -1 = absent).
         n_routed_experts: number of experts (output size).
 
     Returns:
         [n_routed_experts] int tensor of masked histogram counts.
     """
     counts = torch.bincount(indices.flatten().to(torch.int64), minlength=n_routed_experts).to(torch.int32)
-    mask = (expert_mask > 0).to(torch.int32)
+    mask = (expert_dispatch_table >= 0).to(torch.int32)
     return counts[:n_routed_experts] * mask
 
 
@@ -82,10 +84,11 @@ def test_masked_bincount(
     mesh_config = extract_mesh_config(mesh_device)
     sp_axis = mesh_config.sp_axis
     dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
 
     logger.info(
         f"Testing masked_bincount: {mesh_device.shape=}, {sp_dim=}, {topk=}, "
-        f"{n_routed_experts=}, {mask_all_present=}"
+        f"{n_routed_experts=}, {mask_all_present=}, {num_dispatch_groups=}"
     )
     ttnn.visualize_mesh_device(mesh_device)
 
@@ -95,19 +98,24 @@ def test_masked_bincount(
     total_sp = dispatch_group_size * sp_dim
     indices = torch.randint(0, n_routed_experts, (total_sp, topk), dtype=torch.int32)
 
-    # Expert mask
-    if mask_all_present:
-        expert_mask = torch.ones(n_routed_experts, dtype=torch.int32)
-    else:
-        expert_mask = torch.randint(0, 2, (n_routed_experts,), dtype=torch.int32)
+    # Expert dispatch table: maps expert_id -> chip_id (>= 0) or -1 (absent)
+    dispatch_table = create_expert_dispatch_table(
+        num_routed_experts=n_routed_experts,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    if not mask_all_present:
+        absent = torch.randint(0, 2, (n_routed_experts,)).bool()
+        dispatch_table[:, absent] = -1
 
-    # Compute torch reference per chip (each chip owns a contiguous sp_dim slice)
-    torch_histograms = []
-    for chip in range(dispatch_group_size):
-        chip_indices = indices[chip * sp_dim : (chip + 1) * sp_dim]
-        hist = torch_masked_bincount(chip_indices, expert_mask, n_routed_experts)
-        torch_histograms.append(hist)
-    torch_histograms = torch.stack(torch_histograms)  # [dispatch_group_size, n_routed_experts]
+    # Compute torch reference per (dispatch_group, chip) pair
+    # torch_histograms[group][chip] = histogram for that group/chip combination
+    torch_histograms = {}
+    for group in range(num_dispatch_groups):
+        for chip in range(dispatch_group_size):
+            chip_indices = indices[chip * sp_dim : (chip + 1) * sp_dim]
+            hist = torch_masked_bincount(chip_indices, dispatch_table[group], n_routed_experts)
+            torch_histograms[(group, chip)] = hist
 
     # Height-shard config matching the gate module pattern: 8x8 core grid
     num_cores = 64
@@ -136,18 +144,33 @@ def test_masked_bincount(
     )
     tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
 
-    tt_expert_mask = ttnn.from_torch(
-        expert_mask,
-        device=mesh_device,
-        dtype=ttnn.uint32,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-    )
+    # Dispatch table -> UINT32 for kernel (-1 in int32 becomes 0xFFFFFFFF in uint32)
+    if num_dispatch_groups == 1:
+        tt_dispatch_table = ttnn.from_torch(
+            dispatch_table[0],
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+    else:
+        tt_dispatch_table = ttnn.from_torch(
+            dispatch_table,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                mesh_shape=mesh_device.shape,
+                dims=(None, 0),
+            ),
+        )
 
     # Run ttnn op
-    tt_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(tt_indices, tt_expert_mask, n_routed_experts)
+    tt_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(tt_indices, tt_dispatch_table, n_routed_experts)
 
-    # Compare per-device (TP replicas in the same dispatch row should match)
+    # Compare per-device
     device_tensors = ttnn.get_device_tensors(tt_histograms)
     n_cols = mesh_device.shape[1]
     all_passed = True
@@ -158,7 +181,10 @@ def test_masked_bincount(
         row = device_id // n_cols
         col = device_id % n_cols
         chip_idx = row if sp_axis == 0 else col
-        ref_hist = torch_histograms[chip_idx]
+        group_idx = col if sp_axis == 0 else row
+        if num_dispatch_groups == 1:
+            group_idx = 0
+        ref_hist = torch_histograms[(group_idx, chip_idx)]
 
         matches = torch.equal(tt_hist[:n_routed_experts], ref_hist)
         if not matches:

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -168,7 +168,9 @@ def test_masked_bincount(
         )
 
     # Run ttnn op
-    tt_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(tt_indices, tt_dispatch_table, n_routed_experts)
+    tt_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
+        tt_indices, tt_dispatch_table, n_routed_experts, topk
+    )
 
     # Compare per-device
     device_tensors = ttnn.get_device_tensors(tt_histograms)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_gate_outputs
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.moe_gate_prefill2d import MoEGateConfig, MoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     adjust_shapes_for_testing,
@@ -147,6 +147,37 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
+    n_sp_devices = mesh_device.shape[0]
+    n_tp_devices = mesh_device.shape[1]
+    n_routed_experts = config.n_routed_experts
+
+    dispatch_table = create_expert_dispatch_table(
+        num_routed_experts=n_routed_experts,
+        dispatch_group_size=n_sp_devices,
+        num_dispatch_groups=n_tp_devices,
+    )
+    if n_tp_devices == 1:
+        tt_model.expert_dispatch_table = ttnn.from_torch(
+            dispatch_table[0],
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+    else:
+        tt_model.expert_dispatch_table = ttnn.from_torch(
+            dispatch_table,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, 0),
+                mesh_shape=mesh_device.shape,
+            ),
+        )
+
     # Reshape reference outputs to match device mesh structure upfront
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]
     reference_logits_reshaped = reference_logits.view(mesh_device.shape[0], seq_len_per_device, -1)
@@ -210,34 +241,38 @@ def test_forward_pass(
                 f"Device {device_id} (row={row}, col={col}): Weights PCC is {weights_pcc:.4f}, expected > 0.99"
             )
 
-    # Compute reference dispatch offsets from tt_topk_indices using get_gate_outputs
-    n_sp_devices = mesh_device.shape[0]
-    n_tp_devices = mesh_device.shape[1]
-    n_routed_experts = config.n_routed_experts
-    experts_per_chip = n_routed_experts // n_sp_devices
-
+    # Compute reference dispatch offsets from tt_topk_indices, masked by dispatch table
     indices_for_gate = torch.zeros(n_sp_devices, seq_len_per_device, config.n_activated_experts, dtype=torch.int32)
     for row in range(n_sp_devices):
         device_id = row * n_tp_devices
         indices_for_gate[row] = ttnn.to_torch(per_device_topk_indices[device_id]).int()
 
-    expert_offsets, _, cum_sum = get_gate_outputs(
-        indices=indices_for_gate,
-        dispatch_group_size=n_sp_devices,
-        num_routed_experts=n_routed_experts,
-        experts_per_chip=experts_per_chip,
-        seq_len_per_chip=seq_len_per_device,
-        num_experts_per_tok=config.n_activated_experts,
-    )
+    # Unmasked expert counter: same for all dispatch groups (all groups see the same tokens)
+    expert_counter = torch.zeros((n_sp_devices, n_routed_experts), dtype=torch.int32)
+    for chip in range(n_sp_devices):
+        for token in range(seq_len_per_device):
+            for k in range(config.n_activated_experts):
+                expert_id = indices_for_gate[chip, token, k].item()
+                expert_counter[chip, expert_id] += 1
 
-    reference_offsets = expert_offsets.long()
-    reference_totals = cum_sum[-1:].long()
+    # Per-dispatch-group masked offsets and totals
+    per_group_offsets = {}
+    per_group_totals = {}
+    for group in range(n_tp_devices):
+        group_mask = dispatch_table[group] >= 0
+        masked_counter = expert_counter.clone()
+        masked_counter[:, ~group_mask] = 0
+        cum_sum = torch.cumsum(masked_counter, dim=0)
+        offsets = torch.vstack([torch.zeros([1, n_routed_experts], dtype=torch.int32), cum_sum[:-1]])
+        per_group_offsets[group] = offsets.long()
+        per_group_totals[group] = cum_sum[-1:].long()
 
     per_device_dispatch_offsets = ttnn.get_device_tensors(dispatch_offsets)
     for device_id in range(len(per_device_dispatch_offsets)):
         tt_offsets_torch = ttnn.to_torch(per_device_dispatch_offsets[device_id]).long()
         row = device_id // n_tp_devices
         col = device_id % n_tp_devices
+        reference_offsets = per_group_offsets[col]
 
         offsets_match = torch.equal(tt_offsets_torch, reference_offsets)
         status_char = "✅" if offsets_match else "❌"
@@ -264,6 +299,7 @@ def test_forward_pass(
         tt_totals_torch = ttnn.to_torch(per_device_totals[device_id]).long()
         row = device_id // n_tp_devices
         col = device_id % n_tp_devices
+        reference_totals = per_group_totals[col]
 
         totals_match = torch.equal(tt_totals_torch, reference_totals)
         status_char = "✅" if totals_match else "❌"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -160,7 +160,7 @@ def test_forward_pass(
         tt_model.expert_dispatch_table = ttnn.from_torch(
             dispatch_table[0],
             device=mesh_device,
-            dtype=ttnn.uint32,
+            dtype=ttnn.int32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
@@ -168,7 +168,7 @@ def test_forward_pass(
         tt_model.expert_dispatch_table = ttnn.from_torch(
             dispatch_table,
             device=mesh_device,
-            dtype=ttnn.uint32,
+            dtype=ttnn.int32,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, create_fabric_router_config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.moe_gate_prefill2d import MoEGateConfig, MoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     adjust_shapes_for_testing,
@@ -151,32 +151,23 @@ def test_forward_pass(
     n_tp_devices = mesh_device.shape[1]
     n_routed_experts = config.n_routed_experts
 
-    dispatch_table = create_expert_dispatch_table(
+    dispatch_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=n_routed_experts,
         dispatch_group_size=n_sp_devices,
         num_dispatch_groups=n_tp_devices,
     )
-    if n_tp_devices == 1:
-        tt_model.expert_dispatch_table = ttnn.from_torch(
-            dispatch_table[0],
-            device=mesh_device,
-            dtype=ttnn.int32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-    else:
-        tt_model.expert_dispatch_table = ttnn.from_torch(
-            dispatch_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device,
-                dims=(None, 0),
-                mesh_shape=mesh_device.shape,
-            ),
-        )
+    tt_model.expert_dispatch_table = ttnn.from_torch(
+        dispatch_table,
+        device=mesh_device,
+        dtype=ttnn.int32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 0),
+            mesh_shape=mesh_device.shape,
+        ),
+    )
 
     # Reshape reference outputs to match device mesh structure upfront
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -272,7 +272,7 @@ def test_forward_pass(
         tt_offsets_torch = ttnn.to_torch(per_device_dispatch_offsets[device_id]).long()
         row = device_id // n_tp_devices
         col = device_id % n_tp_devices
-        reference_offsets = per_group_offsets[col]
+        reference_offsets = per_group_offsets[col][row : row + 1, :]
 
         offsets_match = torch.equal(tt_offsets_torch, reference_offsets)
         status_char = "✅" if offsets_match else "❌"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
@@ -153,24 +153,33 @@ def test_offset_cumsum(
 
     all_passed = True
 
-    # Verify dispatch_offsets on each device
+    mesh_rows, mesh_cols = mesh_device.shape
+
+    def get_row_idx(dev_idx):
+        coord_row = dev_idx // mesh_cols
+        coord_col = dev_idx % mesh_cols
+        return coord_row if sp_axis == 0 else coord_col
+
+    # Verify dispatch_offsets on each device (each device holds only its own [1, W] row)
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(tt_offsets)):
         tt_out = ttnn.to_torch(dt).to(torch.int32)
         while tt_out.dim() > 2:
             tt_out = tt_out.squeeze(0)
 
-        logger.info(f"Device {dev_idx} offsets: tt_shape={tt_out.shape}, ref_shape={torch_offsets.shape}")
+        row_idx = get_row_idx(dev_idx)
+        ref_row = torch_offsets[row_idx : row_idx + 1, :]
+        logger.info(f"Device {dev_idx} (row_idx={row_idx}) offsets: tt_shape={tt_out.shape}, ref_shape={ref_row.shape}")
 
-        if tt_out.shape != torch_offsets.shape:
-            logger.error(f"Device {dev_idx}: offsets shape mismatch tt={tt_out.shape} ref={torch_offsets.shape}")
+        if tt_out.shape != ref_row.shape:
+            logger.error(f"Device {dev_idx}: offsets shape mismatch tt={tt_out.shape} ref={ref_row.shape}")
             all_passed = False
             continue
 
-        if not torch.equal(tt_out, torch_offsets):
-            diff_mask = tt_out != torch_offsets
+        if not torch.equal(tt_out, ref_row):
+            diff_mask = tt_out != ref_row
             num_diff = diff_mask.sum().item()
-            logger.error(f"Device {dev_idx}: offsets {num_diff}/{torch_offsets.numel()} elements differ")
-            logger.error(f"  Max abs diff: {(tt_out - torch_offsets).abs().max().item()}")
+            logger.error(f"Device {dev_idx}: offsets {num_diff}/{ref_row.numel()} elements differ")
+            logger.error(f"  Max abs diff: {(tt_out - ref_row).abs().max().item()}")
             all_passed = False
         else:
             logger.info(f"Device {dev_idx} offsets: PASS")

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -43,14 +43,9 @@ def extract_mesh_config(mesh_device) -> MeshConfig:
       - num_dispatch_groups = 1
       - sp_axis = whichever dimension has size > 1
     """
-    if mesh_device.shape[0] > 1 and mesh_device.shape[1] > 1:
-        sp_axis = 0
-        dispatch_group_size = mesh_device.shape[sp_axis]
-        num_dispatch_groups = mesh_device.shape[1]
-    else:
-        dispatch_group_size = mesh_device.get_num_devices()
-        num_dispatch_groups = 1
-        sp_axis = 0 if mesh_device.shape[0] > 1 else 1
+    sp_axis = 0
+    dispatch_group_size = mesh_device.shape[sp_axis]
+    num_dispatch_groups = mesh_device.shape[1]
 
     return MeshConfig(
         sp_axis=sp_axis,

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -178,7 +178,7 @@ class MoEGatePrefill(LightweightModule):
         )
 
         expert_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
-            ttnn_top_k_experts_indices, self.expert_dispatch_table, self.n_routed_experts
+            ttnn_top_k_experts_indices, self.expert_dispatch_table, self.n_routed_experts, self.topk
         )
 
         dispatch_offsets, total_counts_per_expert = ttnn.experimental.deepseek_prefill.offset_cumsum(

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -9,7 +9,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, extract_mesh_config
 
 
 @dataclass
@@ -104,32 +104,23 @@ class MoEGatePrefill(LightweightModule):
         )
 
         mesh_config = extract_mesh_config(mesh_device)
-        dispatch_table = create_expert_dispatch_table(
+        dispatch_table = ExpertMapping.create_dispatch_table(
             num_routed_experts=config.n_routed_experts,
             dispatch_group_size=mesh_config.dispatch_group_size,
             num_dispatch_groups=mesh_config.num_dispatch_groups,
         )
-        if mesh_config.num_dispatch_groups == 1:
-            self.expert_dispatch_table = ttnn.from_torch(
-                dispatch_table[0],
-                device=mesh_device,
-                dtype=ttnn.int32,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-            )
-        else:
-            self.expert_dispatch_table = ttnn.from_torch(
-                dispatch_table,
-                device=mesh_device,
-                dtype=ttnn.int32,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    mesh_device,
-                    dims=(None, 0),
-                    mesh_shape=mesh_device.shape,
-                ),
-            )
+        self.expert_dispatch_table = ttnn.from_torch(
+            dispatch_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, 0),
+                mesh_shape=mesh_device.shape,
+            ),
+        )
 
         self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
             shape=(config.sp_dim // 64, self.topk),

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -9,6 +9,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_expert_dispatch_table, extract_mesh_config
 
 
 @dataclass
@@ -102,13 +103,33 @@ class MoEGatePrefill(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
         )
 
-        self.experts_in_dispatch_row = ttnn.from_torch(
-            torch.ones(config.n_routed_experts, dtype=torch.int32),
-            device=mesh_device,
-            dtype=ttnn.uint32,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_config = extract_mesh_config(mesh_device)
+        dispatch_table = create_expert_dispatch_table(
+            num_routed_experts=config.n_routed_experts,
+            dispatch_group_size=mesh_config.dispatch_group_size,
+            num_dispatch_groups=mesh_config.num_dispatch_groups,
         )
+        if mesh_config.num_dispatch_groups == 1:
+            self.expert_dispatch_table = ttnn.from_torch(
+                dispatch_table[0],
+                device=mesh_device,
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+        else:
+            self.expert_dispatch_table = ttnn.from_torch(
+                dispatch_table,
+                device=mesh_device,
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device,
+                    dims=(None, 0),
+                    mesh_shape=mesh_device.shape,
+                ),
+            )
 
         self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
             shape=(config.sp_dim // 64, self.topk),
@@ -157,7 +178,7 @@ class MoEGatePrefill(LightweightModule):
         )
 
         expert_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
-            ttnn_top_k_experts_indices, self.experts_in_dispatch_row, self.n_routed_experts
+            ttnn_top_k_experts_indices, self.expert_dispatch_table, self.n_routed_experts
         )
 
         dispatch_offsets, total_counts_per_expert = ttnn.experimental.deepseek_prefill.offset_cumsum(

--- a/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/moe_gate_prefill2d.py
@@ -113,7 +113,7 @@ class MoEGatePrefill(LightweightModule):
             self.expert_dispatch_table = ttnn.from_torch(
                 dispatch_table[0],
                 device=mesh_device,
-                dtype=ttnn.uint32,
+                dtype=ttnn.int32,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
             )
@@ -121,7 +121,7 @@ class MoEGatePrefill(LightweightModule):
             self.expert_dispatch_table = ttnn.from_torch(
                 dispatch_table,
                 device=mesh_device,
-                dtype=ttnn.uint32,
+                dtype=ttnn.int32,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ShardTensor2dMesh(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -64,7 +64,7 @@ void kernel_main() {
     constexpr uint32_t input_page_size = get_compile_time_arg_val(2);
     constexpr uint32_t output_page_size = get_compile_time_arg_val(3);
     constexpr uint32_t h_count = get_compile_time_arg_val(4);
-    constexpr uint32_t W = get_compile_time_arg_val(5);
+    constexpr uint32_t num_experts_per_token = get_compile_time_arg_val(5);
     constexpr uint32_t n_routed_experts = get_compile_time_arg_val(6);
     constexpr bool is_initializer = (bool)get_compile_time_arg_val(7);
     constexpr uint32_t init_sem_idx = get_compile_time_arg_val(8);
@@ -117,7 +117,7 @@ void kernel_main() {
     for (uint32_t h = 0; h < h_count; h++) {
         volatile tt_l1_ptr uint16_t* row =
             reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr + h * input_page_size);
-        for (uint32_t w = 0; w < W; w++) {
+        for (uint32_t w = 0; w < num_experts_per_token; w++) {
             uint32_t expert_idx = row[w];
             if (expert_idx < n_routed_experts && mask[expert_idx] != 0xFFFFFFFF) {
                 uint64_t noc_addr = get_noc_addr(out_addr + expert_idx * sizeof(uint32_t));

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -10,8 +10,9 @@
 // Inputs:
 //   - input [sp_dim, topk_dim]: UINT16 height-sharded tensor of expert indices
 //     selected for each token (one row per token, one column per top-k slot).
-//   - expert_mask [n_routed_experts]: UINT32 tensor where nonzero means the
-//     expert is present on this device and should be counted, zero means skip.
+//   - expert_dispatch_table [n_routed_experts]: UINT32 tensor mapping experts to
+//     chip IDs. 0xFFFFFFFF (-1 as int32) means absent (skip), any other value
+//     means present (count).
 //
 // Output:
 //   - histogram [n_routed_experts]: UINT32 count of token assignments per expert.
@@ -118,7 +119,7 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr + h * input_page_size);
         for (uint32_t w = 0; w < W; w++) {
             uint32_t expert_idx = row[w];
-            if (expert_idx < n_routed_experts && mask[expert_idx] != 0) {
+            if (expert_idx < n_routed_experts && mask[expert_idx] != 0xFFFFFFFF) {
                 uint64_t noc_addr = get_noc_addr(out_addr + expert_idx * sizeof(uint32_t));
                 noc_semaphore_inc(noc_addr, 1);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -10,9 +10,9 @@
 // Inputs:
 //   - input [sp_dim, topk_dim]: UINT16 height-sharded tensor of expert indices
 //     selected for each token (one row per token, one column per top-k slot).
-//   - expert_dispatch_table [n_routed_experts]: UINT32 tensor mapping experts to
-//     chip IDs. 0xFFFFFFFF (-1 as int32) means absent (skip), any other value
-//     means present (count).
+//   - expert_dispatch_table [n_routed_experts]: INT32 tensor mapping experts to
+//     chip IDs. Negative (-1) means absent (skip), non-negative values (chip IDs)
+//     mean present (count).
 //
 // Output:
 //   - histogram [n_routed_experts]: UINT32 count of token assignments per expert.
@@ -112,14 +112,14 @@ void kernel_main() {
         noc_semaphore_wait(init_sem_ptr, 1);
     }
 
-    volatile tt_l1_ptr uint32_t* mask = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mask_l1_addr);
+    volatile tt_l1_ptr int32_t* mask = reinterpret_cast<volatile tt_l1_ptr int32_t*>(mask_l1_addr);
 
     for (uint32_t h = 0; h < h_count; h++) {
         volatile tt_l1_ptr uint16_t* row =
             reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr + h * input_page_size);
         for (uint32_t w = 0; w < num_experts_per_token; w++) {
             uint32_t expert_idx = row[w];
-            if (expert_idx < n_routed_experts && mask[expert_idx] != 0xFFFFFFFF) {
+            if (expert_idx < n_routed_experts && mask[expert_idx] >= 0) {
                 uint64_t noc_addr = get_noc_addr(out_addr + expert_idx * sizeof(uint32_t));
                 noc_semaphore_inc(noc_addr, 1);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -28,7 +28,7 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
         input_shape[input_shape.size() - 1],
         args.num_experts_per_token);
 
-    TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::UINT32, "Expert dispatch table must be UINT32!");
+    TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::INT32, "Expert dispatch table must be INT32!");
     TT_FATAL(expert_mask.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Expert dispatch table must be ROW_MAJOR!");
     const auto& mask_shape = expert_mask.padded_shape();
     bool valid_1d = mask_shape.size() == 1 && mask_shape[0] == args.n_routed_experts;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -23,14 +23,17 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor.shard_spec().has_value(), "Input tensor must have a shard spec!");
     TT_FATAL(args.n_routed_experts > 0, "n_routed_experts must be > 0");
 
-    TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::UINT32, "Expert mask must be UINT32!");
-    TT_FATAL(expert_mask.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Expert mask must be ROW_MAJOR!");
+    TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::UINT32, "Expert dispatch table must be UINT32!");
+    TT_FATAL(expert_mask.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Expert dispatch table must be ROW_MAJOR!");
     const auto& mask_shape = expert_mask.padded_shape();
+    bool valid_1d = mask_shape.size() == 1 && mask_shape[0] == args.n_routed_experts;
+    bool valid_2d = mask_shape.size() == 2 && mask_shape[0] == 1 && mask_shape[1] == args.n_routed_experts;
     TT_FATAL(
-        mask_shape.size() == 1 && mask_shape[0] == args.n_routed_experts,
-        "Expert mask must have shape [n_routed_experts={}], got [{}]",
+        valid_1d || valid_2d,
+        "Expert dispatch table must have shape [{}] or [1, {}], got {}D tensor",
         args.n_routed_experts,
-        mask_shape[0]);
+        args.n_routed_experts,
+        mask_shape.size());
 }
 
 MaskedBincountDeviceOperation::spec_return_value_t MaskedBincountDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -22,6 +22,11 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
         "Input tensor must be height sharded!");
     TT_FATAL(input_tensor.shard_spec().has_value(), "Input tensor must have a shard spec!");
     TT_FATAL(args.n_routed_experts > 0, "n_routed_experts must be > 0");
+    TT_FATAL(
+        args.num_experts_per_token > 0 && args.num_experts_per_token <= input_shape[input_shape.size() - 1],
+        "num_experts_per_token must be in (0, {}], got {}",
+        input_shape[input_shape.size() - 1],
+        args.num_experts_per_token);
 
     TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::UINT32, "Expert dispatch table must be UINT32!");
     TT_FATAL(expert_mask.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Expert dispatch table must be ROW_MAJOR!");
@@ -64,9 +69,11 @@ MaskedBincountDeviceOperation::tensor_return_value_t MaskedBincountDeviceOperati
 
 namespace ttnn::prim {
 
-Tensor masked_bincount(const Tensor& input_tensor, const Tensor& expert_mask, uint32_t n_routed_experts) {
+Tensor masked_bincount(
+    const Tensor& input_tensor, const Tensor& expert_mask, uint32_t n_routed_experts, uint32_t num_experts_per_token) {
     using OperationType = ttnn::experimental::prim::MaskedBincountDeviceOperation;
-    auto operation_attributes = OperationType::operation_attributes_t{.n_routed_experts = n_routed_experts};
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .n_routed_experts = n_routed_experts, .num_experts_per_token = num_experts_per_token};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .expert_mask = expert_mask};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
@@ -30,5 +30,6 @@ struct MaskedBincountDeviceOperation {
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {
-Tensor masked_bincount(const Tensor& input_tensor, const Tensor& expert_mask, uint32_t n_routed_experts);
+Tensor masked_bincount(
+    const Tensor& input_tensor, const Tensor& expert_mask, uint32_t n_routed_experts, uint32_t num_experts_per_token);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation_types.hpp
@@ -10,6 +10,7 @@ namespace ttnn::experimental::prim {
 
 struct MaskedBincountParams {
     const uint32_t n_routed_experts;
+    const uint32_t num_experts_per_token;
 };
 
 struct MaskedBincountInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
@@ -31,7 +31,6 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
     auto all_cores = shard_spec.grid;
     uint32_t num_cores = all_cores.num_cores();
     uint32_t shard_height = shard_spec.shape[0];
-    uint32_t W = shard_spec.shape[1];
 
     uint32_t h_brisc = shard_height / 2;
     uint32_t h_ncrisc = shard_height - h_brisc;
@@ -104,7 +103,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
         input_page_size,
         output_page_size,
         h_brisc,
-        W,
+        operation_attributes.num_experts_per_token,
         n_routed_experts,
         1,  // is_initializer
         init_sem_idx,
@@ -126,7 +125,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
         input_page_size,
         output_page_size,
         h_ncrisc,
-        W,
+        operation_attributes.num_experts_per_token,
         n_routed_experts,
         0,  // is_initializer
         init_sem_idx,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
@@ -78,10 +78,11 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
             .set_page_size(cb_gather_tmp, output_page_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_gather_config);
 
-    // CB 4: expert mask (UINT32, one value per expert)
+    // CB 4: expert dispatch table (INT32, one value per expert; negative = absent, non-negative = present)
+    tt::DataFormat mask_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(tt::tt_metal::DataType::INT32);
     uint32_t cb_mask = tt::CBIndex::c_4;
     tt::tt_metal::CircularBufferConfig cb_mask_config =
-        tt::tt_metal::CircularBufferConfig(mask_page_size, {{cb_mask, output_cb_data_format}})
+        tt::tt_metal::CircularBufferConfig(mask_page_size, {{cb_mask, mask_cb_data_format}})
             .set_page_size(cb_mask, mask_page_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_config);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount.cpp
@@ -8,8 +8,11 @@
 namespace ttnn::operations::experimental::deepseek_prefill::masked_bincount {
 
 ttnn::Tensor masked_bincount(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& expert_mask, uint32_t n_routed_experts) {
-    return ttnn::prim::masked_bincount(input_tensor, expert_mask, n_routed_experts);
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_mask,
+    uint32_t n_routed_experts,
+    uint32_t num_experts_per_token) {
+    return ttnn::prim::masked_bincount(input_tensor, expert_mask, n_routed_experts, num_experts_per_token);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::masked_bincount

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount.hpp
@@ -10,7 +10,10 @@
 namespace ttnn::operations::experimental::deepseek_prefill::masked_bincount {
 
 ttnn::Tensor masked_bincount(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& expert_mask, uint32_t n_routed_experts);
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_mask,
+    uint32_t n_routed_experts,
+    uint32_t num_experts_per_token);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::masked_bincount
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
@@ -32,13 +32,15 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
                 * :attr:`input_tensor`: 2D UINT16 height-sharded tensor of expert indices [sp_dim, topk_dim].
                 * :attr:`expert_mask`: UINT32 tensor of shape [n_routed_experts] or [1, n_routed_experts] (0xFFFFFFFF = skip, other = count).
                 * :attr:`n_routed_experts`: Number of routed experts (output dimension size).
+                * :attr:`num_experts_per_token`: Number of expert columns per row to count (must be <= topk_dim). Columns beyond this index are ignored, allowing padded shard widths.
 
         )doc",
         ttnn::overload_t(
             &masked_bincount,
             nb::arg("input_tensor").noconvert(),
             nb::arg("expert_mask").noconvert(),
-            nb::arg("n_routed_experts")));
+            nb::arg("n_routed_experts"),
+            nb::arg("num_experts_per_token")));
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::masked_bincount::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
@@ -15,13 +15,14 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
         mod,
         R"doc(
             Counts occurrences of each expert index in a height-sharded input tensor (bincount / histogram),
-            masked by a per-expert presence vector.
+            masked by an expert dispatch table that maps experts to chip IDs.
 
             Input tensor must be a 2D UINT16 height-sharded ROW_MAJOR tensor of shape [sp_dim, topk_dim]
             containing expert indices selected for each token.
 
-            Expert mask must be a 1D UINT32 ROW_MAJOR tensor of shape [n_routed_experts] where non-zero
-            means the expert is present (counted) and zero means it is absent (skipped).
+            Expert dispatch table must be a UINT32 ROW_MAJOR tensor of shape [n_routed_experts] or
+            [1, n_routed_experts]. Values encode chip placement: 0xFFFFFFFF (-1 as int32) means the
+            expert is absent (skipped), any other value means the expert is present (counted).
 
             Returns a 1D UINT32 tensor of shape [n_routed_experts] where each element is the
             count of how many times the corresponding expert index appears in the input,
@@ -29,7 +30,7 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
 
             Args:
                 * :attr:`input_tensor`: 2D UINT16 height-sharded tensor of expert indices [sp_dim, topk_dim].
-                * :attr:`expert_mask`: 1D UINT32 tensor of shape [n_routed_experts] (0 = skip, nonzero = count).
+                * :attr:`expert_mask`: UINT32 tensor of shape [n_routed_experts] or [1, n_routed_experts] (0xFFFFFFFF = skip, other = count).
                 * :attr:`n_routed_experts`: Number of routed experts (output dimension size).
 
         )doc",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
@@ -20,9 +20,9 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
             Input tensor must be a 2D UINT16 height-sharded ROW_MAJOR tensor of shape [sp_dim, topk_dim]
             containing expert indices selected for each token.
 
-            Expert dispatch table must be a UINT32 ROW_MAJOR tensor of shape [n_routed_experts] or
-            [1, n_routed_experts]. Values encode chip placement: 0xFFFFFFFF (-1 as int32) means the
-            expert is absent (skipped), any other value means the expert is present (counted).
+            Expert dispatch table must be an INT32 ROW_MAJOR tensor of shape [n_routed_experts] or
+            [1, n_routed_experts]. Negative (-1) means the expert is absent (skipped), non-negative
+            values (chip IDs) mean the expert is present.
 
             Returns a 1D UINT32 tensor of shape [n_routed_experts] where each element is the
             count of how many times the corresponding expert index appears in the input,
@@ -30,7 +30,7 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
 
             Args:
                 * :attr:`input_tensor`: 2D UINT16 height-sharded tensor of expert indices [sp_dim, topk_dim].
-                * :attr:`expert_mask`: UINT32 tensor of shape [n_routed_experts] or [1, n_routed_experts] (0xFFFFFFFF = skip, other = count).
+                * :attr:`expert_mask`: INT32 tensor of shape [n_routed_experts] or [1, n_routed_experts] (negative = skip, non-negative = count).
                 * :attr:`n_routed_experts`: Number of routed experts (output dimension size).
                 * :attr:`num_experts_per_token`: Number of expert columns per row to count (must be <= topk_dim). Columns beyond this index are ignored, allowing padded shard widths.
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/kernels/reader_offset_cumsum_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/kernels/reader_offset_cumsum_interleaved.cpp
@@ -4,8 +4,9 @@
 
 // Offset Cumsum Kernel
 //
-// Computes per-device dispatch offsets into each expert's token buffer by
-// taking a shifted (exclusive) prefix sum over gathered per-device histograms.
+// Computes this device's dispatch offset into each expert's token buffer by
+// taking a shifted (exclusive) prefix sum over gathered per-device histograms
+// and keeping only the row corresponding to this device.
 //
 // Inputs:
 //   - input [H, W]: UINT32 interleaved tensor of per-device expert histograms
@@ -13,28 +14,18 @@
 //     device's masked_bincount output.
 //
 // Outputs:
-//   - offsets [H, W]: row k = sum of input rows 0..k-1 (row 0 is all zeros).
-//     These are the starting positions where each device writes into each
-//     expert's buffer — hence the name "offsets" rather than prefix sum.
+//   - offsets [1, W]: the starting positions where this device writes into each
+//     expert's buffer. Equivalent to row `row_idx` of the full shifted prefix
+//     sum (row k = sum of input rows 0..k-1; row 0 is all zeros).
 //   - totals  [1, W]: sum of all H input rows (total tokens per expert).
 //
-// The kernel loops over H rows. Before the loop it writes a zeroed row to
-// offsets[0]. On each iteration it reads input row h, adds it element-wise into
-// the running sum, then writes the updated sum to offsets[h+1] (or to totals
-// on the final iteration).
+// Runtime args:
+//   - src_addr, dst_offsets_addr, dst_totals_addr: buffer addresses
+//   - row_idx: which row of the prefix sum this device keeps
 //
-// Design choices:
-//  - This is a single data-movement kernel that reads, computes,
-// and writes — there is no separate compute or writer kernel. W is typically
-// n_routed_experts (e.g. 256 for DeepSeek-V3), so the element-wise add is a
-// short scalar loop on UINT32 values in L1 and does not warrant SFPU/FPU
-// compute.
-//  - Because there is only one kernel there is no producer/consumer
-// relationship, so CBs are used as raw L1 scratch (no cb_push_back /
-// cb_pop_front).
-//  - The partial sums are called "offsets" because in the MoE
-// dispatch context they are the starting write positions for each device into
-// each expert's token buffer.
+// The kernel loops over all H rows to compute the running sum (needed for
+// totals), but only writes to the offsets output at the position matching
+// row_idx.
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -43,6 +34,7 @@ void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t dst_offsets_addr = get_arg_val<uint32_t>(1);
     uint32_t dst_totals_addr = get_arg_val<uint32_t>(2);
+    uint32_t row_idx = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
@@ -74,19 +66,13 @@ void kernel_main() {
         running_sum[i] = 0;
     }
 
-    noc_async_write(out_cb_addr, dst_offsets_accessor.get_noc_addr(0), offsets_page_size);
-    noc_async_write_barrier();
+    // row_idx == 0: offset is all zeros — write immediately
+    if (row_idx == 0) {
+        noc_async_write(out_cb_addr, dst_offsets_accessor.get_noc_addr(0), offsets_page_size);
+        noc_async_write_barrier();
+    }
 
     uint32_t in_cb_addr = get_write_ptr(cb_id_in0);
-
-    // The three tensors are allocated independently and could in principle have
-    // different aligned page sizes (even though in practice they'll likely be the
-    // same, since they all share W and dtype). This doesn't cause correctness
-    // issues because:
-    //  - The inner loop always operates on exactly W elements and ignores any
-    //    padding bytes beyond the W-th element.
-    //  - NOC writes use the destination tensor's own page size (offsets_page_size
-    //    or totals_page_size)
 
     for (uint32_t h = 0; h < H; h++) {
         noc_async_read_page(h, src_accessor, in_cb_addr);
@@ -97,11 +83,16 @@ void kernel_main() {
             running_sum[i] += stick[i];
         }
 
-        if (h < H - 1) {
-            noc_async_write(out_cb_addr, dst_offsets_accessor.get_noc_addr(h + 1), offsets_page_size);
-        } else {
-            noc_async_write(out_cb_addr, dst_totals_accessor.get_noc_addr(0), totals_page_size);
+        // Write offsets when we've accumulated exactly rows 0..row_idx-1
+        if (h + 1 == row_idx) {
+            noc_async_write(out_cb_addr, dst_offsets_accessor.get_noc_addr(0), offsets_page_size);
+            noc_async_write_barrier();
         }
-        noc_async_write_barrier();
+
+        // Write totals on the final iteration
+        if (h == H - 1) {
+            noc_async_write(out_cb_addr, dst_totals_accessor.get_noc_addr(0), totals_page_size);
+            noc_async_write_barrier();
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.cpp
@@ -23,7 +23,6 @@ void OffsetCumsumDeviceOperation::validate_on_program_cache_miss(
 OffsetCumsumDeviceOperation::spec_return_value_t OffsetCumsumDeviceOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& input_tensor) {
     const auto& logical_shape = input_tensor.logical_shape();
-    uint32_t H = logical_shape[-2];
     uint32_t W = logical_shape[-1];
 
     auto layout = tt::tt_metal::TensorLayout(
@@ -31,9 +30,32 @@ OffsetCumsumDeviceOperation::spec_return_value_t OffsetCumsumDeviceOperation::co
         tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM});
 
-    auto offsets_spec = TensorSpec(ttnn::Shape({H, W}), layout);
+    auto offsets_spec = TensorSpec(ttnn::Shape({1, W}), layout);
     auto totals_spec = TensorSpec(ttnn::Shape({1, W}), layout);
     return {offsets_spec, totals_spec};
+}
+
+OffsetCumsumDeviceOperation::topology_return_value_t OffsetCumsumDeviceOperation::compute_output_topologies(
+    const operation_attributes_t& /*args*/, const tensor_args_t& input_tensor) {
+    using Shard = tt::tt_metal::distributed::MeshMapperConfig::Shard;
+
+    const auto& input_topology = input_tensor.tensor_topology();
+    const auto& dist_shape = input_topology.distribution_shape();
+    size_t ndims = dist_shape.dims();
+
+    // Both outputs are unique per device on all mesh dimensions:
+    //  - Along cluster_axis: each device holds a different row of the prefix sum
+    //  - Along other axes: masked_bincount uses per-dispatch-group expert masks,
+    //    so histograms (and therefore cumsums/totals) differ across dispatch groups
+    ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement> placements;
+    for (size_t i = 0; i < ndims; i++) {
+        placements.push_back(Shard{static_cast<int>(i)});
+    }
+
+    auto offsets_topology = tt::tt_metal::TensorTopology(dist_shape, placements, input_topology.mesh_coords());
+    auto totals_topology = tt::tt_metal::TensorTopology(dist_shape, placements, input_topology.mesh_coords());
+
+    return {offsets_topology, totals_topology};
 }
 
 tt::stl::hash::hash_t OffsetCumsumDeviceOperation::compute_program_hash(
@@ -56,9 +78,9 @@ OffsetCumsumDeviceOperation::tensor_return_value_t OffsetCumsumDeviceOperation::
 
 namespace ttnn::prim {
 
-std::array<Tensor, 2> offset_cumsum(const Tensor& input_tensor) {
+std::array<Tensor, 2> offset_cumsum(const Tensor& input_tensor, uint32_t cluster_axis) {
     using OperationType = ttnn::experimental::prim::OffsetCumsumDeviceOperation;
-    auto operation_attributes = OperationType::operation_attributes_t{};
+    auto operation_attributes = OperationType::operation_attributes_t{cluster_axis};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, input_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "offset_cumsum_program_factory.hpp"
@@ -20,11 +21,13 @@ struct OffsetCumsumDeviceOperation {
     using operation_attributes_t = OffsetCumsumParams;
     using tensor_args_t = Tensor;
     using spec_return_value_t = std::array<TensorSpec, 2>;
+    using topology_return_value_t = std::vector<tt::tt_metal::TensorTopology>;
     using tensor_return_value_t = std::array<Tensor, 2>;
     using program_factory_t = std::variant<OffsetCumsumProgramFactory>;
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
@@ -32,5 +35,5 @@ struct OffsetCumsumDeviceOperation {
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {
-std::array<Tensor, 2> offset_cumsum(const Tensor& input_tensor);
+std::array<Tensor, 2> offset_cumsum(const Tensor& input_tensor, uint32_t cluster_axis);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation_types.hpp
@@ -9,7 +9,7 @@
 namespace ttnn::experimental::prim {
 
 struct OffsetCumsumParams {
-    // Shape is derived from the input tensor; no extra params needed.
+    uint32_t cluster_axis;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
@@ -109,7 +109,7 @@ OffsetCumsumProgramFactory::cached_mesh_workload_t OffsetCumsumProgramFactory::c
         auto result = create_program(input, tensor_return_value, row_idx);
         auto coord_range = ttnn::MeshCoordinateRange(coord);
         mesh_workload.add_program(coord_range, std::move(result.program));
-        shared_variables.emplace(coord_range, std::move(result.shared_variables));
+        shared_variables.emplace(coord_range, result.shared_variables);
     }
 
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.cpp
@@ -11,13 +11,18 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace ttnn::experimental::prim {
 
-OffsetCumsumProgramFactory::cached_program_t OffsetCumsumProgramFactory::create(
-    const OffsetCumsumParams& /*operation_attributes*/,
-    const Tensor& input,
-    tensor_return_value_t& tensor_return_value) {
+namespace {
+
+struct CreatedProgram {
+    tt::tt_metal::Program program;
+    OffsetCumsumSharedVariables shared_variables;
+};
+
+CreatedProgram create_program(const Tensor& input, std::array<Tensor, 2>& tensor_return_value, uint32_t row_idx) {
     tt::tt_metal::Program program{};
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(tt::tt_metal::DataType::UINT32);
@@ -77,27 +82,55 @@ OffsetCumsumProgramFactory::cached_program_t OffsetCumsumProgramFactory::create(
         tt::tt_metal::ReaderDataMovementConfig(compile_time_args, kernel_defines));
 
     tt::tt_metal::SetRuntimeArgs(
-        program, kernel_id, core, {src_buffer->address(), dst_offsets_buffer->address(), dst_totals_buffer->address()});
+        program,
+        kernel_id,
+        core,
+        {src_buffer->address(), dst_offsets_buffer->address(), dst_totals_buffer->address(), row_idx});
 
-    return cached_program_t{
+    return CreatedProgram{
         std::move(program),
         {/* kernel_id = */ kernel_id,
          /* core      = */ core}};
 }
 
-void OffsetCumsumProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const OffsetCumsumParams&,
+}  // namespace
+
+OffsetCumsumProgramFactory::cached_mesh_workload_t OffsetCumsumProgramFactory::create_mesh_workload(
+    const OffsetCumsumParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const Tensor& input,
     tensor_return_value_t& tensor_return_value) {
-    auto& program = cached_program.program;
-    const auto& core = cached_program.shared_variables.core;
-    const auto& kernel_id = cached_program.shared_variables.kernel_id;
+    tt::tt_metal::distributed::MeshWorkload mesh_workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-    auto& runtime_args = GetRuntimeArgs(program, kernel_id, core);
-    runtime_args[0] = input.buffer()->address();
-    runtime_args[1] = tensor_return_value.at(0).buffer()->address();
-    runtime_args[2] = tensor_return_value.at(1).buffer()->address();
+    for (const auto& coord : tensor_coords.coords()) {
+        uint32_t row_idx = coord[operation_attributes.cluster_axis];
+
+        auto result = create_program(input, tensor_return_value, row_idx);
+        auto coord_range = ttnn::MeshCoordinateRange(coord);
+        mesh_workload.add_program(coord_range, std::move(result.program));
+        shared_variables.emplace(coord_range, std::move(result.shared_variables));
+    }
+
+    return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+}
+
+void OffsetCumsumProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const OffsetCumsumParams& operation_attributes,
+    const Tensor& input,
+    tensor_return_value_t& tensor_return_value) {
+    for (auto& [coord_range, program] : cached_workload.workload.get_programs()) {
+        auto coord = *(coord_range.begin());
+        uint32_t row_idx = coord[operation_attributes.cluster_axis];
+
+        auto& shared_vars = cached_workload.shared_variables.at(coord_range);
+        auto& runtime_args = GetRuntimeArgs(program, shared_vars.kernel_id, shared_vars.core);
+        runtime_args[0] = input.buffer()->address();
+        runtime_args[1] = tensor_return_value.at(0).buffer()->address();
+        runtime_args[2] = tensor_return_value.at(1).buffer()->address();
+        runtime_args[3] = row_idx;
+    }
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
@@ -20,7 +20,7 @@ struct OffsetCumsumSharedVariables {
 
 struct OffsetCumsumProgramFactory {
     using shared_variables_t = OffsetCumsumSharedVariables;
-    using cached_mesh_workload_t = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<shared_variables_t>;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
     using tensor_return_value_t = std::array<Tensor, 2>;
 
     static cached_mesh_workload_t create_mesh_workload(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_program_factory.hpp
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <array>
+#include <unordered_map>
 
 #include "offset_cumsum_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -18,16 +20,17 @@ struct OffsetCumsumSharedVariables {
 
 struct OffsetCumsumProgramFactory {
     using shared_variables_t = OffsetCumsumSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using cached_mesh_workload_t = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<shared_variables_t>;
     using tensor_return_value_t = std::array<Tensor, 2>;
 
-    static cached_program_t create(
+    static cached_mesh_workload_t create_mesh_workload(
         const OffsetCumsumParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const Tensor& input,
         tensor_return_value_t& tensor_return_value);
 
     static void override_runtime_arguments(
-        cached_program_t& cached_program,
+        cached_mesh_workload_t& cached_workload,
         const OffsetCumsumParams& operation_attributes,
         const Tensor& input,
         tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
@@ -32,7 +32,7 @@ std::array<ttnn::Tensor, 2> offset_cumsum(
 
     auto row_major = ttnn::to_layout(gathered, tt::tt_metal::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
 
-    return ttnn::prim::offset_cumsum(row_major);
+    return ttnn::prim::offset_cumsum(row_major, cluster_axis);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum


### PR DESCRIPTION

The current implementation of MoeGate used a dispatch mask of shape (num_routed experts) with 0s and 1s indicating if that specific expert is hosted in that dispatch group:

Group 0: [ 0, 0, 1, 1,  1, 1, 1, 1,  0, 0, 0, 0,  0, 0, 0, 0]
Group 1: [0, 0, 0, 0,  0, 0, 0, 0,   0, 0, 1, 1,   1, 1, 1, 1,]

This PR Changes this to a dispatch table format, which contains information on which chip hosts any given token:

Group 0: [ 0, 0, 1, 1,  2, 2, 3, 3,  -1,-1,-1,-1,  -1,-1,-1,-1]
Group 1: [-1,-1,-1,-1,  -1,-1,-1,-1,   0, 0, 1, 1,   2, 2, 3, 3]

### Changes
#### masked_bincount
- masked_bincount op now takes a dispatch_table as an int32 tensor argument and checks whether the value is >= 0 when it counts
- also, masked_bincount op now takes a num_experts_per_chip as an argument, since we may want to test and experiment with 2 experts per chip instead of 8, so the op knows to ignore the padded values
#### offset_cumsum
- offset_cumsum now passes row_ids as a runtime argument in program factory, so that each device can return only the offset relevant to the device 
- **bugfix**: offset_cumsum was assuming the output tensor topology is the same as the input, I added explicit topology calculation (similar to dispatch op)


- [x] [(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/23591056402)
- [x] [(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23591106914)
- [x] [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23595487395)