### PR TITLE
Low-res proxies for math util on Quiet Box (VideogenModel1)

### DIFF
--- a/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py
@@ -96,14 +96,38 @@ MODEL_CONFIGS = {
         q_chunk_sizes=[224, 256, 288],
         k_chunk_sizes=[128, 256, 512],
     ),
-    # VideogenModel1 — 1×Galaxy deployment (115,200 total tokens)
+    # VideogenModel1 720p — 1×Galaxy deployment (115,200 total tokens)
     # Single benchmark config: Sq_chunk_t=7 (q=224), k=512
-    "videogen_model1": ModelConfig(
+    # Galaxy: 14400/dev, q_per_core=6. QB: 13440/dev, q_per_core=6.
+    "videogen_model1_720p": ModelConfig(
         galaxy_seq_per_device=14400,
         non_galaxy_seq_per_device=13440,
         heads_per_device=10,
         head_dim=128,
         q_chunk_sizes=[224],
+        k_chunk_sizes=[512],
+    ),
+    # VideogenModel1 480p — 1×Galaxy deployment (49,920 total tokens)
+    # q288 chosen for zero slot waste on Galaxy (22 chunks / 11 cores = 2 each).
+    # Galaxy: 6240/dev, q_per_core=2. QB: 5760/dev, q_per_core=2.
+    "videogen_model1_480p": ModelConfig(
+        galaxy_seq_per_device=6240,
+        non_galaxy_seq_per_device=5760,
+        heads_per_device=10,
+        head_dim=128,
+        q_chunk_sizes=[288],
+        k_chunk_sizes=[512],
+    ),
+    # VideogenModel1 768×512 — 1×Galaxy deployment (49,152 total tokens)
+    # q288 chosen for zero slot waste on Galaxy (22 chunks / 11 cores = 2 each).
+    # Zero K pad waste (6144 = 12×512 exactly).
+    # Galaxy: 6144/dev, q_per_core=2. QB: 5760/dev, q_per_core=2.
+    "videogen_model1_768x512": ModelConfig(
+        galaxy_seq_per_device=6144,
+        non_galaxy_seq_per_device=5760,
+        heads_per_device=10,
+        head_dim=128,
+        q_chunk_sizes=[288],
         k_chunk_sizes=[512],
     ),
 }


### PR DESCRIPTION
Rename videogen_model1 → videogen_model1_720p for clarity. Add two new lower-resolution configs with QB-equivalent sequence lengths:

- videogen_model1_480p: 49920 total tokens, Galaxy 6240/dev, QB 5760/dev q288/k512, zero slot waste on Galaxy (22 chunks / 11 cores)
- videogen_model1_768x512: 49152 total tokens, Galaxy 6144/dev, QB 5760/dev q288/k512, zero slot waste + zero K pad waste (6144 = 12×512)

Both configs: q_per_core=2, 10 heads/device, d=128.

## PCC Results (CCLs enabled, QB 4-chip ring)

| Config | Seq/dev | Q/K | PCC | RMSE |
|--------|---------|-----|-----|------|
| videogen_model1_720p | 13440 | 224/512 | 0.9996 | 0.007 |
| videogen_model1_480p | 5760 | 288/512 | 0.9997 | 0.006 |
| videogen_model1_768x512 | 5760 | 288/512 | 0.9997 | 0.006 |

## Math Utilization (CCLs disabled, QB 4-chip ring)

| Config | Seq/dev | Q/K | Duration | Math Util | Cores | Iters/Core |
|--------|---------|-----|----------|-----------|-------|------------|
| videogen_model1_720p | 13440 | 224/512 | 19.044 ms | 70.3% | 100 | 630 |
| videogen_model1_480p | 5760 | 288/512 | 3.629 ms | 67.7% | 100 | 90 |
| videogen_model1_768x512 | 5760 | 288/512 | 3.598 ms | 68.3% | 100 | 90 |

## Galaxy vs Quiet Box — videogen_model1_480p (49,920 tokens, q288/k512)

| | Galaxy | Quiet Box |
|---|---|---|
| Mesh | 4×8 (TP=4, SP=8) | 1×4 (TP=1, SP=4) |
| Seq per device | 6,240 | 5,760 |
| Cores per head | 11 | 10 |
| q_chunks | 22 | 20 |
| q_per_core | 2 | 2 |
| Slot waste | 0.0% | 0.0% |
| Q pad waste | 1.5% | 0.0% |
| K pad waste | 6.2% | 6.2% |
| Tokens/core | 567 | 576 |
| Steps/core/ring iter | 26 | 24 |

## Galaxy vs Quiet Box — videogen_model1_768x512 (49,152 tokens, q288/k512)

| | Galaxy | Quiet Box |
|---|---|---|
| Mesh | 4×8 (TP=4, SP=8) | 1×4 (TP=1, SP=4) |
| Seq per device | 6,144 | 5,760 |
| Cores per head | 11 | 10 |
| q_chunks | 22 | 20 |
| q_per_core | 2 | 2 |
| Slot waste | 0.0% | 0.0% |
| Q pad waste | 3.0% | 0.0% |
| K pad waste | 0.0% | 6.2% |
| Tokens/core | 558 | 576 |
| Steps/core/ring iter | 24 | 24 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)