### PR TITLE
Adding physical grouping descriptor to build multi-mesh physical graph

### DIFF
--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -73,7 +73,7 @@ jobs:
 
           # Topology mapper utils tests with real PSD
           tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/3_pod_16x8_bh_galaxy_cluster_desc_mapping.yaml --rank-binding tests/tt_metal/distributed/config/triple_16x8_quad_bh_galaxy_rank_bindings.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8*"
-          TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_galaxy_xyz_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_*"
+          TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_6u_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_*"
 
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="RoutingTableValidation*"
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*SingleGalaxy*

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -66,12 +66,16 @@ jobs:
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologySolverTest.*"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.*"
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="PhysicalGroupingDescriptorTests*"
-          # PSD tests using mock clusters (CPU-only) - create PSD from mock cluster instead of mock PSD files
-          # Use tt-run with 3 pod 16x8 BH galaxy cluster descriptor mapping
+
+          # PhysicalGroupingDescriptorTests with real PSD
           tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/3_pod_16x8_bh_galaxy_cluster_desc_mapping.yaml --rank-binding tests/tt_metal/distributed/config/triple_16x8_quad_bh_galaxy_rank_bindings.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="PhysicalGroupingDescriptorSP3Tests*"
           tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/dual_t3k_ci_cluster_desc_mapping.yaml --rank-binding tests/tt_metal/distributed/config/dual_t3k_rank_bindings.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="PhysicalGroupingDescriptorDualT3kTests*"
-          TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="RoutingTableValidation*"
 
+          # Topology mapper utils tests with real PSD
+          tt-run --mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/3_pod_16x8_bh_galaxy_cluster_desc_mapping.yaml --rank-binding tests/tt_metal/distributed/config/triple_16x8_quad_bh_galaxy_rank_bindings.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8*"
+          TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/bh_galaxy_xyz_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_*"
+
+          TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="RoutingTableValidation*"
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/6u_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*SingleGalaxy*
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=ControlPlaneFixture.*T3k*
           TT_METAL_MOCK_CLUSTER_DESC_PATH=tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=T3kCustomMeshGraphControlPlaneTests*

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_10stage_4x2_pipeline.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_10stage_4x2_pipeline.textproto
@@ -1,0 +1,76 @@
+# Ten-stage 4×2 (8 ASIC) BH GLX pipeline — same mesh shape as bh_glx_split_4x2 for PGD matching,
+# condensed to 10 FABRIC-linked stages for focused tests.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_11stage_4x2_pipeline.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_11stage_4x2_pipeline.textproto
@@ -1,0 +1,82 @@
+# Eleven-stage 4×2 (8 ASIC) BH GLX pipeline — same mesh shape as bh_glx_split_4x2 for PGD matching,
+# with 11 FABRIC-linked stages (extends bh_glx_10stage_4x2_pipeline by one stage).
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <set>
 #include <iostream>
+#include <sstream>
+#include <cstdlib>
 
 #include <tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
@@ -300,7 +302,7 @@ TEST(PhysicalGroupingDescriptorTests, ParsesValidBasicConfiguration) {
 
 TEST(PhysicalGroupingDescriptorTests, ParsesFromTriple16x8QuadBhGalaxyFile) {
     const std::filesystem::path text_proto_file_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     EXPECT_NO_THROW({ PhysicalGroupingDescriptor desc(text_proto_file_path); });
 }
 
@@ -1057,7 +1059,7 @@ TEST(PhysicalGroupingDescriptorTests, CornerOrientation_RowMajorMesh) {
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_FromTriple16x8File) {
     // Load the triple_16x8 groupings file
     const std::filesystem::path text_proto_file_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     PhysicalGroupingDescriptor desc(text_proto_file_path);
 
     // Get one of the MESH grouping infos - "8x16_Mesh" which has 4 hosts in a 2x2 grid
@@ -1100,7 +1102,7 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_FromTriple16x8
 
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_4x4Mesh) {
     const std::filesystem::path text_proto_file_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     PhysicalGroupingDescriptor desc(text_proto_file_path);
 
     GroupingInfo mesh_4x4;
@@ -1133,7 +1135,7 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_4x4Mesh) {
 
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x8Mesh) {
     const std::filesystem::path text_proto_file_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     PhysicalGroupingDescriptor desc(text_proto_file_path);
 
     GroupingInfo mesh_2x8;
@@ -1166,22 +1168,22 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x8Mesh) {
 
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x2Halftray) {
     const std::filesystem::path text_proto_file_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     PhysicalGroupingDescriptor desc(text_proto_file_path);
 
     GroupingInfo mesh_halftray;
     bool found = false;
     for (const auto& mesh : desc.get_groupings_by_type("MESH")) {
-        if (mesh.name == "2x2_Mesh_Halftray") {
+        if (mesh.name == "2x2 Mesh") {
             mesh_halftray = mesh;
             found = true;
             break;
         }
     }
-    ASSERT_TRUE(found) << "Expected to find '2x2_Mesh_Halftray' grouping";
+    ASSERT_TRUE(found) << "Expected to find 'halftray_2x2' grouping";
 
-    EXPECT_EQ(mesh_halftray.asic_count, 4u) << "2x2_Mesh_Halftray should have 4 ASICs (1 halftray)";
-    EXPECT_EQ(mesh_halftray.items.size(), 1u) << "2x2_Mesh_Halftray should have 1 instance (halftray)";
+    EXPECT_EQ(mesh_halftray.asic_count, 4u) << "halftray_2x2 should have 4 ASICs (1 halftray)";
+    EXPECT_EQ(mesh_halftray.items.size(), 1u) << "2x2 Mesh should have 1 instance (halftray)";
 
     auto flattened_meshes = desc.build_flattened_adjacency_mesh(mesh_halftray);
     ASSERT_FALSE(flattened_meshes.empty());
@@ -1266,7 +1268,7 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_CornerInferenc
 
 TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple8x16PsdWithGalaxyGroupings) {
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
 
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
 
@@ -1363,7 +1365,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple8x16PsdWi
 
 TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple16x8PsdWithTriple16x8QuadGroupings) {
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
 
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
 
@@ -1564,7 +1566,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidateGroupingWithPsd_PodAndSuperpodL
 TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_BlitzPipeline2x4) {
     // Test matching a 2x4 mesh MGD (8 ASICs) to the 2x4_Mesh grouping
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path = "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
 
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
@@ -1632,7 +1634,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_4x4Mesh) {
     // Test matching a 4x4 mesh MGD (16 ASICs) to the 4x4_Mesh grouping
     // Using dual_4x4_mesh_graph_descriptor which has 4x4 meshes in a graph
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path =
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_4x4_mesh_graph_descriptor.textproto";
 
@@ -1688,7 +1690,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_2x8Mesh) {
     // Test matching a 2x8 mesh MGD (16 ASICs) to the 2x8_Mesh grouping
     // Using wh_galaxy_split_2x8_2x4_3_mesh which has a 2x8 mesh (MESH4)
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path =
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_2x8_2x4_3_mesh.textproto";
 
@@ -1743,7 +1745,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_2x8Mesh) {
 TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_8x16Mesh) {
     // Test matching an 8x16 mesh MGD (128 ASICs) to the 8x16_Mesh grouping
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path = "tt_metal/fabric/mesh_graph_descriptors/quad_galaxy_mesh_graph_descriptor.textproto";
 
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
@@ -1789,7 +1791,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_SingleGalaxy4x8
     // Test matching a single galaxy mesh MGD (32 ASICs) to the 4x8_Mesh grouping
     // Using single_bh_galaxy_mesh_graph_descriptor which has 8x4 (32 ASICs, same count but different topology)
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path =
         "tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto";
 
@@ -1836,7 +1838,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_DualGalaxy8x8) 
     // Using dual_galaxy_mesh_graph_descriptor which has 8x8 (64 ASICs) - different from 4x8 but testing dual mesh
     // matching
     const std::string pgd_path =
-        "tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto";
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path = "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
@@ -2002,6 +2004,234 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_Phase3_HigherLa
     ASSERT_EQ(g2_groupings.size(), 1u) << "G2 should have exactly 1 matching grouping";
     EXPECT_EQ(g2_groupings[0].name, "super_pod_4_all_to_all")
         << "G2 has ALL_TO_ALL -> only all_to_all PGD grouping matches (not super_pod_4_mesh)";
+}
+
+TEST(PhysicalGroupingDescriptorTests, GetValidGroupingsForMGD_32x4Quad) {
+    // Load the physical grouping descriptor
+    const std::filesystem::path pgd_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+
+    PhysicalGroupingDescriptor pgd(pgd_file_path);
+
+    // Test with 32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+    const std::filesystem::path mgd_file_path =
+        "tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto";
+
+    MeshGraphDescriptor mgd(mgd_file_path);
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    auto valid_groupings = pgd.get_valid_groupings_for_mgd(mgd, psd);
+
+    // M0 mesh has device_topology [32, 4] = 128 chips
+    // Should match meshes grouping with 4 hosts (4 * 32 = 128 ASICs, exact match)
+    EXPECT_TRUE(valid_groupings.contains("MESH")) << "Should have MESH type in results";
+    EXPECT_TRUE(valid_groupings.at("MESH").contains("M0")) << "Should have M0 mesh instance";
+
+    ASSERT_FALSE(valid_groupings.at("MESH").at("M0").empty()) << "M0 should have at least one matching grouping";
+    const auto& m0_grouping = valid_groupings.at("MESH").at("M0").front();
+    EXPECT_EQ(m0_grouping.name, "meshes") << "M0 should match 'meshes' grouping";
+    EXPECT_EQ(m0_grouping.asic_count, 128u) << "M0 grouping should have 128 ASICs (4 hosts)";
+
+    // Verify it matches the 4 hosts grouping
+    EXPECT_EQ(m0_grouping.items.size(), 4u) << "Should have 4 items (4 hosts)";
+    if (!m0_grouping.items.empty()) {
+        EXPECT_EQ(m0_grouping.items[0].type, GroupingItemInfo::ItemType::GROUPING_REF)
+            << "First item should be a GROUPING_REF";
+        EXPECT_EQ(m0_grouping.items[0].grouping_name, "hosts") << "Should reference 'hosts' grouping";
+    }
+}
+
+TEST(PhysicalGroupingDescriptorTests, GetValidGroupingsForMGD_SingleGalaxy) {
+    // Load the physical grouping descriptor
+    const std::filesystem::path pgd_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+
+    PhysicalGroupingDescriptor pgd(pgd_file_path);
+
+    // Test with bh_glx_split_4x2.textproto
+    const std::filesystem::path mgd_file_path =
+        "tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto";
+
+    MeshGraphDescriptor mgd(mgd_file_path);
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    auto valid_groupings = pgd.get_valid_groupings_for_mgd(mgd, psd);
+
+    // M0 mesh has device_topology [8, 4] = 32 chips
+    // Should match meshes grouping with 1 host (32 ASICs, exact match)
+    EXPECT_TRUE(valid_groupings.contains("MESH")) << "Should have MESH type in results";
+    EXPECT_TRUE(valid_groupings.at("MESH").contains("M0")) << "Should have M0 mesh instance";
+
+    ASSERT_FALSE(valid_groupings.at("MESH").at("M0").empty()) << "M0 should have at least one matching grouping";
+    const auto& m0_grouping = valid_groupings.at("MESH").at("M0").front();
+    EXPECT_EQ(m0_grouping.name, "meshes") << "M0 should match 'meshes' grouping";
+    EXPECT_EQ(m0_grouping.asic_count, 32u) << "M0 grouping should have 32 ASICs (1 host)";
+
+    // Verify it matches the 1 host grouping
+    EXPECT_EQ(m0_grouping.items.size(), 1u) << "Should have 1 item (1 host)";
+    if (!m0_grouping.items.empty()) {
+        EXPECT_EQ(m0_grouping.items[0].type, GroupingItemInfo::ItemType::GROUPING_REF)
+            << "First item should be a GROUPING_REF";
+        EXPECT_EQ(m0_grouping.items[0].grouping_name, "hosts") << "Should reference 'hosts' grouping";
+    }
+}
+
+TEST(PhysicalGroupingDescriptorTests, GetValidGroupingsForMGD_BhGlxSplit4x2) {
+    // Load the physical grouping descriptor
+    const std::filesystem::path pgd_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+
+    PhysicalGroupingDescriptor pgd(pgd_file_path);
+
+    // Test with bh_glx_split_4x2.textproto
+    const std::filesystem::path mgd_file_path = "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
+
+    MeshGraphDescriptor mgd(mgd_file_path);
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    auto valid_groupings = pgd.get_valid_groupings_for_mgd(mgd, psd);
+
+    // M0 mesh has device_topology [4, 2] = 8 chips
+    // Should match meshes grouping with 1 tray (8 ASICs, exact match)
+    // Note: This test has multiple mesh instances (M0 mesh_id 0-47), all with same topology
+    EXPECT_TRUE(valid_groupings.contains("MESH")) << "Should have MESH type in results";
+    EXPECT_TRUE(valid_groupings.at("MESH").contains("M0")) << "Should have M0 mesh instance";
+
+    ASSERT_FALSE(valid_groupings.at("MESH").at("M0").empty()) << "M0 should have at least one matching grouping";
+    const auto& m0_grouping = valid_groupings.at("MESH").at("M0").front();
+    EXPECT_EQ(m0_grouping.name, "meshes") << "M0 should match 'meshes' grouping";
+    EXPECT_EQ(m0_grouping.asic_count, 8u) << "M0 grouping should have 8 ASICs (1 tray, exact match)";
+
+    // Verify it matches the 1 tray grouping exactly (not oversized)
+    EXPECT_EQ(m0_grouping.items.size(), 1u) << "Should have exactly 1 item (1 tray)";
+    EXPECT_TRUE(!m0_grouping.items.empty()) << "Should have at least one item";
+    EXPECT_EQ(m0_grouping.items[0].type, GroupingItemInfo::ItemType::GROUPING_REF)
+        << "First item should be a GROUPING_REF";
+    EXPECT_EQ(m0_grouping.items[0].grouping_name, "trays") << "Should reference 'trays' grouping";
+
+    // Verify all items reference trays (should be exactly 1 tray reference)
+    uint32_t tray_ref_count = 0;
+    for (const auto& item : m0_grouping.items) {
+        if (item.type == GroupingItemInfo::ItemType::GROUPING_REF && item.grouping_name == "trays") {
+            tray_ref_count++;
+        }
+    }
+    EXPECT_EQ(tray_ref_count, 1u) << "Should reference exactly 1 tray";
+}
+
+TEST(PhysicalGroupingDescriptorTests, GetValidGroupingsForMGD_Dual4x4) {
+    // Load the physical grouping descriptor
+    const std::filesystem::path pgd_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+
+    PhysicalGroupingDescriptor pgd(pgd_file_path);
+
+    // Test with dual_4x4_mesh_graph_descriptor.textproto
+    // This is a dual mesh configuration with two 4x4 WORMHOLE_B0 meshes, each with host_topology [1, 1] (1 host)
+    const std::filesystem::path mgd_file_path =
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_4x4_mesh_graph_descriptor.textproto";
+
+    MeshGraphDescriptor mgd(mgd_file_path);
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    auto valid_groupings = pgd.get_valid_groupings_for_mgd(mgd, psd);
+
+    // M0 mesh has device_topology [4, 4] = 16 chips
+    // Should match meshes grouping with 2 trays (2 * 8 = 16 ASICs, exact match)
+    // Note: This test has 2 mesh instances (M0 mesh_id 0 and 1), both with same topology
+    EXPECT_TRUE(valid_groupings.contains("MESH")) << "Should have MESH type in results";
+    EXPECT_TRUE(valid_groupings.at("MESH").contains("M0")) << "Should have M0 mesh instance";
+
+    ASSERT_FALSE(valid_groupings.at("MESH").at("M0").empty()) << "M0 should have at least one matching grouping";
+    const auto& m0_grouping = valid_groupings.at("MESH").at("M0").front();
+    EXPECT_EQ(m0_grouping.name, "meshes") << "M0 should match 'meshes' grouping";
+    EXPECT_EQ(m0_grouping.asic_count, 16u) << "M0 grouping should have 16 ASICs (2 trays, exact match)";
+
+    // Verify it matches the 2 trays grouping exactly (not oversized)
+    EXPECT_EQ(m0_grouping.items.size(), 2u) << "Should have exactly 2 items (2 trays)";
+    EXPECT_TRUE(!m0_grouping.items.empty()) << "Should have at least one item";
+    EXPECT_EQ(m0_grouping.items[0].type, GroupingItemInfo::ItemType::GROUPING_REF)
+        << "First item should be a GROUPING_REF";
+    EXPECT_EQ(m0_grouping.items[0].grouping_name, "trays") << "Should reference 'trays' grouping";
+
+    // Verify all items reference trays (should be exactly 2 tray references)
+    uint32_t tray_ref_count = 0;
+    for (const auto& item : m0_grouping.items) {
+        if (item.type == GroupingItemInfo::ItemType::GROUPING_REF && item.grouping_name == "trays") {
+            tray_ref_count++;
+        }
+    }
+    EXPECT_EQ(tray_ref_count, 2u) << "Should reference exactly 2 trays";
+}
+
+TEST(PhysicalGroupingDescriptorTests, GetValidGroupingsForMGD_Dual8x2) {
+    // Load the physical grouping descriptor
+    const std::filesystem::path pgd_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+
+    PhysicalGroupingDescriptor pgd(pgd_file_path);
+
+    // Test with dual_8x2_mesh_graph_descriptor.textproto
+    // This is a dual mesh configuration with two 8x2 WORMHOLE_B0 meshes, each with host_topology [1, 1] (1 host)
+    const std::filesystem::path mgd_file_path =
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_8x2_mesh_graph_descriptor.textproto";
+
+    MeshGraphDescriptor mgd(mgd_file_path);
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    auto valid_groupings = pgd.get_valid_groupings_for_mgd(mgd, psd);
+
+    // M0 mesh has device_topology [8, 2] = 16 chips
+    // Should match meshes grouping with 2 trays (2 * 8 = 16 ASICs, exact match)
+    // Note: This test has 2 mesh instances (M0 mesh_id 0 and 1), both with same topology
+    EXPECT_TRUE(valid_groupings.contains("MESH")) << "Should have MESH type in results";
+    EXPECT_TRUE(valid_groupings.at("MESH").contains("M0")) << "Should have M0 mesh instance";
+
+    ASSERT_FALSE(valid_groupings.at("MESH").at("M0").empty()) << "M0 should have at least one matching grouping";
+    const auto& m0_grouping = valid_groupings.at("MESH").at("M0").front();
+    EXPECT_EQ(m0_grouping.name, "meshes") << "M0 should match 'meshes' grouping";
+    EXPECT_EQ(m0_grouping.asic_count, 16u) << "M0 grouping should have 16 ASICs (2 trays, exact match)";
+
+    // Verify it matches the 2 trays grouping exactly (not oversized)
+    EXPECT_EQ(m0_grouping.items.size(), 2u) << "Should have exactly 2 items (2 trays)";
+    EXPECT_TRUE(!m0_grouping.items.empty()) << "Should have at least one item";
+    EXPECT_EQ(m0_grouping.items[0].type, GroupingItemInfo::ItemType::GROUPING_REF)
+        << "First item should be a GROUPING_REF";
+    EXPECT_EQ(m0_grouping.items[0].grouping_name, "trays") << "Should reference 'trays' grouping";
+
+    // Verify all items reference trays (should be exactly 2 tray references)
+    uint32_t tray_ref_count = 0;
+    for (const auto& item : m0_grouping.items) {
+        if (item.type == GroupingItemInfo::ItemType::GROUPING_REF && item.grouping_name == "trays") {
+            tray_ref_count++;
+        }
+    }
+    EXPECT_EQ(tray_ref_count, 2u) << "Should reference exactly 2 trays";
 }
 
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -1180,9 +1180,9 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x2Halftray) {
             break;
         }
     }
-    ASSERT_TRUE(found) << "Expected to find 'halftray_2x2' grouping";
+    ASSERT_TRUE(found) << "Expected to find '2x2 Mesh' grouping";
 
-    EXPECT_EQ(mesh_halftray.asic_count, 4u) << "halftray_2x2 should have 4 ASICs (1 halftray)";
+    EXPECT_EQ(mesh_halftray.asic_count, 4u) << "2x2 Mesh should have 4 ASICs (1 halftray)";
     EXPECT_EQ(mesh_halftray.items.size(), 1u) << "2x2 Mesh should have 1 instance (halftray)";
 
     auto flattened_meshes = desc.build_flattened_adjacency_mesh(mesh_halftray);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -1199,6 +1199,45 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x2Halftray) {
     }
 }
 
+// Two HALFTRAY instances in row_major_mesh [2,1] produce non-contiguous node IDs when joined; items must be
+// indexed by node_id (rebuild_items_from_flattened_mesh), not push_back order.
+TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_4x2Mesh_TwoHalftray_ItemsPerGraphNode) {
+    const std::filesystem::path text_proto_file_path =
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    PhysicalGroupingDescriptor desc(text_proto_file_path);
+
+    GroupingInfo mesh_4x2;
+    bool found = false;
+    for (const auto& mesh : desc.get_groupings_by_type("MESH")) {
+        if (mesh.name == "4x2_Mesh") {
+            mesh_4x2 = mesh;
+            found = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(found) << "Expected to find '4x2_Mesh' grouping";
+
+    EXPECT_EQ(mesh_4x2.asic_count, 8u) << "4x2_Mesh: 2 halftrays x 4 ASICs";
+    EXPECT_EQ(mesh_4x2.items.size(), 2u) << "4x2_Mesh should have 2 instance refs before flatten";
+
+    auto flattened_meshes = desc.build_flattened_adjacency_mesh(mesh_4x2);
+    ASSERT_FALSE(flattened_meshes.empty());
+    const GroupingInfo& flat = flattened_meshes.front();
+    const auto& flattened_mesh = flat.adjacency_graph;
+
+    auto nodes = flattened_mesh.get_nodes();
+    EXPECT_EQ(nodes.size(), 8u) << "Flattened mesh should have 8 nodes";
+
+    for (uint32_t node_id : nodes) {
+        ASSERT_LT(node_id, flat.items.size())
+            << "items must be sized so items[node_id] exists for every graph node (node_id=" << node_id
+            << ", items.size()=" << flat.items.size() << ")";
+        const auto& item = flat.items[node_id];
+        EXPECT_EQ(item.type, GroupingItemInfo::ItemType::ASIC_LOCATION)
+            << "node_id " << node_id << " should have ASIC_LOCATION metadata from flattened mesh";
+    }
+}
+
 // Corner-inferred dims: dims inferred from items' corners, not stored in GroupingInfo
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_CornerInference) {
     const std::string text_proto = wrap_with_required_groupings(R"proto(
@@ -1281,7 +1320,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple8x16PsdWi
     ASSERT_FALSE(all_mesh_groupings.empty()) << "No MESH groupings found in PGD";
 
     // Find specific mesh groupings by name or by dimensions (name can have WH/BH suffix)
-    // Prefer exact match first so "2x4_Mesh" matches the single-tray grouping, not "2x4_Mesh_2tray"
+    // Prefer exact match first so "4x2_Mesh" matches the two-halftray grouping, not a longer prefix
     auto find_mesh_by_name = [&all_mesh_groupings](const std::string& name) -> const GroupingInfo* {
         for (const auto& mesh : all_mesh_groupings) {
             if (mesh.name == name) {
@@ -1307,15 +1346,15 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple8x16PsdWi
             << "Expected validation result: 8x16_Mesh grouping validation against mock cluster PSD";
     }
 
-    // Test 2x4_Mesh - validation against mock cluster
+    // Test 4x2_Mesh (two HALFTRAY instances, row_major_mesh [2,1]) - validation against mock cluster
     {
-        const auto* mesh_grouping = find_mesh_by_name("2x4_Mesh");
-        ASSERT_NE(mesh_grouping, nullptr) << "2x4_Mesh grouping not found";
+        const auto* mesh_grouping = find_mesh_by_name("4x2_Mesh");
+        ASSERT_NE(mesh_grouping, nullptr) << "4x2_Mesh grouping not found";
 
         auto asic_ids = pgd.find_any_in_psd(*mesh_grouping, psd);
 
         EXPECT_FALSE(asic_ids.empty())
-            << "Expected validation to pass: 2x4_Mesh grouping should map to mock cluster PSD";
+            << "Expected validation to pass: 4x2_Mesh grouping should map to mock cluster PSD";
     }
 
     // Test 4x4_Mesh - validation against mock cluster
@@ -1503,14 +1542,14 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidatePreformedGroups_Triple16x8PsdWi
     }
 
     {
-        auto mesh_groupings = pgd.get_groupings_by_name("2x4_Mesh");
-        ASSERT_FALSE(mesh_groupings.empty()) << "2x4_Mesh grouping not found";
+        auto mesh_groupings = pgd.get_groupings_by_name("4x2_Mesh");
+        ASSERT_FALSE(mesh_groupings.empty()) << "4x2_Mesh grouping not found";
 
         auto asic_ids = pgd.find_all_in_psd(mesh_groupings, psd);
 
-        // Expect 48 groups
+        // Expect 48 groups (same tiling count as former 2x4_Mesh: 8-ASIC two-halftray mesh)
         EXPECT_EQ(asic_ids.size(), 48u)
-            << "Expected validation to pass: 2x4_Mesh grouping should map to mock cluster PSD";
+            << "Expected validation to pass: 4x2_Mesh grouping should map to mock cluster PSD";
     }
 
     {
@@ -1564,7 +1603,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, ValidateGroupingWithPsd_PodAndSuperpodL
 // ============================================================================
 
 TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_BlitzPipeline2x4) {
-    // Test matching a 2x4 mesh MGD (8 ASICs) to the 2x4_Mesh grouping
+    // Test matching a 4x2 mesh MGD (8 ASICs) to the 4x2_Mesh grouping in bh_galaxy PGD
     const std::string pgd_path =
         "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     const std::string mgd_path = "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
@@ -1604,14 +1643,14 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_BlitzPipeline2x
     ASSERT_EQ(valid_groupings.count("MESH"), 1u) << "Should have MESH instance type";
     ASSERT_EQ(valid_groupings.at("MESH").size(), 1u) << "Should have exactly one MESH instance";
 
-    // Check that we have a match for the 2x4_Mesh grouping (8 ASICs)
+    // Check that we have a match for the 4x2_Mesh grouping (8 ASICs)
     // Flattened groupings have "_flat" appended to their name
     bool found_mesh_match = false;
     for (const auto& [instance_name, groupings] : valid_groupings.at("MESH")) {
         for (const auto& grouping : groupings) {
-            if (grouping.asic_count == 8u && grouping.name == "2x4_Mesh_flat") {
+            if (grouping.asic_count == 8u && grouping.name == "4x2_Mesh_flat") {
                 found_mesh_match = true;
-                EXPECT_EQ(grouping.name, "2x4_Mesh_flat") << "Should match 2x4_Mesh_flat grouping";
+                EXPECT_EQ(grouping.name, "4x2_Mesh_flat") << "Should match 4x2_Mesh_flat grouping";
                 EXPECT_EQ(grouping.asic_count, 8u) << "Should have 8 ASICs";
                 break;
             }
@@ -1620,7 +1659,7 @@ TEST(PhysicalGroupingDescriptorSP3Tests, GetValidGroupingsForMGD_BlitzPipeline2x
             break;
         }
     }
-    EXPECT_TRUE(found_mesh_match) << "Should find a match for 2x4 mesh (8 ASICs) matching 2x4_Mesh_flat grouping";
+    EXPECT_TRUE(found_mesh_match) << "Should find a match for 4x2 mesh (8 ASICs) matching 4x2_Mesh_flat grouping";
 
     // Check that we have FABRIC level grouping (G0)
     ASSERT_EQ(valid_groupings.count("FABRIC"), 1u) << "Should have FABRIC instance type";

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -1167,23 +1167,29 @@ TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x8Mesh) {
 }
 
 TEST(PhysicalGroupingDescriptorTests, BuildFlattenedAdjacencyMesh_2x2Halftray) {
+    // PGD names this MESH grouping "2x2 Mesh" (one halftray_2x2 HALFTRAY ref, 4 ASICs); see
+    // bh_galaxy_physical_grouping_descriptor.textproto.
     const std::filesystem::path text_proto_file_path =
         "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
     PhysicalGroupingDescriptor desc(text_proto_file_path);
 
+    constexpr const char* kMeshGroupingName = "2x2 Mesh";
+
     GroupingInfo mesh_halftray;
     bool found = false;
     for (const auto& mesh : desc.get_groupings_by_type("MESH")) {
-        if (mesh.name == "2x2 Mesh") {
+        if (mesh.name == kMeshGroupingName) {
             mesh_halftray = mesh;
             found = true;
             break;
         }
     }
-    ASSERT_TRUE(found) << "Expected to find '2x2 Mesh' grouping";
+    ASSERT_TRUE(found) << "Expected MESH grouping named \"" << kMeshGroupingName << "\" in " << text_proto_file_path;
 
-    EXPECT_EQ(mesh_halftray.asic_count, 4u) << "2x2 Mesh should have 4 ASICs (1 halftray)";
-    EXPECT_EQ(mesh_halftray.items.size(), 1u) << "2x2 Mesh should have 1 instance (halftray)";
+    EXPECT_EQ(mesh_halftray.asic_count, 4u)
+        << "MESH grouping \"" << kMeshGroupingName << "\" should have 4 ASICs (1 halftray_2x2 instance)";
+    EXPECT_EQ(mesh_halftray.items.size(), 1u)
+        << "MESH grouping \"" << kMeshGroupingName << "\" should have 1 instance (one halftray ref)";
 
     auto flattened_meshes = desc.build_flattened_adjacency_mesh(mesh_halftray);
     ASSERT_FALSE(flattened_meshes.empty());

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -3855,7 +3855,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 12u);
 
-    // Each oft he mesh level graphs should have connections to other nodes
+    // Each of the mesh level graphs should have connections to other nodes
     for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
         EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
     }
@@ -3920,7 +3920,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 3u);
 
-    // Each oft he mesh level graphs should have connections to other nodes
+    // Each of the mesh level graphs should have connections to other nodes
     for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
         EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
     }
@@ -3982,7 +3982,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48u);
 
-    // Each oft he mesh level graphs should have connections to other nodes
+    // Each of the mesh level graphs should have connections to other nodes
     for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
         EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
     }
@@ -4042,7 +4042,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // Should have 2 meshes
+    // MGD has 2 logical meshes; this PGD+PSD yields 24 physical mesh graphs (one adjacency graph per physical mesh).
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 24u);
 
     // Each of the mesh level graphs should have connections to other nodes
@@ -4105,7 +4105,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // Should have 2 meshes
+    // MGD has 2 logical meshes; this PGD+PSD yields 24 physical mesh graphs (one adjacency graph per physical mesh).
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 24u);
 
     // Each of the mesh level graphs should have connections to other nodes
@@ -4227,6 +4227,8 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Single
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
     // Single BH galaxy: 1 mesh (full 32-ASIC 8x4 torus)
+    // The MGD describes a single logical 1x16 mesh (one BH galaxy), but on this BH system it
+    // is realized as 2 physical meshes (each 1x16, totaling 32 ASICs), so we expect 2 graphs.
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 2u);
 
     // Check that the graph has exit nodes (single-host may have 0 exit nodes)

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -33,7 +33,7 @@ namespace tt::tt_metal::experimental::tt_fabric {
 namespace {
 
 // BH Galaxy half-pod pairing: all ASICs in a mesh subgraph must sit on trays 1&3 only, or trays 2&4 only.
-static std::string format_uint_set(const std::set<uint32_t>& values) {
+std::string format_uint_set(const std::set<uint32_t>& values) {
     std::string out;
     for (uint32_t v : values) {
         if (!out.empty()) {
@@ -44,7 +44,7 @@ static std::string format_uint_set(const std::set<uint32_t>& values) {
     return out;
 }
 
-static void expect_bh_halfpod_tray_pairing_for_graph_nodes(
+void expect_bh_halfpod_tray_pairing_for_graph_nodes(
     const std::string& context,
     const tt::tt_metal::PhysicalSystemDescriptor& psd,
     const AdjacencyGraph<tt::tt_metal::AsicID>& adjacency_graph) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -4076,7 +4076,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // THere should be 12 indvidual meshes connected, verify that this is the case
+    // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 12u);
 
     // Each oft he mesh level graphs should have connections to other nodes
@@ -4141,7 +4141,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // THere should be 12 indvidual meshes connected, verify that this is the case
+    // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 3u);
 
     // Each oft he mesh level graphs should have connections to other nodes
@@ -4203,7 +4203,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // THere should be 12 indvidual meshes connected, verify that this is the case
+    // Verify the expected number of individual meshes
     EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48u);
 
     // Each oft he mesh level graphs should have connections to other nodes

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <random>
 #include <unordered_set>
+#include <string>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
@@ -30,6 +31,39 @@
 
 namespace tt::tt_metal::experimental::tt_fabric {
 namespace {
+
+// BH Galaxy half-pod pairing: all ASICs in a mesh subgraph must sit on trays 1&3 only, or trays 2&4 only.
+static std::string format_uint_set(const std::set<uint32_t>& values) {
+    std::string out;
+    for (uint32_t v : values) {
+        if (!out.empty()) {
+            out += ',';
+        }
+        out += std::to_string(v);
+    }
+    return out;
+}
+
+static void expect_bh_halfpod_tray_pairing_for_graph_nodes(
+    const std::string& context,
+    const tt::tt_metal::PhysicalSystemDescriptor& psd,
+    const AdjacencyGraph<tt::tt_metal::AsicID>& adjacency_graph) {
+    std::set<uint32_t> trays;
+    std::vector<tt::tt_metal::AsicID> sorted_nodes(
+        adjacency_graph.get_nodes().begin(), adjacency_graph.get_nodes().end());
+    std::sort(sorted_nodes.begin(), sorted_nodes.end(), [](const auto& a, const auto& b) { return *a < *b; });
+    for (const auto& node : sorted_nodes) {
+        const uint32_t tray = *psd.get_tray_id(node);
+        trays.insert(tray);
+        EXPECT_GE(tray, 1u) << context << " asic_id=" << *node;
+        EXPECT_LE(tray, 4u) << context << " asic_id=" << *node;
+    }
+    const bool only_13 = std::all_of(trays.begin(), trays.end(), [](uint32_t t) { return t == 1u || t == 3u; });
+    const bool only_24 = std::all_of(trays.begin(), trays.end(), [](uint32_t t) { return t == 2u || t == 4u; });
+    EXPECT_TRUE(only_13 || only_24)
+        << context << " — BH Galaxy nodes must use only tray pair {1,3} or only {2,4}; distinct trays=["
+        << format_uint_set(trays) << "]";
+}
 
 // =============================================================================
 // Test Fixture with Helper Methods
@@ -3998,6 +4032,9 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
         // Check that there should be 32 nodes in the graph
         EXPECT_EQ(adjacency_graph.get_nodes().size(), 8u);
 
+        expect_bh_halfpod_tray_pairing_for_graph_nodes(
+            std::string("[ThreePod16x8_Blitz2x4] mesh_id=") + std::to_string(*mesh_id), psd, adjacency_graph);
+
         // Check that each node should have 2 - 3 neighbors
         for (const auto& node : adjacency_graph.get_nodes()) {
             EXPECT_GE(
@@ -4386,6 +4423,9 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Single
     for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
         // Check that there should be 8 nodes in the graph (2x4)
         EXPECT_EQ(adjacency_graph.get_nodes().size(), 8u);
+
+        expect_bh_halfpod_tray_pairing_for_graph_nodes(
+            std::string("[SingleBHGalaxy_2x4Pipeline] mesh_id=") + std::to_string(*mesh_id), psd, adjacency_graph);
 
         // Check that each node should have neighbors (1D topology, so 1-2 neighbors)
         for (const auto& node : adjacency_graph.get_nodes()) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -10,7 +10,6 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <initializer_list>
 #include <map>
 #include <set>
@@ -18,8 +17,6 @@
 #include <cstdint>
 #include <random>
 #include <unordered_set>
-#include <string_view>
-#include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
@@ -59,99 +56,6 @@ protected:
         for (MeshId m : meshes) {
             config.mesh_validation_modes[m] = ::tt::tt_fabric::ConnectionValidationMode::STRICT;
         }
-    }
-
-    // Debug dumps for mesh-level exit / cardinality tests (stderr — always visible; no gtest failure).
-    // map_multi_mesh_to_physical also emits Fabric log_critical lines for each mesh-level exit cardinality constraint
-    // (min_count, fabric nodes, exit ASICs) from topology_mapper_utils.cpp.
-    static void dump_logical_multi_mesh_debug(std::string_view tag, const LogicalMultiMeshGraph& g) {
-        using namespace ::tt::tt_fabric;
-        std::cerr << "\n========== DEBUG: " << tag << " — LogicalMultiMeshGraph ==========\n";
-        std::cerr << "Mesh-level adjacency (repeated neighbor id = channel multiplicity):\n";
-        for (const auto& mid : g.mesh_level_graph_.get_nodes()) {
-            std::cerr << "  mesh " << mid.get() << " -> [";
-            const auto& nb = g.mesh_level_graph_.get_neighbors(mid);
-            for (size_t i = 0; i < nb.size(); ++i) {
-                if (i) {
-                    std::cerr << ", ";
-                }
-                std::cerr << nb[i].get();
-            }
-            std::cerr << "]\n";
-        }
-        std::cerr << "Per-mesh fabric node adjacency (intra-mesh):\n";
-        for (const auto& [mid, adj_g] : g.mesh_adjacency_graphs_) {
-            std::cerr << "  mesh " << mid.get() << ":\n";
-            for (const auto& n : adj_g.get_nodes()) {
-                std::cerr << "    " << n << " -> ";
-                const auto& nb = adj_g.get_neighbors(n);
-                for (size_t i = 0; i < nb.size(); ++i) {
-                    if (i) {
-                        std::cerr << ", ";
-                    }
-                    std::cerr << nb[i];
-                }
-                std::cerr << "\n";
-            }
-        }
-        std::cerr << "Logical exit-node graphs (parallel edges = logical inter-mesh channel count):\n";
-        for (const auto& [mid, exg] : g.mesh_exit_node_graphs_) {
-            std::cerr << "  mesh " << mid.get() << ":\n";
-            for (const auto& src : exg.get_nodes()) {
-                const auto& nb = exg.get_neighbors(src);
-                std::cerr << "    " << fmt::format("{}", src) << " -> " << nb.size() << " edge(s):";
-                for (const auto& d : nb) {
-                    std::cerr << " " << fmt::format("{}", d);
-                }
-                std::cerr << "\n";
-            }
-        }
-        std::cerr << "================================================================\n\n";
-    }
-
-    static void dump_physical_multi_mesh_debug(std::string_view tag, const PhysicalMultiMeshGraph& g) {
-        using namespace ::tt::tt_fabric;
-        std::cerr << "\n========== DEBUG: " << tag << " — PhysicalMultiMeshGraph ==========\n";
-        std::cerr << "Mesh-level adjacency:\n";
-        for (const auto& mid : g.mesh_level_graph_.get_nodes()) {
-            std::cerr << "  mesh " << mid.get() << " -> [";
-            const auto& nb = g.mesh_level_graph_.get_neighbors(mid);
-            for (size_t i = 0; i < nb.size(); ++i) {
-                if (i) {
-                    std::cerr << ", ";
-                }
-                std::cerr << nb[i].get();
-            }
-            std::cerr << "]\n";
-        }
-        std::cerr << "Per-mesh ASIC adjacency (intra-mesh):\n";
-        for (const auto& [mid, adj_g] : g.mesh_adjacency_graphs_) {
-            std::cerr << "  mesh " << mid.get() << ":\n";
-            for (const auto& a : adj_g.get_nodes()) {
-                std::cerr << "    " << a << " -> ";
-                const auto& nb = adj_g.get_neighbors(a);
-                for (size_t i = 0; i < nb.size(); ++i) {
-                    if (i) {
-                        std::cerr << ", ";
-                    }
-                    std::cerr << nb[i];
-                }
-                std::cerr << "\n";
-            }
-        }
-        std::cerr << "Physical exit-node graphs (parallel edges = physical inter-mesh links per exit ASIC):\n";
-        for (const auto& [mid, exg] : g.mesh_exit_node_graphs_) {
-            std::cerr << "  mesh " << mid.get() << ":\n";
-            for (const auto& src : exg.get_nodes()) {
-                const auto& nb = exg.get_neighbors(src);
-                std::cerr << "    " << fmt::format("{}", src) << " -> " << nb.size() << " edge(s):";
-                for (const auto& d : nb) {
-                    std::cerr << " " << fmt::format("{}", d);
-                }
-                std::cerr << "\n";
-            }
-        }
-        std::cerr << "================================================================\n\n";
     }
 
     // -------------------------------------------------------------------------
@@ -1616,15 +1520,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_MeshLevelExitMultiplicity
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds", logical);
-    dump_physical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds", physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     ASSERT_TRUE(result.success) << result.error_message;
     verify_bidirectional_consistency(result);
@@ -1696,19 +1592,7 @@ TEST_F(
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_MeshLevelExitEightLogicalChannelsTwoPhysicalLinksPerExitAsic_RelaxedCapsCardinality_"
-        "Succeeds",
-        logical);
-    dump_physical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_MeshLevelExitEightLogicalChannelsTwoPhysicalLinksPerExitAsic_RelaxedCapsCardinality_"
-        "Succeeds",
-        physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     ASSERT_TRUE(result.success) << result.error_message;
     verify_bidirectional_consistency(result);
@@ -1740,15 +1624,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMu
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityMatchesNodes_Succeeds", logical);
-    dump_physical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityMatchesNodes_Succeeds", physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     ASSERT_TRUE(result.success) << result.error_message;
     verify_bidirectional_consistency(result);
@@ -1769,13 +1645,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMu
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug("MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityOne_Succeeds", logical);
-    dump_physical_multi_mesh_debug("MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityOne_Succeeds", physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     ASSERT_TRUE(result.success) << result.error_message;
     verify_bidirectional_consistency(result);
@@ -1835,15 +1705,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FabricExitEdgeMultiplicit
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityExceedsPhysicalExitAsics_Fails", logical);
-    dump_physical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityExceedsPhysicalExitAsics_Fails", physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     EXPECT_FALSE(result.success)
         << "Three parallel fabric-level exit edges to one neighbor require more than two physical exit ASICs";
@@ -1900,15 +1762,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FabricExitEdgeMultiplicit
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
-    dump_logical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityWithinPhysicalCap_Succeeds", logical);
-    dump_physical_multi_mesh_debug(
-        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityWithinPhysicalCap_Succeeds", physical);
-
     const auto result = map_multi_mesh_to_physical(logical, physical, config);
-
-    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
-              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
 
     ASSERT_TRUE(result.success) << result.error_message;
     verify_bidirectional_consistency(result);
@@ -2489,28 +2343,6 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ImpossibleIntraMeshConstr
 
     TopologyMappingResult result =
         map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
-
-    // Debug: Print the mapping results
-    std::cout << "\n=== Mapping Results ===" << std::endl;
-    std::cout << "Success: " << (result.success ? "true" : "false") << std::endl;
-    std::cout << "Error message: " << result.error_message << std::endl;
-    std::cout << "Number of mapped nodes: " << result.fabric_node_to_asic.size() << std::endl;
-    std::cout << "\n=== Mappings ===" << std::endl;
-
-    // Group mappings by logical mesh
-    std::map<MeshId, std::vector<std::pair<FabricNodeId, tt::tt_metal::AsicID>>> mappings_by_mesh;
-    for (const auto& [logical_node, asic] : result.fabric_node_to_asic) {
-        mappings_by_mesh[logical_node.mesh_id].emplace_back(logical_node, asic);
-    }
-
-    for (const auto& [mesh_id, mappings] : mappings_by_mesh) {
-        std::cout << "\nLogical Mesh " << mesh_id.get() << " -> Physical Mesh mappings:" << std::endl;
-        for (const auto& [logical_node, asic] : mappings) {
-            std::cout << "  Logical node (mesh=" << logical_node.mesh_id.get() << ", chip=" << logical_node.chip_id
-                      << ") -> ASIC " << asic.get() << std::endl;
-        }
-    }
-    std::cout << "======================\n" << std::endl;
 
     EXPECT_FALSE(result.success) << "Multi-mesh mapping should fail due to impossible intra-mesh constraints "
                                     "(2x2 logical grid cannot map to 3x3 physical grid)";
@@ -3890,46 +3722,6 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_TwoHostsTwoAsicsEach_Rota
     }
 }
 
-// Dumps mapping inputs to stderr when MapMultiMeshToPhysical_PartialRankBinding_* fails (exception or result.success).
-void PrintPartialRankBindingOneHostUnsetContext(
-    const ::tt::tt_fabric::MeshId& mesh_id,
-    const std::map<::tt::tt_fabric::MeshId, std::map<tt::tt_metal::AsicID, ::tt::tt_fabric::MeshHostRankId>>&
-        asic_id_to_mesh_rank,
-    const std::map<::tt::tt_fabric::MeshId, std::map<::tt::tt_fabric::FabricNodeId, ::tt::tt_fabric::MeshHostRankId>>&
-        fabric_node_id_to_mesh_rank,
-    const TopologyMappingConfig& config,
-    const char* exception_what,
-    const std::string& result_error_message) {
-    std::cerr << "\n=== MapMultiMeshToPhysical_PartialRankBinding_OneHostExplicitOthersUnset (failure context) ===\n";
-    if (exception_what != nullptr && exception_what[0] != '\0') {
-        std::cerr << "exception: " << exception_what << "\n";
-    }
-    if (!result_error_message.empty()) {
-        std::cerr << "result.error_message: " << result_error_message << "\n";
-    }
-    std::cerr << "strict_mode=" << config.strict_mode << " disable_rank_bindings=" << config.disable_rank_bindings
-              << "\n";
-    std::cerr << "hostname_to_asics:\n";
-    for (const auto& [host, asics] : config.hostname_to_asics) {
-        std::cerr << "  " << host << ":";
-        for (const auto& a : asics) {
-            std::cerr << " " << a.get();
-        }
-        std::cerr << "\n";
-    }
-    std::cerr << "fabric_node -> mesh rank (mesh " << mesh_id.get() << "):\n";
-    for (const auto& [fn, r] : fabric_node_id_to_mesh_rank.at(mesh_id)) {
-        std::cerr << "  " << fn << " -> " << r.get() << (r == ::tt::tt_fabric::MESH_HOST_RANK_UNSET ? " (UNSET)" : "")
-                  << "\n";
-    }
-    std::cerr << "asic -> mesh rank (mesh " << mesh_id.get() << "):\n";
-    for (const auto& [asic, r] : asic_id_to_mesh_rank.at(mesh_id)) {
-        std::cerr << "  asic " << asic.get() << " -> " << r.get()
-                  << (r == ::tt::tt_fabric::MESH_HOST_RANK_UNSET ? " (UNSET)" : "") << "\n";
-    }
-    std::cerr << "================================================================================\n" << std::flush;
-}
-
 TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_PartialRankBinding_OneHostExplicitOthersUnset_Succeeds) {
     using namespace ::tt::tt_fabric;
 
@@ -3983,24 +3775,8 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_PartialRankBinding_OneHos
     config.hostname_to_asics["host_0"] = {physical_asics[0], physical_asics[1]};
     config.hostname_to_asics["host_1"] = {physical_asics[2], physical_asics[3]};
 
-    TopologyMappingResult result;
-    try {
-        result = map_multi_mesh_to_physical(
-            logical_multi_mesh_graph,
-            physical_multi_mesh_graph,
-            config,
-            asic_id_to_mesh_rank,
-            fabric_node_id_to_mesh_rank);
-    } catch (const std::exception& e) {
-        PrintPartialRankBindingOneHostUnsetContext(
-            mesh_id, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank, config, e.what(), "");
-        throw;
-    }
-
-    if (!result.success) {
-        PrintPartialRankBindingOneHostUnsetContext(
-            mesh_id, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank, config, nullptr, result.error_message);
-    }
+    const auto result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
 
     ASSERT_TRUE(result.success)
         << "Partial rank binding (one host explicit, others UNSET) should succeed with UNSET pooling: "
@@ -4627,10 +4403,7 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Single
     config.strict_mode = true;
     config.disable_rank_bindings = true;
 
-    const auto topology_mapping_result =
-        map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
-
-    log_info(tt::LogFabric, "Topology mapping result: {}", topology_mapping_result.success);
-    log_info(tt::LogFabric, "Topology mapping error message: {}", topology_mapping_result.error_message);
+    const auto mapping_result = map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
+    ASSERT_TRUE(mapping_result.success) << mapping_result.error_message;
 }
 }  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -3980,9 +3980,73 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     }
 }
 
+// Single 16×4 (LINE×LINE) mesh — PGD/PSD physical multi-mesh build must include a 64-ASIC partition spanning at
+// most two SP4 hosts (32 ASICs per BH Galaxy host).
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_2GalMaxTwoHosts) {
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+    if (psd.get_asic_descriptors().size() < 64) {
+        GTEST_SKIP() << "Merged SP4 PSD required (>=64 ASICs for 16×4). Run tt-run with sp4_glx_cluster_desc_mapping "
+                        "and SP4 rank bindings.";
+    }
+
+    static constexpr const char k16x4LineLineMgdTextProto[] = R"mgd(
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 16, 4 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 2, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+)mgd";
+
+    const std::filesystem::path pgd_path = std::filesystem::path(tt_metal_home) /
+                                           "tests/tt_metal/tt_fabric/physical_groupings/"
+                                           "bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    MeshGraphDescriptor mgd{std::string(k16x4LineLineMgdTextProto)};
+
+    const auto physical = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    ASSERT_FALSE(physical.mesh_adjacency_graphs_.empty())
+        << "Expected non-empty physical multi-mesh graph (16×4 MGD + bh_galaxy PGD + SP4 PSD)";
+
+    size_t meshes_with_64_asics = 0;
+    for (const auto& [mesh_id, adjacency_graph] : physical.mesh_adjacency_graphs_) {
+        (void)mesh_id;
+        const size_t n = adjacency_graph.get_nodes().size();
+        if (n != 64u) {
+            continue;
+        }
+        meshes_with_64_asics++;
+
+        std::set<std::string> hosts;
+        for (const auto& asic_id : adjacency_graph.get_nodes()) {
+            hosts.insert(psd.get_host_name_for_asic(asic_id));
+        }
+        EXPECT_LE(hosts.size(), 2u) << "64-ASIC physical mesh should cover at most 2 SP4 hosts";
+        EXPECT_EQ(hosts.size(), 2u) << "BH Galaxy SP4: 64 ASICs should use exactly 2 hosts (32 ASICs each)";
+    }
+
+    EXPECT_GE(meshes_with_64_asics, 1u) << "16×4 MGD should yield at least one 64-ASIC physical mesh partition";
+}
+
 TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Blitz2x4) {
-    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
-    // Uses triple_pod_16x8 MGD with matching PGD and 3_pod_16x8_bh_galaxy cluster descriptor
+    // build_physical + map_multi_mesh with bh_galaxy PGD and a custom 10-stage 4×2 GLX pipeline MGD
+    // (bh_glx_10stage_4x2_pipeline.textproto).
     using namespace ::tt::tt_fabric;
 
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");
@@ -4004,17 +4068,18 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
     ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
     PhysicalGroupingDescriptor pgd{pgd_path};
 
-    // Load MGD - using bh_glx_split_4x2 which has 48 meshes of 4x2 (8 nodes each)
+    // Custom 10-stage 4×2 pipeline (8 ASICs/stage) — see bh_glx_10stage_4x2_pipeline.textproto
     const std::filesystem::path mgd_path =
-        std::filesystem::path(tt_metal_home) / "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_10stage_4x2_pipeline.textproto";
     ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
     MeshGraphDescriptor mgd{mgd_path};
 
     // Build physical multi-mesh graph using PGD and PSD
     const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
 
-    // Verify the expected number of individual meshes
-    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48u);
+    // THere should be 48 physical meshes in the graph for 3 pod
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48);
 
     // Each of the mesh level graphs should have connections to other nodes
     for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
@@ -4043,6 +4108,207 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreeP
                 adjacency_graph.get_neighbors(node).size(), 3u * 2u);  // num directions * 2 channels per direction
         }
     }
+
+    MeshGraph mesh_graph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, mgd_path.string());
+    const auto logical_multi_mesh_graph = build_logical_multi_mesh_adjacency_graph(mesh_graph);
+
+    size_t expected_fabric_nodes = 0;
+    for (const auto& [logical_mesh_id, logical_adj] : logical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        (void)logical_mesh_id;
+        expected_fabric_nodes += logical_adj.get_nodes().size();
+    }
+    ASSERT_GT(expected_fabric_nodes, 0u);
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+
+    for (const auto& [asic_id, desc] : psd.get_asic_descriptors()) {
+        config.hostname_to_asics[desc.host_name].insert(asic_id);
+    }
+
+    const auto& pinnings = mgd.get_pinnings();
+    for (const auto& [pos, fabric_node] : pinnings) {
+        config.pinnings.emplace_back(pos, fabric_node);
+    }
+
+    if (!config.pinnings.empty()) {
+        const auto& asic_descriptors = psd.get_asic_descriptors();
+        for (const auto& [asic_id, _] : asic_descriptors) {
+            auto tray_id = psd.get_tray_id(asic_id);
+            auto asic_location = psd.get_asic_location(asic_id);
+            config.asic_positions[asic_id] = std::make_pair(tray_id, asic_location);
+        }
+    }
+
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        config.mesh_validation_modes[mesh_id] = mesh_graph.is_intra_mesh_policy_relaxed(mesh_id)
+                                                    ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                                    : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+    }
+
+    config.inter_mesh_validation_mode = mesh_graph.is_inter_mesh_policy_relaxed()
+                                            ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                            : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        for (const auto& [coord, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            (void)coord;
+            FabricNodeId fabric_node_id(mesh_id, chip_id);
+            auto mesh_host_rank = mesh_graph.get_host_rank_for_chip(mesh_id, chip_id);
+            if (mesh_host_rank.has_value()) {
+                fabric_node_id_to_mesh_rank[mesh_id][fabric_node_id] = mesh_host_rank.value();
+            }
+        }
+    }
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank = {};
+
+    const auto mapping_result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+    ASSERT_TRUE(mapping_result.success) << mapping_result.error_message;
+
+    EXPECT_EQ(mapping_result.fabric_node_to_asic.size(), expected_fabric_nodes);
+
+    std::set<std::string> hosts_spanning_blitz_mapped;
+    for (const auto& [fabric_node, asic_id] : mapping_result.fabric_node_to_asic) {
+        (void)fabric_node;
+        hosts_spanning_blitz_mapped.insert(psd.get_host_name_for_asic(asic_id));
+    }
+    EXPECT_GE(hosts_spanning_blitz_mapped.size(), 1u);
+    EXPECT_LE(hosts_spanning_blitz_mapped.size(), 3u)
+        << "Mapped Blitz pipeline: at most one host per logical 4×2 mesh (10 stages)";
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Blitz2x4_11Stage) {
+    // Same as BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Blitz2x4 but 11 pipeline stages
+    // (bh_glx_11stage_4x2_pipeline.textproto).
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    constexpr std::size_t kPipelineStages = 11;
+    constexpr std::size_t kAsicsPerStage = 8;
+
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_11stage_4x2_pipeline.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48u);
+
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        (void)mesh_id;
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), kAsicsPerStage);
+
+        expect_bh_halfpod_tray_pairing_for_graph_nodes(
+            std::string("[ThreePod16x8_Blitz2x4_11Stage] mesh_id=") + std::to_string(*mesh_id), psd, adjacency_graph);
+
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(adjacency_graph.get_neighbors(node).size(), 2u * 2u);
+            EXPECT_LE(adjacency_graph.get_neighbors(node).size(), 3u * 2u);
+        }
+    }
+
+    MeshGraph mesh_graph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, mgd_path.string());
+    const auto logical_multi_mesh_graph = build_logical_multi_mesh_adjacency_graph(mesh_graph);
+
+    EXPECT_EQ(logical_multi_mesh_graph.mesh_adjacency_graphs_.size(), kPipelineStages);
+
+    size_t expected_fabric_nodes = 0;
+    for (const auto& [logical_mesh_id, logical_adj] : logical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        (void)logical_mesh_id;
+        expected_fabric_nodes += logical_adj.get_nodes().size();
+    }
+    ASSERT_EQ(expected_fabric_nodes, kPipelineStages * kAsicsPerStage);
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+
+    for (const auto& [asic_id, desc] : psd.get_asic_descriptors()) {
+        config.hostname_to_asics[desc.host_name].insert(asic_id);
+    }
+
+    const auto& pinnings = mgd.get_pinnings();
+    for (const auto& [pos, fabric_node] : pinnings) {
+        config.pinnings.emplace_back(pos, fabric_node);
+    }
+
+    if (!config.pinnings.empty()) {
+        const auto& asic_descriptors = psd.get_asic_descriptors();
+        for (const auto& [asic_id, _] : asic_descriptors) {
+            auto tray_id = psd.get_tray_id(asic_id);
+            auto asic_location = psd.get_asic_location(asic_id);
+            config.asic_positions[asic_id] = std::make_pair(tray_id, asic_location);
+        }
+    }
+
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        config.mesh_validation_modes[mesh_id] = mesh_graph.is_intra_mesh_policy_relaxed(mesh_id)
+                                                    ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                                    : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+    }
+
+    config.inter_mesh_validation_mode = mesh_graph.is_inter_mesh_policy_relaxed()
+                                            ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                            : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        for (const auto& [coord, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            (void)coord;
+            FabricNodeId fabric_node_id(mesh_id, chip_id);
+            auto mesh_host_rank = mesh_graph.get_host_rank_for_chip(mesh_id, chip_id);
+            if (mesh_host_rank.has_value()) {
+                fabric_node_id_to_mesh_rank[mesh_id][fabric_node_id] = mesh_host_rank.value();
+            }
+        }
+    }
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank = {};
+
+    const auto mapping_result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+    ASSERT_TRUE(mapping_result.success) << mapping_result.error_message;
+
+    EXPECT_EQ(mapping_result.fabric_node_to_asic.size(), expected_fabric_nodes);
+
+    std::set<std::string> hosts_spanning_blitz_mapped;
+    for (const auto& [fabric_node, asic_id] : mapping_result.fabric_node_to_asic) {
+        (void)fabric_node;
+        hosts_spanning_blitz_mapped.insert(psd.get_host_name_for_asic(asic_id));
+    }
+    EXPECT_GE(hosts_spanning_blitz_mapped.size(), 1u);
+    EXPECT_LE(hosts_spanning_blitz_mapped.size(), 3u)
+        << "Mapped Blitz pipeline: at most one host per logical 4×2 mesh (11 stages)";
 }
 
 TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_BHGalaxy4x4Z) {
@@ -4437,8 +4703,6 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Single
     }
 
     MeshGraph mesh_graph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, mgd_path.string());
-
-    // Test the multi-mesh mapping
     const auto logical_multi_mesh_graph = build_logical_multi_mesh_adjacency_graph(mesh_graph);
 
     TopologyMappingConfig config;

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -11,15 +11,25 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <initializer_list>
 #include <map>
 #include <set>
+#include <vector>
+#include <cstdint>
 #include <random>
+#include <unordered_set>
+#include <string_view>
+#include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/cluster.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
+#include "tt_metal/fabric/physical_system_discovery.hpp"
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal::experimental::tt_fabric {
 namespace {
@@ -37,6 +47,112 @@ protected:
     const MeshId mesh_id_{kDefaultMeshId};
     const MeshHostRankId rank0_{0};
     const MeshHostRankId rank1_{1};
+
+    static void set_strict_intra_mesh(TopologyMappingConfig& config, std::initializer_list<MeshId> meshes) {
+        for (MeshId m : meshes) {
+            config.mesh_validation_modes[m] = ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+        }
+    }
+
+    static void set_strict_intra_and_inter_mesh(TopologyMappingConfig& config, std::initializer_list<MeshId> meshes) {
+        config.inter_mesh_validation_mode = ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+        for (MeshId m : meshes) {
+            config.mesh_validation_modes[m] = ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+        }
+    }
+
+    // Debug dumps for mesh-level exit / cardinality tests (stderr — always visible; no gtest failure).
+    // map_multi_mesh_to_physical also emits Fabric log_critical lines for each mesh-level exit cardinality constraint
+    // (min_count, fabric nodes, exit ASICs) from topology_mapper_utils.cpp.
+    static void dump_logical_multi_mesh_debug(std::string_view tag, const LogicalMultiMeshGraph& g) {
+        using namespace ::tt::tt_fabric;
+        std::cerr << "\n========== DEBUG: " << tag << " — LogicalMultiMeshGraph ==========\n";
+        std::cerr << "Mesh-level adjacency (repeated neighbor id = channel multiplicity):\n";
+        for (const auto& mid : g.mesh_level_graph_.get_nodes()) {
+            std::cerr << "  mesh " << mid.get() << " -> [";
+            const auto& nb = g.mesh_level_graph_.get_neighbors(mid);
+            for (size_t i = 0; i < nb.size(); ++i) {
+                if (i) {
+                    std::cerr << ", ";
+                }
+                std::cerr << nb[i].get();
+            }
+            std::cerr << "]\n";
+        }
+        std::cerr << "Per-mesh fabric node adjacency (intra-mesh):\n";
+        for (const auto& [mid, adj_g] : g.mesh_adjacency_graphs_) {
+            std::cerr << "  mesh " << mid.get() << ":\n";
+            for (const auto& n : adj_g.get_nodes()) {
+                std::cerr << "    " << n << " -> ";
+                const auto& nb = adj_g.get_neighbors(n);
+                for (size_t i = 0; i < nb.size(); ++i) {
+                    if (i) {
+                        std::cerr << ", ";
+                    }
+                    std::cerr << nb[i];
+                }
+                std::cerr << "\n";
+            }
+        }
+        std::cerr << "Logical exit-node graphs (parallel edges = logical inter-mesh channel count):\n";
+        for (const auto& [mid, exg] : g.mesh_exit_node_graphs_) {
+            std::cerr << "  mesh " << mid.get() << ":\n";
+            for (const auto& src : exg.get_nodes()) {
+                const auto& nb = exg.get_neighbors(src);
+                std::cerr << "    " << fmt::format("{}", src) << " -> " << nb.size() << " edge(s):";
+                for (const auto& d : nb) {
+                    std::cerr << " " << fmt::format("{}", d);
+                }
+                std::cerr << "\n";
+            }
+        }
+        std::cerr << "================================================================\n\n";
+    }
+
+    static void dump_physical_multi_mesh_debug(std::string_view tag, const PhysicalMultiMeshGraph& g) {
+        using namespace ::tt::tt_fabric;
+        std::cerr << "\n========== DEBUG: " << tag << " — PhysicalMultiMeshGraph ==========\n";
+        std::cerr << "Mesh-level adjacency:\n";
+        for (const auto& mid : g.mesh_level_graph_.get_nodes()) {
+            std::cerr << "  mesh " << mid.get() << " -> [";
+            const auto& nb = g.mesh_level_graph_.get_neighbors(mid);
+            for (size_t i = 0; i < nb.size(); ++i) {
+                if (i) {
+                    std::cerr << ", ";
+                }
+                std::cerr << nb[i].get();
+            }
+            std::cerr << "]\n";
+        }
+        std::cerr << "Per-mesh ASIC adjacency (intra-mesh):\n";
+        for (const auto& [mid, adj_g] : g.mesh_adjacency_graphs_) {
+            std::cerr << "  mesh " << mid.get() << ":\n";
+            for (const auto& a : adj_g.get_nodes()) {
+                std::cerr << "    " << a << " -> ";
+                const auto& nb = adj_g.get_neighbors(a);
+                for (size_t i = 0; i < nb.size(); ++i) {
+                    if (i) {
+                        std::cerr << ", ";
+                    }
+                    std::cerr << nb[i];
+                }
+                std::cerr << "\n";
+            }
+        }
+        std::cerr << "Physical exit-node graphs (parallel edges = physical inter-mesh links per exit ASIC):\n";
+        for (const auto& [mid, exg] : g.mesh_exit_node_graphs_) {
+            std::cerr << "  mesh " << mid.get() << ":\n";
+            for (const auto& src : exg.get_nodes()) {
+                const auto& nb = exg.get_neighbors(src);
+                std::cerr << "    " << fmt::format("{}", src) << " -> " << nb.size() << " edge(s):";
+                for (const auto& d : nb) {
+                    std::cerr << " " << fmt::format("{}", d);
+                }
+                std::cerr << "\n";
+            }
+        }
+        std::cerr << "================================================================\n\n";
+    }
 
     // -------------------------------------------------------------------------
     // Factory helpers
@@ -99,6 +215,107 @@ protected:
             }
         }
         return adj;
+    }
+
+    // Three meshes in a triangle, two-node chains, two physical inter-mesh ASIC pairs per mesh pair (each pair can be
+    // repeated physical_intermesh_parallel_edges_per_asic_pair times for parallel links per exit ASIC toward a
+    // neighbor mesh).
+    static void build_three_mesh_two_node_triangle_topology(
+        uint32_t mesh_level_multiplicity,
+        uint32_t exit_multiplicity,
+        LogicalMultiMeshGraph& logical,
+        PhysicalMultiMeshGraph& physical,
+        uint32_t physical_intermesh_parallel_edges_per_asic_pair = 1) {
+        using namespace ::tt::tt_fabric;
+
+        auto make_chain_nodes = [](MeshId m) {
+            std::vector<FabricNodeId> n;
+            n.push_back(FabricNodeId(m, 0));
+            n.push_back(FabricNodeId(m, 1));
+            return n;
+        };
+
+        for (uint32_t mid = 0; mid < 3; ++mid) {
+            const MeshId m{mid};
+            auto nodes = make_chain_nodes(m);
+            logical.mesh_adjacency_graphs_[m] = AdjacencyGraph<FabricNodeId>(build_chain_adjacency(nodes));
+        }
+
+        AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level;
+        for (uint32_t a = 0; a < 3; ++a) {
+            for (uint32_t b = 0; b < 3; ++b) {
+                if (a == b) {
+                    continue;
+                }
+                for (uint32_t k = 0; k < mesh_level_multiplicity; ++k) {
+                    logical_mesh_level[MeshId{a}].push_back(MeshId{b});
+                }
+            }
+        }
+        logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level);
+
+        auto push_mesh_exit_edges =
+            [](AdjacencyGraph<LogicalExitNode>::AdjacencyMap& adj, MeshId src_mesh, MeshId dst_mesh, uint32_t count) {
+                LogicalExitNode src{src_mesh, std::nullopt};
+                LogicalExitNode dst{dst_mesh, std::nullopt};
+                for (uint32_t k = 0; k < count; ++k) {
+                    adj[src].push_back(dst);
+                }
+            };
+
+        AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit0, exit1, exit2;
+        push_mesh_exit_edges(exit0, MeshId{0}, MeshId{1}, exit_multiplicity);
+        push_mesh_exit_edges(exit0, MeshId{0}, MeshId{2}, exit_multiplicity);
+        push_mesh_exit_edges(exit1, MeshId{1}, MeshId{0}, exit_multiplicity);
+        push_mesh_exit_edges(exit1, MeshId{1}, MeshId{2}, exit_multiplicity);
+        push_mesh_exit_edges(exit2, MeshId{2}, MeshId{0}, exit_multiplicity);
+        push_mesh_exit_edges(exit2, MeshId{2}, MeshId{1}, exit_multiplicity);
+        logical.mesh_exit_node_graphs_[MeshId{0}] = AdjacencyGraph<LogicalExitNode>(exit0);
+        logical.mesh_exit_node_graphs_[MeshId{1}] = AdjacencyGraph<LogicalExitNode>(exit1);
+        logical.mesh_exit_node_graphs_[MeshId{2}] = AdjacencyGraph<LogicalExitNode>(exit2);
+
+        std::vector<tt::tt_metal::AsicID> as0 = make_asics(2, 100);
+        std::vector<tt::tt_metal::AsicID> as1 = make_asics(2, 200);
+        std::vector<tt::tt_metal::AsicID> as2 = make_asics(2, 300);
+
+        PhysicalAdjacencyMap flat;
+        auto g0 = build_chain_adjacency(as0);
+        auto g1 = build_chain_adjacency(as1);
+        auto g2 = build_chain_adjacency(as2);
+        for (const auto& [asic, neighbors] : g0) {
+            flat[asic] = neighbors;
+        }
+        for (const auto& [asic, neighbors] : g1) {
+            flat[asic] = neighbors;
+        }
+        for (const auto& [asic, neighbors] : g2) {
+            flat[asic] = neighbors;
+        }
+
+        for (uint32_t pe = 0; pe < physical_intermesh_parallel_edges_per_asic_pair; ++pe) {
+            flat[as0[0]].push_back(as1[0]);
+            flat[as1[0]].push_back(as0[0]);
+            flat[as0[1]].push_back(as1[1]);
+            flat[as1[1]].push_back(as0[1]);
+
+            flat[as1[0]].push_back(as2[0]);
+            flat[as2[0]].push_back(as1[0]);
+            flat[as1[1]].push_back(as2[1]);
+            flat[as2[1]].push_back(as1[1]);
+
+            flat[as0[0]].push_back(as2[0]);
+            flat[as2[0]].push_back(as0[0]);
+            flat[as0[1]].push_back(as2[1]);
+            flat[as2[1]].push_back(as0[1]);
+        }
+
+        AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat);
+        std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+        mesh_groupings.push_back({as0[0], as0[1]});
+        mesh_groupings.push_back({as1[0], as1[1]});
+        mesh_groupings.push_back({as2[0], as2[1]});
+
+        physical = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
     }
 
     // Build a fully connected graph (clique)
@@ -229,6 +446,114 @@ protected:
         }
     }
 
+    template <typename Node>
+    static std::map<Node, std::vector<Node>> adjacency_graph_to_neighbor_map(
+        const ::tt::tt_fabric::AdjacencyGraph<Node>& g) {
+        std::map<Node, std::vector<Node>> m;
+        for (const auto& n : g.get_nodes()) {
+            m[n] = g.get_neighbors(n);
+        }
+        return m;
+    }
+
+    static uint32_t count_logical_exit_channels_between_meshes(
+        const LogicalMultiMeshGraph& logical, MeshId src_mesh, MeshId dst_mesh) {
+        const auto& ex = logical.mesh_exit_node_graphs_.at(src_mesh);
+        uint32_t c = 0;
+        for (const auto& sen : ex.get_nodes()) {
+            for (const auto& nb : ex.get_neighbors(sen)) {
+                if (nb.mesh_id == dst_mesh) {
+                    c++;
+                }
+            }
+        }
+        return c;
+    }
+
+    static uint32_t count_physical_exit_links_between_meshes(
+        const PhysicalMultiMeshGraph& physical, MeshId src_mesh, MeshId dst_mesh) {
+        const auto& ex = physical.mesh_exit_node_graphs_.at(src_mesh);
+        uint32_t c = 0;
+        for (const auto& pen : ex.get_nodes()) {
+            for (const auto& nb : ex.get_neighbors(pen)) {
+                if (nb.mesh_id == dst_mesh) {
+                    c++;
+                }
+            }
+        }
+        return c;
+    }
+
+    // Parallel inter-mesh links from mapped exit ASICs on src_mesh toward dst_mesh (subset of topology total).
+    static uint32_t mapped_exit_link_capacity_toward_dst(
+        const TopologyMappingResult& result, const PhysicalMultiMeshGraph& physical, MeshId src_mesh, MeshId dst_mesh) {
+        std::unordered_set<tt::tt_metal::AsicID> mapped_src_asics;
+        for (const auto& [node, asic] : result.fabric_node_to_asic) {
+            if (node.mesh_id == src_mesh) {
+                mapped_src_asics.insert(asic);
+            }
+        }
+        uint32_t s = 0;
+        const auto& ex = physical.mesh_exit_node_graphs_.at(src_mesh);
+        for (const auto& pen : ex.get_nodes()) {
+            if (!mapped_src_asics.contains(pen.asic_id)) {
+                continue;
+            }
+            for (const auto& nb : ex.get_neighbors(pen)) {
+                if (nb.mesh_id == dst_mesh) {
+                    s++;
+                }
+            }
+        }
+        return s;
+    }
+
+    // After a successful map_multi_mesh_to_physical: intra-mesh connectivity, ASIC membership, and inter-mesh exit
+    // bandwidth on mapped ASICs >= min(logical_exit_channels, physical_topology_links) per direction (RELAXED demand).
+    static void verify_multi_mesh_mapping_result_end_to_end(
+        const TopologyMappingResult& result,
+        const LogicalMultiMeshGraph& logical,
+        const PhysicalMultiMeshGraph& physical) {
+        for (const auto& [fabric_node, asic_id] : result.fabric_node_to_asic) {
+            const MeshId m = fabric_node.mesh_id;
+            ASSERT_TRUE(physical.mesh_adjacency_graphs_.contains(m));
+            const auto& phys_intra = physical.mesh_adjacency_graphs_.at(m);
+            bool asic_in_mesh = false;
+            for (const auto& a : phys_intra.get_nodes()) {
+                if (a == asic_id) {
+                    asic_in_mesh = true;
+                    break;
+                }
+            }
+            EXPECT_TRUE(asic_in_mesh) << "Fabric node mapped to ASIC not in physical intra-mesh graph for mesh "
+                                      << m.get();
+        }
+
+        for (const auto& [mid, log_g] : logical.mesh_adjacency_graphs_) {
+            const auto& phys_g = physical.mesh_adjacency_graphs_.at(mid);
+            verify_connectivity_preserved(
+                result, adjacency_graph_to_neighbor_map(log_g), adjacency_graph_to_neighbor_map(phys_g));
+        }
+
+        for (const auto& [src_mesh, _] : logical.mesh_adjacency_graphs_) {
+            for (const auto& [dst_mesh, _2] : logical.mesh_adjacency_graphs_) {
+                if (src_mesh == dst_mesh) {
+                    continue;
+                }
+                const uint32_t L = count_logical_exit_channels_between_meshes(logical, src_mesh, dst_mesh);
+                if (L == 0) {
+                    continue;
+                }
+                const uint32_t T = count_physical_exit_links_between_meshes(physical, src_mesh, dst_mesh);
+                const uint32_t R = std::min(L, T);
+                const uint32_t S = mapped_exit_link_capacity_toward_dst(result, physical, src_mesh, dst_mesh);
+                EXPECT_GE(S, R) << "mesh " << src_mesh.get() << " -> mesh " << dst_mesh.get()
+                                << ": mapped exit ASICs must expose at least min(logical_channels=" << L
+                                << ", physical_links=" << T << ")=" << R << " parallel link(s); mapped_capacity=" << S;
+            }
+        }
+    }
+
     // Verify rank constraints are satisfied
     static void verify_rank_constraints(
         const TopologyMappingResult& result,
@@ -327,6 +652,7 @@ protected:
             << "Exit node should exist";
     }
 };
+}  // namespace
 
 // =============================================================================
 // Basic Functionality Tests
@@ -540,7 +866,7 @@ TEST_F(TopologyMapperUtilsTest, StrictMode_SufficientChannels_Succeeds) {
     const auto asic_ranks = make_uniform_asic_ranks(asics, rank0_);
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh_id_});
 
     const auto result = map_mesh_to_physical(mesh_id_, logical_adj, physical_adj, node_ranks, asic_ranks, config);
 
@@ -565,7 +891,7 @@ TEST_F(TopologyMapperUtilsTest, StrictMode_InsufficientChannels_Fails) {
     const auto asic_ranks = make_uniform_asic_ranks(asics, rank0_);
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh_id_});
 
     const auto result = map_mesh_to_physical(mesh_id_, logical_adj, physical_adj, node_ranks, asic_ranks, config);
 
@@ -591,7 +917,6 @@ TEST_F(TopologyMapperUtilsTest, RelaxedMode_InsufficientChannels_Succeeds) {
     const auto asic_ranks = make_uniform_asic_ranks(asics, rank0_);
 
     TopologyMappingConfig config;
-    config.strict_mode = false;
 
     const auto result = map_mesh_to_physical(mesh_id_, logical_adj, physical_adj, node_ranks, asic_ranks, config);
 
@@ -1171,7 +1496,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_TwoMeshes_Succeeds) {
 
     // Create mapping config
     TopologyMappingConfig config;
-    config.strict_mode = true;            // Use strict mode for testing
+    set_strict_intra_and_inter_mesh(config, {logical_mesh0, logical_mesh1});
     config.disable_rank_bindings = true;  // Disable rank bindings - any mapping is valid
 
     // Call map_multi_mesh_to_physical (rank mappings omitted since disable_rank_bindings is true)
@@ -1246,12 +1571,349 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_IncompatibleTopology_Fail
     physical_graph.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_adj);
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_and_inter_mesh(config, {MeshId{0}, MeshId{1}});
     config.disable_rank_bindings = true;
     const auto result = map_multi_mesh_to_physical(logical_graph, physical_graph, config);
 
     EXPECT_FALSE(result.success);
     EXPECT_LT(result.fabric_node_to_asic.size(), 13u);  // Should not map all 9+4 nodes
+}
+
+// Mesh-level exit multiplicity is aggregated into one cardinality constraint per (source mesh, destination mesh).
+// Per-ASIC and total parallel link counts come from the physical exit graph toward the mapped destination mesh.
+// RELAXED uses min(logical_channels, total_physical_links_in_that_direction) for pair math, then
+// ceil(channels / max_links_per_exit_asic), capped by mappable (fabric_node, exit-ASIC) pairs. STRICT uses full
+// logical channel count for pair math and fails if required pairs exceed the mappable cap.
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    PhysicalMultiMeshGraph physical;
+    build_three_mesh_two_node_triangle_topology(
+        /*mesh_level_multiplicity=*/4, /*exit_multiplicity=*/4, logical, physical);
+
+    for (MeshId m : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+        const auto& nbrs = logical.mesh_level_graph_.get_neighbors(m);
+        for (MeshId other : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+            if (other == m) {
+                continue;
+            }
+            EXPECT_EQ(count_occurrences(nbrs, other), 4u)
+                << "Logical mesh " << m.get() << " should list mesh " << other.get() << " four times";
+        }
+    }
+
+    for (MeshId m : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+        const auto& pexit = physical.mesh_exit_node_graphs_.at(m);
+        size_t edge_count = 0;
+        for (const auto& pen : pexit.get_nodes()) {
+            edge_count += pexit.get_neighbors(pen).size();
+        }
+        EXPECT_EQ(edge_count, 4u) << "mesh " << m.get();
+    }
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds", logical);
+    dump_physical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds", physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    verify_multi_mesh_mapping_result_end_to_end(result, logical, physical);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 6u);
+}
+
+// Same topology as MeshLevelExitMultiplicityFour_RelaxedCapsCardinality_Succeeds: 4 logical mesh-level channels per
+// neighbor vs 2 physical mesh-level edges (two exit ASIC pairs × one link). RELAXED allows the mapping; STRICT
+// inter-mesh validation requires per-edge channel capacity, so solve fails before intra-mesh placement.
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_MeshLevelExitMultiplicityFour_StrictInterMesh_Fails) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    PhysicalMultiMeshGraph physical;
+    build_three_mesh_two_node_triangle_topology(
+        /*mesh_level_multiplicity=*/4, /*exit_multiplicity=*/4, logical, physical);
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::STRICT;
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    EXPECT_FALSE(result.success)
+        << "expected STRICT inter-mesh rejection when logical requires 4 channels but physical mesh graph has 2";
+    EXPECT_THAT(result.error_message, ::testing::HasSubstr("Strict mode"));
+}
+
+// 8 logical mesh-level / exit channels per neighbor; physical topology has 2 parallel inter-mesh links per exit ASIC
+// toward each neighbor (4 total physical links per direction between meshes). Pair math: min(8,4)=4 channels,
+// ceil(4/2)=2 cardinality pairs; mappable cap 2 → mapping succeeds under RELAXED.
+TEST_F(
+    TopologyMapperUtilsTest,
+    MapMultiMeshToPhysical_MeshLevelExitEightLogicalChannelsTwoPhysicalLinksPerExitAsic_RelaxedCapsCardinality_Succeeds) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    PhysicalMultiMeshGraph physical;
+    build_three_mesh_two_node_triangle_topology(
+        /*mesh_level_multiplicity=*/8,
+        /*exit_multiplicity=*/8,
+        logical,
+        physical,
+        /*physical_intermesh_parallel_edges_per_asic_pair=*/2);
+
+    for (MeshId m : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+        const auto& nbrs = logical.mesh_level_graph_.get_neighbors(m);
+        for (MeshId other : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+            if (other == m) {
+                continue;
+            }
+            EXPECT_EQ(count_occurrences(nbrs, other), 8u)
+                << "Logical mesh " << m.get() << " should list mesh " << other.get() << " eight times";
+        }
+    }
+
+    for (MeshId m : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+        const auto& pexit = physical.mesh_exit_node_graphs_.at(m);
+        size_t edge_count = 0;
+        for (const auto& pen : pexit.get_nodes()) {
+            edge_count += pexit.get_neighbors(pen).size();
+        }
+        EXPECT_EQ(edge_count, 8u) << "mesh " << m.get()
+                                  << " (2 exit ASICs × 2 neighbor meshes × 2 parallel links each)";
+    }
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_MeshLevelExitEightLogicalChannelsTwoPhysicalLinksPerExitAsic_RelaxedCapsCardinality_"
+        "Succeeds",
+        logical);
+    dump_physical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_MeshLevelExitEightLogicalChannelsTwoPhysicalLinksPerExitAsic_RelaxedCapsCardinality_"
+        "Succeeds",
+        physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    verify_multi_mesh_mapping_result_end_to_end(result, logical, physical);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 6u);
+}
+
+// Same topology as above but exit multiplicity matches the number of fabric nodes (and physical exit ASICs) per
+// direction, so aggregated cardinality constraints are satisfiable.
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityMatchesNodes_Succeeds) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    PhysicalMultiMeshGraph physical;
+    build_three_mesh_two_node_triangle_topology(
+        /*mesh_level_multiplicity=*/2, /*exit_multiplicity=*/2, logical, physical);
+
+    for (MeshId m : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+        const auto& nbrs = logical.mesh_level_graph_.get_neighbors(m);
+        for (MeshId other : {MeshId{0}, MeshId{1}, MeshId{2}}) {
+            if (other == m) {
+                continue;
+            }
+            EXPECT_EQ(count_occurrences(nbrs, other), 2u);
+        }
+    }
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityMatchesNodes_Succeeds", logical);
+    dump_physical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityMatchesNodes_Succeeds", physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    verify_multi_mesh_mapping_result_end_to_end(result, logical, physical);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 6u);
+}
+
+// Single mesh-level exit channel per neighbor: min_count 1 per destination; should map.
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityOne_Succeeds) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    PhysicalMultiMeshGraph physical;
+    build_three_mesh_two_node_triangle_topology(
+        /*mesh_level_multiplicity=*/1, /*exit_multiplicity=*/1, logical, physical);
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug("MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityOne_Succeeds", logical);
+    dump_physical_multi_mesh_debug("MapMultiMeshToPhysical_ThreeMeshesTwoNodesExitMultiplicityOne_Succeeds", physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    verify_multi_mesh_mapping_result_end_to_end(result, logical, physical);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 6u);
+}
+
+// One fabric node advertises more parallel exit edges to a neighbor mesh than there are physical inter-mesh ASICs.
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FabricExitEdgeMultiplicityExceedsPhysicalExitAsics_Fails) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    logical.mesh_adjacency_graphs_[MeshId{0}] = AdjacencyGraph<FabricNodeId>(
+        build_chain_adjacency(std::vector<FabricNodeId>{FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 1)}));
+    logical.mesh_adjacency_graphs_[MeshId{1}] = AdjacencyGraph<FabricNodeId>(
+        build_chain_adjacency(std::vector<FabricNodeId>{FabricNodeId(MeshId{1}, 0), FabricNodeId(MeshId{1}, 1)}));
+
+    AdjacencyGraph<MeshId>::AdjacencyMap mesh_level;
+    mesh_level[MeshId{0}] = {MeshId{1}};
+    mesh_level[MeshId{1}] = {MeshId{0}};
+    logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(mesh_level);
+
+    LogicalExitNode src_fabric{MeshId{0}, FabricNodeId(MeshId{0}, 0)};
+    LogicalExitNode dst_mesh{MeshId{1}, std::nullopt};
+    AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit0;
+    for (int k = 0; k < 3; ++k) {
+        exit0[src_fabric].push_back(dst_mesh);
+    }
+    logical.mesh_exit_node_graphs_[MeshId{0}] = AdjacencyGraph<LogicalExitNode>(exit0);
+    LogicalExitNode src_m1{MeshId{1}, std::nullopt};
+    LogicalExitNode dst_m0{MeshId{0}, std::nullopt};
+    AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit1;
+    exit1[src_m1].push_back(dst_m0);
+    logical.mesh_exit_node_graphs_[MeshId{1}] = AdjacencyGraph<LogicalExitNode>(exit1);
+
+    std::vector<tt::tt_metal::AsicID> as0 = make_asics(2, 100);
+    std::vector<tt::tt_metal::AsicID> as1 = make_asics(2, 200);
+    PhysicalAdjacencyMap flat;
+    for (const auto& [asic, neighbors] : build_chain_adjacency(as0)) {
+        flat[asic] = neighbors;
+    }
+    for (const auto& [asic, neighbors] : build_chain_adjacency(as1)) {
+        flat[asic] = neighbors;
+    }
+    flat[as0[0]].push_back(as1[0]);
+    flat[as1[0]].push_back(as0[0]);
+    flat[as0[1]].push_back(as1[1]);
+    flat[as1[1]].push_back(as0[1]);
+
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat);
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> groupings;
+    groupings.push_back({as0[0], as0[1]});
+    groupings.push_back({as1[0], as1[1]});
+    PhysicalMultiMeshGraph physical = build_hierarchical_from_flat_graph(flat_graph, groupings);
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityExceedsPhysicalExitAsics_Fails", logical);
+    dump_physical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityExceedsPhysicalExitAsics_Fails", physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    EXPECT_FALSE(result.success)
+        << "Three parallel fabric-level exit edges to one neighbor require more than two physical exit ASICs";
+}
+
+// Two parallel fabric-level edges to the same neighbor with two physical inter-mesh links: allowed (<= 2 ASICs).
+TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FabricExitEdgeMultiplicityWithinPhysicalCap_Succeeds) {
+    using namespace ::tt::tt_fabric;
+
+    LogicalMultiMeshGraph logical;
+    logical.mesh_adjacency_graphs_[MeshId{0}] = AdjacencyGraph<FabricNodeId>(
+        build_chain_adjacency(std::vector<FabricNodeId>{FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 1)}));
+    logical.mesh_adjacency_graphs_[MeshId{1}] = AdjacencyGraph<FabricNodeId>(
+        build_chain_adjacency(std::vector<FabricNodeId>{FabricNodeId(MeshId{1}, 0), FabricNodeId(MeshId{1}, 1)}));
+
+    AdjacencyGraph<MeshId>::AdjacencyMap mesh_level;
+    mesh_level[MeshId{0}] = {MeshId{1}};
+    mesh_level[MeshId{1}] = {MeshId{0}};
+    logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(mesh_level);
+
+    LogicalExitNode src_fabric{MeshId{0}, FabricNodeId(MeshId{0}, 0)};
+    LogicalExitNode dst_mesh{MeshId{1}, std::nullopt};
+    AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit0;
+    exit0[src_fabric].push_back(dst_mesh);
+    exit0[src_fabric].push_back(dst_mesh);
+    logical.mesh_exit_node_graphs_[MeshId{0}] = AdjacencyGraph<LogicalExitNode>(exit0);
+    LogicalExitNode src_m1{MeshId{1}, std::nullopt};
+    LogicalExitNode dst_m0{MeshId{0}, std::nullopt};
+    AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit1;
+    exit1[src_m1].push_back(dst_m0);
+    logical.mesh_exit_node_graphs_[MeshId{1}] = AdjacencyGraph<LogicalExitNode>(exit1);
+
+    std::vector<tt::tt_metal::AsicID> as0 = make_asics(2, 100);
+    std::vector<tt::tt_metal::AsicID> as1 = make_asics(2, 200);
+    PhysicalAdjacencyMap flat;
+    for (const auto& [asic, neighbors] : build_chain_adjacency(as0)) {
+        flat[asic] = neighbors;
+    }
+    for (const auto& [asic, neighbors] : build_chain_adjacency(as1)) {
+        flat[asic] = neighbors;
+    }
+    flat[as0[0]].push_back(as1[0]);
+    flat[as1[0]].push_back(as0[0]);
+    flat[as0[1]].push_back(as1[1]);
+    flat[as1[1]].push_back(as0[1]);
+
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat);
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> groupings;
+    groupings.push_back({as0[0], as0[1]});
+    groupings.push_back({as1[0], as1[1]});
+    PhysicalMultiMeshGraph physical = build_hierarchical_from_flat_graph(flat_graph, groupings);
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    dump_logical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityWithinPhysicalCap_Succeeds", logical);
+    dump_physical_multi_mesh_debug(
+        "MapMultiMeshToPhysical_FabricExitEdgeMultiplicityWithinPhysicalCap_Succeeds", physical);
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+
+    std::cerr << "[DEBUG] map_multi_mesh_to_physical success=" << result.success
+              << " fabric_node_to_asic.size()=" << result.fabric_node_to_asic.size() << "\n";
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    verify_multi_mesh_mapping_result_end_to_end(result, logical, physical);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 4u);
 }
 
 TEST_F(TopologyMapperUtilsTest, ConvertFlatAdjacencyToMultiMeshGraph_SingleMesh) {
@@ -1264,12 +1926,10 @@ TEST_F(TopologyMapperUtilsTest, ConvertFlatAdjacencyToMultiMeshGraph_SingleMesh)
     flat_adj[asic2] = {asic1};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[MeshId{0}][asic0] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{0}][asic1] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{0}][asic2] = MeshHostRankId{0};
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0, asic1, asic2});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_EQ(multi_mesh_graph.mesh_adjacency_graphs_.size(), 1u);
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 3u);
@@ -1294,15 +1954,11 @@ TEST_F(TopologyMapperUtilsTest, ConvertFlatAdjacencyToMultiMeshGraph_TwoMeshes) 
     flat_adj[asic1_3] = {asic1_2};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (auto asic : {asic0_0, asic0_1, asic0_2, asic0_3}) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic1_0, asic1_1, asic1_2, asic1_3}) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = MeshHostRankId{0};
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0_0, asic0_1, asic0_2, asic0_3});
+    mesh_groupings.push_back({asic1_0, asic1_1, asic1_2, asic1_3});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_EQ(multi_mesh_graph.mesh_adjacency_graphs_.size(), 2u);
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 4u);
@@ -1331,15 +1987,11 @@ TEST_F(TopologyMapperUtilsTest, ConvertFlatAdjacencyToMultiMeshGraph_MultipleCha
     flat_adj[asic1_2] = {asic1_1};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (auto asic : {asic0_0, asic0_1, asic0_2}) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic1_0, asic1_1, asic1_2}) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = MeshHostRankId{0};
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0_0, asic0_1, asic0_2});
+    mesh_groupings.push_back({asic1_0, asic1_1, asic1_2});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 3u);
     verify_mesh_size(multi_mesh_graph, MeshId{1}, 3u);
@@ -1358,12 +2010,12 @@ TEST_F(TopologyMapperUtilsTest, ConvertFlatAdjacencyToMultiMeshGraph_ThreeMeshes
     flat_adj[asic2] = {asic1};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[MeshId{0}][asic0] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{1}][asic1] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{2}][asic2] = MeshHostRankId{0};
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0});
+    mesh_groupings.push_back({asic1});
+    mesh_groupings.push_back({asic2});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_EQ(multi_mesh_graph.mesh_adjacency_graphs_.size(), 3u);
     verify_mesh_connectivity(multi_mesh_graph, MeshId{0}, 1u);
@@ -1398,18 +2050,12 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_DisconnectedMeshe
     flat_adj[asic2_1] = {asic2_0};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (auto asic : {asic0_0, asic0_1, asic0_2, asic0_3, asic0_4}) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic1_0, asic1_1, asic1_2, asic1_3}) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic2_0, asic2_1}) {
-        asic_id_to_mesh_rank[MeshId{2}][asic] = MeshHostRankId{0};
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0_0, asic0_1, asic0_2, asic0_3, asic0_4});
+    mesh_groupings.push_back({asic1_0, asic1_1, asic1_2, asic1_3});
+    mesh_groupings.push_back({asic2_0, asic2_1});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_EQ(multi_mesh_graph.mesh_adjacency_graphs_.size(), 3u);
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 5u);
@@ -1441,18 +2087,12 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_MultipleExitNodes
     flat_adj[asic2_2] = {asic2_1};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (auto asic : {asic0_0, asic0_1, asic0_2, asic0_3, asic0_4}) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic1_0, asic1_1, asic1_2}) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic2_0, asic2_1, asic2_2}) {
-        asic_id_to_mesh_rank[MeshId{2}][asic] = MeshHostRankId{0};
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0_0, asic0_1, asic0_2, asic0_3, asic0_4});
+    mesh_groupings.push_back({asic1_0, asic1_1, asic1_2});
+    mesh_groupings.push_back({asic2_0, asic2_1, asic2_2});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 5u);
     verify_mesh_size(multi_mesh_graph, MeshId{1}, 3u);
@@ -1483,15 +2123,11 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_MeshWithOnlyExitN
     flat_adj[asic1_4] = {asic1_3, asic0_4};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (auto asic : {asic0_0, asic0_1, asic0_2, asic0_3, asic0_4}) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
-    }
-    for (auto asic : {asic1_0, asic1_1, asic1_2, asic1_3, asic1_4}) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = MeshHostRankId{0};
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0_0, asic0_1, asic0_2, asic0_3, asic0_4});
+    mesh_groupings.push_back({asic1_0, asic1_1, asic1_2, asic1_3, asic1_4});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 5u);
     verify_mesh_size(multi_mesh_graph, MeshId{1}, 5u);
@@ -1509,9 +2145,9 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_EmptyGraph) {
 
     PhysicalAdjacencyMap flat_adj;
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_TRUE(multi_mesh_graph.mesh_adjacency_graphs_.empty());
     EXPECT_TRUE(multi_mesh_graph.mesh_exit_node_graphs_.empty());
@@ -1527,11 +2163,11 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_UnassignedASICs) 
     flat_adj[unassigned] = {asic0, asic1};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[MeshId{0}][asic0] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{1}][asic1] = MeshHostRankId{0};
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0});
+    mesh_groupings.push_back({asic1});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     verify_mesh_size(multi_mesh_graph, MeshId{0}, 1u);
     verify_mesh_size(multi_mesh_graph, MeshId{1}, 1u);
@@ -1552,13 +2188,13 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_RingTopology) {
     flat_adj[asic3] = {asic2, asic0};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[MeshId{0}][asic0] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{1}][asic1] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{2}][asic2] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{3}][asic3] = MeshHostRankId{0};
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0});
+    mesh_groupings.push_back({asic1});
+    mesh_groupings.push_back({asic2});
+    mesh_groupings.push_back({asic3});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     EXPECT_EQ(multi_mesh_graph.mesh_adjacency_graphs_.size(), 4u);
     verify_mesh_connectivity(multi_mesh_graph, MeshId{0}, 2u);
@@ -1583,13 +2219,13 @@ TEST_F(TopologyMapperUtilsTest, BuildHierarchicalFromFlatGraph_StarTopology) {
     flat_adj[asic3] = {asic0};
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[MeshId{0}][asic0] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{1}][asic1] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{2}][asic2] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[MeshId{3}][asic3] = MeshHostRankId{0};
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic0});
+    mesh_groupings.push_back({asic1});
+    mesh_groupings.push_back({asic2});
+    mesh_groupings.push_back({asic3});
 
-    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    const auto multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     verify_mesh_connectivity(multi_mesh_graph, MeshId{0}, 3u);
     verify_mesh_connectivity(multi_mesh_graph, MeshId{1}, 1u);
@@ -1680,21 +2316,18 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_InterMeshConnectivity_2x2
     }
 
     // Build hierarchical physical graph from flat graph
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (const auto& asic : physical_asics_m0) {
-        asic_id_to_mesh_rank[MeshId{0}][asic] = rank0_;
-    }
-    for (const auto& asic : physical_asics_m1) {
-        asic_id_to_mesh_rank[MeshId{1}][asic] = rank0_;
-    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back(
+        std::unordered_set<tt::tt_metal::AsicID>(physical_asics_m0.begin(), physical_asics_m0.end()));
+    mesh_groupings.push_back(
+        std::unordered_set<tt::tt_metal::AsicID>(physical_asics_m1.begin(), physical_asics_m1.end()));
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // Run mapping
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_and_inter_mesh(config, {MeshId{0}, MeshId{1}});
     config.disable_rank_bindings = true;
     const auto result = map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
 
@@ -1839,20 +2472,19 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ImpossibleIntraMeshConstr
     }
 
     // Build hierarchical physical graph from flat graph
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.reserve(kNumMeshes);
     for (size_t mesh_idx = 0; mesh_idx < kNumMeshes; ++mesh_idx) {
-        for (const auto& asic : physical_asics_by_mesh[mesh_idx]) {
-            asic_id_to_mesh_rank[MeshId{mesh_idx}][asic] = rank0_;
-        }
+        mesh_groupings.push_back(std::unordered_set<tt::tt_metal::AsicID>(
+            physical_asics_by_mesh[mesh_idx].begin(), physical_asics_by_mesh[mesh_idx].end()));
     }
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // Run mapping - should fail at intra-mesh level
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_and_inter_mesh(config, {MeshId{0}, MeshId{1}, MeshId{2}});
     config.disable_rank_bindings = true;
 
     TopologyMappingResult result =
@@ -2120,7 +2752,17 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_MixedStrictAndRelaxedConn
     // Create flat physical graph from adjacency map
     AdjacencyGraph<tt::tt_metal::AsicID> flat_physical_graph(flat_physical_adj);
 
-    // ASIC to mesh/rank mapping
+    // Build physical multi-mesh graph from flat graph
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back(
+        std::unordered_set<tt::tt_metal::AsicID>(physical_asics_m0.begin(), physical_asics_m0.end()));
+    mesh_groupings.push_back(
+        std::unordered_set<tt::tt_metal::AsicID>(physical_asics_m1.begin(), physical_asics_m1.end()));
+    mesh_groupings.push_back(
+        std::unordered_set<tt::tt_metal::AsicID>(physical_asics_m2.begin(), physical_asics_m2.end()));
+    physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_physical_graph, mesh_groupings);
+
+    // Rebuild asic_id_to_mesh_rank from mesh_groupings for map_multi_mesh_to_physical
     std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
     for (const auto& asic : physical_asics_m0) {
         asic_id_to_mesh_rank[MeshId{0}][asic] = MeshHostRankId{0};
@@ -2132,12 +2774,8 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_MixedStrictAndRelaxedConn
         asic_id_to_mesh_rank[MeshId{2}][asic] = MeshHostRankId{0};
     }
 
-    // Build physical multi-mesh graph from flat graph
-    physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_physical_graph, asic_id_to_mesh_rank);
-
     // Perform mapping
     TopologyMappingConfig config;
-    config.strict_mode = false;  // Use relaxed mode for mapping (allows flexibility)
 
     const auto result =
         map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank);
@@ -2278,16 +2916,15 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeLogicalFivePhysical_
     }
 
     // Build hierarchical physical graph from flat graph
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.reserve(kNumPhysicalMeshes);
     for (size_t mesh_idx = 0; mesh_idx < kNumPhysicalMeshes; ++mesh_idx) {
-        for (const auto& asic : physical_asics_by_mesh[mesh_idx]) {
-            asic_id_to_mesh_rank[MeshId{mesh_idx}][asic] = rank0_;
-        }
+        mesh_groupings.push_back(std::unordered_set<tt::tt_metal::AsicID>(
+            physical_asics_by_mesh[mesh_idx].begin(), physical_asics_by_mesh[mesh_idx].end()));
     }
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // Verify physical mesh-level connectivity (ring: 0-1-2-3-4-0)
     const auto& physical_mesh_level_graph = physical_multi_mesh_graph.mesh_level_graph_;
@@ -2299,7 +2936,6 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeLogicalFivePhysical_
     }
 
     TopologyMappingConfig config;
-    config.strict_mode = false;
     config.disable_rank_bindings = true;
     config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
 
@@ -2461,23 +3097,22 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeLogicalFivePhysical_
     }
 
     // Build hierarchical physical graph from flat graph
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.reserve(kNumPhysicalMeshes);
     for (size_t mesh_idx = 0; mesh_idx < kNumPhysicalMeshes; ++mesh_idx) {
-        for (const auto& asic : physical_asics_by_mesh[mesh_idx]) {
-            asic_id_to_mesh_rank[MeshId{mesh_idx}][asic] = rank0_;
-        }
+        mesh_groupings.push_back(std::unordered_set<tt::tt_metal::AsicID>(
+            physical_asics_by_mesh[mesh_idx].begin(), physical_asics_by_mesh[mesh_idx].end()));
     }
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // =========================================================================
     // Run mapping and verify failure
     // =========================================================================
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_and_inter_mesh(config, {MeshId{0}, MeshId{1}, MeshId{2}});
     config.disable_rank_bindings = true;
 
     TopologyMappingResult result;
@@ -2644,23 +3279,22 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_ThreeLogicalFivePhysical_
     }
 
     // Build hierarchical physical graph from flat graph
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.reserve(kNumPhysicalMeshes);
     for (size_t mesh_idx = 0; mesh_idx < kNumPhysicalMeshes; ++mesh_idx) {
-        for (const auto& asic : physical_asics_by_mesh[mesh_idx]) {
-            asic_id_to_mesh_rank[MeshId{mesh_idx}][asic] = rank0_;
-        }
+        mesh_groupings.push_back(std::unordered_set<tt::tt_metal::AsicID>(
+            physical_asics_by_mesh[mesh_idx].begin(), physical_asics_by_mesh[mesh_idx].end()));
     }
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // =========================================================================
     // Run mapping and verify results
     // =========================================================================
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_and_inter_mesh(config, {MeshId{0}, MeshId{1}, MeshId{2}});
     config.disable_rank_bindings = true;
 
     const auto result = map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
@@ -2810,7 +3444,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FourNodesFourHosts_Partia
     fabric_node_id_to_mesh_rank[mesh0][logical_nodes[3]] = MeshHostRankId{3};
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     config.hostname_to_asics["host0"] = {physical_asics[0]};
     config.hostname_to_asics["host1"] = {physical_asics[1]};
@@ -2885,7 +3519,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_FourNodesFourHosts_NoHost
     }
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     // 4 hosts, 2 ASICs each. Rotated layout - solver picks assignment (same-host same-rank enforced).
     config.hostname_to_asics["host0"] = {physical_asics[2], physical_asics[3]};
@@ -2967,7 +3601,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_2x2Tor
     fabric_node_id_to_mesh_rank[mesh0][logical_nodes[3]] = MeshHostRankId{1};
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     config.hostname_to_asics["host0"] = {physical_asics[0], physical_asics[1]};
     config.hostname_to_asics["host1"] = {physical_asics[2], physical_asics[3]};
@@ -3020,7 +3654,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_1x1) {
     fabric_node_id_to_mesh_rank[mesh0][logical_nodes[0]] = MeshHostRankId{0};
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     config.hostname_to_asics["host0"] = {physical_asics[0]};
 
@@ -3071,7 +3705,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_4x4Tor
     }
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     config.hostname_to_asics["host0"] = {physical_asics[4], physical_asics[5], physical_asics[6], physical_asics[7]};
     config.hostname_to_asics["host1"] = {physical_asics[0], physical_asics[1], physical_asics[2], physical_asics[3]};
@@ -3153,7 +3787,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_NoHostRankAssigned_4x6Tor
     fabric_node_id_to_mesh_rank[mesh0][logical_nodes[23]] = MeshHostRankId{5};
 
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh0});
     config.disable_rank_bindings = false;
     config.hostname_to_asics["host0"] = {physical_asics[2], physical_asics[3], physical_asics[8], physical_asics[9]};
     config.hostname_to_asics["host1"] = {physical_asics[0], physical_asics[1], physical_asics[6], physical_asics[7]};
@@ -3237,7 +3871,7 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_TwoHostsTwoAsicsEach_Rota
         }
 
         TopologyMappingConfig config;
-        config.strict_mode = true;
+        set_strict_intra_mesh(config, {mesh0});
         config.disable_rank_bindings = false;
         config.hostname_to_asics = hostname_to_asics;
 
@@ -3308,16 +3942,12 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_PartialRankBinding_OneHos
     auto physical_adj = build_grid_adjacency(physical_asics, kGridSize, kGridSize);
     PhysicalAdjacencyMap flat_physical_adj(physical_adj.begin(), physical_adj.end());
 
-    // ASIC ranks: host_0 (100,101) -> rank 0; host_1 (102,103) -> UNSET
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    asic_id_to_mesh_rank[mesh_id][physical_asics[0]] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[mesh_id][physical_asics[1]] = MeshHostRankId{0};
-    asic_id_to_mesh_rank[mesh_id][physical_asics[2]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
-    asic_id_to_mesh_rank[mesh_id][physical_asics[3]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    // All ASICs belong to the same mesh (rank information is not needed for graph building)
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({physical_asics[0], physical_asics[1], physical_asics[2], physical_asics[3]});
 
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_physical_adj);
-    PhysicalMultiMeshGraph physical_multi_mesh_graph =
-        build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph physical_multi_mesh_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
 
     // Build logical graph: 2x2 grid
     std::vector<FabricNodeId> logical_nodes;
@@ -3340,8 +3970,16 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_PartialRankBinding_OneHos
             MeshHostRankId{i / kGridSize};  // row 0 -> rank 0, row 1 -> rank 1
     }
 
+    // Rebuild asic_id_to_mesh_rank from mesh_groupings for map_multi_mesh_to_physical
+    // ASIC ranks: host_0 (100,101) -> rank 0; host_1 (102,103) -> UNSET
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    asic_id_to_mesh_rank[mesh_id][physical_asics[0]] = MeshHostRankId{0};
+    asic_id_to_mesh_rank[mesh_id][physical_asics[1]] = MeshHostRankId{0};
+    asic_id_to_mesh_rank[mesh_id][physical_asics[2]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+    asic_id_to_mesh_rank[mesh_id][physical_asics[3]] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+
     TopologyMappingConfig config;
-    config.strict_mode = true;
+    set_strict_intra_mesh(config, {mesh_id});
     config.hostname_to_asics["host_0"] = {physical_asics[0], physical_asics[1]};
     config.hostname_to_asics["host_1"] = {physical_asics[2], physical_asics[3]};
 
@@ -3381,5 +4019,618 @@ TEST_F(TopologyMapperUtilsTest, MapMultiMeshToPhysical_PartialRankBinding_OneHos
     }
 }
 
-}  // namespace
+// =============================================================================
+// Tier 2: build_physical_multi_mesh_adjacency_graph with PGD and PSD Tests
+// =============================================================================
+// Tests for build_physical_multi_mesh_adjacency_graph using PhysicalGroupingDescriptor
+// and PhysicalSystemDescriptor. These tests use tt-run with mock cluster descriptors
+// to form the PSD, ensuring integration with the full stack.
+// =============================================================================
+
+// Helper function to create PSD from mock cluster (similar to test_physical_grouping_descriptor.cpp)
+static tt::tt_metal::PhysicalSystemDescriptor create_psd_from_mock_cluster() {
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        throw std::runtime_error("TT_METAL_MOCK_CLUSTER_DESC_PATH must be set for PSD tests");
+    }
+
+    // Create PSD from mock cluster (CPU-only test)
+    auto distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    auto& driver_ref = const_cast<tt::umd::Cluster&>(*cluster.get_driver());
+    return tt::tt_metal::run_physical_system_discovery(driver_ref, distributed_context, rtoptions.get_target_device());
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_SingleBHGalaxy) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses single_bh_galaxy MGD with matching PGD
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using single_bh_galaxy which has 8x4 topology (32 ASICs)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // THere should be 12 indvidual meshes connected, verify that this is the case
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 12u);
+
+    // Each oft he mesh level graphs should have connections to other nodes
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    // Check that each graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graphs
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 32 nodes in the graph
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 32u);
+
+        // Check that each node should have 2 - 4 neighbors
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 2 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 4u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_TriplePod) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses triple_pod_16x8 MGD with matching PGD and 3_pod_16x8_bh_galaxy cluster descriptor
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using triple_pod_16x8_quad_bh_galaxy_torus_xy_graph_descriptor
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tt_metal/fabric/mesh_graph_descriptors/triple_pod_16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto";
+    if (!std::filesystem::exists(mgd_path)) {
+        GTEST_SKIP() << "MGD file not found: " << mgd_path;
+    }
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // THere should be 12 indvidual meshes connected, verify that this is the case
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 3u);
+
+    // Each oft he mesh level graphs should have connections to other nodes
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    // Check that each graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graphs
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 32 nodes in the graph
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 4u * 32u);  // 4 pods * 32 ASICs per pod
+
+        // Check that each node should have 2 - 3 neighbors
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 2 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 4u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Blitz2x4) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses triple_pod_16x8 MGD with matching PGD and 3_pod_16x8_bh_galaxy cluster descriptor
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using bh_glx_split_4x2 which has 48 meshes of 4x2 (8 nodes each)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) / "tt_metal/fabric/mesh_graph_descriptors/bh_glx_split_4x2.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // THere should be 12 indvidual meshes connected, verify that this is the case
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 48u);
+
+    // Each oft he mesh level graphs should have connections to other nodes
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    // Check that each graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graphs
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 32 nodes in the graph
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 8u);
+
+        // Check that each node should have 2 - 3 neighbors
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 2 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 3u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_BHGalaxy4x4Z) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses bh_galaxy_4x4_z_mesh_graph_descriptor with 2 meshes of 4x4 (16 nodes each)
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using bh_galaxy_4x4_z_mesh_graph_descriptor which has 2 meshes of 4x4 (16 nodes each)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_z_mesh_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // Should have 2 meshes
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 24u);
+
+    // Each of the mesh level graphs should have connections to other nodes
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    // Check that each graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graphs
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 16 nodes in the graph (4x4)
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 16u);
+
+        // Check that each node should have neighbors
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 2 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 4u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Dual8x2) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses dual_8x2_mesh_graph_descriptor with 2 meshes of 8x2 (16 nodes each)
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using dual_8x2_mesh_graph_descriptor which has 2 meshes of 8x2 (16 nodes each)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/dual_8x2_mesh_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // Should have 2 meshes
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 24u);
+
+    // Each of the mesh level graphs should have connections to other nodes
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    // Check that each graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graphs
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 16 nodes in the graph (8x2)
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 16u);
+
+        // Check that each node should have neighbors
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 2 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 3u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Galaxy1x32) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Uses galaxy_1x32_mesh_graph_descriptor with 1 mesh of 1x32 (32 nodes)
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (set by tt-run)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using galaxy_1x32_mesh_graph_descriptor which has 1 mesh of 1x32 (32 nodes)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // Should have 12 meshes
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 12u);
+
+    // Check that the graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graph
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 32 nodes in the graph (1x32)
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 32u);
+
+        // Check that each node should have neighbors (1D topology, so 1-2 neighbors)
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 4 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 4u * 2u);  // num directions * 4 channels per direction
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_1x16Torus) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Single BH galaxy (32 ASICs): uses single_bh_galaxy_torus_x (8x4, 32 nodes per mesh)
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    // Check if mock cluster descriptor is available (TT_METAL_MOCK_CLUSTER_DESC_PATH for single BH)
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with TT_METAL_MOCK_CLUSTER_DESC_PATH=...";
+    }
+
+    // Create PSD from mock cluster
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    // Load PGD - using triple_16x8_quad_bh_galaxy_physical_groupings
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    // Load MGD - using single_galaxy_1x16_torus_graph_descriptor which has 1 mesh of 1x16 (16 nodes)
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/single_galaxy_1x16_torus_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // Single BH galaxy: 1 mesh (full 32-ASIC 8x4 torus)
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 2u);
+
+    // Check that the graph has exit nodes (single-host may have 0 exit nodes)
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+    }
+
+    // Check the shape of the mesh adjacency graph (4x4 or 2x8)
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 16u);
+
+        // 8x4 with LINE x RING: 2D topology, 2-4 neighbors per node (BH may have more links)
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(adjacency_graph.get_neighbors(node).size(), 2u * 2u);
+            EXPECT_LE(adjacency_graph.get_neighbors(node).size(), 4u * 2u);
+        }
+    }
+}
+
+// Closest match for 2x1 is 2x2
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_N300) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Single BH galaxy (32 ASICs): p300 (1x2) matches PGD halftray_2x2 (4 ASICs), 32/4 = 8 meshes
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with TT_METAL_MOCK_CLUSTER_DESC_PATH=...";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tt_metal/fabric/mesh_graph_descriptors/p300_mesh_graph_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // PGD 2x2 halftray (4 ASICs) is smallest; 32/4 = 8 meshes
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 8u);
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 4u);  // 2x2
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_EQ(adjacency_graph.get_neighbors(node).size(), 2u * 2u);
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_Custom1x17) {
+    // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
+    // Single BH galaxy (32 ASICs): PGD has no 1x17 grouping; 1x17 BLACKHOLE matches 4x8_Mesh (32 ASICs)
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with TT_METAL_MOCK_CLUSTER_DESC_PATH=...";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    const std::string mgd_text_proto = R"proto(
+        mesh_descriptors {
+          name: "M0"
+          arch: BLACKHOLE
+          device_topology { dims: [ 1, 17 ] }
+          host_topology { dims: [ 1, 1 ] }
+          channels { count: 2 policy: RELAXED }
+        }
+
+        top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    )proto";
+    MeshGraphDescriptor mgd{mgd_text_proto};
+
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // PGD 4x8_Mesh (32 ASICs) is closest match for 1x17; 1 mesh with 32 nodes
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 1u);
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 32u);
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(adjacency_graph.get_neighbors(node).size(), 2u * 2u);
+            EXPECT_LE(adjacency_graph.get_neighbors(node).size(), 12u);
+        }
+    }
+}
+
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_SingleBHGalaxy_2x4Pipeline) {
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_2x4_pipeline.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    // Build physical multi-mesh graph using PGD and PSD
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    // Single BH galaxy (32 ASICs): 32/8 = 4 meshes of 2x4
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 4u);
+
+    // Check that the graph has exit nodes
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    // Check the shape of the mesh adjacency graph
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        // Check that there should be 8 nodes in the graph (2x4)
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), 8u);
+
+        // Check that each node should have neighbors (1D topology, so 1-2 neighbors)
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(
+                adjacency_graph.get_neighbors(node).size(), 2u * 2u);  // num directions * 4 channels per direction
+            EXPECT_LE(
+                adjacency_graph.get_neighbors(node).size(), 3u * 2u);  // num directions * 2 channels per direction
+        }
+    }
+
+    MeshGraph mesh_graph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, mgd_path.string());
+
+    // Test the multi-mesh mapping
+    const auto logical_multi_mesh_graph = build_logical_multi_mesh_adjacency_graph(mesh_graph);
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = true;
+
+    const auto topology_mapping_result =
+        map_multi_mesh_to_physical(logical_multi_mesh_graph, physical_multi_mesh_graph, config);
+
+    log_info(tt::LogFabric, "Topology mapping result: {}", topology_mapping_result.success);
+    log_info(tt::LogFabric, "Topology mapping error message: {}", topology_mapping_result.error_message);
+}
 }  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -3091,6 +3091,26 @@ TEST_F(TopologySolverTest, MappingConstraintsForbiddenManyToOne) {
     EXPECT_EQ(constraints.get_valid_mappings(2).count(11), 0u);
 }
 
+TEST_F(TopologySolverTest, MappingConstraintsForbiddenTwoFullListsCartesian) {
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+    constraints.add_required_constraint(1, std::set<TestGlobalNode>{10, 11});
+    constraints.add_required_constraint(2, std::set<TestGlobalNode>{10, 12});
+    EXPECT_TRUE(constraints.add_forbidden_constraint(std::set<TestTargetNode>{1, 2}, std::set<TestGlobalNode>{10}));
+    EXPECT_EQ(constraints.get_valid_mappings(1).size(), 1u);
+    EXPECT_EQ(constraints.get_valid_mappings(1).count(11), 1u);
+    EXPECT_EQ(constraints.get_valid_mappings(2).size(), 1u);
+    EXPECT_EQ(constraints.get_valid_mappings(2).count(12), 1u);
+}
+
+TEST_F(TopologySolverTest, MappingConstraintsForbiddenTwoListsRequiresBothNonEmpty) {
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+    constraints.add_required_constraint(1, 10);
+    EXPECT_FALSE(constraints.add_forbidden_constraint(std::set<TestTargetNode>{}, std::set<TestGlobalNode>{10}));
+    EXPECT_FALSE(constraints.add_forbidden_constraint(std::set<TestTargetNode>{1}, std::set<TestGlobalNode>{}));
+    EXPECT_FALSE(constraints.add_forbidden_constraint(std::set<TestTargetNode>{}, std::set<TestGlobalNode>{}));
+    EXPECT_EQ(constraints.get_valid_mappings(1).size(), 1u);
+}
+
 TEST_F(TopologySolverTest, MappingConstraintsForbiddenContradiction) {
     // Test that forbidden constraint cannot contradict required constraint
     MappingConstraints<TestTargetNode, TestGlobalNode> constraints;

--- a/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
@@ -98,7 +98,7 @@ groupings {
 # For triple connection / smaller pipeline stages
 groupings {
   name: "halftray_2x2"
-  custom_type: "HALFTRAY"
+  custom_type: "HALFTRAY1"
   instances: [
     { id: 0 asic_location: ASIC_LOCATION_1 },
     { id: 1 asic_location: ASIC_LOCATION_2 },
@@ -111,7 +111,20 @@ groupings {
 }
 groupings {
   name: "halftray_2x2"
-  custom_type: "HALFTRAY"
+  custom_type: "HALFTRAY2"
+  instances: [
+    { id: 0 asic_location: ASIC_LOCATION_5 },
+    { id: 1 asic_location: ASIC_LOCATION_6 },
+    { id: 2 asic_location: ASIC_LOCATION_1 },
+    { id: 3 asic_location: ASIC_LOCATION_2 }
+  ]
+  row_major_mesh {
+    dims: [2, 2]
+  }
+}
+groupings {
+  name: "halftray_2x2"
+  custom_type: "HALFTRAY1"
   instances: [
     { id: 0 asic_location: ASIC_LOCATION_3 },
     { id: 1 asic_location: ASIC_LOCATION_4 },
@@ -124,10 +137,32 @@ groupings {
 }
 
 groupings {
+  name: "halftray_2x2"
+  custom_type: "HALFTRAY2"
+  instances: [
+    { id: 0 asic_location: ASIC_LOCATION_7 },
+    { id: 1 asic_location: ASIC_LOCATION_8 },
+    { id: 2 asic_location: ASIC_LOCATION_3 },
+    { id: 3 asic_location: ASIC_LOCATION_4 }
+  ]
+  row_major_mesh {
+    dims: [2, 2]
+  }
+}
+
+groupings {
   name: "2x2 Mesh"
   preset_type: MESH
   instances: [
-    { id: 0 grouping_ref { custom_type: "HALFTRAY" } }
+    { id: 0 grouping_ref { custom_type: "HALFTRAY1" } }
+  ]
+}
+
+groupings {
+  name: "2x2 Mesh"
+  preset_type: MESH
+  instances: [
+    { id: 0 grouping_ref { custom_type: "HALFTRAY2" } }
   ]
 }
 
@@ -135,11 +170,11 @@ groupings {
   name: "4x2_Mesh"
   preset_type: MESH
   instances: [
-    { id: 0 grouping_ref { custom_type: "HALFTRAY" } },
-    { id: 1 grouping_ref { custom_type: "HALFTRAY" } }
+    { id: 0 grouping_ref { custom_type: "HALFTRAY1" } },
+    { id: 1 grouping_ref { custom_type: "HALFTRAY2" } }
   ]
   row_major_mesh {
-    dims: [1, 2]
+    dims: [2, 1]
   }
 }
 

--- a/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
@@ -162,18 +162,6 @@ groupings {
   ]
 }
 
-#groupings {
-#  name: "4x2 Mesh"
-#  preset_type: MESH
-#  instances: [
-#    { id: 0 grouping_ref { custom_type: "HALFTRAY" } },
-#    { id: 1 grouping_ref { custom_type: "HALFTRAY" } }
-#  ]
-#  row_major_mesh {
-#    dims: [2, 1]
-#  }
-#}
-
 # MESH: 2 trays (16 ASICs)
 groupings {
   name: "4x4_Mesh BH"

--- a/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
@@ -131,35 +131,16 @@ groupings {
   ]
 }
 
-# MESH: 1 tray (8 ASICs)
 groupings {
-  name: "2x4_Mesh"
+  name: "4x2_Mesh"
   preset_type: MESH
   instances: [
-    { id: 0 grouping_ref { preset_type: TRAY_1 } }
+    { id: 0 grouping_ref { custom_type: "HALFTRAY" } },
+    { id: 1 grouping_ref { custom_type: "HALFTRAY" } }
   ]
-}
-groupings {
-  name: "2x4_Mesh"
-  preset_type: MESH
-  instances: [
-    { id: 0 grouping_ref { preset_type: TRAY_2 } }
-  ]
-}
-groupings {
-  name: "2x4_Mesh"
-  preset_type: MESH
-  instances: [
-    { id: 0 grouping_ref { preset_type: TRAY_3 } }
-  ]
-}
-# MESH: 1 tray (8 ASICs)
-groupings {
-  name: "2x4_Mesh"
-  preset_type: MESH
-  instances: [
-    { id: 0 grouping_ref { preset_type: TRAY_4 } }
-  ]
+  row_major_mesh {
+    dims: [1, 2]
+  }
 }
 
 # MESH: 2 trays (16 ASICs)

--- a/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto
@@ -95,33 +95,40 @@ groupings {
   }
 }
 
-# HALFTRAY: 4 ASICs in 2x2 layout - either locations 1-4 or 5-8
 # For triple connection / smaller pipeline stages
 groupings {
-  name: "halftray_1_4"
-  custom_type: "halftray"
+  name: "halftray_2x2"
+  custom_type: "HALFTRAY"
   instances: [
     { id: 0 asic_location: ASIC_LOCATION_1 },
     { id: 1 asic_location: ASIC_LOCATION_2 },
-    { id: 2 asic_location: ASIC_LOCATION_3 },
-    { id: 3 asic_location: ASIC_LOCATION_4 }
+    { id: 2 asic_location: ASIC_LOCATION_5 },
+    { id: 3 asic_location: ASIC_LOCATION_6 }
   ]
   row_major_mesh {
     dims: [2, 2]
   }
 }
 groupings {
-  name: "halftray_5_8"
-  custom_type: "halftray"
+  name: "halftray_2x2"
+  custom_type: "HALFTRAY"
   instances: [
-    { id: 0 asic_location: ASIC_LOCATION_5 },
-    { id: 1 asic_location: ASIC_LOCATION_6 },
+    { id: 0 asic_location: ASIC_LOCATION_3 },
+    { id: 1 asic_location: ASIC_LOCATION_4 },
     { id: 2 asic_location: ASIC_LOCATION_7 },
     { id: 3 asic_location: ASIC_LOCATION_8 }
   ]
   row_major_mesh {
     dims: [2, 2]
   }
+}
+
+groupings {
+  name: "2x2 Mesh"
+  preset_type: MESH
+  instances: [
+    { id: 0 grouping_ref { custom_type: "HALFTRAY" } }
+  ]
 }
 
 # MESH: 1 tray (8 ASICs)
@@ -154,6 +161,18 @@ groupings {
     { id: 0 grouping_ref { preset_type: TRAY_4 } }
   ]
 }
+
+#groupings {
+#  name: "4x2 Mesh"
+#  preset_type: MESH
+#  instances: [
+#    { id: 0 grouping_ref { custom_type: "HALFTRAY" } },
+#    { id: 1 grouping_ref { custom_type: "HALFTRAY" } }
+#  ]
+#  row_major_mesh {
+#    dims: [2, 1]
+#  }
+#}
 
 # MESH: 2 trays (16 ASICs)
 groupings {

--- a/tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto
@@ -9,6 +9,44 @@ groupings {
   name: "tray_1"
   preset_type: TRAY_1
   instances: [
+    { id: 0 asic_location: ASIC_LOCATION_1 },
+    { id: 1 asic_location: ASIC_LOCATION_2 },
+    { id: 2 asic_location: ASIC_LOCATION_3 },
+    { id: 3 asic_location: ASIC_LOCATION_4 },
+    { id: 4 asic_location: ASIC_LOCATION_5 },
+    { id: 5 asic_location: ASIC_LOCATION_6 },
+    { id: 6 asic_location: ASIC_LOCATION_7 },
+    { id: 7 asic_location: ASIC_LOCATION_8 }
+  ]
+  row_major_mesh {
+    dims: [2, 4]
+  }
+}
+
+# TRAY_2: Bottom left corner is ASIC_LOCATION_1
+groupings {
+  name: "tray_2"
+  preset_type: TRAY_2
+  instances: [
+    { id: 0 asic_location: ASIC_LOCATION_4 },
+    { id: 1 asic_location: ASIC_LOCATION_3 },
+    { id: 2 asic_location: ASIC_LOCATION_2 },
+    { id: 3 asic_location: ASIC_LOCATION_1 },
+    { id: 4 asic_location: ASIC_LOCATION_8 },
+    { id: 5 asic_location: ASIC_LOCATION_7 },
+    { id: 6 asic_location: ASIC_LOCATION_6 },
+    { id: 7 asic_location: ASIC_LOCATION_5 }
+  ]
+  row_major_mesh {
+    dims: [2, 4]
+  }
+}
+
+# TRAY_3: Top right corner is ASIC_LOCATION_1
+groupings {
+  name: "tray_3"
+  preset_type: TRAY_3
+  instances: [
     { id: 0 asic_location: ASIC_LOCATION_5 },
     { id: 1 asic_location: ASIC_LOCATION_6 },
     { id: 2 asic_location: ASIC_LOCATION_7 },
@@ -23,7 +61,8 @@ groupings {
   }
 }
 
-# TRAY_2: Bottom left corner is ASIC_LOCATION_1
+
+# TRAY_4: Bottom right corner is ASIC_LOCATION_1
 groupings {
   name: "tray_2"
   preset_type: TRAY_2
@@ -61,6 +100,24 @@ groupings {
   }
 }
 
+# TRAY_3: Bottom left corner is ASIC_LOCATION_1
+groupings {
+  name: "tray_3"
+  preset_type: TRAY_3
+  instances: [
+    { id: 0 asic_location: ASIC_LOCATION_4 },
+    { id: 1 asic_location: ASIC_LOCATION_3 },
+    { id: 2 asic_location: ASIC_LOCATION_2 },
+    { id: 3 asic_location: ASIC_LOCATION_1 },
+    { id: 4 asic_location: ASIC_LOCATION_8 },
+    { id: 5 asic_location: ASIC_LOCATION_7 },
+    { id: 6 asic_location: ASIC_LOCATION_6 },
+    { id: 7 asic_location: ASIC_LOCATION_5 }
+  ]
+  row_major_mesh {
+    dims: [2, 4]
+  }
+}
 
 # TRAY_4: Bottom right corner is ASIC_LOCATION_1
 groupings {
@@ -221,6 +278,18 @@ groupings {
   instances: [
     { id: 0 grouping_ref { preset_type: TRAY_3 } },
     { id: 1 grouping_ref { preset_type: TRAY_4 } }
+  ]
+  row_major_mesh {
+    dims: [1, 2]
+  }
+}
+
+groupings {
+  name: "2x8_Mesh BH"
+  preset_type: MESH
+  instances: [
+    { id: 0 grouping_ref { preset_type: TRAY_1 } },
+    { id: 1 grouping_ref { preset_type: TRAY_2 } }
   ]
   row_major_mesh {
     dims: [1, 2]

--- a/tests/tt_metal/tt_fabric/physical_groupings/wh_t3k_physical_grouping_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/wh_t3k_physical_grouping_descriptor.textproto
@@ -6,10 +6,10 @@ groupings {
   name: "2x2_Mesh_t3k"
   preset_type: MESH
   instances: [
-    { id: 0 asic_location: ASIC_LOCATION_1 },
-    { id: 1 asic_location: ASIC_LOCATION_1 },
-    { id: 2 asic_location: ASIC_LOCATION_0 },
-    { id: 3 asic_location: ASIC_LOCATION_0 }
+    { id: 0 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 1 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 2 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 3 asic_location: ASIC_LOCATION_UNSPECIFIED }
   ]
   row_major_mesh {
     dims: [2, 2]
@@ -20,14 +20,14 @@ groupings {
   name: "2x4_Mesh_t3k"
   preset_type: MESH
   instances: [
-    { id: 0 asic_location: ASIC_LOCATION_1 },
-    { id: 1 asic_location: ASIC_LOCATION_0 },
-    { id: 2 asic_location: ASIC_LOCATION_0 },
-    { id: 3 asic_location: ASIC_LOCATION_1 },
-    { id: 4 asic_location: ASIC_LOCATION_1 },
-    { id: 5 asic_location: ASIC_LOCATION_0 },
-    { id: 6 asic_location: ASIC_LOCATION_0 },
-    { id: 7 asic_location: ASIC_LOCATION_1 }
+    { id: 0 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 1 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 2 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 3 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 4 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 5 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 6 asic_location: ASIC_LOCATION_UNSPECIFIED },
+    { id: 7 asic_location: ASIC_LOCATION_UNSPECIFIED }
   ]
   row_major_mesh {
     dims: [2, 4]

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -55,10 +55,12 @@ struct GroupingItemInfo {
 struct GroupingInfo {
     std::string name;  // Unique identifier/name for this specific grouping instance
     std::string type;  // Type of grouping (e.g., "MESH", "TRAY_1", "meshes", "pods")
-    std::vector<GroupingItemInfo> items;  // items[i] is the item for graph node i (0..n-1)
+    // items[node_id] is the item for graph node node_id. Flattened meshes may use non-contiguous IDs;
+    // in that case size is max_node_id+1 (only indices present in adjacency_graph are meaningful).
+    std::vector<GroupingItemInfo> items;
     uint32_t asic_count = 0;  // Total ASICs provided by this grouping, calculated bottom-up during population
 
-    // Adjacency graph. For flattened groupings, nodes are 0..n-1 and items[i] = item for node i.
+    // Adjacency graph. For flattened groupings, items[node_id] matches each node in the graph.
     // Empty graph if no connection type is specified.
     AdjacencyGraph<uint32_t> adjacency_graph;
 };

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -145,6 +145,20 @@ public:
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
         std::vector<std::string>& errors_out) const;
 
+    // Same as find_all_in_psd above, but uses a prebuilt flat ASIC adjacency graph from the PSD (from
+    // build_flat_adjacency_map_from_psd). Callers that already built the graph can pass it to avoid a
+    // duplicate O(|PSD|) scan and graph construction.
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> find_all_in_psd(
+        const std::vector<GroupingInfo>& groupings,
+        const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+        const AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph) const;
+
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> find_all_in_psd(
+        const std::vector<GroupingInfo>& groupings,
+        const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+        const AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph,
+        std::vector<std::string>& errors_out) const;
+
     // Build flattened adjacency meshes - one per possibility based on possible groupings that can be formed
     // Returns vector of GroupingInfo objects, each with adjacency_graph populated and node metadata maps filled
     std::vector<GroupingInfo> build_flattened_adjacency_mesh(const GroupingInfo& grouping) const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -4,9 +4,14 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
+#include <map>
+#include <numeric>
 #include <ostream>
+#include <set>
 #include <string>
+#include <utility>
 #include <filesystem>
 #include <memory>
 #include <vector>
@@ -166,6 +171,39 @@ public:
     // Overload that accepts a PhysicalSystemDescriptor reference for validation/filtering
     std::vector<GroupingInfo> build_flattened_adjacency_mesh(
         const GroupingInfo& grouping, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) const;
+
+    // Greedy minimum coverage over disjoint global groups (e.g. one set per host). Returns whether some single group
+    // has enough capacity for all targets, and the union of the largest groups until target count is covered.
+    template <typename TargetNode, typename GlobalNode>
+    static std::pair<bool, std::set<GlobalNode>> find_minimum_coverage_group(
+        const std::set<TargetNode>& all_targets, const std::vector<std::set<GlobalNode>>& global_groups) {
+        std::pair<bool, std::set<GlobalNode>> out{false, {}};
+        if (all_targets.empty() || global_groups.empty()) {
+            return out;
+        }
+        const std::size_t target_count = all_targets.size();
+        for (const auto& g : global_groups) {
+            if (g.size() >= target_count) {
+                out.first = true;
+                break;
+            }
+        }
+        std::vector<std::size_t> group_indices(global_groups.size());
+        std::iota(group_indices.begin(), group_indices.end(), 0);
+        std::sort(group_indices.begin(), group_indices.end(), [&](std::size_t a, std::size_t b) {
+            return global_groups[a].size() > global_groups[b].size();
+        });
+        std::size_t covered = 0;
+        for (std::size_t idx : group_indices) {
+            const auto& g = global_groups[idx];
+            out.second.insert(g.begin(), g.end());
+            covered += g.size();
+            if (covered >= target_count) {
+                break;
+            }
+        }
+        return out;
+    }
 
 private:
     // Data members

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -455,6 +455,8 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
  *       inter-mesh pairings. If all attempts fail, result.success will be false
  * @note If config.disable_rank_bindings is true, rank constraints are ignored and any valid connectivity
  *       mapping is allowed
+ * @note When config.hostname_to_asics is non-empty, inter-mesh solving applies the same minimal host-cover bias as PGD
+ *       (same-rank / preferred globals) so mesh-to-mesh mapping tends to use fewer hosts when possible.
  */
 TopologyMappingResult map_multi_mesh_to_physical(
     const LogicalMultiMeshGraph& adjacency_map_logical,

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -19,6 +19,10 @@ namespace tt::tt_metal {
 class PhysicalSystemDescriptor;
 }  // namespace tt::tt_metal
 
+namespace tt::tt_fabric {
+class PhysicalGroupingDescriptor;
+}  // namespace tt::tt_fabric
+
 namespace tt::tt_metal::experimental::tt_fabric {
 
 // Import types from tt::tt_fabric for use in this API
@@ -47,9 +51,9 @@ using PinningConstraint = std::pair<AsicPosition, FabricNodeId>;
  * @brief Configuration options for topology mapping
  */
 struct TopologyMappingConfig {
-    // When true, validates that physical connections have at least as many
-    // channels as required by logical connections. When false, only checks
-    // that connections exist (relaxed mode).
+    // Deprecated: ignored by topology mapping. Use mesh_validation_modes and inter_mesh_validation_mode
+    // with ConnectionValidationMode::STRICT / RELAXED instead. Kept for backward compatibility with callers
+    // that still set the field.
     bool strict_mode = false;
 
     // Optional pinning constraints that restrict which physical ASICs
@@ -61,7 +65,7 @@ struct TopologyMappingConfig {
     AsicPositionMap asic_positions;
 
     // Per-mesh validation modes for intra-mesh mapping (fabric node to ASIC).
-    // If empty, falls back to strict_mode for backward compatibility.
+    // If a logical mesh ID is missing, intra-mesh mapping uses RELAXED for that mesh.
     std::map<MeshId, ConnectionValidationMode> mesh_validation_modes;
 
     // Validation mode for inter-mesh mapping (mesh to mesh).
@@ -111,7 +115,7 @@ struct TopologyMappingResult {
  * @param physical_adjacency   Map from AsicID to list of neighbor AsicIDs
  * @param node_to_host_rank    Map from FabricNodeId to the host rank that owns it
  * @param asic_to_host_rank    Map from AsicID to the host rank that owns it
- * @param config               Optional configuration (strict mode, pinning constraints)
+ * @param config               Optional configuration (validation modes, pinning constraints)
  *
  * @return TopologyMappingResult containing success status and bidirectional mappings
  *
@@ -128,7 +132,7 @@ struct TopologyMappingResult {
  * // Populate adjacency maps from your topology data...
  *
  * TopologyMappingConfig config;
- * config.strict_mode = true;  // Validate channel counts
+ * config.mesh_validation_modes[MeshId{0}] = ConnectionValidationMode::STRICT;  // validate channel counts
  *
  * auto result = map_mesh_to_physical(
  *     MeshId{0}, logical_adj, physical_adj, node_to_rank, asic_to_rank, config);
@@ -162,21 +166,6 @@ TopologyMappingResult map_mesh_to_physical(
  * @return std::map<MeshId, LogicalAdjacencyMap> Map from mesh ID to logical adjacency map
  */
 std::map<MeshId, LogicalAdjacencyMap> build_adjacency_map_logical(const ::tt::tt_fabric::MeshGraph& mesh_graph);
-
-/**
- * @brief Build a flat PhysicalAdjacencyMap from PhysicalSystemDescriptor
- *
- * Builds a complete flat adjacency map including all connections (both intra-mesh and intermesh),
- * with multiple entries per channel. If asic_id_to_mesh_rank is empty, includes all ASICs from PSD.
- *
- * @param physical_system_descriptor Reference to the physical system descriptor containing ASIC topology
- * @param asic_id_to_mesh_rank Optional mapping of mesh IDs to ASIC IDs to mesh host ranks.
- *                              If empty, all ASICs from PSD are included.
- * @return PhysicalAdjacencyMap Map from AsicID to vector of neighbor AsicIDs
- */
-PhysicalAdjacencyMap build_flat_adjacency_map_from_psd(
-    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
-    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank = {});
 
 /**
  * @brief Build physical adjacency maps from system descriptor connectivity
@@ -385,10 +374,40 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 
 /**
+ * @brief Build a physical multi-mesh adjacency graph from physical system descriptor and physical grouping descriptor
+ *
+ * Creates a PhysicalMultiMeshGraph with:
+ * - Mesh-level adjacency graph (AdjacencyGraph<MeshId>) representing inter-mesh connectivity
+ * - Map of mesh IDs to their internal adjacency graphs (AdjacencyGraph<AsicID>)
+ *
+ * @param physical_system_descriptor Reference to the physical system descriptor containing ASIC topology
+ * @param physical_grouping_descriptor Reference to the physical grouping descriptor containing mesh grouping
+ * information
+ * @param mesh_graph_descriptor Reference to the mesh graph descriptor containing logical mesh topology
+ * @return PhysicalMultiMeshGraph containing mesh-level graph and internal mesh nodes
+ */
+PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const tt::tt_fabric::PhysicalGroupingDescriptor& physical_grouping_descriptor,
+    const tt::tt_fabric::MeshGraphDescriptor& mesh_graph_descriptor);
+
+/**
+ * @brief Build a flat PhysicalAdjacencyMap from PhysicalSystemDescriptor
+ *
+ * Builds a complete flat adjacency map including all connections
+ * (both intra-mesh and intermesh), with multiple entries per channel.
+ *
+ * @param physical_system_descriptor Reference to the physical system descriptor containing ASIC topology
+ * @return PhysicalAdjacencyMap Map from AsicID to vector of neighbor AsicIDs (with multiple entries per channel)
+ */
+PhysicalAdjacencyMap build_flat_adjacency_map_from_psd(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor);
+
+/**
  * @brief Build hierarchical multi-mesh graph from a flattened adjacency graph
  *
  * Takes a flat adjacency graph (all ASICs and their neighbors) and splits it into a multi-mesh graph
- * based on mesh assignments. This is useful when you have a pre-built adjacency graph and need to
+ * based on mesh groupings. This is useful when you have a pre-built adjacency graph and need to
  * organize it by mesh.
  *
  * The function:
@@ -397,13 +416,13 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
  * - Builds exit node graphs for each mesh
  *
  * @param flat_adjacency_graph Flat adjacency graph containing all ASICs and their neighbors
- * @param asic_id_to_mesh_rank Mapping of mesh IDs to ASIC IDs to mesh host ranks.
- *                              Used to determine which mesh each ASIC belongs to.
+ * @param mesh_groupings Vector of mesh groupings, where each grouping is a set of ASIC IDs belonging to one mesh.
+ *                       Each element in the vector represents one mesh, and the index becomes the MeshId.
  * @return PhysicalMultiMeshGraph containing mesh-level graph, per-mesh adjacency graphs, and exit node graphs
  */
 PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
     const AdjacencyGraph<tt::tt_metal::AsicID>& flat_adjacency_graph,
-    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
+    const std::vector<std::unordered_set<tt::tt_metal::AsicID>>& mesh_groupings);
 
 /**
  * @brief Map logical multi-mesh topology to physical multi-mesh topology
@@ -420,9 +439,8 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
  * @param adjacency_map_logical Logical multi-mesh adjacency graph
  * @param adjacency_map_physical Physical multi-mesh adjacency graph
  * @param config Configuration options including pinning constraints, ASIC positions, and validation modes.
- *               config.mesh_validation_modes and config.inter_mesh_validation_mode should be set for proper
- *               validation. If not set, defaults to RELAXED mode. If config.strict_mode is true, it will be
- *               used as a fallback for backward compatibility.
+ *               config.mesh_validation_modes and config.inter_mesh_validation_mode select STRICT vs RELAXED.
+ *               If unset, mapping defaults to RELAXED for that scope.
  *               If config.disable_rank_bindings is true, rank mappings are ignored and can be omitted.
  * @param asic_id_to_mesh_rank Optional mapping of mesh IDs to ASIC IDs to mesh host ranks.
  *                             Required if config.disable_rank_bindings is false.

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -277,6 +277,18 @@ public:
     bool add_forbidden_constraint(const std::set<TargetNode>& target_nodes, GlobalNode global_node);
 
     /**
+     * @brief Add explicit forbidden constraint (two full lists, Cartesian product)
+     *
+     * Forbids every (target, global) pair in `target_nodes` × `global_nodes`. Both sets must be
+     * non-empty explicit lists; empty target or global set is rejected (returns false, logged).
+     *
+     * @param target_nodes Non-empty set of target nodes
+     * @param global_nodes Non-empty set of global nodes (e.g. chips / ASICs)
+     * @return true if all pairs were added and constraints remain valid
+     */
+    bool add_forbidden_constraint(const std::set<TargetNode>& target_nodes, const std::set<GlobalNode>& global_nodes);
+
+    /**
      * @brief Add cardinality constraint (at-least-N constraint)
      *
      * Requires that at least `min_count` of the provided (target, global) mapping pairs

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -888,6 +888,46 @@ bool MappingConstraints<TargetNode, GlobalNode>::add_forbidden_constraint(
 }
 
 template <typename TargetNode, typename GlobalNode>
+bool MappingConstraints<TargetNode, GlobalNode>::add_forbidden_constraint(
+    const std::set<TargetNode>& target_nodes, const std::set<GlobalNode>& global_nodes) {
+    if (target_nodes.empty() || global_nodes.empty()) {
+        log_info(
+            tt::LogFabric,
+            "add_forbidden_constraint: target_nodes and global_nodes must both be non-empty explicit lists "
+            "(Cartesian product); got {} target(s) and {} global(s)",
+            target_nodes.size(),
+            global_nodes.size());
+        return false;
+    }
+
+    std::vector<std::pair<TargetNode, GlobalNode>> pairs;
+    for (const auto& t : target_nodes) {
+        for (const auto& g : global_nodes) {
+            pairs.emplace_back(t, g);
+        }
+    }
+
+    std::map<TargetNode, std::optional<std::set<GlobalNode>>> saved_state;
+    for (const auto& [t, g] : pairs) {
+        forbidden_pairs_.insert({t, g});
+        auto it = valid_mappings_.find(t);
+        if (it != valid_mappings_.end()) {
+            if (saved_state.find(t) == saved_state.end()) {
+                saved_state[t] = std::make_optional(it->second);
+            }
+            it->second.erase(g);
+        }
+    }
+    const bool ok = validate(saved_state.empty() ? nullptr : &saved_state);
+    if (!ok) {
+        for (const auto& [t, g] : pairs) {
+            forbidden_pairs_.erase({t, g});
+        }
+    }
+    return ok;
+}
+
+template <typename TargetNode, typename GlobalNode>
 bool MappingConstraints<TargetNode, GlobalNode>::add_cardinality_constraint(
     const std::set<std::pair<TargetNode, GlobalNode>>& mapping_pairs, size_t min_count) {
     if (mapping_pairs.empty()) {

--- a/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_graph_building.cpp
@@ -817,11 +817,19 @@ tt::tt_fabric::AdjacencyGraph<uint32_t> join_mesh_level(
     return ::tt::tt_metal::ASICLocation{0};
 }
 
-// Rebuild GroupingInfo.items from FlattenedMesh. Graph nodes are 0..n-1; items[i] is the item for node i.
+// Rebuild GroupingInfo.items from FlattenedMesh. items[node_id] is the item for graph node `node_id`.
+// Joined meshes may use non-contiguous node IDs (e.g. 0..3 and 8..11); index by node_id, not push order.
 void rebuild_items_from_flattened_mesh(tt::tt_fabric::GroupingInfo& info, const FlattenedMesh& mesh) {
     info.items.clear();
     const auto& node_ids = mesh.graph.get_nodes();
-    info.items.reserve(node_ids.size());
+    if (node_ids.empty()) {
+        return;
+    }
+    uint32_t max_node_id = 0;
+    for (uint32_t node_id : node_ids) {
+        max_node_id = std::max(max_node_id, node_id);
+    }
+    info.items.resize(max_node_id + 1);
 
     for (uint32_t node_id : node_ids) {
         tt::tt_fabric::GroupingItemInfo item;
@@ -836,7 +844,7 @@ void rebuild_items_from_flattened_mesh(tt::tt_fabric::GroupingInfo& info, const 
             item.asic_location = extract_asic_location_from_path(metadata.grouping_path);
             item.grouping_path = metadata.grouping_path;
         }
-        info.items.push_back(std::move(item));
+        info.items[node_id] = std::move(item);
     }
 }
 

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -1053,41 +1053,8 @@ bool is_flattened(const GroupingInfo& grouping) {
 
 namespace tt::tt_fabric {
 
-// Helper: add forbidden constraints for used ASICs so they won't be reused.
-// Returns false if any constraint could not be added (e.g. would overconstrain).
-static bool add_forbidden_for_used_asics(
-    const std::set<AsicID>& used_asic_ids,
-    const std::set<uint32_t>& target_nodes,
-    MappingConstraints<uint32_t, AsicID>& constraints) {
-    for (const auto& asic_id : used_asic_ids) {
-        if (!constraints.add_forbidden_constraint(target_nodes, asic_id)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 // Maximum placements to find before stopping (safeguard against infinite loops).
 constexpr size_t kMaxPlacementsPerRun = 10000;
-
-// Helper: add forbidden constraints to all groupings (ASICs shared globally).
-static bool add_forbidden_for_used_asics_to_all_groupings(
-    const std::set<AsicID>& used_asic_ids,
-    const std::vector<GroupingInfo>& groupings,
-    std::vector<MappingConstraints<uint32_t, AsicID>>& constraints) {
-    for (size_t j = 0; j < groupings.size(); ++j) {
-        const auto& nodes = groupings[j].adjacency_graph.get_nodes();
-        if (nodes.empty()) {
-            continue;
-        }
-        std::set<uint32_t> targets(nodes.begin(), nodes.end());
-        if (!add_forbidden_for_used_asics(used_asic_ids, targets, constraints[j])) {
-            return false;
-        }
-    }
-    return true;
-}
-
 // TODO: Optimize constraints for maximum usage
 // https://github.com/tenstorrent/tt-metal/issues/40639
 std::vector<MappingResult<uint32_t, AsicID>> solve_for_many_groupings_to_psd(
@@ -1120,18 +1087,12 @@ std::vector<MappingResult<uint32_t, AsicID>> solve_for_many_groupings_to_psd(
             used_asic_ids.insert(asic_id);
         }
 
-        if (seen_asic_sets.contains(used_asic_ids)) {
-            log_warning(tt::LogFabric, "Homogeneous solver: repeated result - stopping to prevent infinite loop");
-            break;
-        }
-        seen_asic_sets.insert(used_asic_ids);
-
         results.push_back(result);
 
         std::set<uint32_t> all_target_nodes(flat_mesh.get_nodes().begin(), flat_mesh.get_nodes().end());
-        if (!add_forbidden_for_used_asics(used_asic_ids, all_target_nodes, current_constraints)) {
-            break;
-        }
+        TT_FATAL(
+            current_constraints.add_forbidden_constraint(all_target_nodes, used_asic_ids),
+            "Homogeneous solver: failed to add forbidden constraints to all groupings");
     }
 
     return results;
@@ -1149,8 +1110,14 @@ solve_for_many_groupings_to_psd_heterogeneous(
     const AdjacencyGraph<AsicID>& physical_graph,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
     std::vector<std::vector<MappingResult<uint32_t, AsicID>>> results(groupings.size());
-    std::vector<MappingConstraints<uint32_t, AsicID>> current_constraints(groupings.size());
-    std::vector<std::set<std::set<AsicID>>> seen_asic_sets_per_grouping(groupings.size());
+    MappingConstraints<uint32_t, AsicID> current_constraints;
+
+    std::set<uint32_t> all_target_nodes_union;
+    for (const auto& grouping : groupings) {
+        for (uint32_t n : grouping.adjacency_graph.get_nodes()) {
+            all_target_nodes_union.insert(n);
+        }
+    }
 
     while (true) {
         size_t total_results = 0;
@@ -1175,7 +1142,7 @@ solve_for_many_groupings_to_psd_heterogeneous(
             }
 
             MappingResult<uint32_t, AsicID> result = solve_for_one_grouping_to_psd(
-                grouping, physical_graph, physical_system_descriptor, current_constraints[i]);
+                grouping, physical_graph, physical_system_descriptor, current_constraints);
 
             if (!result.success) {
                 ++i;
@@ -1187,52 +1154,12 @@ solve_for_many_groupings_to_psd_heterogeneous(
                 used_asic_ids.insert(asic_id);
             }
 
-            // Skip if this placement overlaps with results from a different grouping family (different name).
-            // Forbidden constraints may fail (validate) when adding to groupings with required traits that
-            // only allow the used ASICs; this check ensures we use only one disjoint family.
-            bool overlaps_other_family = false;
-            for (size_t j = 0; j < groupings.size(); ++j) {
-                if (groupings[j].name != grouping.name) {
-                    for (const auto& prev_result : results[j]) {
-                        for (const auto& [_, prev_asic] : prev_result.target_to_global) {
-                            if (used_asic_ids.contains(prev_asic)) {
-                                overlaps_other_family = true;
-                                break;
-                            }
-                        }
-                        if (overlaps_other_family) {
-                            break;
-                        }
-                    }
-                }
-                if (overlaps_other_family) {
-                    break;
-                }
-            }
-            if (overlaps_other_family) {
-                ++i;
-                continue;
-            }
-
-            // Guard against infinite loop when forbidden constraints don't take effect
-            if (seen_asic_sets_per_grouping[i].contains(used_asic_ids)) {
-                log_warning(
-                    tt::LogFabric,
-                    "Heterogeneous solver: grouping {} repeated result - stopping to prevent infinite loop",
-                    i);
-                overconstrained = true;
-                break;
-            }
-            seen_asic_sets_per_grouping[i].insert(used_asic_ids);
-
             results[i].push_back(result);
             found_any = true;
 
-            if (!add_forbidden_for_used_asics_to_all_groupings(used_asic_ids, groupings, current_constraints)) {
-                overconstrained = true;
-                break;
-            }
-            ++i;
+            TT_FATAL(
+                current_constraints.add_forbidden_constraint(all_target_nodes_union, used_asic_ids),
+                "Internal Error: Heterogeneous solver: failed to add forbidden constraints to all groupings");
         }
         if (!found_any || overconstrained) {
             break;

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -1256,15 +1256,29 @@ std::vector<std::unordered_set<tt::tt_metal::AsicID>> PhysicalGroupingDescriptor
     return find_all_in_psd(groupings, physical_system_descriptor, errors);
 }
 
-// NOTE this only works on flattenable meshes right now
+std::vector<std::unordered_set<tt::tt_metal::AsicID>> PhysicalGroupingDescriptor::find_all_in_psd(
+    const std::vector<GroupingInfo>& groupings,
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const AdjacencyGraph<AsicID>& physical_graph) const {
+    std::vector<std::string> errors;
+    return find_all_in_psd(groupings, physical_system_descriptor, physical_graph, errors);
+}
+
 std::vector<std::unordered_set<tt::tt_metal::AsicID>> PhysicalGroupingDescriptor::find_all_in_psd(
     const std::vector<GroupingInfo>& groupings,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     std::vector<std::string>& errors_out) const {
-    // Build physical adjacency map from PSD (empty map means include all ASICs)
     PhysicalAdjacencyMap physical_adj_map = build_flat_adjacency_map_from_psd(physical_system_descriptor);
     AdjacencyGraph<AsicID> physical_graph(physical_adj_map);
+    return find_all_in_psd(groupings, physical_system_descriptor, physical_graph, errors_out);
+}
 
+// NOTE this only works on flattenable meshes right now
+std::vector<std::unordered_set<tt::tt_metal::AsicID>> PhysicalGroupingDescriptor::find_all_in_psd(
+    const std::vector<GroupingInfo>& groupings,
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const AdjacencyGraph<AsicID>& physical_graph,
+    std::vector<std::string>& errors_out) const {
     // Flatten each grouping and collect all non-empty flat meshes
     std::vector<GroupingInfo> flat_meshes;
     for (const auto& grouping : groupings) {

--- a/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor_matching.cpp
@@ -877,50 +877,6 @@ void configure_pgd_psd_host_alignment_constraints(
         return;
     }
 
-    // Check if some host can hold the mesh
-    const size_t mesh_target_count = all_targets.size();
-    bool some_host_can_hold_mesh = false;
-    for (const auto& [_, asics] : host_to_asics) {
-        if (asics.size() >= mesh_target_count) {
-            some_host_can_hold_mesh = true;
-            break;
-        }
-    }
-
-    // Greedy minimal host cover algo to find the smallest set of hosts that can hold the mesh
-    std::set<AsicID> preferred_asics_minimal_host_cover;
-    if (!some_host_can_hold_mesh) {
-        std::vector<std::string> hostnames_by_size;
-        hostnames_by_size.reserve(host_to_asics.size());
-        for (const auto& [hn, asics] : host_to_asics) {
-            if (!asics.empty()) {
-                hostnames_by_size.push_back(hn);
-            }
-        }
-        // Sort hosts by size descending, then alphabetically ascending
-        std::sort(hostnames_by_size.begin(), hostnames_by_size.end(), [&](const std::string& a, const std::string& b) {
-            size_t sa = host_to_asics.at(a).size();
-            size_t sb = host_to_asics.at(b).size();
-            if (sa != sb) {
-                return sa > sb;
-            }
-            return a < b;
-        });
-        size_t covered = 0;
-        for (const std::string& hn : hostnames_by_size) {
-            const auto& asics = host_to_asics.at(hn);
-            preferred_asics_minimal_host_cover.insert(asics.begin(), asics.end());
-            covered += asics.size();
-            if (covered >= mesh_target_count) {
-                break;
-            }
-        }
-    }
-
-    std::vector<std::set<uint32_t>> target_groups;
-    target_groups.push_back(std::move(all_targets));
-
-    // Find groups that can hold the mesh
     std::vector<std::set<AsicID>> global_groups;
     global_groups.reserve(host_to_asics.size());
     for (auto& [_, asics] : host_to_asics) {
@@ -929,33 +885,29 @@ void configure_pgd_psd_host_alignment_constraints(
         }
     }
 
-    if (global_groups.empty()) {
-        return;
-    }
-
-    // Set same-rank groups constraint if some host can hold the mesh
-    if (some_host_can_hold_mesh) {
-        bool success = constraints.set_same_rank_groups_constraint(target_groups, global_groups);
-        if (!success) {
-            log_warning(
-                tt::LogFabric,
-                "PGD host alignment: failed to set same-rank groups constraint; groupings might cross host boundaries");
+    const auto [single_group_fits, preferred_globals] =
+        ::tt::tt_fabric::PhysicalGroupingDescriptor::find_minimum_coverage_group(all_targets, global_groups);
+    if (single_group_fits) {
+        std::vector<std::set<uint32_t>> target_groups;
+        target_groups.push_back(all_targets);
+        if (constraints.set_same_rank_groups_constraint(target_groups, global_groups)) {
             return;
         }
-        return;
+        log_warning(
+            tt::LogFabric,
+            "PGD host alignment: failed to set same-rank groups constraint; falling back to preferred globals");
     }
-
-    // If the rank groups constraint fails because they are constrained to too small a group of hosts, set a preferred
-    // constraint to the minimal host cover and allow the solver to choose the best one.
-    log_debug(
-        tt::LogFabric,
-        "PGD host alignment: mesh size {} exceeds every host's ASIC count; preferring minimal host cover ({} ASICs)",
-        mesh_target_count,
-        preferred_asics_minimal_host_cover.size());
-
-    if (!preferred_asics_minimal_host_cover.empty()) {
-        for (uint32_t target : target_groups.front()) {
-            constraints.add_preferred_constraint(target, preferred_asics_minimal_host_cover);
+    if (!preferred_globals.empty()) {
+        if (!single_group_fits) {
+            log_debug(
+                tt::LogFabric,
+                "PGD host alignment: target count {} exceeds largest single partition; preferring minimal host cover "
+                "({} preferred globals)",
+                all_targets.size(),
+                preferred_globals.size());
+        }
+        for (const uint32_t& target : all_targets) {
+            constraints.add_preferred_constraint(target, preferred_globals);
         }
     }
 }

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <tuple>
@@ -659,18 +660,122 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
 }
 
 namespace {
+
+static std::optional<std::string> hostname_for_asic_from_hostname_map(
+    tt::tt_metal::AsicID asic_id, const std::map<std::string, std::set<tt::tt_metal::AsicID>>& hostname_to_asics) {
+    for (const auto& [hostname, asics] : hostname_to_asics) {
+        if (asics.contains(asic_id)) {
+            return hostname;
+        }
+    }
+    return std::nullopt;
+}
+
+// Minimal host cover for inter-mesh mapping: partition physical meshes by host, then apply.
+// `rank_bound_logical_to_physical`: logical meshes already fixed by rank bindings → skip those and their physical
+// meshes for host-alignment bias (empty when rank bindings are disabled).
+// TODO: THis can be removed and replaced with cost hieristics when using a SAT solver because preferred constraints
+// aren't very effective here
+// https://github.com/tenstorrent/tt-metal/issues/40640
+static void add_inter_mesh_minimal_host_cover_from_hostname_map(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId>& inter_mesh_constraints,
+    const std::map<MeshId, MeshId>& rank_bound_logical_to_physical) {
+    if (config.hostname_to_asics.empty()) {
+        return;
+    }
+
+    std::set<MeshId> bound_physical_mesh_ids;
+    for (const auto& [_, physical_mesh_id] : rank_bound_logical_to_physical) {
+        bound_physical_mesh_ids.insert(physical_mesh_id);
+    }
+
+    std::set<MeshId> logical_target_set;
+    for (const MeshId& m : mesh_logical_level_graph.get_nodes()) {
+        if (!rank_bound_logical_to_physical.contains(m)) {
+            logical_target_set.insert(m);
+        }
+    }
+    if (logical_target_set.size() <= 1) {
+        return;
+    }
+
+    // Build global_mesh_groups in one pass: one group per host for single-host meshes, singleton for multi-host.
+    std::vector<std::set<MeshId>> global_mesh_groups;
+    std::map<std::string, std::size_t> host_group_index;
+    for (const auto& [phys_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+        if (bound_physical_mesh_ids.contains(phys_mesh_id)) {
+            continue;
+        }
+        if (adj.get_nodes().empty()) {
+            continue;
+        }
+        std::set<std::string> hosts_for_mesh;
+        for (const auto& asic_id : adj.get_nodes()) {
+            auto hostname = hostname_for_asic_from_hostname_map(asic_id, config.hostname_to_asics);
+            if (hostname.has_value()) {
+                hosts_for_mesh.insert(*hostname);
+            }
+        }
+        if (hosts_for_mesh.size() == 1) {
+            auto [it, inserted] = host_group_index.try_emplace(*hosts_for_mesh.begin(), global_mesh_groups.size());
+            if (inserted) {
+                global_mesh_groups.emplace_back();
+            }
+            global_mesh_groups[it->second].insert(phys_mesh_id);
+        } else {
+            global_mesh_groups.push_back({phys_mesh_id});
+        }
+    }
+    if (global_mesh_groups.empty()) {
+        return;
+    }
+
+    const auto [single_group_fits, preferred_globals] =
+        ::tt::tt_fabric::PhysicalGroupingDescriptor::find_minimum_coverage_group(
+            logical_target_set, global_mesh_groups);
+    if (single_group_fits) {
+        std::vector<std::set<MeshId>> target_groups;
+        target_groups.push_back(logical_target_set);
+        if (inter_mesh_constraints.set_same_rank_groups_constraint(target_groups, global_mesh_groups)) {
+            return;
+        }
+        log_warning(
+            tt::LogFabric,
+            "Inter-mesh host alignment: failed to set same-rank groups constraint; falling back to preferred globals");
+    }
+    if (!preferred_globals.empty()) {
+        if (!single_group_fits) {
+            log_debug(
+                tt::LogFabric,
+                "Inter-mesh host alignment: target count {} exceeds largest single partition; preferring minimal host "
+                "cover ({} preferred globals)",
+                logical_target_set.size(),
+                preferred_globals.size());
+        }
+        for (const MeshId& target : logical_target_set) {
+            inter_mesh_constraints.add_preferred_constraint(target, preferred_globals);
+        }
+    }
+}
+
 // Helper function to build inter-mesh constraints
 // Maps logical meshes to physical meshes based on matching mesh host ranks
 // A logical mesh maps to a physical mesh if the ASICs in that physical mesh have matching ranks
 ::tt::tt_fabric::MappingConstraints<MeshId, MeshId> build_inter_mesh_constraints(
     const TopologyMappingConfig& config,
     const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
     const std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>>& fabric_node_id_to_mesh_rank,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
     ::tt::tt_fabric::MappingConstraints<MeshId, MeshId> inter_mesh_constraints;
 
     // Skip if rank bindings are disabled
     if (config.disable_rank_bindings) {
+        add_inter_mesh_minimal_host_cover_from_hostname_map(
+            config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
         return inter_mesh_constraints;
     }
 
@@ -701,14 +806,18 @@ namespace {
         }
     }
 
-    // Set constraints from the Mesh ID in asic id to mesh rank to the logical mesh id
+    std::map<MeshId, MeshId> rank_bound_logical_to_physical;
     for (const auto& [logical_mesh_id, _] : fabric_node_id_to_mesh_rank) {
-        if (real_mesh_to_physical_mesh_id.contains(logical_mesh_id)) {
-            inter_mesh_constraints.add_required_constraint(
-                logical_mesh_id, real_mesh_to_physical_mesh_id.at(logical_mesh_id));
+        const auto physical_it = real_mesh_to_physical_mesh_id.find(logical_mesh_id);
+        if (physical_it == real_mesh_to_physical_mesh_id.end()) {
+            continue;
         }
+        rank_bound_logical_to_physical.emplace(logical_mesh_id, physical_it->second);
+        inter_mesh_constraints.add_required_constraint(logical_mesh_id, physical_it->second);
     }
 
+    add_inter_mesh_minimal_host_cover_from_hostname_map(
+        config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
     return inter_mesh_constraints;
 }
 
@@ -1311,8 +1420,8 @@ TopologyMappingResult map_multi_mesh_to_physical(
     const auto& mesh_physical_graph = adjacency_map_physical.mesh_level_graph_;
 
     // Build inter-mesh constraints and determine validation mode
-    auto inter_mesh_constraints =
-        build_inter_mesh_constraints(config, adjacency_map_physical, fabric_node_id_to_mesh_rank, asic_id_to_mesh_rank);
+    auto inter_mesh_constraints = build_inter_mesh_constraints(
+        config, adjacency_map_physical, mesh_logical_graph, fabric_node_id_to_mesh_rank, asic_id_to_mesh_rank);
     auto inter_mesh_validation_mode = determine_inter_mesh_validation_mode(config);
 
     // Track statistics for error reporting

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -661,7 +661,7 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
 
 namespace {
 
-static std::optional<std::string> hostname_for_asic_from_hostname_map(
+std::optional<std::string> hostname_for_asic_from_hostname_map(
     tt::tt_metal::AsicID asic_id, const std::map<std::string, std::set<tt::tt_metal::AsicID>>& hostname_to_asics) {
     for (const auto& [hostname, asics] : hostname_to_asics) {
         if (asics.contains(asic_id)) {
@@ -677,7 +677,7 @@ static std::optional<std::string> hostname_for_asic_from_hostname_map(
 // TODO: THis can be removed and replaced with cost hieristics when using a SAT solver because preferred constraints
 // aren't very effective here
 // https://github.com/tenstorrent/tt-metal/issues/40640
-static void add_inter_mesh_minimal_host_cover_from_hostname_map(
+void add_inter_mesh_minimal_host_cover_from_hostname_map(
     const TopologyMappingConfig& config,
     const PhysicalMultiMeshGraph& physical_graph,
     const AdjacencyGraph<MeshId>& mesh_logical_level_graph,

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -10,7 +10,10 @@
 #include <exception>
 #include <functional>
 #include <limits>
+#include <map>
 #include <string>
+#include <utility>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -21,6 +24,7 @@
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
+#include <tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
 
@@ -172,9 +176,11 @@ TopologyMappingResult map_mesh_to_physical(
         }
     }
 
-    // Determine connection validation mode
-    ConnectionValidationMode validation_mode =
-        config.strict_mode ? ConnectionValidationMode::STRICT : ConnectionValidationMode::RELAXED;
+    ConnectionValidationMode validation_mode = ConnectionValidationMode::RELAXED;
+    auto mode_it = config.mesh_validation_modes.find(mesh_id);
+    if (mode_it != config.mesh_validation_modes.end()) {
+        validation_mode = mode_it->second;
+    }
 
     // Solve using topology solver
     // Catch exceptions from constraint validation and convert to failure result
@@ -259,16 +265,19 @@ get_requested_intermesh_from_mgd(const ::tt::tt_fabric::MeshGraphDescriptor& mgd
         bool is_device_level = (src_instance.kind == ::tt::tt_fabric::NodeKind::Device) &&
                                (dst_instance.kind == ::tt::tt_fabric::NodeKind::Device);
 
+        uint32_t src_mesh_id_val;
+        uint32_t dst_mesh_id_val;
+
         if (is_device_level) {
             const auto& src_mesh_instance = mgd.get_instance(src_instance.hierarchy.back());
             const auto& dst_mesh_instance = mgd.get_instance(dst_instance.hierarchy.back());
-            uint32_t src_mesh_id_val = src_mesh_instance.local_id;
-            uint32_t dst_mesh_id_val = dst_mesh_instance.local_id;
+            src_mesh_id_val = src_mesh_instance.local_id;
+            dst_mesh_id_val = dst_mesh_instance.local_id;
             requested_intermesh_ports[src_mesh_id_val][dst_mesh_id_val].push_back(
                 {src_instance.local_id, dst_instance.local_id, connection_data.count});
         } else {
-            uint32_t src_mesh_id_val = src_instance.local_id;
-            uint32_t dst_mesh_id_val = dst_instance.local_id;
+            src_mesh_id_val = src_instance.local_id;
+            dst_mesh_id_val = dst_instance.local_id;
             requested_intermesh_connections[src_mesh_id_val][dst_mesh_id_val] = connection_data.count;
         }
     }
@@ -424,6 +433,7 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
     auto mesh_adjacency_graphs = ::tt::tt_fabric::build_adjacency_graph_logical(mesh_graph);
     const auto& requested_intermesh_connections = mesh_graph.get_requested_intermesh_connections();
     const auto& requested_intermesh_ports = mesh_graph.get_requested_intermesh_ports();
+
     return build_logical_multi_mesh_adjacency_graph_impl(
         mesh_adjacency_graphs, requested_intermesh_connections, requested_intermesh_ports);
 }
@@ -435,40 +445,14 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
  * with multiple entries per channel. If asic_id_to_mesh_rank is empty, includes all ASICs from PSD.
  */
 PhysicalAdjacencyMap build_flat_adjacency_map_from_psd(
-    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
-    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
     PhysicalAdjacencyMap flat_adj;
-
-    // Build a set of all ASIC IDs for quick lookup
-    std::unordered_set<tt::tt_metal::AsicID> all_asics;
-    if (!asic_id_to_mesh_rank.empty()) {
-        // Filter to only ASICs in the mesh assignment
-        for (const auto& [mesh_id, asic_map] : asic_id_to_mesh_rank) {
-            for (const auto& [asic_id, _] : asic_map) {
-                all_asics.insert(asic_id);
-            }
-        }
-    } else {
-        // Include all ASICs from PSD
-        for (const auto& [asic_id, _] : physical_system_descriptor.get_asic_descriptors()) {
-            all_asics.insert(asic_id);
-        }
-    }
 
     // Go through all connections in the physical system descriptor
     for (const auto& host_name : physical_system_descriptor.get_all_hostnames()) {
         for (const auto& [src_asic_id, asic_connections] : physical_system_descriptor.get_asic_topology(host_name)) {
-            // Skip ASICs not in any mesh assignment
-            if (!all_asics.contains(src_asic_id)) {
-                continue;
-            }
-
             for (const auto& asic_connection : asic_connections) {
                 auto dst_asic_id = asic_connection.first;
-                // Skip ASICs not in any mesh assignment
-                if (!all_asics.contains(dst_asic_id)) {
-                    continue;
-                }
 
                 // Skip self-connections
                 if (src_asic_id == dst_asic_id) {
@@ -489,18 +473,111 @@ PhysicalAdjacencyMap build_flat_adjacency_map_from_psd(
 
 PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const tt::tt_fabric::PhysicalGroupingDescriptor& physical_grouping_descriptor,
+    const tt::tt_fabric::MeshGraphDescriptor& mesh_graph_descriptor) {
+    using namespace ::tt::tt_fabric;
+
+    log_info(tt::LogFabric, "Building flat adjacency map from PSD");
+
+    // Build flat adjacency map from PhysicalSystemDescriptor
+    PhysicalAdjacencyMap flat_adj = build_flat_adjacency_map_from_psd(physical_system_descriptor);
+
+    log_info(tt::LogFabric, "Getting valid groupings map from MGD and PGD");
+
+    // Get valid groupings map from MGD and PGD
+    auto valid_groupings_map =
+        physical_grouping_descriptor.get_valid_groupings_for_mgd(mesh_graph_descriptor, physical_system_descriptor);
+
+    log_info(tt::LogFabric, "Got {} valid groupings map from MGD and PGD", valid_groupings_map.size());
+
+    // Get groupings for mesh level mappings
+    TT_ASSERT(valid_groupings_map.contains("MESH"), "Internal error: MESH grouping not found in valid groupings map");
+    TT_ASSERT(
+        !valid_groupings_map.at("MESH").empty(),
+        "Internal error: Physical grouping descriptor was not able to find mesh groupings");
+
+    // Collect all mesh groupings from all instances into a single vector
+    std::vector<GroupingInfo> all_mesh_grouping_infos;
+    for (const auto& [instance_name, groupings] : valid_groupings_map.at("MESH")) {
+        for (const auto& grouping : groupings) {
+            log_info(tt::LogFabric, "Found mesh grouping from PGD file: {}", grouping.name);
+            all_mesh_grouping_infos.push_back(grouping);
+        }
+    }
+
+    // Find all possible mappings of mesh groupings to the PSD
+    std::vector<std::string> errors;
+    auto all_mesh_groupings =
+        physical_grouping_descriptor.find_all_in_psd(all_mesh_grouping_infos, physical_system_descriptor, errors);
+
+    log_info(
+        tt::LogFabric, "Found {} mesh grouping mappings in PSD (errors: {})", all_mesh_groupings.size(), errors.size());
+
+    PhysicalMultiMeshGraph result;
+    if (all_mesh_groupings.empty()) {
+        log_warning(tt::LogFabric, "No mesh groupings found in PSD - returning empty graph");
+        return result;
+    }
+
+    // Convert flat adjacency map to graph and build hierarchical structure
+    // Pass mesh groupings directly - function will build asic_id_to_mesh_rank internally
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
+    result = build_hierarchical_from_flat_graph(flat_graph, all_mesh_groupings);
+
+    // Build asic_id_to_mesh_rank from mesh groupings for computing intermesh_assign_z_direction
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < all_mesh_groupings.size(); ++i) {
+        MeshId mesh_id{static_cast<uint32_t>(i)};
+        for (const auto& asic_id : all_mesh_groupings[i]) {
+            asic_id_to_mesh_rank[mesh_id][asic_id] = MeshHostRankId{0};
+        }
+    }
+
+    return result;
+}
+
+PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
     // Build flat adjacency map from PhysicalSystemDescriptor
-    PhysicalAdjacencyMap flat_adj = build_flat_adjacency_map_from_psd(physical_system_descriptor, asic_id_to_mesh_rank);
+    PhysicalAdjacencyMap flat_adj = build_flat_adjacency_map_from_psd(physical_system_descriptor);
+
+    // Convert asic_id_to_mesh_rank to mesh_groupings format
+    // Find the maximum mesh ID to determine vector size
+    MeshId max_mesh_id{0};
+    for (const auto& [mesh_id, _] : asic_id_to_mesh_rank) {
+        if (mesh_id.get() > max_mesh_id.get()) {
+            max_mesh_id = mesh_id;
+        }
+    }
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings(max_mesh_id.get() + 1);
+    for (const auto& [mesh_id, asic_map] : asic_id_to_mesh_rank) {
+        for (const auto& [asic_id, _] : asic_map) {
+            mesh_groupings[mesh_id.get()].insert(asic_id);
+        }
+    }
 
     // Convert to AdjacencyGraph and use the common algorithm
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
-    return build_hierarchical_from_flat_graph(flat_graph, asic_id_to_mesh_rank);
+    PhysicalMultiMeshGraph result = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
+
+    return result;
 }
 
 PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
     const AdjacencyGraph<tt::tt_metal::AsicID>& flat_adjacency_graph,
-    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
+    const std::vector<std::unordered_set<tt::tt_metal::AsicID>>& mesh_groupings) {
+    // Build asic_id_to_mesh_rank map from mesh groupings
+    // Each element in mesh_groupings represents one mesh, with index becoming the MeshId
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
+    for (size_t i = 0; i < mesh_groupings.size(); ++i) {
+        MeshId mesh_id{static_cast<uint32_t>(i)};
+        for (const auto& asic_id : mesh_groupings[i]) {
+            // Default to rank 0 - proper rank assignment would come from hostname_to_asics or other config
+            asic_id_to_mesh_rank[mesh_id][asic_id] = MeshHostRankId{0};
+        }
+    }
+
     // Build a map from AsicID to MeshId for quick lookup
     std::unordered_map<tt::tt_metal::AsicID, MeshId> asic_id_to_mesh_id;
     for (const auto& [mesh_id, asic_map] : asic_id_to_mesh_rank) {
@@ -592,21 +669,48 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
 }
 
 namespace {
+// Helper function to add Z-direction constraints
+// Logical meshes that need Z connections can only be mapped to physical meshes that have Z connections
+
 // Helper function to build inter-mesh constraints
+// Maps logical meshes to physical meshes based on matching mesh host ranks
+// A logical mesh maps to a physical mesh if the ASICs in that physical mesh have matching ranks
 ::tt::tt_fabric::MappingConstraints<MeshId, MeshId> build_inter_mesh_constraints(
-    const ::tt::tt_fabric::AdjacencyGraph<MeshId>& mesh_physical_graph, const TopologyMappingConfig& config) {
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>>& fabric_node_id_to_mesh_rank,
+    const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
     ::tt::tt_fabric::MappingConstraints<MeshId, MeshId> inter_mesh_constraints;
 
-    // Only add required constraints when rank bindings are enabled
-    if (!config.disable_rank_bindings) {
-        // TODO: Remove this once rank bindings file is removed from multi-host systems
-        // Use placeholder mesh id 1:1 mapping for physical to logical constraints for now
-        for (const auto& mesh_id : mesh_physical_graph.get_nodes()) {
-            if (!inter_mesh_constraints.add_required_constraint(mesh_id, mesh_id)) {
-                TT_THROW("Failed to add required constraint for mesh {}", mesh_id.get());
+    // Skip if rank bindings are disabled
+    if (config.disable_rank_bindings) {
+        return inter_mesh_constraints;
+    }
+
+    // Find the Physical graph mesh ID to asic id to mesh rank mapping based on the asics in the physical graph
+    // Map: mesh_id_from_rank_map -> physical_mesh_id (from asic_id_to_mesh_rank)
+    std::map<MeshId, MeshId> real_mesh_to_physical_mesh_id;
+    for (const auto& [physical_mesh_id, physical_mesh_graph] : physical_graph.mesh_adjacency_graphs_) {
+        const auto& asic_nodes = physical_mesh_graph.get_nodes();
+        // Check that every asic node in physical mesh has a rank in asic_id_to_mesh_rank
+        for (const auto& asic_id : asic_nodes) {
+            for (const auto& [real_mesh_id, asic_ranks] : asic_id_to_mesh_rank) {
+                if (asic_ranks.contains(asic_id)) {
+                    real_mesh_to_physical_mesh_id[real_mesh_id] = physical_mesh_id;
+                    break;
+                }
             }
         }
     }
+
+    // Set constraints from the Mesh ID in asic id to mesh rank to the logical mesh id
+    for (const auto& [logical_mesh_id, _] : fabric_node_id_to_mesh_rank) {
+        if (real_mesh_to_physical_mesh_id.contains(logical_mesh_id)) {
+            inter_mesh_constraints.add_required_constraint(
+                logical_mesh_id, real_mesh_to_physical_mesh_id.at(logical_mesh_id));
+        }
+    }
+
     return inter_mesh_constraints;
 }
 
@@ -614,10 +718,6 @@ namespace {
 ::tt::tt_fabric::ConnectionValidationMode determine_inter_mesh_validation_mode(const TopologyMappingConfig& config) {
     if (config.inter_mesh_validation_mode.has_value()) {
         return config.inter_mesh_validation_mode.value();
-    }
-    if (config.strict_mode) {
-        // Fallback for backward compatibility
-        return ::tt::tt_fabric::ConnectionValidationMode::STRICT;
     }
     return ::tt::tt_fabric::ConnectionValidationMode::RELAXED;
 }
@@ -628,10 +728,6 @@ namespace {
     auto config_mode_it = config.mesh_validation_modes.find(logical_mesh_id);
     if (config_mode_it != config.mesh_validation_modes.end()) {
         return config_mode_it->second;
-    }
-    if (config.strict_mode) {
-        // Fallback for backward compatibility
-        return ::tt::tt_fabric::ConnectionValidationMode::STRICT;
     }
     return ::tt::tt_fabric::ConnectionValidationMode::RELAXED;
 }
@@ -661,11 +757,22 @@ void add_rank_binding_constraints(
     MeshId logical_mesh_id,
     const std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>>& fabric_node_id_to_mesh_rank,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
-    if (!fabric_node_id_to_mesh_rank.contains(logical_mesh_id) || !asic_id_to_mesh_rank.contains(logical_mesh_id)) {
+    if (!fabric_node_id_to_mesh_rank.contains(logical_mesh_id)) {
         return;
     }
     const auto& fabric_node_ranks = fabric_node_id_to_mesh_rank.at(logical_mesh_id);
-    const auto& asic_ranks = asic_id_to_mesh_rank.at(logical_mesh_id);
+
+    // When asic_id_to_mesh_rank has no entry for this mesh, treat all physical ASICs as UNSET
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks_unset;
+    if (!asic_id_to_mesh_rank.contains(logical_mesh_id)) {
+        for (const auto& [_, asic_set] : config.hostname_to_asics) {
+            for (const auto& asic_id : asic_set) {
+                asic_ranks_unset[asic_id] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+            }
+        }
+    }
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_ranks =
+        asic_id_to_mesh_rank.contains(logical_mesh_id) ? asic_id_to_mesh_rank.at(logical_mesh_id) : asic_ranks_unset;
 
     // Group fabric nodes by rank: rank_to_fabric_nodes[R] = { fabric nodes that must map to rank R's ASICs }
     std::map<MeshHostRankId, std::set<FabricNodeId>> rank_to_fabric_nodes;
@@ -819,6 +926,8 @@ void add_pinning_constraints(
         fabric_node_to_positions[fabric_node].push_back(position);
     }
 
+    bool success = true;
+
     // Apply pinning constraints
     for (const auto& [fabric_node, positions] : fabric_node_to_positions) {
         std::set<tt::tt_metal::AsicID> asic_ids;
@@ -827,6 +936,15 @@ void add_pinning_constraints(
         for (const auto& position : positions) {
             auto it = asic_positions_to_asic_ids.find(position);
             if (it == asic_positions_to_asic_ids.end()) {
+                log_critical(
+                    tt::LogFabric,
+                    "Pinned ASIC position (tray_id: {}, asic_location: {}) to fabric node id (mesh_id: {}, chip_id: "
+                    "{}) from MGD not found in physical topology",
+                    position.first.get(),
+                    position.second.get(),
+                    fabric_node.mesh_id.get(),
+                    fabric_node.chip_id);
+                success = false;
                 continue;
             }
             asic_ids.insert(it->second.begin(), it->second.end());
@@ -841,6 +959,37 @@ void add_pinning_constraints(
             }
         }
     }
+    TT_FATAL(success, "Failed to add pinning constraints");
+}
+
+// Parallel physical inter-mesh edges from one exit ASIC to a destination mesh (each edge is one link / channel).
+uint32_t max_physical_exit_edges_per_asic_toward_mesh(
+    const ::tt::tt_fabric::AdjacencyGraph<PhysicalExitNode>& physical_exit_node_graph, MeshId dst_physical_mesh_id) {
+    uint32_t max_toward_dst = 0;
+    for (const auto& src_exit : physical_exit_node_graph.get_nodes()) {
+        uint32_t count = 0;
+        for (const auto& dst_exit : physical_exit_node_graph.get_neighbors(src_exit)) {
+            if (dst_exit.mesh_id == dst_physical_mesh_id) {
+                count++;
+            }
+        }
+        max_toward_dst = std::max(max_toward_dst, count);
+    }
+    return max_toward_dst;
+}
+
+// Total physical inter-mesh links from this mesh toward dst_physical_mesh_id (sum over exit ASICs).
+uint32_t total_physical_exit_edges_toward_mesh(
+    const ::tt::tt_fabric::AdjacencyGraph<PhysicalExitNode>& physical_exit_node_graph, MeshId dst_physical_mesh_id) {
+    uint32_t total = 0;
+    for (const auto& src_exit : physical_exit_node_graph.get_nodes()) {
+        for (const auto& dst_exit : physical_exit_node_graph.get_neighbors(src_exit)) {
+            if (dst_exit.mesh_id == dst_physical_mesh_id) {
+                total++;
+            }
+        }
+    }
+    return total;
 }
 
 // Helper function to add exit node constraints
@@ -853,7 +1002,8 @@ bool add_exit_node_constraints(
     const std::unordered_map<MeshId, MeshId>& mesh_mappings,
     const ::tt::tt_fabric::AdjacencyGraph<FabricNodeId>& logical_graph,
     const ::tt::tt_fabric::AdjacencyGraph<LogicalExitNode>& logical_exit_node_graph,
-    const ::tt::tt_fabric::AdjacencyGraph<PhysicalExitNode>& physical_exit_node_graph) {
+    const ::tt::tt_fabric::AdjacencyGraph<PhysicalExitNode>& physical_exit_node_graph,
+    ::tt::tt_fabric::ConnectionValidationMode inter_mesh_validation_mode) {
     std::unordered_map<MeshId, std::set<tt::tt_metal::AsicID>> valid_physical_exit_nodes_by_mesh;
     std::set<FabricNodeId> valid_logical_exit_nodes(logical_graph.get_nodes().begin(), logical_graph.get_nodes().end());
 
@@ -889,55 +1039,123 @@ bool add_exit_node_constraints(
         }
     }
 
-    // Add cardinal constraints for each mesh
     for (const auto& src_exit_node : logical_exit_node_graph.get_nodes()) {
-        // Get the valid logical exit nodes for this source exit node
         const auto& dst_exit_nodes = logical_exit_node_graph.get_neighbors(src_exit_node);
 
-        // Loop through all destination exit nodes (can be multiple) and add a constraint for each
+        if (src_exit_node.fabric_node_id.has_value()) {
+            // Fabric node-level: parallel edges to the same destination mesh share one required constraint.
+            // num_logical_exit_nodes_assigned counts duplicate exit edges per (fabric node, logical dst mesh); it
+            // cannot exceed the number of physical exit ASICs toward that destination mesh.
+            std::map<std::pair<FabricNodeId, MeshId>, uint32_t> num_logical_exit_nodes_assigned_per_fabric_dst;
+            for (const auto& dst_exit_node : dst_exit_nodes) {
+                num_logical_exit_nodes_assigned_per_fabric_dst[{
+                    src_exit_node.fabric_node_id.value(), dst_exit_node.mesh_id}]++;
+            }
+            for (const auto& [fabric_dst_key, num_logical_exit_nodes_assigned] :
+                 num_logical_exit_nodes_assigned_per_fabric_dst) {
+                const auto& [fabric_node_id, dst_logical_mesh] = fabric_dst_key;
+                auto mesh_mapping_it = mesh_mappings.find(dst_logical_mesh);
+                TT_ASSERT(
+                    mesh_mapping_it != mesh_mappings.end(),
+                    "Mesh mapping missing for logical mesh ID {} (destination exit node mesh ID)",
+                    dst_logical_mesh.get());
+
+                const auto& mapped_physical_dst_mesh_id = mesh_mappings.at(dst_logical_mesh);
+                auto valid_physical_exit_nodes_it = valid_physical_exit_nodes_by_mesh.find(mapped_physical_dst_mesh_id);
+                if (valid_physical_exit_nodes_it == valid_physical_exit_nodes_by_mesh.end()) {
+                    return false;
+                }
+                const auto& valid_physical_exit_nodes = valid_physical_exit_nodes_it->second;
+                if (num_logical_exit_nodes_assigned > valid_physical_exit_nodes.size()) {
+                    return false;
+                }
+                if (!intra_mesh_constraints.add_required_constraint(fabric_node_id, valid_physical_exit_nodes)) {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        // Mesh-level: one cardinality constraint per destination logical mesh. Each duplicate neighbor is one logical
+        // inter-mesh channel. Per-ASIC parallel link counts and total link count come only from the physical exit graph
+        // toward the mapped physical destination mesh. In RELAXED mode, channel demand for pair math is capped by that
+        // physical link total (not logical multiplicity alone).
+        std::map<MeshId, uint32_t> num_logical_exit_nodes_assigned_per_dst_mesh;
         for (const auto& dst_exit_node : dst_exit_nodes) {
-            // Error if the mesh mapping doesn't include the destination exit node mesh ID
-            auto mesh_mapping_it = mesh_mappings.find(dst_exit_node.mesh_id);
+            num_logical_exit_nodes_assigned_per_dst_mesh[dst_exit_node.mesh_id]++;
+        }
+
+        for (const auto& [dst_logical_mesh, num_logical_exit_nodes_assigned] :
+             num_logical_exit_nodes_assigned_per_dst_mesh) {
+            auto mesh_mapping_it = mesh_mappings.find(dst_logical_mesh);
             TT_ASSERT(
                 mesh_mapping_it != mesh_mappings.end(),
                 "Mesh mapping missing for logical mesh ID {} (destination exit node mesh ID)",
-                dst_exit_node.mesh_id.get());
+                dst_logical_mesh.get());
 
-            // Get the valid physical exit nodes for this destination exit node
-            const auto& mapped_physical_dst_mesh_id = mesh_mappings.at(dst_exit_node.mesh_id);
-
-            // Check if there are valid physical exit nodes for this destination mesh
+            const auto& mapped_physical_dst_mesh_id = mesh_mappings.at(dst_logical_mesh);
             auto valid_physical_exit_nodes_it = valid_physical_exit_nodes_by_mesh.find(mapped_physical_dst_mesh_id);
             if (valid_physical_exit_nodes_it == valid_physical_exit_nodes_by_mesh.end()) {
-                // No physical exit nodes found for this destination mesh - constraints cannot be satisfied
-                // Return false to indicate failure, allowing caller to try next combination
+                return false;
+            }
+            const auto& valid_physical_exit_nodes = valid_physical_exit_nodes_it->second;
+
+            const size_t max_mappable_exit_pairs =
+                std::min(valid_logical_exit_nodes.size(), valid_physical_exit_nodes.size());
+
+            const uint32_t total_physical_links_toward_dst =
+                total_physical_exit_edges_toward_mesh(physical_exit_node_graph, mapped_physical_dst_mesh_id);
+            const uint32_t max_edges_per_exit_asic =
+                max_physical_exit_edges_per_asic_toward_mesh(physical_exit_node_graph, mapped_physical_dst_mesh_id);
+            const uint32_t physical_links_per_exit_asic = std::max(1u, max_edges_per_exit_asic);
+
+            uint32_t channels_for_pair_count = num_logical_exit_nodes_assigned;
+            if (inter_mesh_validation_mode == ::tt::tt_fabric::ConnectionValidationMode::RELAXED) {
+                channels_for_pair_count = std::min(num_logical_exit_nodes_assigned, total_physical_links_toward_dst);
+            }
+
+            const uint32_t required_exit_pair_count =
+                (channels_for_pair_count + physical_links_per_exit_asic - 1) / physical_links_per_exit_asic;
+
+            uint32_t effective_exit_pair_min_count = required_exit_pair_count;
+            if (inter_mesh_validation_mode == ::tt::tt_fabric::ConnectionValidationMode::RELAXED) {
+                effective_exit_pair_min_count = static_cast<uint32_t>(
+                    std::min(static_cast<size_t>(required_exit_pair_count), max_mappable_exit_pairs));
+                if (effective_exit_pair_min_count < num_logical_exit_nodes_assigned) {
+                    log_debug(
+                        tt::LogFabric,
+                        "Relaxed mode: mesh-level exit toward logical mesh {}: {} logical channel(s), {} physical "
+                        "link(s) toward mapped mesh → {} channel(s) for pair math (up to {} parallel link(s)/exit "
+                        "ASIC); need at least {} (fabric_node, exit-ASIC) pair(s); exit cardinality min_count {} "
+                        "(mappable pair cap {}).",
+                        dst_logical_mesh.get(),
+                        num_logical_exit_nodes_assigned,
+                        total_physical_links_toward_dst,
+                        channels_for_pair_count,
+                        physical_links_per_exit_asic,
+                        required_exit_pair_count,
+                        effective_exit_pair_min_count,
+                        max_mappable_exit_pairs);
+                }
+            } else if (required_exit_pair_count > max_mappable_exit_pairs) {
                 return false;
             }
 
-            const auto& valid_physical_exit_nodes = valid_physical_exit_nodes_it->second;
-
-            // Add cardinal constraints for this source exit node and destination exit node pair
-            // The API guarantees that if constraint addition fails, no partial state is added
-            bool constraint_success = false;
-            // If source exit node is fabric node-level, add cardinal constraint for the logical exit node
-            if (src_exit_node.fabric_node_id.has_value()) {
-                constraint_success = intra_mesh_constraints.add_required_constraint(
-                    src_exit_node.fabric_node_id.value(), valid_physical_exit_nodes);
-                // If source exit node is mesh-level, add cardinal constraint for all logical exit nodes
-            } else {
-                constraint_success = intra_mesh_constraints.add_cardinality_constraint(
-                    valid_logical_exit_nodes, valid_physical_exit_nodes, 1);
+            if (effective_exit_pair_min_count == 0) {
+                return false;
             }
 
-            if (!constraint_success) {
-                // Constraint addition failed (e.g., over-constrained) - return false to try next combination
-                // The API guarantees no partial state was added, so intra_mesh_constraints remains unchanged
+            MeshId src_logical_mesh_for_log = MeshId{0};
+            if (!logical_graph.get_nodes().empty()) {
+                src_logical_mesh_for_log = logical_graph.get_nodes().front().mesh_id;
+            }
+            if (!intra_mesh_constraints.add_cardinality_constraint(
+                    valid_logical_exit_nodes, valid_physical_exit_nodes, effective_exit_pair_min_count)) {
                 return false;
             }
         }
     }
 
-    // All constraints successfully added
     return true;
 }
 
@@ -1092,7 +1310,8 @@ TopologyMappingResult map_multi_mesh_to_physical(
     const auto& mesh_physical_graph = adjacency_map_physical.mesh_level_graph_;
 
     // Build inter-mesh constraints and determine validation mode
-    auto inter_mesh_constraints = build_inter_mesh_constraints(mesh_physical_graph, config);
+    auto inter_mesh_constraints =
+        build_inter_mesh_constraints(config, adjacency_map_physical, fabric_node_id_to_mesh_rank, asic_id_to_mesh_rank);
     auto inter_mesh_validation_mode = determine_inter_mesh_validation_mode(config);
 
     // Track statistics for error reporting
@@ -1240,7 +1459,8 @@ TopologyMappingResult map_multi_mesh_to_physical(
                     mesh_mappings,
                     logical_graph,
                     logical_exit_node_graph,
-                    physical_exit_node_graph);
+                    physical_exit_node_graph,
+                    inter_mesh_validation_mode);
 
                 // If exit node constraints cannot be satisfied (no valid physical exit nodes or over-constrained),
                 // treat this as a mapping failure and try next combination

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -491,8 +491,8 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     log_info(tt::LogFabric, "Got {} valid groupings map from MGD and PGD", valid_groupings_map.size());
 
     // Get groupings for mesh level mappings
-    TT_ASSERT(valid_groupings_map.contains("MESH"), "Internal error: MESH grouping not found in valid groupings map");
-    TT_ASSERT(
+    TT_FATAL(valid_groupings_map.contains("MESH"), "Internal error: MESH grouping not found in valid groupings map");
+    TT_FATAL(
         !valid_groupings_map.at("MESH").empty(),
         "Internal error: Physical grouping descriptor was not able to find mesh groupings");
 
@@ -524,15 +524,6 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
     result = build_hierarchical_from_flat_graph(flat_graph, all_mesh_groupings);
 
-    // Build asic_id_to_mesh_rank from mesh groupings for computing intermesh_assign_z_direction
-    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank;
-    for (size_t i = 0; i < all_mesh_groupings.size(); ++i) {
-        MeshId mesh_id{static_cast<uint32_t>(i)};
-        for (const auto& asic_id : all_mesh_groupings[i]) {
-            asic_id_to_mesh_rank[mesh_id][asic_id] = MeshHostRankId{0};
-        }
-    }
-
     return result;
 }
 
@@ -544,6 +535,9 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
 
     // Convert asic_id_to_mesh_rank to mesh_groupings format
     // Find the maximum mesh ID to determine vector size
+    if (asic_id_to_mesh_rank.empty()) {
+        return PhysicalMultiMeshGraph{};
+    }
     MeshId max_mesh_id{0};
     for (const auto& [mesh_id, _] : asic_id_to_mesh_rank) {
         if (mesh_id.get() > max_mesh_id.get()) {
@@ -669,9 +663,6 @@ PhysicalMultiMeshGraph build_hierarchical_from_flat_graph(
 }
 
 namespace {
-// Helper function to add Z-direction constraints
-// Logical meshes that need Z connections can only be mapped to physical meshes that have Z connections
-
 // Helper function to build inter-mesh constraints
 // Maps logical meshes to physical meshes based on matching mesh host ranks
 // A logical mesh maps to a physical mesh if the ASICs in that physical mesh have matching ranks
@@ -1145,10 +1136,6 @@ bool add_exit_node_constraints(
                 return false;
             }
 
-            MeshId src_logical_mesh_for_log = MeshId{0};
-            if (!logical_graph.get_nodes().empty()) {
-                src_logical_mesh_for_log = logical_graph.get_nodes().front().mesh_id;
-            }
             if (!intra_mesh_constraints.add_cardinality_constraint(
                     valid_logical_exit_nodes, valid_physical_exit_nodes, effective_exit_pair_min_count)) {
                 return false;
@@ -1304,6 +1291,13 @@ TopologyMappingResult map_multi_mesh_to_physical(
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank,
     const std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>>& fabric_node_id_to_mesh_rank) {
     using namespace ::tt::tt_fabric;
+
+    if (config.strict_mode) {
+        log_warning(
+            tt::LogFabric,
+            "TopologyMappingConfig::strict_mode is deprecated and has no effect. "
+            "Set mesh_validation_modes and/or inter_mesh_validation_mode explicitly.");
+    }
 
     // Step 1: Run Mesh to Mesh mapping algorithm
     const auto& mesh_logical_graph = adjacency_map_logical.mesh_level_graph_;

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -265,19 +265,16 @@ get_requested_intermesh_from_mgd(const ::tt::tt_fabric::MeshGraphDescriptor& mgd
         bool is_device_level = (src_instance.kind == ::tt::tt_fabric::NodeKind::Device) &&
                                (dst_instance.kind == ::tt::tt_fabric::NodeKind::Device);
 
-        uint32_t src_mesh_id_val;
-        uint32_t dst_mesh_id_val;
-
         if (is_device_level) {
             const auto& src_mesh_instance = mgd.get_instance(src_instance.hierarchy.back());
             const auto& dst_mesh_instance = mgd.get_instance(dst_instance.hierarchy.back());
-            src_mesh_id_val = src_mesh_instance.local_id;
-            dst_mesh_id_val = dst_mesh_instance.local_id;
+            const uint32_t src_mesh_id_val = src_mesh_instance.local_id;
+            const uint32_t dst_mesh_id_val = dst_mesh_instance.local_id;
             requested_intermesh_ports[src_mesh_id_val][dst_mesh_id_val].push_back(
                 {src_instance.local_id, dst_instance.local_id, connection_data.count});
         } else {
-            src_mesh_id_val = src_instance.local_id;
-            dst_mesh_id_val = dst_instance.local_id;
+            const uint32_t src_mesh_id_val = src_instance.local_id;
+            const uint32_t dst_mesh_id_val = dst_instance.local_id;
             requested_intermesh_connections[src_mesh_id_val][dst_mesh_id_val] = connection_data.count;
         }
     }
@@ -442,7 +439,7 @@ LogicalMultiMeshGraph build_logical_multi_mesh_adjacency_graph(const ::tt::tt_fa
  * @brief Build a flat PhysicalAdjacencyMap from PhysicalSystemDescriptor
  *
  * Builds a complete flat adjacency map including all connections (both intra-mesh and intermesh),
- * with multiple entries per channel. If asic_id_to_mesh_rank is empty, includes all ASICs from PSD.
+ * with multiple entries per channel (one edge per Ethernet link).
  */
 PhysicalAdjacencyMap build_flat_adjacency_map_from_psd(
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
@@ -479,8 +476,9 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
 
     log_info(tt::LogFabric, "Building flat adjacency map from PSD");
 
-    // Build flat adjacency map from PhysicalSystemDescriptor
-    PhysicalAdjacencyMap flat_adj = build_flat_adjacency_map_from_psd(physical_system_descriptor);
+    // Build flat adjacency once; reused for find_all_in_psd and build_hierarchical_from_flat_graph (avoids a second
+    // O(|PSD|) pass inside find_all_in_psd).
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(build_flat_adjacency_map_from_psd(physical_system_descriptor));
 
     log_info(tt::LogFabric, "Getting valid groupings map from MGD and PGD");
 
@@ -507,8 +505,8 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
 
     // Find all possible mappings of mesh groupings to the PSD
     std::vector<std::string> errors;
-    auto all_mesh_groupings =
-        physical_grouping_descriptor.find_all_in_psd(all_mesh_grouping_infos, physical_system_descriptor, errors);
+    auto all_mesh_groupings = physical_grouping_descriptor.find_all_in_psd(
+        all_mesh_grouping_infos, physical_system_descriptor, flat_graph, errors);
 
     log_info(
         tt::LogFabric, "Found {} mesh grouping mappings in PSD (errors: {})", all_mesh_groupings.size(), errors.size());
@@ -519,9 +517,7 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
         return result;
     }
 
-    // Convert flat adjacency map to graph and build hierarchical structure
-    // Pass mesh groupings directly - function will build asic_id_to_mesh_rank internally
-    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat_adj);
+    // Build hierarchical structure from the same flat graph; mesh groupings drive mesh partitioning
     result = build_hierarchical_from_flat_graph(flat_graph, all_mesh_groupings);
 
     return result;
@@ -687,7 +683,18 @@ namespace {
         for (const auto& asic_id : asic_nodes) {
             for (const auto& [real_mesh_id, asic_ranks] : asic_id_to_mesh_rank) {
                 if (asic_ranks.contains(asic_id)) {
-                    real_mesh_to_physical_mesh_id[real_mesh_id] = physical_mesh_id;
+                    auto [it, inserted] = real_mesh_to_physical_mesh_id.try_emplace(real_mesh_id, physical_mesh_id);
+                    if (!inserted && it->second != physical_mesh_id) {
+                        TT_THROW(
+                            "Internal Error: Inter-mesh rank binding conflict: logical mesh {} is associated with "
+                            "physical mesh {}, "
+                            "but ASIC {} in physical mesh {} is also listed under that logical mesh in "
+                            "asic_id_to_mesh_rank. Each logical mesh must map to a single physical mesh.",
+                            real_mesh_id.get(),
+                            it->second.get(),
+                            asic_id.get(),
+                            physical_mesh_id.get());
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`PhysicalMultiMeshGraph` previously required mesh membership from a rank binding file before it could be constructed. This PR enables building the graph directly from PSD + PGD + MGD, making rank/binding inputs optional until they are needed for full `map_multi_mesh_to_physical`.

### What's changed

#### New API: `build_physical_multi_mesh_adjacency_graph(PSD, PGD, MGD)`
Adds a new overload so `PhysicalMultiMeshGraph` is built from **PSD + PGD + MGD** instead of requiring mesh membership from a rank binding file first.

Flow: (1) flat adjacency from **full PSD**; (2) **PGD** + **MGD** → valid MESH groupings via `find_all_in_psd`; (3) `build_hierarchical_from_flat_graph` from groupings → per-mesh graphs, mesh-level graph, exit nodes.

**Mental model:** PSD = connectivity; MGD = logical meshes; PGD = physical mesh partitions on the machine.

#### Supporting API changes
- **`build_flat_adjacency_map_from_psd`** — PSD only (no ASIC filter); mesh boundaries come from PGD, not from flattening.
- **`build_hierarchical_from_flat_graph`** — now takes `vector<unordered_set<AsicID>>` mesh groupings (PGD-shaped); the `asic_id_to_mesh_rank` overload converts to that form for legacy callers. An empty `asic_id_to_mesh_rank` map now correctly returns an empty `PhysicalMultiMeshGraph` rather than creating a spurious single empty mesh.

#### Other changes
- **`strict_mode` deprecated** — `map_multi_mesh_to_physical` now emits a `log_warning` when `strict_mode == true` is detected so callers migrating from the old API are notified. Use `mesh_validation_modes` / `inter_mesh_validation_mode` (defaults **RELAXED** when unset) instead.
- **`build_inter_mesh_constraints`** — required logical→physical mesh pairs for the solver come from **ASIC overlap**, not logical *k* → physical *k*. PGD's physical mesh ids and MGD's logical mesh ids are not assumed to use the same numbering.
- Missing `asic_id_to_mesh_rank` for a mesh: ASICs can be **UNSET** via `hostname_to_asics` for incremental mapping.
- Stricter **pinning** diagnostics (`TT_FATAL` on missing pinned ASIC position); helpers `max_physical_exit_edges_per_asic_toward_mesh` / `total_physical_exit_edges_toward_mesh` for inter-mesh capacity checks.
- Runtime invariant checks in the PGD overload use `TT_FATAL` (not `TT_ASSERT`) to ensure they hold in release builds.
- Removed dead code: unused `asic_id_to_mesh_rank` block that was built but never consumed in the PGD overload.
- Removed unused variable `src_logical_mesh_for_log` in `add_exit_node_constraints`.

#### Tests & CI
**TopologyMapperUtils** tests with real PSD (`BuildPhysicalMultiMeshGraph_WithPGDAndPSD_*`, galaxy / WH fixtures). `fabric-cpu-only-tests-impl` runs those plus existing fabric CPU tests; PGD-related suites use `tt-run` with mock cluster + rank-binding YAML.

**`PhysicalGroupingDescriptor`** tests and textprotos updated alongside. Commented-out `"4x2 Mesh"` textproto block removed. WH T3K textproto ASIC locations updated to `ASIC_LOCATION_UNSPECIFIED`.

#### Migration
Callers that relied on **`strict_mode`** for STRICT validation should set `mesh_validation_modes` / `inter_mesh_validation_mode` explicitly. A runtime warning is now emitted when `strict_mode == true` is passed.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/topology-mapper-pgd)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/topology-mapper-pgd)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/topology-mapper-pgd)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/topology-mapper-pgd)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/topology-mapper-pgd)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/topology-mapper-pgd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/topology-mapper-pgd)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.