### PR TITLE
[tt-train] lazy init + mesh parameter materialization

### DIFF
--- a/tt-train/sources/examples/llama_tp/train_llama_distributed.py
+++ b/tt-train/sources/examples/llama_tp/train_llama_distributed.py
@@ -40,11 +40,65 @@ from ttml.datasets import Batch, InMemoryDataloader
 # Layout-aware dispatch layer
 from ttml.distributed import (
     parallelize_module,
+    TpPlan,
     ColwiseParallel,
     RowwiseParallel,
     init_ops,
 )
 from ttml.distributed.debug import DispatchTraceCallback
+from ttml.distributed.layout import Shard, get_layout
+
+
+def _mesh_axis_sizes(mesh_device) -> list[int]:
+    ms = mesh_device.shape
+    if hasattr(ms, "dims"):
+        return [int(ms[i]) for i in range(ms.dims())]
+    return [int(x) for x in ms]
+
+
+def _global_numel_from_shard_shape_and_layout(
+    local_shape: tuple[int, ...],
+    layout,
+    mesh_device,
+) -> int:
+    """Invert ``Layout.shard_shape``: recover global element count from shard-local logical shape.
+
+    For each ``Shard(dim)`` on mesh axis ``a``, multiplies ``local_shape[dim]`` by
+    ``mesh_shape[a]``. Replicated axes leave sizes unchanged.
+    """
+    if layout is None or mesh_device is None:
+        return math.prod(local_shape)
+    mesh_sizes = _mesh_axis_sizes(mesh_device)
+    rank = len(local_shape)
+    g = list(local_shape)
+    for mesh_axis, placement in enumerate(layout.placements):
+        if mesh_axis >= len(mesh_sizes):
+            break
+        if isinstance(placement, Shard):
+            dim = placement.dim if placement.dim >= 0 else rank + placement.dim
+            n = mesh_sizes[mesh_axis]
+            if n > 1:
+                g[dim] *= n
+    return math.prod(g)
+
+
+def parameter_count_stats_from_sharding(model, mesh_device) -> tuple[int, int]:
+    """Sum over ``model.parameters()``: (local_shard_numel, global_unique_numel).
+
+    ``local_shard_numel`` is ``sum(prod(t.shape()))`` as reported by the runtime.
+    ``global_unique_numel`` applies the mesh × ``Layout`` shard inverse (same convention
+    as ``Layout.shard_shape``) so TP-sharded weights count once at full width.
+    """
+    local_total = 0
+    global_total = 0
+    for _name, t in model.parameters().items():
+        sh = tuple(int(x) for x in t.shape())
+        local_total += math.prod(sh)
+        layout = get_layout(t)
+        global_total += _global_numel_from_shard_shape_and_layout(
+            sh, layout, mesh_device
+        )
+    return local_total, global_total
 
 
 # Memory profiling
@@ -282,8 +336,9 @@ def distributed_collate_fn(
 # TP plan for Llama (PyTorch-style ParallelStyle)
 # ---------------------------------------------------------------------------
 
-# Module name patterns (regex or exact) -> ParallelStyle. No Layout in user code.
-LLAMA_TP_PLAN = {
+# Module name patterns (regex or exact) -> ParallelStyle.
+# tp_axis is set at model creation time via TpPlan(..., tp_axis=...).
+LLAMA_TP_STYLES = {
     r".*\.(q_linear|kv_linear|w1|w3)": ColwiseParallel(),
     r".*\.(out_linear|w2)": RowwiseParallel(),
     "fc": ColwiseParallel(gather_output=True),  # LM head
@@ -529,24 +584,37 @@ def main():
     if args.track_memory:
         model_guard = MemoryUsageTracker.begin_capture()
 
-    model = Llama(llama_config)
-    total_params = sum(math.prod(p.shape()) for p in model.parameters().values())
+    # Build model — when TP is enabled, pass a TpPlan so TransformerBase
+    # creates weights directly sharded on device (no allocate-full → scatter).
+    tp_plan = TpPlan(LLAMA_TP_STYLES, tp_axis=tp_axis) if tp_axis is not None else None
+    if tp_plan is not None:
+        print(f"   Using lazy init with {len(tp_plan)} tp_plan patterns")
+    model = Llama(llama_config, mesh_device=mesh_device, tp_plan=tp_plan)
+
+    local_p, global_p = parameter_count_stats_from_sharding(model, mesh_device)
     print(
         f"   Config: {llama_config.num_hidden_layers} layers, {llama_config.hidden_size} hidden, "
         f"{llama_config.num_attention_heads} heads, {llama_config.num_key_value_heads} kv_heads"
     )
-    print(f"   Total parameters: {total_params:,}")
+    print(
+        f"   Parameters (local shard logical, sum of prod(shape) per weight): {local_p:,}"
+    )
+    print(f"   Parameters (global unique, from Layout × mesh sharding): {global_p:,}")
 
     if args.track_memory:
         MemoryUsageTracker.end_capture("MODEL_CREATION")
         print_memory_stats("MODEL_CREATION")
 
-    # Distribute model with TP and/or CP
+    # Install forward collective hooks (all_reduce / all_gather / ring_sdpa).
+    # Weights are already sharded from lazy init; parallelize_module only patches
+    # module.forward here (skips distribute_tensor for already-distributed tensors).
     if tp_axis is not None or cp_axis is not None:
-        print("\n4. Distributing model...")
+        print("\n4. Installing distributed forward hooks...")
         if tp_axis is not None:
             print(f"   TP enabled on axis {tp_axis}")
-            print(f"   Plan: {len(LLAMA_TP_PLAN)} module patterns (ColwiseParallel / RowwiseParallel)")
+            print(
+                f"   Plan: {len(LLAMA_TP_STYLES)} module patterns (ColwiseParallel / RowwiseParallel)"
+            )
         if cp_axis is not None:
             print(f"   CP enabled on axis {cp_axis}")
 
@@ -557,7 +625,7 @@ def main():
             model = parallelize_module(
                 model,
                 mesh_device,
-                LLAMA_TP_PLAN,
+                LLAMA_TP_STYLES,
                 tp_axis=tp_axis,
                 cp_axis=cp_axis,
             )
@@ -569,7 +637,7 @@ def main():
             MemoryUsageTracker.end_capture("MODEL_DISTRIBUTION")
             print_memory_stats("MODEL_DISTRIBUTION")
 
-        print("   Model distributed.")
+        print("   Hooks installed.")
     else:
         print("\n4. TP/CP not enabled, skipping distribution...")
 

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -391,7 +391,8 @@ void py_module(nb::module_& m) {
         nb::kw_only(),
         nb::arg("seed") = std::nullopt,
         nb::arg("dtype") = tt::tt_metal::DataType::BFLOAT16,
-        nb::arg("layout") = tt::tt_metal::Layout::TILE);
+        nb::arg("layout") = tt::tt_metal::Layout::TILE,
+        nb::arg("mapper") = std::nullopt);
 
     m.def(
         "randn",
@@ -402,7 +403,8 @@ void py_module(nb::module_& m) {
         nb::kw_only(),
         nb::arg("seed") = std::nullopt,
         nb::arg("dtype") = tt::tt_metal::DataType::BFLOAT16,
-        nb::arg("layout") = tt::tt_metal::Layout::TILE);
+        nb::arg("layout") = tt::tt_metal::Layout::TILE,
+        nb::arg("mapper") = std::nullopt);
 
     {
         auto py_sample = static_cast<nb::module_>(m.attr("sample"));

--- a/tt-train/sources/ttml/ops/rand_op.cpp
+++ b/tt-train/sources/ttml/ops/rand_op.cpp
@@ -26,13 +26,14 @@ autograd::TensorPtr rand(
     float b,
     std::optional<uint32_t> seed,
     tt::tt_metal::DataType dtype,
-    tt::tt_metal::Layout layout) {
+    tt::tt_metal::Layout layout,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mapper) {
     auto* device = &autograd::ctx().get_device();
     ttnn::MemoryConfig mem_config{};
 
     uint32_t effective_seed = avoid_zero_seed(seed.value_or(autograd::ctx().get_generator()()));
 
-    auto t = ttnn::rand(shape, *device, dtype, layout, mem_config, a, b, effective_seed);
+    auto t = ttnn::rand(shape, *device, dtype, layout, mem_config, a, b, effective_seed, mapper);
     return ttml::autograd::create_tensor(t);
 }
 

--- a/tt-train/sources/ttml/ops/rand_op.hpp
+++ b/tt-train/sources/ttml/ops/rand_op.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <ttnn/distributed/distributed_configs.hpp>
 
 #include "autograd/tensor.hpp"
 
@@ -17,6 +18,7 @@ autograd::TensorPtr rand(
     float b = 1.0f,
     std::optional<uint32_t> seed = std::nullopt,
     tt::tt_metal::DataType dtype = tt::tt_metal::DataType::BFLOAT16,
-    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE);
+    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mapper = std::nullopt);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/randn_op.cpp
+++ b/tt-train/sources/ttml/ops/randn_op.cpp
@@ -32,7 +32,8 @@ autograd::TensorPtr randn(
     float stddev,
     std::optional<uint32_t> seed,
     tt::tt_metal::DataType dtype,
-    tt::tt_metal::Layout layout) {
+    tt::tt_metal::Layout layout,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mapper) {
     TT_FATAL(stddev >= 0.0f, "[ttml::ops::randn] stddev must be non-negative, got {}.", stddev);
 
     auto* device = &autograd::ctx().get_device();
@@ -49,9 +50,25 @@ autograd::TensorPtr randn(
     // Box-Muller transform: z = sqrt(-2 * log(u1)) * cos(2 * pi * u2)
     // u1 in (eps, 1] to avoid log(0); u2 in [0, 1)
     auto u1 = ttnn::rand(
-        shape, *device, tt::tt_metal::DataType::FLOAT32, tt::tt_metal::Layout::TILE, mem_config, 1e-6f, 1.0f, u1_seed);
+        shape,
+        *device,
+        tt::tt_metal::DataType::FLOAT32,
+        tt::tt_metal::Layout::TILE,
+        mem_config,
+        1e-6f,
+        1.0f,
+        u1_seed,
+        mapper);
     auto u2 = ttnn::rand(
-        shape, *device, tt::tt_metal::DataType::FLOAT32, tt::tt_metal::Layout::TILE, mem_config, 0.0f, 1.0f, u2_seed);
+        shape,
+        *device,
+        tt::tt_metal::DataType::FLOAT32,
+        tt::tt_metal::Layout::TILE,
+        mem_config,
+        0.0f,
+        1.0f,
+        u2_seed,
+        mapper);
 
     auto log_u1 = ttnn::log(u1, false, mem_config);
     auto neg2log = ttnn::multiply(log_u1, -2.0f, std::nullopt, mem_config);

--- a/tt-train/sources/ttml/ops/randn_op.hpp
+++ b/tt-train/sources/ttml/ops/randn_op.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <ttnn/distributed/distributed_configs.hpp>
 
 #include "autograd/tensor.hpp"
 
@@ -17,6 +18,7 @@ autograd::TensorPtr randn(
     float stddev = 1.0f,
     std::optional<uint32_t> seed = std::nullopt,
     tt::tt_metal::DataType dtype = tt::tt_metal::DataType::BFLOAT16,
-    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE);
+    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mapper = std::nullopt);
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ttml/distributed/__init__.py
+++ b/tt-train/sources/ttml/ttml/distributed/__init__.py
@@ -42,7 +42,7 @@ from .rules.registry import (
 )
 from .debug import DispatchTracer, DispatchTraceCallback, dispatch_trace
 from .training import distribute_tensor, parallelize_module
-from .style import ParallelStyle, ColwiseParallel, RowwiseParallel
+from .style import ParallelStyle, TpPlan, ColwiseParallel, RowwiseParallel
 from ._register_ops import init_ops
 
 from . import module_rules as _module_rules  # register module rules  # noqa: F401
@@ -77,6 +77,7 @@ __all__ = [
     "parallelize_module",
     "sync_gradients",
     "ParallelStyle",
+    "TpPlan",
     "ColwiseParallel",
     "RowwiseParallel",
     "init_ops",

--- a/tt-train/sources/ttml/ttml/distributed/debug.py
+++ b/tt-train/sources/ttml/ttml/distributed/debug.py
@@ -35,7 +35,8 @@ import threading
 from collections import Counter
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from itertools import zip_longest
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from ttml.trainers import SFTTrainer
@@ -52,7 +53,11 @@ def _thread_local() -> threading.local:
 
 @dataclass
 class TraceEntry:
-    """Single dispatch event."""
+    """Single dispatch event.
+
+    ``input_shapes`` holds ``tuple(t.shape())`` for each tensor argument, same order
+    as ``input_layouts`` (logical shapes as seen by the Python op).
+    """
 
     op_name: str
     input_layouts: List[Optional[DistributedLayout]]
@@ -62,6 +67,7 @@ class TraceEntry:
     redistributions: List[Dict[str, Any]]
     post_collectives: List[Dict[str, Any]]
     output_layout: Optional[DistributedLayout]
+    input_shapes: List[Tuple[int, ...]] = field(default_factory=list)
     depth: int = 0
     module_stack: List[str] = field(default_factory=list)
     op_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -69,6 +75,8 @@ class TraceEntry:
     def __repr__(self) -> str:
         parts = [f"op={self.op_name}"]
         parts.append(f"inputs={self.input_layouts}")
+        if self.input_shapes:
+            parts.append(f"input_shapes={self.input_shapes}")
         if self.rule_name:
             parts.append(f"rule={self.rule_name}")
         if self.op_kwargs:
@@ -106,6 +114,7 @@ class TraceEntry:
             "depth": self.depth,
             "module_stack": list(self.module_stack),
             "input_layouts": [layout_repr(l) for l in self.input_layouts],
+            "input_shapes": [list(s) for s in self.input_shapes],
             "output_layout": layout_repr(self.output_layout),
             "op_kwargs": json_safe(self.op_kwargs),
             "pre_collectives": json_safe(self.pre_collectives),
@@ -338,6 +347,8 @@ class DispatchTrace:
 
         def short_summary(entry: TraceEntry) -> str:
             parts = [f"op={entry.op_name}"]
+            if entry.input_shapes:
+                parts.append(f"in_shapes={entry.input_shapes}")
             if entry.rule_name:
                 parts.append(f"rule={entry.rule_name}")
             if entry.op_kwargs:
@@ -427,6 +438,8 @@ class DispatchTrace:
 
         def entry_summary(ent: TraceEntry) -> str:
             parts = [f"op={escape(ent.op_name)}"]
+            if ent.input_shapes:
+                parts.append(f"in_shapes={escape(repr(ent.input_shapes))}")
             if ent.rule_name:
                 parts.append(f"rule={escape(ent.rule_name)}")
             if ent.op_kwargs:
@@ -441,6 +454,20 @@ class DispatchTrace:
 
         # Execution order: entries in record order with CCLs visible
         exec_lines: List[str] = []
+
+        def inputs_shapes_layouts_html(ent: TraceEntry) -> str:
+            if not ent.input_shapes and not ent.input_layouts:
+                return ""
+            pairs = []
+            for idx, (sh, ly) in enumerate(
+                zip_longest(ent.input_shapes, ent.input_layouts, fillvalue=None)
+            ):
+                pairs.append(
+                    f'<span class="in-pair">in[{idx}]: shape={escape(repr(sh))} '
+                    f"layout={layout_str(ly)}</span>"
+                )
+            return '<div class="exec-inputs">' + "<br/>".join(pairs) + "</div>"
+
         for i, ent in enumerate(entries):
             path_str = escape(" / ".join(ent.module_stack)) if ent.module_stack else "—"
             exec_lines.append(
@@ -449,6 +476,7 @@ class DispatchTrace:
                 f'<span class="exec-path">{path_str}</span> '
                 f'<span class="op-name">{escape(ent.op_name)}</span>'
                 f'<span class="op-summary">{entry_summary(ent)}</span>'
+                f"{inputs_shapes_layouts_html(ent)}"
                 f"{ccls_html(ent)}</div>"
             )
         execution_body = "\n".join(exec_lines)
@@ -491,6 +519,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .ccl.pre {{ color: #4ec9b0; }}
     .ccl.redist {{ color: #ce9178; }}
     .ccl.post {{ color: #569cd6; }}
+    .exec-inputs {{ margin: 0.35rem 0 0 1.5rem; font-size: 0.88em; color: #b5cea8; }}
+    .in-pair {{ display: block; }}
   </style>
 </head>
 <body>

--- a/tt-train/sources/ttml/ttml/distributed/dispatch.py
+++ b/tt-train/sources/ttml/ttml/distributed/dispatch.py
@@ -42,6 +42,17 @@ def _get_raw(op_name: str) -> Callable:
     return _RAW_OPS[op_name]
 
 
+def _tensor_input_shapes_for_trace(tensor_args: List[Any]) -> List[Tuple[int, ...]]:
+    """Logical shapes at the Python op boundary (``tuple(t.shape())`` per tensor input)."""
+    shapes: List[Tuple[int, ...]] = []
+    for t in tensor_args:
+        try:
+            shapes.append(tuple(int(x) for x in t.shape()))
+        except (TypeError, ValueError, AttributeError):
+            shapes.append(())
+    return shapes
+
+
 # ---------------------------------------------------------------------------
 # Plan cache helpers
 # ---------------------------------------------------------------------------
@@ -107,6 +118,7 @@ def _fallback_replicated(op_name: str, tensor_args, other_args, kwargs):
                 redistributions=redistributions,
                 post_collectives=[],
                 output_layout=rep,
+                input_shapes=_tensor_input_shapes_for_trace(tensor_args),
                 op_kwargs=dict(kwargs),
             )
         )
@@ -157,6 +169,7 @@ def dispatch(op_name: str, *args, **kwargs):
                     redistributions=[],
                     post_collectives=[],
                     output_layout=None,
+                    input_shapes=_tensor_input_shapes_for_trace(tensor_args),
                     op_kwargs=dict(kwargs),
                 )
             )
@@ -268,6 +281,7 @@ def dispatch(op_name: str, *args, **kwargs):
                 redistributions=redistributions,
                 post_collectives=post_collectives_log,
                 output_layout=plan.output_layout,
+                input_shapes=_tensor_input_shapes_for_trace(tensor_args),
                 op_kwargs=dict(rule_kwargs),
             )
         )

--- a/tt-train/sources/ttml/ttml/distributed/layout.py
+++ b/tt-train/sources/ttml/ttml/distributed/layout.py
@@ -112,6 +112,24 @@ class DistributedLayout:
                 axis_placements[i] = p
         return DistributedLayout(ndim=ndim, axis_placements=axis_placements)
 
+    def build_mapper(self, mesh_device, tensor_rank: int = 4):
+        """Build a TensorToMesh mapper for this layout.
+
+        Returns a shard mapper for the first ``Shard`` placement found,
+        or a replicate mapper if fully replicated.
+        """
+        import ttml
+
+        for mesh_axis, placement in enumerate(self.placements):
+            if isinstance(placement, Shard):
+                dim = (
+                    placement.dim if placement.dim >= 0 else tensor_rank + placement.dim
+                )
+                return ttml.core.distributed.shard_tensor_to_mesh_mapper(
+                    mesh_device, dim, mesh_axis
+                )
+        return ttml.core.distributed.replicate_tensor_to_mesh_mapper(mesh_device)
+
     def __eq__(self, other):
         if not isinstance(other, DistributedLayout):
             return False

--- a/tt-train/sources/ttml/ttml/distributed/style.py
+++ b/tt-train/sources/ttml/ttml/distributed/style.py
@@ -26,8 +26,15 @@ def _mesh_ndim(mesh_device) -> int:
 class ParallelStyle(ABC):
     """Contract for how a module should be parallelized.
 
-    Defines _apply for parallelize_module to use.
+    Subclasses must implement:
+    - ``get_layouts`` — return a ``{param_name: Layout}`` dict for materialization.
+    - ``_apply`` — apply forward hooks / redistribute for parallelize_module.
     """
+
+    @abstractmethod
+    def get_layouts(self, mesh_device, tp_axis: int) -> dict[str, DistributedLayout]:
+        """Return a mapping of parameter name to DistributedLayout for this parallel style."""
+        ...
 
     @abstractmethod
     def _apply(
@@ -38,6 +45,41 @@ class ParallelStyle(ABC):
     ) -> "AbstractModuleBase":
         """Apply parallelization to the module. Returns the (mutated) module."""
         ...
+
+
+class TpPlan:
+    """Tensor-parallel plan: style patterns + axis.
+
+    Bundles a ``{pattern: ParallelStyle}`` dict with the mesh axis
+    so callers pass a single object to ``TransformerBase``.
+
+    Usage::
+
+        plan = TpPlan({
+            r".*\\.(q_linear|kv_linear)": ColwiseParallel(),
+            r".*\\.out_linear": RowwiseParallel(),
+        }, tp_axis=1)
+        model = Llama(config, mesh_device=mesh, tp_plan=plan)
+    """
+
+    __slots__ = ("styles", "tp_axis")
+
+    def __init__(self, styles: dict[str, ParallelStyle], tp_axis: int = 0) -> None:
+        self.styles = styles
+        self.tp_axis = tp_axis
+
+    def resolve(self, mesh_device) -> dict:
+        """Convert styles to a ``{pattern: Layout}`` dict for materialization."""
+        resolved = {}
+        for pattern, style in self.styles.items():
+            for param_name, layout in style.get_layouts(
+                mesh_device, self.tp_axis
+            ).items():
+                resolved[pattern + r"\." + param_name] = layout
+        return resolved
+
+    def __len__(self) -> int:
+        return len(self.styles)
 
 
 class ColwiseParallel(ParallelStyle):
@@ -62,6 +104,13 @@ class ColwiseParallel(ParallelStyle):
         ndim = _mesh_ndim(mesh_device)
         return DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-2)})
 
+    def get_layouts(self, mesh_device, tp_axis: int) -> dict[str, DistributedLayout]:
+        ndim = _mesh_ndim(mesh_device)
+        return {
+            "weight": DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-2)}),
+            "bias": DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-1)}),
+        }
+
     def _apply(
         self,
         module: "AbstractModuleBase",
@@ -74,21 +123,31 @@ class ColwiseParallel(ParallelStyle):
             raise NotImplementedError("ColwiseParallel currently only supports LinearLayer!")
 
         from .training import distribute_tensor
+        from .layout import get_layout
 
-        layout = self.get_layout(mesh_device, tp_axis)
+        layouts = self.get_layouts(mesh_device, tp_axis)
+        layout = layouts["weight"]
 
-        # Distribute weight
-        new_w = distribute_tensor(module.weight.tensor, mesh_device, layout)
-        module.weight.tensor = new_w
-        module.override_tensor(new_w, "weight")
+        # Skip distribute_tensor if weight is already in the correct layout.
+        # This happens when the model was built with lazy init (mesh_device + tp_plan).
+        current_layout = None
+        try:
+            current_layout = get_layout(module.weight.tensor)
+        except Exception:
+            pass
 
-        # Distribute bias (sharded on last dim for column-parallel)
-        if module.bias is not None:
-            ndim = _mesh_ndim(mesh_device)
-            bias_layout = DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-1)})
-            new_b = distribute_tensor(module.bias.tensor, mesh_device, bias_layout)
-            module.bias.tensor = new_b
-            module.override_tensor(new_b, "bias")
+        if current_layout != layout:
+            # Distribute weight
+            new_w = distribute_tensor(module.weight.tensor, mesh_device, layout)
+            module.weight.tensor = new_w
+            module.override_tensor(new_w, "weight")
+
+            # Distribute bias (sharded on last dim for column-parallel)
+            if module.bias is not None:
+                bias_layout = layouts["bias"]
+                new_b = distribute_tensor(module.bias.tensor, mesh_device, bias_layout)
+                module.bias.tensor = new_b
+                module.override_tensor(new_b, "bias")
 
         import ttml
         from .layout import get_layout, set_layout
@@ -133,6 +192,13 @@ class RowwiseParallel(ParallelStyle):
         ndim = _mesh_ndim(mesh_device)
         return DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-1)})
 
+    def get_layouts(self, mesh_device, tp_axis: int) -> dict[str, DistributedLayout]:
+        ndim = _mesh_ndim(mesh_device)
+        return {
+            "weight": DistributedLayout(ndim=ndim, axis_placements={tp_axis: Shard(-1)}),
+            "bias": DistributedLayout(ndim=ndim),
+        }
+
     def _apply(
         self,
         module: "AbstractModuleBase",
@@ -145,21 +211,31 @@ class RowwiseParallel(ParallelStyle):
             raise NotImplementedError("RowwiseParallel currently only supports LinearLayer!")
 
         from .training import distribute_tensor
+        from .layout import get_layout
 
-        layout = self.get_layout(mesh_device, tp_axis)
+        layouts = self.get_layouts(mesh_device, tp_axis)
+        layout = layouts["weight"]
 
-        # Distribute weight
-        new_w = distribute_tensor(module.weight.tensor, mesh_device, layout)
-        module.weight.tensor = new_w
-        module.override_tensor(new_w, "weight")
+        # Skip distribute_tensor if weight is already in the correct layout.
+        # This happens when the model was built with lazy init (mesh_device + tp_plan).
+        current_layout = None
+        try:
+            current_layout = get_layout(module.weight.tensor)
+        except Exception:
+            pass
 
-        # Bias stays replicated for row-parallel
-        if module.bias is not None:
-            ndim = _mesh_ndim(mesh_device)
-            bias_layout = DistributedLayout(ndim=ndim)
-            new_b = distribute_tensor(module.bias.tensor, mesh_device, bias_layout)
-            module.bias.tensor = new_b
-            module.override_tensor(new_b, "bias")
+        if current_layout != layout:
+            # Distribute weight
+            new_w = distribute_tensor(module.weight.tensor, mesh_device, layout)
+            module.weight.tensor = new_w
+            module.override_tensor(new_w, "weight")
+
+            # Bias stays replicated for row-parallel
+            if module.bias is not None:
+                bias_layout = layouts["bias"]
+                new_b = distribute_tensor(module.bias.tensor, mesh_device, bias_layout)
+                module.bias.tensor = new_b
+                module.override_tensor(new_b, "bias")
 
         # Post: all_reduce on output (row-parallel partial sums)
         from .layout import get_layout, set_layout

--- a/tt-train/sources/ttml/ttml/distributed/training.py
+++ b/tt-train/sources/ttml/ttml/distributed/training.py
@@ -61,22 +61,7 @@ def distribute_tensor(
     if np_data.shape[0] > 1:
         np_data = np_data[:1]
 
-    shard_dim = None
-    shard_axis = None
-    for axis, p in enumerate(layout.placements):
-        if isinstance(p, Shard):
-            shard_dim = p.dim
-            shard_axis = axis
-            break
-
-    mapper = None
-    if shard_dim is not None:
-        rank = len(np_data.shape)
-        dim = shard_dim if shard_dim >= 0 else rank + shard_dim
-        mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(mesh_device, dim, shard_axis)
-    else:
-        # Use replicate mapper for fully replicated tensors to get correct 2D topology
-        mapper = ttml.core.distributed.replicate_tensor_to_mesh_mapper(mesh_device)
+    mapper = layout.build_mapper(mesh_device, tensor_rank=len(np_data.shape))
 
     result = ttml.autograd.Tensor.from_numpy(
         np_data,

--- a/tt-train/sources/ttml/ttml/init.py
+++ b/tt-train/sources/ttml/ttml/init.py
@@ -4,23 +4,57 @@
 
 """Parameter initialization functions for ttml modules.
 
-Each function returns an initializer with signature::
+Factory variants (uniform, normal, constant, zeros, ones, xavier_uniform,
+    xavier_normal, kaiming_uniform, kaiming_normal):
+    Each returns an initializer callable with signature::
 
-    init_fn(shape, layout=None, mesh_device=None) -> Tensor
+        init_fn(shape, layout=None, mesh_device=None) -> Tensor
 
-- Single device: ``ttnn.zeros`` / ``ones`` on AutoContext device (full logical shape).
-- Mesh: always a host buffer whose shape equals the parameter's **global** logical
-  shape (``TensorMetadata.shape``), then ``from_numpy`` + ``TensorToMesh`` --- same as
-  ``ttnn::distributed::create_distributed_tensor`` (buffer size = global shape).
-  Do not pre-shard the NumPy array here; the mapper splits. Replicate when no layout.
+    When ``layout`` (a ``DistributedLayout``) and ``mesh_device`` are provided,
+    the tensor is distributed across the mesh according to that layout (shard or
+    replicate). This is used by the lazy-init path in ``parallelize_module``.
+
+In-place variants (uniform_, normal_, constant_, zeros_, ones_, xavier_uniform_,
+    xavier_normal_, kaiming_uniform_, kaiming_normal_):
+    Take an existing tensor (or Parameter/Buffer wrapping one) and fill it
+    in-place, returning the same object that was passed in.
+    Mirrors the PyTorch torch.nn.init convention.
+
+    Note: these are not truly in-place at the device level. Each call
+    allocates a temporary tensor with the new values and then copies it
+    into the existing tensor via set_value. The temporary is freed
+    afterwards, but callers should be aware of the transient allocation.
 """
 
 from __future__ import annotations
+
+import math
+from typing import Literal
 
 import numpy as np
 import ml_dtypes
 import ttnn
 import ttml
+
+
+_NonlinearityType = Literal[
+    "linear",
+    "conv1d",
+    "conv2d",
+    "conv3d",
+    "conv_transpose1d",
+    "conv_transpose2d",
+    "conv_transpose3d",
+    "sigmoid",
+    "tanh",
+    "relu",
+    "leaky_relu",
+    "selu",
+]
+
+_FanMode = Literal["fan_in", "fan_out"]
+
+_FULL_PRECISION = ttml.autograd.PreferredPrecision.FULL
 
 
 def _get_device():
@@ -29,7 +63,7 @@ def _get_device():
 
 def _mesh_ndim(mesh_device):
     mesh_shape = mesh_device.shape
-    return mesh_shape.dims()
+    return mesh_shape.dims() if hasattr(mesh_shape, "dims") else len(mesh_shape)
 
 
 def _to_tensor(arr, layout=None, mesh_device=None):
@@ -49,15 +83,111 @@ def _to_tensor(arr, layout=None, mesh_device=None):
             mapper = layout.build_mapper(mesh_device, tensor_rank=rank)
             stamp_layout = layout
         else:
-            mapper = ttml.core.distributed.replicate_tensor_to_mesh_mapper(mesh_device)
-            stamp_layout = DistributedLayout(ndim=_mesh_ndim(mesh_device))
+            ndim = _mesh_ndim(mesh_device)
+            # Use 2D replicate mapper so topology matches mesh dimensionality
+            mapper = ttml.core.distributed.create_tensor_to_mesh_mapper(mesh_device, [None] * ndim)
+            stamp_layout = DistributedLayout(ndim=ndim)
     tensor = ttml.autograd.Tensor.from_numpy(arr, ttnn.Layout.TILE, mapper=mapper)
     if stamp_layout is not None:
         set_layout(tensor, stamp_layout)
     return tensor
 
 
-def _stamp(tensor, layout):
+def _layout_to_mapper(layout, mesh_device, tensor_rank=4):
+    """Convert a DistributedLayout + mesh_device to a MeshMapperConfig."""
+    if mesh_device is None:
+        return None
+    from ttml.distributed.layout import Shard
+
+    if layout is None:
+        mesh_shape = mesh_device.shape
+        ndim = mesh_shape.dims() if hasattr(mesh_shape, "dims") else len(mesh_shape)
+        return ttnn.MeshMapperConfig(placements=[ttnn.PlacementReplicate() for _ in range(ndim)])
+    placements = []
+    for p in layout.placements:
+        if isinstance(p, Shard):
+            dim = p.dim if p.dim >= 0 else tensor_rank + p.dim
+            placements.append(ttnn.PlacementShard(dim))
+        else:
+            placements.append(ttnn.PlacementReplicate())
+    return ttnn.MeshMapperConfig(placements=placements)
+
+
+def _calculate_fan_in_and_fan_out(shape) -> tuple[int, int]:
+    # ttml pads weight shapes to 4D with leading 1s (e.g. [1, 1, out, in]).
+    # Strip them so the standard PyTorch fan calculation works correctly.
+    while len(shape) > 2 and shape[0] == 1:
+        shape = shape[1:]
+
+    if len(shape) < 2:
+        raise ValueError("Fan in and fan out can not be computed for tensor with fewer than 2 dimensions")
+
+    num_output_fmaps = shape[0]
+    num_input_fmaps = shape[1]
+    receptive_field_size = 1
+    for s in shape[2:]:
+        receptive_field_size *= s
+
+    fan_in = num_input_fmaps * receptive_field_size
+    fan_out = num_output_fmaps * receptive_field_size
+    return fan_in, fan_out
+
+
+def _calculate_correct_fan(shape, mode: _FanMode) -> int:
+    if mode not in ("fan_in", "fan_out"):
+        raise ValueError(f"Mode {mode} not supported, please use one of ('fan_in', 'fan_out')")
+
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
+    return fan_in if mode == "fan_in" else fan_out
+
+
+def calculate_gain(nonlinearity: _NonlinearityType, param: int | float | None = None) -> float:
+    """Return the recommended gain value for the given nonlinearity function."""
+    linear_fns = [
+        "linear",
+        "conv1d",
+        "conv2d",
+        "conv3d",
+        "conv_transpose1d",
+        "conv_transpose2d",
+        "conv_transpose3d",
+    ]
+    if nonlinearity in linear_fns or nonlinearity == "sigmoid":
+        return 1
+    elif nonlinearity == "tanh":
+        return 5.0 / 3
+    elif nonlinearity == "relu":
+        return math.sqrt(2.0)
+    elif nonlinearity == "leaky_relu":
+        if param is None:
+            negative_slope = 0.01
+        elif not isinstance(param, bool) and isinstance(param, (int, float)):
+            negative_slope = param
+        else:
+            raise ValueError(f"negative_slope {param} not a valid number")
+        return math.sqrt(2.0 / (1 + negative_slope**2))
+    elif nonlinearity == "selu":
+        return 3.0 / 4
+    else:
+        raise ValueError(f"Unsupported nonlinearity {nonlinearity}")
+
+
+# ---------------------------------------------------------------------------
+# Factory variants (return initializer callables)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_layout(layout, mesh_device):
+    if layout is not None:
+        return layout
+    if mesh_device is not None:
+        from ttml.distributed.layout import DistributedLayout
+
+        return DistributedLayout(ndim=_mesh_ndim(mesh_device))
+    return None
+
+
+def _stamp_layout(tensor, layout):
     if layout is not None:
         from ttml.distributed.layout import set_layout
 
@@ -65,61 +195,234 @@ def _stamp(tensor, layout):
     return tensor
 
 
-def uniform(low: float = 0.0, high: float = 1.0):
-    """Uniform distribution over [low, high)."""
+def uniform(a: float = 0.0, b: float = 1.0):
+    """Uniform distribution over [a, b)."""
 
-    def init_fn(shape, layout=None, mesh_device=None):
-        arr = np.random.uniform(low, high, shape).astype(ml_dtypes.bfloat16)
+    def uniform_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        if on_device_init and mesh_device is not None:
+            mapper = _layout_to_mapper(layout, mesh_device, len(shape))
+            tensor = ttml.ops.rand(shape, a, b, mapper=mapper)
+            return _stamp_layout(tensor, _resolve_layout(layout, mesh_device))
+        arr = np.random.uniform(a, b, shape).astype(ml_dtypes.bfloat16)
         return _to_tensor(arr, layout, mesh_device)
 
-    return init_fn
+    return uniform_init
 
 
 def normal(mean: float = 0.0, std: float = 1.0):
     """Normal (Gaussian) distribution."""
 
-    def init_fn(shape, layout=None, mesh_device=None):
+    def normal_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        if on_device_init and mesh_device is not None:
+            mapper = _layout_to_mapper(layout, mesh_device, len(shape))
+            tensor = ttml.ops.randn(shape, mean, std, mapper=mapper)
+            return _stamp_layout(tensor, _resolve_layout(layout, mesh_device))
         arr = np.random.normal(mean, std, shape).astype(ml_dtypes.bfloat16)
         return _to_tensor(arr, layout, mesh_device)
 
-    return init_fn
+    return normal_init
+
+
+def constant(val: float):
+    """All elements set to val."""
+
+    def constant_init(shape, layout=None, mesh_device=None, **_kwargs):
+        arr = np.full(shape, val, dtype=ml_dtypes.bfloat16)
+        return _to_tensor(arr, layout, mesh_device)
+
+    return constant_init
 
 
 def zeros():
     """All zeros."""
 
-    def init_fn(shape, layout=None, mesh_device=None):
-        if mesh_device is not None:
-            arr = np.zeros(shape, dtype=ml_dtypes.bfloat16)
-            return _to_tensor(arr, layout, mesh_device)
-        device = _get_device()
-        t = ttnn.zeros(
-            shape, device=device, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.Layout.TILE
-        )
-        return _stamp(ttml.autograd.create_tensor(t), layout)
+    def zeros_init(shape, layout=None, mesh_device=None, **_kwargs):
+        arr = np.zeros(shape, dtype=ml_dtypes.bfloat16)
+        return _to_tensor(arr, layout, mesh_device)
 
-    return init_fn
+    return zeros_init
 
 
 def ones():
     """All ones."""
 
-    def init_fn(shape, layout=None, mesh_device=None):
-        if mesh_device is not None:
-            arr = np.ones(shape, dtype=ml_dtypes.bfloat16)
-            return _to_tensor(arr, layout, mesh_device)
-        device = _get_device()
-        t = ttnn.ones(
-            shape, device=device, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.Layout.TILE
-        )
-        return _stamp(ttml.autograd.create_tensor(t), layout)
+    def ones_init(shape, layout=None, mesh_device=None, **_kwargs):
+        arr = np.ones(shape, dtype=ml_dtypes.bfloat16)
+        return _to_tensor(arr, layout, mesh_device)
 
-    return init_fn
+    return ones_init
+
+
+def xavier_uniform(gain: float = 1.0):
+    """Xavier uniform initialization (Glorot 2010)."""
+
+    def xavier_uniform_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
+        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+        a = math.sqrt(3.0) * std
+        return uniform(-a, a)(shape, layout=layout, mesh_device=mesh_device, on_device_init=on_device_init)
+
+    return xavier_uniform_init
+
+
+def xavier_normal(gain: float = 1.0):
+    """Xavier normal initialization (Glorot 2010)."""
+
+    def xavier_normal_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
+        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+        return normal(0.0, std)(shape, layout=layout, mesh_device=mesh_device, on_device_init=on_device_init)
+
+    return xavier_normal_init
+
+
+def kaiming_uniform(
+    a: float = 0,
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
+):
+    """Kaiming uniform initialization (He 2015)."""
+
+    def kaiming_uniform_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        fan = _calculate_correct_fan(shape, mode)
+        gain = calculate_gain(nonlinearity, a)
+        std = gain / math.sqrt(fan)
+        bound = math.sqrt(3.0) * std
+        return uniform(-bound, bound)(shape, layout=layout, mesh_device=mesh_device, on_device_init=on_device_init)
+
+    return kaiming_uniform_init
+
+
+def kaiming_normal(
+    a: float = 0,
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
+):
+    """Kaiming normal initialization (He 2015)."""
+
+    def kaiming_normal_init(shape, layout=None, mesh_device=None, *, on_device_init=False):
+        fan = _calculate_correct_fan(shape, mode)
+        gain = calculate_gain(nonlinearity, a)
+        std = gain / math.sqrt(fan)
+        return normal(0.0, std)(shape, layout=layout, mesh_device=mesh_device, on_device_init=on_device_init)
+
+    return kaiming_normal_init
+
+
+# ---------------------------------------------------------------------------
+# In-place variants (fill existing tensor, return it)
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_tensor(tensor_or_param):
+    """Return the underlying autograd tensor, unwrapping Parameter/Buffer if needed."""
+    from ttml.modules.parameter import Buffer, Parameter
+
+    if isinstance(tensor_or_param, (Parameter, Buffer)):
+        return tensor_or_param.tensor
+    return tensor_or_param
+
+
+def uniform_(tensor, a: float = 0.0, b: float = 1.0):
+    """Fill tensor in-place with values from uniform distribution [a, b)."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = uniform(a, b)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def normal_(tensor, mean: float = 0.0, std: float = 1.0):
+    """Fill tensor in-place with values from normal (Gaussian) distribution."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = normal(mean, std)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def constant_(tensor, val: float):
+    """Fill tensor in-place with a constant value."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = constant(val)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def zeros_(tensor):
+    """Fill tensor in-place with zeros."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = zeros()(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def ones_(tensor):
+    """Fill tensor in-place with ones."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = ones()(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def xavier_uniform_(tensor, gain: float = 1.0):
+    """Fill tensor in-place using Xavier uniform initialization."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = xavier_uniform(gain)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def xavier_normal_(tensor, gain: float = 1.0):
+    """Fill tensor in-place using Xavier normal initialization."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = xavier_normal(gain)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def kaiming_uniform_(
+    tensor,
+    a: float = 0,
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
+):
+    """Fill tensor in-place using Kaiming uniform initialization."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = kaiming_uniform(a, mode, nonlinearity)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
+
+
+def kaiming_normal_(
+    tensor,
+    a: float = 0,
+    mode: _FanMode = "fan_in",
+    nonlinearity: _NonlinearityType = "leaky_relu",
+):
+    """Fill tensor in-place using Kaiming normal initialization."""
+    inner = _unwrap_tensor(tensor)
+    reinit_val = kaiming_normal(a, mode, nonlinearity)(inner.shape())
+    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
+    return tensor
 
 
 __all__ = [
+    "calculate_gain",
+    "constant",
+    "constant_",
+    "kaiming_normal",
+    "kaiming_normal_",
+    "kaiming_uniform",
+    "kaiming_uniform_",
     "normal",
+    "normal_",
     "ones",
+    "ones_",
     "uniform",
+    "uniform_",
+    "xavier_normal",
+    "xavier_normal_",
+    "xavier_uniform",
+    "xavier_uniform_",
     "zeros",
+    "zeros_",
 ]

--- a/tt-train/sources/ttml/ttml/init.py
+++ b/tt-train/sources/ttml/ttml/init.py
@@ -4,429 +4,122 @@
 
 """Parameter initialization functions for ttml modules.
 
-Factory variants (uniform, normal, constant, zeros, ones, xavier_uniform,
-    xavier_normal, kaiming_uniform, kaiming_normal):
-    Each returns an initializer callable that takes a shape tuple and returns
-    a new ttml.autograd.Tensor.
+Each function returns an initializer with signature::
 
-    Usage:
-        layer = LinearLayer(
-            128, 64,
-            weight_init=ttml.init.xavier_uniform(gain=1.0),
-            bias_init=ttml.init.constant(0.0),
-        )
+    init_fn(shape, layout=None, mesh_device=None) -> Tensor
 
-In-place variants (uniform_, normal_, constant_, zeros_, ones_, xavier_uniform_,
-    xavier_normal_, kaiming_uniform_, kaiming_normal_):
-    Take an existing tensor (or Parameter/Buffer wrapping one) and fill it
-    in-place, returning the same object that was passed in.
-    Mirrors the PyTorch torch.nn.init convention.
-
-    Note: these are not truly in-place at the device level. Each call
-    allocates a temporary tensor with the new values and then copies it
-    into the existing tensor via set_value. The temporary is freed
-    afterwards, but callers should be aware of the transient allocation.
-
-    Usage:
-        ttml.init.uniform_(tensor, a=-0.1, b=0.1)
-        ttml.init.xavier_uniform_(model.fc1.weight, gain=1.0)
+- Single device: ``ttnn.zeros`` / ``ones`` on AutoContext device (full logical shape).
+- Mesh: always a host buffer whose shape equals the parameter's **global** logical
+  shape (``TensorMetadata.shape``), then ``from_numpy`` + ``TensorToMesh`` --- same as
+  ``ttnn::distributed::create_distributed_tensor`` (buffer size = global shape).
+  Do not pre-shard the NumPy array here; the mapper splits. Replicate when no layout.
 """
 
 from __future__ import annotations
 
-import math
-from typing import Literal
-
+import numpy as np
+import ml_dtypes
 import ttnn
 import ttml
-
-
-_NonlinearityType = Literal[
-    "linear",
-    "conv1d",
-    "conv2d",
-    "conv3d",
-    "conv_transpose1d",
-    "conv_transpose2d",
-    "conv_transpose3d",
-    "sigmoid",
-    "tanh",
-    "relu",
-    "leaky_relu",
-    "selu",
-]
-
-_FanMode = Literal["fan_in", "fan_out"]
-
-_FULL_PRECISION = ttml.autograd.PreferredPrecision.FULL
 
 
 def _get_device():
     return ttml.autograd.AutoContext.get_instance().get_device()
 
 
-def _calculate_fan_in_and_fan_out(shape) -> tuple[int, int]:
-    # ttml pads weight shapes to 4D with leading 1s (e.g. [1, 1, out, in]).
-    # Strip them so the standard PyTorch fan calculation works correctly.
-    while len(shape) > 2 and shape[0] == 1:
-        shape = shape[1:]
-
-    if len(shape) < 2:
-        raise ValueError("Fan in and fan out can not be computed for tensor with fewer than 2 dimensions")
-
-    num_output_fmaps = shape[0]
-    num_input_fmaps = shape[1]
-    receptive_field_size = 1
-    for s in shape[2:]:
-        receptive_field_size *= s
-
-    fan_in = num_input_fmaps * receptive_field_size
-    fan_out = num_output_fmaps * receptive_field_size
-    return fan_in, fan_out
+def _mesh_ndim(mesh_device):
+    mesh_shape = mesh_device.shape
+    return mesh_shape.dims()
 
 
-def _calculate_correct_fan(shape, mode: _FanMode) -> int:
-    if mode not in ("fan_in", "fan_out"):
-        raise ValueError(f"Mode {mode} not supported, please use one of ('fan_in', 'fan_out')")
+def _to_tensor(arr, layout=None, mesh_device=None):
+    """Numpy array -> ttml Tensor on mesh.
 
-    fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
-    return fan_in if mode == "fan_in" else fan_out
-
-
-def calculate_gain(nonlinearity: _NonlinearityType, param: int | float | None = None) -> float:
-    """Return the recommended gain value for the given nonlinearity function.
-
-    ================= ====================================================
-    nonlinearity      gain
-    ================= ====================================================
-    linear / conv*    1
-    sigmoid           1
-    tanh              5/3
-    relu              sqrt(2)
-    leaky_relu        sqrt(2 / (1 + negative_slope^2))
-    selu              3/4
-    ================= ====================================================
-
-    Args:
-        nonlinearity: the non-linear function name.
-        param: optional parameter for the non-linear function (e.g. negative
-            slope for leaky_relu, default 0.01).
+    With ``layout`` (from TpPlan): shard/replicate per layout. With ``layout is None``
+    but ``mesh_device`` set: **replicate** full tensor on the mesh so non-TP params
+    (embedding, norm gamma, etc.) match distributed ops.
     """
-    linear_fns = [
-        "linear",
-        "conv1d",
-        "conv2d",
-        "conv3d",
-        "conv_transpose1d",
-        "conv_transpose2d",
-        "conv_transpose3d",
-    ]
-    if nonlinearity in linear_fns or nonlinearity == "sigmoid":
-        return 1
-    elif nonlinearity == "tanh":
-        return 5.0 / 3
-    elif nonlinearity == "relu":
-        return math.sqrt(2.0)
-    elif nonlinearity == "leaky_relu":
-        if param is None:
-            negative_slope = 0.01
-        elif not isinstance(param, bool) and isinstance(param, (int, float)):
-            negative_slope = param
+    from ttml.distributed.layout import DistributedLayout, set_layout
+
+    mapper = None
+    stamp_layout = None
+    if mesh_device is not None:
+        rank = len(arr.shape)
+        if layout is not None:
+            mapper = layout.build_mapper(mesh_device, tensor_rank=rank)
+            stamp_layout = layout
         else:
-            raise ValueError(f"negative_slope {param} not a valid number")
-        return math.sqrt(2.0 / (1 + negative_slope**2))
-    elif nonlinearity == "selu":
-        return 3.0 / 4
-    else:
-        raise ValueError(f"Unsupported nonlinearity {nonlinearity}")
+            mapper = ttml.core.distributed.replicate_tensor_to_mesh_mapper(mesh_device)
+            stamp_layout = DistributedLayout(ndim=_mesh_ndim(mesh_device))
+    tensor = ttml.autograd.Tensor.from_numpy(arr, ttnn.Layout.TILE, mapper=mapper)
+    if stamp_layout is not None:
+        set_layout(tensor, stamp_layout)
+    return tensor
 
 
-# ---------------------------------------------------------------------------
-# Factory variants (return initializer callables)
-# ---------------------------------------------------------------------------
+def _stamp(tensor, layout):
+    if layout is not None:
+        from ttml.distributed.layout import set_layout
+
+        set_layout(tensor, layout)
+    return tensor
 
 
-def uniform(a: float = 0.0, b: float = 1.0):
-    """Uniform distribution over [a, b)."""
+def uniform(low: float = 0.0, high: float = 1.0):
+    """Uniform distribution over [low, high)."""
 
-    def uniform_init(shape):
-        return ttml.ops.rand(shape, a, b)
+    def init_fn(shape, layout=None, mesh_device=None):
+        arr = np.random.uniform(low, high, shape).astype(ml_dtypes.bfloat16)
+        return _to_tensor(arr, layout, mesh_device)
 
-    return uniform_init
+    return init_fn
 
 
 def normal(mean: float = 0.0, std: float = 1.0):
     """Normal (Gaussian) distribution."""
 
-    def normal_init(shape):
-        return ttml.ops.randn(shape, mean, std)
+    def init_fn(shape, layout=None, mesh_device=None):
+        arr = np.random.normal(mean, std, shape).astype(ml_dtypes.bfloat16)
+        return _to_tensor(arr, layout, mesh_device)
 
-    return normal_init
-
-
-def constant(val: float):
-    """All elements set to val."""
-
-    def constant_init(shape):
-        device = _get_device()
-        t = ttnn.full(
-            shape,
-            fill_value=val,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
-        )
-        return ttml.autograd.create_tensor(t)
-
-    return constant_init
+    return init_fn
 
 
 def zeros():
     """All zeros."""
 
-    def zeros_init(shape):
+    def init_fn(shape, layout=None, mesh_device=None):
+        if mesh_device is not None:
+            arr = np.zeros(shape, dtype=ml_dtypes.bfloat16)
+            return _to_tensor(arr, layout, mesh_device)
         device = _get_device()
         t = ttnn.zeros(
-            shape,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
+            shape, device=device, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.Layout.TILE
         )
-        return ttml.autograd.create_tensor(t)
+        return _stamp(ttml.autograd.create_tensor(t), layout)
 
-    return zeros_init
+    return init_fn
 
 
 def ones():
     """All ones."""
 
-    def ones_init(shape):
+    def init_fn(shape, layout=None, mesh_device=None):
+        if mesh_device is not None:
+            arr = np.ones(shape, dtype=ml_dtypes.bfloat16)
+            return _to_tensor(arr, layout, mesh_device)
         device = _get_device()
         t = ttnn.ones(
-            shape,
-            device=device,
-            dtype=ttnn.DataType.BFLOAT16,
-            layout=ttnn.Layout.TILE,
+            shape, device=device, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.Layout.TILE
         )
-        return ttml.autograd.create_tensor(t)
+        return _stamp(ttml.autograd.create_tensor(t), layout)
 
-    return ones_init
-
-
-def xavier_uniform(gain: float = 1.0):
-    """Xavier uniform initialization (Glorot 2010).
-
-    Samples from U(-a, a) where a = gain * sqrt(6 / (fan_in + fan_out)).
-    Use ``calculate_gain`` to compute gain for a specific nonlinearity.
-    """
-
-    def xavier_uniform_init(shape):
-        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
-        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
-        a = math.sqrt(3.0) * std
-        return uniform(-a, a)(shape)
-
-    return xavier_uniform_init
-
-
-def xavier_normal(gain: float = 1.0):
-    """Xavier normal initialization (Glorot 2010).
-
-    Samples from N(0, std^2) where std = gain * sqrt(2 / (fan_in + fan_out)).
-    Use ``calculate_gain`` to compute gain for a specific nonlinearity.
-    """
-
-    def xavier_normal_init(shape):
-        fan_in, fan_out = _calculate_fan_in_and_fan_out(shape)
-        std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
-        return normal(0.0, std)(shape)
-
-    return xavier_normal_init
-
-
-def kaiming_uniform(
-    a: float = 0,
-    mode: _FanMode = "fan_in",
-    nonlinearity: _NonlinearityType = "leaky_relu",
-):
-    """Kaiming uniform initialization (He 2015).
-
-    Samples from U(-bound, bound) where bound = gain * sqrt(3 / fan).
-
-    Args:
-        a: negative slope of the rectifier (only used with leaky_relu).
-        mode: "fan_in" preserves forward-pass variance,
-            "fan_out" preserves backward-pass variance.
-        nonlinearity: nonlinearity function name, recommended "relu" or
-            "leaky_relu".
-    """
-
-    def kaiming_uniform_init(shape):
-        fan = _calculate_correct_fan(shape, mode)
-        gain = calculate_gain(nonlinearity, a)
-        std = gain / math.sqrt(fan)
-        bound = math.sqrt(3.0) * std
-        return uniform(-bound, bound)(shape)
-
-    return kaiming_uniform_init
-
-
-def kaiming_normal(
-    a: float = 0,
-    mode: _FanMode = "fan_in",
-    nonlinearity: _NonlinearityType = "leaky_relu",
-):
-    """Kaiming normal initialization (He 2015).
-
-    Samples from N(0, std^2) where std = gain / sqrt(fan).
-
-    Args:
-        a: negative slope of the rectifier (only used with leaky_relu).
-        mode: "fan_in" preserves forward-pass variance,
-            "fan_out" preserves backward-pass variance.
-        nonlinearity: nonlinearity function name, recommended "relu" or
-            "leaky_relu".
-    """
-
-    def kaiming_normal_init(shape):
-        fan = _calculate_correct_fan(shape, mode)
-        gain = calculate_gain(nonlinearity, a)
-        std = gain / math.sqrt(fan)
-        return normal(0.0, std)(shape)
-
-    return kaiming_normal_init
-
-
-# ---------------------------------------------------------------------------
-# In-place variants (fill existing tensor, return it)
-#
-# NOTE: Not truly in-place - each function allocates a new temporary tensor
-# via the corresponding factory variant and copies the values into the
-# existing tensor with set_value(). The temporary is freed after the call.
-# ---------------------------------------------------------------------------
-
-
-def _unwrap_tensor(tensor_or_param):
-    """Return the underlying autograd tensor, unwrapping Parameter/Buffer if needed."""
-    from ttml.modules.parameter import Buffer, Parameter
-
-    if isinstance(tensor_or_param, (Parameter, Buffer)):
-        return tensor_or_param.tensor
-    return tensor_or_param
-
-
-def uniform_(tensor, a: float = 0.0, b: float = 1.0):
-    """Fill tensor in-place with values from uniform distribution [a, b)."""
-    inner = _unwrap_tensor(tensor)
-    reinit_val = uniform(a, b)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def normal_(tensor, mean: float = 0.0, std: float = 1.0):
-    """Fill tensor in-place with values from normal (Gaussian) distribution."""
-    inner = _unwrap_tensor(tensor)
-    reinit_val = normal(mean, std)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def constant_(tensor, val: float):
-    """Fill tensor in-place with a constant value."""
-    inner = _unwrap_tensor(tensor)
-    reinit_val = constant(val)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def zeros_(tensor):
-    """Fill tensor in-place with zeros."""
-    inner = _unwrap_tensor(tensor)
-    reinit_val = zeros()(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def ones_(tensor):
-    """Fill tensor in-place with ones."""
-    inner = _unwrap_tensor(tensor)
-    reinit_val = ones()(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def xavier_uniform_(tensor, gain: float = 1.0):
-    """Fill tensor in-place using Xavier uniform initialization (Glorot 2010).
-
-    See ``xavier_uniform`` for details.
-    """
-    inner = _unwrap_tensor(tensor)
-    reinit_val = xavier_uniform(gain)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def xavier_normal_(tensor, gain: float = 1.0):
-    """Fill tensor in-place using Xavier normal initialization (Glorot 2010).
-
-    See ``xavier_normal`` for details.
-    """
-    inner = _unwrap_tensor(tensor)
-    reinit_val = xavier_normal(gain)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def kaiming_uniform_(
-    tensor,
-    a: float = 0,
-    mode: _FanMode = "fan_in",
-    nonlinearity: _NonlinearityType = "leaky_relu",
-):
-    """Fill tensor in-place using Kaiming uniform initialization (He 2015).
-
-    See ``kaiming_uniform`` for details.
-    """
-    inner = _unwrap_tensor(tensor)
-    reinit_val = kaiming_uniform(a, mode, nonlinearity)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
-
-
-def kaiming_normal_(
-    tensor,
-    a: float = 0,
-    mode: _FanMode = "fan_in",
-    nonlinearity: _NonlinearityType = "leaky_relu",
-):
-    """Fill tensor in-place using Kaiming normal initialization (He 2015).
-
-    See ``kaiming_normal`` for details.
-    """
-    inner = _unwrap_tensor(tensor)
-    reinit_val = kaiming_normal(a, mode, nonlinearity)(inner.shape())
-    inner.set_value(reinit_val.get_value(_FULL_PRECISION))
-    return tensor
+    return init_fn
 
 
 __all__ = [
-    "calculate_gain",
-    "constant",
-    "constant_",
-    "kaiming_normal",
-    "kaiming_normal_",
-    "kaiming_uniform",
-    "kaiming_uniform_",
     "normal",
-    "normal_",
     "ones",
-    "ones_",
     "uniform",
-    "uniform_",
-    "xavier_normal",
-    "xavier_normal_",
-    "xavier_uniform",
-    "xavier_uniform_",
     "zeros",
-    "zeros_",
 ]

--- a/tt-train/sources/ttml/ttml/models/llama/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/llama/__init__.py
@@ -5,11 +5,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, Optional
 
+import numpy as np
+import ml_dtypes
 import ttnn
 import ttml
-from ttml.modules import AbstractModuleBase, Embedding, ModuleList, LinearLayer
+from ttml.modules import Embedding, ModuleList, LinearLayer, TransformerBase
 
 from .. import RunnerType, WeightTyingType, memory_efficient_runner
 from .transformer import LlamaBlock, RMSNormLayer
@@ -73,28 +75,43 @@ class LlamaConfig:
             )
 
 
-class Llama(AbstractModuleBase):
-    def __init__(self, config: LlamaConfig) -> None:
-        super().__init__()
+def initialize_parameters(parameters: Dict[str, ttml.autograd.Tensor]) -> None:
+    for name, tensor in parameters.items():
+        shape = tensor.shape()
 
+        if "weight" in name:
+            # Re-initialize weights with normal(0, 0.02)
+            weight_np = np.random.normal(0.0, 0.02, size=shape).astype(
+                ml_dtypes.bfloat16
+            )
+            new_tensor = ttml.autograd.Tensor.from_numpy(
+                weight_np, layout=ttnn.Layout.TILE
+            )
+            tensor.assign(new_tensor)
+        elif "bias" in name:
+            # Re-initialize biases with 0
+            bias_np = np.zeros(shape, dtype=ml_dtypes.bfloat16)
+            new_tensor = ttml.autograd.Tensor.from_numpy(
+                bias_np, layout=ttnn.Layout.TILE
+            )
+            tensor.assign(new_tensor)
+
+
+class Llama(TransformerBase):
+    def __init__(self, config: LlamaConfig, **kwargs) -> None:
         self.config = config
 
-        self.fc = LinearLayer(
-            config.hidden_size,
-            config.vocab_size,
-            False,
-            weight_init=ttml.init.normal(0.0, 0.02),
-        )
+        self.fc = LinearLayer(config.hidden_size, config.vocab_size, False, **kwargs)
 
         vocab_size_divisible_by_32 = (config.vocab_size + 31) // 32 * 32
         self.tok_emb = Embedding(
-            vocab_size_divisible_by_32,
-            config.hidden_size,
-            weight_init=ttml.init.normal(0.0, 0.02),
+            vocab_size_divisible_by_32, config.hidden_size, **kwargs
         )
 
         if config.weight_tying == ttml.models.WeightTyingType.Enabled:
-            self.tok_emb.weight = self.fc.weight.tensor
+            # Share the Parameter object so lazy materialization runs once; assigning
+            # .tensor would copy TensorMetadata and break Embedding.forward (expects Parameter).
+            self.tok_emb.weight = self.fc.weight
 
         head_dim = config.hidden_size // config.num_attention_heads
 
@@ -124,12 +141,16 @@ class Llama(AbstractModuleBase):
                     mlp_dropout=config.mlp_dropout,
                     intermediate_size=config.intermediate_size,
                     attention_bias=config.attention_bias,
+                    **kwargs,
                 )
                 for _ in range(config.num_hidden_layers)
-            ]
+            ],
+            **kwargs,
         )
 
-        self.ln_fc = RMSNormLayer(config.hidden_size)
+        self.ln_fc = RMSNormLayer(config.hidden_size, **kwargs)
+
+        super().__init__(**kwargs)
 
     def forward(
         self,

--- a/tt-train/sources/ttml/ttml/models/llama/gqattn.py
+++ b/tt-train/sources/ttml/ttml/models/llama/gqattn.py
@@ -22,9 +22,8 @@ class GroupedQueryAttention(AbstractModuleBase):
         dropout: float,
         rope_params: ttml.ops.rope.RotaryEmbeddingParams,
         bias_linears: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__()
-
         if embedding_size % num_heads != 0:
             raise ValueError(
                 "Embedding size must be divisible by the number of attention heads. "
@@ -41,26 +40,16 @@ class GroupedQueryAttention(AbstractModuleBase):
         concat_kv_dim = 2 * num_groups * (embedding_size // num_heads)
 
         self.q_linear = LinearLayer(
-            embedding_size,
-            embedding_size,
-            bias_linears,
-            weight_init=ttml.init.normal(0.0, 0.02),
-            bias_init=ttml.init.zeros(),
+            embedding_size, embedding_size, bias_linears, **kwargs
         )
         self.kv_linear = LinearLayer(
-            embedding_size,
-            concat_kv_dim,
-            bias_linears,
-            weight_init=ttml.init.normal(0.0, 0.02),
-            bias_init=ttml.init.zeros(),
+            embedding_size, concat_kv_dim, bias_linears, **kwargs
         )
         self.out_linear = LinearLayer(
-            embedding_size,
-            embedding_size,
-            bias_linears,
-            weight_init=ttml.init.normal(0.0, 0.02),
-            bias_init=ttml.init.zeros(),
+            embedding_size, embedding_size, bias_linears, **kwargs
         )
+
+        super().__init__(**kwargs)
 
     def forward_no_kv(self, input: ttml.autograd.Tensor, mask: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         q = self.q_linear(input)

--- a/tt-train/sources/ttml/ttml/models/llama/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/llama/transformer.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import ttml
 from ttml.modules import AbstractModuleBase, Parameter, RunMode, LinearLayer
+from ttml.modules.parameter import TensorMetadata
 
 from .gqattn import GroupedQueryAttention
 
@@ -20,25 +21,21 @@ class RMSNormLayer(AbstractModuleBase):
         features: int,
         epsilon: float = 1e-5,
         use_composite: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__()
-
         self.epsilon = epsilon
         self.use_composite = use_composite
 
-        gamma_shape = (1, 1, 1, features)
-        self.gamma = Parameter(ttml.init.ones()(gamma_shape))
+        self.gamma = Parameter(
+            TensorMetadata(
+                shape=(1, 1, 1, features),
+                init_fn=ttml.init.ones(),
+            )
+        )
+
+        super().__init__(**kwargs)
 
     def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
-        """Forward pass of RMSNorm.
-
-        Args:
-            x: Input tensor
-
-        Returns:
-            Normalized output tensor
-        """
-
         if self.use_composite:
             rmsnorm_op = ttml.ops.rmsnorm.rmsnorm_composite
         else:
@@ -55,9 +52,8 @@ class LlamaMLP(AbstractModuleBase):
         embedding_size: int,
         intermediate_size: Optional[int] = None,
         dropout: float = 0.0,
+        **kwargs,
     ) -> None:
-        super().__init__()
-
         self.embedding_size = embedding_size
         self.dropout_prob = dropout
 
@@ -67,34 +63,13 @@ class LlamaMLP(AbstractModuleBase):
             unrounded_size = (4 * embedding_size * 2) // 3
             intermediate_size = ((unrounded_size + multiple_of - 1) // multiple_of) * multiple_of
 
-        self.w1 = LinearLayer(
-            embedding_size,
-            intermediate_size,
-            False,
-            weight_init=ttml.init.normal(0.0, 0.02),
-        )
-        self.w3 = LinearLayer(
-            embedding_size,
-            intermediate_size,
-            False,
-            weight_init=ttml.init.normal(0.0, 0.02),
-        )
-        self.w2 = LinearLayer(
-            intermediate_size,
-            embedding_size,
-            False,
-            weight_init=ttml.init.normal(0.0, 0.02),
-        )
+        self.w1 = LinearLayer(embedding_size, intermediate_size, False, **kwargs)
+        self.w3 = LinearLayer(embedding_size, intermediate_size, False, **kwargs)
+        self.w2 = LinearLayer(intermediate_size, embedding_size, False, **kwargs)
+
+        super().__init__(**kwargs)
 
     def forward(self, input: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
-        """Forward pass of MLP.
-
-        Args:
-            x: Input tensor
-
-        Returns:
-            Output tensor after MLP
-        """
         swished = ttml.ops.unary.silu(self.w1(input))
         gate = self.w3(input)
         gated = ttml.ops.binary.mul(swished, gate)
@@ -117,16 +92,11 @@ class LlamaBlock(AbstractModuleBase):
         mlp_dropout: float = 0.0,
         intermediate_size: Optional[int] = None,
         attention_bias: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__()
-
-        self.mlp = LlamaMLP(
-            hidden_size,
-            intermediate_size,
-            mlp_dropout,
-        )
-        self.attention_norm = RMSNormLayer(hidden_size)
-        self.mlp_norm = RMSNormLayer(hidden_size)
+        self.mlp = LlamaMLP(hidden_size, intermediate_size, mlp_dropout, **kwargs)
+        self.attention_norm = RMSNormLayer(hidden_size, **kwargs)
+        self.mlp_norm = RMSNormLayer(hidden_size, **kwargs)
         self.attention = GroupedQueryAttention(
             embedding_size=hidden_size,
             num_heads=num_attention_heads,
@@ -134,7 +104,10 @@ class LlamaBlock(AbstractModuleBase):
             dropout=attention_dropout,
             rope_params=rope_params,
             bias_linears=attention_bias,
+            **kwargs,
         )
+
+        super().__init__(**kwargs)
 
     def forward(
         self,

--- a/tt-train/sources/ttml/ttml/modules/__init__.py
+++ b/tt-train/sources/ttml/ttml/modules/__init__.py
@@ -12,8 +12,8 @@ from _ttml.modules import InferenceMode, ModuleBase, RunMode
 from .embedding import Embedding
 from .linear import LinearLayer
 from .lora import LoraConfig, LoraLinear, LoraModel
-from .module_base import AbstractModuleBase, ModuleDict, ModuleList
-from .parameter import Buffer, Parameter
+from .module_base import AbstractModuleBase, ModuleDict, ModuleList, TransformerBase
+from .parameter import Buffer, Parameter, TensorMetadata
 
 __all__ = [
     # C++ bindings
@@ -31,4 +31,6 @@ __all__ = [
     "ModuleDict",
     "ModuleList",
     "Parameter",
+    "TensorMetadata",
+    "TransformerBase",
 ]

--- a/tt-train/sources/ttml/ttml/modules/embedding.py
+++ b/tt-train/sources/ttml/ttml/modules/embedding.py
@@ -9,27 +9,32 @@ from __future__ import annotations
 import ttml
 
 from .module_base import AbstractModuleBase
-from .parameter import Parameter
+from .parameter import Parameter, TensorMetadata
 
 
 class Embedding(AbstractModuleBase):
     """Embedding layer implemented in Python using ttml operations."""
 
-    def __init__(self, num_embeddings: int, embedding_dim: int, weight_init=None) -> None:
+    def __init__(self, num_embeddings: int, embedding_dim: int, **kwargs) -> None:
         """Initialize embedding layer.
 
         Args:
-            num_embeddings: Size of vocabulary
-            embedding_dim: Dimension of embeddings
-            weight_init: Initializer for weight tensor. Defaults to normal(0, 0.02).
+            num_embeddings: Size of vocabulary.
+            embedding_dim: Dimension of embeddings.
+            **kwargs: Forwarded to AbstractModuleBase (mesh_device, tp_plan, etc.).
         """
-        super().__init__()
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
 
-        if weight_init is None:
-            weight_init = ttml.init.normal(0.0, 0.02)
+        # Match C++ modules/embedding_module.cpp: normal_init(..., {0.F, 1.F})
+        self.weight = Parameter(
+            TensorMetadata(
+                shape=(1, 1, num_embeddings, embedding_dim),
+                init_fn=ttml.init.normal(0.0, 1.0),
+            )
+        )
 
-        weight_shape = (1, 1, num_embeddings, embedding_dim)
-        self.weight = Parameter(weight_init(weight_shape))
+        super().__init__(**kwargs)
 
     def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         """Forward pass of embedding layer.

--- a/tt-train/sources/ttml/ttml/modules/linear.py
+++ b/tt-train/sources/ttml/ttml/modules/linear.py
@@ -5,12 +5,11 @@
 import math
 
 import ml_dtypes
-
 import ttnn
 import ttml
 
 from .module_base import AbstractModuleBase
-from .parameter import Parameter
+from .parameter import Parameter, TensorMetadata
 
 
 class LinearLayer(AbstractModuleBase):
@@ -21,29 +20,31 @@ class LinearLayer(AbstractModuleBase):
         in_features: int,
         out_features: int,
         has_bias: bool = True,
-        weight_init=None,
-        bias_init=None,
+        **kwargs,
     ) -> None:
-        super().__init__()
-
         self.in_features = in_features
         self.out_features = out_features
 
-        if weight_init is None:
-            k = math.sqrt(1.0 / in_features)
-            weight_init = ttml.init.uniform(-k, k)
+        k = math.sqrt(1.0 / in_features)
 
-        weight_shape = (1, 1, out_features, in_features)
-        self.weight = Parameter(weight_init(weight_shape))
+        self.weight = Parameter(
+            TensorMetadata(
+                shape=(1, 1, out_features, in_features),
+                init_fn=ttml.init.uniform(-k, k),
+            )
+        )
 
         if has_bias:
-            if bias_init is None:
-                k = math.sqrt(1.0 / in_features)
-                bias_init = ttml.init.uniform(-k, k)
-            bias_shape = (1, 1, 1, out_features)
-            self.bias = Parameter(bias_init(bias_shape))
+            self.bias = Parameter(
+                TensorMetadata(
+                    shape=(1, 1, 1, out_features),
+                    init_fn=ttml.init.uniform(-k, k),
+                )
+            )
         else:
             self.bias = None
+
+        super().__init__(**kwargs)
 
     def __reduce__(self):
         return (

--- a/tt-train/sources/ttml/ttml/modules/module_base.py
+++ b/tt-train/sources/ttml/ttml/modules/module_base.py
@@ -39,9 +39,7 @@ class AbstractModuleBase(CppModuleBase):
                 continue
             if isinstance(value, CppModuleBase):
                 self._bind_module(value, name)
-            elif isinstance(value, Parameter) and not isinstance(
-                value.tensor, TensorMetadata
-            ):
+            elif isinstance(value, Parameter) and not isinstance(value.tensor, TensorMetadata):
                 self._bind_parameter(value.tensor, name)
             elif isinstance(value, Buffer):
                 self._bind_buffer(value.tensor, name)
@@ -182,9 +180,10 @@ class TransformerBase(AbstractModuleBase):
                 super().__init__(**kwargs)
     """
 
-    def __init__(self, mesh_device=None, tp_plan=None, **kwargs) -> None:
+    def __init__(self, mesh_device=None, tp_plan=None, on_device_init=False, **kwargs) -> None:
         self._mesh_device = mesh_device
         self._tp_plan = tp_plan.resolve(mesh_device) if tp_plan is not None else None
+        self._on_device_init = on_device_init
         super().__init__(**kwargs)
         self._materialize_tree()
 
@@ -198,9 +197,7 @@ class TransformerBase(AbstractModuleBase):
             if isinstance(module, AbstractModuleBase):
                 self._materialize_module_params(module, prefix)
 
-    def _materialize_module_params(
-        self, module: AbstractModuleBase, prefix: str
-    ) -> None:
+    def _materialize_module_params(self, module: AbstractModuleBase, prefix: str) -> None:
         """Materialize a single module's own TensorMetadata Parameters."""
         for name in list(vars(module)):
             attr = getattr(module, name, None)
@@ -208,15 +205,16 @@ class TransformerBase(AbstractModuleBase):
                 full_path = f"{prefix}.{name}" if prefix else name
                 self._materialize_param(module, name, attr, full_path)
 
-    def _materialize_param(
-        self, module: AbstractModuleBase, name: str, param: Parameter, full_path: str
-    ) -> None:
+    def _materialize_param(self, module: AbstractModuleBase, name: str, param: Parameter, full_path: str) -> None:
         """Convert a single TensorMetadata Parameter into a device tensor."""
         metadata = param.tensor
         layout = _match_policy(full_path, self._tp_plan)
 
         tensor = metadata.init_fn(
-            metadata.shape, layout=layout, mesh_device=self._mesh_device
+            metadata.shape,
+            layout=layout,
+            mesh_device=self._mesh_device,
+            on_device_init=self._on_device_init,
         )
         tensor.set_requires_grad(metadata.requires_grad)
         param.tensor = tensor
@@ -433,9 +431,7 @@ class ModuleDict(AbstractModuleBase):
 
     def __init__(
         self,
-        modules: Optional[
-            Union[dict[str, CppModuleBase], Iterable[tuple[str, CppModuleBase]]]
-        ] = None,
+        modules: Optional[Union[dict[str, CppModuleBase], Iterable[tuple[str, CppModuleBase]]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/tt-train/sources/ttml/ttml/modules/module_base.py
+++ b/tt-train/sources/ttml/ttml/modules/module_base.py
@@ -4,33 +4,67 @@
 
 """Python module base inheriting from C++ ModuleBase with auto-registration."""
 
+import re
 from typing import Any, Iterable, Iterator, Optional, Union, overload
 from _ttml.modules import ModuleBase as CppModuleBase
-from .parameter import Buffer, Parameter
+from .parameter import Buffer, Parameter, TensorMetadata
+
+
+def _match_policy(path: str, tp_plan: Optional[dict]) -> Any:
+    """Return the Layout for the first matching pattern in tp_plan, or None."""
+    if tp_plan is None:
+        return None
+    for pattern, layout in tp_plan.items():
+        if re.search(pattern, path):
+            return layout
+    return None
 
 
 class AbstractModuleBase(CppModuleBase):
-    """Module base with PyTorch-like auto-registration via __setattr__."""
+    """Module base with PyTorch-like auto-registration via __setattr__.
 
-    def __init__(self) -> None:
+    Subclasses create ``TensorMetadata`` Parameters in their constructor
+    **before** calling ``super().__init__()``.  No materialization happens
+    here — use ``TransformerBase`` as the root to materialize the full tree.
+    """
+
+    def __init__(self, **kwargs) -> None:
         super().__init__()
         object.__setattr__(self, "_buffers", {})
         self.create_name(self.__class__.__name__)
 
+        # Retroactively register modules/params assigned before super().__init__().
+        for name, value in list(self.__dict__.items()):
+            if name.startswith("_"):
+                continue
+            if isinstance(value, CppModuleBase):
+                self._bind_module(value, name)
+            elif isinstance(value, Parameter) and not isinstance(
+                value.tensor, TensorMetadata
+            ):
+                self._bind_parameter(value.tensor, name)
+            elif isinstance(value, Buffer):
+                self._bind_buffer(value.tensor, name)
+
+    # ------------------------------------------------------------------
+    # Attribute registration
+    # ------------------------------------------------------------------
+
     def __setattr__(self, name: str, value: Any) -> None:
         object.__setattr__(self, name, value)
 
-        # Skip if not initialized yet
+        # Skip if not initialized yet.
         if "_buffers" not in self.__dict__:
             return
 
-        # Auto-register modules and tensors
         if isinstance(value, CppModuleBase):
             self._bind_module(value, name)
             return
 
         if isinstance(value, Parameter):
-            self._bind_parameter(value.tensor, name)
+            # TensorMetadata Parameters are not bound to C++ until materialized.
+            if not isinstance(value.tensor, TensorMetadata):
+                self._bind_parameter(value.tensor, name)
             return
 
         if isinstance(value, Buffer):
@@ -43,6 +77,10 @@ class AbstractModuleBase(CppModuleBase):
     def __delattr__(self, name: str) -> None:
         self._buffers.pop(name, None)
         object.__delattr__(self, name)
+
+    # ------------------------------------------------------------------
+    # C++ registration helpers
+    # ------------------------------------------------------------------
 
     def _bind_module(self, module, name: str) -> None:
         """Register or override a child module by name."""
@@ -61,6 +99,10 @@ class AbstractModuleBase(CppModuleBase):
     def _bind_buffer(self, buffer, name: str) -> None:
         """Register a buffer by name."""
         self._buffers[name] = buffer
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
 
     def named_parameters(self, prefix: str = "") -> Iterator[tuple[str, Any]]:
         """Yield (name, parameter) pairs."""
@@ -124,6 +166,63 @@ class AbstractModuleBase(CppModuleBase):
         return result
 
 
+class TransformerBase(AbstractModuleBase):
+    """Root-level transformer base that materializes the full module tree.
+
+    Subclasses create child modules in their constructor, then call
+    ``super().__init__(**kwargs)``.  This class captures ``mesh_device``
+    and ``tp_plan``, then walks the tree to materialize every
+    ``TensorMetadata`` Parameter.
+
+    Usage::
+
+        class Llama(TransformerBase):
+            def __init__(self, config, **kwargs):
+                self.fc = LinearLayer(...)
+                super().__init__(**kwargs)
+    """
+
+    def __init__(self, mesh_device=None, tp_plan=None, **kwargs) -> None:
+        self._mesh_device = mesh_device
+        self._tp_plan = tp_plan.resolve(mesh_device) if tp_plan is not None else None
+        super().__init__(**kwargs)
+        self._materialize_tree()
+
+    # ------------------------------------------------------------------
+    # Materialization
+    # ------------------------------------------------------------------
+
+    def _materialize_tree(self) -> None:
+        """Walk the full module tree and materialize all TensorMetadata Parameters."""
+        for prefix, module in self.named_modules():
+            if isinstance(module, AbstractModuleBase):
+                self._materialize_module_params(module, prefix)
+
+    def _materialize_module_params(
+        self, module: AbstractModuleBase, prefix: str
+    ) -> None:
+        """Materialize a single module's own TensorMetadata Parameters."""
+        for name in list(vars(module)):
+            attr = getattr(module, name, None)
+            if isinstance(attr, Parameter) and isinstance(attr.tensor, TensorMetadata):
+                full_path = f"{prefix}.{name}" if prefix else name
+                self._materialize_param(module, name, attr, full_path)
+
+    def _materialize_param(
+        self, module: AbstractModuleBase, name: str, param: Parameter, full_path: str
+    ) -> None:
+        """Convert a single TensorMetadata Parameter into a device tensor."""
+        metadata = param.tensor
+        layout = _match_policy(full_path, self._tp_plan)
+
+        tensor = metadata.init_fn(
+            metadata.shape, layout=layout, mesh_device=self._mesh_device
+        )
+        tensor.set_requires_grad(metadata.requires_grad)
+        param.tensor = tensor
+        module._bind_parameter(tensor, name)
+
+
 class ModuleList(AbstractModuleBase):
     """A list of modules with automatic registration (PyTorch-compatible).
 
@@ -142,13 +241,12 @@ class ModuleList(AbstractModuleBase):
                 return x
     """
 
-    def __init__(self, modules: Optional[Iterable[CppModuleBase]] = None) -> None:
-        """Initialize ModuleList.
-
-        Args:
-            modules: Optional iterable of modules to add.
-        """
-        super().__init__()
+    def __init__(
+        self,
+        modules: Optional[Iterable[CppModuleBase]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
         self._modules_list: list[CppModuleBase] = []
         if modules is not None:
             for module in modules:
@@ -335,14 +433,12 @@ class ModuleDict(AbstractModuleBase):
 
     def __init__(
         self,
-        modules: Optional[Union[dict[str, CppModuleBase], Iterable[tuple[str, CppModuleBase]]]] = None,
+        modules: Optional[
+            Union[dict[str, CppModuleBase], Iterable[tuple[str, CppModuleBase]]]
+        ] = None,
+        **kwargs,
     ) -> None:
-        """Initialize ModuleDict.
-
-        Args:
-            modules: Optional dict or iterable of (name, module) pairs.
-        """
-        super().__init__()
+        super().__init__(**kwargs)
         self._modules_dict: dict[str, CppModuleBase] = {}
         if modules is not None:
             if isinstance(modules, dict):

--- a/tt-train/sources/ttml/ttml/modules/parameter.py
+++ b/tt-train/sources/ttml/ttml/modules/parameter.py
@@ -4,16 +4,56 @@
 
 """Parameter and Buffer wrappers for tensor registration."""
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable, Tuple
+
+
+@dataclass(frozen=True)
+class TensorMetadata:
+    """Describes a tensor's properties without allocating memory.
+
+    Used with deferred initialization: module constructors create TensorMetadata
+    Parameters before calling super().__init__(). The root TransformerBase then
+    walks the tree and materializes all parameters on device.
+
+    Attributes:
+        shape: Full (unsharded) tensor shape.
+        init_fn: A closure returned by ttml.init (e.g. ttml.init.uniform(-k, k)).
+                 Signature: init_fn(shape) -> Tensor
+        requires_grad: Whether the materialized tensor needs gradients.
+    """
+
+    shape: Tuple[int, ...]
+    init_fn: Callable
+    requires_grad: bool = True
 
 
 class Parameter:
-    """Wrapper marking a tensor as a trainable parameter."""
+    """Wrapper marking a tensor as a trainable parameter.
 
-    def __init__(self, tensor: Any) -> None:
-        self.tensor = tensor
+    Can hold either:
+    - TensorMetadata (before materialization) - describes shape/init_fn.
+    - ttml.autograd.Tensor (after materialization).
+    """
+
+    def __init__(self, tensor_or_metadata: Any) -> None:
+        self.tensor = tensor_or_metadata
+
+    @property
+    def is_materialized(self) -> bool:
+        """True if the tensor has been allocated on device."""
+        return not isinstance(self.tensor, TensorMetadata)
+
+    @property
+    def shape(self):
+        """Return tensor shape (works for both metadata and materialized tensor)."""
+        if isinstance(self.tensor, TensorMetadata):
+            return self.tensor.shape
+        return tuple(self.tensor.shape())
 
     def __repr__(self) -> str:
+        if isinstance(self.tensor, TensorMetadata):
+            return f"Parameter(TensorMetadata(shape={self.tensor.shape}))"
         return f"Parameter({self.tensor})"
 
 

--- a/tt-train/tests/python/test_distributed_dispatch.py
+++ b/tt-train/tests/python/test_distributed_dispatch.py
@@ -194,6 +194,7 @@ class TestTraceEntry:
         )
         d = entry.to_dict()
         assert d["op_kwargs"] == {"dim": -1, "cluster_axis": 1}
+        assert d["input_shapes"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Introduces a deferred (lazy) parameter initialization system for Python-side TTML models, replacing eager per-parameter allocation with a two-phase approach that correctly handles tensor-parallel mesh distribution.
https://github.com/tenstorrent/tt-metal/issues/39804
### How parameter initialization works now

**Phase 1 — declare shape + initializer (no allocation)**

Module constructors assign `Parameter(TensorMetadata(...))` instead of allocating tensors immediately:

```python
class LinearLayer(AbstractModuleBase):
    def __init__(self, in_features, out_features):
        k = math.sqrt(1.0 / in_features)
        self.weight = Parameter(TensorMetadata(
            shape=(1, 1, out_features, in_features),
            init_fn=ttml.init.uniform(-k, k),
        ))
        super().__init__()
```

`TensorMetadata` stores the **global** (unsharded) shape and an `init_fn` closure from `ttml.init`. No device memory is touched.

**Phase 2 — materialize the full tree at root `__init__`**

`TransformerBase.__init__` calls `_materialize_tree()`, which walks every `TensorMetadata` Parameter, resolves its TP layout (if any), and calls:

```python
tensor = metadata.init_fn(metadata.shape, layout=layout, mesh_device=mesh_device)
```

Parameters with a matching `TpPlan` pattern get sharded; all others are **replicated** across the mesh automatically — fixing the prior bug where non-TP params (embedding, RMSNorm gamma) were silently left as single-device tensors.

**`ttml.init` initializers**

| Function | Distribution |
|---|---|
| `ttml.init.uniform(low, high)` | Uniform over `[low, high)` |
| `ttml.init.normal(mean, std)` | Gaussian |
| `ttml.init.zeros()` | All zeros |
| `ttml.init.ones()` | All ones |
| `ttml.init.constant(val)` | All elements set to `val` |
| `ttml.init.xavier_uniform(gain)` | Xavier/Glorot uniform |
| `ttml.init.xavier_normal(gain)` | Xavier/Glorot normal |
| `ttml.init.kaiming_uniform(a, mode, nonlinearity)` | Kaiming/He uniform |
| `ttml.init.kaiming_normal(a, mode, nonlinearity)` | Kaiming/He normal |

In-place variants (`uniform_`, `normal_`, `zeros_`, `ones_`, `xavier_uniform_`, etc.) are also available for reinitializing existing tensors.

On a mesh, initializers allocate a NumPy buffer of the **global** shape and route through `from_numpy` + `TensorToMesh`, matching `create_distributed_tensor` semantics.

**`on_device_init` parameter (experimental)**

`TransformerBase` accepts an `on_device_init=True` flag that switches `uniform` and `normal` initializers to use `ttnn::rand` / `ttml.ops.randn` with `MeshMapperConfig` directly on the device mesh, avoiding the host→device round-trip through NumPy. This path generates random values per-device with correct seed offsets (replicated axes share seeds, sharded axes get distinct seeds). Default is `False` (NumPy host path).

```python
# Host init (default, proven with CP+TP)
model = Llama(config, mesh_device=mesh, tp_plan=plan)

# On-device init (experimental, avoids host round-trip)
model = Llama(config, mesh_device=mesh, tp_plan=plan, on_device_init=True)
```

**Direct tensor initialization (eager path)**

You can bypass deferred init and pass a live tensor straight to `Parameter`:

```python
self.weight = Parameter(some_already_materialized_tensor)
```

`AbstractModuleBase.__setattr__` detects it's not a `TensorMetadata` and binds it to the C++ backend immediately. Useful for weight tying or custom init logic.

**`ParallelStyle.get_layouts`**

`get_layout` + `get_bias_layout` merged into a single `get_layouts(mesh_device, tp_axis) -> dict[str, Layout]`. `TpPlan.resolve` iterates the dict, so adding a new parameter type only requires updating `get_layouts` in one place.

**Initialization parity with C++**

- `Embedding`: `normal(0, 1)` to match C++ `normal_init(..., {0.F, 1.F})`
- Linear weights: `uniform(±sqrt(1/fan_in))` to match C++ uniform init
- Linear biases: `uniform(±k)` where `k` matches sibling weight fan_in
