### PR TITLE
Fix broken import in test_deepseek_ccl_ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_deepseek_ccl_ops.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_deepseek_ccl_ops.py
@@ -22,7 +22,7 @@ To run only these deepseek tests:
 # pytest will automatically discover and run these imported test functions
 
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_ccl_broadcast import (
-    test_ccl_broadcast_dual_axis,
+    test_ccl_broadcast,
 )
 
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_ccl_all_reduce import (
@@ -36,7 +36,7 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.test_reduce_to_one_b1 import (
 
 # Re-export for pytest discovery
 __all__ = [
-    "test_ccl_broadcast_dual_axis",
+    "test_ccl_broadcast",
     "test_ccl_all_reduce",
     "test_reduce_to_one_2d",
 ]


### PR DESCRIPTION
## Summary
- PR #39053 renamed `test_ccl_broadcast_dual_axis` → `test_ccl_broadcast` in `test_ccl_broadcast.py` but did not update the import in `test_deepseek_ccl_ops.py`, causing `ImportError` at collection time for the entire `all_post_commit` CCL test suite.
- Updates the import and `__all__` export to use the new name.

## Test plan
- [ ] Verify `pytest --collect-only tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit` no longer errors
- [ ] Blackhole e2e pipeline passes