### PR TITLE
Move create_q_heads logic to only ncrisc, and flash_mla k read to brisc

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -282,35 +282,66 @@ void kernel_main() {
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
+        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
+        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
+        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
+
         flash_mla_args = {
-            .k_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .St = get_named_compile_time_arg_val("St"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
+            .cur_batch = cur_batch,
+            .core_num_in_reduce = core_num_in_reduce,
+            .is_output_core = is_output_core,
+            .is_mcast_sender = is_mcast_sender,
+            .output_core_noc_x = output_core_noc_x,
+            .output_core_noc_y = output_core_noc_y,
+            .mcast_start_x = mcast_start_x,
+            .mcast_start_y = mcast_start_y,
+            .mcast_end_x = mcast_end_x,
+            .mcast_end_y = mcast_end_y,
+            .tree_reduction_info = tree_reduction_info,
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
+            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
-            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
             .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
+            .num_tree_reduction_steps = num_tree_reduction_steps,
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_semaphore_addr =
-                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
+            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
+            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
+            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
+            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
+        get_named_compile_time_arg_val("k_page_size"),
+        get_named_compile_time_arg_val("vDHt"),
+        get_named_compile_time_arg_val("mla_out_o_cb")>;
 
     // Matmul4 CTArgs
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
@@ -595,66 +626,35 @@ void kernel_main() {
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
-        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
-        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
-        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
-
         flash_mla_args = {
+            .k_addr = get_common_arg_val<uint32_t>(0),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = cur_batch,
-            .core_num_in_reduce = core_num_in_reduce,
-            .is_output_core = is_output_core,
-            .is_mcast_sender = is_mcast_sender,
-            .output_core_noc_x = output_core_noc_x,
-            .output_core_noc_y = output_core_noc_y,
-            .mcast_start_x = mcast_start_x,
-            .mcast_start_y = mcast_start_y,
-            .mcast_end_x = mcast_end_x,
-            .mcast_end_y = mcast_end_y,
-            .tree_reduction_info = tree_reduction_info,
+            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .St = get_named_compile_time_arg_val("St"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
-            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
-            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
-            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
             .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
-            .num_tree_reduction_steps = num_tree_reduction_steps,
+            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_semaphore_addr =
+                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
-            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
-            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
-            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
-            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
-            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
-        get_named_compile_time_arg_val("k_page_size"),
-        get_named_compile_time_arg_val("vDHt"),
-        get_named_compile_time_arg_val("mla_out_o_cb")>;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
     // Matmul4/2 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -10,11 +10,11 @@
 // - NCRISC: CCL Broadcast Reader + RMSNorm reader + Mcast receiver (on matmul cores), Matmul reader + Gather sender (on
 // matmul cores),
 //           RMSNorm2 reader + Mcast2 receiver (on matmul2 cores), Matmul2 reader (on matmul2 cores),
-//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores), CreateQHeads sender (on qnope/qrope cores)
+//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores),
+//           CreateQHeads sender (on qnope/qrope cores) + receiver (on sdpa input cores)
 // - BRISC: CCL Broadcast Writer + RMSNorm writer + Mcast sender (on input core), Matmul writer (on matmul cores),
 // Gather receiver (on
-//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores),
-//          CreateQHeads receiver (on sdpa input cores) - matching gather pattern: NCRISC sender, BRISC receiver
+//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores)
 // - TRISC: RMSNorm compute (on input core), Matmul compute (on matmul cores), RMSNorm2 compute (on input core),
 //          Matmul2 compute (on matmul2 cores), Matmul3 compute (on qnope cores), RoPE compute (on qrope cores)
 //
@@ -181,14 +181,12 @@ void kernel_main() {
         .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
     };
 
-    // NCRISC: Sender args for QNOPE/QROPE cores
-    // Senders write to intermediate CB, then compute tilizes to output CB
-    // 3-phase synchronization: nope_phase1, nope_phase2, rope semaphores
+    // NCRISC: All CreateQHeads data movement (sender on qnope/qrope cores, receiver on sdpa input cores)
     constexpr uint32_t cqh_receiver_in_cb = get_named_compile_time_arg_val("cqh_receiver_in_cb");
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+    using CreateQHeadsSenderCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
         get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
         get_named_compile_time_arg_val("cqh_qrope_head_size_bytes")>;
-    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
+    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_sender_args{
         0,  // sender_grid_start_x (logical 0)
         0,  // sender_grid_start_y (logical 0)
         get_named_compile_time_arg_val("cqh_head_stride_bytes"),
@@ -211,6 +209,18 @@ void kernel_main() {
             get_named_compile_time_arg_val("cqh_target_noc_coords_row7"),
         },
         get_write_ptr(cqh_receiver_in_cb),
+    };
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
+    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_receiver_args{
+        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_num_nope_senders"),
+        get_named_compile_time_arg_val("cqh_num_rope_senders"),
+        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
+        get_named_compile_time_arg_val("cqh_out_cb"),
+        get_named_compile_time_arg_val("cqh_nope_tiles"),
+        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
@@ -521,20 +531,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
-    };
-
-    // BRISC: Receiver args for SDPA input cores
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
-    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
-        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_num_nope_senders"),
-        get_named_compile_time_arg_val("cqh_num_rope_senders"),
-        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
-        get_named_compile_time_arg_val("cqh_out_cb"),
-        get_named_compile_time_arg_val("cqh_nope_tiles"),
-        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul2 writer args (BRISC is no-op)
@@ -932,8 +928,8 @@ void kernel_main() {
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
-    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
+    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_receiver_args{
         get_named_compile_time_arg_val("cqh_receiver_in_cb"),
         get_named_compile_time_arg_val("cqh_out_cb"),
         get_named_compile_time_arg_val("cqh_nope_tiles"),
@@ -1279,15 +1275,23 @@ void kernel_main() {
                 }
 
                 // ================================================================
-                // CreateQHeads
+                // CreateQHeads (all data movement on NCRISC)
                 // ================================================================
                 {
                     DeviceZoneScopedN("CREATE_Q_HEADS");
                     constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
+#if defined(COMPILE_FOR_NCRISC)
                     deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads;
-                    create_q_heads(create_q_heads_args);
+                        Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                            create_q_heads_sender;
+                    create_q_heads_sender(create_q_heads_sender_args);
+#endif
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
+                    deepseek_b1_ops::CreateQHeads::
+                        Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                            create_q_heads_receiver;
+                    create_q_heads_receiver(create_q_heads_receiver_args);
+#endif
                 }
             }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -1281,15 +1281,25 @@ void kernel_main() {
                     DeviceZoneScopedN("CREATE_Q_HEADS");
                     constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
 #if defined(COMPILE_FOR_NCRISC)
-                    deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads_sender;
+                    deepseek_b1_ops::CreateQHeads::Op<
+                        CreateQHeadsSenderCTArgs,
+                        is_create_q_heads_sender,
+                        Core::is_sdpa_input_core,
+                        true,
+                        false,
+                        true>
+                        create_q_heads_sender;
                     create_q_heads_sender(create_q_heads_sender_args);
 #endif
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
-                    deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads_receiver;
+                    deepseek_b1_ops::CreateQHeads::Op<
+                        CreateQHeadsReceiverCTArgs,
+                        is_create_q_heads_sender,
+                        Core::is_sdpa_input_core,
+                        true,
+                        false,
+                        true>
+                        create_q_heads_receiver;
                     create_q_heads_receiver(create_q_heads_receiver_args);
 #endif
                 }

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1199,7 +1199,7 @@ class AttentionBlock:
         nope_tiles = 8  # [8, 256] / [8, 32] = 8 tiles per NOPE phase
         rope_tiles = 2  # [8, 64] / [8, 32] = 2 tiles for ROPE phase
 
-        # NCRISC sender compile-time args (QNOPE/QROPE -> SDPA Input) - matching gather pattern: NCRISC sender, BRISC receiver
+        # NCRISC compile-time args: all CreateQHeads data movement (sender + receiver) on NCRISC
         # 3-phase synchronization: senders write to intermediate CB, TRISC tilizes to output
         # Pack NOC coordinates for each row's target SDPA Input core (x in lower 16 bits, y in upper 16 bits)
         create_q_heads_ncrisc_named_compile_time_args = [
@@ -1225,18 +1225,9 @@ class AttentionBlock:
             ("cqh_qrope_src_num_pages", matmul2_out_w),  # 4 tiles of 1x32 (2 heads × 2 tiles)
             ("cqh_qnope_cols", QNOPE_COLS),
             ("cqh_receiver_in_cb", create_q_heads_receiver_in_cb),  # Intermediate CB for row-major data
-        ]
-
-        # BRISC receiver compile-time args (SDPA Input cores) - matching gather pattern: NCRISC sender, BRISC receiver
-        # 3-phase receiver: waits for each phase's semaphore, then marks pages in intermediate CB
-        # Prefixed with "cqh_" to avoid name collisions with other BRISC args
-        create_q_heads_brisc_named_compile_time_args = [
-            ("cqh_nope_phase1_semaphore_addr", nope_phase1_semaphore_addr),
-            ("cqh_nope_phase2_semaphore_addr", nope_phase2_semaphore_addr),
-            ("cqh_rope_semaphore_addr", rope_semaphore_addr),
+            # Receiver args (also on NCRISC, for sdpa input cores)
             ("cqh_num_nope_senders", QNOPE_COLS),  # 8 QNOPE senders per receiver
             ("cqh_num_rope_senders", QROPE_COLS),  # 4 QROPE senders per receiver
-            ("cqh_receiver_in_cb", create_q_heads_receiver_in_cb),  # Intermediate CB
             ("cqh_out_cb", create_q_heads_out_cb),  # Output CB (backed by output tensor)
             ("cqh_nope_tiles", nope_tiles),  # 8 tiles per NOPE phase
             ("cqh_rope_tiles", rope_tiles),  # 2 tiles for ROPE phase
@@ -3084,7 +3075,6 @@ class AttentionBlock:
             + mcast2_brisc_named_compile_time_args
             + matmul3_brisc_named_compile_time_args
             + qrope_brisc_named_compile_time_args
-            + create_q_heads_brisc_named_compile_time_args
             + dkv_gather_receiver_named_compile_time_args
             + kv_rmsnorm_brisc_named_compile_time_args
             + kv_cache_brisc_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -4029,6 +4029,5 @@ class AttentionBlock:
                 extend_fabric_args(sender_brisc_rt_args_ref, sender_fabric_args)
 
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
-        print("Run")
         result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
         return result

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1928,6 +1928,7 @@ class AttentionBlock:
         # CB descriptor creation (device-invariant, using reference tensors)
         # ========================================================================
         sdpa_out_interm_running_offset = 0
+        sdpa_out_interm_running_offset_kv_cache_update_offset = 0
         # CBs overlapped with sdpa_kv_cache L1 buffer (consumed before SDPA runs)
         sdpa_kv_cache_running_offset = 0
         # CBs overlapped with sdpa_kv_cache L1 buffer permanently allocated on the mcast core
@@ -1935,6 +1936,7 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset_mcast_core = 0
 
         sdpa_forwarder_scratch_running_offset = 0
+        sdpa_forwarder_scratch_running_offset_kv_cache_update_offset = 0
 
         # Create circular buffer descriptors
         # CB: Input (created from sharded tensor)
@@ -2028,6 +2030,8 @@ class AttentionBlock:
             )
         ]
         sdpa_out_interm_running_offset += matmul_input_cb_descriptor.total_size  # +14336 B
+
+        sdpa_out_interm_running_offset_kv_cache_update_offset = sdpa_out_interm_running_offset
 
         # CB: Matmul output buffer (single tile) — overlap with sdpa_out_interm L1 buffer
         # at offset 0 B. This CB is consumed before SDPA runs.
@@ -2135,6 +2139,11 @@ class AttentionBlock:
             )
         ]
         sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size  # +3072 B
+
+        # Make sure mcast does not trample kv cache update data
+        sdpa_out_interm_running_offset_kv_cache_update_offset = max(
+            sdpa_out_interm_running_offset_kv_cache_update_offset, sdpa_out_interm_running_offset
+        )
 
         # CB 12: Matmul2 output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 12352 B. This CB is consumed before SDPA runs.
@@ -2320,8 +2329,8 @@ class AttentionBlock:
         dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
         dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             dkv_matmul_output_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,  # 37824 B
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_offset,
             total_size=dkv_matmul_output_page_size,
             core_ranges=dkv_matmul_weights_core_grid,
         )
@@ -2333,7 +2342,14 @@ class AttentionBlock:
                 tile=dkv_matmul_output_tile_descriptor,
             )
         ]
-        sdpa_kv_cache_running_offset += dkv_matmul_output_cb_descriptor.total_size  # +64 B
+        sdpa_out_interm_running_offset_kv_cache_update_offset += dkv_matmul_output_cb_descriptor.total_size
+
+        sdpa_out_interm_running_offset_kv_cache_update_rope_offset = (
+            sdpa_out_interm_running_offset_kv_cache_update_offset
+        )
+        sdpa_out_interm_running_offset_kv_cache_update_nope_offset = (
+            sdpa_out_interm_running_offset_kv_cache_update_offset
+        )
 
         # CB 25: KV RMSNorm input buffer — overlap with sdpa_kv_cache L1 buffer
         # at offset 37888 B. This CB is consumed before SDPA runs.
@@ -2346,8 +2362,8 @@ class AttentionBlock:
         kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
         kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_input_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,  # 37888 B
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
             total_size=1 * kv_rmsnorm_page_size,
             core_ranges=dkv_gather_sender_grid.merge(dkv_gather_receiver_core_grid),
         )
@@ -2359,15 +2375,15 @@ class AttentionBlock:
                 tile=kv_rmsnorm_tile_descriptor,
             )
         ]
-        sdpa_kv_cache_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
+        sdpa_out_interm_running_offset_kv_cache_update_nope_offset += kv_rmsnorm_input_cb_descriptor.total_size
 
         # CB 27: KV RMSNorm output buffer — overlap with sdpa_kv_cache L1 buffer
         # at offset 38912 B. This CB is consumed before SDPA runs.
         # Shares CB ID with rmsnorm2_output_cb (disjoint grids: rows 0-7 vs rows 8-9)
         kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_output_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,  # 38912 B
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
             total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
             core_ranges=dkv_gather_receiver_core_grid,  # Only the nope core (BRISC) reads kv_rmsnorm_output_cb
         )
@@ -2379,7 +2395,7 @@ class AttentionBlock:
                 tile=kv_rmsnorm_tile_descriptor,
             )
         ]
-        sdpa_kv_cache_running_offset += kv_rmsnorm_output_cb_descriptor.total_size  # +1024 B
+        sdpa_out_interm_running_offset_kv_cache_update_nope_offset += kv_rmsnorm_output_cb_descriptor.total_size
         # CB 29: Cos (DRAM, read by NCRISC)
         krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         krope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
@@ -2390,13 +2406,13 @@ class AttentionBlock:
         )
         krope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             qkv_rope_cos_sin_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
             total_size=krope_Wt * krope_rope_tile_size * 2,
             core_ranges=krope_grid,
         )
         krope_cos_sin_cb_descriptor.format_descriptors = [krope_cos_sin_cb_format]
-        sdpa_kv_cache_running_offset += krope_cos_sin_cb_descriptor.total_size
+        sdpa_out_interm_running_offset_kv_cache_update_rope_offset += krope_cos_sin_cb_descriptor.total_size
 
         # CB 28: KRoPE output — overlap with sdpa_kv_cache L1 buffer
         # at offset 39936 B. This CB is consumed before SDPA runs.
@@ -2404,8 +2420,8 @@ class AttentionBlock:
         krope_tile_size = TILE_1x32.get_tile_size(data_format)
         krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             krope_output_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,  # 39936 B
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
             total_size=1 * krope_tile_size,
             core_ranges=krope_grid,
         )
@@ -2417,7 +2433,12 @@ class AttentionBlock:
                 tile=ttnn.TileDescriptor(TILE_1x32),
             )
         ]
-        sdpa_kv_cache_running_offset += krope_output_cb_descriptor.total_size  # +64 B
+        sdpa_out_interm_running_offset_kv_cache_update_rope_offset += krope_output_cb_descriptor.total_size
+
+        sdpa_out_interm_running_offset_kv_cache_update_offset = max(
+            sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
+            sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
+        )
 
         TILE_32x32 = ttnn.Tile((32, 32))
         kv_cache_page_size = TILE_32x32.get_tile_size(k_df)
@@ -2428,30 +2449,22 @@ class AttentionBlock:
             page_size=kv_cache_page_size,
             tile=ttnn.TileDescriptor(TILE_32x32),
         )
-        kv_cache_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            kv_cache_input_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,
-            total_size=kv_cache_num_tiles * kv_cache_page_size,
-            core_ranges=full_device_grid,
-        )
-        kv_cache_input_cb_descriptor.format_descriptors = [kv_cache_input_cb_format]
-        sdpa_kv_cache_running_offset += kv_cache_input_cb_descriptor.total_size
         kv_cache_output_cb_format = ttnn.CBFormatDescriptor(
             buffer_index=kv_cache_output_cb,
             data_format=k_df,
             page_size=kv_cache_page_size,
             tile=ttnn.TileDescriptor(TILE_32x32),
         )
-        kv_cache_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-            kv_cache_output_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,
+        kv_cache_input_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            kv_cache_input_cb,
+            ref_sdpa_out_interm_buffer,
+            address_offset=sdpa_out_interm_running_offset_kv_cache_update_offset,
             total_size=kv_cache_num_tiles * kv_cache_page_size,
             core_ranges=full_device_grid,
         )
-        kv_cache_output_cb_descriptor.format_descriptors = [kv_cache_output_cb_format]
-        sdpa_kv_cache_running_offset += kv_cache_output_cb_descriptor.total_size
+        # Overlap the input and output CBs
+        kv_cache_input_output_cb_descriptor.format_descriptors = [kv_cache_input_cb_format, kv_cache_output_cb_format]
+        sdpa_out_interm_running_offset_kv_cache_update_offset += kv_cache_input_output_cb_descriptor.total_size
         kv_cache_intermed_cb_format = ttnn.CBFormatDescriptor(
             buffer_index=kv_cache_intermed_cb,
             data_format=untilize_df,
@@ -2461,13 +2474,13 @@ class AttentionBlock:
         # One extra tile for syncing, can optimize to remove
         kv_cache_intermed_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_cache_intermed_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset,
+            ref_sdpa_forwarder_scratch,
+            address_offset=sdpa_forwarder_scratch_running_offset_kv_cache_update_offset,
             total_size=(kv_cache_num_tiles + 1) * TILE_32x32.get_tile_size(untilize_df),
             core_ranges=full_device_grid,
         )
         kv_cache_intermed_cb_descriptor.format_descriptors = [kv_cache_intermed_cb_format]
-        sdpa_kv_cache_running_offset += kv_cache_intermed_cb_descriptor.total_size
+        sdpa_forwarder_scratch_running_offset_kv_cache_update_offset += kv_cache_intermed_cb_descriptor.total_size
         # Flash MLA cb descriptors
         mla_cb_descriptors = []
 
@@ -3273,9 +3286,8 @@ class AttentionBlock:
             krope_output_cb_descriptor,
             krope_cos_sin_cb_descriptor,
             create_q_heads_interm_cb_descriptor,
-            kv_cache_output_cb_descriptor,
+            kv_cache_input_output_cb_descriptor,
             kv_cache_intermed_cb_descriptor,
-            kv_cache_input_cb_descriptor,
             *mla_cb_descriptors,
             *post_sdpa_cb_list,
         ]
@@ -4018,6 +4030,6 @@ class AttentionBlock:
                 extend_fabric_args(sender_brisc_rt_args_ref, sender_fabric_args)
 
             mesh_program_descriptor[ttnn.MeshCoordinateRange(mesh_coord, mesh_coord)] = program
-
+        print("Run")
         result = ttnn.generic_op(io_tensors, mesh_program_descriptor)
         return result

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1595,7 +1595,7 @@ class AttentionBlock:
         # Since all S blocks have 8 cores, num_mcast_dests is the same for all (7 = 8-1)
         num_mcast_dests = cores_per_s_block - 1  # 7 receivers per S block
 
-        mla_brisc_named_compile_time_args = [
+        mla_ncrisc_named_compile_time_args = [
             ("vDHt", vDHt),
             ("Sk_chunk_t", Sk_chunk_t),
             ("num_cores_per_head", num_cores_per_head),
@@ -1624,7 +1624,7 @@ class AttentionBlock:
             ("mla_out_o_cb", mla_out_o_cb),
             ("mla_out_ms_cb", mla_out_ms_cb),
         ]
-        mla_ncrisc_named_compile_time_args = [
+        mla_brisc_named_compile_time_args = [
             ("St", St),
             ("DHt", DHt),
             ("Sk_chunk_t", Sk_chunk_t),
@@ -1936,7 +1936,7 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset_mcast_core = 0
 
         sdpa_forwarder_scratch_running_offset = 0
-        sdpa_forwarder_scratch_running_offset_kv_cache_update_offset = 0
+        input_running_offset = 0
 
         # Create circular buffer descriptors
         # CB: Input (created from sharded tensor)
@@ -2307,8 +2307,8 @@ class AttentionBlock:
         create_q_heads_out_total_size = create_q_heads_out_page_size * q_tiles
         create_q_heads_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             create_q_heads_out_cb,
-            ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset,
+            ref_attention_block_output_tensor,  # Overlap with attn output since it's only on the mcast core
+            address_offset=0,
             total_size=create_q_heads_out_total_size,
             core_ranges=full_device_grid,
         )
@@ -2320,7 +2320,6 @@ class AttentionBlock:
                 tile=create_q_heads_out_tile_descriptor,
             )
         ]
-        sdpa_forwarder_scratch_running_offset += create_q_heads_out_cb_descriptor.total_size
 
         # CB 24: DKV Matmul output — shares CB ID with matmul_output_cb (disjoint grids)
         # matmul_output_cb covers matmul_weights_core_grid (rows 0-7)
@@ -2475,12 +2474,12 @@ class AttentionBlock:
         kv_cache_intermed_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_cache_intermed_cb,
             ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset_kv_cache_update_offset,
+            address_offset=sdpa_forwarder_scratch_running_offset,
             total_size=(kv_cache_num_tiles + 1) * TILE_32x32.get_tile_size(untilize_df),
             core_ranges=full_device_grid,
         )
         kv_cache_intermed_cb_descriptor.format_descriptors = [kv_cache_intermed_cb_format]
-        sdpa_forwarder_scratch_running_offset_kv_cache_update_offset += kv_cache_intermed_cb_descriptor.total_size
+        sdpa_forwarder_scratch_running_offset += kv_cache_intermed_cb_descriptor.total_size
         # Flash MLA cb descriptors
         mla_cb_descriptors = []
 
@@ -2555,8 +2554,8 @@ class AttentionBlock:
         # cb_mask: Mask input
         mla_mask_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             mla_mask_cb,
-            ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset,
+            ref_input_tensor,
+            address_offset=input_running_offset,
             total_size=q_tile_size,
             core_ranges=full_device_grid,
         )
@@ -2568,14 +2567,14 @@ class AttentionBlock:
                 tile=q_tile_descriptor,
             )
         ]
-        sdpa_forwarder_scratch_running_offset += mla_mask_cb_descriptor.total_size
+        input_running_offset += mla_mask_cb_descriptor.total_size
         mla_cb_descriptors.append(mla_mask_cb_descriptor)
 
         # mla_out_o_cb/mla_interm_out_cb: output O (tiny tile)
         mla_out_o_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             mla_out_o_cb,
-            ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset,
+            ref_input_tensor,
+            address_offset=input_running_offset,
             total_size=out0_t * stats_tile_size,
             core_ranges=full_device_grid,
         )
@@ -2583,7 +2582,7 @@ class AttentionBlock:
             ttnn.CBFormatDescriptor(mla_out_o_cb, stats_df, stats_tile_size, stats_tile_descriptor),
             ttnn.CBFormatDescriptor(mla_interm_out_cb, stats_df, stats_tile_size, stats_tile_descriptor),
         ]
-        sdpa_forwarder_scratch_running_offset += mla_out_o_cb_descriptor.total_size
+        input_running_offset += mla_out_o_cb_descriptor.total_size
         mla_cb_descriptors.append(mla_out_o_cb_descriptor)
         # Uncomment to debug local FlashMLA output
         # mla_out_o_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(mla_out_o_cb, output_tensor_device)
@@ -2597,8 +2596,8 @@ class AttentionBlock:
         # cb_out_ms/cb_interm_ms: output m/s stats (tiny tile, shared for both m and s)
         mla_out_ms_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             mla_out_ms_cb,
-            ref_sdpa_forwarder_scratch,
-            address_offset=sdpa_forwarder_scratch_running_offset,
+            ref_input_tensor,
+            address_offset=input_running_offset,
             total_size=statistics_tiles * stats_tile_size,
             core_ranges=full_device_grid,
         )
@@ -2606,7 +2605,7 @@ class AttentionBlock:
             ttnn.CBFormatDescriptor(mla_out_ms_cb, stats_df, stats_tile_size, stats_tile_descriptor),
             ttnn.CBFormatDescriptor(mla_interm_ms_cb, stats_df, stats_tile_size, stats_tile_descriptor),
         ]
-        sdpa_forwarder_scratch_running_offset += mla_out_ms_cb_descriptor.total_size
+        input_running_offset += mla_out_ms_cb_descriptor.total_size
         mla_cb_descriptors.append(mla_out_ms_cb_descriptor)
 
         # Post SDPA
@@ -2998,8 +2997,8 @@ class AttentionBlock:
             output_core_noc_x = output_core_physical_xs[cur_batch] if cur_batch < len(output_core_physical_xs) else 0
             output_core_noc_y = output_core_physical_ys[cur_batch] if cur_batch < len(output_core_physical_ys) else 0
 
-            # NCRISC per-core runtime args (common args: k_addr, pos_addr)
-            mla_ncrisc_per_core_args.append(
+            # BRISC per-core runtime args (common args: k_addr, pos_addr)
+            mla_brisc_per_core_args.append(
                 (
                     core,
                     [
@@ -3016,8 +3015,8 @@ class AttentionBlock:
             # Tree reduction partner coordinates
             tree_reduction_info = optimized_mla_grid.get_tree_reduction_partner_coords(device, s_block_idx, cur_batch)
 
-            # BRISC per-core runtime args (common args: pos_addr)
-            mla_brisc_args = [
+            # NCRISC per-core runtime args (common args: pos_addr)
+            mla_ncrisc_args = [
                 cur_batch,
                 core_num_in_reduce,
                 is_output_core,
@@ -3030,8 +3029,8 @@ class AttentionBlock:
                 mcast_end_y,
             ]
             for role_code, partner_s_block_idx, partner_x, partner_y in tree_reduction_info:
-                mla_brisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
-            mla_brisc_per_core_args.append((core, mla_brisc_args))
+                mla_ncrisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
+            mla_ncrisc_per_core_args.append((core, mla_ncrisc_args))
 
             is_sender_after_reduce = (
                 1 if (do_reduce and optimized_mla_grid.is_tree_reduction_sender(s_block_idx)) else 0

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -10,11 +10,11 @@
 // - NCRISC: CCL Broadcast Reader + RMSNorm reader + Mcast receiver (on matmul cores), Matmul reader + Gather sender (on
 // matmul cores),
 //           RMSNorm2 reader + Mcast2 receiver (on matmul2 cores), Matmul2 reader (on matmul2 cores),
-//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores), CreateQHeads sender (on qnope/qrope cores)
+//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores),
+//           CreateQHeads sender (on qnope/qrope cores) + receiver (on sdpa input cores)
 // - BRISC: CCL Broadcast Writer + RMSNorm writer + Mcast sender (on input core), Matmul writer (on matmul cores),
 // Gather receiver (on
-//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores),
-//          CreateQHeads receiver (on sdpa input cores) - matching gather pattern: NCRISC sender, BRISC receiver
+//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores)
 // - TRISC: RMSNorm compute (on input core), Matmul compute (on matmul cores), RMSNorm2 compute (on input core),
 //          Matmul2 compute (on matmul2 cores), Matmul3 compute (on qnope cores), RoPE compute (on qrope cores)
 //
@@ -220,14 +220,12 @@ void kernel_main() {
         .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
     };
 
-    // NCRISC: Sender args for QNOPE/QROPE cores
-    // Senders write to intermediate CB, then compute tilizes to output CB
-    // 3-phase synchronization: nope_phase1, nope_phase2, rope semaphores
+    // NCRISC: All CreateQHeads data movement (sender on qnope/qrope cores, receiver on sdpa input cores)
     constexpr uint32_t cqh_receiver_in_cb = get_named_compile_time_arg_val("cqh_receiver_in_cb");
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+    using CreateQHeadsSenderCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
         get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
         get_named_compile_time_arg_val("cqh_qrope_head_size_bytes")>;
-    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
+    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_sender_args{
         0,  // sender_grid_start_x (logical 0)
         0,  // sender_grid_start_y (logical 0)
         get_named_compile_time_arg_val("cqh_head_stride_bytes"),
@@ -250,6 +248,18 @@ void kernel_main() {
             get_named_compile_time_arg_val("cqh_target_noc_coords_row7"),
         },
         get_write_ptr(cqh_receiver_in_cb),
+    };
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
+    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_receiver_args{
+        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_num_nope_senders"),
+        get_named_compile_time_arg_val("cqh_num_rope_senders"),
+        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
+        get_named_compile_time_arg_val("cqh_out_cb"),
+        get_named_compile_time_arg_val("cqh_nope_tiles"),
+        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
@@ -560,20 +570,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
-    };
-
-    // BRISC: Receiver args for SDPA input cores
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
-    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
-        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_num_nope_senders"),
-        get_named_compile_time_arg_val("cqh_num_rope_senders"),
-        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
-        get_named_compile_time_arg_val("cqh_out_cb"),
-        get_named_compile_time_arg_val("cqh_nope_tiles"),
-        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul2 writer args (BRISC is no-op)
@@ -971,8 +967,8 @@ void kernel_main() {
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
-    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
+    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_receiver_args{
         get_named_compile_time_arg_val("cqh_receiver_in_cb"),
         get_named_compile_time_arg_val("cqh_out_cb"),
         get_named_compile_time_arg_val("cqh_nope_tiles"),
@@ -2112,15 +2108,23 @@ void kernel_main() {
                 }
 
                 // ================================================================
-                // CreateQHeads
+                // CreateQHeads (all data movement on NCRISC)
                 // ================================================================
                 {
                     DeviceZoneScopedN("CREATE_Q_HEADS");
                     constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
+#if defined(COMPILE_FOR_NCRISC)
                     deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads;
-                    create_q_heads(create_q_heads_args);
+                        Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                            create_q_heads_sender;
+                    create_q_heads_sender(create_q_heads_sender_args);
+#endif
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
+                    deepseek_b1_ops::CreateQHeads::
+                        Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                            create_q_heads_receiver;
+                    create_q_heads_receiver(create_q_heads_receiver_args);
+#endif
                 }
             }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -321,35 +321,66 @@ void kernel_main() {
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
+        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
+        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
+        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
+
         flash_mla_args = {
-            .k_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .St = get_named_compile_time_arg_val("St"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
+            .cur_batch = cur_batch,
+            .core_num_in_reduce = core_num_in_reduce,
+            .is_output_core = is_output_core,
+            .is_mcast_sender = is_mcast_sender,
+            .output_core_noc_x = output_core_noc_x,
+            .output_core_noc_y = output_core_noc_y,
+            .mcast_start_x = mcast_start_x,
+            .mcast_start_y = mcast_start_y,
+            .mcast_end_x = mcast_end_x,
+            .mcast_end_y = mcast_end_y,
+            .tree_reduction_info = tree_reduction_info,
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
+            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
-            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
             .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
+            .num_tree_reduction_steps = num_tree_reduction_steps,
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_semaphore_addr =
-                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
+            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
+            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
+            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
+            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
+        get_named_compile_time_arg_val("k_page_size"),
+        get_named_compile_time_arg_val("vDHt"),
+        get_named_compile_time_arg_val("mla_out_o_cb")>;
 
     // Matmul4 CTArgs
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
@@ -634,66 +665,35 @@ void kernel_main() {
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
-        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
-        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
-        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
-
         flash_mla_args = {
+            .k_addr = get_common_arg_val<uint32_t>(0),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = cur_batch,
-            .core_num_in_reduce = core_num_in_reduce,
-            .is_output_core = is_output_core,
-            .is_mcast_sender = is_mcast_sender,
-            .output_core_noc_x = output_core_noc_x,
-            .output_core_noc_y = output_core_noc_y,
-            .mcast_start_x = mcast_start_x,
-            .mcast_start_y = mcast_start_y,
-            .mcast_end_x = mcast_end_x,
-            .mcast_end_y = mcast_end_y,
-            .tree_reduction_info = tree_reduction_info,
+            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .St = get_named_compile_time_arg_val("St"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
-            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
-            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
-            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
             .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
-            .num_tree_reduction_steps = num_tree_reduction_steps,
+            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_semaphore_addr =
+                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
-            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
-            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
-            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
-            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
-            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
-        get_named_compile_time_arg_val("k_page_size"),
-        get_named_compile_time_arg_val("vDHt"),
-        get_named_compile_time_arg_val("mla_out_o_cb")>;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
     // Matmul4/2 CTArgs (BRISC is no-op for matmul)
     using Matmul4CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2114,15 +2114,25 @@ void kernel_main() {
                     DeviceZoneScopedN("CREATE_Q_HEADS");
                     constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
 #if defined(COMPILE_FOR_NCRISC)
-                    deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads_sender;
+                    deepseek_b1_ops::CreateQHeads::Op<
+                        CreateQHeadsSenderCTArgs,
+                        is_create_q_heads_sender,
+                        Core::is_sdpa_input_core,
+                        true,
+                        false,
+                        true>
+                        create_q_heads_sender;
                     create_q_heads_sender(create_q_heads_sender_args);
 #endif
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
-                    deepseek_b1_ops::CreateQHeads::
-                        Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                            create_q_heads_receiver;
+                    deepseek_b1_ops::CreateQHeads::Op<
+                        CreateQHeadsReceiverCTArgs,
+                        is_create_q_heads_sender,
+                        Core::is_sdpa_input_core,
+                        true,
+                        false,
+                        true>
+                        create_q_heads_receiver;
                     create_q_heads_receiver(create_q_heads_receiver_args);
 #endif
                 }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -10,11 +10,11 @@
 // - NCRISC: CCL Broadcast Reader + RMSNorm reader + Mcast receiver (on matmul cores), Matmul reader + Gather sender (on
 // matmul cores),
 //           RMSNorm2 reader + Mcast2 receiver (on matmul2 cores), Matmul2 reader (on matmul2 cores),
-//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores), CreateQHeads sender (on qnope/qrope cores)
+//           Matmul3 reader (on qnope cores), RoPE reader (on qrope cores),
+//           CreateQHeads sender (on qnope/qrope cores) + receiver (on sdpa input cores)
 // - BRISC: CCL Broadcast Writer + RMSNorm writer + Mcast sender (on input core), Matmul writer (on matmul cores),
 // Gather receiver (on
-//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores),
-//          CreateQHeads receiver (on sdpa input cores) - matching gather pattern: NCRISC sender, BRISC receiver
+//          input core), Mcast2 sender (on input core), Matmul2 writer (on matmul2 cores)
 // - TRISC: RMSNorm compute (on input core), Matmul compute (on matmul cores), RMSNorm2 compute (on input core),
 //          Matmul2 compute (on matmul2 cores), Matmul3 compute (on qnope cores), RoPE compute (on qrope cores)
 //
@@ -186,14 +186,12 @@ if constexpr (!Core::skip_ccl) {
         .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
         .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address")};
 
-    // NCRISC: Sender args for QNOPE/QROPE cores
-    // Senders write to intermediate CB, then compute tilizes to output CB
-    // 3-phase synchronization: nope_phase1, nope_phase2, rope semaphores
+    // NCRISC: All CreateQHeads data movement (sender on qnope/qrope cores, receiver on sdpa input cores)
     constexpr uint32_t cqh_receiver_in_cb = get_named_compile_time_arg_val("cqh_receiver_in_cb");
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+    using CreateQHeadsSenderCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
         get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
         get_named_compile_time_arg_val("cqh_qrope_head_size_bytes")>;
-    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
+    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_sender_args{
         0,  // sender_grid_start_x (logical 0)
         0,  // sender_grid_start_y (logical 0)
         get_named_compile_time_arg_val("cqh_head_stride_bytes"),
@@ -216,6 +214,18 @@ if constexpr (!Core::skip_ccl) {
             get_named_compile_time_arg_val("cqh_target_noc_coords_row7"),
         },
         get_write_ptr(cqh_receiver_in_cb),
+    };
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
+    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_receiver_args{
+        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
+        get_named_compile_time_arg_val("cqh_num_nope_senders"),
+        get_named_compile_time_arg_val("cqh_num_rope_senders"),
+        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
+        get_named_compile_time_arg_val("cqh_out_cb"),
+        get_named_compile_time_arg_val("cqh_nope_tiles"),
+        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
@@ -373,20 +383,6 @@ if constexpr (!Core::skip_ccl) {
         get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
         get_named_compile_time_arg_val("gather_reduce_dst_cb"),
         get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
-    };
-
-    // BRISC: Receiver args for SDPA input cores
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
-    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
-        get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_rope_semaphore_addr"),
-        get_named_compile_time_arg_val("cqh_num_nope_senders"),
-        get_named_compile_time_arg_val("cqh_num_rope_senders"),
-        get_named_compile_time_arg_val("cqh_receiver_in_cb"),
-        get_named_compile_time_arg_val("cqh_out_cb"),
-        get_named_compile_time_arg_val("cqh_nope_tiles"),
-        get_named_compile_time_arg_val("cqh_rope_tiles"),
     };
 
     // Matmul2 writer args (BRISC is no-op)
@@ -626,8 +622,8 @@ if constexpr (!Core::skip_ccl) {
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
-    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
+    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_receiver_args{
         get_named_compile_time_arg_val("cqh_receiver_in_cb"),
         get_named_compile_time_arg_val("cqh_out_cb"),
         get_named_compile_time_arg_val("cqh_nope_tiles"),
@@ -940,15 +936,23 @@ if constexpr (!Core::skip_ccl) {
             }
 
             // ================================================================
-            // CreateQHeads
+            // CreateQHeads (all data movement on NCRISC)
             // ================================================================
             {
                 DeviceZoneScopedN("CREATE_Q_HEADS");
                 constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
+#if defined(COMPILE_FOR_NCRISC)
                 deepseek_b1_ops::CreateQHeads::
-                    Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                        create_q_heads;
-                create_q_heads(create_q_heads_args);
+                    Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                        create_q_heads_sender;
+                create_q_heads_sender(create_q_heads_sender_args);
+#endif
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
+                deepseek_b1_ops::CreateQHeads::
+                    Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                        create_q_heads_receiver;
+                create_q_heads(create_q_heads_receiver_args);
+#endif
             }
         }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -943,14 +943,19 @@ if constexpr (!Core::skip_ccl) {
                 constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
 #if defined(COMPILE_FOR_NCRISC)
                 deepseek_b1_ops::CreateQHeads::
-                    Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                    Op<CreateQHeadsSenderCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, true, false, true>
                         create_q_heads_sender;
                 create_q_heads_sender(create_q_heads_sender_args);
 #endif
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
-                deepseek_b1_ops::CreateQHeads::
-                    Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                        create_q_heads_receiver;
+                deepseek_b1_ops::CreateQHeads::Op<
+                    CreateQHeadsReceiverCTArgs,
+                    is_create_q_heads_sender,
+                    Core::is_sdpa_input_core,
+                    true,
+                    false,
+                    true>
+                    create_q_heads_receiver;
                 create_q_heads_receiver(create_q_heads_receiver_args);
 #endif
             }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -286,35 +286,66 @@ if constexpr (!Core::skip_ccl) {
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
+        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
+        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
+        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
+
         flash_mla_args = {
-            .k_addr = get_common_arg_val<uint32_t>(5),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .St = get_named_compile_time_arg_val("St"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
+            .cur_batch = cur_batch,
+            .core_num_in_reduce = core_num_in_reduce,
+            .is_output_core = is_output_core,
+            .is_mcast_sender = is_mcast_sender,
+            .output_core_noc_x = output_core_noc_x,
+            .output_core_noc_y = output_core_noc_y,
+            .mcast_start_x = mcast_start_x,
+            .mcast_start_y = mcast_start_y,
+            .mcast_end_x = mcast_end_x,
+            .mcast_end_y = mcast_end_y,
+            .tree_reduction_info = tree_reduction_info,
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
+            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
-            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
             .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
+            .num_tree_reduction_steps = num_tree_reduction_steps,
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_semaphore_addr =
-                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
-            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
+            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
+            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
+            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
+            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
+        get_named_compile_time_arg_val("k_page_size"),
+        get_named_compile_time_arg_val("vDHt"),
+        get_named_compile_time_arg_val("mla_out_o_cb")>;
 
 // ============================================================================
 // BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
@@ -447,66 +478,35 @@ if constexpr (!Core::skip_ccl) {
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
     };
 
-    deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
+    deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
-        constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
-        uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
-        per_core_rta_arg_idx += num_tree_reduction_steps * 4;
-
         flash_mla_args = {
+            .k_addr = get_common_arg_val<uint32_t>(0),
             .local_cur_pos = 0,  // set via flash_mla.set_local_cur_pos() below
-            .cur_batch = cur_batch,
-            .core_num_in_reduce = core_num_in_reduce,
-            .is_output_core = is_output_core,
-            .is_mcast_sender = is_mcast_sender,
-            .output_core_noc_x = output_core_noc_x,
-            .output_core_noc_y = output_core_noc_y,
-            .mcast_start_x = mcast_start_x,
-            .mcast_start_y = mcast_start_y,
-            .mcast_end_x = mcast_end_x,
-            .mcast_end_y = mcast_end_y,
-            .tree_reduction_info = tree_reduction_info,
+            .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
+            .St = get_named_compile_time_arg_val("St"),
+            .DHt = get_named_compile_time_arg_val("DHt"),
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
-            .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
-            .DHt = get_named_compile_time_arg_val("DHt"),
-            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
-            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
-            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
+            .k_page_size = get_named_compile_time_arg_val("k_page_size"),
             .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
-            .num_tree_reduction_steps = num_tree_reduction_steps,
+            .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_semaphore_addr =
+                get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
+            .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
-            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
-            .cb_mask = get_named_compile_time_arg_val("mla_mask_cb"),
-            .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
-            .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
-            .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
         };
     }
 
-    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::WriterCTArgs<
-        get_named_compile_time_arg_val("k_page_size"),
-        get_named_compile_time_arg_val("vDHt"),
-        get_named_compile_time_arg_val("mla_out_o_cb")>;
+    using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
 // ============================================================================
 // TRISC (Compute) - ComputeConfigDescriptor compiles as TRISC

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -951,7 +951,7 @@ if constexpr (!Core::skip_ccl) {
                 deepseek_b1_ops::CreateQHeads::
                     Op<CreateQHeadsReceiverCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
                         create_q_heads_receiver;
-                create_q_heads(create_q_heads_receiver_args);
+                create_q_heads_receiver(create_q_heads_receiver_args);
 #endif
             }
         }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1204,7 +1204,7 @@ class PreSDPA:
         # Since all S blocks have 8 cores, num_mcast_dests is the same for all (7 = 8-1)
         num_mcast_dests = cores_per_s_block - 1  # 7 receivers per S block
 
-        mla_brisc_named_compile_time_args = [
+        mla_ncrisc_named_compile_time_args = [
             ("vDHt", vDHt),
             ("Sk_chunk_t", Sk_chunk_t),
             ("num_cores_per_head", num_cores_per_head),
@@ -1233,7 +1233,7 @@ class PreSDPA:
             ("mla_out_o_cb", mla_out_o_cb),
             ("mla_out_ms_cb", mla_out_ms_cb),
         ]
-        mla_ncrisc_named_compile_time_args = [
+        mla_brisc_named_compile_time_args = [
             ("St", St),
             ("DHt", DHt),
             ("Sk_chunk_t", Sk_chunk_t),
@@ -1965,8 +1965,8 @@ class PreSDPA:
                         output_core_physical_ys[cur_batch] if cur_batch < len(output_core_physical_ys) else 0
                     )
 
-                    # NCRISC per-core runtime args (common args: k_addr, pos_addr)
-                    mla_ncrisc_per_core_args.append(
+                    # BRISC per-core runtime args (common args: k_addr, pos_addr)
+                    mla_brisc_per_core_args.append(
                         (
                             core,
                             [
@@ -1985,8 +1985,8 @@ class PreSDPA:
                         device, s_block_idx, cur_batch
                     )
 
-                    # BRISC per-core runtime args (common args: pos_addr)
-                    mla_brisc_args = [
+                    # NCRISC per-core runtime args (common args: pos_addr)
+                    mla_ncrisc_args = [
                         cur_batch,
                         core_num_in_reduce,
                         is_output_core,
@@ -1999,8 +1999,8 @@ class PreSDPA:
                         mcast_end_y,
                     ]
                     for role_code, partner_s_block_idx, partner_x, partner_y in tree_reduction_info:
-                        mla_brisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
-                    mla_brisc_per_core_args.append((core, mla_brisc_args))
+                        mla_ncrisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
+                    mla_ncrisc_per_core_args.append((core, mla_ncrisc_args))
 
                     is_sender_after_reduce = (
                         1 if (do_reduce and optimized_mla_grid.is_tree_reduction_sender(s_block_idx)) else 0

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -818,7 +818,7 @@ class PreSDPA:
         nope_tiles = 8  # [8, 256] / [8, 32] = 8 tiles per NOPE phase
         rope_tiles = 2  # [8, 64] / [8, 32] = 2 tiles for ROPE phase
 
-        # NCRISC sender compile-time args (QNOPE/QROPE -> SDPA Input) - matching gather pattern: NCRISC sender, BRISC receiver
+        # NCRISC compile-time args: all CreateQHeads data movement (sender + receiver) on NCRISC
         # 3-phase synchronization: senders write to intermediate CB, TRISC tilizes to output
         # Pack NOC coordinates for each row's target SDPA Input core (x in lower 16 bits, y in upper 16 bits)
         create_q_heads_ncrisc_named_compile_time_args = [
@@ -844,18 +844,9 @@ class PreSDPA:
             ("cqh_qrope_src_num_pages", matmul2_out_w),  # 4 tiles of 1x32 (2 heads × 2 tiles)
             ("cqh_qnope_cols", QNOPE_COLS),
             ("cqh_receiver_in_cb", create_q_heads_receiver_in_cb),  # Intermediate CB for row-major data
-        ]
-
-        # BRISC receiver compile-time args (SDPA Input cores) - matching gather pattern: NCRISC sender, BRISC receiver
-        # 3-phase receiver: waits for each phase's semaphore, then marks pages in intermediate CB
-        # Prefixed with "cqh_" to avoid name collisions with other BRISC args
-        create_q_heads_brisc_named_compile_time_args = [
-            ("cqh_nope_phase1_semaphore_addr", nope_phase1_semaphore_addr),
-            ("cqh_nope_phase2_semaphore_addr", nope_phase2_semaphore_addr),
-            ("cqh_rope_semaphore_addr", rope_semaphore_addr),
+            # Receiver args (also on NCRISC, for sdpa input cores)
             ("cqh_num_nope_senders", QNOPE_COLS),  # 8 QNOPE senders per receiver
             ("cqh_num_rope_senders", QROPE_COLS),  # 4 QROPE senders per receiver
-            ("cqh_receiver_in_cb", create_q_heads_receiver_in_cb),  # Intermediate CB
             ("cqh_out_cb", create_q_heads_out_cb),  # Output CB (backed by output tensor)
             ("cqh_nope_tiles", nope_tiles),  # 8 tiles per NOPE phase
             ("cqh_rope_tiles", rope_tiles),  # 2 tiles for ROPE phase
@@ -2113,7 +2104,6 @@ class PreSDPA:
                     + mcast2_brisc_named_compile_time_args
                     + matmul3_brisc_named_compile_time_args
                     + qrope_brisc_named_compile_time_args
-                    + create_q_heads_brisc_named_compile_time_args
                     + dkv_gather_receiver_named_compile_time_args
                     + kv_rmsnorm_brisc_named_compile_time_args
                     + kv_cache_brisc_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_sdpa_custom_mm.h
@@ -42,6 +42,7 @@ inline void _llk_unpack_AB_sdpa_custom_mm_(
 
     if (mask_chunk) {
         cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = base_address_mask;
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
         TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcB, 0b00000000, 1, 1);
     }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/kernels/create_q_heads_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/kernels/create_q_heads_kernel.cpp
@@ -86,13 +86,13 @@ void kernel_main() {
 #endif
 #if defined(COMPILE_FOR_NCRISC)
     using CreateQHeadsSenderOp = deepseek_b1_ops::CreateQHeads::
-        Op<CreateQHeadsSenderCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true>;
+        Op<CreateQHeadsSenderCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true, true>;
     CreateQHeadsSenderOp create_q_heads_sender;
     create_q_heads_sender(sender_args);
 #endif
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
     using CreateQHeadsReceiverOp = deepseek_b1_ops::CreateQHeads::
-        Op<CreateQHeadsReceiverCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true>;
+        Op<CreateQHeadsReceiverCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true, true>;
     CreateQHeadsReceiverOp create_q_heads_receiver;
     create_q_heads_receiver(receiver_args);
 #endif

--- a/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/kernels/create_q_heads_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/kernels/create_q_heads_kernel.cpp
@@ -12,9 +12,9 @@
 //   Phase 2: Second 8 halves of QNOPE - shape [8, 256] → 8 tiles
 //   Phase 3: QROPE - shape [8, 64] → 2 tiles
 //
-// Standalone op pattern (matching pre_sdpa gather pattern):
-//   - NCRISC: All senders (always sender, never receiver)
-//   - BRISC: All receivers (always receiver, never sender)
+// Standalone op pattern:
+//   - NCRISC: All data movement (sender on qnope/qrope cores, receiver on sdpa input cores)
+//   - BRISC: Idle
 //   - TRISC: Tilization on receiver cores
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
@@ -31,12 +31,12 @@ struct Core {
 
 void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
-    // NCRISC: Sender args for QNOPE/QROPE cores (matching pre_sdpa gather pattern: NCRISC sender, BRISC receiver)
+    // NCRISC: All data movement — sender on qnope/qrope cores, receiver on sdpa input cores
     uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+    using CreateQHeadsSenderCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
         get_named_compile_time_arg_val("qnope_data_size_bytes"),
         get_named_compile_time_arg_val("qrope_head_size_bytes")>;
-    deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
+    deepseek_b1_ops::CreateQHeads::SenderArgs sender_args{
         get_named_compile_time_arg_val("sender_grid_start_x"),
         get_named_compile_time_arg_val("sender_grid_start_y"),
         get_named_compile_time_arg_val("head_stride_bytes"),
@@ -44,7 +44,6 @@ void kernel_main() {
         get_named_compile_time_arg_val("qnope_cb"),
         get_named_compile_time_arg_val("qrope_cb"),
         get_named_compile_time_arg_val("src_num_pages"),
-        // 3 semaphores for race-free synchronization
         get_semaphore(get_named_compile_time_arg_val("nope_phase1_semaphore_id")),
         get_semaphore(get_named_compile_time_arg_val("nope_phase2_semaphore_id")),
         get_semaphore(get_named_compile_time_arg_val("rope_semaphore_id")),
@@ -61,10 +60,8 @@ void kernel_main() {
         receiver_data_addr,
     };
 
-#elif defined(COMPILE_FOR_BRISC)
-    // BRISC: Receiver args for SDPA input cores (matching pre_sdpa gather pattern: NCRISC sender, BRISC receiver)
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
-    deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
+    deepseek_b1_ops::CreateQHeads::ReceiverArgs receiver_args{
         get_semaphore(get_named_compile_time_arg_val("nope_phase1_semaphore_id")),
         get_semaphore(get_named_compile_time_arg_val("nope_phase2_semaphore_id")),
         get_semaphore(get_named_compile_time_arg_val("rope_semaphore_id")),
@@ -78,8 +75,8 @@ void kernel_main() {
 
 #elif defined(COMPILE_FOR_TRISC)
     // TRISC (Compute): Tilization args for receiver cores
-    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
-    deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
+    using CreateQHeadsReceiverCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
+    deepseek_b1_ops::CreateQHeads::ComputeArgs receiver_args{
         get_named_compile_time_arg_val("receiver_in_cb"),
         get_named_compile_time_arg_val("out_cb"),
         get_named_compile_time_arg_val("nope_tiles"),
@@ -87,9 +84,16 @@ void kernel_main() {
     };
     deepseek_compute_kernel_init();
 #endif
-
-    using CreateQHeadsOp =
-        deepseek_b1_ops::CreateQHeads::Op<CreateQHeadsCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true>;
-    CreateQHeadsOp create_q_heads;
-    create_q_heads(create_q_heads_args);
+#if defined(COMPILE_FOR_NCRISC)
+    using CreateQHeadsSenderOp = deepseek_b1_ops::CreateQHeads::
+        Op<CreateQHeadsSenderCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true>;
+    CreateQHeadsSenderOp create_q_heads_sender;
+    create_q_heads_sender(sender_args);
+#endif
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
+    using CreateQHeadsReceiverOp = deepseek_b1_ops::CreateQHeads::
+        Op<CreateQHeadsReceiverCTArgs, Core::is_sender_core, Core::is_receiver_core, true, true>;
+    CreateQHeadsReceiverOp create_q_heads_receiver;
+    create_q_heads_receiver(receiver_args);
+#endif
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/create_q_heads/op.py
@@ -31,9 +31,9 @@ class CreateQHeads:
         - Offset = (8*512) * elem_size + 2*qrope_col*64*elem_size
         - Signals semaphore once
 
-    RISC assignment (matching pre_sdpa gather pattern):
-      - All senders use NCRISC (RISCV_1)
-      - All receivers use BRISC (RISCV_0)
+    RISC assignment:
+      - All data movement (sender + receiver) uses NCRISC (RISCV_1)
+      - BRISC is idle
     """
 
     # Mapping from sender row index to target receiver core
@@ -287,14 +287,13 @@ class CreateQHeads:
         ]
 
         # ========================================================================
-        # Common sender compile-time args (shared by NOC0 and NOC1 senders)
+        # Common compile-time args for sender + receiver (all on NCRISC)
         # Uses 3 separate semaphores for race-free synchronization
         # ========================================================================
-        def create_sender_named_compile_time_args():
+        def create_common_named_compile_time_args(is_receiver):
             args = [
-                # Sender role flags (all senders use NCRISC, matching pre_sdpa pattern)
                 ("is_sender_core", 1),
-                ("is_receiver_core", 0),
+                ("is_receiver_core", 1 if is_receiver else 0),
                 # Sender grid info for offset computation
                 ("sender_grid_start_x", sender_grid_start_x),
                 ("sender_grid_start_y", sender_grid_start_y),
@@ -313,82 +312,70 @@ class CreateQHeads:
                 ("rope_semaphore_id", rope_semaphore_id),
             ]
             # Add target NOC coordinates for each row (packed: x in lower 16 bits, y in upper 16 bits)
-            # Kernel expects args for all 8 rows (hardcoded array size), so always pass all 8
             for row in range(8):
                 if row in target_noc_coords:
                     noc_x, noc_y = target_noc_coords[row]
                     packed_coords = noc_x | (noc_y << 16)
                     args.append((f"target_noc_coords_row{row}", packed_coords))
                 else:
-                    # Fill missing rows with dummy coordinates (0,0)
                     args.append((f"target_noc_coords_row{row}", 0))
+            if is_receiver:
+                args.extend(
+                    [
+                        ("receiver_in_cb", receiver_in_cb),
+                        ("out_cb", out_cb),
+                        ("dst_num_pages", dst_num_pages),
+                        ("nope_tiles", nope_tiles),
+                        ("rope_tiles", rope_tiles),
+                        ("sender_grid_width", sender_grid_width),
+                        ("receiver_grid_start_x", receiver_grid_start_x),
+                        ("receiver_grid_start_y", receiver_grid_start_y),
+                        ("receiver_cols", receiver_cols),
+                        ("num_nope_senders", qnope_cols),
+                        ("num_rope_senders", sender_grid_width - qnope_cols),
+                    ]
+                )
             return args
 
         # ========================================================================
-        # Sender kernel (NCRISC) - all senders use NCRISC (matching pre_sdpa pattern)
+        # NCRISC kernels - all data movement (sender + receiver) on NCRISC
         # ========================================================================
-        sender_kernel = ttnn.KernelDescriptor(
-            kernel_source=kernel_path,
-            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-            core_ranges=sender_core_grid,
-            named_compile_time_args=create_sender_named_compile_time_args(),
-            common_runtime_args=[receiver_data_addr],
-            config=ttnn.DataMovementConfigDescriptor(
-                processor=ttnn.DataMovementProcessor.RISCV_1,  # NCRISC
-                noc=ttnn.NOC.NOC_0,
-            ),
-        )
-        kernels.append(sender_kernel)
+        # Sender-only cores (not receivers)
+        sender_only_cores = [c for c in sender_cores_list if not receiver_core_grid.contains(c)]
+        if sender_only_cores:
+            sender_only_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in sender_only_cores])
+            sender_only_kernel = ttnn.KernelDescriptor(
+                kernel_source=kernel_path,
+                source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+                core_ranges=sender_only_core_range_set,
+                named_compile_time_args=create_common_named_compile_time_args(is_receiver=False),
+                common_runtime_args=[receiver_data_addr],
+                config=ttnn.DataMovementConfigDescriptor(
+                    processor=ttnn.DataMovementProcessor.RISCV_1,  # NCRISC
+                    noc=ttnn.NOC.NOC_0,
+                ),
+            )
+            kernels.append(sender_only_kernel)
 
-        # ========================================================================
-        # Receiver kernel (BRISC) - all receivers use BRISC (matching pre_sdpa pattern)
-        # ========================================================================
-        def create_receiver_named_compile_time_args():
-            """Create receiver compile-time args (all receivers use BRISC)."""
-            args = [
-                # All receiver cores are also sender cores (receiver grid is within sender grid)
-                ("is_sender_core", 1),
-                ("is_receiver_core", 1),
-                # Semaphores (3 separate for race-free synchronization)
-                ("nope_phase1_semaphore_id", nope_phase1_semaphore_id),
-                ("nope_phase2_semaphore_id", nope_phase2_semaphore_id),
-                ("rope_semaphore_id", rope_semaphore_id),
-                ("receiver_in_cb", receiver_in_cb),
-                ("out_cb", out_cb),
-                ("dst_num_pages", dst_num_pages),
-                ("nope_tiles", nope_tiles),
-                ("rope_tiles", rope_tiles),
-                ("sender_grid_width", sender_grid_width),
-                ("receiver_grid_start_x", receiver_grid_start_x),
-                ("receiver_grid_start_y", receiver_grid_start_y),
-                ("receiver_cols", receiver_cols),
-                # Number of QNOPE senders (8 cols) and QROPE senders (4 cols) per receiver row
-                ("num_nope_senders", qnope_cols),
-                ("num_rope_senders", sender_grid_width - qnope_cols),
-            ]
-            return args
-
-        # All receivers use BRISC (matching pre_sdpa pattern)
+        # Sender+receiver cores (receiver cores are always also senders)
         if not receiver_core_grid.empty():
-            receiver_kernel = ttnn.KernelDescriptor(
+            sender_receiver_kernel = ttnn.KernelDescriptor(
                 kernel_source=kernel_path,
                 source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
                 core_ranges=receiver_core_grid,
-                named_compile_time_args=create_receiver_named_compile_time_args(),
+                named_compile_time_args=create_common_named_compile_time_args(is_receiver=True),
+                common_runtime_args=[receiver_data_addr],
                 config=ttnn.DataMovementConfigDescriptor(
-                    processor=ttnn.DataMovementProcessor.RISCV_0,  # BRISC
-                    noc=ttnn.NOC.NOC_1,  # Use different NOC than sender
+                    processor=ttnn.DataMovementProcessor.RISCV_1,  # NCRISC
+                    noc=ttnn.NOC.NOC_0,
                 ),
             )
-            kernels.append(receiver_kernel)
+            kernels.append(sender_receiver_kernel)
 
         # ========================================================================
         # Compute kernels (TRISC) - tilization on receiver cores
         # ========================================================================
-        # Sender-only cores need no-op compute kernel
-        sender_only_cores = [c for c in sender_cores_list if not receiver_core_grid.contains(c)]
         if sender_only_cores:
-            sender_only_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in sender_only_cores])
             sender_compute_kernel = ttnn.KernelDescriptor(
                 kernel_source=kernel_path,
                 source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
@@ -3,15 +3,15 @@
 
 // Flash MLA Decode kernel: uses FlashMLADecode Op from flash_mla_kernel.hpp
 //
-// NCRISC (Reader): Read Q from sharded memory, pipelined DRAM reads of K chunks
-// BRISC (Writer):  Multicast K to S block receivers, tree reduction send/receive
+// BRISC (Reader): Read Q from sharded memory, pipelined DRAM reads of K chunks
+// NCRISC (Writer):  Multicast K to S block receivers, tree reduction send/receive
 // TRISC (Compute): SDPA flash attention chunking, tree reduction tail
 
 #include "../../../unified_kernels/flash_mla.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
 
 void kernel_main() {
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
     uint32_t arg_idx = 0;
     deepseek_b1_ops::FlashMLADecode::ReaderArgs args{
         .k_addr = get_common_arg_val<uint32_t>(0),
@@ -41,7 +41,7 @@ void kernel_main() {
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
 
-#elif defined(COMPILE_FOR_BRISC)
+#elif defined(COMPILE_FOR_NCRISC)
     constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
     uint32_t arg_idx = 0;
     uint32_t cur_batch = get_arg_val<uint32_t>(arg_idx++);
@@ -141,15 +141,15 @@ void kernel_main() {
     deepseek_compute_kernel_init();
 #endif
 
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC)
     if (args.is_output_core == 1) {
         unified_kernels::setup_sharded_buffer(args.cb_q_in, args.DHt);
     }
 #endif
 
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
     uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
-#elif defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_TRISC)
+#elif defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_TRISC)
     uint32_t pos_addr = get_common_arg_val<uint32_t>(0);
 #endif
 

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/op.py
@@ -625,8 +625,8 @@ class FlashMLADecode:
         # =========================================================================
         # Named compile-time args per RISC (for UnifiedKernelDescriptor)
         # =========================================================================
-        # NCRISC (reader) named compile-time args
-        ncrisc_named_compile_time_args = [
+        # BRISC (reader) named compile-time args
+        brisc_named_compile_time_args = [
             ("St", St),
             ("DHt", DHt),
             ("Sk_chunk_t", Sk_chunk_t),
@@ -642,10 +642,10 @@ class FlashMLADecode:
             ("cb_k_in", cb_k_in),
         ]
         # TensorAccessorArgs for K (indexed, starting at index 0)
-        ncrisc_compile_time_args = list(get_tensor_accessor_args(kv_cache_tensor))
+        brisc_compile_time_args = list(get_tensor_accessor_args(kv_cache_tensor))
 
-        # BRISC (writer) named compile-time args
-        brisc_named_compile_time_args = [
+        # NCRISC (writer) named compile-time args
+        ncrisc_named_compile_time_args = [
             ("vDHt", vDHt),
             ("Sk_chunk_t", Sk_chunk_t),
             ("num_cores_per_head", num_cores_per_head),
@@ -815,8 +815,8 @@ class FlashMLADecode:
         k_addr = kv_cache_tensor.buffer_address()
         pos_addr = cur_pos_tensor.buffer_address()
 
-        ncrisc_per_core_args = []
         brisc_per_core_args = []
+        ncrisc_per_core_args = []
         trisc_per_core_args = []
 
         for i in range(num_active_cores):
@@ -840,8 +840,8 @@ class FlashMLADecode:
             output_core_noc_x = output_core_physical_xs[cur_batch] if cur_batch < len(output_core_physical_xs) else 0
             output_core_noc_y = output_core_physical_ys[cur_batch] if cur_batch < len(output_core_physical_ys) else 0
 
-            # NCRISC per-core runtime args (common args: k_addr, pos_addr)
-            ncrisc_per_core_args.append(
+            # BRISC per-core runtime args (common args: k_addr, pos_addr)
+            brisc_per_core_args.append(
                 (
                     core,
                     [
@@ -858,8 +858,8 @@ class FlashMLADecode:
             # Tree reduction partner coordinates
             tree_reduction_info = grid.get_tree_reduction_partner_coords(device, s_block_idx, cur_batch)
 
-            # BRISC per-core runtime args (common args: pos_addr)
-            brisc_args = [
+            # NCRISC per-core runtime args (common args: pos_addr)
+            ncrisc_args = [
                 cur_batch,
                 core_num_in_reduce,
                 is_output_core,
@@ -872,8 +872,8 @@ class FlashMLADecode:
                 mcast_end_y,
             ]
             for role_code, partner_s_block_idx, partner_x, partner_y in tree_reduction_info:
-                brisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
-            brisc_per_core_args.append((core, brisc_args))
+                ncrisc_args.extend([role_code, partner_s_block_idx, partner_x, partner_y])
+            ncrisc_per_core_args.append((core, ncrisc_args))
 
             is_sender_after_reduce = 1 if (do_reduce and grid.is_tree_reduction_sender(s_block_idx)) else 0
 
@@ -895,12 +895,12 @@ class FlashMLADecode:
         unified_kernel = UnifiedKernelDescriptor(
             kernel_source="models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp",
             core_ranges=core_grid,
-            ncrisc_compile_time_args=ncrisc_compile_time_args,
-            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+            brisc_compile_time_args=brisc_compile_time_args,
             brisc_named_compile_time_args=brisc_named_compile_time_args,
+            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
             trisc_named_compile_time_args=trisc_named_compile_time_args,
-            ncrisc_common_runtime_args=[k_addr, pos_addr],
-            brisc_common_runtime_args=[pos_addr],
+            brisc_common_runtime_args=[k_addr, pos_addr],
+            ncrisc_common_runtime_args=[pos_addr],
             trisc_common_runtime_args=[pos_addr],
             trisc_compute_config=ttnn.ComputeConfigDescriptor(
                 math_fidelity=math_fidelity,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -193,7 +193,7 @@ def test_attention_block(
     # Matches flash_mla's cb_out_im sizing: 51 tiles of [8, 32] at bfloat16 = 26112 B per core.
     # Shard shape (24, 544) = 3 tile-rows x 17 tile-cols = 51 tiles per core.
     sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
-    sdpa_out_interm_num_slots = 3
+    sdpa_out_interm_num_slots = 5
     sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8  # 3 tile-rows of [8, 32]
     sdpa_out_interm_shard_width = 17 * 32  # 17 tile-cols of [8, 32]
     sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -190,8 +190,8 @@ def test_attention_block(
     )
 
     # SDPA output intermediate tensor declared here to overlap with remaining pre-SDPA CBs.
-    # Matches flash_mla's cb_out_im sizing: 51 tiles of [8, 32] at bfloat16 = 26112 B per core.
-    # Shard shape (24, 544) = 3 tile-rows x 17 tile-cols = 51 tiles per core.
+    # Matches flash_mla's cb_out_im sizing: 85 tiles of [8, 32] at bfloat16 = 43520 B per core.
+    # Shard shape (40, 544) = 5 tile-rows x 17 tile-cols = 85 tiles per core.
     sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_num_slots = 5
     sdpa_out_interm_shard_height = sdpa_out_interm_num_slots * 8  # 3 tile-rows of [8, 32]

--- a/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
@@ -117,14 +117,20 @@ struct CreateQHeads {
     //   setup_sharded_input: whether to setup the sharded input CB
     //   pop_src: whether to pop the source CB after sending
     // ========================================================================
-    template <typename CTArgs, bool IsSenderCore, bool IsReceiverCore, bool setup_sharded_input, bool pop_src>
+    template <
+        typename CTArgs,
+        bool IsSenderCore,
+        bool IsReceiverCore,
+        bool shared_dm_risc,
+        bool setup_sharded_input,
+        bool pop_src>
     class Op {
     public:
         // Overload for sender args
         void operator()([[maybe_unused]] const SenderArgs& args) {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             if constexpr (IsSenderCore) {
-                sender_impl(args);
+                sender_impl<shared_dm_risc && IsReceiverCore>(args);
             }
 #endif
         }
@@ -133,7 +139,7 @@ struct CreateQHeads {
         void operator()([[maybe_unused]] const ReceiverArgs& args) {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
             if constexpr (IsReceiverCore) {
-                receiver_impl(args);
+                receiver_impl<shared_dm_risc && IsSenderCore>(args);
             }
 #endif
         }
@@ -149,8 +155,10 @@ struct CreateQHeads {
 
     private:
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+        static constexpr uint8_t WRITE_NOC = 0;
+
+        template <bool is_receiver_same_risc>
         FORCE_INLINE void sender_impl(const SenderArgs& args) {
-            constexpr uint8_t WRITE_NOC = 0;
             static_assert(
                 WRITE_NOC == noc_index || noc_mode == DM_DYNAMIC_NOC,
                 "WRITE_NOC differs from noc_index; must be in dynamic NOC mode");
@@ -206,7 +214,6 @@ struct CreateQHeads {
                 noc_async_write<half_qnope_data_size_bytes, true, /*posted=*/true>(
                     src_addr + half_qnope_data_size_bytes, dst_data_noc_addr_1, half_qnope_data_size_bytes, WRITE_NOC);
                 noc_semaphore_inc(phase2_semaphore_noc_addr, 1, WRITE_NOC);
-                noc_async_atomic_barrier(WRITE_NOC);
             } else {
                 // QROPE core: Write 2 heads × 64 elements = 128 elements
                 // Memory layout: after all QNOPE data, QROPE is packed row-major [8, 64]
@@ -220,15 +227,21 @@ struct CreateQHeads {
                 noc_async_write<double_qrope_head_size_bytes, true, /*posted=*/true>(
                     src_addr, dst_data_noc_addr, double_qrope_head_size_bytes, WRITE_NOC);
                 noc_semaphore_inc(rope_semaphore_noc_addr, 1, WRITE_NOC);
-                noc_async_atomic_barrier();
             }
 
+            if constexpr (!is_receiver_same_risc) {
+                noc_async_atomic_barrier(WRITE_NOC);
+            }
             // Pop source CB after sending
             if constexpr (pop_src) {
+                if constexpr (is_receiver_same_risc) {
+                    noc_async_writes_flushed(WRITE_NOC);
+                }
                 cb_pop_front(src_cb, args.src_num_pages);
             }
         }
 
+        template <bool is_sender_same_risc>
         FORCE_INLINE void receiver_impl(const ReceiverArgs& args) {
             // Multi-phase receiver for tilization with 3 separate semaphores
             // Each phase has its own semaphore to prevent race conditions
@@ -261,6 +274,12 @@ struct CreateQHeads {
                 noc_semaphore_set(rope_semaphore_ptr, 0);
                 cb_reserve_back(args.receiver_in_cb, args.rope_tiles);
                 cb_push_back(args.receiver_in_cb, args.rope_tiles);
+            }
+            if constexpr (is_sender_same_risc) {
+                static_assert(
+                    WRITE_NOC == noc_index || noc_mode == DM_DYNAMIC_NOC,
+                    "WRITE_NOC differs from noc_index; must be in dynamic NOC mode");
+                noc_async_atomic_barrier(WRITE_NOC);
             }
         }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/create_q_heads.hpp
@@ -150,6 +150,11 @@ struct CreateQHeads {
     private:
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
         FORCE_INLINE void sender_impl(const SenderArgs& args) {
+            constexpr uint8_t WRITE_NOC = 0;
+            static_assert(
+                WRITE_NOC == noc_index || noc_mode == DM_DYNAMIC_NOC,
+                "WRITE_NOC differs from noc_index; must be in dynamic NOC mode");
+
             // Compute my row and column indices within the sender grid
             uint32_t my_col = my_logical_x_ - args.sender_grid_start_x;
             uint32_t my_row = my_logical_y_ - args.sender_grid_start_y;
@@ -165,7 +170,7 @@ struct CreateQHeads {
             uint32_t target_noc_x = packed_coords & 0xFFFF;          // Lower 16 bits
             uint32_t target_noc_y = (packed_coords >> 16) & 0xFFFF;  // Upper 16 bits
 
-            const uint64_t dst_noc_coord = get_noc_addr(target_noc_x, target_noc_y, 0);
+            const uint64_t dst_noc_coord = get_noc_addr(target_noc_x, target_noc_y, 0, WRITE_NOC);
             constexpr uint32_t half_qnope_data_size_bytes = CTArgs::qnope_data_size_bytes / 2;
 
             // Setup sharded input buffer if needed (standalone op)
@@ -192,16 +197,16 @@ struct CreateQHeads {
                 uint32_t dst_offset_0 = my_col * half_qnope_data_size_bytes;
                 uint64_t dst_data_noc_addr_0 = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset_0);
                 noc_async_write<half_qnope_data_size_bytes, true, /*posted=*/true>(
-                    src_addr, dst_data_noc_addr_0, half_qnope_data_size_bytes);
-                noc_semaphore_inc(phase1_semaphore_noc_addr, 1);
+                    src_addr, dst_data_noc_addr_0, half_qnope_data_size_bytes, WRITE_NOC);
+                noc_semaphore_inc(phase1_semaphore_noc_addr, 1, WRITE_NOC);
 
                 // Second half: continues after first block
                 uint32_t dst_offset_1 = (args.qnope_cols * half_qnope_data_size_bytes) + dst_offset_0;
                 uint64_t dst_data_noc_addr_1 = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset_1);
                 noc_async_write<half_qnope_data_size_bytes, true, /*posted=*/true>(
-                    src_addr + half_qnope_data_size_bytes, dst_data_noc_addr_1, half_qnope_data_size_bytes);
-                noc_semaphore_inc(phase2_semaphore_noc_addr, 1);
-                noc_async_atomic_barrier();
+                    src_addr + half_qnope_data_size_bytes, dst_data_noc_addr_1, half_qnope_data_size_bytes, WRITE_NOC);
+                noc_semaphore_inc(phase2_semaphore_noc_addr, 1, WRITE_NOC);
+                noc_async_atomic_barrier(WRITE_NOC);
             } else {
                 // QROPE core: Write 2 heads × 64 elements = 128 elements
                 // Memory layout: after all QNOPE data, QROPE is packed row-major [8, 64]
@@ -213,8 +218,8 @@ struct CreateQHeads {
                 uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(args.receiver_data_addr + dst_offset);
                 constexpr uint32_t double_qrope_head_size_bytes = CTArgs::qrope_head_size_bytes * 2;
                 noc_async_write<double_qrope_head_size_bytes, true, /*posted=*/true>(
-                    src_addr, dst_data_noc_addr, double_qrope_head_size_bytes);
-                noc_semaphore_inc(rope_semaphore_noc_addr, 1);
+                    src_addr, dst_data_noc_addr, double_qrope_head_size_bytes, WRITE_NOC);
+                noc_semaphore_inc(rope_semaphore_noc_addr, 1, WRITE_NOC);
                 noc_async_atomic_barrier();
             }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -6,10 +6,10 @@
 #include "kernel_op_api.hpp"
 #include "../micro_ops/flash_mla/kernels/rt_args_common.hpp"
 
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "mcast.hpp"
-#elif defined(COMPILE_FOR_BRISC)
+#elif defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "mcast.hpp"
 #include "api/debug/assert.h"
@@ -25,9 +25,9 @@ static_assert(noc_mode == DM_DYNAMIC_NOC, "Flash MLA Decode kernel only supports
 #endif
 
 // ============================================================================
-// NCRISC helpers
+// BRISC helpers (Reader)
 // ============================================================================
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
 template <typename Accessor>
 FORCE_INLINE uint64_t get_shard_noc_addr_helper(const Accessor& reader, uint32_t shard_id) {
     return reader.get_shard_noc_addr(shard_id);
@@ -38,9 +38,9 @@ constexpr uint32_t MCAST_VALID = 1;
 #endif
 
 // ============================================================================
-// BRISC helpers
+// NCRISC helpers (Writer)
 // ============================================================================
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC)
 template <uint32_t bits_per_step>
 FORCE_INLINE constexpr uint32_t step_semaphore_inc(uint32_t step) {
     return 1U << (step * bits_per_step);
@@ -81,8 +81,8 @@ namespace deepseek_b1_ops {
 // Flash MLA Decode micro-op
 //
 // Implements flash attention decode for MLA where K and V share the same tensor.
-//   NCRISC (Reader): Read Q from sharded memory, read K from ND-sharded DRAM
-//   BRISC (Writer):  Multicast K data to S block receivers, tree reduction
+//   BRISC (Reader): Read Q from sharded memory, read K from ND-sharded DRAM
+//   NCRISC (Writer):  Multicast K data to S block receivers, tree reduction
 //   TRISC (Compute): SDPA compute with flash attention chunking and tree reduction
 // ============================================================================
 struct FlashMLADecode {
@@ -200,7 +200,7 @@ struct FlashMLADecode {
         uint32_t num_tree_reduction_steps;
     };
 
-    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+    using RTArgs = unified_kernels::SelectByRISCV<WriterArgs, ReaderArgs, ComputeArgs>;
 
     // ========================================================================
     // Op - templated on CTArgs (compile-time args) and IsActiveCore
@@ -242,9 +242,9 @@ struct FlashMLADecode {
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
 // ====================================================================
-// NCRISC (Reader)
+// BRISC (Reader)
 // ====================================================================
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
             constexpr uint8_t READ_NOC_INDEX = 0;
             constexpr uint8_t ATOMIC_NOC_INDEX = 1;
             constexpr auto k_tensor_args = TensorAccessorArgs<0>();
@@ -304,7 +304,7 @@ struct FlashMLADecode {
 
             // Only the core handling the last chunk needs to wait for the KV cache cur pos ready
             bool wait_for_kv_cache_ready = k_chunk_end == k_num_chunks;
-
+            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; k_chunk += args.num_cores_per_head) {
                 {
                     DeviceZoneScopedN("reader-k-read");
@@ -377,9 +377,9 @@ struct FlashMLADecode {
             noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
 
 // ====================================================================
-// BRISC (Writer)
+// NCRISC (Writer)
 // ====================================================================
-#elif defined(COMPILE_FOR_BRISC)
+#elif defined(COMPILE_FOR_NCRISC)
             constexpr uint8_t MCAST_NOC_INDEX = 0;
             constexpr uint8_t READ_NOC_INDEX = 1;
             constexpr uint8_t WRITE_NOC_INDEX = 1;

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -49,6 +49,30 @@ template <uint32_t bits_per_step>
 FORCE_INLINE constexpr uint32_t step_semaphore_shift(uint32_t step) {
     return step * bits_per_step;
 }
+
+FORCE_INLINE void mask_last_chunk(
+    uint32_t cb_mask, uint32_t k_chunk_size, uint32_t cur_pos, uint32_t k_chunk_end, uint32_t k_num_chunks) {
+    bool mask_last_chunk = k_chunk_end == k_num_chunks && (cur_pos + 1) % k_chunk_size != 0;
+    if (mask_last_chunk) {
+        DeviceZoneScopedN("mask-last-chunk");
+        cb_reserve_back(cb_mask, 1);
+        volatile tt_l1_ptr uint32_t* mask_write_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_mask));
+        uint32_t num_unmasked = cur_pos % k_chunk_size + 1;
+        uint32_t i = 0;
+        for (; i < num_unmasked / 2; i++) {
+            *mask_write_ptr++ = 0x00000000;
+        }
+        if (num_unmasked % 2 == 1) {
+            *mask_write_ptr++ = 0xFF800000;
+            i++;
+        }
+        for (; i < k_chunk_size / 2; i++) {
+            *mask_write_ptr++ = 0xFF80FF80;
+        }
+        cb_push_back(cb_mask, 1);
+    }
+}
 #endif
 
 namespace deepseek_b1_ops {
@@ -274,10 +298,13 @@ struct FlashMLADecode {
                 const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk_start;
                 uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
                 noc_async_read_one_packet_set_state<true>(k_src_noc_addr, args.k_page_size, args.vc, READ_NOC_INDEX);
+                // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
+                reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, READ_NOC_INDEX);
             }
 
-            // Wait for KV cache cur pos ready
-            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
+            // Only the core handling the last chunk needs to wait for the KV cache cur pos ready
+            bool wait_for_kv_cache_ready = k_chunk_end == k_num_chunks;
+
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; k_chunk += args.num_cores_per_head) {
                 {
                     DeviceZoneScopedN("reader-k-read");
@@ -287,8 +314,6 @@ struct FlashMLADecode {
 
                     if (is_mcast_sender) {
                         DeviceZoneScopedN("mcast-sender-sharded-read");
-                        // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
-                        reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, READ_NOC_INDEX);
                         const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk;
                         uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
 
@@ -301,6 +326,9 @@ struct FlashMLADecode {
                         uint32_t wait_trid = 1;
                         uint32_t pages_issued = 0;
                         uint32_t pages_completed = 0;
+                        if (wait_for_kv_cache_ready && (k_chunk + args.num_cores_per_head) >= k_chunk_end) {
+                            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
+                        }
 
                         noc_semaphore_wait(ncrisc_brisc_sync_curr_ptr, 0);
                         *k_write_curr_ptr_shared = k_write_ptr;
@@ -345,6 +373,7 @@ struct FlashMLADecode {
                     cb_push_back(args.cb_k_in, k_chunk_tiles);
                 }
             }
+            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
             noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
 
 // ====================================================================
@@ -374,6 +403,11 @@ struct FlashMLADecode {
             const bool is_output_core = args.is_output_core == 1;
             noc_async_write_set_trid(0, WRITE_NOC_INDEX);
 
+            uint32_t cur_pos = args.local_cur_pos;
+
+            auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
+                cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
+
             {
                 DeviceZoneScopedN("reader-q-read");
                 if (is_output_core) {
@@ -388,6 +422,7 @@ struct FlashMLADecode {
                             args.q_input_mcast_semaphore_addr);
                         noc_semaphore_inc_multicast(
                             q_input_mcast_sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC_INDEX);
+                        mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
                         // This is needed because we need to wait for all transactions before resetting the trids
                         // Could move it later but don't think it makes much difference
                         noc_async_atomic_barrier(MCAST_NOC_INDEX);
@@ -398,51 +433,28 @@ struct FlashMLADecode {
                             args.q_input_mcast_semaphore_addr,
                             ATOMIC_NOC_INDEX);
                         noc_semaphore_inc(sender_receiver_ready_noc_addr, 1, ATOMIC_NOC_INDEX);
+                        mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
                         noc_async_atomic_barrier(ATOMIC_NOC_INDEX);
                         noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
                     }
+                } else if (k_chunk_start == k_chunk_end) {
+                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
                 } else {
                     // wait for 8 q heads
-                    uint64_t q_noc_addr =
-                        get_noc_addr(args.output_core_noc_x, args.output_core_noc_y, get_read_ptr(args.cb_q_in));
+                    uint64_t q_noc_addr = get_noc_addr(
+                        args.output_core_noc_x, args.output_core_noc_y, get_read_ptr(args.cb_q_in), READ_NOC_INDEX);
                     cb_reserve_back(args.cb_q_in, q_chunk_tiles);
                     noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
                     noc_async_read(q_noc_addr, get_write_ptr(args.cb_q_in), args.q_chunk_size_bytes, READ_NOC_INDEX);
+                    mask_last_chunk(args.cb_mask, args.k_chunk_size, cur_pos, k_chunk_end, k_num_chunks);
                     noc_async_read_barrier(READ_NOC_INDEX);
                     cb_push_back(args.cb_q_in, q_chunk_tiles);
                 }
                 noc_semaphore_set(q_input_mcast_semaphore_ptr, 0);
             }
 
-            uint32_t cur_pos = args.local_cur_pos;
-
-            auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
-                cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
-
             if (k_chunk_start == k_chunk_end) {
                 return;
-            }
-            // Mask logic could be overlapped with the noc txns above, but currently DRAM reading fully overlaps with
-            // the mask logic
-            bool mask_last_chunk = k_chunk_end == k_num_chunks && (cur_pos + 1) % args.k_chunk_size != 0;
-            if (mask_last_chunk) {
-                DeviceZoneScopedN("mask-last-chunk");
-                cb_reserve_back(args.cb_mask, 1);
-                volatile tt_l1_ptr uint32_t* mask_write_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(args.cb_mask));
-                uint32_t num_unmasked = cur_pos % args.k_chunk_size + 1;
-                uint32_t i = 0;
-                for (; i < num_unmasked / 2; i++) {
-                    *mask_write_ptr++ = 0x00000000;
-                }
-                if (num_unmasked % 2 == 1) {
-                    *mask_write_ptr++ = 0xFF800000;
-                    i++;
-                }
-                for (; i < args.k_chunk_size / 2; i++) {
-                    *mask_write_ptr++ = 0xFF80FF80;
-                }
-                cb_push_back(args.cb_mask, 1);
             }
 
             // =================================================================
@@ -608,11 +620,10 @@ struct FlashMLADecode {
             constexpr bool transpose_k = true;
             constexpr bool transpose_v = false;
 
-            PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
             reconfig_data_format<false, true>(cb_k_in, cb_q_in);
             pack_reconfig_data_format<true>(cb_out_o);
+            PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
             PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, true, scale_fp32, true));
-            sdpa_custom_mm_block_init_short<transpose_k>(cb_q_in, cb_k_in, cb_out_o, Sk_chunk_t);
 
             uint32_t cur_pos = args.local_cur_pos;
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -29,8 +29,8 @@ static_assert(noc_mode == DM_DYNAMIC_NOC, "Flash MLA Decode kernel only supports
 // ============================================================================
 #if defined(COMPILE_FOR_BRISC)
 template <typename Accessor>
-FORCE_INLINE uint64_t get_shard_noc_addr_helper(const Accessor& reader, uint32_t shard_id) {
-    return reader.get_shard_noc_addr(shard_id);
+FORCE_INLINE uint64_t get_shard_noc_addr_helper(const Accessor& reader, uint32_t shard_id, uint8_t noc = noc_index) {
+    return reader.get_shard_noc_addr(shard_id, 0, noc);
 }
 
 constexpr uint32_t MCAST_INVALID = 0;
@@ -296,7 +296,7 @@ struct FlashMLADecode {
 
             if (is_mcast_sender) {
                 const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk_start;
-                uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
+                uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id, READ_NOC_INDEX);
                 noc_async_read_one_packet_set_state<true>(k_src_noc_addr, args.k_page_size, args.vc, READ_NOC_INDEX);
                 // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
                 reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, READ_NOC_INDEX);
@@ -314,7 +314,7 @@ struct FlashMLADecode {
                     if (is_mcast_sender) {
                         DeviceZoneScopedN("mcast-sender-sharded-read");
                         const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk;
-                        uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
+                        uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id, READ_NOC_INDEX);
 
                         constexpr uint32_t NUM_TRIDS = NOC_MAX_TRANSACTION_ID - 1;
                         uint32_t src_base_addr = (uint32_t)(k_src_noc_addr & 0xFFFFFFFF);

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -304,7 +304,6 @@ struct FlashMLADecode {
 
             // Only the core handling the last chunk needs to wait for the KV cache cur pos ready
             bool wait_for_kv_cache_ready = k_chunk_end == k_num_chunks;
-            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; k_chunk += args.num_cores_per_head) {
                 {
                     DeviceZoneScopedN("reader-k-read");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38718

### Problem description
We want to unblock kv cache read from dram as soon as possible. Most DM logic that happens before flash mla uses ncrisc, so if we move create_q_heads logic fully to ncrisc, then this unblocks streaming k chunks ahead of q heads creation.

### What's changed
Move create_q_heads DM logic to ncrisc.
Swap brisc/ncrisc work for flash_mla so kv cache read is on brisc. Only block kv cache read to wait for kv cache update on the last chunk.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/optimizations2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/optimizations2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/optimizations2)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/optimizations2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/optimizations2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/optimizations2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/optimizations2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
