### PR TITLE
Fix llama & qwen segfault 

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -226,3 +226,79 @@ INSTANTIATE_TEST_SUITE_P(
             //         false}
             // }
             )));
+
+// =============================================================================
+// Workaround test for https://github.com/tenstorrent/tt-metal/issues/40716
+//
+// This test verifies that constructing a Tensor from a deallocated DeviceStorage
+// still preserves the mesh_device_ pointer. This is a WORKAROUND for models that
+// incorrectly operate on deallocated tensors (e.g., reshape after deallocate in
+// llama_attention.py).
+//
+// TODO: Remove this test once the underlying model bugs are fixed. The models
+// should not be passing deallocated tensors to operations like reshape. Once
+// models are fixed to properly manage tensor lifetimes, this workaround in the
+// Tensor constructor (using get_device_bypass_deallocate_check()) should be
+// reverted to use get_device() with proper is_allocated() checks.
+// =============================================================================
+class TensorFromDeallocatedStorageTest : public ttnn::TTNNFixtureWithSuiteDevice<TensorFromDeallocatedStorageTest> {};
+
+TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStoragePreservesMeshDevice) {
+    // This test verifies the workaround for issue #40716:
+    // When a new Tensor is constructed from a DeviceStorage that has been deallocated,
+    // the mesh_device_ should still be set (not nullptr).
+    //
+    // The bug scenario (from Llama 70B Galaxy model):
+    // 1. Tensor A is created on device
+    // 2. view(A) creates Tensor B - B's DeviceStorage has a copy of shared_ptr<MeshBuffer>
+    // 3. A is deallocated - A's mesh_buffer is reset to nullptr, but B still has the ptr
+    // 4. B's MeshBuffer is now in DeallocatedState (is_allocated() == false)
+    // 5. view(B) creates Tensor C from B's DeviceStorage
+    // 6. C's device() returns nullptr because is_allocated() was false -> segfault
+
+    MemoryConfig mem_cfg = MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
+
+    // Step 1: Create initial tensor on device
+    auto input_buffer = tt::tt_metal::tensor_impl::allocate_device_buffer(device_, tensor_spec);
+    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
+    Tensor tensor_a = Tensor(input_storage, tensor_spec, TensorTopology{});
+
+    ASSERT_NE(tensor_a.device(), nullptr) << "Tensor A should have valid device";
+    ASSERT_TRUE(tensor_a.is_allocated()) << "Tensor A should be allocated";
+
+    // Step 2: Copy the DeviceStorage (simulating what view() does internally)
+    // This creates a separate DeviceStorage with a copy of the shared_ptr<MeshBuffer>
+    auto storage_copy = tensor_a.device_storage();  // Makes a copy, not a reference
+    Tensor tensor_b = Tensor(storage_copy, tensor_spec, TensorTopology{});
+
+    ASSERT_NE(tensor_b.device(), nullptr) << "Tensor B should have valid device";
+    ASSERT_TRUE(tensor_b.is_allocated()) << "Tensor B should be allocated";
+
+    // Step 3: Deallocate tensor A with force=true
+    // This calls mesh_buffer->deallocate() putting it in DeallocatedState,
+    // then calls mesh_buffer.reset() on A's storage (setting A's ptr to nullptr)
+    // But tensor_b's storage still holds the shared_ptr to the now-deallocated MeshBuffer!
+    tensor_a.deallocate(/*force=*/true);
+
+    // Verify B's storage state: mesh_buffer exists but is deallocated
+    const auto& storage_b = tensor_b.device_storage();
+    EXPECT_FALSE(storage_b.is_allocated()) << "is_allocated() should return false (MeshBuffer is in DeallocatedState)";
+    EXPECT_NE(storage_b.get_device_bypass_deallocate_check(), nullptr)
+        << "get_device_bypass_deallocate_check() should return device even when deallocated";
+
+    // Step 4: Create tensor C from B's storage (simulating another view() call)
+    // This is where the bug manifests - if Tensor constructor uses is_allocated(),
+    // mesh_device_ won't be set because is_allocated() returns false
+    Tensor tensor_c = Tensor(storage_b, tensor_spec, TensorTopology{});
+
+    // THE KEY ASSERTION: tensor C must have valid device pointer
+    // This is the workaround - without it, device() returns nullptr and causes segfaults
+    ASSERT_NE(tensor_c.device(), nullptr)
+        << "REGRESSION (issue #40716): Tensor constructed from deallocated storage has null device! "
+           "The Tensor constructor should use get_device_bypass_deallocate_check() to preserve mesh_device_.";
+
+    // Verify it's the same device
+    EXPECT_EQ(tensor_c.device(), device_) << "Tensor C should have same device as original";
+}

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -73,6 +73,12 @@ public:
 
     bool is_allocated() const;
 
+    // Returns true if the mesh_buffer exists (non-null), regardless of allocation state.
+    // Use this for cases where you need to check buffer existence without the stricter
+    // is_allocated() check (which also validates the MeshDevice weak_ptr).
+    // This is a hack to preserve mesh_device_ even when the buffer is deallocated.
+    bool has_mesh_buffer() const;
+
     distributed::MeshDevice* get_device() const;
 
     // Returns true if the tensor spans across all devices in a mesh.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -73,11 +73,18 @@ public:
 
     bool is_allocated() const;
 
-    // Returns true if the mesh_buffer exists (non-null), regardless of allocation state.
-    // Use this for cases where you need to check buffer existence without the stricter
-    // is_allocated() check (which also validates the MeshDevice weak_ptr).
-    // This is a hack to preserve mesh_device_ even when the buffer is deallocated.
-    bool has_mesh_buffer() const;
+    // Returns the MeshDevice pointer if mesh_buffer exists, or nullptr otherwise.
+    // Unlike get_device(), this does NOT throw when the buffer is deallocated.
+    //
+    // Workaround for https://github.com/tenstorrent/tt-metal/issues/40716:
+    // When a tensor's DeviceStorage is copied (e.g., by view/reshape) and the original
+    // is deallocated, the copy's MeshBuffer is in DeallocatedState but still exists.
+    // This function allows retrieving the device even in that state, preventing nullptr
+    // device propagation when constructing new tensors from such storage.
+    //
+    // TODO: Remove this workaround once models properly manage tensor lifetimes and
+    // don't operate on deallocated tensors.
+    distributed::MeshDevice* get_device_bypass_deallocate_check() const;
 
     distributed::MeshDevice* get_device() const;
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -73,6 +73,8 @@ void DeviceStorage::reset_root_mesh_buffer() {
 
 bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }
 
+bool DeviceStorage::has_mesh_buffer() const { return this->mesh_buffer != nullptr; }
+
 distributed::MeshDevice* DeviceStorage::get_device() const {
     if (this->mesh_buffer != nullptr) {
         return this->mesh_buffer->device();

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -73,7 +73,9 @@ void DeviceStorage::reset_root_mesh_buffer() {
 
 bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }
 
-bool DeviceStorage::has_mesh_buffer() const { return this->mesh_buffer != nullptr; }
+distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
+    return this->mesh_buffer ? this->mesh_buffer->device() : nullptr;
+}
 
 distributed::MeshDevice* DeviceStorage::get_device() const {
     if (this->mesh_buffer != nullptr) {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -112,11 +112,12 @@ Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology ten
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
         std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
-    // Use has_mesh_buffer() instead of is_allocated() to preserve mesh_device_
-    // even when the buffer is deallocated. This prevents nullptr device propagation
-    // when operations like reshape create new tensors from existing DeviceStorage.
-    if (device_storage().has_mesh_buffer()) {
-        mesh_device_ = device_storage().get_device();
+    // Workaround for https://github.com/tenstorrent/tt-metal/issues/40716:
+    // Use get_device_bypass_deallocate_check() to preserve mesh_device_ even when the
+    // buffer is deallocated. This prevents nullptr device propagation when operations
+    // like reshape create new tensors from existing DeviceStorage.
+    if (auto* device = device_storage().get_device_bypass_deallocate_check()) {
+        mesh_device_ = device;
     }
 }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -112,7 +112,10 @@ Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology ten
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
         std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
-    if (device_storage().is_allocated()) {
+    // Use has_mesh_buffer() instead of is_allocated() to preserve mesh_device_
+    // even when the buffer is deallocated. This prevents nullptr device propagation
+    // when operations like reshape create new tensors from existing DeviceStorage.
+    if (device_storage().has_mesh_buffer()) {
         mesh_device_ = device_storage().get_device();
     }
 }


### PR DESCRIPTION
### Ticket
#40716

### Problem description
d6c6a6d12e2a4ac32a591916eb50c714e455ef18 caused this following pipelines to break:
Llama 3.3 70B: https://github.com/tenstorrent/tt-metal/actions/runs/23466923295/job/68281801941
Qwen3 32B: https://github.com/tenstorrent/tt-metal/actions/runs/23466923295/job/68281801939

The pr uncovered a latent bug in the models, see write ups here: https://github.com/tenstorrent/tt-metal/issues/40716#issuecomment-4129088022

### What's changed

Partial behavior revert of d6c6a6d12e2a4ac32a591916eb50c714e455ef18 as a workaround.

`ttnn::Tensor` now has a `mesh_device_` associated with it even if the `MeshBuffer` is deallocated.

### Verification run

#### llama:

llama pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/23561128864
70B only: 
- https://github.com/tenstorrent/tt-metal/actions/runs/23558388932
- https://github.com/tenstorrent/tt-metal/actions/runs/23569238407

#### Qwen:
https://github.com/tenstorrent/tt-metal/actions/runs/23567293271


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

