### PR TITLE
adjust exabox run_validation.sh, add volume arg for mnt to support de…

### DIFF
--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -6,6 +6,7 @@ print_usage() {
     echo
     echo "  --image <image>       (Optional) Docker image to use"
     echo "  --empty-entrypoint    (Optional) Pass --entrypoint=\"\" to docker run"
+    echo "  --volume <path>       (Optional) Extra host path to mount into the container (repeatable)"
     echo "  --print               Print the command alongside execution"
     echo "  --print-only          Print the command without executing it"
     echo "  [global-mpi-args]     Global MPI arguments applied to all ranks"
@@ -40,6 +41,7 @@ print_usage() {
 default() {
     local image="ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
     local empty_entrypoint=false
+    local extra_volumes=""
     local print_flag=false
     local print_only=false
 
@@ -57,6 +59,15 @@ default() {
                 ;;
             --empty-entrypoint)
                 empty_entrypoint=true
+                shift
+                ;;
+            --volume)
+                extra_volumes="$extra_volumes -v ${2}:${2}"
+                shift 2
+                ;;
+            --volume=*)
+                local vol="${1#--volume=}"
+                extra_volumes="$extra_volumes -v ${vol}:${vol}"
                 shift
                 ;;
             --print)
@@ -233,7 +244,7 @@ default() {
         fi
 
         # Build docker command
-        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/scaleout_configs:/data/scaleout_configs -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
 
         # Single segment without per-rank args
         mpirun_segments+=("bash -c '$docker_cmd'")
@@ -306,7 +317,7 @@ default() {
             fi
 
             # Build docker command for this group
-            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/scaleout_configs:/data/scaleout_configs -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
 
             # Combine this group's MPI args with docker command
             mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -62,11 +62,21 @@ default() {
                 shift
                 ;;
             --volume)
+                if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                    echo "Error: --volume requires a non-empty path value"
+                    print_usage
+                    exit 1
+                fi
                 extra_volumes="$extra_volumes -v ${2}:${2}"
                 shift 2
                 ;;
             --volume=*)
                 local vol="${1#--volume=}"
+                if [[ -z "$vol" ]]; then
+                    echo "Error: --volume requires a non-empty path value"
+                    print_usage
+                    exit 1
+                fi
                 extra_volumes="$extra_volumes -v ${vol}:${vol}"
                 shift
                 ;;

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -241,6 +241,7 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
     if [[ -n "$DOCKER_IMAGE" ]]; then
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
+            --volume /data/scaleout_configs \
             --host "$HOSTS" \
             ./build/tools/scaleout/run_cluster_validation \
             "${VALIDATION_ARGS[@]}"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -22,6 +22,8 @@ Optional:
     --factory-descriptor-path <path>        Path to pregenerated factory system descriptor (FSD) file (.textproto)
                                             (if provided, cabling and deployment descriptors are ignored)
     --output <directory>                    Output directory for log files (default: validation_output)
+    --volume <host-path>                    Extra volume mount for Docker containers (can be repeated)
+                                            The host path is mounted at the same path inside the container
     --rerun-on-retrain                      Rerun validation when Ethernet links are retrained
     --help                                  Display this help message and exit
 
@@ -41,6 +43,7 @@ ITERATIONS=50
 
 FACTORY_DESCRIPTOR_PATH=""
 OUTPUT_DIR="validation_output"
+EXTRA_VOLUMES=(/data/scaleout_configs)
 RERUN_ON_RETRAIN=false
 
 while [[ $# -gt 0 ]]; do
@@ -105,6 +108,14 @@ while [[ $# -gt 0 ]]; do
             OUTPUT_DIR="$2"
             shift 2
             ;;
+        --volume)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --volume requires a non-empty value"
+                exit 1
+            fi
+            EXTRA_VOLUMES+=("$2")
+            shift 2
+            ;;
         --rerun-on-retrain)
             if [[ -n "$2" ]] && [[ "$2" != --* ]]; then
                 echo "Error: --rerun-on-retrain does not accept a value"
@@ -148,6 +159,11 @@ run_cluster_validation() {
         local descriptor_args=(--cabling-descriptor-path "$CABLING_DESCRIPTOR_PATH" --deployment-descriptor-path "$DEPLOYMENT_DESCRIPTOR_PATH")
     fi
 
+    local volume_args=()
+    for vol in "${EXTRA_VOLUMES[@]}"; do
+        volume_args+=(--volume "$vol")
+    done
+
     if [[ $DOCKER_IMAGE == "none" ]]; then
         mpirun --host "$HOSTS" \
             --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
@@ -159,6 +175,7 @@ run_cluster_validation() {
     else
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
+            "${volume_args[@]}" \
             --host "$HOSTS" \
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -22,8 +22,9 @@ Optional:
     --factory-descriptor-path <path>        Path to pregenerated factory system descriptor (FSD) file (.textproto)
                                             (if provided, cabling and deployment descriptors are ignored)
     --output <directory>                    Output directory for log files (default: validation_output)
-    --volume <host-path>                    Extra volume mount for Docker containers (can be repeated)
-                                            The host path is mounted at the same path inside the container
+    --volume <host-path>                    Additional volume mount for Docker containers (can be repeated)
+                                            /data/scaleout_configs is mounted by default; each host path
+                                            is mounted at the same path inside the container
     --rerun-on-retrain                      Rerun validation when Ethernet links are retrained
     --help                                  Display this help message and exit
 


### PR DESCRIPTION

Added ability to designate volume mounts instead of hard coding volume mount in scripts for deployments

Tested on SP1 system

changes, -added volume amount arg

how to run_validation.sh

./tools/scaleout/exabox/run_validation.sh --hosts $HOST --image $IMG --factory-descriptor-path $FSD --iterations 1 --rerun-on-retrain --output /home/ubuntu/Rack10_quad --volume /mnt/tt_data

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mchiou/0-deployment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mchiou/0-deployment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mchiou/0-deployment)