### PR TITLE
#38763: move matmul kernels to device 2.0 apis

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -112,7 +112,7 @@ DEVICE_PERF_EXPECTATIONS = {
         "blackhole": 115_731_183 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
     },
     "unet_512x512": {
-        "wormhole": 83_531_333 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+        "wormhole": 82_300_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
         "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "refiner_unet_1024x1024": {

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            4_182_858,
+            4_120_000,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -82,7 +82,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
     // Get DRAM usage
     auto dram_usage = ttml::utils::MemoryUsageTracker::get_dram_usage();
 
-    size_t binary_size = 18432;          // Size of DRAM buffer used for matmul program
+    size_t binary_size = 16384;          // Size of DRAM buffer used for matmul program
     size_t expected_size = binary_size;  // Allocated left over is program cache
     size_t expected_peak_size = tensor1_size + tensor2_size + result_size + expected_size;
     // LLK_ASSERTs add constant DRAM overhead (one page) due to additional assertion code
@@ -399,7 +399,7 @@ TEST_F(MemoryUtilsTest, SnapshotFeature) {
     // LLK_ASSERTs add constant DRAM overhead (one page) due to additional assertion code
     // in unpacker/packer configurations that invoke functions exclusively used for assertions.
     size_t peak_1 = 34816, alloc_1 = 34816, dealloc_1 = 10240;
-    size_t peak_2 = 86016, alloc_2 = 86016, dealloc_2 = 20480;
+    size_t peak_2 = 83968, alloc_2 = 83968, dealloc_2 = 18432;
     size_t peak_3 = 272384, alloc_3 = 280576, dealloc_3 = 18432;
     if (ttml::core::is_llk_assert_enabled()) {
         constexpr size_t llk_assert_overhead = 2048;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 using std::uint32_t;
 
@@ -26,6 +27,10 @@ void kernel_main() {
     constexpr uint32_t cb_in1 = get_named_compile_time_arg_val("cb_in1");
     constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
 
+    experimental::CircularBuffer in0_cb(cb_in0);
+    experimental::CircularBuffer in1_cb(cb_in1);
+    experimental::CircularBuffer out_cb(cb_out);
+
     mm_init(cb_in0, cb_in1, cb_out);
 
     // the simplest possible version of outer product blocked matmul
@@ -36,18 +41,18 @@ void kernel_main() {
             {
                 acquire_dst();
                 for (uint32_t kt = 0; kt < Kt; kt++) {
-                    cb_wait_front(cb_in0, onetile);
-                    cb_wait_front(cb_in1, onetile);
+                    in0_cb.wait_front(onetile);
+                    in1_cb.wait_front(onetile);
 
                     matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
 
-                    cb_pop_front(cb_in0, onetile);
-                    cb_pop_front(cb_in1, onetile);
+                    in0_cb.pop_front(onetile);
+                    in1_cb.pop_front(onetile);
                 }
 
-                cb_reserve_back(cb_out, onetile);
+                out_cb.reserve_back(onetile);
                 pack_tile(0, cb_out);
-                cb_push_back(cb_out, onetile);
+                out_cb.push_back(onetile);
 
                 release_dst();
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/matmul.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() {
     uint32_t in0_block_w = get_compile_time_arg_val(0);              // inner block size in tiles
@@ -26,6 +27,11 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t cb_intermed0 = get_named_compile_time_arg_val("cb_intermed0");
 
+    experimental::CircularBuffer in0_cb(cb_in0);
+    experimental::CircularBuffer in1_cb(cb_in1);
+    experimental::CircularBuffer out_cb(cb_out);
+    experimental::CircularBuffer intermed0_cb(cb_intermed0);
+
     mm_init(cb_in0, cb_in1, cb_intermed0);
 
     for (uint32_t b = 0; b < batch; b++) {
@@ -36,8 +42,8 @@ void kernel_main() {
         for (uint32_t block = 0; block < num_blocks; block++) {
             bool last_out = block == (num_blocks - 1);
 
-            cb_wait_front(cb_in0, in0_block_num_tiles);
-            cb_wait_front(cb_in1, in1_block_num_tiles);
+            in0_cb.wait_front(in0_block_num_tiles);
+            in1_cb.wait_front(in1_block_num_tiles);
             int in0_index_subblock_offset = 0;
             for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                 int in1_index_subblock_offset = 0;
@@ -46,11 +52,11 @@ void kernel_main() {
 
                     if (enable_reload) {
                         copy_tile_to_dst_init_short_with_dt(cb_in1, cb_intermed0);
-                        cb_wait_front(cb_intermed0, out_subblock_num_tiles);
+                        intermed0_cb.wait_front(out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             copy_tile(cb_intermed0, i, i);
                         }
-                        cb_pop_front(cb_intermed0, out_subblock_num_tiles);
+                        intermed0_cb.pop_front(out_subblock_num_tiles);
                         mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed0);
                     }
 
@@ -73,23 +79,23 @@ void kernel_main() {
 
                     if (last_out) {
                         // Pack out to output buffer
-                        cb_reserve_back(cb_out, out_subblock_num_tiles);
+                        out_cb.reserve_back(out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, cb_out);
                         }
-                        cb_push_back(cb_out, out_subblock_num_tiles);
+                        out_cb.push_back(out_subblock_num_tiles);
                     } else {
                         // Wait for tiles in output buffer to be written out since interm and output share memory
                         if (block == 0) {
-                            cb_reserve_back(cb_out, out_num_tiles_to_wait);
+                            out_cb.reserve_back(out_num_tiles_to_wait);
                             out_num_tiles_to_wait += out_subblock_num_tiles;
                         }
                         // Move partial result to interm buffer
-                        cb_reserve_back(cb_intermed0, out_subblock_num_tiles);
+                        intermed0_cb.reserve_back(out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, cb_intermed0);
                         }
-                        cb_push_back(cb_intermed0, out_subblock_num_tiles);
+                        intermed0_cb.push_back(out_subblock_num_tiles);
                     }
 
                     release_dst();
@@ -102,8 +108,8 @@ void kernel_main() {
                 enable_reload = true;
             }
 
-            cb_pop_front(cb_in0, in0_block_num_tiles);
-            cb_pop_front(cb_in1, in1_block_num_tiles);
+            in0_cb.pop_front(in0_block_num_tiles);
+            in1_cb.pop_front(in1_block_num_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -8,6 +8,7 @@
 #include "api/compute/pack_untilize.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/transpose_wh.h"
+#include "experimental/circular_buffer.h"
 #include "internal/mod_div_lib.h"
 
 #ifdef FUSE_BIAS
@@ -38,43 +39,45 @@
  */
 template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
 FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
+    experimental::CircularBuffer in0_transpose_cb(in0_transpose_cb_id);
+    experimental::CircularBuffer in0_cb(in0_cb_id);
     constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
     constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
     // Lets do 2 passes: One loop until last and one last for the left overs
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-        cb_wait_front(in0_transpose_cb_id, block_size);
+        in0_transpose_cb.wait_front(block_size);
         tile_regs_acquire();
         for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
             transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
         }
         tile_regs_commit();
-        cb_pop_front(in0_transpose_cb_id, block_size);
+        in0_transpose_cb.pop_front(block_size);
 
-        cb_reserve_back(in0_cb_id, block_size);
+        in0_cb.reserve_back(block_size);
         tile_regs_wait();
         for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
             pack_tile(tile_idx, in0_cb_id);
         }
         tile_regs_release();
-        cb_push_back(in0_cb_id, block_size);
+        in0_cb.push_back(block_size);
     }
 
     if constexpr (last_block_size > 0) {
-        cb_wait_front(in0_transpose_cb_id, last_block_size);
+        in0_transpose_cb.wait_front(last_block_size);
         tile_regs_acquire();
         for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
             transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
         }
         tile_regs_commit();
-        cb_pop_front(in0_transpose_cb_id, last_block_size);
+        in0_transpose_cb.pop_front(last_block_size);
 
-        cb_reserve_back(in0_cb_id, last_block_size);
+        in0_cb.reserve_back(last_block_size);
         tile_regs_wait();
         for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
             pack_tile(tile_idx, in0_cb_id);
         }
         tile_regs_release();
-        cb_push_back(in0_cb_id, last_block_size);
+        in0_cb.push_back(last_block_size);
     }
 }
 
@@ -87,15 +90,16 @@ FORCE_INLINE void reload_from_cb_to_dst(
     uint32_t out_subblock_w,
     uint32_t out_subblock_h,
     uint32_t in0_block_w) {
+    experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
     // Reconfigure input
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
-    cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
     copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-    cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
     mm_block_init_short_with_dt(
         in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
@@ -108,14 +112,16 @@ inline void reblock_and_untilize(
     uint32_t out_subblock_h,
     uint32_t interm_cb_id,
     uint32_t out_cb_id) {
+    experimental::CircularBuffer interm_cb(interm_cb_id);
+    experimental::CircularBuffer out_cb(out_cb_id);
     uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
-    cb_wait_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
 
     uint32_t within_block_index = 0;
     for (uint32_t h = 0; h < out_subblock_h; h++) {
         uint32_t block_offset = 0;
 
-        cb_reserve_back(out_cb_id, out_block_w);
+        out_cb.reserve_back(out_block_w);
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             tile_regs_acquire();
             for (uint32_t w = 0; w < out_subblock_w; w++) {
@@ -128,11 +134,11 @@ inline void reblock_and_untilize(
             tile_regs_release();
             block_offset += out_subblock_num_tiles;
         }
-        cb_push_back(out_cb_id, out_block_w);
+        out_cb.push_back(out_block_w);
 
         within_block_index += out_subblock_w;
     }
-    cb_pop_front(interm_cb_id, num_tiles_in_row_of_subblocks);
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
 }
 
 void kernel_main() {
@@ -181,12 +187,20 @@ void kernel_main() {
     // as input for the matmul call.
     constexpr uint32_t in0_transpose_cb_id = get_named_compile_time_arg_val("cb_in0");
 
+    experimental::CircularBuffer in0_cb(in0_cb_id);
+    experimental::CircularBuffer in1_cb(in1_cb_id);
+    experimental::CircularBuffer out_cb(out_cb_id);
+    experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    experimental::CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
+
 #ifdef FUSE_BIAS
     constexpr uint32_t bias_cb_id = get_named_compile_time_arg_val("cb_bias");
     constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    experimental::CircularBuffer bias_cb(bias_cb_id);
 #else
     constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
 #endif
+    experimental::CircularBuffer mm_out_cb(mm_out_cb_id);
 
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
@@ -252,8 +266,8 @@ void kernel_main() {
                         PACK((pack_reconfig_data_format(mm_partials_cb_id)));
                     }
 
-                    cb_wait_front(in0_cb_id, in0_block_num_tiles);
-                    cb_wait_front(in1_cb_id, in1_block_num_tiles);
+                    in0_cb.wait_front(in0_block_num_tiles);
+                    in1_cb.wait_front(in1_block_num_tiles);
 
                     int in0_index_subblock_offset = 0;
                     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
@@ -310,7 +324,7 @@ void kernel_main() {
 #endif
                                 tile_regs_commit();
                                 // Pack out to output buffer
-                                cb_reserve_back(mm_out_cb_id, out_subblock_num_tiles);
+                                mm_out_cb.reserve_back(out_subblock_num_tiles);
                                 tile_regs_wait();
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -333,18 +347,18 @@ void kernel_main() {
                                 pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
-                                cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
+                                mm_out_cb.push_back(out_subblock_num_tiles);
 
                             } else {
                                 tile_regs_commit();
                                 // Wait for tiles in output buffer to be written out since interm and output share
                                 // memory
                                 if (block == 0) {
-                                    cb_reserve_back(out_cb_id, out_num_tiles_to_wait);
+                                    out_cb.reserve_back(out_num_tiles_to_wait);
                                     out_num_tiles_to_wait += out_subblock_num_tiles;
                                 }
                                 // Move partial result to interm buffer
-                                cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                                mm_partials_cb.reserve_back(out_subblock_num_tiles);
                                 tile_regs_wait();
 
 #ifdef PACKER_L1_ACC
@@ -363,7 +377,7 @@ void kernel_main() {
                                 pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
-                                cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
+                                mm_partials_cb.push_back(out_subblock_num_tiles);
                             }
 
                             in1_index_subblock_offset += out_subblock_w;
@@ -376,16 +390,16 @@ void kernel_main() {
                     if (block < num_blocks_inner_dim - 1) {
                         // Wait for l1 accumulation to populate interm buffer,
                         // then pop to update fifo rd pointer
-                        cb_wait_front(mm_partials_cb_id, out_block_num_tiles);
-                        cb_pop_front(mm_partials_cb_id, out_block_num_tiles);
+                        mm_partials_cb.wait_front(out_block_num_tiles);
+                        mm_partials_cb.pop_front(out_block_num_tiles);
                     }
                     // never reload when with bias, bias uses interm buffer
                     enable_reload = false;
 #else
                     // Last iteration does spill and reload to output buffer
                     if (block < num_blocks_inner_dim - 2) {
-                        cb_wait_front(mm_partials_cb_id, out_block_num_tiles);
-                        cb_pop_front(mm_partials_cb_id, out_block_num_tiles);
+                        mm_partials_cb.wait_front(out_block_num_tiles);
+                        mm_partials_cb.pop_front(out_block_num_tiles);
                     }
                     if (block == num_blocks_inner_dim - 2) {
                         enable_reload = true;
@@ -397,8 +411,8 @@ void kernel_main() {
                     }
 #endif
 
-                    cb_pop_front(in0_cb_id, in0_block_num_tiles);
-                    cb_pop_front(in1_cb_id, in1_block_num_tiles);
+                    in0_cb.pop_front(in0_block_num_tiles);
+                    in1_cb.pop_front(in1_block_num_tiles);
                 }
 
 #ifdef FUSE_BIAS
@@ -416,12 +430,12 @@ void kernel_main() {
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
                 add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
                 // reconfigure unpacker df for src B
-                cb_wait_front(bias_cb_id, in1_block_w);
+                bias_cb.wait_front(in1_block_w);
                 for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                     int in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
                         // Redundant wait since we know data was just pushed
-                        cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
+                        mm_partials_cb.wait_front(out_subblock_num_tiles);
                         tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                             uint32_t bcast_tile_idx = in1_index_subblock_offset;
@@ -435,7 +449,7 @@ void kernel_main() {
                         tile_regs_commit();
 #endif
 
-                        cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
+                        mm_partials_cb.pop_front(out_subblock_num_tiles);
 
 // sfpu activation
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -446,19 +460,19 @@ void kernel_main() {
 #endif
 
                         // Pack out to output buffer
-                        cb_reserve_back(untilize_mode_out_cb_id, out_subblock_num_tiles);
+                        untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, untilize_mode_out_cb_id);
                         }
                         tile_regs_release();
-                        cb_push_back(untilize_mode_out_cb_id, out_subblock_num_tiles);
+                        untilize_mode_out_cb.push_back(out_subblock_num_tiles);
 
                         in1_index_subblock_offset += out_subblock_w;
                     }
                 }
                 if constexpr (num_blocks_w_dim > 1) {
-                    cb_pop_front(bias_cb_id, in1_block_w);
+                    bias_cb.pop_front(in1_block_w);
                 }
 #endif  // FUSE_BIAS
                 if constexpr (untilize_out) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/pack_untilize.h"
 #include "api/compute/tile_move_copy.h"
+#include "experimental/circular_buffer.h"
 #include "internal/mod_div_lib.h"
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
@@ -22,15 +23,16 @@ FORCE_INLINE void reload_from_cb_to_dst(
     uint32_t out_subblock_w,
     uint32_t out_subblock_h,
     uint32_t in0_block_w) {
+    experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
     // Reconfigure input
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
-    cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
     copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-    cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
     mm_block_init_short_with_dt(
         in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
@@ -207,6 +209,10 @@ void kernel_main() {
     constexpr uint32_t sync_cb = get_named_compile_time_arg_val("cb_sync");
     constexpr uint32_t sync_cb2 = get_named_compile_time_arg_val("cb_sync2");
 
+    experimental::CircularBuffer in1_cb(in1_cb_id);
+    experimental::CircularBuffer sync_buf(sync_cb);
+    experimental::CircularBuffer sync2_buf(sync_cb2);
+
     constexpr std::array<uint32_t, batch> mm_out_cb_ids = fill_named_cb_array<batch>(mm_out_cb_names);
     constexpr std::array<uint32_t, batch> mm_partials_cb_ids = fill_named_cb_array<batch>(mm_partials_cb_names);
 
@@ -256,6 +262,8 @@ void kernel_main() {
 #endif
         const uint32_t mm_out_cb_id = mm_out_cb_ids[b];
         const uint32_t mm_partials_cb_id = mm_partials_cb_ids[b];
+        experimental::CircularBuffer mm_out_cb(mm_out_cb_id);
+        experimental::CircularBuffer mm_partials_cb(mm_partials_cb_id);
 
         bool enable_reload = false;
         uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
@@ -272,8 +280,8 @@ void kernel_main() {
         }
 
         // Wait to receive in1
-        cb_wait_front(sync_cb2, 1);
-        cb_pop_front(sync_cb2, 1);
+        sync2_buf.wait_front(1);
+        sync2_buf.pop_front(1);
 
         for (uint32_t block = 0; block < num_blocks; block++) {
             const uint32_t curr_ring_idx = (ring_idx + block) % ring_size;
@@ -281,10 +289,11 @@ void kernel_main() {
 
             // Wait for in1 block
             if constexpr (in1_is_dram) {
-                cb_wait_front(in1_cb_id, in1_block_num_tiles);
+                in1_cb.wait_front(in1_block_num_tiles);
             }
 
             const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
+            experimental::CircularBuffer input0_cb(input0_cb_id);
             bool last_out = block == (num_blocks - 1);
 // Configure packer once for pack out without Bias
 #if not defined FUSE_BIAS and defined PACK_RELU
@@ -296,10 +305,10 @@ void kernel_main() {
 
             // Wait to receive in0 block
             if (block == 0) {
-                cb_reserve_back(input0_cb_id, in0_block_num_tiles);
-                cb_push_back(input0_cb_id, in0_block_num_tiles);
+                input0_cb.reserve_back(in0_block_num_tiles);
+                input0_cb.push_back(in0_block_num_tiles);
             }
-            cb_wait_front(input0_cb_id, in0_block_num_tiles);
+            input0_cb.wait_front(in0_block_num_tiles);
 
 #ifdef ENABLE_GLOBAL_CB
             UNPACK((calculate_next_block_index_and_update_rd_ptr(
@@ -375,7 +384,7 @@ void kernel_main() {
                         }
                         tile_regs_commit();
                         // Pack out to output buffer
-                        cb_reserve_back(mm_out_cb_id, out_subblock_num_tiles);
+                        mm_out_cb.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -398,12 +407,12 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_uninit(mm_out_cb_id);
                         }
-                        cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
+                        mm_out_cb.push_back(out_subblock_num_tiles);
 
                     } else if (spill) {
                         tile_regs_commit();
                         // Move partial result to interm buffer
-                        cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        mm_partials_cb.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #ifdef PACKER_L1_ACC
@@ -418,7 +427,7 @@ void kernel_main() {
                         pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
-                        cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        mm_partials_cb.push_back(out_subblock_num_tiles);
                     }
 
                     in1_index_subblock_offset += out_subblock_w;
@@ -430,8 +439,8 @@ void kernel_main() {
 
             // Last iteration does spill and reload to output buffer
             if (block < num_blocks - 2 && spill) {
-                cb_wait_front(mm_partials_cb_id, out_block_num_tiles);
-                cb_pop_front(mm_partials_cb_id, out_block_num_tiles);
+                mm_partials_cb.wait_front(out_block_num_tiles);
+                mm_partials_cb.pop_front(out_block_num_tiles);
             }
             if (block == num_blocks - 2 && spill) {
                 enable_reload = true;
@@ -442,9 +451,9 @@ void kernel_main() {
             }
 #endif
 
-            cb_pop_front(input0_cb_id, in0_block_num_tiles);
+            input0_cb.pop_front(in0_block_num_tiles);
             if constexpr (in1_is_dram) {
-                cb_pop_front(in1_cb_id, in1_block_num_tiles);
+                in1_cb.pop_front(in1_block_num_tiles);
             }
 #ifdef ENABLE_GLOBAL_CB
             curr_in1_block_index = next_in1_block_index;
@@ -454,8 +463,8 @@ void kernel_main() {
 
 #ifdef ENABLE_GLOBAL_CB
         // Release in1
-        cb_reserve_back(sync_cb, 1);
-        cb_push_back(sync_cb, 1);
+        sync_buf.reserve_back(1);
+        sync_buf.push_back(1);
         UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr
         UNPACK((update_rd_ptr_to_ring_index(
             in1_cb_id, in1_block_size_bytes, ring_size, in1_tensor_split)));  // update to next tensor addr

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -6,6 +6,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // same arg indices as in reader_binary_diff_lengths for compat
@@ -51,34 +54,36 @@ void kernel_main() {
     const auto s0 = TensorAccessor(src0_args, src0_addr, in0_tile_bytes);
     const auto s1 = TensorAccessor(src1_args, src1_addr, in1_tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+
     for (uint32_t n = 0; n < num_output_tiles; n++) {
         for (uint32_t kt = 0; kt < Kt; kt++) {
             {  // Read A's tile at (mt, kt)
-                cb_reserve_back(cb_id_in0, onetile);
-                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(itileA, s0, l1_write_addr_in0);
-                noc_async_read_barrier();
+                cb_in0.reserve_back(onetile);
+                noc.async_read(s0, cb_in0, in0_tile_bytes, {.page_id = itileA}, {.offset_bytes = 0});
+                noc.async_read_barrier();
                 if constexpr (in0_last_ktile_w > 0) {
                     if (kt == Kt - 1) {
                         constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(l1_write_addr_in0);
+                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(cb_in0.get_write_ptr());
                     }
                 }
                 if constexpr (in0_last_ktile_h > 0) {
                     if (kt == Kt - 1) {
                         constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(l1_write_addr_in0);
+                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(cb_in0.get_write_ptr());
                     }
                 }
-                cb_push_back(cb_id_in0, onetile);
+                cb_in0.push_back(onetile);
             }
 
             {  // Read B's tile at (kt, nt)
-                cb_reserve_back(cb_id_in1, onetile);
-                uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(itileB, s1, l1_write_addr_in1);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in1, onetile);
+                cb_in1.reserve_back(onetile);
+                noc.async_read(s1, cb_in1, in1_tile_bytes, {.page_id = itileB}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_in1.push_back(onetile);
             }
             // DPRINT << "Pushed itileA=" << itileA << " itileB=" << itileB << ENDL();
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     bool one_time_profile = true;
@@ -51,28 +54,34 @@ void kernel_main() {
     const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
 
-    uint32_t l1_write_addr_in0;
-    uint32_t l1_write_addr_in1;
-
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, in0_single_tile_size_bytes);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in1(cb_id_in1);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
         uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
         for (uint32_t block = 0; block < num_blocks; block++) {
-            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-            cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+            cb_in0.reserve_back(in0_block_num_tiles);
+            cb_in1.reserve_back(in1_block_num_tiles);
 
-            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            uint32_t in0_write_offset = 0;
+            uint32_t in1_write_offset = 0;
 
             uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
             for (uint32_t h = 0; h < in0_block_h; h++) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; w++) {
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
-                    l1_write_addr_in0 += in0_single_tile_size_bytes;
+                    noc.async_read(
+                        s0,
+                        cb_in0,
+                        in0_single_tile_size_bytes,
+                        {.page_id = in0_tensor_tile_id},
+                        {.offset_bytes = in0_write_offset});
+                    in0_write_offset += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
                 }
                 in0_tensor_row_start_tile_id += in0_tensor_stride_h;
@@ -83,18 +92,23 @@ void kernel_main() {
             for (uint32_t h = 0; h < in1_block_h; h++) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; w++) {
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
-                    l1_write_addr_in1 += in1_single_tile_size_bytes;
+                    noc.async_read(
+                        s1,
+                        cb_in1,
+                        in1_single_tile_size_bytes,
+                        {.page_id = in1_tensor_tile_id},
+                        {.offset_bytes = in1_write_offset});
+                    in1_write_offset += in1_single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                 }
                 in1_tensor_row_start_tile_id += in1_tensor_stride_h;
             }
             in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 
-            cb_push_back(cb_id_in0, in0_block_num_tiles);
-            cb_push_back(cb_id_in1, in1_block_num_tiles);
+            cb_in0.push_back(in0_block_num_tiles);
+            cb_in1.push_back(in1_block_num_tiles);
         }
         if (bcast_B == 0) {
             in1_tensor_start_tile_id += KtNt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -6,6 +6,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -37,79 +40,95 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t one_tile = 1;
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+
 #ifdef IN0_SHARDED
     const uint32_t in0_num_tiles = batch * num_blocks * in0_block_h * in0_block_w;
-    cb_reserve_back(cb_id_in0, in0_num_tiles);
-    cb_push_back(cb_id_in0, in0_num_tiles);
+    cb_in0.reserve_back(in0_num_tiles);
+    cb_in0.push_back(in0_num_tiles);
 #else
 
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     constexpr const uint32_t in0_tile_hw = get_tile_hw(cb_id_in0);
 
-    uint32_t l1_write_addr_in0;
-
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, in0_single_tile_size_bytes);
+
+#ifdef INTERMEDIATE_CB_READ
+    constexpr uint32_t in0_intermediate_cb_index = get_named_compile_time_arg_val("cb_in0_intermediate");
+    experimental::CircularBuffer cb_helper(in0_intermediate_cb_index);
+#endif
 
     for (uint32_t b = 0; b < batch; ++b) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
         for (uint32_t block = 0; block < num_blocks; ++block) {
-            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.reserve_back(in0_block_num_tiles);
 
 #ifdef INTERMEDIATE_CB_READ
-            constexpr uint32_t in0_intermediate_cb_index = get_named_compile_time_arg_val("cb_in0_intermediate");
-            cb_reserve_back(in0_intermediate_cb_index, one_tile);
-            uint32_t l1_write_addr_helper = get_write_ptr(in0_intermediate_cb_index);
+            cb_helper.reserve_back(one_tile);
 #endif  // INTERMEDIATE_CB_READ
 
-            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            uint32_t in0_write_offset = 0;
 
             uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
             for (uint32_t h = 0; h < in0_block_h; ++h) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; ++w) {
 #ifndef INTERMEDIATE_CB_READ
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                    noc.async_read(
+                        s0,
+                        cb_in0,
+                        in0_single_tile_size_bytes,
+                        {.page_id = in0_tensor_tile_id},
+                        {.offset_bytes = in0_write_offset});
 #else
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_helper);
-                    noc_async_read_barrier();
+                    noc.async_read(
+                        s0,
+                        cb_helper,
+                        in0_single_tile_size_bytes,
+                        {.page_id = in0_tensor_tile_id},
+                        {.offset_bytes = 0});
+                    noc.async_read_barrier();
                     memcpy(
-                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in0),
-                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                        /*dst=*/reinterpret_cast<void*>(cb_in0.get_write_ptr() + in0_write_offset),
+                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
                         /*size=*/in0_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
 
                     // Zero out padded regions for the very last tile
                     if constexpr (last_ktile_w > 0) {
                         if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                            pad_last_ktile<in0_data_format, last_ktile_w>(l1_write_addr_in0);
+                            pad_last_ktile<in0_data_format, last_ktile_w>(cb_in0.get_write_ptr() + in0_write_offset);
                         }
                     }
                     if constexpr (last_ktile_h > 0) {
                         if ((block == num_blocks - 1) && (w == in0_block_w - 1)) {
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                             constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                            pad_last_transposed_ktile<in0_data_format, last_ktile_h>(l1_write_addr_in0);
+                            pad_last_transposed_ktile<in0_data_format, last_ktile_h>(
+                                cb_in0.get_write_ptr() + in0_write_offset);
                         }
                     }
 
-                    l1_write_addr_in0 += in0_single_tile_size_bytes;
+                    in0_write_offset += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
                 }
                 in0_tensor_row_start_tile_id += in0_tensor_stride_h;
             }
             in0_tensor_current_block_start_tile_id += in0_tensor_next_block_stride;
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 
-            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.push_back(in0_block_num_tiles);
 
 #ifdef INTERMEDIATE_CB_READ
             // Clean up helper CB
-            cb_push_back(in0_intermediate_cb_index, one_tile);
-            cb_wait_front(in0_intermediate_cb_index, one_tile);
-            cb_pop_front(in0_intermediate_cb_index, one_tile);
+            cb_helper.push_back(one_tile);
+            cb_helper.wait_front(one_tile);
+            cb_helper.pop_front(one_tile);
 #endif  // INTERMEDIATE_CB_READ
         }
         in0_tensor_start_tile_id += MtKt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -8,6 +8,9 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
     // in0 mcast args
@@ -22,7 +25,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
     uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(6);
@@ -32,11 +34,13 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+
     volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-
-    const uint64_t in0_mcast_sender_semaphore_noc_addr =
-        get_noc_addr(in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, in0_mcast_sender_semaphore_addr);
 
     for (uint32_t b = 0; b < batch; ++b) {
         if constexpr (get_batch_from_reader) {
@@ -45,11 +49,11 @@ void kernel_main() {
             // We do this by passing the value to the compute kernel via mailbox.
             // But first, lets wait for the sparsity data to be multicast to us.
             // Set in0 semaphore value to INVALID
-            noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+            receiver_sem.set(INVALID);
             // Atomic increment source core counter
-            noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+            sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
             // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-            noc_semaphore_wait_min(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+            receiver_sem.wait_min(VALID);
 
             const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
 
@@ -68,18 +72,18 @@ void kernel_main() {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                     // Operand 0
-                    cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                    cb_in0.reserve_back(in0_block_num_tiles);
 
                     // Set in0 semaphore value to INVALID
-                    noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+                    sender_sem.up(noc, in0_mcast_sender_noc_x, in0_mcast_sender_noc_y, 1);
 
                     // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+                    receiver_sem.wait(VALID);
 
-                    cb_push_back(cb_id_in0, in0_block_num_tiles);
+                    cb_in0.push_back(in0_block_num_tiles);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -7,6 +7,11 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/debug/dprint.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
@@ -18,7 +23,6 @@ void kernel_main() {
 
     // All Gather specific
     constexpr uint32_t ring_size = get_compile_time_arg_val(3);
-    uint32_t signal_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
 
     // Runtime args
     uint32_t rt_args_idx = 0;
@@ -31,7 +35,7 @@ void kernel_main() {
     uint32_t ring_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t next_core_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t next_core_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t noc = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t noc_id = get_arg_val<uint32_t>(rt_args_idx++);
     bool end_of_hop = (bool)get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t* unpadded_in0_shard_widths_in_tiles = nullptr;
     if (!is_hop_core) {
@@ -39,22 +43,24 @@ void kernel_main() {
         rt_args_idx += ring_size;
     }
 
-    volatile tt_l1_ptr uint32_t* l1_signal_sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
-    uint64_t remote_signal_semaphore_addr = get_noc_addr(next_core_noc_x, next_core_noc_y, signal_semaphore_addr, noc);
+    experimental::Noc noc_obj(noc_id);
+    experimental::Semaphore<> signal_sem(get_compile_time_arg_val(4));
 
     constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t cb_id_in2 = get_named_compile_time_arg_val("cb_in2");
+
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in2(cb_id_in2);
 
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     constexpr uint32_t shard_size_in_tiles = shard_width_in_tiles * shard_height_in_tiles;
     constexpr uint32_t shard_size_bytes = shard_size_in_tiles * in0_single_tile_size_bytes;
 
     // Reserving/pushing the local shard is done in compute
-    cb_reserve_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
+    cb_in2.reserve_back((ring_size - 1) * shard_size_in_tiles);
 
-    uint32_t local_shard_read_addr = get_read_ptr(cb_id_in0);
-    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in2);
+    uint32_t local_shard_read_addr = cb_in0.get_read_ptr();
+    uint32_t l1_write_addr_in0 = cb_in2.get_write_ptr();
 
     uint32_t hop_core_offset = static_cast<uint32_t>(is_hop_core);
 
@@ -63,35 +69,39 @@ void kernel_main() {
         bool skip_send = !is_hop_core && unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0;
 
         uint32_t curr_shard_write_addr = l1_write_addr_in0 + shard_size_bytes * (shard_cnt - hop_core_offset);
-        uint64_t remote_curr_shard_write_addr =
-            get_noc_addr(next_core_noc_x, next_core_noc_y, curr_shard_write_addr, noc);
         uint32_t curr_shard_read_addr =
             shard_cnt == 0 ? local_shard_read_addr : l1_write_addr_in0 + shard_size_bytes * (shard_cnt - 1);
 
         // Wait for signal from previous core that data has been added to this core's in0
-        noc_semaphore_wait_min(l1_signal_sem_addr, shard_cnt);
+        signal_sem.wait_min(shard_cnt);
 
         // Send data to next core
         if (shard_cnt < ring_size - 1 || is_hop_core) {  // Skip sending the last shard
             if (!skip_send) {
-                noc_async_write(curr_shard_read_addr, remote_curr_shard_write_addr, shard_size_bytes, noc);
+                experimental::UnicastEndpoint dst_ep;
+                noc_obj.async_write(
+                    experimental::CoreLocalMem<uint32_t>(curr_shard_read_addr),
+                    dst_ep,
+                    shard_size_bytes,
+                    {},
+                    {.noc_x = next_core_noc_x, .noc_y = next_core_noc_y, .addr = curr_shard_write_addr});
             }
 
             // Signal the next core that data is ready
-            noc_semaphore_inc(remote_signal_semaphore_addr, 1, noc);
+            signal_sem.up(noc_obj, next_core_noc_x, next_core_noc_y, 1);
         }
 
         // Do stuff for matmul fusion here
         if (shard_cnt > 0) {
-            cb_push_back(cb_id_in2, shard_size_in_tiles);
+            cb_in2.push_back(shard_size_in_tiles);
         }
     }
 
     if (!is_hop_core) {
         for (uint32_t b = 0; b < batch - 1; ++b) {  // for rest batches, not need to gather in0 anymore
-            cb_reserve_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
-            cb_push_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
+            cb_in2.reserve_back((ring_size - 1) * shard_size_in_tiles);
+            cb_in2.push_back((ring_size - 1) * shard_size_in_tiles);
         }
     }
-    noc_async_atomic_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -7,6 +7,11 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // COMPILE TIME ARGS
@@ -16,7 +21,6 @@ void kernel_main() {
     constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
     constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(3);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
     uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(6);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(7);
@@ -53,16 +57,18 @@ void kernel_main() {
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in2(cb_id_in2);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+
     uint32_t l1_write_addr_in0;
 
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-    *(in0_mcast_receiver_semaphore_addr_ptr) = VALID;
+    receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
 
     const uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
         in0_mcast_dest_noc_start_x,
@@ -71,10 +77,7 @@ void kernel_main() {
         in0_mcast_dest_noc_end_y,
         in0_mcast_receiver_semaphore_addr);
 
-    const uint64_t in0_multicast_data_noc = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x, in0_mcast_dest_noc_start_y, in0_mcast_dest_noc_end_x, in0_mcast_dest_noc_end_y, 0);
-
-    uint32_t local_read_addr = get_read_ptr(cb_id_in2);
+    uint32_t local_read_addr = cb_in2.get_read_ptr();
 
     if (worker_core_type == 1) {  // mcast sender + no compute
 
@@ -82,19 +85,18 @@ void kernel_main() {
             const uint32_t block_id = sender_block_id + i;
 
             // Operand 0
-            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            l1_write_addr_in0 = cb_in0.get_write_ptr();
             if (block_id % 2 != 0) {  // double buffer
                 l1_write_addr_in0 += in0_block_size_bytes;
             }
 
-            uint64_t in0_start_address = l1_write_addr_in0;  // copy start address of block, to be used for mcasting
+            // copy start address of block, to be used for mcasting
 
             // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
-            noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
-            noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+            sender_sem.wait(in0_mcast_num_dests);
+            sender_sem.set(0);
 
             // Now we have the block in the CB address, we can mcast to dests!
-            uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
             // Zero out padded regions for the very last tile
             if constexpr (in0_last_ktile_w > 0) {
@@ -112,12 +114,28 @@ void kernel_main() {
 
 #ifndef SKIP_MCAST
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_async_write_multicast(
-                local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores - 1, true);
+            experimental::MulticastEndpoint mcast_dst;
+            noc.async_write_multicast(
+                experimental::CoreLocalMem<uint32_t>(local_read_addr),
+                mcast_dst,
+                in0_block_size_bytes,
+                in0_mcast_num_cores - 1,
+                {},
+                {.noc_x_start = in0_mcast_dest_noc_start_x,
+                 .noc_y_start = in0_mcast_dest_noc_start_y,
+                 .noc_x_end = in0_mcast_dest_noc_end_x,
+                 .noc_y_end = in0_mcast_dest_noc_end_y,
+                 .addr = l1_write_addr_in0},
+                true);
 #endif
 
-            noc_semaphore_set_multicast(
-                in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores - 1);
+            receiver_sem.set_multicast(
+                noc,
+                in0_mcast_dest_noc_start_x,
+                in0_mcast_dest_noc_start_y,
+                in0_mcast_dest_noc_end_x,
+                in0_mcast_dest_noc_end_y,
+                in0_mcast_num_cores - 1);
 
             local_read_addr += in0_block_size_bytes;
         }
@@ -127,19 +145,17 @@ void kernel_main() {
         for (uint32_t block = 0; block < num_blocks; ++block) {
             const uint32_t block_id = block / num_blocks_per_shard;
 
-            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.reserve_back(in0_block_num_tiles);
             // Set in0 semaphore value to INVALID
-            noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+            receiver_sem.set(INVALID);
 
             if (block_id == sender_id) {
-                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                uint64_t in0_start_address = l1_write_addr_in0;  // copy start address of block, to be used for mcasting
+                uint32_t l1_write_addr_in0 = cb_in0.get_write_ptr();
+                // copy start address of block, to be used for mcasting
 
                 // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
-                noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests - 1);
-                noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
-
-                uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
+                sender_sem.wait(in0_mcast_num_dests - 1);
+                sender_sem.set(0);
 
                 // Zero out padded regions for the very last tile
                 if constexpr (in0_last_ktile_w > 0) {
@@ -155,8 +171,19 @@ void kernel_main() {
                     }
                 }
 #ifndef SKIP_MCAST
-                noc_async_write_multicast_loopback_src(
-                    local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);
+                experimental::MulticastEndpoint mcast_dst;
+                noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                    experimental::CoreLocalMem<uint32_t>(local_read_addr),
+                    mcast_dst,
+                    in0_block_size_bytes,
+                    in0_mcast_num_cores,
+                    {},
+                    {.noc_x_start = in0_mcast_dest_noc_start_x,
+                     .noc_y_start = in0_mcast_dest_noc_start_y,
+                     .noc_x_end = in0_mcast_dest_noc_end_x,
+                     .noc_y_end = in0_mcast_dest_noc_end_y,
+                     .addr = l1_write_addr_in0},
+                    true);
 #endif
                 noc_semaphore_set_multicast_loopback_src(
                     in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
@@ -164,17 +191,12 @@ void kernel_main() {
                 local_read_addr += in0_block_size_bytes;
 
             } else {
-                uint64_t in0_mcast_sender_semaphore_noc_addr = get_noc_addr(
-                    in0_mcast_sender_noc_x[block_id],
-                    in0_mcast_sender_noc_y[block_id],
-                    in0_mcast_sender_semaphore_addr);
-
                 // Atomic increment source core counter
-                noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+                sender_sem.up(noc, in0_mcast_sender_noc_x[block_id], in0_mcast_sender_noc_y[block_id], 1);
             }
 
-            noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
-            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            receiver_sem.wait(VALID);
+            cb_in0.push_back(in0_block_num_tiles);
         }
     } else {  // mcast receiver + compute
 
@@ -182,24 +204,20 @@ void kernel_main() {
             const uint32_t block_id = block / num_blocks_per_shard;
 
             // get the mcast sender noc
-            uint64_t in0_mcast_sender_semaphore_noc_addr = get_noc_addr(
-                in0_mcast_sender_noc_x[block_id], in0_mcast_sender_noc_y[block_id], in0_mcast_sender_semaphore_addr);
 
             // Operand 0
-            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.reserve_back(in0_block_num_tiles);
 
             // Set in0 semaphore value to INVALID
-            noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
-
+            receiver_sem.set(INVALID);
             // Atomic increment source core counter
-            noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
-
+            sender_sem.up(noc, in0_mcast_sender_noc_x[block_id], in0_mcast_sender_noc_y[block_id], 1);
             // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-            noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+            receiver_sem.wait(VALID);
 
-            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.push_back(in0_block_num_tiles);
         }
     }
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc.async_write_barrier();
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -13,6 +13,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
 
 void kernel_main() {
     // COMPILE TIME ARGS
@@ -37,7 +40,9 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
 
     // Build NOC address for the remote input storage core
-    uint64_t remote_shard_base_noc_addr = get_noc_addr(input_storage_noc_x, input_storage_noc_y, input_shard_l1_addr);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::UnicastEndpoint src_core;
 
     // Process each batch
     for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
@@ -45,16 +50,19 @@ void kernel_main() {
 
         // Process K blocks within each batch
         for (uint32_t block = 0; block < num_blocks; ++block) {
-            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(in0_block_num_tiles);
 
             // NOC read block from REMOTE input storage core to local CB
             uint32_t read_offset = batch_offset + block * in0_block_size_bytes;
-            uint64_t src_noc_addr = remote_shard_base_noc_addr + read_offset;
-            noc_async_read(src_noc_addr, l1_write_addr, in0_block_size_bytes);
-            noc_async_read_barrier();
+            noc.async_read(
+                src_core,
+                cb_in0,
+                in0_block_size_bytes,
+                {.noc_x = input_storage_noc_x, .noc_y = input_storage_noc_y, .addr = input_shard_l1_addr + read_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
 
-            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            cb_in0.push_back(in0_block_num_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -10,6 +10,12 @@
 #include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     uint32_t rt_args_idx = 0;
@@ -48,28 +54,26 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(13);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(14);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
     uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(17);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(18);
     // batch args
     constexpr uint32_t MtKt = get_compile_time_arg_val(19);  // if 0
-    constexpr uint32_t in0_B = get_compile_time_arg_val(20);
-    constexpr uint32_t in1_B = get_compile_time_arg_val(21);
+    constexpr uint32_t batch = get_compile_time_arg_val(20);
 
     // sparsity args
 
-    constexpr uint32_t batchB = get_compile_time_arg_val(22);
-    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(23);
+    constexpr uint32_t batchB = get_compile_time_arg_val(21);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(22);
     // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
     // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
-    constexpr bool bcast_A = (bool)get_compile_time_arg_val(24);
+    constexpr bool bcast_A = (bool)get_compile_time_arg_val(23);
     // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
-    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(25);
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(24);
 
-    constexpr bool fuse_op = (bool)get_compile_time_arg_val(26);
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(25);
 
-    constexpr auto in0_args = TensorAccessorArgs<27>();
+    constexpr auto in0_args = TensorAccessorArgs<26>();
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
     // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
@@ -95,6 +99,11 @@ void kernel_main() {
     constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
     constexpr uint32_t one_tile = 1;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(15));
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(16));
+
 #ifdef IN0_SHARDED
     // In case we need to send multiple blocks per shard, in0 sharded cb is cb2 and we extract the sub-blocks to cb0
     constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
@@ -107,52 +116,46 @@ void kernel_main() {
     if constexpr (extract_shard_sub_blocks) {
         constexpr uint32_t cb_id_in2 =
             get_named_compile_time_arg_val("cb_in0_sharded");  // in0 sharded cb if extract_shard_sub_blocks
-        noc_shard_read_start_addr = get_read_ptr(cb_id_in2);
+        experimental::CircularBuffer cb_in2(cb_id_in2);
+        noc_shard_read_start_addr = cb_in2.get_read_ptr();
     }
 
 #else
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, in0_single_tile_size_bytes);
+#ifndef IN0_SHARDED
+#ifdef INTERMEDIATE_CB_READ
+    constexpr uint32_t in0_intermediate_cb_index = get_named_compile_time_arg_val("cb_in0_intermediate");
+    experimental::CircularBuffer cb_helper(in0_intermediate_cb_index);
+#endif  // INTERMEDIATE_CB_READ
+#endif
 #endif  // IN0_SHARDED
 
     // sparsity accessor
     constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    experimental::CircularBuffer cb_sparsity(cb_id_sparsity);
     const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr, sparsity_pagesize);
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
-    *(in0_mcast_receiver_semaphore_addr_ptr) = VALID;
+    receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
-
-    const uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
-
-    const uint64_t in0_multicast_data_noc = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x, in0_mcast_dest_noc_start_y, in0_mcast_dest_noc_end_x, in0_mcast_dest_noc_end_y, 0);
 
 #ifdef IN0_SHARDED
-    uint32_t in0_start_address = get_write_ptr(cb_id_in0);
+    uint32_t in0_start_address = cb_in0.get_write_ptr();
 #endif  // IN0_SHARDED
 #endif  // SKIP_MCAST
 
     uint32_t l1_write_addr_sparsity = 0;
     if constexpr (batchB > 0) {
-        cb_reserve_back(cb_id_sparsity, 1);
-        l1_write_addr_sparsity = get_write_ptr(cb_id_sparsity);
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
     }
 
-    for (uint32_t b = 0; b < in0_B; ++b) {
+    for (uint32_t b = 0; b < batch; ++b) {
         if constexpr (batchB > 0) {
             noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
-            noc_async_read_barrier();
+            noc.async_read_barrier();
         }
 
         for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
@@ -163,14 +166,19 @@ void kernel_main() {
                 if constexpr (get_batch_from_reader) {
 #ifndef SKIP_MCAST
                     // First broadcast this to other cores
-                    noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
-                    noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
-                    noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, is_batch_valid ? VALID : IGNORE_BATCH);
-                    noc_semaphore_set_multicast(
-                        in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
-                    noc_async_writes_flushed();
+                    sender_sem.wait(in0_mcast_num_dests);
+                    sender_sem.set(0);
+                    receiver_sem.set(is_batch_valid ? VALID : IGNORE_BATCH);
+                    receiver_sem.set_multicast(
+                        noc,
+                        in0_mcast_dest_noc_start_x,
+                        in0_mcast_dest_noc_start_y,
+                        in0_mcast_dest_noc_end_x,
+                        in0_mcast_dest_noc_end_y,
+                        in0_mcast_num_cores);
+                    noc.async_writes_flushed();
                     // Reset the semaphore value to VALID
-                    noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+                    receiver_sem.set(VALID);
 #endif  // SKIP_MCAST
 
                     // We need to pass the value to compute cores regardless of the value of is_batch_valid
@@ -205,22 +213,19 @@ void kernel_main() {
 
                         // Operand 0
                         // Common for sharded and interleaved paths
-                        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                        cb_in0.reserve_back(in0_block_num_tiles);
 #ifndef IN0_SHARDED
 
 #ifdef INTERMEDIATE_CB_READ
-                        constexpr uint32_t in0_intermediate_cb_index =
-                            get_named_compile_time_arg_val("cb_in0_intermediate");
-                        cb_reserve_back(in0_intermediate_cb_index, one_tile);
-                        uint32_t l1_write_addr_helper = get_write_ptr(in0_intermediate_cb_index);
+                        cb_helper.reserve_back(one_tile);
 #endif  // INTERMEDIATE_CB_READ
 
-                        uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                        uint32_t in0_write_offset = 0;
 
 #ifndef SKIP_MCAST
                         uint32_t in0_start_address =
-                            l1_write_addr_in0;  // copy start address of block, to be used for mcasting
-#endif                                          // SKIP_MCAST
+                            cb_in0.get_write_ptr();  // copy start address of block, to be used for mcasting
+#endif                                               // SKIP_MCAST
 
                         // Copy in0 block into CB, as the default kernel
                         uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_inner_dim_block_start_tile_id;
@@ -229,13 +234,23 @@ void kernel_main() {
                             for (uint32_t w = 0; w < in0_block_w; ++w) {
                                 if (bh < num_blocks_h_dim - 1 || h < last_block_h) {
 #ifndef INTERMEDIATE_CB_READ
-                                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                                    noc.async_read(
+                                        s0,
+                                        cb_in0,
+                                        in0_single_tile_size_bytes,
+                                        {.page_id = in0_tensor_tile_id},
+                                        {.offset_bytes = in0_write_offset});
 #else
-                                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_helper);
-                                    noc_async_read_barrier();
+                                    noc.async_read(
+                                        s0,
+                                        cb_helper,
+                                        in0_single_tile_size_bytes,
+                                        {.page_id = in0_tensor_tile_id},
+                                        {.offset_bytes = 0});
+                                    noc.async_read_barrier();
                                     memcpy(
-                                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in0),
-                                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                                        /*dst=*/reinterpret_cast<void*>(cb_in0.get_write_ptr() + in0_write_offset),
+                                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
                                         /*size=*/in0_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
                                 }
@@ -243,20 +258,22 @@ void kernel_main() {
                                 // Zero out padded regions for the very last tile
                                 if constexpr (in0_last_ktile_w > 0) {
                                     if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
-                                        noc_async_read_barrier();
+                                        noc.async_read_barrier();
                                         const DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(l1_write_addr_in0);
+                                        pad_last_ktile<in0_data_format, in0_last_ktile_w>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
                                     }
                                 }
                                 if constexpr (in0_last_ktile_h > 0) {
                                     if ((block == num_blocks_inner_dim - 1) && (w == in0_block_w - 1)) {
-                                        noc_async_read_barrier();
+                                        noc.async_read_barrier();
                                         const DataFormat in0_data_format = get_dataformat(cb_id_in0);
-                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(l1_write_addr_in0);
+                                        pad_last_transposed_ktile<in0_data_format, in0_last_ktile_h>(
+                                            cb_in0.get_write_ptr() + in0_write_offset);
                                     }
                                 }
 
-                                l1_write_addr_in0 += in0_single_tile_size_bytes;
+                                in0_write_offset += in0_single_tile_size_bytes;
                                 in0_tensor_tile_id += in0_tensor_stride_w;
                             }
                             in0_tensor_row_start_tile_id += in0_tensor_stride_h;
@@ -264,27 +281,33 @@ void kernel_main() {
                         in0_tensor_current_inner_dim_block_start_tile_id += in0_tensor_next_inner_dim_block_stride;
 
                         // Barrier! make sure the reads are done
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #else
                         if constexpr (extract_shard_sub_blocks) {
-                            uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                            uint32_t l1_write_addr_in0 = cb_in0.get_write_ptr();
 
 #ifndef SKIP_MCAST
                             in0_start_address =
                                 l1_write_addr_in0;  // copy start address of block, to be used for mcasting
 #endif  // SKIP_MCAST
 
-                            uint64_t noc_shard_read_addr = get_noc_addr(in0_tensor_current_inner_dim_block_start_addr);
+                            experimental::UnicastEndpoint self_ep;
+                            uint32_t noc_shard_read_l1_addr = in0_tensor_current_inner_dim_block_start_addr;
 
                             for (uint32_t i = 0; i < in0_block_h; i++) {
-                                noc_async_read(noc_shard_read_addr, l1_write_addr_in0, shard_read_width);
+                                noc.async_read(
+                                    self_ep,
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_in0),
+                                    shard_read_width,
+                                    {.noc_x = my_x[0], .noc_y = my_y[0], .addr = noc_shard_read_l1_addr},
+                                    {});
 
                                 l1_write_addr_in0 += shard_read_width;
-                                noc_shard_read_addr += shard_read_stride;
+                                noc_shard_read_l1_addr += shard_read_stride;
                             }
 
                             in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
                         }
 #endif  // IN0_SHARDED
 
@@ -292,18 +315,23 @@ void kernel_main() {
                         // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
-                        noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
-                        noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+                        sender_sem.wait(in0_mcast_num_dests);
+                        sender_sem.set(0);
 
                         // Now we have the block in the CB address, we can mcast to dests!
-                        uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
-
+                        experimental::MulticastEndpoint mcast_dst;
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(
-                            in0_start_address,
-                            in0_multicast_data_addr,
+                        noc.async_write_multicast(
+                            experimental::CoreLocalMem<uint32_t>(in0_start_address),
+                            mcast_dst,
                             in0_block_size_bytes,
                             in0_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in0_mcast_dest_noc_start_x,
+                             .noc_y_start = in0_mcast_dest_noc_start_y,
+                             .noc_x_end = in0_mcast_dest_noc_end_x,
+                             .noc_y_end = in0_mcast_dest_noc_end_y,
+                             .addr = in0_start_address},
                             true);
 
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
@@ -312,24 +340,27 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
                         // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV
                         // latency which means data could be changed before write is issued.
-                        noc_async_writes_flushed();
+                        noc.async_writes_flushed();
 #endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(
-                            in0_mcast_receiver_semaphore_addr,
-                            in0_mcast_receiver_semaphore_noc_addr,
+                        receiver_sem.set_multicast(
+                            noc,
+                            in0_mcast_dest_noc_start_x,
+                            in0_mcast_dest_noc_start_y,
+                            in0_mcast_dest_noc_end_x,
+                            in0_mcast_dest_noc_end_y,
                             in0_mcast_num_cores);
 #endif  // SKIP_MCAST
 
                         // Common for sharded and interleaved paths
-                        cb_push_back(cb_id_in0, in0_block_num_tiles);
+                        cb_in0.push_back(in0_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
                         // Clean up helper CB
-                        cb_push_back(in0_intermediate_cb_index, one_tile);
-                        cb_wait_front(in0_intermediate_cb_index, one_tile);
-                        cb_pop_front(in0_intermediate_cb_index, one_tile);
+                        cb_helper.push_back(one_tile);
+                        cb_helper.wait_front(one_tile);
+                        cb_helper.pop_front(one_tile);
 #endif  // INTERMEDIATE_CB_READ
                     }
                 }
@@ -353,20 +384,12 @@ void kernel_main() {
         // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
         // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
         // CB so compute kernel thinks it has new data
-        if (in0_B == 1 && in1_B > 1) {
-            for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
-                for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
-                    cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-                    cb_push_back(cb_id_in0, in0_block_num_tiles);
-                }
-            }
-        }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     // For completeness, we empty the sparsity CB if it was reserved earlier
     if constexpr (batchB > 0) {
-        cb_push_back(cb_id_sparsity, 1);
-        cb_wait_front(cb_id_sparsity, 1);
-        cb_pop_front(cb_id_sparsity, 1);
+        cb_sparsity.push_back(1);
+        cb_sparsity.wait_front(1);
+        cb_sparsity.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -59,21 +59,22 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(18);
     // batch args
     constexpr uint32_t MtKt = get_compile_time_arg_val(19);  // if 0
-    constexpr uint32_t batch = get_compile_time_arg_val(20);
+    constexpr uint32_t in0_B = get_compile_time_arg_val(20);
+    constexpr uint32_t in1_B = get_compile_time_arg_val(21);
 
     // sparsity args
 
-    constexpr uint32_t batchB = get_compile_time_arg_val(21);
-    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(22);
+    constexpr uint32_t batchB = get_compile_time_arg_val(22);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(23);
     // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
     // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
-    constexpr bool bcast_A = (bool)get_compile_time_arg_val(23);
+    constexpr bool bcast_A = (bool)get_compile_time_arg_val(24);
     // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
-    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(24);
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(25);
 
-    constexpr bool fuse_op = (bool)get_compile_time_arg_val(25);
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(26);
 
-    constexpr auto in0_args = TensorAccessorArgs<26>();
+    constexpr auto in0_args = TensorAccessorArgs<27>();
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
     // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
@@ -152,7 +153,7 @@ void kernel_main() {
         l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
     }
 
-    for (uint32_t b = 0; b < batch; ++b) {
+    for (uint32_t b = 0; b < in0_B; ++b) {
         if constexpr (batchB > 0) {
             noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
             noc.async_read_barrier();
@@ -384,6 +385,14 @@ void kernel_main() {
         // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
         // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
         // CB so compute kernel thinks it has new data
+        if (in0_B == 1 && in1_B > 1) {
+            for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
+                for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
+                    cb_in0.reserve_back(in0_block_num_tiles);
+                    cb_in0.push_back(in0_block_num_tiles);
+                }
+            }
+        }
     }
     noc.async_write_barrier();
     // For completeness, we empty the sparsity CB if it was reserved earlier

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -54,7 +54,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(13);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(14);
     // in0 mcast args
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(17);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(18);
     // batch args

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -8,6 +8,11 @@
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     constexpr bool core_has_output_block_work = (bool)get_compile_time_arg_val(0);
@@ -62,17 +67,19 @@ void kernel_main() {
     constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
     constexpr uint32_t in0_tensor_next_h_dim_block_stride = shard_read_stride * in0_block_h;
 
-    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in0(cb_id_in0);
+    experimental::CircularBuffer cb_in2(cb_id_in2);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(9));
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(10));
 
-    // L1 array
+    // L1 array for valid semaphore value
     constexpr uint32_t cb_l1_array = get_named_compile_time_arg_val("cb_l1_array");
-    uint32_t in0_mcast_sender_semaphore_valid_addr = get_write_ptr(cb_l1_array);
+    experimental::CircularBuffer cb_l1(cb_l1_array);
+    uint32_t in0_mcast_sender_semaphore_valid_addr = cb_l1.get_write_ptr();
     volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_valid_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_valid_addr);
     // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -80,12 +87,13 @@ void kernel_main() {
         VALID;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
 
     constexpr uint32_t num_remote_senders = (num_blocks_inner_dim + num_blocks_per_shard - 1) / num_blocks_per_shard;
-    uint64_t remote_sender_noc_addrs[num_remote_senders];
+    uint32_t remote_sender_noc_x[num_remote_senders];
+    uint32_t remote_sender_noc_y[num_remote_senders];
     if constexpr (transpose_mcast) {
         uint32_t x = 0, y = 0;
         for (uint32_t i = 0; i < num_remote_senders; ++i) {
-            remote_sender_noc_addrs[i] =
-                get_noc_addr(in0_mcast_noc_x[x], in0_mcast_noc_y[y], in0_mcast_sender_semaphore_addr);
+            remote_sender_noc_x[i] = in0_mcast_noc_x[x];
+            remote_sender_noc_y[i] = in0_mcast_noc_y[y];
             ++y;
             if (y == num_y) {
                 y = 0;
@@ -95,8 +103,8 @@ void kernel_main() {
     } else {
         uint32_t x = 0, y = 0;
         for (uint32_t i = 0; i < num_remote_senders; ++i) {
-            remote_sender_noc_addrs[i] =
-                get_noc_addr(in0_mcast_noc_x[x], in0_mcast_noc_y[y], in0_mcast_sender_semaphore_addr);
+            remote_sender_noc_x[i] = in0_mcast_noc_x[x];
+            remote_sender_noc_y[i] = in0_mcast_noc_y[y];
             ++x;
             if (x == num_x) {
                 x = 0;
@@ -104,17 +112,18 @@ void kernel_main() {
             }
         }
     }
-    const uint64_t in0_multicast_data_noc = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x, in0_mcast_dest_noc_start_y, in0_mcast_dest_noc_end_x, in0_mcast_dest_noc_end_y, 0);
+    uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+        in0_mcast_dest_noc_start_x,
+        in0_mcast_dest_noc_start_y,
+        in0_mcast_dest_noc_end_x,
+        in0_mcast_dest_noc_end_y,
+        in0_mcast_receiver_semaphore_addr);
 
-    uint64_t in0_mcast_receiver_semaphore_noc_addr =
-        in0_multicast_data_noc | (uint64_t)in0_mcast_receiver_semaphore_addr;
+    receiver_sem.set(VALID);
 
-    noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+    cb_in2.reserve_back(batch * in0_block_num_tiles);
 
-    cb_reserve_back(cb_id_in2, batch * in0_block_num_tiles);
-
-    uint32_t in0_tensor_shard_read_addr = get_read_ptr(cb_id_in2);
+    uint32_t in0_tensor_shard_read_addr = cb_in2.get_read_ptr();
     uint32_t in0_tensor_read_addr = 0;
 
     MatmulOpReceiver fused_op_receiver;
@@ -140,7 +149,7 @@ void kernel_main() {
                         block_id = fused_op_receiver.align_to_slice_and_sync(block, sender_id);
                     }
 
-                    cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                    cb_in0.reserve_back(in0_block_num_tiles);
 
                     // All cores in receiver grid need to participate in receiving regardless if they produce output
                     // work or not. Otherwise, data corruption since we mcast from and to the same CB (eg.
@@ -148,28 +157,34 @@ void kernel_main() {
                     // CB), we can have just the cores that produce work participate in receiving.
                     if constexpr (core_in_in0_receiver_mcast_grid) {
                         // Set in0 semaphore value to INVALID
-                        noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+                        receiver_sem.set(INVALID);
                     }
 
                     if (block_id == sender_id) {
                         // Operand 0
-                        uint32_t in0_tensor_local_l1_write_addr = get_write_ptr(cb_id_in0);
+                        uint32_t in0_tensor_local_l1_write_addr = cb_in0.get_write_ptr();
 
                         if constexpr (extract_shard_sub_blocks) {
                             in0_tensor_read_addr = in0_tensor_local_l1_write_addr;
 
                             uint32_t l1_write_extract_shard_in0 = in0_tensor_local_l1_write_addr;
-                            uint64_t noc_shard_read_addr = get_noc_addr(in0_tensor_current_inner_dim_block_start_addr);
+                            experimental::UnicastEndpoint self_ep;
+                            uint32_t noc_shard_read_l1_addr = in0_tensor_current_inner_dim_block_start_addr;
 
                             for (uint32_t i = 0; i < out_block_h; i++) {
-                                noc_async_read(noc_shard_read_addr, l1_write_extract_shard_in0, shard_read_width);
+                                noc.async_read(
+                                    self_ep,
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_extract_shard_in0),
+                                    shard_read_width,
+                                    {.noc_x = my_x[0], .noc_y = my_y[0], .addr = noc_shard_read_l1_addr},
+                                    {});
                                 l1_write_extract_shard_in0 += shard_read_width;
-                                noc_shard_read_addr += shard_read_stride;
+                                noc_shard_read_l1_addr += shard_read_stride;
                             }
 
                             in0_tensor_current_inner_dim_block_start_addr += shard_read_width;
 
-                            noc_async_read_barrier();
+                            noc.async_read_barrier();
 
                             if constexpr (in0_last_ktile_w > 0) {
                                 if ((block == num_blocks_inner_dim - 1)) {
@@ -208,16 +223,14 @@ void kernel_main() {
                         // zero for the next block
                         if constexpr (core_in_in0_receiver_mcast_grid) {
                             // wait for every core in receiver grid EXCLUDING myself
-                            noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests - 1);
+                            sender_sem.wait(in0_mcast_num_dests - 1);
                         } else {
                             // wait for every core in receiver grid
-                            noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
+                            sender_sem.wait(in0_mcast_num_dests);
                         }
-                        noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+                        sender_sem.set(0);
 
                         // Now we have the block in the CB address, we can mcast to dests!
-                        uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_tensor_local_l1_write_addr;
-
                         if constexpr (core_in_in0_receiver_mcast_grid) {
                             // Mcast from/to same CB
                             if constexpr (extract_shard_sub_blocks) {
@@ -225,11 +238,18 @@ void kernel_main() {
                                 // Skip if there are no other cores since this core already has the data.
                                 // Note: noc_async_write_multicast[_loopback_src] may hang if called with 0 cores.
                                 if constexpr (in0_mcast_num_cores > 1) {
-                                    noc_async_write_multicast(
-                                        in0_tensor_read_addr,
-                                        in0_multicast_data_addr,
+                                    experimental::MulticastEndpoint mcast_dst;
+                                    noc.async_write_multicast(
+                                        experimental::CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        mcast_dst,
                                         in0_block_size_bytes,
                                         in0_mcast_num_cores - 1,
+                                        {},
+                                        {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                         .noc_y_start = in0_mcast_dest_noc_start_y,
+                                         .noc_x_end = in0_mcast_dest_noc_end_x,
+                                         .noc_y_end = in0_mcast_dest_noc_end_y,
+                                         .addr = in0_tensor_local_l1_write_addr},
                                         true);
                                 }
                             }
@@ -237,15 +257,29 @@ void kernel_main() {
                             else {
                                 if constexpr (in0_mcast_num_cores == 1) {
                                     // noc_async_write if we only want to copy data between CB locally
-                                    noc_async_write(
-                                        in0_tensor_read_addr, in0_multicast_data_addr, in0_block_size_bytes);
+                                    experimental::UnicastEndpoint ucast_dst;
+                                    noc.async_write(
+                                        experimental::CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        ucast_dst,
+                                        in0_block_size_bytes,
+                                        {},
+                                        {.noc_x = in0_mcast_dest_noc_start_x,
+                                         .noc_y = in0_mcast_dest_noc_start_y,
+                                         .addr = in0_tensor_local_l1_write_addr});
                                 } else {
                                     // multicast to every core in receiver grid
-                                    noc_async_write_multicast_loopback_src(
-                                        in0_tensor_read_addr,
-                                        in0_multicast_data_addr,
+                                    experimental::MulticastEndpoint mcast_dst;
+                                    noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                        experimental::CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                        mcast_dst,
                                         in0_block_size_bytes,
                                         in0_mcast_num_cores,
+                                        {},
+                                        {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                         .noc_y_start = in0_mcast_dest_noc_start_y,
+                                         .noc_x_end = in0_mcast_dest_noc_end_x,
+                                         .noc_y_end = in0_mcast_dest_noc_end_y,
+                                         .addr = in0_tensor_local_l1_write_addr},
                                         true);
                                 }
                             }
@@ -255,7 +289,7 @@ void kernel_main() {
                                 // All work is done on one core (the current one).
                                 // noc_semaphore_set_multicast_loopback_src is a no-op in this case.
                                 // Data needs to be written directly in the core.
-                                in0_mcast_receiver_semaphore_addr_ptr[0] = VALID;
+                                receiver_sem.set(VALID);
                             } else {
                                 noc_semaphore_set_multicast_loopback_src(
                                     in0_mcast_sender_semaphore_valid_addr,
@@ -265,11 +299,18 @@ void kernel_main() {
                         } else {
                             // If we are not part of receiver grid, always do a regular noc_async_write_multicast to all
                             // cores in receiver grid
-                            noc_async_write_multicast(
-                                in0_tensor_read_addr,
-                                in0_multicast_data_addr,
+                            experimental::MulticastEndpoint mcast_dst;
+                            noc.async_write_multicast(
+                                experimental::CoreLocalMem<uint32_t>(in0_tensor_read_addr),
+                                mcast_dst,
                                 in0_block_size_bytes,
                                 in0_mcast_num_cores,
+                                {},
+                                {.noc_x_start = in0_mcast_dest_noc_start_x,
+                                 .noc_y_start = in0_mcast_dest_noc_start_y,
+                                 .noc_x_end = in0_mcast_dest_noc_end_x,
+                                 .noc_y_end = in0_mcast_dest_noc_end_y,
+                                 .addr = in0_tensor_local_l1_write_addr},
                                 true);
 
                             // We should also multicast the flag to destinations
@@ -285,28 +326,26 @@ void kernel_main() {
                         // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
                         // which means data could be changed before
                         //  write is issued.
-                        noc_async_writes_flushed();
+                        noc.async_writes_flushed();
 #endif
 
                     } else if constexpr (core_in_in0_receiver_mcast_grid) {
-                        uint64_t in0_mcast_sender_semaphore_noc_addr = remote_sender_noc_addrs[block_id];
-
-                        // Atomic increment source core counter
-                        noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+                        // Increment remote sender's semaphore using pre-computed coordinates
+                        sender_sem.up(noc, remote_sender_noc_x[block_id], remote_sender_noc_y[block_id], 1);
                     }
 
                     if constexpr (core_in_in0_receiver_mcast_grid) {
                         // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
-                        noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+                        receiver_sem.wait(VALID);
                     }
-                    cb_push_back(cb_id_in0, in0_block_num_tiles);
+                    cb_in0.push_back(in0_block_num_tiles);
 
                     // If core does not produce output block work, free cb_id_in0 immediately.
                     // This is necessary since mcast is in lockstep; this ensures write ptr addresses are synced
                     // properly for cores that only send and have no compute / writer active. Technically, don't have to
                     // do this if cb_id_in0 is not double buffered.
                     if constexpr (!core_has_output_block_work) {
-                        cb_pop_front(cb_id_in0, in0_block_num_tiles);
+                        cb_in0.pop_front(in0_block_num_tiles);
                     }
                 }
             }
@@ -314,5 +353,5 @@ void kernel_main() {
         }
     }
 
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -7,6 +7,10 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // READER
@@ -46,8 +50,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
     // in1 mcast args
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(6);
 
@@ -94,14 +96,17 @@ void kernel_main() {
     const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
     constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
 
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_out(cb_id_out0);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(4));
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+#ifdef FUSE_BIAS
+    experimental::CircularBuffer cb_in3(cb_id_in3);
+#endif
 
     // WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr, output_single_tile_size_bytes);
-
-    const uint64_t in1_mcast_sender_semaphore_noc_addr =
-        get_noc_addr(in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, in1_mcast_sender_semaphore_addr);
 
     for (uint32_t b = 0; b < batch; ++b) {
         uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
@@ -110,36 +115,36 @@ void kernel_main() {
             for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                 for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                     // Operand 1
-                    cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                    cb_in1.reserve_back(in1_block_num_tiles);
 
                     // Set in1 semaphore value to INVALID
-                    noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
 
                     // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
+                    receiver_sem.wait(VALID);
 
-                    cb_push_back(cb_id_in1, in1_block_num_tiles);
+                    cb_in1.push_back(in1_block_num_tiles);
                 }
 
 #ifdef FUSE_BIAS
                 // Only read bias on first batch, or we have multiple output blocks
                 if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
                     // Operand 2
-                    cb_reserve_back(cb_id_in3, in3_block_w);
+                    cb_in3.reserve_back(in3_block_w);
 
                     // Set in1 semaphore value to INVALID
-                    noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    receiver_sem.set(INVALID);
 
                     // Atomic increment source core counter
-                    noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
 
                     // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
-                    noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
+                    receiver_sem.wait(VALID);
 
-                    cb_push_back(cb_id_in3, in3_block_w);
+                    cb_in3.push_back(in3_block_w);
                 }
 #endif
 
@@ -172,41 +177,46 @@ void kernel_main() {
                             subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                         }
 
-                        cb_wait_front(cb_id_out0, out_subblock_tile_count);
-                        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                        cb_out.wait_front(out_subblock_tile_count);
+                        uint32_t out_read_offset = 0;
 
                         for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                             uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                             for (uint32_t w = 0; w < out_subblock_w_; ++w) {
                                 if (bh < num_blocks_h_dim_ && bw < num_blocks_w_dim_) {
-                                    noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                    noc.async_write(
+                                        experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                                        s,
+                                        output_single_tile_size_bytes,
+                                        {.offset_bytes = out_read_offset},
+                                        {.page_id = out_tensor_tile_id});
                                 }
 
-                                l1_read_addr += output_single_tile_size_bytes;
+                                out_read_offset += output_single_tile_size_bytes;
 
                                 out_tensor_tile_id += out_tensor_stride_w;
                             }
                             // Skip padded tiles in subblock along row
-                            l1_read_addr += subblock_tiles_addr_skip;
+                            out_read_offset += subblock_tiles_addr_skip;
                             out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                         }
 
-                        noc_async_write_barrier();
+                        noc.async_write_barrier();
 
-                        cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                        cb_out.pop_front(out_subblock_tile_count);
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
                     // Pop fully padded subblocks along the row
                     if (bw == num_blocks_w_dim_ - 1) {
-                        cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
-                        cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
+                        cb_out.wait_front(padded_block_tiles_w_skip);
+                        cb_out.pop_front(padded_block_tiles_w_skip);
                     }
                     out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
                 }
                 // Pop row(s) of fully padded subblocks
                 if (bh == num_blocks_h_dim_ - 1) {
-                    cb_wait_front(cb_id_out0, padded_block_tiles_h_skip);
-                    cb_pop_front(cb_id_out0, padded_block_tiles_h_skip);
+                    cb_out.wait_front(padded_block_tiles_h_skip);
+                    cb_out.pop_front(padded_block_tiles_h_skip);
                 }
 #endif
                 out_tensor_current_w_dim_block_tile_id += out_tensor_next_w_dim_block_stride;
@@ -222,8 +232,7 @@ void kernel_main() {
     }
 
 #if OUT_SHARDED
-    cb_wait_front(
-        cb_id_out0,
+    cb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -9,12 +9,17 @@
 #include "api/remote_circular_buffer.h"
 #include "api/debug/dprint.h"
 #include "api/debug/dprint_tile.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
 template <typename TensorAccessorType>
 void read_block_from_dram(
-    uint32_t cb_id,
+    const experimental::Noc& noc,
+    experimental::CircularBuffer& cb,
     const TensorAccessorType& s1,
     uint32_t tensor_width_in_tiles,
     uint32_t block_w_idx,
@@ -22,25 +27,26 @@ void read_block_from_dram(
     uint32_t block_w_t,
     uint32_t block_h_t,
     uint32_t tile_size_bytes) {
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t write_offset = 0;
 
     // Horizontal idx + vertical idx * width = row major index
     uint32_t block_tile_id = block_w_idx * block_w_t + (block_h_idx * block_h_t) * tensor_width_in_tiles;
     for (uint32_t h = 0; h < block_h_t; ++h) {
         uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
         for (uint32_t w = 0; w < block_w_t; ++w) {
-            noc_async_read_tile(tile_id + w, s1, l1_write_addr);
-            l1_write_addr += tile_size_bytes;
+            noc.async_read(s1, cb, tile_size_bytes, {.page_id = tile_id + w}, {.offset_bytes = write_offset});
+            write_offset += tile_size_bytes;
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-void do_signaling(uint32_t& rt_args_idx) {
+void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-    volatile tt_l1_ptr uint32_t* pv_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pv_semaphore);
+    const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
+    experimental::Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
         const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
@@ -53,12 +59,11 @@ void do_signaling(uint32_t& rt_args_idx) {
         const uint64_t signalling_semaphore_address =
             get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
             signalling_semaphore;
-        noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
-        noc_semaphore_set(pv_semaphore_ptr, 1);
+        pv_sem.wait(target_sem_value);
+        pv_sem.set(1);
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
     } else {
-        const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
-        noc_semaphore_inc(sem_addr, 1);
+        pv_sem.up(noc, pv_core_x, pv_core_y, 1);
     }
 }
 
@@ -81,8 +86,9 @@ void kernel_main() {
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
-            do_signaling(rt_args_idx);
-            noc_async_write_barrier();
+            experimental::Noc early_noc;
+            do_signaling(early_noc, rt_args_idx);
+            early_noc.async_write_barrier();
         }
         return;
     }
@@ -111,6 +117,11 @@ void kernel_main() {
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_sync(sync_cb);
+    experimental::CircularBuffer cb_sync2(sync_cb2);
+
     uint32_t in1_shard_width_offset_bytes = 0;
     uint32_t in1_dram_shard_block_size_bytes = 0;
     uint32_t dram_read_offset_bytes = 0;
@@ -124,20 +135,21 @@ void kernel_main() {
     }
 
     for (uint32_t b = 0; b < batch; ++b) {
-        cb_reserve_back(sync_cb2, 1);
+        cb_sync2.reserve_back(1);
 #ifdef ENABLE_GLOBAL_CB
         experimental::remote_cb_wait_front(remote_cb_id, num_blocks);
 #endif
 
-        cb_push_back(sync_cb2, 1);
+        cb_sync2.push_back(1);
 
         if constexpr (in1_is_dram_interleaved) {
             for (uint32_t block = 0; block < num_blocks; ++block) {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
 
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.reserve_back(in1_block_num_tiles);
                 read_block_from_dram(
-                    cb_id_in1,
+                    noc,
+                    cb_in1,
                     s1,
                     in1_tensor_width_in_tiles,
                     ring_idx,
@@ -145,7 +157,7 @@ void kernel_main() {
                     in1_block_width_in_tiles,
                     in1_block_height_in_tiles,
                     in1_single_tile_size_bytes);
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.push_back(in1_block_num_tiles);
             }
         } else if constexpr (in1_is_dram_sharded) {  // when in1 is sharded in DRAM, each core reads from its own bank,
                                                      // two cores on the same row share one bank.
@@ -153,8 +165,8 @@ void kernel_main() {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
                 l1_read_addr_in1 = block_idx * in1_dram_shard_block_size_bytes + dram_read_offset_bytes;
                 // Operand 1
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-                l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                cb_in1.reserve_back(in1_block_num_tiles);
+                l1_write_addr_in1 = cb_in1.get_write_ptr();
 
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
@@ -171,27 +183,27 @@ void kernel_main() {
                     l1_read_addr_in1 += in1_shard_width_offset_bytes;
                 }
 
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                noc.async_read_barrier();
+                cb_in1.push_back(in1_block_num_tiles);
             }
         }
 
 #ifdef ENABLE_GLOBAL_CB
-        cb_wait_front(sync_cb, 1);
+        cb_sync.wait_front(1);
         experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
-        cb_pop_front(sync_cb, 1);
+        cb_sync.pop_front(1);
 #endif
         // Signal Here
         if constexpr (needs_signaler) {
             if (b == 0) {
-                do_signaling(rt_args_idx);
+                do_signaling(noc, rt_args_idx);
             }
         }
     }
 
 #ifdef ENABLE_GLOBAL_CB
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 #endif
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -6,6 +6,10 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -55,6 +59,14 @@ void kernel_main() {
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_out(cb_id_out);
+    experimental::CircularBuffer cb_out_reshard(cb_id_out_reshard);
+#ifdef FUSE_BIAS
+    experimental::CircularBuffer cb_in3(cb_id_in3);
+#endif
+
     //  READER
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
@@ -66,8 +78,8 @@ void kernel_main() {
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
         // Operand 1
-        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+        cb_in1.reserve_back(in1_block_num_tiles);
+        l1_write_addr_in1 = cb_in1.get_write_ptr();
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
             noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
@@ -75,8 +87,8 @@ void kernel_main() {
             l1_write_addr_in1 += in1_page_size;
         }
 
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in1, in1_block_num_tiles);
+        noc.async_read_barrier();
+        cb_in1.push_back(in1_block_num_tiles);
     }
 #else
     constexpr uint32_t total_num_blocks_in_buffer = 3;
@@ -85,9 +97,9 @@ void kernel_main() {
     uint32_t curr_block_trid = 1;
     uint32_t block_trid_to_wait = 1;
 
-    cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+    cb_in1.reserve_back(in1_block_num_tiles);
     uint32_t l1_write_addr_in1_offset = 0;
-    uint32_t l1_write_addr_in1_start = get_write_ptr(cb_id_in1);
+    uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
     l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
         noc_async_read_set_trid(curr_block_trid);
@@ -101,11 +113,11 @@ void kernel_main() {
 
         if (num_free_blocks_in_buffer == 2) {
             noc_async_read_barrier_with_trid(block_trid_to_wait);
-            cb_push_back(cb_id_in1, in1_block_num_tiles);
+            cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
             // reserve for next block
-            cb_reserve_back(cb_id_in1, in1_block_num_tiles * 2);
+            cb_in1.reserve_back(in1_block_num_tiles * 2);
         } else {
             num_free_blocks_in_buffer -= 1;
         }
@@ -121,13 +133,13 @@ void kernel_main() {
     }
     // last block to wait
     noc_async_read_barrier_with_trid(block_trid_to_wait);
-    cb_push_back(cb_id_in1, in1_block_num_tiles);
+    cb_in1.push_back(in1_block_num_tiles);
 #endif
 
 #ifdef FUSE_BIAS
     // Operand 1
-    cb_reserve_back(cb_id_in3, in1_block_w);
-    uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
+    cb_in3.reserve_back(in1_block_w);
+    uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
     uint32_t l1_read_addr_in3 = 0;
 
     uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
@@ -140,37 +152,44 @@ void kernel_main() {
     }
 
     // Barrier! make sure the reads are done
-    noc_async_read_barrier();
-    cb_push_back(cb_id_in3, in1_block_w);
+    noc.async_read_barrier();
+    cb_in3.push_back(in1_block_w);
 #endif
 
     // WRITER
-    cb_wait_front(cb_id_out, out_block_num_tiles);
+    cb_out.wait_front(out_block_num_tiles);
 
 #ifndef SKIP_WRITE_BACK
     uint32_t index_offset = 0;
     uint32_t l1_read_addr_out_offset = 0;
 
     for (uint32_t i = 0; i < num_shard_to_write_back; ++i) {
-        uint32_t l1_read_addr_out = get_read_ptr(cb_id_out) + l1_read_addr_out_offset;
-        uint32_t l1_write_addr_out_reshard = get_write_ptr(cb_id_out_reshard);
+        uint32_t l1_read_addr_out = cb_out.get_read_ptr() + l1_read_addr_out_offset;
+        uint32_t l1_write_addr_out_reshard = cb_out_reshard.get_write_ptr();
 
         if (i == 0) {
             l1_write_addr_out_reshard += reshard_tensor_start_offset;
         }
 
-        uint64_t reshard_dest_addr = get_noc_addr(
-            in0_mcast_sender_noc_x[index_offset], in0_mcast_sender_noc_y[index_offset], l1_write_addr_out_reshard);
+        experimental::UnicastEndpoint dst_ep;
+        uint32_t reshard_dest_local_addr = l1_write_addr_out_reshard;
 
         for (uint32_t h = 0; h < per_core_M; ++h) {
-            noc_async_write(l1_read_addr_out, reshard_dest_addr, per_core_N_reshard_bytes[index_offset]);
+            noc.async_write(
+                experimental::CoreLocalMem<uint32_t>(l1_read_addr_out),
+                dst_ep,
+                per_core_N_reshard_bytes[index_offset],
+                {},
+                {.noc_x = in0_mcast_sender_noc_x[index_offset],
+                 .noc_y = in0_mcast_sender_noc_y[index_offset],
+                 .addr = reshard_dest_local_addr});
             l1_read_addr_out += out_tensor_stride_w_bytes;
-            reshard_dest_addr += out_reshard_tensor_stride_w_bytes;
+            reshard_dest_local_addr += out_reshard_tensor_stride_w_bytes;
         }
         l1_read_addr_out_offset += per_core_N_reshard_bytes[index_offset];
 
         index_offset += 3;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -12,6 +12,9 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -58,11 +61,16 @@ void kernel_main() {
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
     constexpr uint32_t out_block_size_bytes = out_block_num_tiles * out_single_tile_size_bytes;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_out(cb_id_out);
     // DRAM read setup
-    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
     // Output reshard setup - build NOC address for remote output storage core
-    uint64_t remote_out_base_noc_addr = get_noc_addr(output_storage_noc_x, output_storage_noc_y, output_shard_l1_addr);
+    experimental::UnicastEndpoint remote;
+#ifdef FUSE_BIAS
+    experimental::CircularBuffer cb_in3(cb_id_in3);
+#endif
 
     // Process each batch
     for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
@@ -71,50 +79,61 @@ void kernel_main() {
 
         // Read all N blocks of weights for this batch
         for (uint32_t block = 0; block < num_blocks; ++block) {
-            cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-            uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            cb_in1.reserve_back(in1_block_num_tiles);
 
             // Read weight block from DRAM
             uint32_t remaining_bytes = in1_block_size_bytes;
-            uint32_t curr_l1_addr = l1_write_addr_in1;
+            uint32_t cb_write_offset = 0;
             uint32_t curr_dram_offset = l1_read_addr_in1;
 
             while (remaining_bytes > 0) {
                 uint32_t read_size = (remaining_bytes > in1_page_size) ? in1_page_size : remaining_bytes;
-                noc_async_read(in1_base_addr + in1_batch_offset + curr_dram_offset, curr_l1_addr, read_size);
-                curr_l1_addr += read_size;
+                noc.async_read(
+                    dram_bank,
+                    cb_in1,
+                    read_size,
+                    {.bank_id = dram_bank_id, .addr = in1_tensor_addr + in1_batch_offset + curr_dram_offset},
+                    {.offset_bytes = cb_write_offset});
+                cb_write_offset += read_size;
                 curr_dram_offset += read_size;
                 remaining_bytes -= read_size;
             }
 
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in1, in1_block_num_tiles);
+            noc.async_read_barrier();
+            cb_in1.push_back(in1_block_num_tiles);
             l1_read_addr_in1 += in1_block_size_bytes;
         }
 
 #ifdef FUSE_BIAS
         // Read bias for this batch (if fused)
-        cb_reserve_back(cb_id_in3, in3_block_tiles);
-        uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
-        uint64_t in3_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-        noc_async_read(in3_addr, l1_write_addr_in3, in3_block_tiles * get_tile_size(cb_id_in3));
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in3, in3_block_tiles);
+        cb_in3.reserve_back(in3_block_tiles);
+        noc.async_read(
+            dram_bank,
+            cb_in3,
+            in3_block_tiles * get_tile_size(cb_id_in3),
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in3.push_back(in3_block_tiles);
 #endif
 
         // Wait for compute to finish this batch
-        cb_wait_front(cb_id_out, out_block_num_tiles);
+        cb_out.wait_front(out_block_num_tiles);
 
 #ifdef OUT_SHARDED
         // NOC write output to remote output storage core (CB6)
-        uint32_t local_out_read_addr = get_read_ptr(cb_id_out);
         uint32_t out_batch_offset = batch * out_tensor_stride_batch_bytes;
-        uint64_t remote_out_noc_addr = remote_out_base_noc_addr + out_batch_offset;
-
-        noc_async_write(local_out_read_addr, remote_out_noc_addr, out_block_size_bytes);
-        noc_async_write_barrier();
+        noc.async_write(
+            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+            remote,
+            out_block_size_bytes,
+            {.offset_bytes = 0},
+            {.noc_x = output_storage_noc_x,
+             .noc_y = output_storage_noc_y,
+             .addr = output_shard_l1_addr + out_batch_offset});
+        noc.async_write_barrier();
 #endif
 
-        cb_pop_front(cb_id_out, out_block_num_tiles);
+        cb_out.pop_front(out_block_num_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -7,6 +7,12 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     // READER
@@ -57,8 +63,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(9);
 
     // in1 mcast args
-    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
-    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(11));
     constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(12);
     constexpr uint32_t in1_mcast_num_cores = get_compile_time_arg_val(13);
     // batch args
@@ -166,10 +170,29 @@ void kernel_main() {
     constexpr const uint32_t in1_tile_hw = get_tile_hw(cb_id_in1);
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
 
+    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
+    constexpr uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
+    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_out(cb_id_out0);
+    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(10));
+    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(11));
+#ifdef FUSE_BIAS
+    experimental::CircularBuffer cb_in3(cb_id_in3);
+#endif
+#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED)
+#ifdef INTERMEDIATE_CB_READ
+    constexpr uint32_t in1_intermediate_cb_index = get_named_compile_time_arg_val("cb_in1_intermediate");
+    experimental::CircularBuffer cb_helper(in1_intermediate_cb_index);
+#endif
+#endif
+
 //  READER
 #ifdef IN1_SHARDED
-    cb_reserve_back(cb_id_in1, in1_block_num_tiles * num_blocks_inner_dim);
-    cb_push_back(cb_id_in1, in1_block_num_tiles * num_blocks_inner_dim);
+    cb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
+    cb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
 #else
     uint32_t l1_write_addr_in1;
 
@@ -177,43 +200,28 @@ void kernel_main() {
 #endif  // IN1_SHARDED
 
     //  WRITER
-    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
-    constexpr uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
-    constexpr const uint32_t output_tile_hw = get_tile_hw(cb_id_out0);
     const auto s = TensorAccessor(out_args, out_tensor_addr, output_single_tile_size_bytes);
 
     // sparsity accessor
     constexpr uint32_t cb_id_sparsity = get_named_compile_time_arg_val("cb_sparsity");
+    experimental::CircularBuffer cb_sparsity(cb_id_sparsity);
     const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr, sparsity_pagesize);
 
 #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    volatile tt_l1_ptr uint32_t* in1_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_receiver_semaphore_addr);
-    *(in1_mcast_receiver_semaphore_addr_ptr) = VALID;
+    receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    volatile tt_l1_ptr uint32_t* in1_mcast_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_mcast_sender_semaphore_addr);
 
-    const uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in1_mcast_dest_noc_start_x,
-        in1_mcast_dest_noc_start_y,
-        in1_mcast_dest_noc_end_x,
-        in1_mcast_dest_noc_end_y,
-        in1_mcast_receiver_semaphore_addr);
-
-    const uint64_t in1_multicast_data_noc = get_noc_multicast_addr(
-        in1_mcast_dest_noc_start_x, in1_mcast_dest_noc_start_y, in1_mcast_dest_noc_end_x, in1_mcast_dest_noc_end_y, 0);
 #ifdef IN1_SHARDED
-    uint64_t in1_start_address = get_write_ptr(cb_id_in1);
+    uint64_t in1_start_address = cb_in1.get_write_ptr();
 #endif  // IN1_SHARDED
 #endif  // SKIP_MCAST
 
     uint32_t l1_write_addr_sparsity = 0;
     if constexpr (batchB > 0) {
-        cb_reserve_back(cb_id_sparsity, 1);
-        l1_write_addr_sparsity = get_write_ptr(cb_id_sparsity);
+        cb_sparsity.reserve_back(1);
+        l1_write_addr_sparsity = cb_sparsity.get_write_ptr();
     }
 
 #ifdef IN1_DRAM_WIDTH_SHARDED
@@ -232,13 +240,13 @@ void kernel_main() {
         // Compute DRAM bank and offset for this batch
         uint32_t in1_dram_bank_id = b / in1_batches_per_bank;
         uint32_t in1_batch_in_shard = b % in1_batches_per_bank;
-        uint64_t in1_dram_base_addr = get_noc_addr_from_bank_id<true>(in1_dram_bank_id, in1_tensor_addr);
+        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_src;
         uint32_t in1_dram_batch_offset = in1_batch_in_shard * in1_batch_stride_bytes;
 #endif  // IN1_DRAM_HEIGHT_SHARDED
 
         if constexpr (batchB > 0) {
             noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
-            noc_async_read_barrier();
+            noc.async_read_barrier();
         }
 
         for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
@@ -274,10 +282,10 @@ void kernel_main() {
                         }
 #if defined(IN1_DRAM_WIDTH_SHARDED)
                         // Operand 1 - DRAM width sharded
-                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                        cb_in1.reserve_back(in1_block_num_tiles);
 
                         uint64_t in1_start_address =
-                            get_write_ptr(cb_id_in1);  // copy start address of block, to be used for mcasting
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
 
                         uint32_t l1_write_addr_in1_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
@@ -292,7 +300,7 @@ void kernel_main() {
                             noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_single_tile_size_bytes, vc);
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
-                            uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1) + l1_write_addr_in1_offset;
+                            uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
                             uint32_t in1_block_w_dram =
                                 in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
                                 in1_single_tile_size_bytes;
@@ -314,14 +322,14 @@ void kernel_main() {
                             next_bank_id_and_dram_stride_index += 2;
                         }
                         l1_read_addr_in1_offset += in1_dram_block_size_bytes;
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #elif defined(IN1_DRAM_HEIGHT_SHARDED)
                         // Operand 1 - DRAM height sharded (batched)
                         // Each DRAM bank holds batches_per_bank complete [K, N] matrices
                         // Bank and offset computed at start of batch loop
-                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                        cb_in1.reserve_back(in1_block_num_tiles);
 
-                        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                        l1_write_addr_in1 = cb_in1.get_write_ptr();
                         uint64_t in1_start_address =
                             l1_write_addr_in1;  // copy start address of block, to be used for mcasting
 
@@ -334,10 +342,12 @@ void kernel_main() {
                                 if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
                                     uint32_t tile_byte_offset =
                                         in1_dram_batch_offset + in1_tensor_tile_id * in1_single_tile_size_bytes;
-                                    noc_async_read(
-                                        in1_dram_base_addr + tile_byte_offset,
-                                        l1_write_addr_in1,
-                                        in1_single_tile_size_bytes);
+                                    noc.async_read(
+                                        dram_src,
+                                        experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = in1_dram_bank_id, .addr = in1_tensor_addr + tile_byte_offset},
+                                        {});
                                 }
                                 l1_write_addr_in1 += in1_single_tile_size_bytes;
                                 in1_tensor_tile_id += in1_tensor_stride_w;
@@ -347,19 +357,16 @@ void kernel_main() {
                         in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
 
                         // Barrier! make sure the reads are done
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #elif !defined(IN1_SHARDED)
                         // Operand 1 - interleaved
-                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                        cb_in1.reserve_back(in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
-                        constexpr uint32_t in1_intermediate_cb_index =
-                            get_named_compile_time_arg_val("cb_in1_intermediate");
-                        cb_reserve_back(in1_intermediate_cb_index, one_tile);
-                        uint32_t l1_write_addr_helper = get_write_ptr(in1_intermediate_cb_index);
+                        cb_helper.reserve_back(one_tile);
 #endif  // INTERMEDIATE_CB_READ
-                        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                        uint32_t in1_write_offset = 0;
                         uint64_t in1_start_address =
-                            l1_write_addr_in1;  // copy start address of block, to be used for mcasting
+                            cb_in1.get_write_ptr();  // copy start address of block, to be used for mcasting
 
                         // Copy in1 block into CB, as the default kernel
                         uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
@@ -368,17 +375,27 @@ void kernel_main() {
                             for (uint32_t w = 0; w < in1_block_w; ++w) {
                                 if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
 #ifndef INTERMEDIATE_CB_READ
-                                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                                    noc.async_read(
+                                        s1,
+                                        cb_in1,
+                                        in1_single_tile_size_bytes,
+                                        {.page_id = in1_tensor_tile_id},
+                                        {.offset_bytes = in1_write_offset});
 #else
-                                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
-                                    noc_async_read_barrier();
+                                    noc.async_read(
+                                        s1,
+                                        cb_helper,
+                                        in1_single_tile_size_bytes,
+                                        {.page_id = in1_tensor_tile_id},
+                                        {.offset_bytes = 0});
+                                    noc.async_read_barrier();
                                     memcpy(
-                                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in1),
-                                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                                        /*dst=*/reinterpret_cast<void*>(cb_in1.get_write_ptr() + in1_write_offset),
+                                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
                                         /*size=*/in1_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
                                 }
-                                l1_write_addr_in1 += in1_single_tile_size_bytes;
+                                in1_write_offset += in1_single_tile_size_bytes;
                                 in1_tensor_tile_id += in1_tensor_stride_w;
                             }
                             in1_tensor_row_start_tile_id += in1_tensor_stride_h;
@@ -386,25 +403,30 @@ void kernel_main() {
                         in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
 
                         // Barrier! make sure the reads are done
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #endif  // IN1_DRAM_WIDTH_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
 
 #ifndef SKIP_MCAST
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
-                        noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-                        noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
 
                         // Now we have the block in the CB address, we can mcast to dests!
-                        uint64_t in1_multicast_data_addr = in1_multicast_data_noc | in1_start_address;
-
+                        experimental::MulticastEndpoint mcast_dst;
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(
-                            in1_start_address,
-                            in1_multicast_data_addr,
+                        noc.async_write_multicast(
+                            experimental::CoreLocalMem<uint32_t>(static_cast<uint32_t>(in1_start_address)),
+                            mcast_dst,
                             in1_block_size_bytes,
                             in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in1_start_address)},
                             true);
 
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
@@ -414,24 +436,27 @@ void kernel_main() {
                         // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
                         // which means data could be changed before
                         //  write is issued.
-                        noc_async_writes_flushed();
+                        noc.async_writes_flushed();
 #endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(
-                            in1_mcast_receiver_semaphore_addr,
-                            in1_mcast_receiver_semaphore_noc_addr,
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
                             in1_mcast_num_cores);
 #endif  // SKIP_MCAST
 
 #ifndef IN1_SHARDED
-                        cb_push_back(cb_id_in1, in1_block_num_tiles);
+                        cb_in1.push_back(in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
                         // Clean up helper CB
-                        cb_push_back(in1_intermediate_cb_index, one_tile);
-                        cb_wait_front(in1_intermediate_cb_index, one_tile);
-                        cb_pop_front(in1_intermediate_cb_index, one_tile);
+                        cb_helper.push_back(one_tile);
+                        cb_helper.wait_front(one_tile);
+                        cb_helper.pop_front(one_tile);
 #endif  // INTERMEDIATE_CB_READ
 #endif  // IN1_SHARDED
                     }
@@ -440,11 +465,11 @@ void kernel_main() {
                     if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
                         // Operand 1
 #ifndef BIAS_SHARDED
-                        cb_reserve_back(cb_id_in3, in1_block_w);
-                        l1_write_addr_in3 = get_write_ptr(cb_id_in3);
+                        cb_in3.reserve_back(in1_block_w);
+                        uint32_t in3_write_offset = 0;
 
                         uint64_t in3_start_address =
-                            l1_write_addr_in3;              // copy start address of block, to be used for mcasting
+                            cb_in3.get_write_ptr();         // copy start address of block, to be used for mcasting
                         uint32_t in3_block_size_bytes = 0;  // can be optimized later, pass it to kernel
 
 #ifdef IN1_DRAM_WIDTH_SHARDED
@@ -465,7 +490,7 @@ void kernel_main() {
                             noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
 
                             uint32_t l1_read_addr_in3 = 0;
-                            uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3) + l1_write_addr_in3_offset;
+                            l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
                             // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
                             // by in1_single_tile_size_bytes (not bias) to get the tile count.
                             uint32_t in3_block_w_dram =
@@ -483,20 +508,25 @@ void kernel_main() {
                             l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
                             next_bank_id_and_dram_stride_index += 2;
                         }
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #else
                         // Copy in1 block into CB, as the default kernel
                         uint32_t in3_tensor_tile_id = in3_tensor_current_w_dim_block_tile_id;
                         for (uint32_t w = 0; w < in1_block_w; ++w) {
                             if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
-                                noc_async_read_tile(in3_tensor_tile_id, s3, l1_write_addr_in3);
+                                noc.async_read(
+                                    s3,
+                                    cb_in3,
+                                    bias_single_tile_size_bytes,
+                                    {.page_id = in3_tensor_tile_id},
+                                    {.offset_bytes = in3_write_offset});
                             }
-                            l1_write_addr_in3 += bias_single_tile_size_bytes;
+                            in3_write_offset += bias_single_tile_size_bytes;
                             in3_tensor_tile_id += in3_tensor_stride_w;
                             in3_block_size_bytes += bias_single_tile_size_bytes;
                         }
                         // Barrier! make sure the reads are done
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
 #endif  // IN1_DRAM_WIDTH_SHARDED
 
 #ifndef SKIP_MCAST
@@ -504,18 +534,23 @@ void kernel_main() {
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
-                        noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-                        noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+                        sender_sem.wait(in1_mcast_num_dests);
+                        sender_sem.set(0);
 
                         // Now we have the block in the CB address, we can mcast to dests!
-                        uint64_t in3_multicast_data_addr = in1_multicast_data_noc | in3_start_address;
-
+                        experimental::MulticastEndpoint mcast_dst;
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(
-                            in3_start_address,
-                            in3_multicast_data_addr,
+                        noc.async_write_multicast(
+                            experimental::CoreLocalMem<uint32_t>(static_cast<uint32_t>(in3_start_address)),
+                            mcast_dst,
                             in3_block_size_bytes,
                             in1_mcast_num_cores,
+                            {},
+                            {.noc_x_start = in1_mcast_dest_noc_start_x,
+                             .noc_y_start = in1_mcast_dest_noc_start_y,
+                             .noc_x_end = in1_mcast_dest_noc_end_x,
+                             .noc_y_end = in1_mcast_dest_noc_end_y,
+                             .addr = static_cast<uint32_t>(in3_start_address)},
                             true);
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
                         // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
@@ -523,21 +558,24 @@ void kernel_main() {
 #ifdef ARCH_BLACKHOLE
                         // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
                         // latency which means data could be changed before write is issued.
-                        noc_async_writes_flushed();
+                        noc.async_writes_flushed();
 #endif  // ARCH_BLACKHOLE
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(
-                            in1_mcast_receiver_semaphore_addr,
-                            in1_mcast_receiver_semaphore_noc_addr,
+                        receiver_sem.set_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
                             in1_mcast_num_cores);
 #endif  // SKIP_MCAST
 
-                        cb_push_back(cb_id_in3, in1_block_w);
+                        cb_in3.push_back(in1_block_w);
 #else
-                        cb_reserve_back(cb_id_in3, in1_block_w);
-                        cb_push_back(cb_id_in3, in1_block_w);
+                        cb_in3.reserve_back(in1_block_w);
+                        cb_in3.push_back(in1_block_w);
 #endif  // BIAS_SHARDED
                     }
 #endif  // FUSE_BIAS
@@ -568,40 +606,46 @@ void kernel_main() {
                                 subblock_tiles_addr_skip = padded_subblock_tiles_addr_skip;
                             }
 
-                            cb_wait_front(cb_id_out0, out_subblock_tile_count);
-                            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                            cb_out.wait_front(out_subblock_tile_count);
+                            uint32_t out_read_offset = 0;
 
                             for (uint32_t h = 0; h < out_subblock_h_; ++h) {
                                 uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                                 for (uint32_t w = 0; w < out_subblock_w_; ++w) {
                                     if (bw < num_blocks_w_dim_) {
-                                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                                        noc.async_write(
+                                            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(
+                                                cb_out),
+                                            s,
+                                            output_single_tile_size_bytes,
+                                            {.offset_bytes = out_read_offset},
+                                            {.page_id = out_tensor_tile_id});
                                     }
 
-                                    l1_read_addr += output_single_tile_size_bytes;
+                                    out_read_offset += output_single_tile_size_bytes;
 
                                     out_tensor_tile_id += out_tensor_stride_w;
                                 }
                                 // Skip padded tiles in subblock along row
-                                l1_read_addr += subblock_tiles_addr_skip;
+                                out_read_offset += subblock_tiles_addr_skip;
                                 out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                             }
 
-                            noc_async_write_barrier();
-                            cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                            noc.async_write_barrier();
+                            cb_out.pop_front(out_subblock_tile_count);
                             out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                         }
                         // Pop fully padded subblocks along the row
                         if (bw == num_blocks_w_dim_ - 1) {
-                            cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);
-                            cb_pop_front(cb_id_out0, padded_block_tiles_w_skip);
+                            cb_out.wait_front(padded_block_tiles_w_skip);
+                            cb_out.pop_front(padded_block_tiles_w_skip);
                         }
                         out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
                     }
                     // Pop row(s) of fully padded subblocks
                     if (bh == num_blocks_h_dim - 1) {
-                        cb_wait_front(cb_id_out0, padded_block_tiles_h_skip);
-                        cb_pop_front(cb_id_out0, padded_block_tiles_h_skip);
+                        cb_out.wait_front(padded_block_tiles_h_skip);
+                        cb_out.pop_front(padded_block_tiles_h_skip);
                     }
 
 #endif
@@ -631,9 +675,8 @@ void kernel_main() {
     }
 
 #if OUT_SHARDED
-    cb_wait_front(
-        cb_id_out0,
+    cb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
 #endif
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -59,14 +62,17 @@ void kernel_main() {
     constexpr auto in1_args = TensorAccessorArgs<19>();
     constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_in1(cb_id_in1);
+    experimental::CircularBuffer cb_out(cb_id_out0);
+
 #ifdef IN1_SHARDED
     const uint32_t in1_num_tiles = batch * num_blocks * in1_block_h * in1_block_w;
-    cb_reserve_back(cb_id_in1, in1_num_tiles);
-    cb_push_back(cb_id_in1, in1_num_tiles);
+    cb_in1.reserve_back(in1_num_tiles);
+    cb_in1.push_back(in1_num_tiles);
 #else
     const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, in1_single_tile_size_bytes);
-    uint32_t l1_write_addr_in1;
 #endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
@@ -79,45 +85,55 @@ void kernel_main() {
 #ifndef IN1_SHARDED
         uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
         for (uint32_t block = 0; block < num_blocks; ++block) {
-            cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+            cb_in1.reserve_back(in1_block_num_tiles);
 
 #ifdef INTERMEDIATE_CB_READ
             constexpr uint32_t in1_intermediate_cb_index = get_named_compile_time_arg_val("cb_in1_intermediate");
-            cb_reserve_back(in1_intermediate_cb_index, one_tile);
-            uint32_t l1_write_addr_helper = get_write_ptr(in1_intermediate_cb_index);
+            experimental::CircularBuffer cb_helper(in1_intermediate_cb_index);
+            cb_helper.reserve_back(one_tile);
 #endif  // INTERMEDIATE_CB_READ
 
-            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            uint32_t in1_write_offset = 0;
 
             uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_block_start_tile_id;
             for (uint32_t h = 0; h < in1_block_h; ++h) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; ++w) {
 #ifndef INTERMEDIATE_CB_READ
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                    noc.async_read(
+                        s1,
+                        cb_in1,
+                        in1_single_tile_size_bytes,
+                        {.page_id = in1_tensor_tile_id},
+                        {.offset_bytes = in1_write_offset});
 #else
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_helper);
-                    noc_async_read_barrier();
+                    noc.async_read(
+                        s1,
+                        cb_helper,
+                        in1_single_tile_size_bytes,
+                        {.page_id = in1_tensor_tile_id},
+                        {.offset_bytes = 0});
+                    noc.async_read_barrier();
                     memcpy(
-                        /*dst=*/reinterpret_cast<void*>(l1_write_addr_in1),
-                        /*src=*/reinterpret_cast<const void*>(l1_write_addr_helper),
+                        /*dst=*/reinterpret_cast<void*>(cb_in1.get_write_ptr() + in1_write_offset),
+                        /*src=*/reinterpret_cast<const void*>(cb_helper.get_write_ptr()),
                         /*size=*/in1_single_tile_size_bytes);
 #endif  // INTERMEDIATE_CB_READ
-                    l1_write_addr_in1 += in1_single_tile_size_bytes;
+                    in1_write_offset += in1_single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                 }
                 in1_tensor_row_start_tile_id += in1_tensor_stride_h;
             }
             in1_tensor_current_block_start_tile_id += in1_tensor_next_block_stride;
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 
-            cb_push_back(cb_id_in1, in1_block_num_tiles);
+            cb_in1.push_back(in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
             // Clean up helper CB
-            cb_push_back(in1_intermediate_cb_index, one_tile);
-            cb_wait_front(in1_intermediate_cb_index, one_tile);
-            cb_pop_front(in1_intermediate_cb_index, one_tile);
+            cb_helper.push_back(one_tile);
+            cb_helper.wait_front(one_tile);
+            cb_helper.pop_front(one_tile);
 #endif  // INTERMEDIATE_CB_READ
         }
         if (bcast_B == 0) {
@@ -133,23 +149,28 @@ void kernel_main() {
             for (uint32_t sbw = 0; sbw < out_num_subblocks_w; ++sbw) {
                 uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
 
-                cb_wait_front(cb_id_out0, out_subblock_tile_count);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                cb_out.wait_front(out_subblock_tile_count);
+                uint32_t out_read_offset = 0;
 
                 for (uint32_t h = 0; h < out_subblock_h; ++h) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w; ++w) {
-                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                        noc.async_write(
+                            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            s,
+                            output_single_tile_size_bytes,
+                            {.offset_bytes = out_read_offset},
+                            {.page_id = out_tensor_tile_id});
 
-                        l1_read_addr += output_single_tile_size_bytes;
+                        out_read_offset += output_single_tile_size_bytes;
 
                         out_tensor_tile_id += out_tensor_stride_w;
                     }
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                 }
 
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                noc.async_write_barrier();
+                cb_out.pop_front(out_subblock_tile_count);
                 out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
             }
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
@@ -160,6 +181,6 @@ void kernel_main() {
 #endif  // not defined IN1_SHARDED or not defined OUT_SHARDED
 
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out0, batch * out_num_subblocks_h * out_num_subblocks_w * out_subblock_w * out_subblock_h);
+    cb_out.wait_front(batch * out_num_subblocks_h * out_num_subblocks_w * out_subblock_w * out_subblock_h);
 #endif  // OUT_SHARDED
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     // out tensor args
@@ -32,6 +35,9 @@ void kernel_main() {
     constexpr auto out_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(out_args, out_tensor_addr, single_tile_size_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out(cb_id_out0);
+
     bool one_time_profile = true;
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;
@@ -40,22 +46,27 @@ void kernel_main() {
             for (uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
                 uint32_t out_tensor_sb_row_start_tile_id = out_tensor_sbw_start_tile_id;
 
-                cb_wait_front(cb_id_out0, out_subblock_tile_count);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                cb_out.wait_front(out_subblock_tile_count);
+                uint32_t out_read_offset = 0;
 
                 for (uint32_t h = 0; h < out_subblock_h; h++) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w; w++) {
-                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
-                        l1_read_addr += single_tile_size_bytes;
+                        noc.async_write(
+                            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            s,
+                            single_tile_size_bytes,
+                            {.offset_bytes = out_read_offset},
+                            {.page_id = out_tensor_tile_id});
+                        out_read_offset += single_tile_size_bytes;
 
                         out_tensor_tile_id += out_tensor_stride_w;
                     }
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                 }
 
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                noc.async_write_barrier();
+                cb_out.pop_front(out_subblock_tile_count);
                 out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
             }
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -15,8 +18,11 @@ void kernel_main() {
     // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out(cb_id_out);
+
 #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, num_pages);
+    cb_out.wait_front(num_pages);
 #else
 
     // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
@@ -31,12 +37,16 @@ void kernel_main() {
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_wait_front(cb_id_out, onepage);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_page(i, s, l1_read_addr);
-        noc_async_writes_flushed();
-        cb_pop_front(cb_id_out, onepage);
+        cb_out.wait_front(onepage);
+        noc.async_write(
+            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+            s,
+            page_bytes,
+            {.offset_bytes = 0},
+            {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 #endif
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #38763

### Problem description
A new device 2.0 (1.1) api has been created

### What's changed
- Use the new api for matmul
- update tt-train memory expectations
- update device perf expectations

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-38763_mm_m20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38763_mm_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38763_mm_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38763_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38763_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38763_mm_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38763_mm_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
