### PR TITLE
Fix pinned memory cleanup after async mesh writes

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -896,6 +896,58 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
     }
 }
 
+TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryWaitsOnClose) {
+    if (!tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    const uint32_t tiles_per_device = 128;
+    const uint32_t bytes_per_device = tiles_per_device * single_tile_size;
+
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    constexpr int device_read_align{64};
+    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+        << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
+        << std::endl;
+
+    auto src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
+        bytes_per_device / sizeof(uint32_t), 0);
+    std::iota(src->begin(), src->end(), 0);
+    std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>> dst(
+        bytes_per_device / sizeof(uint32_t), 0);
+
+    distributed::MeshCoordinate coord(0, 0);
+    {
+        HostBuffer host_buffer(tt::stl::Span<uint32_t>(src->data(), bytes_per_device / sizeof(uint32_t)), MemoryPin(src));
+        auto pinned_shared = tt_metal::experimental::PinnedMemory::Create(
+            *mesh_device_,
+            MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord)),
+            host_buffer,
+            /*map_to_noc=*/true);
+        ASSERT_TRUE(pinned_shared);
+
+        auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
+        distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+
+        EXPECT_TRUE(pinned_shared->lock_may_block());
+    }
+
+    auto read_transfer = distributed::ShardDataTransfer{coord}
+                             .host_data(static_cast<void*>(dst.data()))
+                             .region(BufferRegion(0, bytes_per_device));
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    EXPECT_EQ(*src, dst);
+}
+
 TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage) {
     if (!tt_metal::experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
         GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -926,7 +926,8 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryWaitsOnClose) {
 
     distributed::MeshCoordinate coord(0, 0);
     {
-        HostBuffer host_buffer(tt::stl::Span<uint32_t>(src->data(), bytes_per_device / sizeof(uint32_t)), MemoryPin(src));
+        HostBuffer host_buffer(
+            tt::stl::Span<uint32_t>(src->data(), bytes_per_device / sizeof(uint32_t)), MemoryPin(src));
         auto pinned_shared = tt_metal::experimental::PinnedMemory::Create(
             *mesh_device_,
             MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord)),

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <memory>
 #include <cstdint>
+#include <utility>
 #include <unistd.h>
 
 #include <tt-metalium/device.hpp>
@@ -39,29 +40,26 @@ PinnedMemoryImpl::~PinnedMemoryImpl() {
 }
 
 PinnedMemoryImpl::PinnedMemoryImpl(PinnedMemoryImpl&& other) noexcept :
-    buffer_size_(other.buffer_size_),
-    map_to_noc_(other.map_to_noc_),
-    host_offset_(other.host_offset_),
+    buffer_size_(std::exchange(other.buffer_size_, 0)),
+    map_to_noc_(std::exchange(other.map_to_noc_, false)),
+    use_64bit_address_space_(std::exchange(other.use_64bit_address_space_, false)),
+    host_offset_(std::exchange(other.host_offset_, 0)),
     device_buffers_(std::move(other.device_buffers_)),
-    device_to_mmio_map_(std::move(other.device_to_mmio_map_)) {
-    other.buffer_size_ = 0;
-    other.map_to_noc_ = false;
-    other.host_offset_ = 0;
-}
+    device_to_mmio_map_(std::move(other.device_to_mmio_map_)),
+    barrier_events_(std::move(other.barrier_events_)) {}
 
 PinnedMemoryImpl& PinnedMemoryImpl::operator=(PinnedMemoryImpl&& other) noexcept {
     if (this != &other) {
+        drain_barrier_events();
         device_buffers_.clear();
 
-        buffer_size_ = other.buffer_size_;
-        map_to_noc_ = other.map_to_noc_;
-        host_offset_ = other.host_offset_;
+        buffer_size_ = std::exchange(other.buffer_size_, 0);
+        map_to_noc_ = std::exchange(other.map_to_noc_, false);
+        use_64bit_address_space_ = std::exchange(other.use_64bit_address_space_, false);
+        host_offset_ = std::exchange(other.host_offset_, 0);
         device_buffers_ = std::move(other.device_buffers_);
         device_to_mmio_map_ = std::move(other.device_to_mmio_map_);
-
-        other.buffer_size_ = 0;
-        other.map_to_noc_ = false;
-        other.host_offset_ = 0;
+        barrier_events_ = std::move(other.barrier_events_);
     }
     return *this;
 }

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -33,7 +33,10 @@ PinnedMemoryImpl::PinnedMemoryImpl(
     initialize_from_devices(devices, host_buffer, buffer_size, map_to_noc);
 }
 
-PinnedMemoryImpl::~PinnedMemoryImpl() { device_buffers_.clear(); }
+PinnedMemoryImpl::~PinnedMemoryImpl() {
+    drain_barrier_events();
+    device_buffers_.clear();
+}
 
 PinnedMemoryImpl::PinnedMemoryImpl(PinnedMemoryImpl&& other) noexcept :
     buffer_size_(other.buffer_size_),
@@ -266,12 +269,16 @@ void PinnedMemoryImpl::add_barrier_event(const distributed::MeshEvent& event) {
 
 bool PinnedMemoryImpl::lock_may_block() const { return !barrier_events_.empty(); }
 
-void* PinnedMemoryImpl::lock() {
+void PinnedMemoryImpl::drain_barrier_events() {
     while (!barrier_events_.empty()) {
         auto& event = barrier_events_.front();
         distributed::EventSynchronize(event);
         barrier_events_.pop_front();
     }
+}
+
+void* PinnedMemoryImpl::lock() {
+    drain_barrier_events();
     return get_host_ptr();
 }
 

--- a/tt_metal/distributed/pinned_memory_impl.hpp
+++ b/tt_metal/distributed/pinned_memory_impl.hpp
@@ -82,6 +82,8 @@ public:
     void unlock();
 
 private:
+    void drain_barrier_events();
+
     void initialize_from_devices(
         const std::vector<IDevice*>& devices, void* host_buffer, size_t buffer_size, bool map_to_noc);
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Pinned host memory can retain pending barrier events after a non-blocking mesh write. If the pinned allocation is released before those events are drained, teardown can race an in-flight transfer.

### What's changed
- Factor barrier-event draining into a shared helper and call it from both `lock()` and the pinned-memory destructor.
- Add a distributed mesh-buffer regression test that verifies async pinned-memory shard writes complete before teardown.
- Include the required `clang-format` follow-up for the new test.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/pinnedmemorylockdestroy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/pinnedmemorylockdestroy)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
