### PR TITLE
Add validation tests for fatals introduced in #39330 and update tt-metal-l2-nightly-impl.yaml to run compute_fused tests on a CPU-only tt-sim runner

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -90,6 +90,14 @@ on:
         required: false
         type: boolean
         default: true
+      run_compute_only_tests:
+        required: false
+        type: boolean
+        default: true
+      ttsim-version:
+        required: false
+        type: string
+        default: "v1.4.6"
 
 
 # This is a fallback timeout for tests that are not marked with pytest.mark.timeout(xxx)
@@ -873,6 +881,74 @@ jobs:
       - name: ttnn misc (rand and ssm) tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/rand tests/ttnn/nightly/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ttnn-compute-only-tests:
+    if: ${{ inputs.run_compute_only_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        TT_METAL_HOME: /work
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        TT_METAL_SIMULATOR_HOME: /work/sim
+        TT_METAL_SIMULATOR: /work/sim/libttsim.so
+        TT_METAL_SLOW_DISPATCH_MODE: 1
+        TT_METAL_DISABLE_SFPLOADMACRO: 1
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ttnn compute-only validation tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Compute ttsim asset name
+        id: ttsim-info
+        run: |
+          case "${{ inputs.arch }}" in
+            wormhole_b0) suffix="wh"; soc="wormhole_b0_80_arch.yaml" ;;
+            blackhole)   suffix="bh"; soc="blackhole_140_arch.yaml" ;;
+            *) echo "::error::Unknown architecture: ${{ inputs.arch }}"; exit 1 ;;
+          esac
+          echo "asset_name=libttsim_${suffix}.so" >> "$GITHUB_OUTPUT"
+          echo "soc_desc=${soc}" >> "$GITHUB_OUTPUT"
+      - name: Download ttsim binary
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
+        with:
+          repository: tenstorrent/ttsim
+          tag: ${{ inputs.ttsim-version }}
+          fileName: ${{ steps.ttsim-info.outputs.asset_name }}
+          out-file-path: /tmp/ttsim
+      - name: Install ttsim
+        run: |
+          set -euo pipefail
+          mkdir -p $TT_METAL_SIMULATOR_HOME
+          mv /tmp/ttsim/${{ steps.ttsim-info.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
+          cp /work/tt_metal/soc_descriptors/${{ steps.ttsim-info.outputs.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
+      - name: ttnn compute-only validation tests
+        timeout-minutes: 20
+        run: pytest tests/ttnn/nightly/unit_tests/operations_compute_only -xv --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -90,7 +90,7 @@ on:
         required: false
         type: boolean
         default: true
-      run_compute_only_tests:
+      run_compute_fused_tests:
         required: false
         type: boolean
         default: true
@@ -889,8 +889,8 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
-  ttnn-compute-only-tests:
-    if: ${{ inputs.run_compute_only_tests }}
+  ttnn-compute-fused-tests:
+    if: ${{ inputs.run_compute_fused_tests }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
@@ -909,7 +909,7 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    name: ttnn compute-only validation tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    name: ttnn compute-fused validation tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: ubuntu-latest
     steps:
       - name: 🧬 Checkout Repository
@@ -946,9 +946,9 @@ jobs:
           mkdir -p $TT_METAL_SIMULATOR_HOME
           mv /tmp/ttsim/${{ steps.ttsim-info.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
           cp /work/tt_metal/soc_descriptors/${{ steps.ttsim-info.outputs.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
-      - name: ttnn compute-only validation tests
+      - name: ttnn compute-fused validation tests
         timeout-minutes: 20
-        run: pytest tests/ttnn/nightly/unit_tests/operations_compute_only -xv --timeout=${{ env.TEST_BUDGET_SECONDS }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations_compute_only/fused -xv --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -71,7 +71,7 @@ on:
         type: boolean
         default: false
       additional_test_categories:
-        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers)'
+        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers,compute_only)'
         required: false
         type: string
         default: ''
@@ -290,6 +290,7 @@ jobs:
       run_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',fused,') }}
       run_reduction_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',reduction,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
+      run_compute_only_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',compute_only,') }}
   ttnn-ops-docs-check:
     needs: [build-artifact, generate-arch-matrix]
     if: |

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -71,7 +71,7 @@ on:
         type: boolean
         default: false
       additional_test_categories:
-        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers,compute_only)'
+        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers,compute_fused)'
         required: false
         type: string
         default: ''
@@ -290,7 +290,7 @@ jobs:
       run_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',fused,') }}
       run_reduction_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',reduction,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
-      run_compute_only_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',compute_only,') }}
+      run_compute_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',compute_fused,') }}
   ttnn-ops-docs-check:
     needs: [build-artifact, generate-arch-matrix]
     if: |

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation-failure tests for group_norm checks added by PR #39330.
+
+This file runs on a CPU-only runner using TT-Sim (software simulator) in the
+L2 nightly workflow.  Tests that call host-side C++ helpers directly do not
+need a device at all; tests that go through ``ttnn.group_norm`` use the
+simulated device provided by the ``device`` fixture under TT-Sim.
+
+Covers the following checks:
+
+  groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
+    TT_FATAL  — num_cores_across_channel == 0
+    TT_FATAL  — num_groups not divisible by num_cores_across_channel
+
+  groupnorm_nanobind.cpp  _find_expected_dram_grid wrapper:
+    RuntimeError  — no valid DRAM grid found
+
+  groupnorm.cpp  get_mask_tensor():
+    TT_FATAL  — compute_num_virtual_cols returns 0 (non-L1 buffer path)
+
+  groupnorm.cpp  validate_dram_grid():
+    TT_THROW  — invalid grid with a valid sub-grid suggestion
+    TT_THROW  — no valid grid exists at all
+
+  groupnorm_mcast_program_factory.cpp / groupnorm_no_mcast_program_factory.cpp:
+    TT_FATAL  — num_out_blocks > block_ht
+"""
+
+import pytest
+import torch
+
+import ttnn
+from ttnn._ttnn.operations.normalization import (
+    create_group_norm_input_mask,
+    _compute_num_virtual_cols,
+    _find_expected_dram_grid,
+)
+
+
+# ===========================================================================
+#  Pure CPU-only tests (no device fixture required)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# create_group_norm_input_mask_impl: num_cores_across_channel must be > 0
+# Source: groupnorm_input_mask.cpp
+# ---------------------------------------------------------------------------
+def test_input_mask_num_cores_across_channel_zero():
+    with pytest.raises(RuntimeError, match="num_cores_across_channel must be > 0"):
+        create_group_norm_input_mask(
+            num_channel=256,
+            num_groups=32,
+            num_cores_across_channel=0,
+            data_type=ttnn.DataType.BFLOAT16,
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_group_norm_input_mask_impl: num_groups % num_cores_across_channel != 0
+# Source: groupnorm_input_mask.cpp
+# ---------------------------------------------------------------------------
+def test_input_mask_num_groups_not_divisible_by_num_cores():
+    with pytest.raises(RuntimeError, match="must be divisible by num_cores_across_channel"):
+        create_group_norm_input_mask(
+            num_channel=256,
+            num_groups=32,
+            num_cores_across_channel=3,
+            data_type=ttnn.DataType.BFLOAT16,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _find_expected_dram_grid: no valid grid exists
+# Source: groupnorm_nanobind.cpp (RuntimeError wrapper around find_expected_dram_grid)
+# ---------------------------------------------------------------------------
+def test_find_expected_dram_grid_no_valid_grid():
+    with pytest.raises(RuntimeError, match="Cannot find a valid DRAM group-norm grid"):
+        _find_expected_dram_grid(
+            max_x=8,
+            max_y=8,
+            num_channels=33,
+            num_groups=3,
+            input_nhw=32,
+        )
+
+
+# ===========================================================================
+#  Device-dependent tests (use TT-Sim simulated device)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# get_mask_tensor: compute_num_virtual_cols returns 0 (non-L1 buffer path)
+# Source: groupnorm.cpp
+# ---------------------------------------------------------------------------
+def test_get_mask_tensor_num_virtual_cols_zero(device):
+    torch_x = torch.randn(1, 1, 32, 48, dtype=torch.bfloat16)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        (32, 48),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    dram_height_sharded = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.DRAM,
+        shard_spec,
+    )
+    x = ttnn.interleaved_to_sharded(
+        ttnn.from_torch(torch_x, dtype=ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        dram_height_sharded,
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot determine num_virtual_cols"):
+        ttnn.group_norm(x, num_groups=16, core_grid=ttnn.CoreGrid(x=1, y=1), inplace=True)
+
+
+# ---------------------------------------------------------------------------
+# validate_dram_grid: invalid grid / no valid grid
+# Source: groupnorm.cpp
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "input_shape, num_groups, core_grid, msg_pattern",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            1,
+            ttnn.CoreGrid(x=8, y=8),
+            r"Requested core_grid .* is invalid for the input dimensions",
+            id="invalid_grid_with_suggestion",
+        ),
+        pytest.param(
+            (1, 1, 32, 48),
+            16,
+            ttnn.CoreGrid(x=32, y=1),
+            r"Cannot find any valid core grid",
+            id="no_valid_grid",
+        ),
+    ],
+)
+def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, device):
+    x = ttnn.empty(input_shape, dtype=ttnn.DataType.BFLOAT16, device=device)
+    with pytest.raises(RuntimeError, match=msg_pattern):
+        ttnn.group_norm(x, num_groups=num_groups, core_grid=core_grid, inplace=False)
+
+
+# ---------------------------------------------------------------------------
+# num_out_blocks > block_ht in mcast and no_mcast program factories
+# Source: groupnorm_mcast_program_factory.cpp, groupnorm_no_mcast_program_factory.cpp
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "input_shape, core_grid, num_out_blocks",
+    [
+        pytest.param(
+            (1, 1, 256, 256),
+            ttnn.CoreGrid(y=2, x=4),
+            5,
+            id="mcast_num_out_blocks_exceeds_block_ht",
+        ),
+        pytest.param(
+            (2, 1, 64, 256),
+            ttnn.CoreGrid(y=1, x=1),
+            3,
+            id="no_mcast_num_out_blocks_exceeds_block_ht",
+        ),
+    ],
+)
+def test_num_out_blocks_exceeds_block_ht(input_shape, core_grid, num_out_blocks, device):
+    x = ttnn.from_torch(
+        torch.randn(*input_shape, dtype=torch.bfloat16),
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    with pytest.raises(RuntimeError, match=r"num_out_blocks.*must be in"):
+        ttnn.group_norm(
+            x,
+            num_groups=32,
+            core_grid=core_grid,
+            num_out_blocks=num_out_blocks,
+            inplace=False,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -35,7 +35,6 @@ import torch
 import ttnn
 from ttnn._ttnn.operations.normalization import (
     create_group_norm_input_mask,
-    _compute_num_virtual_cols,
     _find_expected_dram_grid,
 )
 

--- a/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py
@@ -9,24 +9,6 @@ L2 nightly workflow.  Tests that call host-side C++ helpers directly do not
 need a device at all; tests that go through ``ttnn.group_norm`` use the
 simulated device provided by the ``device`` fixture under TT-Sim.
 
-Covers the following checks:
-
-  groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
-    TT_FATAL  — num_cores_across_channel == 0
-    TT_FATAL  — num_groups not divisible by num_cores_across_channel
-
-  groupnorm_nanobind.cpp  _find_expected_dram_grid wrapper:
-    RuntimeError  — no valid DRAM grid found
-
-  groupnorm.cpp  get_mask_tensor():
-    TT_FATAL  — compute_num_virtual_cols returns 0 (non-L1 buffer path)
-
-  groupnorm.cpp  validate_dram_grid():
-    TT_THROW  — invalid grid with a valid sub-grid suggestion
-    TT_THROW  — no valid grid exists at all
-
-  groupnorm_mcast_program_factory.cpp / groupnorm_no_mcast_program_factory.cpp:
-    TT_FATAL  — num_out_blocks > block_ht
 """
 
 import pytest
@@ -45,8 +27,8 @@ from ttnn._ttnn.operations.normalization import (
 
 
 # ---------------------------------------------------------------------------
-# create_group_norm_input_mask_impl: num_cores_across_channel must be > 0
-# Source: groupnorm_input_mask.cpp
+# groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
+#   TT_FATAL — num_cores_across_channel must be > 0
 # ---------------------------------------------------------------------------
 def test_input_mask_num_cores_across_channel_zero():
     with pytest.raises(RuntimeError, match="num_cores_across_channel must be > 0"):
@@ -59,8 +41,8 @@ def test_input_mask_num_cores_across_channel_zero():
 
 
 # ---------------------------------------------------------------------------
-# create_group_norm_input_mask_impl: num_groups % num_cores_across_channel != 0
-# Source: groupnorm_input_mask.cpp
+# groupnorm_input_mask.cpp  create_group_norm_input_mask_impl():
+#   TT_FATAL — num_groups must be divisible by num_cores_across_channel
 # ---------------------------------------------------------------------------
 def test_input_mask_num_groups_not_divisible_by_num_cores():
     with pytest.raises(RuntimeError, match="must be divisible by num_cores_across_channel"):
@@ -73,8 +55,8 @@ def test_input_mask_num_groups_not_divisible_by_num_cores():
 
 
 # ---------------------------------------------------------------------------
-# _find_expected_dram_grid: no valid grid exists
-# Source: groupnorm_nanobind.cpp (RuntimeError wrapper around find_expected_dram_grid)
+# groupnorm_nanobind.cpp  _find_expected_dram_grid (wrapper):
+#   RuntimeError — no valid DRAM grid (calls find_expected_dram_grid)
 # ---------------------------------------------------------------------------
 def test_find_expected_dram_grid_no_valid_grid():
     with pytest.raises(RuntimeError, match="Cannot find a valid DRAM group-norm grid"):
@@ -93,8 +75,8 @@ def test_find_expected_dram_grid_no_valid_grid():
 
 
 # ---------------------------------------------------------------------------
-# get_mask_tensor: compute_num_virtual_cols returns 0 (non-L1 buffer path)
-# Source: groupnorm.cpp
+# groupnorm.cpp  get_mask_tensor():
+#   TT_FATAL — num_virtual_cols == 0 (non-L1 buffer path; DRAM height-sharded skips validate_dram_grid)
 # ---------------------------------------------------------------------------
 def test_get_mask_tensor_num_virtual_cols_zero(device):
     torch_x = torch.randn(1, 1, 32, 48, dtype=torch.bfloat16)
@@ -118,8 +100,11 @@ def test_get_mask_tensor_num_virtual_cols_zero(device):
 
 
 # ---------------------------------------------------------------------------
-# validate_dram_grid: invalid grid / no valid grid
-# Source: groupnorm.cpp
+# groupnorm.cpp  validate_dram_grid():
+#   TT_THROW — invalid core_grid for input dimensions; suggests largest valid sub-grid
+#     (param id: invalid_grid_with_suggestion)
+#   TT_THROW — cannot find any valid core grid for given Ht, W, num_groups
+#     (param id: no_valid_grid)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "input_shape, num_groups, core_grid, msg_pattern",
@@ -147,8 +132,10 @@ def test_validate_dram_grid(input_shape, num_groups, core_grid, msg_pattern, dev
 
 
 # ---------------------------------------------------------------------------
-# num_out_blocks > block_ht in mcast and no_mcast program factories
-# Source: groupnorm_mcast_program_factory.cpp, groupnorm_no_mcast_program_factory.cpp
+# groupnorm_mcast_program_factory.cpp / groupnorm_no_mcast_program_factory.cpp:
+#   TT_FATAL — num_out_blocks must be in [1, block_h]
+#     (param id: mcast_num_out_blocks_exceeds_block_ht — mcast factory path)
+#     (param id: no_mcast_num_out_blocks_exceeds_block_ht — no-mcast factory path)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "input_shape, core_grid, num_out_blocks",


### PR DESCRIPTION
 ### Ticket
- #39721

### Problem description

PR #39330 added 23 validation checks (20 `TT_FATAL`, 2 `TT_THROW`, 1 `RuntimeError`) across the group norm implementation.

Issue #39721 asks for two things:
1. A test file (`tests/ttnn/nightly/unit_tests/operations_compute_only/fused/test_group_norm.py`) that triggers these validation checks.
2. A new CI job in the L2 nightly workflow that runs these tests on a CPU-only runner.

### What's changed

**New CI job: `ttnn-compute-only-tests`** (`tt-metal-l2-nightly-impl.yaml`)

Added a job gated by `run_compute_only_tests`. It runs-on: `ubuntu-latest`, downloads and installs TT-Sim from tenstorrent/ttsim (same pattern as `ttsim.yaml`), runs `pytest tests/ttnn/nightly/unit_tests/operations_compute_only`. The job can be triggered via `additional_test_categories: compute_only`.

**New test file: `test_group_norm.py`**

8 tests covering the 8 directly triggerable checks out of the 23 added by PR #39330. Each test feeds deliberately invalid parameters and asserts the expected `RuntimeError` is raised via `pytest.raises`.

**Validation check coverage breakdown**

PR #39330 added 23 checks across 5 files. The table below catalogs every check, whether it is tested, and why untested checks are not covered.

#### Host-side checks (6 checks - all tested)

| Source file | Condition | Type | Test |
|---|---|---|---|
| `groupnorm.cpp` - `validate_dram_grid` | Invalid grid, valid sub-grid exists | TT_THROW | `test_validate_dram_grid[invalid_grid_with_suggestion]` |
| `groupnorm.cpp` - `validate_dram_grid` | No valid grid exists at all | TT_THROW | `test_validate_dram_grid[no_valid_grid]` |
| `groupnorm.cpp` - `get_mask_tensor` | `num_virtual_cols == 0` (non-L1 buffer path) | TT_FATAL | `test_get_mask_tensor_num_virtual_cols_zero` |
| `groupnorm_input_mask.cpp` | `num_cores_across_channel == 0` | TT_FATAL | `test_input_mask_num_cores_across_channel_zero` |
| `groupnorm_input_mask.cpp` | `num_groups % num_cores_across_channel != 0` | TT_FATAL | `test_input_mask_num_groups_not_divisible_by_num_cores` |
| `groupnorm_nanobind.cpp` | `_find_expected_dram_grid` returns no result | RuntimeError | `test_find_expected_dram_grid_no_valid_grid` |

#### Program factory checks - directly triggerable (2 checks - tested)

| Source file | Condition | Type | Test |
|---|---|---|---|
| `groupnorm_mcast_program_factory.cpp` | `num_out_blocks > block_ht` | `TT_FATAL` | `test_num_out_blocks_exceeds_block_ht[mcast_...]` |
| `groupnorm_no_mcast_program_factory.cpp` | `num_out_blocks > block_ht` | `TT_FATAL` | `test_num_out_blocks_exceeds_block_ht[no_mcast_...]` |

These are triggerable because `num_out_blocks` is a user-supplied parameter that can independently exceed `block_ht`.

#### Program factory checks - shadowed by `validate_dram_grid` (4 checks - not tested)

| Source file | Condition | Type | Why not tested |
|---|---|---|---|
| `groupnorm_mcast_program_factory.cpp` | `Ht < num_virtual_rows` | TT_FATAL | `validate_dram_grid` in `groupnorm.cpp` checks the same condition and throws first. For sharded inputs (which skip `validate_dram_grid`), the `GroupNormShardedProgramFactory` is used instead, so this code path is never reached. |
| `groupnorm_mcast_program_factory.cpp` | `Ht % num_virtual_rows != 0` | TT_FATAL | Same as above. |
| `groupnorm_no_mcast_program_factory.cpp` | `Ht < num_virtual_rows` | TT_FATAL | Same as above. |
| `groupnorm_no_mcast_program_factory.cpp` | `Ht % num_virtual_rows != 0` | TT_FATAL | Same as above. |

#### Program factory checks - defensive / unreachable (11 checks - not tested)

These guards protect against intermediate values becoming zero or negative. Under normal operation they cannot fire because upstream validation and the math that computes these values guarantees they are always positive when the factories are entered.

| Source file | Condition | Why unreachable |
|---|---|---|
| `groupnorm_mcast_program_factory.cpp` | `num_batches_per_core_group_1 > 0` | Derived from `per_core_M / (H * num_batches)`; `validate_dram_grid` guarantees `per_core_Mt > 0`, so this is always positive. |
| `groupnorm_mcast_program_factory.cpp` | `block_ht_group_1 > 0` | Equals `per_core_Mt / num_batches_per_core`; both are positive after grid validation. |
| `groupnorm_mcast_program_factory.cpp` | `num_channels_per_group > 0` | Equals `W / num_groups`; `groupnorm.cpp` already asserts `W % num_groups == 0` and `W > 0` (from tensor shape). |
| `groupnorm_mcast_program_factory.cpp` | `num_rows_per_batch_per_core_group_1 > 0` | Derived from `per_core_M / num_batches_per_core`; both positive after grid validation. |
| `groupnorm_mcast_program_factory.cpp` | `num_cores_per_batch > 0 && num_cores_per_group > 0` | `num_cores > 0` by construction (grid area), and the division logic guarantees at least 1 core per batch/group. |
| `groupnorm_no_mcast_program_factory.cpp` | `block_ht_group_1 > 0` | Same reasoning as mcast counterpart. |
| `groupnorm_no_mcast_program_factory.cpp` | `block_ht_group_2 > 0` | Only checked when `!equal_batches_per_core`; in that path, `per_core_Mt_group_2` is always positive. |
| `groupnorm_no_mcast_program_factory.cpp` | `num_out_blocks <= block_ht_group_2` | Only checked when `!equal_batches_per_core && block_ht_group_2 > 0`; the auto-heuristic for `num_out_blocks` caps it at `block_ht_group_1`, and group 2 has comparable or larger `block_ht`. User-supplied `num_out_blocks` is caught by the group 1 check first. |
| `groupnorm_no_mcast_program_factory.cpp` | `num_channels_per_group > 0` | Same as mcast counterpart — protected by host-side `W % num_groups == 0` check. |
| `groupnorm_no_mcast_program_factory.cpp` | `num_rows_per_batch_per_core_group_1 > 0` | Same reasoning as mcast counterpart. |
| `groupnorm_no_mcast_program_factory.cpp` | `num_cores_per_batch > 0 && num_cores_per_group > 0` | Same reasoning as mcast counterpart. |

**Summary**: 8 of 23 checks are directly tested. The remaining 15 are either shadowed by upstream validation (4) or are defensive guards on derived values that cannot be zero given valid upstream inputs (11). These defensive checks remain valuable as safety nets against future refactoring but are not independently triggerable through the public API.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-test-groupnorm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-test-groupnorm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-test-groupnorm)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-test-groupnorm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-test-groupnorm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-test-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-test-groupnorm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
