### PR TITLE
Fixing intermesh relaxed mode validation

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2784,12 +2784,10 @@ void ControlPlane::validate_requested_intermesh_connections(
                     dst_mesh,
                     ports.size(),
                     port_directions_str);
-                log_warning(
-                    tt::LogFabric,
-                    "Inter-mesh channel request exceeds physical links (policy {}): {}",
-                    inter_mesh_relaxed ? "relaxed" : "strict",
-                    msg);
-                if (!inter_mesh_relaxed) {
+                if (inter_mesh_relaxed) {
+                    log_warning(
+                        tt::LogFabric, "Inter-mesh channel request exceeds physical links (policy relaxed): {}", msg);
+                } else {
                     TT_THROW("{}", msg);
                 }
             }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2758,6 +2758,7 @@ void ControlPlane::validate_requested_intermesh_connections(
     if (strict_binding) {
         return;
     }
+    const bool inter_mesh_relaxed = this->mesh_graph_->is_inter_mesh_policy_relaxed();
     for (const auto& [src_mesh, dst_mesh_map] : requested_intermesh_connections) {
         auto src_mesh_id = MeshId(src_mesh);
         for (const auto& [dst_mesh, num_channels] : dst_mesh_map) {
@@ -2772,8 +2773,7 @@ void ControlPlane::validate_requested_intermesh_connections(
                     port_directions_str += fmt::format("{}", enchantum::to_string(ports[i].port_id.first)) +
                                            std::to_string(ports[i].port_id.second);
                 }
-                TT_FATAL(
-                    false,
+                const std::string msg = fmt::format(
                     "Requested {} channels between {} and {}, but only have {} physical links. "
                     "If using assign_z_direction, reduce channels.count in the mesh graph descriptor to match "
                     "the physical Z-link capacity (e.g. 4 for torus wrap-around). "
@@ -2784,6 +2784,14 @@ void ControlPlane::validate_requested_intermesh_connections(
                     dst_mesh,
                     ports.size(),
                     port_directions_str);
+                log_warning(
+                    tt::LogFabric,
+                    "Inter-mesh channel request exceeds physical links (policy {}): {}",
+                    inter_mesh_relaxed ? "relaxed" : "strict",
+                    msg);
+                if (!inter_mesh_relaxed) {
+                    TT_THROW("{}", msg);
+                }
             }
         }
     }


### PR DESCRIPTION
Allowing relaxed mode to assign less channels than present when set in intermesh relaxed mode.

Changing this:

```
[1,0]<stdout>: 2026-03-25 21:13:14.554 | critical |          Always | TT_FATAL: Requested 8 channels between 63 and 62, but only have 4 physical links. If using assign_z_direction, reduce channels.count in the mesh graph descriptor to match the physical Z-link capacity (e.g. 4 for torus wrap-around). generate_rank_bindings does not yet validate Z vs non-Z port capacity. Available port directions: N1, N0, Z5, Z4. (assert.hpp:104)
[1,0]<stdout>: unknown file: Failure
```

To this when set in intermesh relaxed mode:
```
[1,0]<stdout>: 2026-03-25 21:40:35.062 | warning  |          Fabric | Inter-mesh channel request exceeds physical links (policy relaxed): Requested 8 channels between 15 and 0, but only have 4 physical links. If using assign_z_direction, reduce channels.count in the mesh graph descriptor to match the physical Z-link capacity (e.g. 4 for torus wrap-around). generate_rank_bindings does not yet validate Z vs non-Z port capacity. Available port directions: S2, S3, S1, S0. (control_plane.cpp:2791)
```

```
  connections {
    nodes { mesh { mesh_descriptor: "M0" mesh_id: 16 } }
    nodes { mesh { mesh_descriptor: "M0" mesh_id: 17 } }
    channels { count: 8 policy: RELAXED }
  }
```

# Testing
- [x] [Galaxy Unit](https://github.com/tenstorrent/tt-metal/actions/runs/23566793701/job/68621161555)
- [x] [Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/23566805488)
- [x] [Multi-host](https://github.com/tenstorrent/tt-metal/actions/runs/23566819634)
