### PR TITLE
[CI] Fix pipeline-select-galaxy perf job to use wh_galaxy_perf SKU

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -255,5 +255,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy
+      enabled-skus: wh_galaxy_perf
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-perf || 'all' }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
PR #40384 changed all Galaxy perf test SKUs from \`wh_galaxy\` to \`wh_galaxy_perf\` in \`galaxy_perf_tests.yaml\` and updated the standalone \`galaxy-perf-tests.yaml\` workflow accordingly, but \`pipeline-select-galaxy.yaml\` (the "Choose your pipeline" workflow) was left passing \`enabled-skus: wh_galaxy\` to \`galaxy-perf-tests-impl.yaml\`. This caused the Galaxy perf matrix load step to fail with:

\`\`\`
No tests selected for enabled SKUs 'wh_galaxy'. Failing pipeline.
\`\`\`

**Failing run**: https://github.com/tenstorrent/tt-metal/actions/runs/23562659483/job/68607804540

The time budget gap for \`wh_galaxy_perf\` was fixed separately in #40708.

### What's changed

1. **\`.github/workflows/pipeline-select-galaxy.yaml\`** — Changed \`enabled-skus: wh_galaxy\` → \`wh_galaxy_perf\` in the \`galaxy-model-perf-tests\` job (line 258). The integration and demo jobs on lines 237/248 correctly remain on \`wh_galaxy\`.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/galaxy-perf-pipeline-select-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/galaxy-perf-pipeline-select-sku)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/galaxy-perf-pipeline-select-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/galaxy-perf-pipeline-select-sku)
  - [ ] [Galaxy perf load-test-matrix](https://github.com/tenstorrent/tt-metal/actions/runs/23562659483/job/68607804540)

Made with [Cursor](https://cursor.com)