### PR TITLE
Fix graph capture performance regression from #36997

### DIFF
--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -9,6 +9,7 @@ TT-NN provides a mechanism for tracing operations and memory activities during n
 - [Basic Usage](#basic-usage)
 - [Saving Reports](#saving-reports)
 - [Advanced Features](#advanced-features)
+  - [Full Capture (all features)](#save-to-file-for-ttnn-visualizer)
   - [Reducing Capture Overhead](#reducing-capture-overhead)
 - [Levelized Graph](#levelized-graph)
 - [Testing & Validation](#testing--validation)
@@ -42,17 +43,22 @@ auto graph = ttnn::graph::GraphProcessor::end_graph_capture();
 
 ### Save to File (for ttnn-visualizer)
 
-For a complete capture with all data (per-op sub-graphs, buffer pages, stack traces):
+For a complete capture with all data (per-op sub-graphs, buffer pages, stack traces), use `full_graph_capture`:
 
 ```python
 import ttnn
 
-with ttnn.manage_config("enable_fast_runtime_mode", False):
-    ttnn.graph.enable_detailed_buffer_tracing()
-    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+with ttnn.graph.full_graph_capture("my_report.json"):
     # ... your operations ...
-    ttnn.graph.end_graph_capture_to_file("my_report.json")
-    ttnn.graph.disable_detailed_buffer_tracing()
+```
+
+This single context manager enables Python stack traces, detailed buffer tracing, and slow dispatch (per-op captured sub-graphs), then restores all settings on exit.
+
+To keep fast dispatch (no per-operation sub-graphs) while still capturing everything else:
+
+```python
+with ttnn.graph.full_graph_capture("my_report.json", slow_dispatch=False):
+    # ... your operations ...
 ```
 
 Then import into the visualizer database:
@@ -61,7 +67,7 @@ Then import into the visualizer database:
 python -m ttnn.graph_report my_report.json ./visualizer_db/
 ```
 
-> **Note**: `enable_fast_runtime_mode=False` uses `Operation` (slow dispatch) which produces per-operation captured sub-graphs. The default `FastOperation` (fast dispatch) records arguments and tensor IDs but reconstructs sub-graphs synthetically. See [FastOperation vs Operation](#fastoperation-vs-operation) for details. Stack traces are enabled by default. To reduce overhead, see [Reducing Capture Overhead](#reducing-capture-overhead).
+> **Note**: `slow_dispatch=True` (default) temporarily sets `enable_fast_runtime_mode=False`, which uses the `Operation` decorator to produce per-operation captured sub-graphs. With `slow_dispatch=False`, the default `FastOperation` records arguments and tensor IDs but sub-graphs are reconstructed synthetically by the importer. See [FastOperation vs Operation](#fastoperation-vs-operation) for details. To reduce overhead further, see [Reducing Capture Overhead](#reducing-capture-overhead).
 
 ---
 
@@ -77,13 +83,13 @@ The trace records:
 - **Call hierarchy**: Nested operations (e.g., `ttnn::add` → `ttnn::prim::binary`)
 - **Stack traces**: C++ call stacks for each operation (enabled by default); Python call stacks (opt-in via `enable_python_stack_traces()`)
 - **Deallocations**: `Tensor::deallocate` is tracked at the C++ level when a device buffer is actually freed (both explicit via `ttnn.deallocate()` and implicit via destructor)
-- **Python I/O**: Function arguments, input tensor IDs, and output tensor IDs recorded by the Python decorators
+- **Python I/O**: Function arguments, input tensor IDs, and output tensor IDs recorded by the Python decorators (only when Python I/O recording is enabled — see [Capture Overhead](#reducing-capture-overhead))
 
 ### Two-Phase Architecture
 
 Graph capture is split into two phases:
 
-1. **C++ runtime capture** — During model execution, the C++ `GraphProcessor` records an in-memory graph of operations, tensors, buffers, and timing. The Python decorators (`FastOperation`, `Operation`) additionally record Python-level arguments and tensor IDs into a `python_io` list. At the end, both are serialized to a JSON report file.
+1. **C++ runtime capture** — During model execution, the C++ `GraphProcessor` records an in-memory graph of operations, tensors, buffers, and timing. When graph capture is started from Python (via `ttnn.graph.begin_graph_capture()`), Python I/O recording is automatically enabled: the decorators (`FastOperation`, `Operation`) record Python-level arguments and tensor IDs into a `python_io` list. When capture is started from C++ (e.g., `MemoryUsageTracker`), Python I/O recording stays disabled and the decorators add zero overhead. At the end, both the C++ graph and (if present) the Python I/O data are serialized to a JSON report file.
 
 2. **Offline Python import** — A separate step reads the JSON report and imports it into a SQLite database that the ttnn-visualizer can consume. No database operations happen during model execution.
 
@@ -91,9 +97,9 @@ Graph capture is split into two phases:
 
 Operations are captured at two levels:
 
-1. **Python-level**: The `ttnn` decorators (`FastOperation`, `Operation`) automatically inject `function_start`/`function_end` graph nodes when capture is active. This produces high-level operation names like `ttnn.conv2d`, `ttnn.linear`, `ttnn.deallocate`. Both decorators also record Python-visible arguments and tensor IDs into `python_io` records that are embedded in the JSON report.
+1. **Python-level**: When Python I/O recording is enabled (automatically by `ttnn.graph.begin_graph_capture()`), the `ttnn` decorators (`FastOperation`, `Operation`) inject `function_start`/`function_end` graph nodes and record Python-visible arguments and tensor IDs into `python_io` records. This produces high-level operation names like `ttnn.conv2d`, `ttnn.linear`, `ttnn.deallocate`. When Python I/O recording is disabled (e.g., C++-initiated capture for memory tracking), the decorators are completely transparent.
 
-2. **C++ level**: Internal C++ operations emit their own `function_start`/`function_end` nodes (e.g., `ttnn::matmul`, `Tensor::to_device`). These appear nested inside the Python-level operation.
+2. **C++ level**: Internal C++ operations always emit their own `function_start`/`function_end` nodes (e.g., `ttnn::matmul`, `Tensor::to_device`). These appear nested inside the Python-level operation when Python I/O recording is active.
 
 The result is a hierarchical graph: `ttnn.conv2d` (Python) → `ttnn::conv2d` (C++) → `Device Operation` → `create_device_tensor`, etc.
 
@@ -211,9 +217,9 @@ The report file contains:
 - `graph`: Full graph trace (list of nodes)
 - `devices`: Device information (architecture, grid size, memory)
 - `metadata`: Capture timestamp
-- `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation)
-- `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`)
-- `buffer_pages_by_address`: Compact per-address page data (when buffer pages are enabled)
+- `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation); present only when Python I/O recording is enabled
+- `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`); present only when `enable_detailed_buffer_tracing()` is active
+- `buffer_pages_by_address`: Compact per-address page data; present only when `enable_detailed_buffer_tracing()` is active
 - `cluster_descriptor`: Cluster configuration YAML (if available)
 - `mesh_coordinate_mapping`: Physical chip mesh coordinate mapping YAML (if available, saved as `physical_chip_mesh_coordinate_mapping_1_of_1.yaml`)
 
@@ -239,7 +245,7 @@ The importer creates these database tables:
 - `buffers`: Cumulative memory allocation snapshots per operation (prefers `per_operation_buffers`)
 - `buffer_pages`: Per-page buffer detail (when enabled)
 - `captured_graph`: Per-operation subgraph JSON for the visualizer
-- `stack_traces`: C++ call stacks (captured by default) and/or Python call stacks (opt-in)
+- `stack_traces`: C++ call stacks (captured by default) and/or Python call stacks (opt-in via `enable_python_stack_traces()`)
 - `edges`: Graph edges extracted from captured subgraphs
 - `errors`: Error information
 
@@ -306,21 +312,17 @@ db_path = import_report("my_report.json", "./output/")
 
 ### Stack Trace Capture
 
-Python stack traces are **enabled by default**. When enabled, each operation invoked through the Python decorators records the Python call stack at invocation time, filtered to exclude ttnn internals and test-runner noise:
+Python stack traces are **disabled by default** to minimize overhead. When enabled, each operation invoked through the Python decorators records the Python call stack at invocation time, filtered to exclude ttnn internals and test-runner noise:
 
 ```python
+ttnn.graph.enable_python_stack_traces()
 ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
 result = ttnn.add(tensor_a, tensor_b)
 ttnn.graph.end_graph_capture_to_file("report.json")
-```
-
-To disable Python stack traces for reduced overhead:
-
-```python
 ttnn.graph.disable_python_stack_traces()
-# ... capture ...
-ttnn.graph.enable_python_stack_traces()  # Restore default
 ```
+
+> **Note**: Stack trace capture requires Python I/O recording to be enabled (automatic when using `ttnn.graph.begin_graph_capture()`). Stack traces add significant per-operation overhead (`traceback.extract_stack()` + path resolution + filtering), so enable them only when needed for debugging.
 
 Python stack traces are stored in the `python_io` section of the JSON report and imported into the `stack_traces` table. Internal C++ operations (nested ops that don't go through the Python decorators) will not have stack traces.
 
@@ -336,7 +338,7 @@ Example `stack_traces` entry (innermost frame first):
 
 ```python
 # Check status
-print(ttnn.graph.is_python_stack_trace_enabled())  # True by default
+print(ttnn.graph.is_python_stack_trace_enabled())  # False by default
 ```
 
 Stack traces are imported into the `stack_traces` table in the visualizer database (one row per operation).
@@ -355,7 +357,7 @@ ttnn.graph.end_graph_capture_to_file("report.json")
 ttnn.graph.disable_detailed_buffer_tracing()
 ```
 
-The report includes `buffer_pages_by_address` (compact, per-address snapshots with versioned timelines for re-allocations) combined with `per_operation_buffers` to reconstruct per-operation page data. Fields per page:
+When enabled, the report includes `buffer_pages_by_address` (compact, per-address snapshots with versioned timelines for re-allocations) and `per_operation_buffers` (live buffer snapshots after each top-level operation) to reconstruct per-operation page data. Fields per page:
 - `device_id`, `address`: Buffer location
 - `core_x`, `core_y`, `bank_id`: Core and bank placement
 - `page_index`, `page_address`, `page_size`: Page details
@@ -363,26 +365,45 @@ The report includes `buffer_pages_by_address` (compact, per-address snapshots wi
 
 ### Reducing Capture Overhead
 
-By default, examples in this guide capture all available data (slow dispatch, buffer pages, stack traces). To reduce overhead or report size, disable individual features:
+Graph capture overhead has several independently controllable layers:
 
-| Feature | Disable With | Effect |
+| Layer | Default | Enable/Disable |
 |---|---|---|
-| Per-op captured sub-graphs | Keep `enable_fast_runtime_mode=True` (default) | Uses `FastOperation`; sub-graphs are reconstructed synthetically by the importer |
-| Buffer pages | Don't call `ttnn.graph.enable_detailed_buffer_tracing()` | Skips per-page L1 detail (~5.8M rows for ResNet-50) |
-| Python stack traces | `ttnn.graph.disable_python_stack_traces()` | Omits Python call stacks from `python_io` records |
+| **C++ graph processor** | Always on when capture is active | Inherent to `begin_graph_capture` |
+| **Python I/O recording** | Auto-enabled by Python `begin_graph_capture()`, off for C++-initiated capture | `enable_python_io_recording()` / `disable_python_io_recording()` |
+| **Python stack traces** | Off | `enable_python_stack_traces()` / `disable_python_stack_traces()` |
+| Per-op buffer snapshots | Off | `enable_detailed_buffer_tracing()` / `disable_detailed_buffer_tracing()` |
+| Per-op captured sub-graphs | Off (fast dispatch) | `enable_fast_runtime_mode=False` |
+
+**C++-initiated capture (zero Python overhead)**: When graph capture is started from C++ (e.g., `MemoryUsageTracker::begin_capture()`), Python I/O recording stays disabled. The Python decorators (`FastOperation`, `Operation`) add zero overhead — no `track_function_start/end`, no argument serialization, no tensor ID tracking. Only the C++ `GraphProcessor` runs.
+
+**Python-initiated capture**: When `ttnn.graph.begin_graph_capture()` is called from Python, Python I/O recording is automatically enabled (and disabled when `end_graph_capture()` / `end_graph_capture_to_file()` completes). This records operation arguments and tensor IDs needed for the JSON report and visualizer database.
 
 ```python
-# Minimal capture: fast dispatch, no buffer pages, no stack traces
-ttnn.graph.disable_python_stack_traces()
+# Minimal Python capture: fast dispatch, no buffer pages, no stack traces
 ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
 # ... your operations ...
 ttnn.graph.end_graph_capture_to_file("lightweight_report.json")
-ttnn.graph.enable_python_stack_traces()  # Restore default
+```
+
+```python
+# Full capture: slow dispatch, buffer pages, stack traces (all-in-one)
+with ttnn.graph.full_graph_capture("full_report.json"):
+    # ... your operations ...
+```
+
+```python
+# Memory-only capture from Python (explicitly disable Python I/O)
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+ttnn.graph.disable_python_io_recording()  # must be called after begin_graph_capture
+# ... your operations ...
+graph = ttnn.graph.end_graph_capture()
+# Use extract_peak_L1_memory_usage(), extract_resource_usage_per_core(), etc.
 ```
 
 ### Operation Arguments
 
-Python-level arguments are automatically captured by both `FastOperation` and `Operation` decorators when graph capture is active. They are embedded in the `python_io` section of the JSON report and imported into the `operation_arguments` table.
+Python-level arguments are captured by both `FastOperation` and `Operation` decorators when Python I/O recording is enabled (automatic for Python-initiated capture via `ttnn.graph.begin_graph_capture()`). They are embedded in the `python_io` section of the JSON report and imported into the `operation_arguments` table. When Python I/O is not recorded, the importer falls back to C++-serialized arguments.
 
 For C++ level arguments:
 
@@ -524,12 +545,9 @@ from ttnn import graph_report
 device = ttnn.open_device(device_id=0, l1_small_size=24576)
 
 # Full capture: slow dispatch for per-op sub-graphs, buffer pages, python stacks
-with ttnn.manage_config("enable_fast_runtime_mode", False):
-    ttnn.graph.enable_detailed_buffer_tracing()
-    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+with ttnn.graph.full_graph_capture("my_report.json"):
     # ... run your model ...
-    ttnn.graph.end_graph_capture_to_file("my_report.json")
-    ttnn.graph.disable_detailed_buffer_tracing()
+    pass
 
 # Import to SQLite (creates db.sqlite, cluster_descriptor.yaml, etc.)
 graph_report.import_report("my_report.json", "./my_visualizer_db/")

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -2167,15 +2167,19 @@ class TestLinearModelE2E:
     def test_linear_model_structural_properties(self, device, tmp_path):
         report_path = tmp_path / "linear_report.json"
 
-        with ttnn.manage_config("enable_fast_runtime_mode", False), ttnn.manage_config(
-            "enable_logging", True
-        ), ttnn.manage_config("enable_graph_report", True):
-            ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
-            a = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
-            b = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
-            c = ttnn.ones([1, 1024], layout=ttnn.TILE_LAYOUT, device=device)
-            ttnn.linear(a, b, bias=c)
-            ttnn.graph.end_graph_capture_to_file(report_path)
+        ttnn.graph.enable_python_stack_traces()
+        try:
+            with ttnn.manage_config("enable_fast_runtime_mode", False), ttnn.manage_config(
+                "enable_logging", True
+            ), ttnn.manage_config("enable_graph_report", True):
+                ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+                a = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+                b = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+                c = ttnn.ones([1, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+                ttnn.linear(a, b, bias=c)
+                ttnn.graph.end_graph_capture_to_file(report_path)
+        finally:
+            ttnn.graph.disable_python_stack_traces()
 
         assert report_path.exists(), "Report JSON should be created"
 
@@ -2269,10 +2273,14 @@ def test_resnet50_e2e_graph_capture(
 
     report_path = tmp_path / "resnet50_report.json"
 
-    with ttnn.manage_config("enable_fast_runtime_mode", False):
-        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
-        run_resnet_inference(batch_size, input_loc, imagenet_label_dict, mesh_device, model_location_generator)
-        ttnn.graph.end_graph_capture_to_file(report_path)
+    ttnn.graph.enable_python_stack_traces()
+    try:
+        with ttnn.manage_config("enable_fast_runtime_mode", False):
+            ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+            run_resnet_inference(batch_size, input_loc, imagenet_label_dict, mesh_device, model_location_generator)
+            ttnn.graph.end_graph_capture_to_file(report_path)
+    finally:
+        ttnn.graph.disable_python_stack_traces()
 
     assert report_path.exists(), "Report JSON should be created"
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -890,6 +890,7 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
 
     auto report_path = std::filesystem::temp_directory_path() / "test_per_op_buffers_report.json";
     {
+        ttnn::graph::GraphProcessor::enable_detailed_buffer_tracing();
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
 
         const auto tensor_spec = ttnn::TensorSpec(
@@ -902,6 +903,7 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
         const auto output_tensor = ttnn::softmax(input_tensor, -1);
 
         capture.end_graph_capture_to_file(report_path);
+        ttnn::graph::GraphProcessor::disable_detailed_buffer_tracing();
     }
 
     std::ifstream file(report_path);
@@ -910,7 +912,7 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
     std::filesystem::remove(report_path);
 
     ASSERT_TRUE(report.contains("per_operation_buffers"))
-        << "Report should contain per_operation_buffers in NORMAL mode";
+        << "Report should contain per_operation_buffers when detailed tracing is enabled";
     const auto& per_op = report.at("per_operation_buffers");
     EXPECT_TRUE(per_op.is_object());
     EXPECT_GT(per_op.size(), 0u) << "Expected at least one operation's buffer snapshot";

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -506,8 +506,10 @@ void GraphProcessor::track_function_end_impl() {
     }
     last_finished_op_id = counter;
 
-    // Snapshot live buffer state after each top-level operation completes
-    if (stacking_level == 1 && !captured_mesh_devices.empty()) {
+    // Snapshot live buffer state after each top-level operation completes.
+    // Only collected when detailed buffer tracing is enabled (report/visualization path)
+    // to avoid the overhead of iterating all allocated buffers on every operation.
+    if (stacking_level == 1 && capture_detailed_buffer_tracing_ && !captured_mesh_devices.empty()) {
         per_op_buffers_[function_start_id] = ttnn::reports::get_buffers(captured_mesh_devices);
     }
 }

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -459,12 +459,10 @@ class FastOperation:
         elif "cq_id" in function_kwargs:
             cq_id = function_kwargs.pop("cq_id")
 
-        tracking = ttnn.graph.is_graph_capture_active()
-        if tracking:
+        recording = ttnn.graph.is_python_io_recording_enabled()
+        if recording:
             ttnn.graph.track_function_start(self.python_fully_qualified_name)
-
             ttnn.graph.record_python_operation(self.python_fully_qualified_name, function_args, function_kwargs)
-
             input_tensors = get_all_tensors((function_args, function_kwargs))
             set_tensor_id(input_tensors)
 
@@ -480,10 +478,10 @@ class FastOperation:
                 raise TypeError(enhanced_msg) from e
             raise
         finally:
-            if tracking:
+            if recording:
                 ttnn.graph.track_function_end()
 
-        if tracking:
+        if recording:
             set_tensor_id(get_all_tensors(result), force=True)
             ttnn.graph.store_output_tensor_ids(get_output_tensor_ids(result))
 
@@ -652,9 +650,7 @@ class Operation:
                         self.python_fully_qualified_name, decorated_function
                     )
 
-                # Record Python I/O BEFORE set_tensor_id mutates tensor IDs.
-                # This ensures input_tensor_ids match the previous op's output_tensor_ids.
-                if ttnn.graph.is_graph_capture_active():
+                if ttnn.graph.is_python_io_recording_enabled():
                     ttnn.graph.record_python_operation(self.python_fully_qualified_name, function_args, function_kwargs)
 
                 if ttnn.CONFIG.enable_logging or ttnn.CONFIG.enable_comparison_mode:
@@ -724,7 +720,7 @@ class Operation:
                 finally:
                     captured_graph = ttnn.graph.end_graph_capture()
 
-                if ttnn.graph.is_graph_capture_active():
+                if ttnn.graph.is_graph_capture_active() and ttnn.graph.is_python_io_recording_enabled():
                     ttnn.graph.store_output_tensor_ids(get_output_tensor_ids(output))
                     ttnn.graph.store_captured_graph(captured_graph)
 
@@ -743,8 +739,8 @@ class Operation:
         self.decorated_function = function
 
     def __call__(self, *function_args, **function_kwargs):
-        tracking = ttnn.graph.is_graph_capture_active()
-        if tracking:
+        recording = ttnn.graph.is_python_io_recording_enabled()
+        if recording:
             ttnn.graph.track_function_start(self.python_fully_qualified_name)
         try:
             if not OPERATION_CALL_STACK:
@@ -753,7 +749,7 @@ class Operation:
             output = self.decorated_function(*function_args, **function_kwargs)
         finally:
             OPERATION_CALL_STACK.pop()
-            if tracking:
+            if recording:
                 ttnn.graph.track_function_end()
         return output
 

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -13,7 +13,7 @@ import graphviz
 from ttnn._ttnn.graph import (
     RunMode,
     begin_graph_capture as _cpp_begin_graph_capture,
-    end_graph_capture,
+    end_graph_capture as _cpp_end_graph_capture,
     end_graph_capture_to_file as _cpp_end_graph_capture_to_file,
     REPORT_VERSION,
     extract_calltrace,
@@ -48,7 +48,8 @@ from ttnn.graph_report import (
 # to set correct input_tensors / output_tensors associations.
 
 _python_io_data: list = []
-_python_stack_traces_enabled: bool = True
+_python_io_recording_enabled: bool = False
+_python_stack_traces_enabled: bool = False
 
 # Glob patterns for frames to strip from stack traces (pathlib-style).
 # Matches ttnn internals (decorators/graph), pytest, pluggy, and the pytest entry script.
@@ -62,6 +63,32 @@ _STACK_TRACE_INTERNAL_PATTERNS = (
     "**/pluggy/**",
     "**/bin/pytest",
 )
+
+
+def enable_python_io_recording():
+    """Enable recording Python-level operation arguments and tensor IDs during graph capture.
+
+    When enabled, each operation records its kwargs, tensor summaries, and
+    (optionally) Python stack traces.  This is required for
+    ``end_graph_capture_to_file`` / ``graph_report`` but adds significant
+    overhead — disable it when graph capture is used only for memory tracking.
+
+    Automatically enabled by :func:`begin_graph_capture` and disabled by
+    :func:`end_graph_capture` / :func:`end_graph_capture_to_file`.
+    """
+    global _python_io_recording_enabled
+    _python_io_recording_enabled = True
+
+
+def disable_python_io_recording():
+    """Disable Python-level I/O recording during graph capture."""
+    global _python_io_recording_enabled
+    _python_io_recording_enabled = False
+
+
+def is_python_io_recording_enabled() -> bool:
+    """Return whether Python I/O recording is currently enabled."""
+    return _python_io_recording_enabled
 
 
 def enable_python_stack_traces():
@@ -126,10 +153,20 @@ def _collect_tensor_ids(value) -> list:
 
 
 def begin_graph_capture(run_mode=None):
-    """Wrapper that clears Python I/O state before starting C++ capture."""
-    global _python_io_data
+    """Wrapper that clears Python I/O state before starting C++ capture.
+
+    Automatically enables Python I/O recording so that
+    ``end_graph_capture_to_file`` can embed operation arguments,
+    tensor IDs, and (if enabled) stack traces in the JSON report.
+
+    When graph capture is started from C++ (e.g. ``MemoryUsageTracker``),
+    this wrapper is bypassed and Python I/O recording stays disabled,
+    avoiding the associated overhead.
+    """
+    global _python_io_data, _python_io_recording_enabled
     if not is_graph_capture_active():
         _python_io_data = []
+        _python_io_recording_enabled = True
         import ttnn
 
         if ttnn.CONFIG.enable_fast_runtime_mode:
@@ -145,11 +182,27 @@ def begin_graph_capture(run_mode=None):
     return _cpp_begin_graph_capture(run_mode)
 
 
+def end_graph_capture():
+    """End graph capture and return the captured graph.
+
+    Automatically disables Python I/O recording when the outermost
+    capture session ends.
+    """
+    global _python_io_recording_enabled
+    result = _cpp_end_graph_capture()
+    if not is_graph_capture_active():
+        _python_io_recording_enabled = False
+    return result
+
+
 def end_graph_capture_to_file(report_path):
     """Wrapper that appends Python I/O data to the JSON report."""
+    global _python_io_recording_enabled
     result_str = _cpp_end_graph_capture_to_file(report_path)
     if _python_io_data:
         _write_python_io_sidecar(report_path)
+    if not is_graph_capture_active():
+        _python_io_recording_enabled = False
     return json.loads(result_str)
 
 
@@ -268,6 +321,57 @@ def _write_python_io_sidecar(report_path):
     sidecar_path = report_path.with_suffix(".python_io.json")
     with open(sidecar_path, "w") as f:
         json.dump(_python_io_data, f)
+
+
+@contextlib.contextmanager
+def full_graph_capture(report_path: str, *, run_mode=None, slow_dispatch: bool = True):
+    """Context manager that captures a complete graph trace with all features enabled.
+
+    Enables Python I/O recording, Python stack traces, and detailed buffer
+    tracing.  Optionally switches to slow dispatch (``Operation`` decorator)
+    for per-operation captured sub-graphs.
+
+    On exit the trace is written to *report_path* and all settings are
+    restored to their previous values.
+
+    Example::
+
+        with ttnn.graph.full_graph_capture("my_report.json"):
+            # ... run your model ...
+
+    Args:
+        report_path: Destination JSON file for the graph report.
+        run_mode: ``RunMode.NORMAL`` (default) or ``RunMode.NO_DISPATCH``.
+        slow_dispatch: If ``True`` (default), temporarily disables
+            ``enable_fast_runtime_mode`` so ``Operation`` produces
+            per-operation captured sub-graphs.
+    """
+    import ttnn
+
+    prev_stack_traces = _python_stack_traces_enabled
+    prev_buffer_tracing = is_detailed_buffer_tracing_enabled()
+    prev_fast_runtime = ttnn.CONFIG.enable_fast_runtime_mode
+
+    enable_python_stack_traces()
+    enable_detailed_buffer_tracing()
+    if slow_dispatch:
+        ttnn.CONFIG.enable_fast_runtime_mode = False
+
+    try:
+        begin_graph_capture(run_mode if run_mode is not None else RunMode.NORMAL)
+        yield
+        end_graph_capture_to_file(report_path)
+    finally:
+        if is_graph_capture_active():
+            try:
+                _cpp_end_graph_capture()
+            except Exception:
+                pass
+        if not prev_buffer_tracing:
+            disable_detailed_buffer_tracing()
+        if not prev_stack_traces:
+            disable_python_stack_traces()
+        ttnn.CONFIG.enable_fast_runtime_mode = prev_fast_runtime
 
 
 class ExitStackWithPop(contextlib.ExitStack):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/40712)

### Problem description
Python I/O recording (argument serialization, tensor ID tracking, stack traces) and per operation buffer snapshots were running unconditionally during every graph capture, including C++-initiated memory only captures (MemoryUsageTracker). This caused a ~160x slowdown on the first training iteration of nanogpt.


### What's changed
- Add _python_io_recording_enabled flag (auto-enabled by Python begin_graph_capture, stays off for C++ captures) so decorators add zero overhead when not needed.
- Default _python_stack_traces_enabled to False (opt-in).
- Gate per-op buffer snapshots in GraphProcessor behind the existing capture_detailed_buffer_tracing_ flag.
- Add full_graph_capture() context manager for one-line full capture.
- Update documentation and tests to reflect new defaults.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
