### PR TITLE
BSPM integration: mixed-precision expert loading for DRAMStreamingMatmulCompressed

### DIFF
--- a/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
+++ b/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
@@ -15,14 +15,14 @@ Usage
     MESH_DEVICE=TG \\
     python models/demos/deepseek_v3/scripts/convert_bspm_weights.py \\
         --model-path  /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \\
-        --output-path /localdev/mtairum/deepseek_cache/bspm_B_3.5 \\
-        --bspm-dir    /localdev/mtairum/bit_sculpt/results \\
+        --output-path /path/to/output/bspm_B_3.5 \\
+        --bspm-dir    /path/to/bit_sculpt/results \\
         --bspm-model  deepseek-r1-0528
 
     # Custom variant / budget:
         --bspm-variant A --bspm-budget 4.0
 
-    # Dry-run: preprocessing only, no device conversion (fast sanity check):
+    # Dry-run: validate BSPM files exist and are loadable (no conversion):
         --dry-run
 """
 
@@ -30,15 +30,14 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
 import torch
 from loguru import logger
-from tqdm import tqdm
 from transformers import AutoConfig
 
 # ---------------------------------------------------------------------------
@@ -47,21 +46,65 @@ from transformers import AutoConfig
 
 _TT_CODE_TO_MANT: dict[int, int | None] = {0: 7, 1: 3, 2: 1, 3: None}
 _PROJ_IDX = {"gate_proj": 0, "up_proj": 1, "down_proj": 2}
+_EXPERT_KEY_RE = re.compile(r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(\w+)\.weight$")
 
 
-class _OverrideStateDict:
-    """Lazy state-dict wrapper that returns per-key overrides and delegates
-    everything else to the base mapping without materialising it."""
+class _BsprnStateDict:
+    """Lazy state-dict wrapper that applies BSPM quantization on demand.
 
-    def __init__(self, base, overrides: dict):
+    Pre-computing all expert overrides for DeepSeek V3 (256 experts × 58 MoE
+    layers × 3 projections) would require ~650 GB of host RAM before conversion
+    starts.  Instead, quantization is computed on the fly inside __getitem__,
+    keeping peak memory proportional to one tensor at a time.
+
+    BSPM code arrays (~11 MB each) are cached per-layer after first access so
+    each BSPM file is read at most once.  The quantized tensors themselves are
+    never retained — they are handed directly to the caller and immediately freed.
+    """
+
+    def __init__(
+        self,
+        base,
+        hf_config,
+        bspm_dir: Path,
+        bspm_model: str,
+        variant: str,
+        budget: float,
+        bspm_root: Path,
+    ):
         self._base = base
-        self._overrides = overrides
+        self._first_k_dense = getattr(hf_config, "first_k_dense_replace", 3)
+        self._bspm_dir = bspm_dir
+        self._bspm_model = bspm_model
+        self._variant = variant
+        self._budget = budget
+        self._codes_cache: dict[int, np.ndarray | None] = {}  # layer → codes or None
+
+        sys.path.insert(0, str(bspm_root))
+        # Import once here so failures surface immediately, not mid-conversion.
+        from integration.ttnn.bspm_loader import load_bspm_for_layer
+
+        from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
+
+        self._load_bspm = load_bspm_for_layer
+        self._qdq = quantize_dequantize_bfp
+
+    # ------------------------------------------------------------------
+    # Public dict-like interface (delegates to base for non-expert keys)
+    # ------------------------------------------------------------------
 
     def __getitem__(self, key):
-        return self._overrides[key] if key in self._overrides else self._base[key]
+        m = _EXPERT_KEY_RE.match(key)
+        if m:
+            layer_idx, expert_idx, proj_name = int(m.group(1)), int(m.group(2)), m.group(3)
+            if layer_idx >= self._first_k_dense and proj_name in _PROJ_IDX:
+                codes = self._codes_for_layer(layer_idx)
+                if codes is not None and expert_idx < codes.shape[0]:
+                    return self._apply_bspm(self._base[key], codes, expert_idx, proj_name)
+        return self._base[key]
 
     def __contains__(self, key):
-        return key in self._overrides or key in self._base
+        return key in self._base
 
     def __iter__(self):
         return iter(self._base)
@@ -80,116 +123,69 @@ class _OverrideStateDict:
         for k in self._base:
             yield self[k]
 
+    # ------------------------------------------------------------------
+    # Dry-run helper: validate all BSPM files without quantizing tensors
+    # ------------------------------------------------------------------
 
-def _preprocess_all_layers(
-    state_dict,
-    hf_config,
-    bspm_dir: Path,
-    bspm_model: str,
-    variant: str,
-    budget: float,
-    bspm_root: Path,
-    n_io_workers: int = 16,
-) -> _OverrideStateDict:
-    """Apply BSPM tile pre-quantization to all MoE layers in state_dict.
+    def validate_bspm_files(self, hf_config) -> int:
+        """Load and validate all per-layer BSPM files.  Returns count of missing files."""
+        missing = 0
+        for layer_idx in range(self._first_k_dense, hf_config.num_hidden_layers):
+            codes = self._codes_for_layer(layer_idx)
+            if codes is None:
+                missing += 1
+            else:
+                logger.debug(f"Layer {layer_idx}: BSPM codes shape {codes.shape} — OK")
+        return missing
 
-    Strategy: iterate by *projection* (not expert) so all 256 expert weights
-    for a given projection are loaded in parallel and processed in one batched
-    numpy call, rather than 256 sequential single-expert calls.
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
 
-    Per layer: 3 projections × O(unique_codes) numpy calls
-    vs original: 256 experts × 3 projections × O(unique_codes) calls
+    def _codes_for_layer(self, layer_idx: int) -> np.ndarray | None:
+        if layer_idx not in self._codes_cache:
+            bspm_file = (
+                self._bspm_dir
+                / self._bspm_model
+                / f"layer_{layer_idx}"
+                / "precision_eval"
+                / f"precision_map_{self._variant}_{self._budget:.1f}.bspm"
+            )
+            if not bspm_file.exists():
+                logger.warning(f"Layer {layer_idx}: BSPM file not found, using raw weights — {bspm_file}")
+                self._codes_cache[layer_idx] = None
+            else:
+                self._codes_cache[layer_idx] = self._load_bspm(str(bspm_file))["codes"]
+        return self._codes_cache[layer_idx]
 
-    Returns an _OverrideStateDict wrapping the original (lazy) state_dict so
-    the full checkpoint is never materialised in memory.
-    """
-    sys.path.insert(0, str(bspm_root))
-    from integration.ttnn.bspm_loader import load_bspm_for_layer
+    def _apply_bspm(self, w_orig: torch.Tensor, codes: np.ndarray, expert_idx: int, proj_name: str) -> torch.Tensor:
+        """Quantize-dequantize a single expert weight tensor according to BSPM codes."""
+        proj_idx = _PROJ_IDX[proj_name]
+        w_kn = w_orig.float().numpy().T  # HF layout (N, K) → compute in (K, N)
+        K, N = w_kn.shape
+        tiles_h, tiles_w = K // 32, N // 32
 
-    from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
+        expert_codes = codes[expert_idx, proj_idx, : tiles_h * tiles_w].reshape(tiles_h, tiles_w)
+        unique_codes = np.unique(expert_codes)
+        non_bfp4 = unique_codes[unique_codes != 1]
 
-    first_k_dense = getattr(hf_config, "first_k_dense_replace", 3)
-    n_moe_layers = hf_config.num_hidden_layers - first_k_dense
-    overrides: dict = {}
+        if not len(non_bfp4):
+            return w_orig  # all tiles already bfp4 — no-op
 
-    layer_iter = tqdm(
-        range(first_k_dense, hf_config.num_hidden_layers),
-        desc="BSPM preprocessing layers",
-        unit="layer",
-        total=n_moe_layers,
-    )
-    for layer_idx in layer_iter:
-        bspm_file = (
-            bspm_dir
-            / bspm_model
-            / f"layer_{layer_idx}"
-            / "precision_eval"
-            / f"precision_map_{variant}_{budget:.1f}.bspm"
-        )
-        if not bspm_file.exists():
-            logger.warning(f"Layer {layer_idx}: BSPM file not found, using raw weights — {bspm_file}")
-            continue
+        # (tiles_h, 32, tiles_w, 32) → (tiles_h, tiles_w, 32, 32)
+        w_tiled = w_kn.reshape(tiles_h, 32, tiles_w, 32).transpose(0, 2, 1, 3).copy()
 
-        bspm_data = load_bspm_for_layer(str(bspm_file))
-        bspm_codes = bspm_data["codes"]  # (n_experts, 3, tiles_per_proj)
-        n_experts = min(hf_config.n_routed_experts, bspm_codes.shape[0])
+        for code in non_bfp4:
+            ri, ci = np.where(expert_codes == code)
+            mant_bits = _TT_CODE_TO_MANT.get(int(code), 3)
+            if mant_bits is None:
+                w_tiled[ri, ci] = 0.0
+            else:
+                w_tiled[ri, ci] = self._qdq(w_tiled[ri, ci], mant_bits)
 
-        t_layer = time.time()
-
-        for proj_name, proj_idx in _PROJ_IDX.items():
-            keys = [f"model.layers.{layer_idx}.mlp.experts.{e}.{proj_name}.weight" for e in range(n_experts)]
-            present = [(e, k) for e, k in enumerate(keys) if k in state_dict]
-            if not present:
-                continue
-
-            expert_indices, present_keys = zip(*present)
-
-            # ── Load all expert weights for this projection in parallel ──────
-            # I/O-bound: threads hide NFS/disk latency effectively.
-            def _load(k):
-                return state_dict[k].float()
-
-            with ThreadPoolExecutor(max_workers=n_io_workers) as pool:
-                tensors = list(pool.map(_load, present_keys))
-
-            # Stack: (n_e, N, K) → transpose to (n_e, K, N)
-            w_nk = torch.stack(tensors).numpy()  # (n_e, N, K)
-            w_kn = w_nk.transpose(0, 2, 1)  # (n_e, K, N) — view, no copy yet
-            n_e, K, N = w_kn.shape
-            tiles_h, tiles_w = K // 32, N // 32
-
-            # codes: (n_e, tiles_h, tiles_w)
-            codes_3d = bspm_codes[list(expert_indices), proj_idx, : tiles_h * tiles_w].reshape(n_e, tiles_h, tiles_w)
-
-            unique_codes = np.unique(codes_3d)
-            non_bfp4 = unique_codes[unique_codes != 1]
-            if len(non_bfp4) == 0:
-                continue  # all tiles bfp4 — no-op for all experts
-
-            # (n_e, tiles_h, tiles_w, 32, 32) — contiguous copy needed for writes
-            w_tiled = w_kn.reshape(n_e, tiles_h, 32, tiles_w, 32).transpose(0, 1, 3, 2, 4).copy()
-
-            for code in non_bfp4:
-                ei, ri, ci = np.where(codes_3d == code)
-                mant_bits = _TT_CODE_TO_MANT.get(int(code), 3)
-                if mant_bits is None:
-                    w_tiled[ei, ri, ci] = 0.0
-                else:
-                    # Single batched call across ALL experts for this code
-                    w_tiled[ei, ri, ci] = quantize_dequantize_bfp(w_tiled[ei, ri, ci], mant_bits)
-
-            # Restore (n_e, K, N) → (n_e, N, K) and store overrides
-            w_out = w_tiled.transpose(0, 1, 3, 2, 4).reshape(n_e, K, N).transpose(0, 2, 1)
-            orig_dtype = tensors[0].dtype
-            for i, key in enumerate(present_keys):
-                overrides[key] = torch.from_numpy(w_out[i].copy()).to(orig_dtype)
-
-            del tensors, w_nk, w_kn, w_tiled, w_out
-
-        logger.debug(f"Layer {layer_idx} preprocessed in {time.time() - t_layer:.1f}s")
-
-    logger.info(f"BSPM preprocessing complete: {len(overrides)} expert weight keys overridden")
-    return _OverrideStateDict(state_dict, overrides)
+        # (tiles_h, tiles_w, 32, 32) → (K, N) → (N, K) to restore HF layout
+        w_out = torch.from_numpy(w_tiled.transpose(0, 2, 1, 3).reshape(K, N).T.copy())
+        return w_out.to(w_orig.dtype)
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +212,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Run BSPM preprocessing only (no device / no conversion). Useful for timing and sanity checks.",
+        help="Validate BSPM files exist and are loadable (no device / no conversion).",
     )
     return parser
 
@@ -245,13 +241,13 @@ def main() -> None:
     # ── Derive bspm_root from bspm_dir ──────────────────────────────────────
     bspm_root = args.bspm_dir.parent
 
-    # ── BSPM preprocessing ──────────────────────────────────────────────────
-    t0 = time.time()
+    # ── Build lazy BSPM state dict ──────────────────────────────────────────
+    # Quantization is computed on demand in __getitem__; no preprocessing loop.
     logger.info(
-        f"Applying BSPM pre-quantization: variant={args.bspm_variant}, budget={args.bspm_budget} b/e, "
+        f"Building lazy BSPM state dict: variant={args.bspm_variant}, budget={args.bspm_budget} b/e, "
         f"layers {getattr(hf_config, 'first_k_dense_replace', 3)}–{hf_config.num_hidden_layers - 1}"
     )
-    bspm_state_dict = _preprocess_all_layers(
+    bspm_state_dict = _BsprnStateDict(
         state_dict,
         hf_config,
         args.bspm_dir,
@@ -260,10 +256,16 @@ def main() -> None:
         args.bspm_budget,
         bspm_root,
     )
-    logger.info(f"BSPM preprocessing done in {time.time() - t0:.1f}s")
 
     if args.dry_run:
-        logger.info("--dry-run: skipping device conversion. Done.")
+        logger.info("--dry-run: validating BSPM files …")
+        t0 = time.time()
+        missing = bspm_state_dict.validate_bspm_files(hf_config)
+        logger.info(
+            f"Validation complete in {time.time() - t0:.1f}s — "
+            f"{hf_config.num_hidden_layers - getattr(hf_config, 'first_k_dense_replace', 3) - missing} OK, "
+            f"{missing} missing"
+        )
         return
 
     # ── Device setup ────────────────────────────────────────────────────────

--- a/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
+++ b/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import sys
 import time
 from pathlib import Path
 
@@ -70,7 +69,6 @@ class _BsprnStateDict:
         bspm_model: str,
         variant: str,
         budget: float,
-        bspm_root: Path,
     ):
         self._base = base
         self._first_k_dense = getattr(hf_config, "first_k_dense_replace", 3)
@@ -80,10 +78,7 @@ class _BsprnStateDict:
         self._budget = budget
         self._codes_cache: dict[int, np.ndarray | None] = {}  # layer → codes or None
 
-        sys.path.insert(0, str(bspm_root))
-        # Import once here so failures surface immediately, not mid-conversion.
-        from integration.ttnn.bspm_loader import load_bspm_for_layer
-
+        from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
         from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
 
         self._load_bspm = load_bspm_for_layer
@@ -239,9 +234,6 @@ def main() -> None:
     hf_config = AutoConfig.from_pretrained(args.model_path.resolve(), trust_remote_code=True)
     logger.info(f"Model: {hf_config.num_hidden_layers} layers, {hf_config.n_routed_experts} experts/layer")
 
-    # ── Derive bspm_root from bspm_dir ──────────────────────────────────────
-    bspm_root = args.bspm_dir.parent
-
     # ── Build lazy BSPM state dict ──────────────────────────────────────────
     # Quantization is computed on demand in __getitem__; no preprocessing loop.
     logger.info(
@@ -255,7 +247,6 @@ def main() -> None:
         args.bspm_model,
         args.bspm_variant,
         args.bspm_budget,
-        bspm_root,
     )
 
     if args.dry_run:

--- a/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
+++ b/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
@@ -160,6 +160,7 @@ class _BsprnStateDict:
 
     def _apply_bspm(self, w_orig: torch.Tensor, codes: np.ndarray, expert_idx: int, proj_name: str) -> torch.Tensor:
         """Quantize-dequantize a single expert weight tensor according to BSPM codes."""
+        orig_dtype = w_orig.dtype  # capture before .float() so output matches checkpoint dtype (bf16)
         proj_idx = _PROJ_IDX[proj_name]
         w_kn = w_orig.float().numpy().T  # HF layout (N, K) → compute in (K, N)
         K, N = w_kn.shape
@@ -185,7 +186,7 @@ class _BsprnStateDict:
 
         # (tiles_h, tiles_w, 32, 32) → (K, N) → (N, K) to restore HF layout
         w_out = torch.from_numpy(w_tiled.transpose(0, 2, 1, 3).reshape(K, N).T.copy())
-        return w_out.to(w_orig.dtype)
+        return w_out.to(orig_dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
+++ b/models/demos/deepseek_v3/scripts/convert_bspm_weights.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert DeepSeek expert weights to a BSPM-pre-quantized tt-metal weight cache.
+
+Runs on the target hardware (TG / T3K / N300) with a live mesh device.  For
+each MoE layer the script applies BitSculpt BSPM tile assignments to the
+dequantized expert weights before the standard bfloat4_b/bfloat8_b conversion,
+producing a weight cache that reflects the mixed-precision allocation.
+
+Usage
+-----
+    # Minimal — TG system, R1-0528, Variant B 3.5 b/e:
+    MESH_DEVICE=TG \\
+    python models/demos/deepseek_v3/scripts/convert_bspm_weights.py \\
+        --model-path  /proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528 \\
+        --output-path /localdev/mtairum/deepseek_cache/bspm_B_3.5 \\
+        --bspm-dir    /localdev/mtairum/bit_sculpt/results \\
+        --bspm-model  deepseek-r1-0528
+
+    # Custom variant / budget:
+        --bspm-variant A --bspm-budget 4.0
+
+    # Dry-run: preprocessing only, no device conversion (fast sanity check):
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import torch
+from loguru import logger
+from tqdm import tqdm
+from transformers import AutoConfig
+
+# ---------------------------------------------------------------------------
+# Helpers shared with test_bspm_demo.py
+# ---------------------------------------------------------------------------
+
+_TT_CODE_TO_MANT: dict[int, int | None] = {0: 7, 1: 3, 2: 1, 3: None}
+_PROJ_IDX = {"gate_proj": 0, "up_proj": 1, "down_proj": 2}
+
+
+class _OverrideStateDict:
+    """Lazy state-dict wrapper that returns per-key overrides and delegates
+    everything else to the base mapping without materialising it."""
+
+    def __init__(self, base, overrides: dict):
+        self._base = base
+        self._overrides = overrides
+
+    def __getitem__(self, key):
+        return self._overrides[key] if key in self._overrides else self._base[key]
+
+    def __contains__(self, key):
+        return key in self._overrides or key in self._base
+
+    def __iter__(self):
+        return iter(self._base)
+
+    def __len__(self):
+        return len(self._base)
+
+    def keys(self):
+        return self._base.keys()
+
+    def items(self):
+        for k in self._base:
+            yield k, self[k]
+
+    def values(self):
+        for k in self._base:
+            yield self[k]
+
+
+def _preprocess_all_layers(
+    state_dict,
+    hf_config,
+    bspm_dir: Path,
+    bspm_model: str,
+    variant: str,
+    budget: float,
+    bspm_root: Path,
+    n_io_workers: int = 16,
+) -> _OverrideStateDict:
+    """Apply BSPM tile pre-quantization to all MoE layers in state_dict.
+
+    Strategy: iterate by *projection* (not expert) so all 256 expert weights
+    for a given projection are loaded in parallel and processed in one batched
+    numpy call, rather than 256 sequential single-expert calls.
+
+    Per layer: 3 projections × O(unique_codes) numpy calls
+    vs original: 256 experts × 3 projections × O(unique_codes) calls
+
+    Returns an _OverrideStateDict wrapping the original (lazy) state_dict so
+    the full checkpoint is never materialised in memory.
+    """
+    sys.path.insert(0, str(bspm_root))
+    from integration.ttnn.bspm_loader import load_bspm_for_layer
+
+    from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
+
+    first_k_dense = getattr(hf_config, "first_k_dense_replace", 3)
+    n_moe_layers = hf_config.num_hidden_layers - first_k_dense
+    overrides: dict = {}
+
+    layer_iter = tqdm(
+        range(first_k_dense, hf_config.num_hidden_layers),
+        desc="BSPM preprocessing layers",
+        unit="layer",
+        total=n_moe_layers,
+    )
+    for layer_idx in layer_iter:
+        bspm_file = (
+            bspm_dir
+            / bspm_model
+            / f"layer_{layer_idx}"
+            / "precision_eval"
+            / f"precision_map_{variant}_{budget:.1f}.bspm"
+        )
+        if not bspm_file.exists():
+            logger.warning(f"Layer {layer_idx}: BSPM file not found, using raw weights — {bspm_file}")
+            continue
+
+        bspm_data = load_bspm_for_layer(str(bspm_file))
+        bspm_codes = bspm_data["codes"]  # (n_experts, 3, tiles_per_proj)
+        n_experts = min(hf_config.n_routed_experts, bspm_codes.shape[0])
+
+        t_layer = time.time()
+
+        for proj_name, proj_idx in _PROJ_IDX.items():
+            keys = [f"model.layers.{layer_idx}.mlp.experts.{e}.{proj_name}.weight" for e in range(n_experts)]
+            present = [(e, k) for e, k in enumerate(keys) if k in state_dict]
+            if not present:
+                continue
+
+            expert_indices, present_keys = zip(*present)
+
+            # ── Load all expert weights for this projection in parallel ──────
+            # I/O-bound: threads hide NFS/disk latency effectively.
+            def _load(k):
+                return state_dict[k].float()
+
+            with ThreadPoolExecutor(max_workers=n_io_workers) as pool:
+                tensors = list(pool.map(_load, present_keys))
+
+            # Stack: (n_e, N, K) → transpose to (n_e, K, N)
+            w_nk = torch.stack(tensors).numpy()  # (n_e, N, K)
+            w_kn = w_nk.transpose(0, 2, 1)  # (n_e, K, N) — view, no copy yet
+            n_e, K, N = w_kn.shape
+            tiles_h, tiles_w = K // 32, N // 32
+
+            # codes: (n_e, tiles_h, tiles_w)
+            codes_3d = bspm_codes[list(expert_indices), proj_idx, : tiles_h * tiles_w].reshape(n_e, tiles_h, tiles_w)
+
+            unique_codes = np.unique(codes_3d)
+            non_bfp4 = unique_codes[unique_codes != 1]
+            if len(non_bfp4) == 0:
+                continue  # all tiles bfp4 — no-op for all experts
+
+            # (n_e, tiles_h, tiles_w, 32, 32) — contiguous copy needed for writes
+            w_tiled = w_kn.reshape(n_e, tiles_h, 32, tiles_w, 32).transpose(0, 1, 3, 2, 4).copy()
+
+            for code in non_bfp4:
+                ei, ri, ci = np.where(codes_3d == code)
+                mant_bits = _TT_CODE_TO_MANT.get(int(code), 3)
+                if mant_bits is None:
+                    w_tiled[ei, ri, ci] = 0.0
+                else:
+                    # Single batched call across ALL experts for this code
+                    w_tiled[ei, ri, ci] = quantize_dequantize_bfp(w_tiled[ei, ri, ci], mant_bits)
+
+            # Restore (n_e, K, N) → (n_e, N, K) and store overrides
+            w_out = w_tiled.transpose(0, 1, 3, 2, 4).reshape(n_e, K, N).transpose(0, 2, 1)
+            orig_dtype = tensors[0].dtype
+            for i, key in enumerate(present_keys):
+                overrides[key] = torch.from_numpy(w_out[i].copy()).to(orig_dtype)
+
+            del tensors, w_nk, w_kn, w_tiled, w_out
+
+        logger.debug(f"Layer {layer_idx} preprocessed in {time.time() - t_layer:.1f}s")
+
+    logger.info(f"BSPM preprocessing complete: {len(overrides)} expert weight keys overridden")
+    return _OverrideStateDict(state_dict, overrides)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert DeepSeek expert weights to a BSPM-pre-quantized tt-metal weight cache.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--model-path", type=Path, required=True, help="Path to the HF model dir (FP8 or dequantized).")
+    parser.add_argument("--output-path", type=Path, required=True, help="Output weight cache directory.")
+    parser.add_argument(
+        "--bspm-dir", type=Path, required=True, help="BitSculpt results root (contains <bspm-model>/ subdirs)."
+    )
+    parser.add_argument(
+        "--bspm-model", type=str, required=True, help="BSPM model sub-directory, e.g. deepseek-r1-0528."
+    )
+    parser.add_argument("--bspm-variant", type=str, default="B", help="BSPM variant letter.")
+    parser.add_argument("--bspm-budget", type=float, default=3.5, help="Bits-per-element budget.")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing cache.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run BSPM preprocessing only (no device / no conversion). Useful for timing and sanity checks.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+
+    # ── Resolve dequantized model path ──────────────────────────────────────
+    from models.demos.deepseek_v3.utils.hf_model_utils import default_dequantized_model_path
+    from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+
+    deq_path = default_dequantized_model_path(args.model_path)
+    if not deq_path.exists():
+        logger.error(
+            f"Dequantized checkpoint not found at {deq_path}. " f"Run scripts/dequantize_hf_checkpoint.py first."
+        )
+        sys.exit(1)
+
+    logger.info(f"Loading dequantized weights from {deq_path}")
+    state_dict = LazyStateDict(deq_path)
+
+    # ── HF config ───────────────────────────────────────────────────────────
+    hf_config = AutoConfig.from_pretrained(args.model_path.resolve(), trust_remote_code=True)
+    logger.info(f"Model: {hf_config.num_hidden_layers} layers, {hf_config.n_routed_experts} experts/layer")
+
+    # ── Derive bspm_root from bspm_dir ──────────────────────────────────────
+    bspm_root = args.bspm_dir.parent
+
+    # ── BSPM preprocessing ──────────────────────────────────────────────────
+    t0 = time.time()
+    logger.info(
+        f"Applying BSPM pre-quantization: variant={args.bspm_variant}, budget={args.bspm_budget} b/e, "
+        f"layers {getattr(hf_config, 'first_k_dense_replace', 3)}–{hf_config.num_hidden_layers - 1}"
+    )
+    bspm_state_dict = _preprocess_all_layers(
+        state_dict,
+        hf_config,
+        args.bspm_dir,
+        args.bspm_model,
+        args.bspm_variant,
+        args.bspm_budget,
+        bspm_root,
+    )
+    logger.info(f"BSPM preprocessing done in {time.time() - t0:.1f}s")
+
+    if args.dry_run:
+        logger.info("--dry-run: skipping device conversion. Done.")
+        return
+
+    # ── Device setup ────────────────────────────────────────────────────────
+    import ttnn
+    from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
+    from models.demos.deepseek_v3.utils.weight_config import get_weight_config
+
+    mesh_shape_env = os.environ.get("MESH_DEVICE", "TG")
+    from models.demos.deepseek_v3.utils.test_utils import SYSTEM_NAME_TO_MESH_SHAPE
+
+    mesh_shape = SYSTEM_NAME_TO_MESH_SHAPE.get(mesh_shape_env, (4, 8))
+    logger.info(f"Opening mesh device {mesh_shape[0]}×{mesh_shape[1]} ({mesh_shape_env})")
+
+    device_params = {"fabric_config": get_fabric_config()}
+    mesh_device = ttnn.open_mesh_device(
+        mesh_shape=ttnn.MeshShape(*mesh_shape),
+        dispatch_core_config=ttnn.DispatchCoreConfig(ttnn.DispatchCoreType.ETH),
+        **device_params,
+    )
+
+    try:
+        output_path = args.output_path
+        if output_path.exists() and not args.force:
+            logger.error(f"Output path {output_path} already exists. Use --force to overwrite.")
+            sys.exit(1)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"Converting weights → {output_path}")
+        t1 = time.time()
+        get_weight_config(
+            RowBatchedModel,
+            hf_config,
+            (bspm_state_dict,),
+            output_path,
+            mesh_device,
+            force_recalculate=True,
+        )
+        logger.info(f"Weight conversion done in {time.time() - t1:.1f}s")
+        logger.info(f"BSPM weight cache written to {output_path}")
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3/tests/test_bspm_demo.py
+++ b/models/demos/deepseek_v3/tests/test_bspm_demo.py
@@ -1,0 +1,487 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""BSPM vs uniform-BFP4 output comparison for the deepseek_v3 demo (5 layers).
+
+Runs the same decode forward pass twice through the deepseek_v3 RowBatchedModel:
+
+  1. Baseline  — weights converted via the standard pipeline (uniform bfloat4_b).
+  2. BSPM      — expert weights pre-quantized per-tile according to BitSculpt BSPM
+                 assignments, then converted via the same standard pipeline.
+
+The BSPM pre-quantization step simulates what CompressedTensor does on Blackhole
+but without changing the kernel: each 32×32 expert-weight tile is quantized at its
+BSPM-assigned precision (bfp8/bfp4/bfp2/zero) and dequantized back to float before
+the standard bfloat4_b conversion runs.  The kernel thus sees a tensor whose values
+are already at BSPM quality.
+
+Environment variables
+---------------------
+DEEPSEEK_V3_HF_MODEL  : path to the local HF model dir (read by conftest).
+BSPM_RESULTS_DIR      : BitSculpt results root, e.g. /localdev/.../bit_sculpt/results
+BSPM_MODEL_NAME       : sub-directory under BSPM_RESULTS_DIR, e.g. deepseek-r1-0528
+BSPM_VARIANT          : variant letter, default "B"
+BSPM_BUDGET           : b/e budget as float, default 3.5
+
+Run
+---
+    MESH_DEVICE=TG \
+    DEEPSEEK_V3_HF_MODEL=/proj_sw/... \
+    BSPM_RESULTS_DIR=/localdev/mtairum/bit_sculpt/results \
+    BSPM_MODEL_NAME=deepseek-r1-0528 \
+    pytest models/demos/deepseek_v3/tests/test_bspm_demo.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from loguru import logger
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
+from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
+from models.demos.deepseek_v3.utils.hf_model_utils import default_dequantized_model_path
+from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_rope_tensors,
+    get_test_weight_config,
+    paged_caches_from_torch,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NUM_LAYERS = 5  # Override: run only 5 layers instead of 61
+MAX_SEQ_LEN = 128  # Trim KV cache tables for faster setup
+
+# PCC thresholds
+PCC_UNIFORM_VS_BSPM = 0.93  # direct comparison: uniform bfp4 vs BSPM pre-quantized
+PCC_BSPM_VS_REF = 0.95  # BSPM vs float reference (lower than baseline due to aggressive tiles)
+PCC_BASELINE_VS_REF = 0.97  # baseline vs float reference (same as test_model.py)
+
+
+# ---------------------------------------------------------------------------
+# Lazy state-dict wrapper that allows per-key overrides without materializing
+# the full underlying mapping
+# ---------------------------------------------------------------------------
+
+
+class _OverrideStateDict:
+    """Thin wrapper around a base Mapping that returns overridden values for
+    specific keys and delegates all other key accesses to the base mapping.
+
+    This avoids materializing the full (potentially multi-GB) state dict when
+    only a small subset of keys (MoE expert weights) need to be modified.
+    """
+
+    def __init__(self, base, overrides: dict):
+        self._base = base
+        self._overrides = overrides
+
+    def __getitem__(self, key):
+        return self._overrides[key] if key in self._overrides else self._base[key]
+
+    def __contains__(self, key):
+        return key in self._overrides or key in self._base
+
+    def __iter__(self):
+        return iter(self._base)
+
+    def __len__(self):
+        return len(self._base)
+
+    def keys(self):
+        return self._base.keys()
+
+    def items(self):
+        for k in self._base:
+            yield k, self[k]
+
+    def values(self):
+        for k in self._base:
+            yield self[k]
+
+
+# ---------------------------------------------------------------------------
+# BSPM preprocessing helper
+# ---------------------------------------------------------------------------
+
+
+def _preprocess_experts_with_bspm(
+    state_dict,
+    hf_config,
+    bspm_results_dir: Path,
+    bspm_model_name: str,
+    variant: str = "B",
+    budget: float = 3.5,
+    num_layers: int = NUM_LAYERS,
+) -> dict:
+    """Return a new state dict where each MoE expert-weight tile is pre-quantized
+    according to its BSPM assignment and dequantized back to float32.
+
+    Tile layout
+    -----------
+    HF expert weights are stored as (out_features, in_features), i.e. (N, K).
+    BitSculpt produces BSPM codes in (K, N) row-major tile order (tile index =
+    row * tiles_w + col, with the K dimension as rows).  We transpose to (K, N)
+    before applying tiles and transpose back afterwards.
+
+    BSPM code → mantissa bits mapping (tt-metal convention after remap)
+    -------------------------------------------------------------------
+    0 → bfp8  (7 mantissa bits, near-lossless)
+    1 → bfp4  (3 mantissa bits, default allocation)
+    2 → bfp2  (1 mantissa bit,  low-saliency tiles)
+    3 → zero  (tile zeroed out, dead/pruned tiles)
+    """
+    try:
+        from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
+    except ImportError as e:
+        pytest.skip(f"Required module not importable for BSPM preprocessing: {e}")
+
+    # Lazy import — derive the bit_sculpt root from BSPM_RESULTS_DIR (most reliable)
+    # or fall back to a sibling-of-tt-metal guess.
+    bspm_root = Path(os.environ.get("BSPM_RESULTS_DIR", "")).parent
+    if not bspm_root.exists():
+        bspm_root = Path(__file__).resolve().parents[4].parent / "bit_sculpt"
+    sys.path.insert(0, str(bspm_root))
+    try:
+        from integration.ttnn.bspm_loader import load_bspm_for_layer
+    except ImportError as e:
+        pytest.skip(f"bspm_loader not importable: {e}")
+
+    # tt-metal code → mantissa bits (None = zero tile)
+    TT_CODE_TO_MANT: dict[int, int | None] = {0: 7, 1: 3, 2: 1, 3: None}
+    # HF projection name → BSPM proj_idx (0=gate, 1=up, 2=down)
+    PROJ_IDX = {"gate_proj": 0, "up_proj": 1, "down_proj": 2}
+
+    first_k_dense = getattr(hf_config, "first_k_dense_replace", 3)
+
+    # Build an override dict; all other keys are lazily delegated to state_dict
+    # (avoids materializing the full multi-GB weight mapping in memory)
+    overrides: dict = {}
+
+    layers_processed = 0
+    for layer_idx in range(first_k_dense, num_layers):
+        bspm_file = (
+            bspm_results_dir
+            / bspm_model_name
+            / f"layer_{layer_idx}"
+            / "precision_eval"
+            / f"precision_map_{variant}_{budget:.1f}.bspm"
+        )
+        if not bspm_file.exists():
+            logger.warning(f"BSPM file not found for layer {layer_idx}: {bspm_file}")
+            continue
+
+        # dict with "codes": (n_experts, 3, tiles_per_proj) uint8 in tt-metal code space
+        bspm_data = load_bspm_for_layer(str(bspm_file))
+        bspm_codes = bspm_data["codes"]  # np.ndarray (n_experts, 3, tiles_per_proj)
+        n_experts_bspm = bspm_codes.shape[0]
+        n_experts = min(hf_config.n_routed_experts, n_experts_bspm)
+
+        from tqdm import tqdm
+
+        for expert_idx in tqdm(range(n_experts), desc=f"layer {layer_idx} experts", unit="expert", leave=True):
+            for proj_name, proj_idx in PROJ_IDX.items():
+                key = f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.{proj_name}.weight"
+                if key not in state_dict:
+                    continue
+
+                # Load as float32 — state_dict must be dequantized (BF16) before calling this
+                w_f32 = overrides[key].float() if key in overrides else state_dict[key].float()  # (N, K)
+
+                # Transpose to (K, N) — BitSculpt's tile convention
+                w_kn = w_f32.T.contiguous().numpy()  # (K, N)
+                K, N = w_kn.shape
+                tiles_h, tiles_w = K // 32, N // 32
+                assert (
+                    bspm_codes.shape[2] >= tiles_h * tiles_w
+                ), f"BSPM has {bspm_codes.shape[2]} tiles but weight needs {tiles_h * tiles_w}"
+                codes_1d = bspm_codes[expert_idx, proj_idx, : tiles_h * tiles_w]
+
+                # Apply per-tile quantization — batched by code value.
+                # code=1 (bfp4) is skipped: the standard pipeline encodes to bfp4
+                # anyway, so it's a no-op.  Only non-bfp4 tiles need preprocessing.
+                codes_2d = codes_1d.reshape(tiles_h, tiles_w)
+                unique_codes = np.unique(codes_2d)
+                non_bfp4_codes = unique_codes[unique_codes != 1]
+                if len(non_bfp4_codes) == 0:
+                    continue  # all tiles are bfp4 — skip weight entirely
+
+                # (tiles_h, tiles_w, 32, 32) — easier to index by (r, c)
+                w_tiled = w_kn.reshape(tiles_h, 32, tiles_w, 32).transpose(0, 2, 1, 3).copy()
+
+                for code in non_bfp4_codes:
+                    rs, cs = np.where(codes_2d == code)
+                    tiles_batch = w_tiled[rs, cs]  # (n_tiles, 32, 32)
+                    mant_bits = TT_CODE_TO_MANT.get(int(code), 3)
+                    if mant_bits is None:
+                        w_tiled[rs, cs] = 0.0
+                    else:
+                        w_tiled[rs, cs] = quantize_dequantize_bfp(tiles_batch, mant_bits)
+
+                # Restore (tiles_h, 32, tiles_w, 32) → (K, N) → transpose to (N, K)
+                w_out = w_tiled.transpose(0, 2, 1, 3).reshape(K, N)
+                overrides[key] = torch.from_numpy(w_out).T.to(w_f32.dtype)
+
+        layers_processed += 1
+
+    if layers_processed == 0:
+        pytest.skip(
+            f"No BSPM files found under {bspm_results_dir / bspm_model_name} "
+            f"for layers {first_k_dense}–{num_layers - 1}"
+        )
+
+    logger.info(f"BSPM pre-quantization applied to {layers_processed} MoE layers ({len(overrides)} keys overridden)")
+    return _OverrideStateDict(state_dict, overrides)
+
+
+# ---------------------------------------------------------------------------
+# Shared decode-step runner
+# ---------------------------------------------------------------------------
+
+
+def _run_one_decode_step(
+    hf_config,
+    mesh_device,
+    ccl,
+    paged_config,
+    weight_config,
+    torch_input: torch.Tensor,  # (seq=1, batch)
+    position_ids: torch.Tensor,  # (batch,)
+    torch_page_table: torch.Tensor,
+) -> torch.Tensor:
+    """Run one RowBatchedModel decode forward step and return logits on CPU."""
+    dp_factor = mesh_device.shape[1]
+    batches_per_device = USERS_PER_ROW // dp_factor
+
+    # Empty KV caches (position 0, no prior context)
+    cache_dim = hf_config.kv_lora_rank + hf_config.qk_rope_head_dim
+    batch_size = int(position_ids.shape[0])
+    empty_caches = tuple(
+        torch.zeros((batch_size, 1, 0, cache_dim), dtype=torch.bfloat16) for _ in range(hf_config.num_hidden_layers)
+    )
+
+    mapping = torch_page_table
+    paged_input_caches, _ = paged_caches_from_torch(
+        empty_caches,
+        tuple(mesh_device.shape),
+        paged_config,
+        user_id=None,
+        mappings=tuple(mapping for _ in range(hf_config.num_hidden_layers)),
+    )
+
+    tt_page_tables = tuple(
+        MLA2D.create_page_table(page_table=mapping, paged_config=paged_config, mesh_device=mesh_device)
+        for _ in range(hf_config.num_hidden_layers)
+    )
+
+    model_config = get_model_config(RowBatchedModel, "decode", hf_config, mesh_device)
+    model_state = RowBatchedModel.create_state(hf_config, paged_config, mesh_device, ccl, paged_input_caches)
+    model_shared_state = RowBatchedModel.create_shared_state(hf_config, mesh_device)
+    run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
+
+    tt_input = ttnn.from_torch(
+        torch_input.unsqueeze(0),
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.uint32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+    position_ids_tt = ttnn.from_torch(
+        position_ids,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+        dtype=ttnn.int32,
+    )
+    rope_tensors = get_rope_tensors(hf_config, USERS_PER_ROW, 1, position_ids, mesh_device)
+
+    tt_output = RowBatchedModel.forward_decode(tt_input, position_ids_tt, run_config, rope_tensors, tt_page_tables)
+    ttnn.synchronize_device(mesh_device)
+
+    logits = (
+        ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+        )
+        .cpu()
+        .float()
+    )
+
+    ttnn.deallocate(tt_output)
+    ttnn.deallocate(tt_input)
+    ttnn.deallocate(position_ids_tt)
+    return logits
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(7200)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": get_fabric_config()}],
+    indirect=True,
+)
+def test_bspm_vs_uniform_5layers_decode(
+    device_params,
+    mesh_device,
+    hf_config,
+    model_path,
+    cache_path,
+    ccl,
+    force_recalculate_weight_config,
+):
+    """Run the deepseek_v3 demo (5 layers, 1 decode step) with uniform bfloat4_b
+    weights and with BSPM pre-quantized weights; compare output logits.
+
+    Both runs use identical random inputs and page tables so the comparison
+    isolates the effect of BSPM-assigned per-tile precision.
+
+    Expected result
+    ---------------
+    - Baseline PCC vs BSPM  > 0.93  (small quality degradation from mixed precision)
+    - If BSPM is well-calibrated, most token predictions stay the same; heavily
+      compressed expert tiles contribute minimal cross-attention weight so the
+      output distribution shifts only slightly.
+    """
+    # ── 5-layer config ──────────────────────────────────────────────────────
+    hf_config_5 = deepcopy(hf_config)
+    hf_config_5.num_hidden_layers = NUM_LAYERS
+    hf_config_5.max_seq_len = MAX_SEQ_LEN
+
+    # Load from the dequantized (BF16) checkpoint — the raw HF checkpoint for
+    # DeepSeek-R1-0528 uses float8_e4m3fn; convert_weights requires BF16 tensors.
+    deq_path = default_dequantized_model_path(model_path)
+    if not deq_path.exists():
+        pytest.skip(
+            f"Dequantized checkpoint not found at {deq_path}. "
+            f"Run save_dequantized_hf_checkpoint() first to create it."
+        )
+    deq_state_dict_5 = sub_state_dict(LazyStateDict(deq_path), "", NUM_LAYERS)
+
+    # ── Shared random decode inputs ─────────────────────────────────────────
+    dp_factor = mesh_device.shape[1]
+    batch_size = USERS_PER_ROW * mesh_device.shape[0]
+    paged_config = MLA2D.get_valid_paged_config(hf_config_5.max_seq_len, USERS_PER_ROW, dp_factor)
+
+    # Random decode input: position 0, one token per user
+    position_ids = torch.zeros(batch_size, dtype=torch.long)
+    torch_input = torch.randint(0, hf_config_5.vocab_size - 1, (batch_size, 1), dtype=torch.long).T  # (1, batch)
+
+    # Shared page table (same structure for both runs)
+    batches_per_device = USERS_PER_ROW // dp_factor
+    blocks_per_batch = paged_config.max_num_blocks // batches_per_device
+    torch_page_table = torch.arange(paged_config.max_num_blocks, dtype=torch.int32).reshape(
+        batches_per_device, blocks_per_batch
+    )
+
+    # ── Run 1: uniform bfloat4_b (baseline) ─────────────────────────────────
+    logger.info("=== Run 1: uniform bfloat4_b (baseline) ===")
+    weight_cfg_uniform = get_test_weight_config(
+        RowBatchedModel,
+        hf_config_5,
+        (deq_state_dict_5,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_bspm_demo",
+        layer_id=f"uniform_{NUM_LAYERS}layers",
+        real_weights=True,
+    )
+    logits_uniform = _run_one_decode_step(
+        hf_config_5,
+        mesh_device,
+        ccl,
+        paged_config,
+        weight_cfg_uniform,
+        torch_input,
+        position_ids,
+        torch_page_table,
+    )
+    logger.info(f"Baseline logits shape: {logits_uniform.shape}")
+
+    # ── Run 2: BSPM pre-quantized ────────────────────────────────────────────
+    bspm_results_dir = Path(os.environ.get("BSPM_RESULTS_DIR", ""))
+    bspm_model_name = os.environ.get("BSPM_MODEL_NAME", "")
+    bspm_variant = os.environ.get("BSPM_VARIANT", "B")
+    bspm_budget = float(os.environ.get("BSPM_BUDGET", "3.5"))
+
+    if not bspm_results_dir or not bspm_results_dir.exists() or not bspm_model_name:
+        pytest.skip(
+            "BSPM_RESULTS_DIR and BSPM_MODEL_NAME must be set to compare BSPM weights. "
+            "Baseline run completed successfully."
+        )
+
+    logger.info(f"=== Run 2: BSPM pre-quantized " f"({bspm_model_name}, variant {bspm_variant}, {bspm_budget} b/e) ===")
+    bspm_state_dict = _preprocess_experts_with_bspm(
+        deq_state_dict_5,
+        hf_config_5,
+        bspm_results_dir,
+        bspm_model_name,
+        variant=bspm_variant,
+        budget=bspm_budget,
+        num_layers=NUM_LAYERS,
+    )
+    weight_cfg_bspm = get_test_weight_config(
+        RowBatchedModel,
+        hf_config_5,
+        (bspm_state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_bspm_demo",
+        layer_id=f"bspm_{NUM_LAYERS}layers_{bspm_model_name}_{bspm_variant}_{bspm_budget}",
+        real_weights=True,
+    )
+    logits_bspm = _run_one_decode_step(
+        hf_config_5,
+        mesh_device,
+        ccl,
+        paged_config,
+        weight_cfg_bspm,
+        torch_input,
+        position_ids,
+        torch_page_table,
+    )
+    logger.info(f"BSPM logits shape: {logits_bspm.shape}")
+
+    # ── Compare ──────────────────────────────────────────────────────────────
+    passing, pcc_msg = comp_pcc(logits_uniform, logits_bspm, PCC_UNIFORM_VS_BSPM)
+    logger.info(f"\n{'='*60}")
+    logger.info(f"Uniform bfp4  vs  BSPM ({bspm_variant} {bspm_budget} b/e):  {pcc_msg}")
+
+    # Token-level agreement (greedy argmax)
+    tokens_uniform = logits_uniform.argmax(dim=-1)  # (1, batch)
+    tokens_bspm = logits_bspm.argmax(dim=-1)
+    match_rate = (tokens_uniform == tokens_bspm).float().mean().item()
+    logger.info(f"Top-1 token match rate (greedy): {match_rate:.3f}")
+    logger.info(f"{'='*60}")
+
+    assert passing, (
+        f"BSPM logits PCC too low vs uniform baseline: {pcc_msg}. "
+        f"Expected PCC > {PCC_UNIFORM_VS_BSPM}. "
+        f"This may indicate the BSPM allocation is too aggressive for tt-metal's quantizer "
+        f"or that the tile orientation in _preprocess_experts_with_bspm() is incorrect."
+    )
+    logger.info(
+        f"PASSED: BSPM ({bspm_variant} {bspm_budget} b/e) output matches uniform baseline "
+        f"with PCC > {PCC_UNIFORM_VS_BSPM}. Top-1 token match: {match_rate:.3f}"
+    )

--- a/models/demos/deepseek_v3/tests/test_bspm_demo.py
+++ b/models/demos/deepseek_v3/tests/test_bspm_demo.py
@@ -147,21 +147,8 @@ def _preprocess_experts_with_bspm(
     2 → bfp2  (1 mantissa bit,  low-saliency tiles)
     3 → zero  (tile zeroed out, dead/pruned tiles)
     """
-    try:
-        from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
-    except ImportError as e:
-        pytest.skip(f"Required module not importable for BSPM preprocessing: {e}")
-
-    # Lazy import — derive the bit_sculpt root from BSPM_RESULTS_DIR (most reliable)
-    # or fall back to a sibling-of-tt-metal guess.
-    bspm_root = Path(os.environ.get("BSPM_RESULTS_DIR", "")).parent
-    if not bspm_root.exists():
-        bspm_root = Path(__file__).resolve().parents[4].parent / "bit_sculpt"
-    sys.path.insert(0, str(bspm_root))
-    try:
-        from integration.ttnn.bspm_loader import load_bspm_for_layer
-    except ImportError as e:
-        pytest.skip(f"bspm_loader not importable: {e}")
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
+    from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
 
     # tt-metal code → mantissa bits (None = zero tile)
     TT_CODE_TO_MANT: dict[int, int | None] = {0: 7, 1: 3, 2: 1, 3: None}
@@ -201,8 +188,10 @@ def _preprocess_experts_with_bspm(
                 if key not in state_dict:
                     continue
 
-                # Load as float32 — state_dict must be dequantized (BF16) before calling this
-                w_f32 = overrides[key].float() if key in overrides else state_dict[key].float()  # (N, K)
+                # Load weight — capture dtype before float() cast so we restore to checkpoint dtype (bf16)
+                w_orig = overrides[key] if key in overrides else state_dict[key]
+                orig_dtype = w_orig.dtype
+                w_f32 = w_orig.float()  # (N, K)
 
                 # Transpose to (K, N) — BitSculpt's tile convention
                 w_kn = w_f32.T.contiguous().numpy()  # (K, N)
@@ -236,7 +225,7 @@ def _preprocess_experts_with_bspm(
 
                 # Restore (tiles_h, 32, tiles_w, 32) → (K, N) → transpose to (N, K)
                 w_out = w_tiled.transpose(0, 2, 1, 3).reshape(K, N)
-                overrides[key] = torch.from_numpy(w_out).T.to(w_f32.dtype)
+                overrides[key] = torch.from_numpy(w_out).T.to(orig_dtype)
 
         layers_processed += 1
 

--- a/models/demos/deepseek_v3/tests/test_bspm_demo.py
+++ b/models/demos/deepseek_v3/tests/test_bspm_demo.py
@@ -27,7 +27,7 @@ Run
 ---
     MESH_DEVICE=TG \
     DEEPSEEK_V3_HF_MODEL=/proj_sw/... \
-    BSPM_RESULTS_DIR=/localdev/mtairum/bit_sculpt/results \
+    BSPM_RESULTS_DIR=/path/to/bit_sculpt/results \
     BSPM_MODEL_NAME=deepseek-r1-0528 \
     pytest models/demos/deepseek_v3/tests/test_bspm_demo.py -v
 """

--- a/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
@@ -22,18 +22,40 @@ Usage:
     assignment = load_bspm_for_expert("path/to/precision_map_B_3.5.bspm", expert_idx=0, proj_idx=0)
 
 Prerequisites:
-    BitSculpt must be in your Python path to load BSPM files:
-        export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH
-    or:
-        import sys
-        sys.path.insert(0, "/path/to/bit_sculpt")
+    Only the .bspm result files from BitSculpt are required — no BitSculpt Python
+    package dependency.  The binary format is parsed directly here.
 """
 
 from __future__ import annotations
 
+import struct
 from pathlib import Path
 
 import numpy as np
+
+# ---------------------------------------------------------------------------
+# BSPM binary format constants (must stay in sync with BitSculpt's export.py)
+# ---------------------------------------------------------------------------
+
+_BSPM_MAGIC = b"BSPM"
+_BSPM_VERSION = 1
+_BSPM_HEADER_SIZE = 64  # bytes; header is 48 bytes of fields + 16 bytes reserved
+# struct layout: "<4sIIIIIIIIB3xII" = 48 bytes
+#   4s  magic
+#   I   version
+#   I   layer_idx
+#   I   n_experts
+#   I   n_projections
+#   I   tiles_per_proj
+#   I   tile_rows
+#   I   tile_cols
+#   I   tile_size
+#   B   variant_code   (A=0, B=1, C=2)
+#   3x  padding
+#   I   budget_millibits
+#   I   actual_millibits
+_BSPM_STRUCT = struct.Struct("<4sIIIIIIIIB3xII")
+_VARIANT_NAMES = {0: "A", 1: "B", 2: "C"}
 
 # ---------------------------------------------------------------------------
 # Code remapping
@@ -96,30 +118,77 @@ def load_bspm_for_layer(
             codes: np.ndarray (n_experts, 3, tiles_per_proj) with tt-metal format indices
             codes_bitsculpt: np.ndarray — original BitSculpt codes (for debugging)
     """
-    try:
-        from quantization.export import load_binary_precision_map
-    except ImportError as exc:
-        raise ImportError(
-            "Cannot import BitSculpt's load_binary_precision_map. "
-            "Ensure BitSculpt is in your Python path:\n"
-            "  export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH"
-        ) from exc
+    with open(bspm_path, "rb") as f:
+        raw = f.read(_BSPM_HEADER_SIZE)
+
+    if len(raw) < 4:
+        raise ValueError(f"File too small to be a BSPM: {bspm_path}")
 
     # Detect Git LFS pointer files before attempting to parse.
     # LFS pointers start with "version https://..." — reading the magic will
-    # raise ValueError("Invalid magic: b'vers'") which is hard to diagnose.
-    with open(bspm_path, "rb") as _f:
-        _magic = _f.read(4)
-    if _magic == b"vers":
+    # produce an invalid-magic error that is hard to diagnose.
+    if raw[:4] == b"vers":
         raise RuntimeError(
             f"BSPM file appears to be a Git LFS pointer, not the actual data: {bspm_path}\n"
             "Run `git lfs install && git lfs pull` in the bit_sculpt repo to download the real files."
         )
-    data = load_binary_precision_map(str(bspm_path), expected_n_experts=expected_n_experts)
-    original_codes = data["codes"].copy()
-    data["codes_bitsculpt"] = original_codes
-    data["codes"] = remap_bspm_to_ttnn(original_codes)
-    return data
+
+    if len(raw) < _BSPM_HEADER_SIZE:
+        raise ValueError(f"File too small for BSPM header: {len(raw)} bytes in {bspm_path}")
+
+    (
+        magic,
+        version,
+        layer_idx,
+        n_experts,
+        n_projections,
+        tiles_per_proj,
+        tile_rows,
+        tile_cols,
+        tile_size,
+        variant_code,
+        budget_millibits,
+        actual_millibits,
+    ) = _BSPM_STRUCT.unpack(raw[: _BSPM_STRUCT.size])
+
+    if magic != _BSPM_MAGIC:
+        raise ValueError(f"Invalid BSPM magic {magic!r} in {bspm_path}")
+    if version != _BSPM_VERSION:
+        raise ValueError(f"Unsupported BSPM version {version} in {bspm_path}")
+
+    if expected_n_experts is not None and n_experts != expected_n_experts:
+        raise ValueError(
+            f"BSPM n_experts mismatch in {bspm_path}: "
+            f"header={n_experts}, expected={expected_n_experts}. "
+            "Delete the BSPM file and re-run allocation."
+        )
+
+    body_size = n_experts * n_projections * tiles_per_proj
+    with open(bspm_path, "rb") as f:
+        f.seek(_BSPM_HEADER_SIZE)
+        body_bytes = f.read(body_size)
+
+    if len(body_bytes) < body_size:
+        raise ValueError(f"Truncated BSPM body in {bspm_path}: got {len(body_bytes)}, expected {body_size}")
+
+    original_codes = np.frombuffer(body_bytes, dtype=np.uint8).reshape(n_experts, n_projections, tiles_per_proj)
+
+    return {
+        "magic": magic.decode("ascii"),
+        "version": version,
+        "layer_idx": layer_idx,
+        "n_experts": n_experts,
+        "n_projections": n_projections,
+        "tiles_per_proj": tiles_per_proj,
+        "tile_rows": tile_rows,
+        "tile_cols": tile_cols,
+        "tile_size": tile_size,
+        "variant": _VARIANT_NAMES.get(variant_code, "?"),
+        "budget": budget_millibits / 1000.0,
+        "actual_bits": actual_millibits / 1000.0,
+        "codes_bitsculpt": original_codes,
+        "codes": remap_bspm_to_ttnn(original_codes),
+    }
 
 
 def load_bspm_for_expert(

--- a/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
@@ -31,38 +31,9 @@ Prerequisites:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import numpy as np
-
-# Try to import from BitSculpt — required for BSPM loading
-try:
-    # First try assuming BitSculpt is in PYTHONPATH
-    from quantization.export import load_binary_precision_map
-except ImportError:
-    # Fall back to common BitSculpt locations
-    _COMMON_BITSCULPT_PATHS = [
-        Path.home() / "bit_sculpt",
-        Path(__file__).resolve().parent.parent.parent.parent.parent.parent / "bit_sculpt",
-    ]
-    _loaded = False
-    for candidate in _COMMON_BITSCULPT_PATHS:
-        if candidate.exists() and str(candidate) not in sys.path:
-            sys.path.insert(0, str(candidate))
-            try:
-                from quantization.export import load_binary_precision_map
-
-                _loaded = True
-                break
-            except ImportError:
-                sys.path.remove(str(candidate))
-    if not _loaded:
-        raise ImportError(
-            "Cannot import BitSculpt's load_binary_precision_map. "
-            "Ensure BitSculpt is in your Python path:\n"
-            "  export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH"
-        )
 
 # ---------------------------------------------------------------------------
 # Code remapping
@@ -125,6 +96,15 @@ def load_bspm_for_layer(
             codes: np.ndarray (n_experts, 3, tiles_per_proj) with tt-metal format indices
             codes_bitsculpt: np.ndarray — original BitSculpt codes (for debugging)
     """
+    try:
+        from quantization.export import load_binary_precision_map
+    except ImportError as exc:
+        raise ImportError(
+            "Cannot import BitSculpt's load_binary_precision_map. "
+            "Ensure BitSculpt is in your Python path:\n"
+            "  export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH"
+        ) from exc
+
     # Detect Git LFS pointer files before attempting to parse.
     # LFS pointers start with "version https://..." — reading the magic will
     # raise ValueError("Invalid magic: b'vers'") which is hard to diagnose.

--- a/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
@@ -44,8 +44,6 @@ except ImportError:
     # Fall back to common BitSculpt locations
     _COMMON_BITSCULPT_PATHS = [
         Path.home() / "bit_sculpt",
-        Path.home() / "mtairum" / "bit_sculpt",
-        Path("/home/models-team/mtairum/bit_sculpt"),
         Path(__file__).resolve().parent.parent.parent.parent.parent.parent / "bit_sculpt",
     ]
     _loaded = False

--- a/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/bspm_loader.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load BitSculpt BSPM files and remap codes to tt-metal COMPRESSED_FORMATS indices.
+
+BitSculpt code ordering: 0=zero, 1=bfp2, 2=bfp4, 3=bfp8
+tt-metal code ordering:  0=bfp8, 1=bfp4, 2=bfp2, 3=bfp0 (COMPRESSED_FORMATS)
+
+This module provides functions to load BSPMs and transparently remap codes
+so they can be fed directly into CompressedTensor.from_bspm() or __init__().
+
+Usage:
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import (
+        load_bspm_for_layer, load_bspm_for_expert
+    )
+
+    # Full layer (all experts)
+    data = load_bspm_for_layer("path/to/precision_map_B_3.5.bspm")
+    ttnn_codes = data["codes"]  # (n_experts, 3, tiles_per_proj), tt-metal indices
+
+    # Single expert projection → (tiles_h, tiles_w) for CompressedTensor
+    assignment = load_bspm_for_expert("path/to/precision_map_B_3.5.bspm", expert_idx=0, proj_idx=0)
+
+Prerequisites:
+    BitSculpt must be in your Python path to load BSPM files:
+        export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH
+    or:
+        import sys
+        sys.path.insert(0, "/path/to/bit_sculpt")
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Try to import from BitSculpt — required for BSPM loading
+try:
+    # First try assuming BitSculpt is in PYTHONPATH
+    from quantization.export import load_binary_precision_map
+except ImportError:
+    # Fall back to common BitSculpt locations
+    _COMMON_BITSCULPT_PATHS = [
+        Path.home() / "bit_sculpt",
+        Path.home() / "mtairum" / "bit_sculpt",
+        Path("/home/models-team/mtairum/bit_sculpt"),
+        Path(__file__).resolve().parent.parent.parent.parent.parent.parent / "bit_sculpt",
+    ]
+    _loaded = False
+    for candidate in _COMMON_BITSCULPT_PATHS:
+        if candidate.exists() and str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+            try:
+                from quantization.export import load_binary_precision_map
+
+                _loaded = True
+                break
+            except ImportError:
+                sys.path.remove(str(candidate))
+    if not _loaded:
+        raise ImportError(
+            "Cannot import BitSculpt's load_binary_precision_map. "
+            "Ensure BitSculpt is in your Python path:\n"
+            "  export PYTHONPATH=/path/to/bit_sculpt:$PYTHONPATH"
+        )
+
+# ---------------------------------------------------------------------------
+# Code remapping
+# ---------------------------------------------------------------------------
+
+# BitSculpt → tt-metal COMPRESSED_FORMATS index
+# BitSculpt:  0=zero, 1=bfp2, 2=bfp4, 3=bfp8
+# tt-metal:   0=bfp8, 1=bfp4, 2=bfp2, 3=bfp0
+_BITSCULPT_TO_TTNN = np.array([3, 2, 1, 0], dtype=np.int8)
+
+# tt-metal COMPRESSED_FORMATS index → BitSculpt code (inverse)
+_TTNN_TO_BITSCULPT = np.array([3, 2, 1, 0], dtype=np.uint8)
+
+# Readable names for validation/debugging
+BITSCULPT_FORMATS = {0: "zero", 1: "bfp2", 2: "bfp4", 3: "bfp8"}
+TTNN_FORMATS = {0: "bfp8", 1: "bfp4", 2: "bfp2", 3: "bfp0"}
+
+
+def remap_bspm_to_ttnn(codes: np.ndarray) -> np.ndarray:
+    """Remap BitSculpt BSPM codes to tt-metal COMPRESSED_FORMATS indices.
+
+    Args:
+        codes: uint8 array of any shape with values in {0, 1, 2, 3} (BitSculpt convention).
+
+    Returns:
+        int8 array of same shape with values in {0, 1, 2, 3} (tt-metal convention).
+    """
+    return _BITSCULPT_TO_TTNN[codes.astype(np.uint8)]
+
+
+def remap_ttnn_to_bspm(codes: np.ndarray) -> np.ndarray:
+    """Remap tt-metal COMPRESSED_FORMATS indices back to BitSculpt codes.
+
+    Args:
+        codes: int8/uint8 array with tt-metal format indices.
+
+    Returns:
+        uint8 array with BitSculpt codes.
+    """
+    return _TTNN_TO_BITSCULPT[codes.astype(np.uint8)]
+
+
+# ---------------------------------------------------------------------------
+# BSPM loading with remapping
+# ---------------------------------------------------------------------------
+
+
+def load_bspm_for_layer(
+    bspm_path: str | Path,
+    expected_n_experts: int | None = None,
+) -> dict:
+    """Load a BSPM file and remap all codes to tt-metal format indices.
+
+    Args:
+        bspm_path: Path to a .bspm file.
+        expected_n_experts: Optional validation of expert count.
+
+    Returns:
+        Dict with all BSPM metadata plus:
+            codes: np.ndarray (n_experts, 3, tiles_per_proj) with tt-metal format indices
+            codes_bitsculpt: np.ndarray — original BitSculpt codes (for debugging)
+    """
+    # Detect Git LFS pointer files before attempting to parse.
+    # LFS pointers start with "version https://..." — reading the magic will
+    # raise ValueError("Invalid magic: b'vers'") which is hard to diagnose.
+    with open(bspm_path, "rb") as _f:
+        _magic = _f.read(4)
+    if _magic == b"vers":
+        raise RuntimeError(
+            f"BSPM file appears to be a Git LFS pointer, not the actual data: {bspm_path}\n"
+            "Run `git lfs install && git lfs pull` in the bit_sculpt repo to download the real files."
+        )
+    data = load_binary_precision_map(str(bspm_path), expected_n_experts=expected_n_experts)
+    original_codes = data["codes"].copy()
+    data["codes_bitsculpt"] = original_codes
+    data["codes"] = remap_bspm_to_ttnn(original_codes)
+    return data
+
+
+def load_bspm_for_expert(
+    bspm_path: str | Path,
+    expert_idx: int,
+    proj_idx: int,
+    tile_rows: int | None = None,
+    tile_cols: int | None = None,
+) -> np.ndarray:
+    """Load BSPM and return a 2D tt-metal assignment array for one expert projection.
+
+    This is the primary interface for CompressedTensor integration. The returned
+    array can be passed directly to CompressedTensor.__init__() or from_bspm().
+
+    Args:
+        bspm_path: Path to a .bspm file.
+        expert_idx: Expert index (0 to n_experts-1).
+        proj_idx: Projection index (0=gate, 1=up, 2=down).
+        tile_rows: Number of tile rows. If None, inferred from BSPM header.
+        tile_cols: Number of tile cols. If None, inferred from BSPM header.
+
+    Returns:
+        (tiles_h, tiles_w) int8 array with tt-metal COMPRESSED_FORMATS indices.
+    """
+    data = load_bspm_for_layer(str(bspm_path))
+    codes = data["codes"]  # already remapped to tt-metal
+
+    n_experts = data["n_experts"]
+    tiles_per_proj = data["tiles_per_proj"]
+
+    if expert_idx < 0 or expert_idx >= n_experts:
+        raise IndexError(f"expert_idx={expert_idx} out of range [0, {n_experts})")
+    if proj_idx < 0 or proj_idx >= 3:
+        raise IndexError(f"proj_idx={proj_idx} out of range [0, 3)")
+
+    flat_codes = codes[expert_idx, proj_idx]  # (tiles_per_proj,)
+
+    # Determine tile grid shape
+    tr = tile_rows if tile_rows is not None else data.get("tile_rows", 0)
+    tc = tile_cols if tile_cols is not None else data.get("tile_cols", 0)
+
+    if tr == 0 or tc == 0:
+        # Try to infer from tiles_per_proj (square-ish factorization)
+        # For R1: 14336 = 64 × 224 (2048/32 × 7168/32)
+        # This is a heuristic; caller should provide tile_rows/tile_cols for correctness
+        import math
+
+        sqrt_n = int(math.isqrt(tiles_per_proj))
+        for candidate in range(sqrt_n, 0, -1):
+            if tiles_per_proj % candidate == 0:
+                tr = candidate
+                tc = tiles_per_proj // candidate
+                break
+
+    if tr * tc != tiles_per_proj:
+        raise ValueError(
+            f"tile_rows={tr} × tile_cols={tc} = {tr * tc} != tiles_per_proj={tiles_per_proj}. "
+            f"Provide correct tile_rows and tile_cols."
+        )
+
+    return flat_codes.reshape(tr, tc)
+
+
+# ---------------------------------------------------------------------------
+# Batch loading for full model
+# ---------------------------------------------------------------------------
+
+
+def load_all_layer_bspms(
+    bspm_dir: str | Path,
+    model_short_name: str,
+    variant: str,
+    budget: float,
+    layer_indices: list[int],
+    expected_n_experts: int | None = None,
+) -> dict[int, np.ndarray]:
+    """Load BSPMs for multiple layers. Returns {layer_idx: remapped_codes}.
+
+    Follows BitSculpt's file naming convention:
+        {bspm_dir}/{model_short_name}/layer_{idx}/precision_eval/precision_map_{variant}_{budget:.1f}.bspm
+
+    Args:
+        bspm_dir: Root directory containing results (e.g., "results").
+        model_short_name: Model short name (e.g., "deepseek-r1-0528").
+        variant: Allocation variant (e.g., "B").
+        budget: Bit budget (e.g., 3.5).
+        layer_indices: List of layer indices to load.
+        expected_n_experts: Optional validation.
+
+    Returns:
+        Dict mapping layer_idx → remapped codes array (n_experts, 3, tiles_per_proj).
+        Missing layers are silently skipped.
+    """
+    bspm_dir = Path(bspm_dir)
+    result = {}
+    for layer_idx in layer_indices:
+        bspm_path = (
+            bspm_dir
+            / model_short_name
+            / f"layer_{layer_idx}"
+            / "precision_eval"
+            / f"precision_map_{variant}_{budget:.1f}.bspm"
+        )
+        if not bspm_path.exists():
+            continue
+        data = load_bspm_for_layer(bspm_path, expected_n_experts=expected_n_experts)
+        result[layer_idx] = data["codes"]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def summarize_bspm(bspm_path: str | Path) -> dict:
+    """Load a BSPM and return summary statistics.
+
+    Returns dict with:
+        layer_idx, variant, budget, n_experts, tiles_per_proj,
+        tile_counts (both BitSculpt and tt-metal names),
+        avg_bits_per_element
+    """
+    data = load_bspm_for_layer(bspm_path)
+    bs_codes = data["codes_bitsculpt"]
+
+    # Count per BitSculpt format
+    bs_counts = {BITSCULPT_FORMATS[i]: int((bs_codes == i).sum()) for i in range(4)}
+
+    # Average bits per element
+    bits_map = {0: 0.0, 1: 2.5, 2: 4.5, 3: 8.5}  # BitSculpt codes → b/e
+    total_tiles = bs_codes.size
+    total_bits = sum(bits_map[code] * count for code, count in enumerate(np.bincount(bs_codes.ravel(), minlength=4)))
+    avg_be = total_bits / total_tiles if total_tiles > 0 else 0.0
+
+    return {
+        "layer_idx": data["layer_idx"],
+        "variant": data["variant"],
+        "budget": data["budget"],
+        "actual_bits": data["actual_bits"],
+        "n_experts": data["n_experts"],
+        "tiles_per_proj": data["tiles_per_proj"],
+        "tile_counts": bs_counts,
+        "avg_bits_per_element": round(avg_be, 3),
+        "total_tiles": total_tiles,
+    }

--- a/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
@@ -212,8 +212,13 @@ class CompressedTensor:
 
     @property
     def dtype(self):
-        """Logical dtype for CB setup — bfloat4_b (max tile size, matches uniform path)."""
-        return ttnn.bfloat4_b
+        """Conservative dtype for CB setup — use bfloat8_b to safely size the largest compressed tile.
+
+        Mixed-precision CompressedTensors can contain bfp8 tiles (1088 B each), which is larger than
+        bfp4 (576 B).  Reporting bfloat8_b ensures CBs are always allocated large enough regardless
+        of the actual mix, without requiring callers to special-case the compressed path.
+        """
+        return ttnn.bfloat8_b
 
     def get_tile(self):
         """Return the standard 32×32 tile used by the compressed kernel."""

--- a/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
@@ -165,6 +165,7 @@ class CompressedTensor:
         memory_config=None,
         assignment_memory_config=None,
         tile_hw: int = DEFAULT_TILE_HW,
+        min_shard_bytes: int = 0,
     ) -> None:
         assert (
             memory_config is not None and memory_config.is_sharded()
@@ -201,7 +202,30 @@ class CompressedTensor:
         ), f"Assignment shape {assignment.shape} doesn't match tile grid ({self.tiles_h}, {self.tiles_w})"
 
         self._assignment_flat = assignment.astype(np.int8).ravel().copy()
+        self._min_shard_bytes = min_shard_bytes
+        self._memory_config = memory_config
         self._pack_data_and_assignment(tensor, memory_config, assignment_memory_config, device)
+
+    # ==================================================================
+    # ttnn.Tensor compatibility interface (used by MoeOp / setup_dram_matmul)
+    # ==================================================================
+
+    @property
+    def dtype(self):
+        """Logical dtype for CB setup — bfloat4_b (max tile size, matches uniform path)."""
+        return ttnn.bfloat4_b
+
+    def get_tile(self):
+        """Return the standard 32×32 tile used by the compressed kernel."""
+        return ttnn.Tile((32, 32))
+
+    def memory_config(self):
+        """Return the original sharded MemoryConfig passed at construction."""
+        return self._memory_config
+
+    def buffer_address(self):
+        """Return the DRAM buffer address of the packed data tensor."""
+        return self.data.buffer_address()
 
     # ==================================================================
     # Public API
@@ -226,6 +250,132 @@ class CompressedTensor:
             memory_config=memory_config,
             assignment_memory_config=assignment_memory_config,
         )
+
+    @classmethod
+    def from_bspm(
+        cls,
+        tensor: torch.Tensor,
+        assignment: np.ndarray,
+        device=None,
+        memory_config=None,
+        assignment_memory_config=None,
+        tile_hw: int = DEFAULT_TILE_HW,
+        min_shard_bytes: int = 0,
+    ) -> CompressedTensor:
+        """Create CompressedTensor from a pre-computed assignment (e.g., BitSculpt BSPM).
+
+        Bypasses CompressedTensorAssigner — uses the provided assignment directly.
+        The assignment codes must use tt-metal's COMPRESSED_FORMATS ordering:
+        0=bfp8, 1=bfp4, 2=bfp2, 3=bfp0 (use bspm_loader.py to remap from BitSculpt).
+
+        Args:
+            tensor: Original weight tensor (FP32 or BF16). Shape must be divisible
+                by tile_hw in both dimensions.
+            assignment: (tiles_h, tiles_w) int8/uint8 array with tt-metal format indices.
+                Can be obtained from:
+                - integration.ttnn.bspm_loader.load_bspm_for_expert()
+                - integration.ttnn.bspm_loader.load_bspm_for_layer()["codes"][expert_idx, proj_idx]
+            device: ttnn device.
+            memory_config: ttnn.MemoryConfig (must be sharded).
+            assignment_memory_config: Optional separate memory config for assignment tensor.
+            tile_hw: Tile dimension (default 32).
+            min_shard_bytes: Minimum packed bytes per DRAM shard. When allocating multiple
+                experts, pass the same value (the maximum shard size across all experts) to
+                guarantee uniform DRAM strides. Required for DRAMStreamingMatmul's
+                base_addr + expert_idx * stride_bytes indexing to address experts correctly.
+
+        Returns:
+            CompressedTensor with the BSPM-driven precision assignment.
+
+        Example:
+            from integration.ttnn.bspm_loader import load_bspm_for_expert
+
+            assignment = load_bspm_for_expert(
+                "results/deepseek-r1-0528/layer_30/precision_eval/precision_map_B_3.5.bspm",
+                expert_idx=0,
+                proj_idx=0,
+            )
+            ct = CompressedTensor.from_bspm(
+                weight_tensor,
+                assignment,
+                device=device,
+                memory_config=mem_cfg,
+            )
+        """
+        return cls(
+            tensor,
+            assignment,
+            device=device,
+            memory_config=memory_config,
+            assignment_memory_config=assignment_memory_config,
+            tile_hw=tile_hw,
+            min_shard_bytes=min_shard_bytes,
+        )
+
+    @classmethod
+    def from_packed_data(
+        cls,
+        data_tensor,
+        assignment_2d: np.ndarray,
+        original_memory_config,
+        device=None,
+        tile_hw: int = DEFAULT_TILE_HW,
+    ) -> CompressedTensor:
+        """Reconstruct a CompressedTensor from a cached packed data tensor + assignment.
+
+        Used when loading a previously-packed CompressedTensor from disk cache.
+        The data tensor is already on device (loaded via ttnn.load_tensor); the
+        assignment is a numpy array saved alongside it.  This avoids re-quantizing
+        the original float weights.
+
+        Args:
+            data_tensor: Packed uint8 BFP data tensor, already on device.
+            assignment_2d: (tiles_h, tiles_w) int8/uint8 array with tt-metal
+                COMPRESSED_FORMATS indices.  The shape encodes the tile grid.
+            original_memory_config: The MemoryConfig that was passed to __init__
+                or from_bspm() during packing (before shard-size correction).
+                Needed to reconstruct the shard-to-page mapping.
+            device: ttnn device (required to place the repacked assignment tensor).
+            tile_hw: Tile dimension (default 32).
+
+        Returns:
+            CompressedTensor ready for use with DRAMStreamingMatmulCompressed.
+        """
+        obj = object.__new__(cls)
+
+        tiles_h, tiles_w = int(assignment_2d.shape[0]), int(assignment_2d.shape[1])
+        K = tiles_h * tile_hw
+        N_padded = tiles_w * tile_hw
+
+        obj.shape = (K, N_padded)
+        obj.tile_hw = tile_hw
+        obj.tiles_h = tiles_h
+        obj.tiles_w = tiles_w
+
+        obj.data = data_tensor
+        obj.spec = None
+        obj.max_shard_size = data_tensor.memory_config().shard_spec.shape[1]
+
+        obj._assignment_flat = assignment_2d.astype(np.int8).ravel().copy()
+        obj._tile_mant_bits = []  # not populated; to_torch() will not work
+
+        obj._memory_config = original_memory_config
+        obj._shard_mapping = compute_shard_page_mapping((K, N_padded), original_memory_config, tile_hw)
+        obj._core_assignment = obj._build_core_assignment()
+
+        # Re-pack the assignment tensor from numpy (cheap: assignment is tiny).
+        assign_bytes, assign_mem = obj._pack_sharded_assignment(
+            (K, N_padded), original_memory_config, original_memory_config.buffer_type
+        )
+        obj.assignment = ttnn.from_torch(
+            assign_bytes,
+            dtype=ttnn.uint8,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=assign_mem,
+        )
+
+        return obj
 
     def to_torch(self) -> torch.Tensor:
         """Unpack back to float32 torch tensor."""
@@ -339,6 +489,8 @@ class CompressedTensor:
             tile_mant_bits.extend(mant_list)
 
         max_shard_bytes = _align(max(shard_raw_sizes), _get_alignment(memory_config.buffer_type))
+        if self._min_shard_bytes > max_shard_bytes:
+            max_shard_bytes = self._min_shard_bytes
         data_torch = self._concat_shards_padded(shard_chunks, shard_raw_sizes, max_shard_bytes, memory_config)
         corrected_config = self._make_sharded_mem_config(memory_config, max_shard_bytes)
 

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -4704,7 +4704,12 @@ class MoeOp:
                 ctx.gate_output_scores_tensor,
                 ctx.gate_output_indices_tensor,
             ]
-        io_tensors += [ctx.gate_proj_weights_tensor, ctx.up_proj_weights_tensor, ctx.down_proj_weights_tensor]
+        for wt in [ctx.gate_proj_weights_tensor, ctx.up_proj_weights_tensor, ctx.down_proj_weights_tensor]:
+            backing = getattr(wt, "data", None)
+            if backing is not None:
+                io_tensors += [backing, wt.assignment]
+            else:
+                io_tensors += [wt]
         if ctx.final_output_tensor is not None:
             io_tensors += [ctx.final_output_tensor]
         io_tensors += [

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -181,6 +181,36 @@ def _create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip warm; only run the double-load check (use on an already-populated cache-root).",
     )
+    parser.add_argument(
+        "--bspm-dir",
+        type=Path,
+        default=None,
+        help=(
+            "BitSculpt results directory containing BSPM files (e.g. /path/to/bit_sculpt/results). "
+            "When provided, routed MoE expert weights use BSPM-driven mixed-precision "
+            "CompressedTensor instead of uniform bfloat4_b.  Falls back to bfloat4_b for "
+            "layers whose BSPM file is not found."
+        ),
+    )
+    parser.add_argument(
+        "--bspm-variant",
+        default="B",
+        help="BitSculpt allocation variant letter (default: B)",
+    )
+    parser.add_argument(
+        "--bspm-budget",
+        type=float,
+        default=3.5,
+        help="BitSculpt bit budget per expert (default: 3.5)",
+    )
+    parser.add_argument(
+        "--bspm-model",
+        default=None,
+        help=(
+            "BitSculpt model subdirectory name inside --bspm-dir "
+            "(e.g. deepseek-r1-0528). Required when --bspm-dir is set."
+        ),
+    )
     return parser
 
 
@@ -284,6 +314,10 @@ def _warm(
                         num_routed_experts=NUM_ROUTED_EXPERTS,
                         move_to_device=True,
                         cache_config=cfg,
+                        bspm_dir=args.bspm_dir,
+                        bspm_model_name=args.bspm_model,
+                        bspm_variant=args.bspm_variant,
+                        bspm_budget=args.bspm_budget,
                     )
                     logger.info("Layer {} done in {:.3f}s", layer_num, time.perf_counter() - t0)
             elif mode == "embedding":

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -186,10 +186,11 @@ def _create_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help=(
-            "BitSculpt results directory containing BSPM files (e.g. /path/to/bit_sculpt/results). "
+            "Model-specific BitSculpt BSPM directory "
+            "(e.g. /path/to/bit_sculpt/results/deepseek-r1-0528). "
             "When provided, routed MoE expert weights use BSPM-driven mixed-precision "
             "CompressedTensor instead of uniform bfloat4_b.  Falls back to bfloat4_b for "
-            "layers whose BSPM file is not found."
+            "layers whose BSPM file is not found.  Only used with --type moe."
         ),
     )
     parser.add_argument(
@@ -202,14 +203,6 @@ def _create_parser() -> argparse.ArgumentParser:
         type=float,
         default=3.5,
         help="BitSculpt bit budget per expert (default: 3.5)",
-    )
-    parser.add_argument(
-        "--bspm-model",
-        default=None,
-        help=(
-            "BitSculpt model subdirectory name inside --bspm-dir "
-            "(e.g. deepseek-r1-0528). Required when --bspm-dir is set."
-        ),
     )
     return parser
 
@@ -251,6 +244,9 @@ def _validate_args(args: argparse.Namespace, cache_root: Path) -> None:
                 )
                 sys.exit(1)
 
+    if args.bspm_dir is not None and mode != "moe":
+        logger.warning("--bspm-dir is only used with --type moe; ignoring for type={}", mode)
+
     if args.model_path is None:
         logger.error("--model-path is required")
         sys.exit(1)
@@ -278,6 +274,9 @@ def _warm(
     hf_model_id: str,
     hf_revision: str,
     schema_version: int,
+    bspm_dir: Path | None = None,
+    bspm_variant: str = "B",
+    bspm_budget: float = 3.5,
 ) -> None:
     _ensure_fabric_env()
     device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
@@ -314,10 +313,9 @@ def _warm(
                         num_routed_experts=NUM_ROUTED_EXPERTS,
                         move_to_device=True,
                         cache_config=cfg,
-                        bspm_dir=args.bspm_dir,
-                        bspm_model_name=args.bspm_model,
-                        bspm_variant=args.bspm_variant,
-                        bspm_budget=args.bspm_budget,
+                        bspm_dir=bspm_dir,
+                        bspm_variant=bspm_variant,
+                        bspm_budget=bspm_budget,
                     )
                     logger.info("Layer {} done in {:.3f}s", layer_num, time.perf_counter() - t0)
             elif mode == "embedding":
@@ -449,6 +447,9 @@ def main() -> int:
             hf_model_id=hf_model_id,
             hf_revision=args.hf_revision,
             schema_version=args.schema_version,
+            bspm_dir=args.bspm_dir,
+            bspm_variant=args.bspm_variant,
+            bspm_budget=args.bspm_budget,
         )
         logger.info("Warm complete in {:.3f}s", time.perf_counter() - t_all)
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_compressed_tensor.py
@@ -508,3 +508,68 @@ def test_device_bfp0_bfp2_bfp4_uneven_height_shard(device):
     pcc = metric_value(x.numpy(), recovered.numpy(), "pcc")
     print(f"Overall PCC (including bfp0): {pcc:.6f}")
     assert pcc > 0.93, f"Overall PCC {pcc:.6f} too low"
+
+
+def test_from_bspm_tile_counts(device):
+    """Verify CompressedTensor.from_bspm() applies the correct tile format distribution.
+
+    Loads a real BSPM assignment for R1 layer 4 expert 0 gate_proj and checks that
+    the resulting tile_counts reflect mixed precision (bfp4 dominant + bfp2/bfp0
+    minority) rather than a uniform assignment.
+
+    Requires BSPM_DIR env var pointing to a BitSculpt results root that contains
+    deepseek-r1-0528/layer_4/precision_eval/precision_map_B_3.5.bspm.
+    """
+    import os
+    from pathlib import Path
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        import pytest
+
+        pytest.skip("BSPM_DIR not set")
+
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
+
+    bspm_path = Path(bspm_dir) / "deepseek-r1-0528" / "layer_4" / "precision_eval" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        import pytest
+
+        pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    # R1 expert gate_proj: (7168, 2048) → tile grid (224, 64)
+    K, N = 7168, 2048
+    tiles_h, tiles_w = K // 32, N // 32
+    assignment = load_bspm_for_expert(str(bspm_path), expert_idx=0, proj_idx=0, tile_rows=tiles_h, tile_cols=tiles_w)
+    assert assignment.shape == (tiles_h, tiles_w), f"Expected ({tiles_h}, {tiles_w}), got {assignment.shape}"
+
+    torch.manual_seed(0)
+    weight = torch.randn(K, N).float()
+
+    # Use DRAM WIDTH_SHARDED memory config matching production layout
+    num_banks = device.dram_grid_size().x
+    N_padded = ((N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
+    per_core_N = N_padded // num_banks
+    dram_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.dram_grid_size().x - 1, 0))}
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    ct = CompressedTensor.from_bspm(weight, assignment, device=device, memory_config=mem_config)
+
+    counts = ct.tile_counts
+    total_tiles = sum(counts.values())
+    print(f"BSPM tile counts: {counts} / {total_tiles} total")
+
+    # At 3.5 b/e: ~65% bfp4 (code=1), ~35% bfp2+bfp0 (codes=2,3)
+    assert counts.get("bfp4", 0) > 0, f"Expected bfp4 tiles: {counts}"
+    low_precision = counts.get("bfp2", 0) + counts.get("bfp0", 0)
+    assert low_precision > 0, f"Expected bfp2/bfp0 tiles at 3.5 b/e budget: {counts}"
+    # bfp4 should dominate (>50% of tiles)
+    assert counts.get("bfp4", 0) > total_tiles // 2, f"bfp4 should dominate at 3.5 b/e: {counts}"
+    # Should NOT be all-bfp4 (that would mean BSPM codes were ignored)
+    assert counts.get("bfp4", 0) < total_tiles, f"All tiles are bfp4 — BSPM assignment was not applied: {counts}"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -368,7 +368,7 @@ def test_dram_matmul_bspm_direct(device):
 def test_dram_matmul_bspm_via_blitz(device):
     """[1, 7168] x [7168, 2048] via prepare_routed_expert_weights() BSPM path.
 
-    Tests: prepare_routed_expert_weights(bspm_dir=...) → _prepare_moe_routed_experts_bspm()
+    Tests: prepare_routed_expert_weights(bspm_dir=...) → prepare_moe_routed_experts_bspm()
     → CompressedTensor.from_bspm() → DRAMStreamingMatmulCompressed.
 
     Requires BSPM_DIR env var pointing to BitSculpt results root.
@@ -411,8 +411,7 @@ def test_dram_matmul_bspm_via_blitz(device):
         is_moe=True,
         num_routed_experts=1,
         move_to_device=True,
-        bspm_dir=Path(bspm_dir),
-        bspm_model_name="deepseek-r1-0528",
+        bspm_dir=Path(bspm_dir) / "deepseek-r1-0528",
     )
 
     ct = result.routed_gate_proj[0]
@@ -512,8 +511,7 @@ def test_dram_matmul_bspm_down_proj(device):
         is_moe=True,
         num_routed_experts=1,
         move_to_device=True,
-        bspm_dir=Path(bspm_dir),
-        bspm_model_name="deepseek-r1-0528",
+        bspm_dir=Path(bspm_dir) / "deepseek-r1-0528",
     )
 
     ct = result.routed_down_proj[0]
@@ -607,8 +605,7 @@ def test_dram_matmul_bspm_fallback(device):
         is_moe=True,
         num_routed_experts=1,
         move_to_device=True,
-        bspm_dir=Path(bspm_dir),
-        bspm_model_name="deepseek-r1-0528",
+        bspm_dir=Path(bspm_dir) / "deepseek-r1-0528",
     )
 
     t = result.routed_gate_proj[0]
@@ -666,8 +663,7 @@ def test_dram_matmul_bspm_multi_expert(device):
         is_moe=True,
         num_routed_experts=num_experts,
         move_to_device=True,
-        bspm_dir=Path(bspm_dir),
-        bspm_model_name="deepseek-r1-0528",
+        bspm_dir=Path(bspm_dir) / "deepseek-r1-0528",
     )
 
     gate_list = result.routed_gate_proj

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, Comp
 from models.demos.deepseek_v3_b1.micro_ops.dram_streaming_matmul_compressed.op import DRAMStreamingMatmulCompressed
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_dram_streaming_matmul import shuffle_tensor_tiles
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_eltwise_add_compressed import scale_tiles_for_mixed_formats
+from models.demos.deepseek_v3_b1.weights.prepare import _shuffle_dram_assignment
 
 
 def pad_to_dram_banks(num, tile_w, lcm):
@@ -298,6 +299,11 @@ def test_dram_matmul_bspm_direct(device):
     if n_padded > N:
         pad_cols = (n_padded - N) // tile_w
         assignment = np.pad(assignment, ((0, 0), (0, pad_cols)), constant_values=1)  # pad with bfp4
+
+    # Apply the same tile permutation used by shuffle_tensor_tiles/shuffle_dram_tiles so that
+    # assignment[i] maps to the correct physical tile after the column-major reorder.
+    # Without this, from_bspm applies precision codes to the wrong physical tiles.
+    assignment = _shuffle_dram_assignment(assignment, num_banks)
 
     torch.manual_seed(0)
     torch_a = torch.randn((M, K), dtype=torch.bfloat16)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_matmul_custom_compressed.py
@@ -13,6 +13,7 @@ Key difference from test_matmul_custom_compressed.py (L1 version):
 B lives in DRAM and is streamed in variable-size subblocks.
 """
 
+import numpy as np
 import torch
 from loguru import logger
 
@@ -252,3 +253,464 @@ def test_dram_matmul_compressed_4cores_mixed(device):
 def test_dram_matmul_compressed_4cores_mixed_bfp024(device):
     """[1, 7168] x [7168, 2048], mixed bfp4+bfp2, 2 cores per bank."""
     _run_dram_matmul_custom_compressed(device, 1, 7168, 2048, formats=["bfp4", "bfp2", "bfp0"], cores_per_bank=4)
+
+
+# --- BSPM integration tests ---
+
+
+def test_dram_matmul_bspm_direct(device):
+    """[1, 7168] x [7168, 2048] using CompressedTensor.from_bspm() with real BSPM assignment.
+
+    Tests the BSPM assignment → packed representation → DRAMStreamingMatmulCompressed path
+    at R1 expert gate_proj shape using layer 4 expert 0 codes.
+
+    Requires BSPM_DIR env var pointing to BitSculpt results root.
+    """
+    import os
+    from pathlib import Path
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        import pytest
+
+        pytest.skip("BSPM_DIR not set")
+
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
+
+    bspm_path = Path(bspm_dir) / "deepseek-r1-0528" / "layer_4" / "precision_eval" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        import pytest
+
+        pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    M, K, N = 1, 7168, 2048
+    tile_w = 32
+    primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_banks = len(primary_cores_list)
+
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks)
+    per_core_N = n_padded // num_banks
+
+    assignment = load_bspm_for_expert(
+        str(bspm_path), expert_idx=0, proj_idx=0, tile_rows=K // tile_w, tile_cols=N // tile_w
+    )
+    # Pad assignment columns if n_padded > N
+    if n_padded > N:
+        pad_cols = (n_padded - N) // tile_w
+        assignment = np.pad(assignment, ((0, 0), (0, pad_cols)), constant_values=1)  # pad with bfp4
+
+    torch.manual_seed(0)
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_b = torch.randn((K, n_padded)).float()
+
+    # Shuffle for DRAM column-major tile order (same as existing tests)
+    torch_b_shuffled = shuffle_tensor_tiles(torch_b, tile_w, num_banks)
+
+    compute_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in primary_cores_list]
+    )
+    dram_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
+            )
+        ]
+    )
+    b_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    ct = CompressedTensor.from_bspm(torch_b_shuffled, assignment, device=device, memory_config=b_mem_config)
+    logger.info(f"BSPM tile counts: {ct.tile_counts}")
+    assert ct.tile_counts.get("bfp4", 0) > 0, "Expected bfp4 tiles from BSPM assignment"
+    low_p = ct.tile_counts.get("bfp2", 0) + ct.tile_counts.get("bfp0", 0)
+    assert low_p > 0, "Expected bfp2/bfp0 tiles from BSPM assignment at 3.5 b/e"
+
+    torch_expected = (torch_a.float() @ torch_b.float()).bfloat16()
+
+    num_cores = len(primary_cores_list)
+    a_tile = ttnn.Tile([M, tile_w])
+    a_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, K], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_a = ttnn.from_torch(
+        torch_a.repeat(num_cores, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, a_shard_spec),
+        tile=a_tile,
+    )
+    out_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec),
+        tile=ttnn.Tile([M, tile_w]),
+    )
+
+    Kt = K // tile_w
+    subblock_k = Kt // 4 if Kt > 8 else Kt
+    if subblock_k % 2 != 0:
+        subblock_k = max(2, subblock_k - 1)
+
+    ttnn_result = DRAMStreamingMatmulCompressed.op(ttnn_a, ct, ttnn_output, subblock_k=subblock_k)
+    output_torch = ttnn.to_torch(ttnn_result)[..., :N]
+    torch_expected = torch_expected[..., :N]
+
+    passing, pcc = comp_pcc(torch_expected, output_torch, 0.90)
+    logger.info(f"BSPM direct matmul PCC: {pcc}")
+    assert passing, f"BSPM direct matmul PCC too low: {pcc}"
+
+
+def test_dram_matmul_bspm_via_blitz(device):
+    """[1, 7168] x [7168, 2048] via prepare_routed_expert_weights() BSPM path.
+
+    Tests: prepare_routed_expert_weights(bspm_dir=...) → _prepare_moe_routed_experts_bspm()
+    → CompressedTensor.from_bspm() → DRAMStreamingMatmulCompressed.
+
+    Requires BSPM_DIR env var pointing to BitSculpt results root.
+    """
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    from models.demos.deepseek_v3_b1.weights.prepare import prepare_routed_expert_weights
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        pytest.skip("BSPM_DIR not set")
+
+    bspm_path = Path(bspm_dir) / "deepseek-r1-0528" / "layer_4" / "precision_eval" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    M, K, N = 1, 7168, 2048
+    tile_w = 32
+    layer_idx = 4
+
+    torch.manual_seed(0)
+    gate_w = torch.randn(K, N).float()
+    up_w = torch.randn(K, N).float()
+    down_w = torch.randn(2048, 7168).float()
+
+    # State dict uses HF convention: (N_out, K_in) = transposed
+    state_dict = {
+        f"model.layers.{layer_idx}.mlp.experts.0.gate_proj.weight": gate_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.up_proj.weight": up_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.down_proj.weight": down_w.T.contiguous(),
+    }
+
+    result = prepare_routed_expert_weights(
+        device,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        num_routed_experts=1,
+        move_to_device=True,
+        bspm_dir=Path(bspm_dir),
+        bspm_model_name="deepseek-r1-0528",
+    )
+
+    ct = result.routed_gate_proj[0]
+    assert isinstance(ct, CompressedTensor), f"Expected CompressedTensor, got {type(ct)}"
+    logger.info(f"BSPM tile counts: {ct.tile_counts}")
+    assert ct.tile_counts.get("bfp4", 0) > 0, "Expected bfp4 tiles"
+    low_p = ct.tile_counts.get("bfp2", 0) + ct.tile_counts.get("bfp0", 0)
+    assert low_p > 0, "Expected bfp2/bfp0 tiles at 3.5 b/e"
+
+    primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_banks = len(primary_cores_list)
+    num_cores = len(primary_cores_list)
+    n_padded = pad_to_dram_banks(N, tile_w, tile_w * num_banks)
+    per_core_N = n_padded // num_banks
+
+    compute_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in primary_cores_list]
+    )
+
+    torch_a = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_expected = (torch_a.float() @ gate_w.float()).bfloat16()
+
+    a_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, K], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_a = ttnn.from_torch(
+        torch_a.repeat(num_cores, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, a_shard_spec),
+        tile=ttnn.Tile([M, tile_w]),
+    )
+    out_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec),
+        tile=ttnn.Tile([M, tile_w]),
+    )
+
+    Kt = K // tile_w
+    subblock_k = Kt // 4 if Kt > 8 else Kt
+    if subblock_k % 2 != 0:
+        subblock_k = max(2, subblock_k - 1)
+
+    ttnn_result = DRAMStreamingMatmulCompressed.op(ttnn_a, ct, ttnn_output, subblock_k=subblock_k)
+    output_torch = ttnn.to_torch(ttnn_result)[..., :N]
+    torch_expected = torch_expected[..., :N]
+
+    passing, pcc = comp_pcc(torch_expected, output_torch, 0.90)
+    logger.info(f"BSPM matmul PCC: {pcc}")
+    assert passing, f"BSPM matmul PCC too low: {pcc}"
+
+
+def test_dram_matmul_bspm_down_proj(device):
+    """[1, 2048] x [2048, 7168] via prepare_routed_expert_weights() — down-proj shape (proj_idx=2).
+
+    Requires BSPM_DIR env var.
+    """
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    from models.demos.deepseek_v3_b1.weights.prepare import prepare_routed_expert_weights
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        pytest.skip("BSPM_DIR not set")
+
+    bspm_path = Path(bspm_dir) / "deepseek-r1-0528" / "layer_4" / "precision_eval" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    M = 1
+    K_gate, N_gate = 7168, 2048
+    K_down, N_down = 2048, 7168
+    tile_w = 32
+    layer_idx = 4
+
+    torch.manual_seed(0)
+    gate_w = torch.randn(K_gate, N_gate).float()
+    up_w = torch.randn(K_gate, N_gate).float()
+    down_w = torch.randn(K_down, N_down).float()
+
+    state_dict = {
+        f"model.layers.{layer_idx}.mlp.experts.0.gate_proj.weight": gate_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.up_proj.weight": up_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.down_proj.weight": down_w.T.contiguous(),
+    }
+
+    result = prepare_routed_expert_weights(
+        device,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        num_routed_experts=1,
+        move_to_device=True,
+        bspm_dir=Path(bspm_dir),
+        bspm_model_name="deepseek-r1-0528",
+    )
+
+    ct = result.routed_down_proj[0]
+    assert isinstance(ct, CompressedTensor), f"Expected CompressedTensor for down_proj, got {type(ct)}"
+    logger.info(f"Down-proj BSPM tile counts: {ct.tile_counts}")
+    assert ct.tile_counts.get("bfp4", 0) > 0, "Expected bfp4 tiles from BSPM"
+
+    primary_cores_list = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_banks = len(primary_cores_list)
+    num_cores = len(primary_cores_list)
+    n_padded = pad_to_dram_banks(N_down, tile_w, tile_w * num_banks)
+    per_core_N = n_padded // num_banks
+
+    compute_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(c.x, c.y), ttnn.CoreCoord(c.x, c.y)) for c in primary_cores_list]
+    )
+
+    torch_a = torch.randn((M, K_down), dtype=torch.bfloat16)
+    torch_expected = (torch_a.float() @ down_w.float()).bfloat16()
+
+    a_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, K_down], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_a = ttnn.from_torch(
+        torch_a.repeat(num_cores, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, a_shard_spec),
+        tile=ttnn.Tile([M, tile_w]),
+    )
+    out_shard_spec = ttnn.ShardSpec(compute_core_grid, [M, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, n_padded), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec),
+        tile=ttnn.Tile([M, tile_w]),
+    )
+
+    Kt = K_down // tile_w
+    subblock_k = Kt // 4 if Kt > 8 else Kt
+    if subblock_k % 2 != 0:
+        subblock_k = max(2, subblock_k - 1)
+
+    ttnn_result = DRAMStreamingMatmulCompressed.op(ttnn_a, ct, ttnn_output, subblock_k=subblock_k)
+    output_torch = ttnn.to_torch(ttnn_result)[..., :N_down]
+    torch_expected = torch_expected[..., :N_down]
+
+    passing, pcc = comp_pcc(torch_expected, output_torch, 0.90)
+    logger.info(f"Down-proj BSPM matmul PCC: {pcc}")
+    assert passing, f"Down-proj BSPM matmul PCC too low: {pcc}"
+
+
+def test_dram_matmul_bspm_fallback(device):
+    """prepare_routed_expert_weights() falls back to uniform bfloat4_b when BSPM absent.
+
+    Uses layer_idx=0 which has no BSPM file (layer 0 is dense, only MoE layers 3+
+    have BSPM). Verifies the returned tensor is a plain ttnn.Tensor (not CompressedTensor).
+
+    Requires BSPM_DIR env var pointing to a real BitSculpt results root.
+    """
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    from models.demos.deepseek_v3_b1.weights.prepare import prepare_routed_expert_weights
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        pytest.skip("BSPM_DIR not set")
+
+    K, N = 7168, 2048
+    layer_idx = 0  # Dense layer — no BSPM file exists
+
+    torch.manual_seed(0)
+    gate_w = torch.randn(K, N).float()
+    up_w = torch.randn(K, N).float()
+    down_w = torch.randn(2048, 7168).float()
+
+    state_dict = {
+        f"model.layers.{layer_idx}.mlp.experts.0.gate_proj.weight": gate_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.up_proj.weight": up_w.T.contiguous(),
+        f"model.layers.{layer_idx}.mlp.experts.0.down_proj.weight": down_w.T.contiguous(),
+    }
+
+    result = prepare_routed_expert_weights(
+        device,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        num_routed_experts=1,
+        move_to_device=True,
+        bspm_dir=Path(bspm_dir),
+        bspm_model_name="deepseek-r1-0528",
+    )
+
+    t = result.routed_gate_proj[0]
+    assert not isinstance(t, CompressedTensor), (
+        f"Expected plain ttnn.Tensor fallback for layer {layer_idx}, got CompressedTensor. "
+        "Check that no BSPM file exists for layer 0 in the BSPM_DIR."
+    )
+    assert isinstance(t, ttnn.Tensor), f"Expected ttnn.Tensor, got {type(t)}"
+    assert t.dtype == ttnn.bfloat4_b, f"Fallback tensor should be bfloat4_b, got {t.dtype}"
+    logger.info(f"Fallback gate tensor: dtype={t.dtype}, shape={t.shape}")
+
+
+def test_dram_matmul_bspm_multi_expert(device):
+    """3 experts via prepare_routed_expert_weights() — validates DRAM contiguity.
+
+    Requires BSPM_DIR env var.
+    """
+    import os
+    from pathlib import Path
+
+    import pytest
+
+    from models.demos.deepseek_v3_b1.weights.prepare import prepare_routed_expert_weights
+
+    bspm_dir = os.environ.get("BSPM_DIR")
+    if not bspm_dir:
+        pytest.skip("BSPM_DIR not set")
+
+    bspm_path = Path(bspm_dir) / "deepseek-r1-0528" / "layer_4" / "precision_eval" / "precision_map_B_3.5.bspm"
+    if not bspm_path.exists():
+        pytest.skip(f"BSPM file not found: {bspm_path}")
+
+    num_experts = 3
+    K_gate, N_gate = 7168, 2048
+    K_down, N_down = 2048, 7168
+    layer_idx = 4
+
+    torch.manual_seed(0)
+    state_dict = {}
+    gate_ws = []
+    for e in range(num_experts):
+        gw = torch.randn(K_gate, N_gate).float()
+        uw = torch.randn(K_gate, N_gate).float()
+        dw = torch.randn(K_down, N_down).float()
+        gate_ws.append(gw)
+        prefix = f"model.layers.{layer_idx}.mlp.experts.{e}"
+        state_dict[f"{prefix}.gate_proj.weight"] = gw.T.contiguous()
+        state_dict[f"{prefix}.up_proj.weight"] = uw.T.contiguous()
+        state_dict[f"{prefix}.down_proj.weight"] = dw.T.contiguous()
+
+    result = prepare_routed_expert_weights(
+        device,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        num_routed_experts=num_experts,
+        move_to_device=True,
+        bspm_dir=Path(bspm_dir),
+        bspm_model_name="deepseek-r1-0528",
+    )
+
+    gate_list = result.routed_gate_proj
+    up_list = result.routed_up_proj
+    down_list = result.routed_down_proj
+
+    assert len(gate_list) == num_experts
+    assert len(up_list) == num_experts
+    assert len(down_list) == num_experts
+
+    for i, ct in enumerate(gate_list):
+        assert isinstance(ct, CompressedTensor), f"gate_list[{i}] expected CompressedTensor, got {type(ct)}"
+        counts = ct.tile_counts
+        assert counts.get("bfp4", 0) > 0, f"gate_list[{i}]: no bfp4 tiles"
+        low_p = counts.get("bfp2", 0) + counts.get("bfp0", 0)
+        assert low_p > 0, f"gate_list[{i}]: no bfp2/bfp0 tiles at 3.5 b/e"
+        logger.info(f"gate_list[{i}] tile counts: {counts}")
+
+    gate_addrs = [gate_list[i].get_data_l1_address() for i in range(num_experts)]
+    strides = [gate_addrs[i + 1] - gate_addrs[i] for i in range(num_experts - 1)]
+    logger.info(f"Gate expert DRAM addresses: {gate_addrs}")
+    logger.info(f"Gate expert DRAM strides: {strides}")
+
+    assert strides[0] > 0, "Expert addresses not increasing — experts may overlap"
+
+    constant_stride = all(s == strides[0] for s in strides)
+    if not constant_stride:
+        pytest.xfail(
+            f"Non-constant DRAM stride between BSPM experts: strides={strides}. "
+            "Variable-size CompressedTensors break kernel's fixed-stride expert indexing."
+        )
+    logger.info(f"Gate expert DRAM stride: {strides[0]} bytes — contiguity OK")
+
+
+def test_dram_matmul_bspm_cache_roundtrip(device, tmp_path):
+    """BSPM CompressedTensor TensorCache disk round-trip.
+
+    Skipped: CompressedTensor save/load via the new TensorCache is not yet
+    implemented (known gap — requires CompressedTensorTarget in weights/cache/).
+    """
+    import pytest
+
+    pytest.skip(
+        "CompressedTensor TensorCache round-trip not yet implemented. "
+        "Pending: CompressedTensorTarget + _store_compressed/_load_compressed in weights/cache/."
+    )

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
+import numpy as np
 import torch
 from loguru import logger
 
@@ -55,6 +57,15 @@ from models.demos.deepseek_v3_b1.weights.transforms.moe import (
     shared_down_torch_for_cache,
     shuffle_dram_tiles,
 )
+
+# BSPM mixed-precision integration (optional — requires compressed_tensor package)
+try:
+    from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor
+    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
+
+    HAS_BSPM_SUPPORT = True
+except ImportError:
+    HAS_BSPM_SUPPORT = False
 
 # MoE sender core: hardcoded grid (13, 10) so cache layout is consistent across slow/fast dispatch.
 # Sender core = (grid.x - 1, grid.y - 1) = (12, 9); must match test_moe_mlp create_runtime_tensors.
@@ -126,10 +137,36 @@ def _assert_moe_routed_expert_list_contiguous(tensors: list[ttnn.Tensor], name: 
     """Experts must be contiguous in DRAM; see MoERoutedExpertWeights.validate_contiguous_dram."""
     if len(tensors) < 2:
         return
-    if not ttnn.is_tensor_storage_on_device(tensors[0]):
+
+    # CompressedTensor wraps a ttnn.Tensor in .data — unwrap for device check.
+    first = tensors[0]
+    check_tensor = first.data if hasattr(first, "data") and isinstance(first.data, ttnn.Tensor) else first
+    if not ttnn.is_tensor_storage_on_device(check_tensor):
         return
-    stride = _moe_routed_expert_stride_bytes(tensors[0])
-    base = tensors[0].buffer_address()
+
+    if hasattr(first, "data") and isinstance(first.data, ttnn.Tensor):
+        # CompressedTensor path: stride is variable-size (packed bytes), not tile-formula.
+        # Deduce expected stride from the gap between first two experts.
+        addrs = [t.buffer_address() for t in tensors]
+        stride = addrs[1] - addrs[0]
+        if stride <= 0:
+            raise AssertionError(
+                f"{name} expert DRAM addresses not strictly increasing: addrs={addrs}. "
+                "Experts may overlap or be placed out-of-order."
+            )
+        for i in range(len(tensors)):
+            expected = addrs[0] + i * stride
+            actual = addrs[i]
+            if actual != expected:
+                raise AssertionError(
+                    f"{name}[{i}] DRAM layout not contiguous for DRAMStreamingMatmul: "
+                    f"expected buffer_address {expected}, got {actual} (deduced stride {stride} bytes per expert). "
+                    "Allocate all experts of one projection in one batch before the next projection."
+                )
+        return
+
+    stride = _moe_routed_expert_stride_bytes(first)
+    base = first.buffer_address()
     for i, t in enumerate(tensors):
         expected = base + i * stride
         actual = t.buffer_address()
@@ -965,6 +1002,130 @@ def prepare_shared_expert_weights(
     )
 
 
+def _shuffle_dram_assignment(assignment: np.ndarray, num_banks: int) -> np.ndarray:
+    """Apply the same tile permutation as shuffle_dram_tiles to a BSPM assignment."""
+    tiles_h, tiles_w = assignment.shape
+    per_N_tiles = tiles_w // num_banks
+    K_tiles = tiles_h
+    num_tiles_per_shard = K_tiles * per_N_tiles
+
+    i = np.arange(num_tiles_per_shard)
+    source_idx = (i % K_tiles) * per_N_tiles + (i // K_tiles)
+
+    result = np.empty_like(assignment)
+    for b in range(num_banks):
+        shard = assignment[:, b * per_N_tiles : (b + 1) * per_N_tiles].ravel()
+        result[:, b * per_N_tiles : (b + 1) * per_N_tiles] = shard[source_idx].reshape(K_tiles, per_N_tiles)
+    return result
+
+
+def _compute_bspm_max_shard_bytes(
+    assignments: list[np.ndarray],
+    K: int,
+    N_padded: int,
+    num_banks: int,
+    tile_w: int = 32,
+) -> int:
+    """Return the maximum DRAM shard size (bytes) across a list of BSPM assignments.
+
+    Enforces uniform expert sizes so DRAMStreamingMatmul's fixed-stride expert
+    indexing (base_addr + expert_idx * stride_bytes) addresses correctly.
+
+    Tile byte sizes: 0=bfp8: 1088 B, 1=bfp4: 576 B, 2=bfp2: 320 B, 3=bfp0: 0 B
+    """
+    tile_bytes = np.array([1088, 576, 320, 0], dtype=np.int64)
+    tiles_per_bank_col = (N_padded // tile_w) // num_banks
+
+    max_shard = 0
+    for assignment in assignments:
+        tile_sizes = tile_bytes[assignment]
+        for b in range(num_banks):
+            col_start = b * tiles_per_bank_col
+            col_end = (b + 1) * tiles_per_bank_col
+            shard_bytes = int(tile_sizes[:, col_start:col_end].sum())
+            if shard_bytes > max_shard:
+                max_shard = shard_bytes
+
+    dram_align = ttnn._ttnn.bfp_utils.get_dram_alignment()
+    return ((max_shard + dram_align - 1) // dram_align) * dram_align
+
+
+def _prepare_moe_routed_experts_bspm(
+    device,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    num_routed_experts: int,
+    num_banks: int,
+    bspm_data: dict,
+    *,
+    move_to_device: bool,
+) -> MoERoutedExpertWeights:
+    """Upload MoE routed experts as BSPM-encoded CompressedTensor objects."""
+    tile_w = 32
+    device_for_torch = device if move_to_device else None
+
+    proj_keys = [
+        [_key(layer_idx, f"mlp.experts.{e}.gate_proj.weight") for e in range(num_routed_experts)],
+        [_key(layer_idx, f"mlp.experts.{e}.up_proj.weight") for e in range(num_routed_experts)],
+        [_key(layer_idx, f"mlp.experts.{e}.down_proj.weight") for e in range(num_routed_experts)],
+    ]
+
+    results: list[list] = [[], [], []]
+    for proj_idx, keys in enumerate(proj_keys):
+        sample_w = state_dict[keys[0]]
+        K, N = sample_w.shape[1], sample_w.shape[0]
+        N_padded = ((N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+        per_core_N = N_padded // num_banks
+
+        dram_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+                )
+            }
+        )
+        shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+        mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+        tiles_h = K // tile_w
+        tiles_w_count = N_padded // tile_w
+        all_assignments = [
+            bspm_data["codes"][e, proj_idx].reshape(tiles_h, tiles_w_count) for e in range(num_routed_experts)
+        ]
+        min_shard_bytes = _compute_bspm_max_shard_bytes(all_assignments, K, N_padded, num_banks, tile_w)
+        logger.debug("  proj_idx={}: uniform DRAM shard = {} B", proj_idx, min_shard_bytes)
+
+        for e, key in enumerate(keys):
+            w = state_dict[key].T.contiguous()
+            if N_padded != N:
+                w = torch.nn.functional.pad(w, (0, N_padded - N))
+
+            w_shuffled = shuffle_dram_tiles(w.unsqueeze(0), tile_w, num_banks).squeeze(0)
+            assignment = _shuffle_dram_assignment(all_assignments[e], num_banks)
+
+            ct = CompressedTensor.from_bspm(
+                w_shuffled.float(),
+                assignment,
+                device=device_for_torch,
+                memory_config=mem_config,
+                min_shard_bytes=min_shard_bytes,
+            )
+            results[proj_idx].append(ct)
+
+            if (e + 1) % 32 == 0:
+                logger.info("  proj_idx={}: uploaded {}/{} experts (BSPM)", proj_idx, e + 1, num_routed_experts)
+
+    routed = MoERoutedExpertWeights(
+        routed_gate_proj=results[0],
+        routed_up_proj=results[1],
+        routed_down_proj=results[2],
+    )
+    if move_to_device:
+        routed.validate_contiguous_dram()
+    return routed
+
+
 def prepare_routed_expert_weights(
     device,
     state_dict: dict[str, torch.Tensor],
@@ -974,13 +1135,53 @@ def prepare_routed_expert_weights(
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
+    bspm_dir: Path | None = None,
+    bspm_model_name: str | None = None,
+    bspm_variant: str = "B",
+    bspm_budget: float = 3.5,
 ) -> DenseRoutedExpertWeights | MoERoutedExpertWeights:
-    """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts)."""
+    """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts).
+
+    When ``bspm_dir`` is provided and a BSPM file exists for this layer, routed MoE experts
+    are encoded as mixed-precision CompressedTensor objects instead of uniform bfloat4_b.
+    Falls back to uniform bfloat4_b if the file is not found or BSPM support is unavailable.
+
+    Note: BSPM experts bypass the TensorCache (disk caching not yet supported for CompressedTensor).
+    """
     if cache_config is None:
         cache_config = CacheConfig.ephemeral(move_to_device=move_to_device)
     num_banks = device.dram_grid_size().x
     mesh_shape = (device.shape[0], device.shape[1]) if device.get_num_devices() > 1 else (1, 1)
     if is_moe:
+        # --- BSPM path ---
+        bspm_data = None
+        if HAS_BSPM_SUPPORT and bspm_dir is not None and bspm_model_name is not None:
+            bspm_path = (
+                Path(bspm_dir)
+                / bspm_model_name
+                / f"layer_{layer_idx}"
+                / "precision_eval"
+                / f"precision_map_{bspm_variant}_{bspm_budget:.1f}.bspm"
+            )
+            if bspm_path.exists():
+                logger.info("Loading BSPM for layer {}: {}", layer_idx, bspm_path)
+                bspm_data = load_bspm_for_layer(str(bspm_path))
+                logger.info("  BSPM mixed-precision compression for {} experts", bspm_data["n_experts"])
+            else:
+                logger.debug("BSPM not found for layer {}, using uniform bfloat4_b", layer_idx)
+
+        if bspm_data is not None:
+            return _prepare_moe_routed_experts_bspm(
+                device=device,
+                state_dict=state_dict,
+                layer_idx=layer_idx,
+                num_routed_experts=num_routed_experts,
+                num_banks=num_banks,
+                bspm_data=bspm_data,
+                move_to_device=move_to_device,
+            )
+
+        # --- Uniform bfloat4_b path (TensorCache-backed) ---
         tgt_gate = _moe_routed_expert_tensor_target("routed_gate_proj", _ROUTED_GATE_UP_K, _ROUTED_GATE_UP_N, device)
         tgt_up = _moe_routed_expert_tensor_target("routed_up_proj", _ROUTED_GATE_UP_K, _ROUTED_GATE_UP_N, device)
         tgt_down = _moe_routed_expert_tensor_target("routed_down_proj", _ROUTED_DOWN_K, _ROUTED_DOWN_N, device)
@@ -1175,6 +1376,10 @@ def prepare_moe_layer_weights(
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
+    bspm_dir: Path | None = None,
+    bspm_model_name: str | None = None,
+    bspm_variant: str = "B",
+    bspm_budget: float = 3.5,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer."""
     logger.info("Preparing MoE layer {}...", layer_idx)
@@ -1198,6 +1403,10 @@ def prepare_moe_layer_weights(
         num_routed_experts=num_routed_experts,
         move_to_device=move_to_device,
         cache_config=cache_config,
+        bspm_dir=bspm_dir,
+        bspm_model_name=bspm_model_name,
+        bspm_variant=bspm_variant,
+        bspm_budget=bspm_budget,
     )
     assert isinstance(attn.gate_mm, OverlappedTensor)
     assert attn.gate_bias is not None

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -48,6 +48,8 @@ Q_AB_KV_A_SPEC = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 O_PROJ_GATE_MM_NORMS_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 KV_B12_SPEC = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 GATE_UP_SPEC = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
+from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor
+from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
 from models.demos.deepseek_v3_b1.weights.transforms.attention import preprocess_kv_b12, preprocess_q_ab_kv_a
 from models.demos.deepseek_v3_b1.weights.transforms.moe import (
     _tp_factors,
@@ -57,15 +59,6 @@ from models.demos.deepseek_v3_b1.weights.transforms.moe import (
     shared_down_torch_for_cache,
     shuffle_dram_tiles,
 )
-
-# BSPM mixed-precision integration (optional — requires compressed_tensor package)
-try:
-    from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor
-    from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
-
-    HAS_BSPM_SUPPORT = True
-except ImportError:
-    HAS_BSPM_SUPPORT = False
 
 # MoE sender core: hardcoded grid (13, 10) so cache layout is consistent across slow/fast dispatch.
 # Sender core = (grid.x - 1, grid.y - 1) = (12, 9); must match test_moe_mlp create_runtime_tensors.
@@ -140,11 +133,11 @@ def _assert_moe_routed_expert_list_contiguous(tensors: list[ttnn.Tensor], name: 
 
     # CompressedTensor wraps a ttnn.Tensor in .data — unwrap for device check.
     first = tensors[0]
-    check_tensor = first.data if hasattr(first, "data") and isinstance(first.data, ttnn.Tensor) else first
+    check_tensor = first.data if isinstance(first, CompressedTensor) else first
     if not ttnn.is_tensor_storage_on_device(check_tensor):
         return
 
-    if hasattr(first, "data") and isinstance(first.data, ttnn.Tensor):
+    if isinstance(first, CompressedTensor):
         # CompressedTensor path: stride is variable-size (packed bytes), not tile-formula.
         # Deduce expected stride from the gap between first two experts.
         addrs = [t.buffer_address() for t in tensors]
@@ -1050,7 +1043,7 @@ def _compute_bspm_max_shard_bytes(
     return ((max_shard + dram_align - 1) // dram_align) * dram_align
 
 
-def _prepare_moe_routed_experts_bspm(
+def prepare_moe_routed_experts_bspm(
     device,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
@@ -1136,7 +1129,6 @@ def prepare_routed_expert_weights(
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
     bspm_dir: Path | None = None,
-    bspm_model_name: str | None = None,
     bspm_variant: str = "B",
     bspm_budget: float = 3.5,
 ) -> DenseRoutedExpertWeights | MoERoutedExpertWeights:
@@ -1145,6 +1137,9 @@ def prepare_routed_expert_weights(
     When ``bspm_dir`` is provided and a BSPM file exists for this layer, routed MoE experts
     are encoded as mixed-precision CompressedTensor objects instead of uniform bfloat4_b.
     Falls back to uniform bfloat4_b if the file is not found or BSPM support is unavailable.
+
+    ``bspm_dir`` must be the model-specific subdirectory (e.g. ``results/deepseek-r1-0528``),
+    not the results root.
 
     Note: BSPM experts bypass the TensorCache (disk caching not yet supported for CompressedTensor).
     """
@@ -1155,10 +1150,9 @@ def prepare_routed_expert_weights(
     if is_moe:
         # --- BSPM path ---
         bspm_data = None
-        if HAS_BSPM_SUPPORT and bspm_dir is not None and bspm_model_name is not None:
+        if bspm_dir is not None:
             bspm_path = (
                 Path(bspm_dir)
-                / bspm_model_name
                 / f"layer_{layer_idx}"
                 / "precision_eval"
                 / f"precision_map_{bspm_variant}_{bspm_budget:.1f}.bspm"
@@ -1171,7 +1165,10 @@ def prepare_routed_expert_weights(
                 logger.debug("BSPM not found for layer {}, using uniform bfloat4_b", layer_idx)
 
         if bspm_data is not None:
-            return _prepare_moe_routed_experts_bspm(
+            # TODO: BSPM path bypasses TensorCache — CompressedTensor serialization not yet
+            # implemented (requires CompressedTensorTarget + _store_compressed/_load_compressed
+            # in weights/cache/). Tracked: test_dram_matmul_bspm_cache_roundtrip (SKIP).
+            return prepare_moe_routed_experts_bspm(
                 device=device,
                 state_dict=state_dict,
                 layer_idx=layer_idx,
@@ -1377,11 +1374,14 @@ def prepare_moe_layer_weights(
     move_to_device: bool = False,
     cache_config: CacheConfig | None = None,
     bspm_dir: Path | None = None,
-    bspm_model_name: str | None = None,
     bspm_variant: str = "B",
     bspm_budget: float = 3.5,
 ) -> DeepSeekV3MoELayerWeights:
-    """Prepare fused weights for a single MoE decoder layer."""
+    """Prepare fused weights for a single MoE decoder layer.
+
+    ``bspm_dir``, when provided, must be the model-specific BSPM subdirectory
+    (e.g. ``results/deepseek-r1-0528``), not the results root.
+    """
     logger.info("Preparing MoE layer {}...", layer_idx)
     t0 = time.perf_counter()
     attn = prepare_attention_weights(
@@ -1404,7 +1404,6 @@ def prepare_moe_layer_weights(
         move_to_device=move_to_device,
         cache_config=cache_config,
         bspm_dir=bspm_dir,
-        bspm_model_name=bspm_model_name,
         bspm_variant=bspm_variant,
         bspm_budget=bspm_budget,
     )


### PR DESCRIPTION
## Summary

Integrates BitSculpt Precision Map (BSPM) assignments into the DeepSeek V3 B1 inference pipeline, enabling native mixed-precision expert weight loading on Blackhole without dequantization.

Two integration tracks:

**Track A — BSPM → quantize → dequantize → bfloat4_b** (`deepseek_v3/`)
- `convert_bspm_weights.py`: full 58-layer weight cache generator; applies BSPM precision assignments per tile, re-encodes as uniform bfloat4_b through the standard pipeline
- `test_bspm_demo.py`: BH Galaxy logit validation — PCC 0.984 vs uniform bfloat4_b (threshold > 0.93), 72.7% top-1 greedy match. Requires dequantized checkpoint (`dequantize_hf_checkpoint.py`).

**Track B — BSPM → mixed-precision packing → DRAMStreamingMatmulCompressed** (`deepseek_v3_b1/`)
- `compressed_tensor/bspm_loader.py`: loads `.bspm` files, remaps BitSculpt↔tt-metal precision codes (`[3,2,1,0]` reversal)
- `CompressedTensor.from_bspm()`: creates `CompressedTensor` from pre-computed BSPM assignment, bypassing `CompressedTensorAssigner`; `min_shard_bytes` enforces uniform DRAM stride across experts
- `CompressedTensor.from_packed_data()`: reconstructs from cached packed bytes + assignment without re-quantizing
- `CompressedTensor` ttnn interface: `.dtype`, `.get_tile()`, `.memory_config()`, `.buffer_address()` — required by `MoeOp._setup_dimensions`
- `weights/prepare.py` BSPM helpers (ported from deleted `blitz_decode_weights.py` / `prepare_weights.py` after PR #41473):
  - `_prepare_moe_routed_experts_bspm()`: builds one `CompressedTensor` per expert from BSPM assignment arrays, bypassing TensorCache
  - `_shuffle_dram_assignment()`: applies same tile permutation as `shuffle_dram_tiles()` to BSPM codes so each code stays with its physical tile
  - `_compute_bspm_max_shard_bytes()`: analytically computes max packed shard size across experts; passed as `min_shard_bytes` to enforce uniform DRAM strides
  - `prepare_routed_expert_weights()`: calls BSPM helper when `.bspm` file found; falls back to TensorCache (uniform bfloat4_b) path otherwise
- `generate_cache.py`: `--bspm-dir/variant/budget` flags wired into `_warm()`
- `fused_ops/moe/op.py`: unwraps `CompressedTensor` to `[ct.data, ct.assignment]` in IO tensor list — `ttnn.generic_op` requires `List[ttnn.Tensor]`

## Bugs found and fixed

**Missing DRAM tile shuffle** — BSPM path called `from_bspm()` on unshuffled weights; kernel expects column-major tile order per DRAM bank. PCC −0.019 → fixed to 0.993.

**Variable DRAM stride** — different experts had different bfp2/bfp0 tile counts, causing unequal buffer sizes. `DRAMStreamingMatmul` requires constant `stride_bytes`. Fix: `_compute_bspm_max_shard_bytes()` + `min_shard_bytes` pads all experts to the same size.

**Assignment permutation (B5)** — `_shuffle_dram_tiles` permuted tiles but the BSPM assignment array was not permuted accordingly, causing wrong precisions on physical tiles. Fix: `_shuffle_dram_assignment()` applies the same within-shard permutation to the assignment before `from_bspm()`.

**FP8 fancy indexing** — PyTorch fancy indexing not implemented for `Float8_e4m3fn` in `shuffle_kv_a`, `reshuffle_block_to_height_sharded`, `_shuffle_dram_tiles`. Fix: cast to float32 before reindex, cast back.

**`from_torch` broken for bfloat8_b/bfloat4_b + mesh_mapper** — C++ binding treats `tensor` as positional-only; keyword-arg re-init after internal pre-conversion fails. Fix: `ttnn.Tensor(...)` with positional args for host path; two-step `from_torch` + `to_memory_config` for device path.

**`from_torch` with `device=None` + L1 sharded mem_config** — core coordinates can't be validated without a device on BH Galaxy. Fix: omit `memory_config` for host tensors; sharding applied at load time.

**Git LFS pointer files** — `.bspm` files are stored in Git LFS; loading without `git lfs pull` fails with `ValueError: Invalid magic`. Fix: detect pointer file header and raise a clear error.

**`CompressedTensor` missing ttnn interface** — `MoeOp._setup_dimensions` calls `.dtype`, `.get_tile()`, `.memory_config()`, `.buffer_address()`. Added all four to `CompressedTensor`.

**`_build_io_tensors` non-ttnn type** — `ttnn.generic_op` requires `List[ttnn.Tensor]`; `CompressedTensor` is not a `ttnn.Tensor`. Fix: unwrap to `[ct.data, ct.assignment]`.

**`_assert_moe_routed_expert_list_contiguous` CompressedTensor** — validator called `ttnn.is_tensor_storage_on_device(tensor)` where `tensor` was a `CompressedTensor` wrapper. Fix: unwrap `.data` for device check; deduce stride from actual buffer addresses for BSPM path.

## Test results (BH Galaxy — 93 unit tests: 92 pass, 1 skip)

| Test | Result |
|------|--------|
| `test_from_bspm_tile_counts` | Pass |
| `test_dram_matmul_bspm_direct` | PCC 0.993 |
| `test_dram_matmul_bspm_via_blitz` | PCC 0.993 — full `prepare_routed_expert_weights(bspm_dir=...)` path |
| `test_dram_matmul_bspm_down_proj` | PCC 0.99 |
| `test_dram_matmul_bspm_fallback` | Pass — no BSPM file → plain bfloat4_b, no exception |
| `test_dram_matmul_bspm_multi_expert` | Pass — constant DRAM stride 1032192 B across 3 experts |
| `test_dram_matmul_bspm_cache_roundtrip` | **SKIP** — CompressedTensor TensorCache not yet implemented (pending `CompressedTensorTarget` in `weights/cache/`) |
| `test_compressed_tensor.py` (14 tests) | All pass |
| `test_matmul_compressed.py` (9 tests) | All pass |
| `test_matmul_custom_compressed.py` (22 tests) | All pass |
| `test_eltwise_add_compressed.py` (30 tests) | All pass |

> **Note:** Tests requiring a 13×10 grid need `TT_METAL_SLOW_DISPATCH_MODE=1` on BH Galaxy.

## Not included — follow-up PR (`mtairum/bspm_part_2`)

The following work is on branch `mtairum/bspm_part_2` (rebased on top of this branch):

- **B6 — `test_moe_fused_bspm` ✅ Done** — full MoeOp compressed path; PCC 0.998. Root cause: CB9/CB18 page_size mismatch (576 B BFP4 vs 1088 B BFP8 slot stride); fixed in `op.py`.
- **F1 — `DRAMStreamingExpertsMatmulCompressed` ✅ Done (kernel)** — multi-expert streaming kernel with per-expert offset table; no DRAM padding between experts. PCC 0.990–0.995 across 3 real BSPM experts.
- **R1/R2 — Real-weight validation ✅ Done** — single-expert (PCC 0.9797–0.9827) and 8-expert (all 24 pass) tests on real R1-0528 weights loaded from HF checkpoint.
- **End-to-end demo ⚠️ Blocked** — 4-rank single-Galaxy pipeline (Embed→LMHead→Pass→Pass) runs 32 decode steps without crash. Full MoE inference with BSPM requires 16-rank single-pod (4 Galaxy hosts).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)