### PR TITLE
 #40805: Rename debug_bus artifact to use job_id

### DIFF
--- a/.github/actions/upload-artifact-with-job-uuid/action.yml
+++ b/.github/actions/upload-artifact-with-job-uuid/action.yml
@@ -30,7 +30,7 @@ runs:
       if: ${{ env.TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH != '' }}
       uses: actions/upload-artifact@v4
       with:
-        name: "debug_bus_signals_${{ steps.generate-artifact-name.outputs.artifact-name }}"
+        name: "debug_bus_signals_${{ job.check_run_id }}"
         path: ${{ env.TT_TRIAGE_DUMP_RISC_DEBUG_SIGNALS_PATH }}
         if-no-files-found: ignore
 


### PR DESCRIPTION
### Ticket
#40805 
### Problem description

When a dispatch timeout runs tt-triage, CI uploads debug bus signal dumps as a workflow artifact. Those artifacts were named debug_bus_signals_<prefix><uuid>, where the UUID came from the same generator used for the main test-report artifact. That made the debug-bus artifact impossible to derive from a job URL alone: auto-triage and other tooling need to list artifacts for a run and pick the right file using the GitHub job id (from …/job/<id>), which matches how triage_output_<job.check_run_id> is already named. The mismatch blocked reliable download of structured debug data alongside full triage text.

### What's changed

Approach: Align debug-bus artifact naming with triage output by keying both off the same stable job identifier GitHub exposes in Actions.

Changes: In .github/actions/upload-artifact-with-job-uuid/action.yml, the debug bus upload step now sets the artifact name to debug_bus_signals_${{ job.check_run_id }} instead of debug_bus_signals_${{ steps.generate-artifact-name.outputs.artifact-name }} (which embedded a random UUID).

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dimitri/rename_dbus_artifact_to_use_job_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dimitri/rename_dbus_artifact_to_use_job_id)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
