### PR TITLE
Updating GLX demo tests to use pipeline-perf

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -130,8 +130,8 @@ models:
   demo:
     wh_llmbox_perf: 1090
     wh_llmbox_perf_release: 1090
-    wh_galaxy: 247
-    wh_galaxy_perf: 40
+    wh_galaxy: 0
+    wh_galaxy_perf: 279
     wh_galaxy_release: 345
     bh_galaxy: 30
     wh_n150: 500

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -52,7 +52,7 @@
   cmd: pytest models/demos/tg/sentence_bert/tests/test_sentence_bert_e2e_performant.py --timeout=1500
   model: sentence_bert
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 5
   owner_id: U088413NP0Q # Ashai Reddy
   team: models

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -21,7 +21,7 @@
     pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 500
   model: llama3
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 32
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
@@ -32,7 +32,7 @@
     pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000
   model: llama3_8b_dp
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 27
   owner_id: U08BH66EXAL # Radoica Draskic
   team: models
@@ -43,7 +43,7 @@
     pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000
   model: llama3_70b_dp
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U08BH66EXAL # Radoica Draskic
   team: models
@@ -63,7 +63,7 @@
     pytest models/tt_dit/tests/models/sd35/test_pipeline_sd35.py -k "4x8cfg1sp0tp1" --timeout 1200
   model: sd35
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 10
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -74,7 +74,7 @@
     pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-dev" --timeout 1200
   model: flux1
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -89,7 +89,7 @@
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
   model: gpt-oss
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 45
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
@@ -100,7 +100,7 @@
     pytest models/tt_dit/tests/models/motif/test_pipeline_motif.py -k "4x8cfg1sp0tp1" --timeout 1200
   model: motif
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -111,7 +111,7 @@
     pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "wh_4x8sp1tp0 and resolution_720p" --timeout 1500
   model: wan22
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -122,7 +122,7 @@
     pytest models/tt_dit/tests/models/mochi/test_pipeline_mochi.py -k "4x8sp1tp0" --timeout=1500
   model: mochi
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
@@ -133,7 +133,7 @@
     pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress" --timeout 900
   model: deepseek_v3
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08H32XUS9W # Yousef Al Rawwash
   team: models
@@ -144,7 +144,7 @@
     pytest models/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py -k "4x8" --timeout 1200
   model: qwenimage
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -178,7 +178,7 @@
 # - name: Galaxy Llama3 long context demo tests
 #   cmd: export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-4k-b1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-8k-b1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-16k-b1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-32k-b1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-64k-b1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "long-128k-b1" --timeout 1000
 #   model: llama3_long_context
-#   sku: wh_galaxy
+#   sku: wh_galaxy_perf
 #   owner_id: U03PUAKE719 # Miguel Tairum
 #   team: models
 #   timeout: 60
@@ -186,7 +186,7 @@
 # - name: Galaxy Llama3 evals tests
 #   cmd: export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "evals-1" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "evals-32" --timeout 1000 && pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "evals-long-prompts" --timeout 1000
 #   model: llama3_evals
-#   sku: wh_galaxy
+#   sku: wh_galaxy_perf
 #   owner_id: U03PUAKE719 # Miguel Tairum
 #   team: models
 #   timeout: 45


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akirby/update-labels)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akirby/update-labels)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akirby/update-labels)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akirby/update-labels)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akirby/update-labels)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akirby/update-labels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akirby/update-labels)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
