### PR TITLE
Enable sampling on device for vLLM interface

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -200,6 +200,8 @@ class DeepseekGenerator(WarmupForwardMixin):
                 )
                 self.hf_config.first_k_dense_replace = self.hf_config.num_hidden_layers
         self.enable_mtp = bool(enable_mtp)
+        # self.hf_config.num_hidden_layers = 5
+        logger.info(f"num_hidden_layers: {self.hf_config.num_hidden_layers}")
 
         if not self.enable_mtp and hasattr(self.hf_config, "num_nextn_predict_layers"):
             self.hf_config.num_nextn_predict_layers = 0
@@ -215,43 +217,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
-        # sampling values of all users are assumed to be the same default values if not provided in constructor.
-        self.sample_on_device = sample_on_device
-        self.sampling_params = (
-            sampling_params
-            if sampling_params is not None
-            else SamplingParams(
-                temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
-                top_p=[DEFAULT_SAMPLING_TOP_P] * self.batch_size,
-                top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
-            )
-        )
-        if self._get_sampling_value(self.sampling_params.top_k, 0) == 0 and self.sample_on_device:
-            raise SystemExit(
-                "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
-            )
-        if self.sample_on_device:
-            enable_internal_trace_sampling = enable_trace and self.sample_on_device
-            self.sampling_args = make_deepseek_sampling_args(mesh_device, self.hf_config.vocab_size)
-            self.sampling_generator = SamplingGenerator(
-                args=self.sampling_args,
-                mesh_device=self.mesh_device,
-                tt_ccl=self.ccl,
-                enable_internal_trace=enable_internal_trace_sampling,
-            )
-
-            self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
-
-        logger.info(f"Sampling mode: {'device' if self.sample_on_device else 'host'}")
-        logger.info(
-            f"Sampling parameters for first user (other users may have different values): "
-            + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
-            + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
-            + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
-        )
-
-        if enable_mtp and sample_on_device:
-            raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+        self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace, enable_mtp)
 
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
@@ -311,6 +277,83 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         self._prepare_weight_configs(cache_dir)
         self._assert_mtp_available()
+
+    def _validate_and_initialize_sampling(
+        self,
+        sampling_params: SamplingParams | None,
+        sample_on_device: bool,
+        enable_trace: bool = False,
+        enable_mtp: bool = False,
+    ) -> None:
+        # sampling values of all users are assumed to be the same default values if not provided.
+        self.sample_on_device = sample_on_device
+        self.sampling_params = (
+            sampling_params
+            if sampling_params is not None
+            else SamplingParams(
+                temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
+                top_p=[DEFAULT_SAMPLING_TOP_P] * self.batch_size,
+                top_k=[DEFAULT_SAMPLING_TOP_K] * self.batch_size,
+            )
+        )
+        if self._get_sampling_value(self.sampling_params.top_k, 0) == 0 and sample_on_device:
+            raise SystemExit(
+                "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
+            )
+        if sample_on_device:
+            enable_internal_trace_sampling = enable_trace and self.sample_on_device
+            self.sampling_args = make_deepseek_sampling_args(self.mesh_device, self.hf_config.vocab_size)
+            self.sampling_generator = SamplingGenerator(
+                args=self.sampling_args,
+                mesh_device=self.mesh_device,
+                tt_ccl=self.ccl,
+                enable_internal_trace=enable_internal_trace_sampling,
+            )
+
+            self._reset_sampling_state(self.sampling_params, self.batch_size, self.batch_size_per_row)
+
+        logger.info(f"Sampling mode: {'device' if sample_on_device else 'host'}")
+        logger.info(
+            f"Sampling parameters for first user (other users may have different values): "
+            + f"temperature={self._get_sampling_value(self.sampling_params.temperature, 0)}, "
+            + f"top_p={self._get_sampling_value(self.sampling_params.top_p, 0)}, "
+            + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
+        )
+
+        if enable_mtp and sample_on_device:
+            raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+
+    @staticmethod
+    def _shape_or_type(value):
+        if value is None:
+            return "None"
+        if hasattr(value, "shape"):
+            try:
+                return tuple(value.shape)
+            except Exception:
+                return f"{type(value).__name__}(shape-unavailable)"
+        if isinstance(value, (list, tuple)):
+            return f"{type(value).__name__}(len={len(value)})"
+        return type(value).__name__
+
+    def _log_sampling_params(self, callsite: str, sampling_params: SamplingParams | None, sample_on_device: bool):
+        logger.info("{} sample_on_device={}", callsite, sample_on_device)
+        if sampling_params is None:
+            logger.info("{} sampling_params=None (using defaults)", callsite)
+            return
+
+        for field_name in (
+            "temperature",
+            "top_k",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "repetition_penalty",
+            "seed",
+            "enable_log_probs",
+        ):
+            field_val = getattr(sampling_params, field_name, None)
+            logger.info("{} sampling_params.{}={}", callsite, field_name, self._shape_or_type(field_val))
 
     def _dump_meminfo(self, header: str) -> None:
         if self.enable_mem_profile:
@@ -2108,9 +2151,10 @@ class DeepseekGenerator(WarmupForwardMixin):
         user_id: int,
         page_table: torch.Tensor | None = None,
         local_user_id: int | None = None,
-        sample_on_device: bool = False,
         prompt_len: int | None = None,
         return_last_hidden: bool = False,
+        sampling_params: SamplingParams | None = None,
+        sample_on_device: bool = False,
     ) -> ttnn.Tensor | torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Run prefill for the full prompt sequence.
 
@@ -2122,6 +2166,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         Returns:
             logits ttnn.Tensor on device if sample_on_device is True, otherwise logits torch.Tensor on host
         """
+        self._log_sampling_params("prefill in generator", sampling_params, sample_on_device)
 
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
@@ -2623,13 +2668,16 @@ class DeepseekGenerator(WarmupForwardMixin):
         enable_trace: bool = False,
         page_table: torch.Tensor | None = None,
         kv_cache: None = None,
-        read_from_device: bool = None,
+        read_from_device: bool = False,
         sampling_params: SamplingParams = None,
         sample_on_device: bool = False,
     ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
+
+        # todo, handle kv_cache?, read_from_device, sampling_params
+        # handle here or in generator_vllm? Pratik
 
         if not enable_trace:
             return self._decode_step(tokens, start_pos, page_table, sample_on_device)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -286,6 +286,10 @@ class DeepseekGenerator(WarmupForwardMixin):
         enable_mtp: bool = False,
     ) -> None:
         # sampling values of all users are assumed to be the same default values if not provided.
+        if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
+            logger.info("Sampling generator already initialized, skipping initialization")
+            return
+
         self.sample_on_device = sample_on_device
         self.sampling_params = (
             sampling_params

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -2178,9 +2178,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         user_id: int,
         page_table: torch.Tensor | None = None,
         local_user_id: int | None = None,
+        sample_on_device: bool = False,
         prompt_len: int | None = None,
         return_last_hidden: bool = False,
-        sample_on_device: bool = False,
     ) -> ttnn.Tensor | torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Run prefill for the full prompt sequence.
 
@@ -2192,7 +2192,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         Returns:
             logits ttnn.Tensor on device if sample_on_device is True, otherwise logits torch.Tensor on host
         """
-        logger.info(f"prefill sample_on_device: {sample_on_device}, user_id: {user_id}")
 
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
@@ -2699,7 +2698,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
-        logger.info(f"decode_forward sample_on_device: {sample_on_device}, enable_trace: {enable_trace}")
 
         if not enable_trace:
             return self._decode_step(tokens, start_pos, page_table, sample_on_device)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -200,8 +200,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                 )
                 self.hf_config.first_k_dense_replace = self.hf_config.num_hidden_layers
         self.enable_mtp = bool(enable_mtp)
-        # self.hf_config.num_hidden_layers = 5
-        logger.info(f"num_hidden_layers: {self.hf_config.num_hidden_layers}")
 
         if not self.enable_mtp and hasattr(self.hf_config, "num_nextn_predict_layers"):
             self.hf_config.num_nextn_predict_layers = 0
@@ -285,12 +283,23 @@ class DeepseekGenerator(WarmupForwardMixin):
         enable_trace: bool = False,
         enable_mtp: bool = False,
     ) -> None:
-        # sampling values of all users are assumed to be the same default values if not provided.
-        if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
-            logger.info("Sampling generator already initialized, skipping initialization")
+        if enable_mtp and sample_on_device:
+            raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+
+        current_sampling_params = getattr(self, "sampling_params", None)
+        if not self._are_sampling_params_same(sampling_params, current_sampling_params):
+            logger.info("Sampling parameters changed, resetting sampling generator")
+            self.sampling_generator = None
+            self.sampling_params = None
+
+        if self.sampling_generator is not None:
+            logger.info(
+                "Sampling generator already initialized and sampling parameters are same, skipping reinitialization"
+            )
             return
 
         self.sample_on_device = sample_on_device
+        # sampling params of all users are assumed to be the same default values if not provided.
         self.sampling_params = (
             sampling_params
             if sampling_params is not None
@@ -324,8 +333,22 @@ class DeepseekGenerator(WarmupForwardMixin):
             + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
         )
 
-        if enable_mtp and sample_on_device:
-            raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+    def _are_sampling_params_same(
+        self, new_sampling_params: SamplingParams | None, current_sampling_params: SamplingParams | None
+    ) -> bool:
+        """Return True when both sampling params are equivalent after formatting.
+
+        Both inputs are normalized with ``format_sampling_params`` so scalar/list
+        representations compare consistently for the configured batch size.
+        If either input is ``None``, this returns ``False``.
+        """
+
+        if new_sampling_params is None or current_sampling_params is None:
+            return False  # if either is None, we can't compare values so return False
+
+        normalized_new = format_sampling_params(new_sampling_params, max_batch_size=self.batch_size)
+        normalized_current = format_sampling_params(current_sampling_params, max_batch_size=self.batch_size)
+        return normalized_new == normalized_current
 
     @staticmethod
     def _shape_or_type(value):
@@ -2157,7 +2180,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         local_user_id: int | None = None,
         prompt_len: int | None = None,
         return_last_hidden: bool = False,
-        sampling_params: SamplingParams | None = None,
         sample_on_device: bool = False,
     ) -> ttnn.Tensor | torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Run prefill for the full prompt sequence.
@@ -2170,7 +2192,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         Returns:
             logits ttnn.Tensor on device if sample_on_device is True, otherwise logits torch.Tensor on host
         """
-        self._log_sampling_params("prefill in generator", sampling_params, sample_on_device)
+        logger.info(f"prefill sample_on_device: {sample_on_device}, user_id: {user_id}")
 
         tokens = tokens.view(1, 1, -1)
         seq_len = tokens.shape[-1]
@@ -2672,16 +2694,12 @@ class DeepseekGenerator(WarmupForwardMixin):
         enable_trace: bool = False,
         page_table: torch.Tensor | None = None,
         kv_cache: None = None,
-        read_from_device: bool = False,
-        sampling_params: SamplingParams = None,
         sample_on_device: bool = False,
     ) -> ttnn.Tensor | torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
-
-        # todo, handle kv_cache?, read_from_device, sampling_params
-        # handle here or in generator_vllm? Pratik
+        logger.info(f"decode_forward sample_on_device: {sample_on_device}, enable_trace: {enable_trace}")
 
         if not enable_trace:
             return self._decode_step(tokens, start_pos, page_table, sample_on_device)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -305,7 +305,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         self.sample_on_device = sample_on_device
         # sampling params of all users are assumed to be the same default values if not provided.
         self.sampling_params = (
-            sampling_params
+            self._to_local_sampling_params(sampling_params)
             if sampling_params is not None
             else SamplingParams(
                 temperature=[DEFAULT_SAMPLING_TEMPERATURE] * self.batch_size,
@@ -337,17 +337,32 @@ class DeepseekGenerator(WarmupForwardMixin):
             + f"top_k={self._get_sampling_value(self.sampling_params.top_k, 0)}"
         )
 
-    def _are_sampling_params_same(
-        self, new_sampling_params: SamplingParams, current_sampling_params: SamplingParams
-    ) -> bool:
+    def _to_local_sampling_params(self, params_obj) -> SamplingParams:
+        """Project duck-typed sampling params to local SamplingParams fields."""
+        return SamplingParams(
+            temperature=getattr(params_obj, "temperature"),
+            top_k=getattr(params_obj, "top_k"),
+            top_p=getattr(params_obj, "top_p"),
+            presence_penalty=getattr(params_obj, "presence_penalty", 0.0),
+            frequency_penalty=getattr(params_obj, "frequency_penalty", 0.0),
+            repetition_penalty=getattr(params_obj, "repetition_penalty", 1.0),
+            seed=getattr(params_obj, "seed", None),
+            enable_log_probs=getattr(params_obj, "enable_log_probs", False),
+        )
+
+    def _are_sampling_params_same(self, new_sampling_params, current_sampling_params) -> bool:
         """Return True when both sampling params are equivalent after formatting.
 
-        Both inputs are normalized with ``format_sampling_params`` so scalar/list
-        representations compare consistently for the configured batch size.
-        Caller must ensure neither argument is ``None``.
+        Inputs may be local ``SamplingParams`` or vLLM duck-typed sampling params.
+        We first project each object to the local ``SamplingParams`` fields and then
+        normalize with ``format_sampling_params`` for an apples-to-apples comparison.
         """
-        normalized_new = format_sampling_params(new_sampling_params, max_batch_size=self.batch_size)
-        normalized_current = format_sampling_params(current_sampling_params, max_batch_size=self.batch_size)
+        normalized_new = format_sampling_params(
+            self._to_local_sampling_params(new_sampling_params), max_batch_size=self.batch_size
+        )
+        normalized_current = format_sampling_params(
+            self._to_local_sampling_params(current_sampling_params), max_batch_size=self.batch_size
+        )
         return normalized_new == normalized_current
 
     @staticmethod
@@ -2337,6 +2352,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             ttnn.deallocate(logits_tt)
         if return_last_hidden:
             return logits, last_hidden
+
         return logits
 
     def _slice_last_token_logits(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -739,6 +739,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
 
     def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
+        # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
         sampling_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         self.sampling_generator.reset_sampling_params(sampling_params)
         seed = getattr(sampling_params, "seed", None)
@@ -756,6 +757,7 @@ class DeepseekGenerator(WarmupForwardMixin):
 
         if isinstance(tt_out, tuple):
             tt_tokens, tt_log_probs = tt_out
+            # TODO: tt_log_probs support not yet implemented.
             if tt_log_probs is not None:
                 ttnn.deallocate(tt_log_probs)
             tt_out = tt_tokens

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -287,15 +287,19 @@ class DeepseekGenerator(WarmupForwardMixin):
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
 
         current_sampling_params = getattr(self, "sampling_params", None)
-        if not self._are_sampling_params_same(sampling_params, current_sampling_params):
-            logger.info("Sampling parameters changed, resetting sampling generator")
+        params_same = (
+            sampling_params is not None
+            and current_sampling_params is not None
+            and self._are_sampling_params_same(sampling_params, current_sampling_params)
+        )
+        if not params_same:
             self.sampling_generator = None
             self.sampling_params = None
 
-        if self.sampling_generator is not None:
-            logger.info(
-                "Sampling generator already initialized and sampling parameters are same, skipping reinitialization"
-            )
+        if not sample_on_device:
+            self.sampling_generator = None
+
+        if getattr(self, "sampling_generator", None) is not None:
             return
 
         self.sample_on_device = sample_on_device
@@ -334,18 +338,14 @@ class DeepseekGenerator(WarmupForwardMixin):
         )
 
     def _are_sampling_params_same(
-        self, new_sampling_params: SamplingParams | None, current_sampling_params: SamplingParams | None
+        self, new_sampling_params: SamplingParams, current_sampling_params: SamplingParams
     ) -> bool:
         """Return True when both sampling params are equivalent after formatting.
 
         Both inputs are normalized with ``format_sampling_params`` so scalar/list
         representations compare consistently for the configured batch size.
-        If either input is ``None``, this returns ``False``.
+        Caller must ensure neither argument is ``None``.
         """
-
-        if new_sampling_params is None or current_sampling_params is None:
-            return False  # if either is None, we can't compare values so return False
-
         normalized_new = format_sampling_params(new_sampling_params, max_batch_size=self.batch_size)
         normalized_current = format_sampling_params(current_sampling_params, max_batch_size=self.batch_size)
         return normalized_new == normalized_current
@@ -362,25 +362,6 @@ class DeepseekGenerator(WarmupForwardMixin):
         if isinstance(value, (list, tuple)):
             return f"{type(value).__name__}(len={len(value)})"
         return type(value).__name__
-
-    def _log_sampling_params(self, callsite: str, sampling_params: SamplingParams | None, sample_on_device: bool):
-        logger.info("{} sample_on_device={}", callsite, sample_on_device)
-        if sampling_params is None:
-            logger.info("{} sampling_params=None (using defaults)", callsite)
-            return
-
-        for field_name in (
-            "temperature",
-            "top_k",
-            "top_p",
-            "presence_penalty",
-            "frequency_penalty",
-            "repetition_penalty",
-            "seed",
-            "enable_log_probs",
-        ):
-            field_val = getattr(sampling_params, field_name, None)
-            logger.info("{} sampling_params.{}={}", callsite, field_name, self._shape_or_type(field_val))
 
     def _dump_meminfo(self, header: str) -> None:
         if self.enable_mem_profile:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import torch
 from loguru import logger
 
+from models.common.sampling.generator import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
@@ -41,6 +42,40 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
     model_capabilities = {
         "supports_prefix_caching": False,
     }
+
+    @staticmethod
+    def _shape_or_type(value):
+        if value is None:
+            return "None"
+        if hasattr(value, "shape"):
+            try:
+                return tuple(value.shape)
+            except Exception:
+                return f"{type(value).__name__}(shape-unavailable)"
+        if isinstance(value, (list, tuple)):
+            return f"{type(value).__name__}(len={len(value)})"
+        return type(value).__name__
+
+    def _log_sampling_params(
+        self, callsite: str, sampling_params: SamplingParams | None, sample_on_device: bool | None = None
+    ):
+        if sample_on_device is not None:
+            logger.info("{} sample_on_device={}", callsite, sample_on_device)
+        if sampling_params is None:
+            logger.info("{} sampling_params=None", callsite)
+            return
+        for field_name in (
+            "temperature",
+            "top_k",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "repetition_penalty",
+            "seed",
+            "enable_log_probs",
+        ):
+            field_val = getattr(sampling_params, field_name, None)
+            logger.info("{} sampling_params.{}={}", callsite, field_name, self._shape_or_type(field_val))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -78,6 +113,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return self.cache_dir
 
     def prefill_forward(self, *args, **kwargs):
+        logger.info(f"prefill_forward, kwargs keys: {kwargs.keys()}")
         start_pos = kwargs.get("start_pos", None)
         assert (start_pos is None) or all(
             x == 0 for x in start_pos
@@ -91,6 +127,27 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         page_table = kwargs.get("page_table", None)
         kv_cache = kwargs.get("kv_cache", None)
         empty_slots = kwargs.get("empty_slots", None)
+        sampling_params = kwargs.get("sampling_params", None)
+        sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
+        # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
+        # sample_on_device = sample_on_device_mode in ["all"]
+        sample_on_device = sampling_params is not None
+        logger.info(
+            "prefill_forward shapes: tokens={} lengths={} page_table={} kv_cache={} empty_slots={} sampling_params={} sample_on_device_mode={} sample_on_device={}",
+            tuple(tokens.shape),
+            len(lengths) if lengths is not None else 0,
+            self._shape_or_type(page_table),
+            self._shape_or_type(kv_cache),
+            self._shape_or_type(empty_slots),
+            self._shape_or_type(sampling_params),
+            sample_on_device_mode,
+            sample_on_device,
+        )
+        self._log_sampling_params("prefill_forward", sampling_params)
+        # sampling_params can be None with server mode???
+        # sample_on_device = sampling_params is not None
+
+        sample_on_device = True
 
         if all(length == 0 for length in lengths):
             return torch.zeros(tokens.shape[0], self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
@@ -106,54 +163,134 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             ((max_prompt_len + pad_block_size - 1) // pad_block_size) * pad_block_size if max_prompt_len > 0 else 0
         )
         num_of_users = tokens.shape[0]
-        last_logits = []
+        prefill_tokens = []
         for i in range(num_of_users):
+            logger.info(f"Prefill step {i}")
             user_id = empty_slots[i] if empty_slots is not None else i
             prompt_len = int(lengths[i])
             if prompt_len == 0:
-                last_logits.append(
+                prefill_tokens.append(
                     torch.zeros(max_padded_len, self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
                 )
                 continue
             user_tokens = tokens[i, :prompt_len].unsqueeze(0)
             user_tokens = _pad_tokens(user_tokens, pad_value, block_size=pad_block_size).squeeze(0)
-            user_out = self._prefill(user_tokens, user_id, page_table, local_user_id=i)
-            user_logits = user_out.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]
-            if user_logits.shape[0] > prompt_len:
-                user_logits = user_logits[:prompt_len]
-            if user_logits.shape[0] < max_padded_len:
-                pad_len = max_padded_len - user_logits.shape[0]
-                pad_logits = user_logits[-1:].expand(pad_len, -1)
-                user_logits = torch.cat([user_logits, pad_logits], dim=0)
-            last_logits.append(user_logits)
-        last_logits = torch.stack(last_logits)  # [num_of_users, S, V]
+            # prefill does not support tracing but sampling can be traced.
+            # call it in every pefill??
+            self._validate_and_initialize_sampling(
+                sampling_params, sample_on_device, enable_trace=True, enable_mtp=False
+            )
+            prefill_logits = self._prefill(
+                user_tokens,
+                user_id,
+                page_table,
+                local_user_id=i,
+                sampling_params=sampling_params,
+                sample_on_device=sample_on_device,
+            )
 
-        return last_logits
+            if sample_on_device:
+                prefill_logits = self._slice_last_token_logits(prefill_logits, prompt_len, expand_to_batch=True)
+                prefill_logits_sampled_device = self._sample_tokens_device(prefill_logits, user_slots=[user_id])
+                prefill_logits_sampled_host = self._tokens_from_device(
+                    prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
+                )
+                pred_token = prefill_logits_sampled_host[0]
+                # ttnn.deallocate(prefill_logits)
+                # ttnn.deallocate(prefill_logits_sampled_device)
+            # else:
+            #     # not tested. TODO, test this path.
+            #     assert False, "Not tested"
+            #     assert isinstance(
+            #         prefill_logits, torch.Tensor
+            #     ), "prefill_logits should be a torch.Tensor on host"
+            #     last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
+            #     pred_token = int(
+            #         self._sample_on_host(last_token_logits.unsqueeze(0), start_user_idx=user_id).item()
+            #     )
+            prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
+        self.ccl.reset_sem_counters()  # is this helping in fixing hang?
+        prefill_tokens = torch.stack(prefill_tokens)  # [num_of_users, S, V]
+
+        logger.info(f"Prefill tokens shape: {prefill_tokens.shape}")
+
+        return prefill_tokens
 
     def decode_forward(self, *args, **kwargs):
+        logger.info(f"decode_forward, kwargs keys: {kwargs.keys()}")
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
 
         page_tables = kwargs.get("page_table", None)
         kv_cache = kwargs.get("kv_cache", None)
         enable_trace = kwargs.get("enable_trace", False)
+        read_from_device = kwargs.get("read_from_device", True)
+        sampling_params = kwargs.get("sampling_params", None)
+        sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
+
+        # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
+        # sample_on_device = sample_on_device_mode in ["all", "decode_only"]
+
+        # sampling_params can be None for warmup. How to handle this?
+        # sample_on_device = sampling_params is not None
+
+        sample_on_device = True
+        self._log_sampling_params("decode_forward", sampling_params, sample_on_device=sample_on_device)
+
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
+        logger.info(
+            "decode_forward shapes: tokens_step={} start_pos={} page_tables={} kv_cache={} sampling_params={} enable_trace={} read_from_device={} sample_on_device_mode={} sample_on_device={}",
+            tuple(tokens_step.shape),
+            self._shape_or_type(kwargs.get("start_pos")),
+            self._shape_or_type(page_tables),
+            self._shape_or_type(kv_cache),
+            self._shape_or_type(sampling_params),
+            enable_trace,
+            read_from_device,
+            sample_on_device_mode,
+            sample_on_device,
+        )
+        # call it in every decode??
+        self._validate_and_initialize_sampling(
+            sampling_params, sample_on_device, enable_trace=enable_trace, enable_mtp=False
+        )
+        decode_logits = super().decode_forward(
+            tokens=tokens_step,
+            start_pos=kwargs["start_pos"],
+            batch_size_per_row=USERS_PER_ROW,
+            enable_trace=enable_trace,
+            page_table=page_tables,
+            sampling_params=sampling_params,
+            sample_on_device=sample_on_device,
+            read_from_device=read_from_device,
+        )
 
-        return_value = (
-            super()
-            .decode_forward(
-                tokens=tokens_step,
-                start_pos=kwargs["start_pos"],
-                batch_size_per_row=USERS_PER_ROW,
-                enable_trace=enable_trace,
-                page_table=page_tables,
+        if sample_on_device:
+            pred_tokens_device = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+            pred_tokens = self._tokens_from_device(
+                pred_tokens_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
             )
-            .unsqueeze(1)
-        )  # [B, V] -> [B, 1, V]
-        return return_value
+            # if not self.enable_trace:
+            #     ttnn.deallocate(decode_logits)
+            #     ttnn.deallocate(pred_tokens_device)
+
+        # else:
+        #     assert False, "Not tested"
+        #     # Normalize legacy decode outputs to [B, V], then expose vLLM shape [B, 1, V].
+        #     # DeepseekGenerator may return either [1, 1, B, V] (non-trace path) or [B, V]
+        #     # (trace path). vLLM sampling expects time-major logits [B, T, V].
+        #     if logits.dim() == 4:
+        #         logits = logits.squeeze(0).squeeze(0)
+        #     elif logits.dim() == 3 and logits.shape[1] == 1:
+        #         logits = logits.squeeze(1)
+        #     elif logits.dim() != 2:
+        #         raise RuntimeError(f"Unexpected decode logits rank for vLLM: shape={tuple(logits.shape)}")
+        #     logits = logits.unsqueeze(1)
+
+        return pred_tokens
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         assert (

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -95,6 +95,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         sample_on_device = bool(sampling_params is not None)
 
         if all(length == 0 for length in lengths):
+            if sample_on_device:
+                return torch.zeros(tokens.shape[0], device=tokens.device, dtype=torch.int64)
             return torch.zeros(tokens.shape[0], self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
 
         # Set kv_cache if provided and all entries are valid
@@ -108,20 +110,27 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             ((max_prompt_len + pad_block_size - 1) // pad_block_size) * pad_block_size if max_prompt_len > 0 else 0
         )
         num_of_users = tokens.shape[0]
-        prefill_tokens = []
+        if sample_on_device:
+            self._validate_and_initialize_sampling(sampling_params, sample_on_device)
+
+        user_outputs = []
         for i in range(num_of_users):
-            logger.info(f"Prefill step {i}")
             user_id = empty_slots[i] if empty_slots is not None else i
             prompt_len = int(lengths[i])
             if prompt_len == 0:
-                prefill_tokens.append(
-                    torch.zeros(max_padded_len, self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
-                )
+                if sample_on_device:
+                    # Device-sampling path returns token ids, even for empty prompts.
+                    user_output = torch.tensor(0, dtype=torch.int64, device=tokens.device)
+                else:
+                    # Host-sampling path returns logits.
+                    user_output = torch.zeros(
+                        max_padded_len, self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype
+                    )
+                user_outputs.append(user_output)
                 continue
+
             user_tokens = tokens[i, :prompt_len].unsqueeze(0)
             user_tokens = _pad_tokens(user_tokens, pad_value, block_size=pad_block_size).squeeze(0)
-            if sample_on_device:
-                self._validate_and_initialize_sampling(sampling_params, sample_on_device)
             prefill_logits = self._prefill(
                 user_tokens,
                 user_id,
@@ -137,19 +146,30 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 prefill_logits_sampled_host = self._tokens_from_device(
                     prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
                 )
-                pred_token = prefill_logits_sampled_host[0]
+                # Device-sampling path emits token ids.
+                user_output = prefill_logits_sampled_host[0].to(torch.int64)
             else:
                 assert isinstance(prefill_logits, torch.Tensor), "prefill_logits should be a torch.Tensor on host"
-                prefill_logits = prefill_logits.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]
-                if prefill_logits.shape[0] > prompt_len:
-                    pred_token = prefill_logits[:prompt_len]
-                if prefill_logits.shape[0] < max_padded_len:
-                    pad_len = max_padded_len - prefill_logits.shape[0]
-                    pad_logits = prefill_logits[-1:].expand(pad_len, -1)
-                    pred_token = torch.cat([prefill_logits, pad_logits], dim=0)
-            prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
-        prefill_tokens = torch.stack(prefill_tokens)  # [num_of_users, S, V]
-        return prefill_tokens
+                user_logits = prefill_logits.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]
+                seq_len = user_logits.shape[0]
+                assert (
+                    seq_len >= prompt_len
+                ), f"Prefill returned fewer tokens ({seq_len}) than prompt length ({prompt_len})"
+                user_logits = user_logits[:prompt_len]
+                if prompt_len < max_padded_len:
+                    pad_len = max_padded_len - prompt_len
+                    pad_logits = user_logits[-1:].expand(pad_len, -1)
+                    user_logits = torch.cat([user_logits, pad_logits], dim=0)
+                user_output = user_logits
+
+            user_outputs.append(user_output)
+
+        prefill_output = torch.stack(user_outputs)
+        # prefill_output semantics:
+        # - sample_on_device=True  -> sampled token ids [B]
+        # - sample_on_device=False -> logits [B, S, V] for host sampling
+
+        return prefill_output
 
     def decode_forward(self, *args, **kwargs):
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
@@ -167,7 +187,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         tokens_step = kwargs["tokens"].squeeze(1)
         if sample_on_device:
             self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace=enable_trace)
-        decode_logits = super().decode_forward(
+        decode_step_output = super().decode_forward(
             tokens=tokens_step,
             start_pos=kwargs["start_pos"],
             batch_size_per_row=USERS_PER_ROW,
@@ -177,16 +197,19 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
 
         if sample_on_device:
-            decode_tokens = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+            decode_output = self._sample_tokens_device(decode_step_output, enable_trace=enable_trace)
             if read_from_device:
-                decode_tokens = self._tokens_from_device(
-                    decode_tokens, self.mesh_device, batch_size_per_row=self.batch_size_per_row
+                decode_output = self._tokens_from_device(
+                    decode_output, self.mesh_device, batch_size_per_row=self.batch_size_per_row
                 )
         else:
-            assert isinstance(decode_logits, torch.Tensor), "decode_logits should be a torch.Tensor on host"
-            decode_tokens = decode_logits.unsqueeze(1)
+            assert isinstance(decode_step_output, torch.Tensor), "decode_step_output should be a torch.Tensor on host"
+            decode_output = decode_step_output.unsqueeze(1)
 
-        return decode_tokens
+        # decode_output semantics:
+        # - sample_on_device=True  -> sampled token ids
+        # - sample_on_device=False -> logits [B, 1, V] for host sampling
+        return decode_output
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         assert (

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import torch
 from loguru import logger
 
-from models.common.sampling.generator import SamplingParams
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
@@ -42,40 +41,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
     model_capabilities = {
         "supports_prefix_caching": False,
     }
-
-    @staticmethod
-    def _shape_or_type(value):
-        if value is None:
-            return "None"
-        if hasattr(value, "shape"):
-            try:
-                return tuple(value.shape)
-            except Exception:
-                return f"{type(value).__name__}(shape-unavailable)"
-        if isinstance(value, (list, tuple)):
-            return f"{type(value).__name__}(len={len(value)})"
-        return type(value).__name__
-
-    def _log_sampling_params(
-        self, callsite: str, sampling_params: SamplingParams | None, sample_on_device: bool | None = None
-    ):
-        if sample_on_device is not None:
-            logger.info("{} sample_on_device={}", callsite, sample_on_device)
-        if sampling_params is None:
-            logger.info("{} sampling_params=None", callsite)
-            return
-        for field_name in (
-            "temperature",
-            "top_k",
-            "top_p",
-            "presence_penalty",
-            "frequency_penalty",
-            "repetition_penalty",
-            "seed",
-            "enable_log_probs",
-        ):
-            field_val = getattr(sampling_params, field_name, None)
-            logger.info("{} sampling_params.{}={}", callsite, field_name, self._shape_or_type(field_val))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -121,7 +86,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         assert self.model_run_config_prefill is not None, "Model run config prefill is not initialized"
 
         kwargs.pop("enable_trace", None)
-        logger.warning("Prefill tracing not supported for DeepseekGenerator")
+        logger.warning("Prefill tracing not supported for DeepseekGenerator. But sampling on device will be traced.")
         tokens = kwargs["tokens"]
         lengths = kwargs["prompt_lens"]
         page_table = kwargs.get("page_table", None)
@@ -129,33 +94,12 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         empty_slots = kwargs.get("empty_slots", None)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
-        # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
-        # sample_on_device = sample_on_device_mode in ["all"]
-        # sample_on_device = sampling_params is not None
+        # sample_on_device_mode is not passed by vLLM, TODO
+        # sample_on_device = sample_on_device_mode in ["all"] and sampling_params is not None
         sample_on_device = True
         logger.info(
-            "prefill_forward shapes: tokens={} lengths={} page_table={} kv_cache={} empty_slots={} sampling_params={} sample_on_device_mode={} sample_on_device={}",
-            tuple(tokens.shape),
-            len(lengths) if lengths is not None else 0,
-            self._shape_or_type(page_table),
-            self._shape_or_type(kv_cache),
-            self._shape_or_type(empty_slots),
-            self._shape_or_type(sampling_params),
-            sample_on_device_mode,
-            sample_on_device,
+            f"prefill_forward sample_on_device_mode: {sample_on_device_mode}, sampling_params: {sampling_params}, sample_on_device: {sample_on_device}"
         )
-        self._log_sampling_params("prefill_forward", sampling_params)
-        # sampling_params can be None with server mode???
-        # sample_on_device = sampling_params is not None
-
-        sample_on_device = True
-
-        if all(length == 0 for length in lengths):
-            return torch.zeros(tokens.shape[0], self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
-
-        # Set kv_cache if provided and all entries are valid
-        if kv_cache is not None and not any(entry is None for entry in kv_cache):
-            self.set_kv_cache(kv_cache)
 
         pad_value = self.tokenizer.pad_token_id
         pad_block_size = self.paged_config.block_size if self.paged_config is not None else USERS_PER_ROW
@@ -177,7 +121,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             user_tokens = tokens[i, :prompt_len].unsqueeze(0)
             user_tokens = _pad_tokens(user_tokens, pad_value, block_size=pad_block_size).squeeze(0)
             # prefill does not support tracing but sampling can be traced.
-            # call it in every pefill??
             self._validate_and_initialize_sampling(
                 sampling_params, sample_on_device, enable_trace=True, enable_mtp=False
             )
@@ -186,8 +129,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 user_id,
                 page_table,
                 local_user_id=i,
-                sampling_params=sampling_params,
                 sample_on_device=sample_on_device,
+                return_last_hidden=False,
             )
 
             if sample_on_device:
@@ -197,23 +140,12 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                     prefill_logits_sampled_device, self.mesh_device, batch_size_per_row=1
                 )
                 pred_token = prefill_logits_sampled_host[0]
-                # ttnn.deallocate(prefill_logits)
-                # ttnn.deallocate(prefill_logits_sampled_device)
-            # else:
-            #     # not tested. TODO, test this path.
-            #     assert False, "Not tested"
-            #     assert isinstance(
-            #         prefill_logits, torch.Tensor
-            #     ), "prefill_logits should be a torch.Tensor on host"
-            #     last_token_logits = prefill_logits[0, 0, max(prompt_len - 1, 0), :]
-            #     pred_token = int(
-            #         self._sample_on_host(last_token_logits.unsqueeze(0), start_user_idx=user_id).item()
-            #     )
+            else:
+                assert False, "Not tested"
+                assert isinstance(prefill_logits, torch.Tensor), "prefill_logits should be a torch.Tensor on host"
+                pred_token = int(prefill_logits[0].item())
             prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
         prefill_tokens = torch.stack(prefill_tokens)  # [num_of_users, S, V]
-
-        logger.info(f"Prefill tokens shape: {prefill_tokens.shape}")
-
         return prefill_tokens
 
     def decode_forward(self, *args, **kwargs):
@@ -226,34 +158,18 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
-
         # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
-        # sample_on_device = sample_on_device_mode in ["all", "decode_only"]
-
-        # sampling_params can be None for warmup. How to handle this?
-        # sample_on_device = sampling_params is not None
-
+        # sample_on_device = sample_on_device_mode in ["all", "decode_only"] and sampling_params is not None
         sample_on_device = True
-        self._log_sampling_params("decode_forward", sampling_params, sample_on_device=sample_on_device)
+        logger.info(
+            f"decode_forward sample_on_device_mode: {sample_on_device_mode}, sampling_params: {sampling_params}, sample_on_device: {sample_on_device}, read_from_device: {read_from_device}"
+        )
 
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
-        logger.info(
-            "decode_forward shapes: tokens_step={} start_pos={} page_tables={} kv_cache={} sampling_params={} enable_trace={} read_from_device={} sample_on_device_mode={} sample_on_device={}",
-            tuple(tokens_step.shape),
-            self._shape_or_type(kwargs.get("start_pos")),
-            self._shape_or_type(page_tables),
-            self._shape_or_type(kv_cache),
-            self._shape_or_type(sampling_params),
-            enable_trace,
-            read_from_device,
-            sample_on_device_mode,
-            sample_on_device,
-        )
-        # call it in every decode??
         self._validate_and_initialize_sampling(
             sampling_params, sample_on_device, enable_trace=enable_trace, enable_mtp=False
         )
@@ -263,32 +179,26 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             batch_size_per_row=USERS_PER_ROW,
             enable_trace=enable_trace,
             page_table=page_tables,
-            sampling_params=sampling_params,
             sample_on_device=sample_on_device,
-            read_from_device=read_from_device,
         )
 
         if sample_on_device:
-            pred_tokens_device = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
-            pred_tokens = self._tokens_from_device(
-                pred_tokens_device, self.mesh_device, batch_size_per_row=self.batch_size_per_row
-            )
-            # if not self.enable_trace:
-            #     ttnn.deallocate(decode_logits)
-            #     ttnn.deallocate(pred_tokens_device)
-
-        # else:
-        #     assert False, "Not tested"
-        #     # Normalize legacy decode outputs to [B, V], then expose vLLM shape [B, 1, V].
-        #     # DeepseekGenerator may return either [1, 1, B, V] (non-trace path) or [B, V]
-        #     # (trace path). vLLM sampling expects time-major logits [B, T, V].
-        #     if logits.dim() == 4:
-        #         logits = logits.squeeze(0).squeeze(0)
-        #     elif logits.dim() == 3 and logits.shape[1] == 1:
-        #         logits = logits.squeeze(1)
-        #     elif logits.dim() != 2:
-        #         raise RuntimeError(f"Unexpected decode logits rank for vLLM: shape={tuple(logits.shape)}")
-        #     logits = logits.unsqueeze(1)
+            pred_tokens = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+            if read_from_device:
+                pred_tokens = self._tokens_from_device(
+                    pred_tokens, self.mesh_device, batch_size_per_row=self.batch_size_per_row
+                )
+        else:
+            # Normalize legacy decode outputs to [B, V], then expose vLLM shape [B, 1, V].
+            # DeepseekGenerator may return either [1, 1, B, V] (non-trace path) or [B, V]
+            # (trace path). vLLM sampling expects time-major logits [B, T, V].
+            # if decode_logits.dim() == 4:
+            #     decode_logits = decode_logits.squeeze(0).squeeze(0)
+            # elif decode_logits.dim() == 3 and decode_logits.shape[1] == 1:
+            #     decode_logits = logits.decode_logits(1)
+            # elif decode_logits.dim() != 2:
+            #     raise RuntimeError(f"Unexpected decode logits rank for vLLM: shape={tuple(logits.shape)}")
+            pred_tokens = decode_logits.unsqueeze(1)
 
         return pred_tokens
 

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -78,7 +78,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return self.cache_dir
 
     def prefill_forward(self, *args, **kwargs):
-        logger.info(f"prefill_forward, kwargs keys: {kwargs.keys()}")
         start_pos = kwargs.get("start_pos", None)
         assert (start_pos is None) or all(
             x == 0 for x in start_pos
@@ -86,20 +85,21 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         assert self.model_run_config_prefill is not None, "Model run config prefill is not initialized"
 
         kwargs.pop("enable_trace", None)
-        logger.warning("Prefill tracing not supported for DeepseekGenerator. But sampling on device will be traced.")
+        logger.warning("Prefill tracing not supported for DeepseekGenerator")
         tokens = kwargs["tokens"]
         lengths = kwargs["prompt_lens"]
         page_table = kwargs.get("page_table", None)
         kv_cache = kwargs.get("kv_cache", None)
         empty_slots = kwargs.get("empty_slots", None)
         sampling_params = kwargs.get("sampling_params", None)
-        sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
-        # sample_on_device_mode is not passed by vLLM, TODO
-        # sample_on_device = sample_on_device_mode in ["all"] and sampling_params is not None
-        sample_on_device = True
-        logger.info(
-            f"prefill_forward sample_on_device_mode: {sample_on_device_mode}, sampling_params: {sampling_params}, sample_on_device: {sample_on_device}"
-        )
+        sample_on_device = bool(sampling_params is not None)
+
+        if all(length == 0 for length in lengths):
+            return torch.zeros(tokens.shape[0], self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
+
+        # Set kv_cache if provided and all entries are valid
+        if kv_cache is not None and not any(entry is None for entry in kv_cache):
+            self.set_kv_cache(kv_cache)
 
         pad_value = self.tokenizer.pad_token_id
         pad_block_size = self.paged_config.block_size if self.paged_config is not None else USERS_PER_ROW
@@ -120,10 +120,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 continue
             user_tokens = tokens[i, :prompt_len].unsqueeze(0)
             user_tokens = _pad_tokens(user_tokens, pad_value, block_size=pad_block_size).squeeze(0)
-            # prefill does not support tracing but sampling can be traced.
-            self._validate_and_initialize_sampling(
-                sampling_params, sample_on_device, enable_trace=True, enable_mtp=False
-            )
+            if sample_on_device:
+                self._validate_and_initialize_sampling(sampling_params, sample_on_device)
             prefill_logits = self._prefill(
                 user_tokens,
                 user_id,
@@ -141,15 +139,19 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 )
                 pred_token = prefill_logits_sampled_host[0]
             else:
-                assert False, "Not tested"
                 assert isinstance(prefill_logits, torch.Tensor), "prefill_logits should be a torch.Tensor on host"
-                pred_token = int(prefill_logits[0].item())
+                prefill_logits = prefill_logits.squeeze(0).squeeze(0)  # [1, 1, S, V] -> [S, V]
+                if prefill_logits.shape[0] > prompt_len:
+                    pred_token = prefill_logits[:prompt_len]
+                if prefill_logits.shape[0] < max_padded_len:
+                    pad_len = max_padded_len - prefill_logits.shape[0]
+                    pad_logits = prefill_logits[-1:].expand(pad_len, -1)
+                    pred_token = torch.cat([prefill_logits, pad_logits], dim=0)
             prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
         prefill_tokens = torch.stack(prefill_tokens)  # [num_of_users, S, V]
         return prefill_tokens
 
     def decode_forward(self, *args, **kwargs):
-        logger.info(f"decode_forward, kwargs keys: {kwargs.keys()}")
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
 
         page_tables = kwargs.get("page_table", None)
@@ -157,22 +159,14 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         enable_trace = kwargs.get("enable_trace", False)
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
-        sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
-        # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
-        # sample_on_device = sample_on_device_mode in ["all", "decode_only"] and sampling_params is not None
-        sample_on_device = True
-        logger.info(
-            f"decode_forward sample_on_device_mode: {sample_on_device_mode}, sampling_params: {sampling_params}, sample_on_device: {sample_on_device}, read_from_device: {read_from_device}"
-        )
-
+        sample_on_device = bool(sampling_params is not None)
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
-        self._validate_and_initialize_sampling(
-            sampling_params, sample_on_device, enable_trace=enable_trace, enable_mtp=False
-        )
+        if sample_on_device:
+            self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace=enable_trace)
         decode_logits = super().decode_forward(
             tokens=tokens_step,
             start_pos=kwargs["start_pos"],
@@ -183,24 +177,16 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
 
         if sample_on_device:
-            pred_tokens = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
+            decode_tokens = self._sample_tokens_device(decode_logits, enable_trace=enable_trace)
             if read_from_device:
-                pred_tokens = self._tokens_from_device(
-                    pred_tokens, self.mesh_device, batch_size_per_row=self.batch_size_per_row
+                decode_tokens = self._tokens_from_device(
+                    decode_tokens, self.mesh_device, batch_size_per_row=self.batch_size_per_row
                 )
         else:
-            # Normalize legacy decode outputs to [B, V], then expose vLLM shape [B, 1, V].
-            # DeepseekGenerator may return either [1, 1, B, V] (non-trace path) or [B, V]
-            # (trace path). vLLM sampling expects time-major logits [B, T, V].
-            # if decode_logits.dim() == 4:
-            #     decode_logits = decode_logits.squeeze(0).squeeze(0)
-            # elif decode_logits.dim() == 3 and decode_logits.shape[1] == 1:
-            #     decode_logits = logits.decode_logits(1)
-            # elif decode_logits.dim() != 2:
-            #     raise RuntimeError(f"Unexpected decode logits rank for vLLM: shape={tuple(logits.shape)}")
-            pred_tokens = decode_logits.unsqueeze(1)
+            assert isinstance(decode_logits, torch.Tensor), "decode_logits should be a torch.Tensor on host"
+            decode_tokens = decode_logits.unsqueeze(1)
 
-        return pred_tokens
+        return decode_tokens
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         assert (

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -131,7 +131,8 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         sample_on_device_mode = kwargs.get("sample_on_device_mode", "unknown")
         # sample_on_device_mode is not passed by vLLM, TODO, check if its missing in the vLLM code
         # sample_on_device = sample_on_device_mode in ["all"]
-        sample_on_device = sampling_params is not None
+        # sample_on_device = sampling_params is not None
+        sample_on_device = True
         logger.info(
             "prefill_forward shapes: tokens={} lengths={} page_table={} kv_cache={} empty_slots={} sampling_params={} sample_on_device_mode={} sample_on_device={}",
             tuple(tokens.shape),
@@ -209,7 +210,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             #         self._sample_on_host(last_token_logits.unsqueeze(0), start_user_idx=user_id).item()
             #     )
             prefill_tokens.append(torch.tensor(pred_token, dtype=torch.int64))
-        self.ccl.reset_sem_counters()  # is this helping in fixing hang?
         prefill_tokens = torch.stack(prefill_tokens)  # [num_of_users, S, V]
 
         logger.info(f"Prefill tokens shape: {prefill_tokens.shape}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40956

### What's changed
Implements glue logic to enable sampling on-device when using the vLLM interface for DeepSeek v3 generation.

Changes:

- Adds vLLM-side plumbing to pass sampling_params / sample_on_device into prefill and decode paths and perform device-side sampling.
- Refactors sampling setup in the base generator into _validate_and_initialize_sampling with parameter change detection.
- Adjusts generator decode API surface by removing unused sampling-related parameters from decode_forward

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/vllm_SOD)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/vllm_SOD)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/vllm_SOD)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/vllm_SOD)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/vllm_SOD)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/vllm_SOD)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/vllm_SOD)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
