### PR TITLE
Removing the accuracy heuristic that was introduced into high batch deepseek demo

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -3,12 +3,10 @@
 
 import json
 import os
-import unicodedata
 from functools import lru_cache
 from pathlib import Path
 
 import pytest
-from loguru import logger
 
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json, run_demo
 
@@ -27,60 +25,6 @@ def get_total_model_layers(model_path: Path) -> int:
     if not isinstance(total_layers, int):
         raise ValueError(f"Expected integer num_hidden_layers in {(model_path / 'config.json')}, got {total_layers!r}")
     return total_layers
-
-
-def is_allowed_unicode_letter(char: str) -> bool:
-    """True for Latin and Greek script letters per Unicode character name."""
-    if not char.isalpha():
-        return False
-    name = unicodedata.name(char, "")
-    return name.startswith("LATIN ") or name.startswith("GREEK ")
-
-
-def find_disallowed_non_ascii_letter(text: str) -> tuple[int, str] | None:
-    """Find the first disallowed non-ASCII letter in the text."""
-    for char_index, char in enumerate(text):
-        if char.isascii() or not char.isalpha() or is_allowed_unicode_letter(char):
-            continue
-        return char_index, char
-    return None
-
-
-def validate_english_keyboard_output(results: dict) -> None:
-    generations = results.get("generations", [])
-    for generation_index, generation in enumerate(generations, start=1):
-        generated_text = generation.get("text")
-        if generated_text is None:
-            continue
-        if not isinstance(generated_text, str):
-            raise ValueError(
-                "Generated output text must be a string or None: "
-                f"generation_index={generation_index}, got={type(generated_text).__name__}"
-            )
-
-        bad_char = find_disallowed_non_ascii_letter(generated_text)
-        if bad_char is None:
-            continue
-
-        bad_char_index, bad_char = bad_char
-        unicode_name = unicodedata.name(bad_char, "UNKNOWN")
-        raise ValueError(
-            "Generated output contains disallowed non-Latin letter: "
-            f"generation_index={generation_index}, char_index={bad_char_index}, "
-            f"char={bad_char!r}, codepoint=U+{ord(bad_char):04X}, unicode_name={unicode_name}. "
-            "Punctuation/symbols and Latin letters (including accents, e.g. é) are allowed; "
-            "other scripts (e.g. CJK) are not."
-        )
-
-
-def maybe_validate_english_keyboard_output(results: dict, override_num_layers: int | None) -> None:
-    total_layers = get_total_model_layers(MODEL_PATH)
-    num_layers = override_num_layers if override_num_layers is not None else total_layers
-    if num_layers < total_layers:
-        logger.info(f"Output validation is skipped as {num_layers} < {total_layers} layers.")
-        return
-
-    validate_english_keyboard_output(results)
 
 
 def _assert_no_garbage_tokens(results: dict) -> None:
@@ -264,8 +208,6 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
         run_kwargs["stop_at_eos"] = case["stop_at_eos"]
 
     results = run_demo(**run_kwargs)
-    maybe_validate_english_keyboard_output(results, case["override_num_layers"])
-    _assert_no_garbage_tokens(results)
 
     # Full-demo cases can stop early on EOS; stress/profile cases disable EOS and
     # should always produce the requested token count.
@@ -301,3 +243,5 @@ def test_demo(case: dict, force_recalculate_weight_config: bool):
             json.dump(output_data, f, indent=2, ensure_ascii=False)
 
         print(f"\nDemo results saved to: {output_file}")
+
+    _assert_no_garbage_tokens(results)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40631

### Problem description
Accuracy heuristic is causing failures even when the output is good. Questions in the prompts are asking for example "What is the capital of Bulgaria?" in which case the thinking trace outputs non-English characters, but the output is logical and makes sense. 

### What's changed
Removing this heuristic and sufficing with the top-100 token check, which should catch garbage tokens and out-of-context words.

Also moving the assert to after the json file creation to allow the json file to be created for viewing by devs in failing cases.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-remove-accuracy-heuristic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-remove-accuracy-heuristic)