### PR TITLE
[QSR] Eltwise Binary Bringup

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -37,6 +37,8 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 namespace tt::tt_metal {
 class IDevice;
@@ -145,26 +147,93 @@ bool single_core_binary(
     // auto output_dram_buffer = CreateBuffer(dram_config);
     uint32_t output_dram_byte_address = output_dram_buffer->address();
 
-    tt_metal::CircularBufferConfig l1_cb_config =
-        tt_metal::CircularBufferConfig(byte_size, {{0, test_config.l1_input_data_format}})
-            .set_page_size(0, test_config.tile_byte_size);
-    tt_metal::CreateCircularBuffer(program_, test_config.core, l1_cb_config);
+    uint32_t inp0_dfb = 0;
+    uint32_t inp1_dfb = 0;
+    uint32_t inp2_dfb = 0;
+    uint32_t out_dfb = 0;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        tt_metal::experimental::dfb::DataflowBufferConfig l1_dfb_config = {
+            .entry_size = test_config.tile_byte_size,
+            .num_entries = test_config.num_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b,
+            .tile = tt_metal::Tile({32, 32}),
+        };
+        
+        tt_metal::experimental::dfb::DataflowBufferConfig l1_input1_dfb_config = {
+            .entry_size = test_config.tile_byte_size,
+            .num_entries = test_config.num_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b,
+            .tile = tt_metal::Tile({32, 32}),
+        };
 
-    tt_metal::CircularBufferConfig l1_input1_cb_config =
-        tt_metal::CircularBufferConfig(byte_size, {{1, test_config.l1_input_data_format}})
-            .set_page_size(1, test_config.tile_byte_size);
-    tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input1_cb_config);
+        tt_metal::experimental::dfb::DataflowBufferConfig l2_input1_dfb_config = {
+            .entry_size = test_config.tile_byte_size,
+            .num_entries = test_config.num_tiles,
+            .producer_risc_mask = 0x1,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x100,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b,
+            .tile = tt_metal::Tile({32, 32}),
+        };
 
-    tt_metal::CircularBufferConfig l2_input1_cb_config =
-        tt_metal::CircularBufferConfig(byte_size, {{2, test_config.l1_input_data_format}})
-            .set_page_size(2, test_config.tile_byte_size);
-    tt_metal::CreateCircularBuffer(program_, test_config.core, l2_input1_cb_config);
+        tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
+            .entry_size = test_config.tile_byte_size,
+            .num_entries = test_config.num_tiles,
+            .producer_risc_mask = 0x100,
+            .num_producers = 1,
+            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = 0x2,
+            .num_consumers = 1,
+            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+            .enable_implicit_sync = false,
+            .data_format = tt::DataFormat::Float16_b,
+            .tile = tt_metal::Tile({32, 32}),
+        };
 
-    tt_metal::CircularBufferConfig l1_output_cb_config =
-        tt_metal::CircularBufferConfig(byte_size, {{16, test_config.l1_output_data_format}})
-            .set_page_size(16, test_config.tile_byte_size);
-    tt_metal::CreateCircularBuffer(program_, test_config.core, l1_output_cb_config);
+        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_dfb_config);
+        inp1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input1_dfb_config);
+        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l2_input1_dfb_config);
+        out_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
 
+    } else {
+        tt_metal::CircularBufferConfig l1_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{0, test_config.l1_input_data_format}})
+                .set_page_size(0, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_cb_config);
+
+        tt_metal::CircularBufferConfig l1_input1_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{1, test_config.l1_input_data_format}})
+                .set_page_size(1, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input1_cb_config);
+
+        tt_metal::CircularBufferConfig l2_input1_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{2, test_config.l1_input_data_format}})
+                .set_page_size(2, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l2_input1_cb_config);
+
+        tt_metal::CircularBufferConfig l1_output_cb_config =
+            tt_metal::CircularBufferConfig(byte_size, {{16, test_config.l1_output_data_format}})
+                .set_page_size(16, test_config.tile_byte_size);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_output_cb_config);
+    }
     vector<uint32_t> compute_kernel_args = {};
     std::map<std::string, std::string> defines = {
         {"ELTWISE_OP_TYPE", binary_op_name_to_op_type.at(test_config.binary_op)}};
@@ -184,29 +253,62 @@ bool single_core_binary(
             }
         }
     }
+    
+    KernelHandle reader_kernel, writer_kernel, binary_kernel;
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        reader_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+            test_config.core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = 1, .defines = defines});
 
-    auto reader_kernel = tt_metal::CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
-        test_config.core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt_metal::NOC::RISCV_1_default,
-            .defines = defines});
+        writer_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tt_metal/kernels/dataflow/writer_unary.cpp",
+            test_config.core,
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
 
-    auto writer_kernel = tt_metal::CreateKernel(
-        program_,
-        "tt_metal/kernels/dataflow/writer_unary.cpp",
-        test_config.core,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+        binary_kernel = tt_metal::experimental::quasar::CreateKernel(
+            program_,
+            "tt_metal/kernels/compute/eltwise_binary.cpp",
+            test_config.core,
+            tt_metal::experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .compile_args = compute_kernel_args, .defines = defines});
 
-    auto binary_kernel = tt_metal::CreateKernel(
-        program_,
-        "tt_metal/kernels/compute/eltwise_binary.cpp",
-        test_config.core,
-        tt_metal::ComputeConfig{
-            .math_fidelity = test_config.math_fidelity, .compile_args = compute_kernel_args, .defines = defines});
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, inp0_dfb, reader_kernel, binary_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, inp1_dfb, reader_kernel, binary_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, inp2_dfb, reader_kernel, binary_kernel);
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program_, out_dfb, binary_kernel, writer_kernel);
+
+    } else {
+        reader_kernel = tt_metal::CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+            test_config.core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_1_default,
+                .defines = defines});
+    
+        writer_kernel = tt_metal::CreateKernel(
+            program_,
+            "tt_metal/kernels/dataflow/writer_unary.cpp",
+            test_config.core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+        binary_kernel = tt_metal::CreateKernel(
+            program_,
+            "tt_metal/kernels/compute/eltwise_binary.cpp",
+            test_config.core,
+            tt_metal::ComputeConfig{
+                .math_fidelity = test_config.math_fidelity, .compile_args = compute_kernel_args, .defines = defines});
+    }
 
     SetRuntimeArgs(program_, binary_kernel, test_config.core, {uint32_t(test_config.num_tiles), 1});
 
@@ -342,6 +444,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
@@ -362,12 +465,13 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -382,6 +486,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
@@ -403,6 +508,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
@@ -424,12 +530,13 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -445,6 +552,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
@@ -525,6 +633,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
@@ -545,12 +654,13 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -565,11 +675,15 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+            return;
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKs for Quasar";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -592,6 +706,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKs for Quasar";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -614,6 +731,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKsfor Quasar";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -77,6 +77,7 @@ struct SingleCoreBinaryConfig {
     std::string binary_op;
     bool acc_to_dest = false;
     bool full_init = true;
+    bool is_quasar = false;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 
@@ -152,13 +153,11 @@ bool single_core_binary(
     uint32_t inp2_dfb = 0;
     uint32_t out_dfb = 0;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_dfb_config = {
+        tt_metal::experimental::dfb::DataflowBufferConfig l1_input0_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x1,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -169,10 +168,8 @@ bool single_core_binary(
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input1_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x1,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -180,13 +177,11 @@ bool single_core_binary(
             .tile = tt_metal::Tile({32, 32}),
         };
 
-        tt_metal::experimental::dfb::DataflowBufferConfig l2_input1_dfb_config = {
+        tt_metal::experimental::dfb::DataflowBufferConfig l1_input2_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x1,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -197,10 +192,8 @@ bool single_core_binary(
         tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
-            .producer_risc_mask = 0x100,
             .num_producers = 1,
             .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x2,
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
@@ -208,26 +201,26 @@ bool single_core_binary(
             .tile = tt_metal::Tile({32, 32}),
         };
 
-        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_dfb_config);
+        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input0_dfb_config);
         inp1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input1_dfb_config);
-        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l2_input1_dfb_config);
+        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input2_dfb_config);
         out_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
 
     } else {
-        tt_metal::CircularBufferConfig l1_cb_config =
+        tt_metal::CircularBufferConfig l1_input0_cb_config =
             tt_metal::CircularBufferConfig(byte_size, {{0, test_config.l1_input_data_format}})
                 .set_page_size(0, test_config.tile_byte_size);
-        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_cb_config);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input0_cb_config);
 
         tt_metal::CircularBufferConfig l1_input1_cb_config =
             tt_metal::CircularBufferConfig(byte_size, {{1, test_config.l1_input_data_format}})
                 .set_page_size(1, test_config.tile_byte_size);
         tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input1_cb_config);
 
-        tt_metal::CircularBufferConfig l2_input1_cb_config =
+        tt_metal::CircularBufferConfig l1_input2_cb_config =
             tt_metal::CircularBufferConfig(byte_size, {{2, test_config.l1_input_data_format}})
                 .set_page_size(2, test_config.tile_byte_size);
-        tt_metal::CreateCircularBuffer(program_, test_config.core, l2_input1_cb_config);
+        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input2_cb_config);
 
         tt_metal::CircularBufferConfig l1_output_cb_config =
             tt_metal::CircularBufferConfig(byte_size, {{16, test_config.l1_output_data_format}})
@@ -331,7 +324,13 @@ bool single_core_binary(
     std::vector<float> temp_golden(input0.size());
     uint16_t srca_fid_mask = 0xFFFF;
     uint16_t srcb_fid_mask = 0xFFFF;
-    set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
+
+    // Quasar has 8x8 mantissa multipliers so fidelity has no effect on bfloat16 multiplications.
+    // Only set FID masks for non-Quasar to ensure we are testing the effect of reduced math fidelity on the binary compute results.
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
+    }
+    
     std::transform(
         input0.begin(),
         input0.end(),
@@ -471,7 +470,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -536,7 +535,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -558,6 +557,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -578,6 +580,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -598,6 +603,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
+    if (this->arch_ == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "DestReuse test support will be added with DestReuse bring-up";
+    }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
@@ -660,7 +668,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::HiFi2); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -682,7 +690,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
     if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKs for Quasar";
+        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
     }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
@@ -707,7 +715,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
     if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKs for Quasar";
+        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
     }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
@@ -732,7 +740,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
     if (this->arch_ == tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DestAcc tests since DestAcc is handled by LLKsfor Quasar";
+        GTEST_SKIP() << "DestAcc test support will be added with DestReuse bring-up";
     }
     for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -77,7 +77,6 @@ struct SingleCoreBinaryConfig {
     std::string binary_op;
     bool acc_to_dest = false;
     bool full_init = true;
-    bool is_quasar = false;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -152,11 +152,6 @@ bool single_core_binary(
     uint32_t inp2_dfb = 0;
     uint32_t out_dfb = 0;
 
-    constexpr uint32_t inp0_dfb_id = 0;
-    constexpr uint32_t inp1_dfb_id = 1;
-    constexpr uint32_t inp2_dfb_id = 2;
-    constexpr uint32_t out_dfb_id = 3;
-
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input0_dfb_config = {
             .entry_size = test_config.tile_byte_size,
@@ -255,7 +250,7 @@ bool single_core_binary(
     KernelHandle reader_kernel, writer_kernel, binary_kernel;
     std::vector<uint32_t> reader_cta, writer_cta, compute_cta;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-        reader_cta = {inp0_dfb_id, inp1_dfb_id};
+        reader_cta = {inp0_dfb, inp1_dfb};
         reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
@@ -263,14 +258,14 @@ bool single_core_binary(
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
                 .num_threads_per_cluster = 1, .compile_args = reader_cta, .defines = defines});
 
-        writer_cta = {out_dfb_id};
+        writer_cta = {out_dfb};
         writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
 
-        compute_cta = {inp0_dfb_id, inp1_dfb_id, inp2_dfb_id, out_dfb_id};
+        compute_cta = {inp0_dfb, inp1_dfb, inp2_dfb, out_dfb};
         binary_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/compute/eltwise_binary.cpp",

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -78,6 +78,7 @@ struct SingleCoreBinaryConfig {
     bool acc_to_dest = false;
     bool full_init = true;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
+    tt::tt_metal::Tile tile = tt::tt_metal::Tile({32, 32});
 };
 
 void set_math_fid_masks(
@@ -162,7 +163,7 @@ bool single_core_binary(
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
             .data_format = tt::DataFormat::Float16_b,
-            .tile = tt_metal::Tile({32, 32}),
+            .tile = test_config.tile,
         };
 
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input1_dfb_config = {
@@ -174,7 +175,7 @@ bool single_core_binary(
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
             .data_format = tt::DataFormat::Float16_b,
-            .tile = tt_metal::Tile({32, 32}),
+            .tile = test_config.tile,
         };
 
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input2_dfb_config = {
@@ -186,7 +187,7 @@ bool single_core_binary(
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
             .data_format = tt::DataFormat::Float16_b,
-            .tile = tt_metal::Tile({32, 32}),
+            .tile = test_config.tile,
         };
 
         tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
@@ -198,7 +199,7 @@ bool single_core_binary(
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
             .data_format = tt::DataFormat::Float16_b,
-            .tile = tt_metal::Tile({32, 32}),
+            .tile = test_config.tile,
         };
 
         inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input0_dfb_config);
@@ -331,6 +332,7 @@ bool single_core_binary(
 
     // Quasar has 8x8 mantissa multipliers so fidelity has no effect on bfloat16 multiplications.
     // Only set FID masks for non-Quasar to ensure we are testing the effect of reduced math fidelity on the binary compute results.
+    // TODO: If the tests are extended to FP32, then the FID masks should also be applied for Quasar.
     if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
         set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
     }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -151,6 +151,12 @@ bool single_core_binary(
     uint32_t inp1_dfb = 0;
     uint32_t inp2_dfb = 0;
     uint32_t out_dfb = 0;
+    
+    constexpr uint32_t inp0_dfb_id = 0;
+    constexpr uint32_t inp1_dfb_id = 1;
+    constexpr uint32_t inp2_dfb_id = 2;
+    constexpr uint32_t out_dfb_id = 3;
+
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input0_dfb_config = {
             .entry_size = test_config.tile_byte_size,
@@ -226,7 +232,7 @@ bool single_core_binary(
                 .set_page_size(16, test_config.tile_byte_size);
         tt_metal::CreateCircularBuffer(program_, test_config.core, l1_output_cb_config);
     }
-    vector<uint32_t> compute_kernel_args = {};
+
     std::map<std::string, std::string> defines = {
         {"ELTWISE_OP_TYPE", binary_op_name_to_op_type.at(test_config.binary_op)}};
 
@@ -247,26 +253,30 @@ bool single_core_binary(
     }
     
     KernelHandle reader_kernel, writer_kernel, binary_kernel;
+    std::vector<uint32_t> reader_cta, writer_cta, compute_cta;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        reader_cta = {inp0_dfb_id, inp1_dfb_id};
         reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1, .defines = defines});
+                .num_threads_per_cluster = 1, .compile_args = reader_cta, .defines = defines});
 
+        writer_cta = {out_dfb_id};
         writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
             test_config.core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
 
+        compute_cta = {inp0_dfb_id, inp1_dfb_id, inp2_dfb_id, out_dfb_id};
         binary_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/compute/eltwise_binary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .compile_args = compute_kernel_args, .defines = defines});
+                .num_threads_per_cluster = 1, .math_fidelity = test_config.math_fidelity, .compile_args = compute_cta, .defines = defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
             program_, inp0_dfb, reader_kernel, binary_kernel);
@@ -299,7 +309,7 @@ bool single_core_binary(
             "tt_metal/kernels/compute/eltwise_binary.cpp",
             test_config.core,
             tt_metal::ComputeConfig{
-                .math_fidelity = test_config.math_fidelity, .compile_args = compute_kernel_args, .defines = defines});
+                .math_fidelity = test_config.math_fidelity, .compile_args = compute_cta, .defines = defines});
     }
 
     SetRuntimeArgs(program_, binary_kernel, test_config.core, {uint32_t(test_config.num_tiles), 1});

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -151,7 +151,7 @@ bool single_core_binary(
     uint32_t inp1_dfb = 0;
     uint32_t inp2_dfb = 0;
     uint32_t out_dfb = 0;
-    
+
     constexpr uint32_t inp0_dfb_id = 0;
     constexpr uint32_t inp1_dfb_id = 1;
     constexpr uint32_t inp2_dfb_id = 2;
@@ -169,7 +169,7 @@ bool single_core_binary(
             .data_format = tt::DataFormat::Float16_b,
             .tile = tt_metal::Tile({32, 32}),
         };
-        
+
         tt_metal::experimental::dfb::DataflowBufferConfig l1_input1_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
@@ -251,7 +251,7 @@ bool single_core_binary(
             }
         }
     }
-    
+
     KernelHandle reader_kernel, writer_kernel, binary_kernel;
     std::vector<uint32_t> reader_cta, writer_cta, compute_cta;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
@@ -296,7 +296,7 @@ bool single_core_binary(
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_1_default,
                 .defines = defines});
-    
+
         writer_kernel = tt_metal::CreateKernel(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
@@ -339,7 +339,7 @@ bool single_core_binary(
     if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
         set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
     }
-    
+
     std::transform(
         input0.begin(),
         input0.end(),

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -250,7 +250,7 @@ bool single_core_binary(
     KernelHandle reader_kernel, writer_kernel, binary_kernel;
     std::vector<uint32_t> reader_cta, writer_cta, compute_cta;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-        reader_cta = {inp0_dfb, inp1_dfb};
+        reader_cta = {inp0_dfb, inp1_dfb, inp2_dfb};
         reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -154,7 +154,7 @@ bool single_core_binary(
     uint32_t out_dfb = 0;
 
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_input0_dfb_config = {
+        tt_metal::experimental::dfb::DataflowBufferConfig common_input_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
             .num_producers = 1,
@@ -162,11 +162,11 @@ bool single_core_binary(
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b,
+            .data_format = test_config.l1_input_data_format,
             .tile = test_config.tile,
         };
 
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_input1_dfb_config = {
+        tt_metal::experimental::dfb::DataflowBufferConfig common_output_dfb_config = {
             .entry_size = test_config.tile_byte_size,
             .num_entries = test_config.num_tiles,
             .num_producers = 1,
@@ -174,38 +174,14 @@ bool single_core_binary(
             .num_consumers = 1,
             .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
             .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b,
+            .data_format = test_config.l1_output_data_format,
             .tile = test_config.tile,
         };
 
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_input2_dfb_config = {
-            .entry_size = test_config.tile_byte_size,
-            .num_entries = test_config.num_tiles,
-            .num_producers = 1,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .num_consumers = 1,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b,
-            .tile = test_config.tile,
-        };
-
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
-            .entry_size = test_config.tile_byte_size,
-            .num_entries = test_config.num_tiles,
-            .num_producers = 1,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .num_consumers = 1,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b,
-            .tile = test_config.tile,
-        };
-
-        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input0_dfb_config);
-        inp1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input1_dfb_config);
-        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input2_dfb_config);
-        out_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
+        inp0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        inp1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        inp2_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_input_dfb_config);
+        out_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, common_output_dfb_config);
 
     } else {
         tt_metal::CircularBufferConfig l1_input0_cb_config =
@@ -449,7 +425,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -470,7 +448,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -491,7 +471,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -513,7 +495,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -535,7 +519,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -557,7 +543,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -647,7 +635,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -668,7 +658,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }
@@ -689,7 +681,9 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            return;
+            if (this->arch_ == ARCH::QUASAR) {
+                return;
+            }
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
@@ -75,7 +75,8 @@ void kernel_main() {
     uint32_t src2_bank_id = get_arg_val<uint32_t>(6);
 
     #ifdef ARCH_QUASAR
-        experimental::DataflowBuffer dfb2(2);
+        constexpr uint32_t dfb_in2_id = get_compile_time_arg_val(2);
+        experimental::DataflowBuffer dfb2(dfb_in2_id);
         uint32_t ublock_size_bytes_2 = dfb2.get_entry_size() * ublock_size_tiles;
     #else
         constexpr uint32_t cb_id_in2 = 2;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
@@ -4,8 +4,13 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
 #include "experimental/endpoints.h"
+
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
+#include "experimental/circular_buffer.h"
+#endif
 
 void kernel_main() {
     uint32_t src0_addr = get_arg_val<uint32_t>(0);
@@ -14,32 +19,47 @@ void kernel_main() {
     uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
     uint32_t num_tiles = get_arg_val<uint32_t>(4);
 
-    constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t cb_id_in1 = 1;
-
-    // single-tile ublocks
-
-    experimental::CircularBuffer cb0(cb_id_in0);
-    experimental::CircularBuffer cb1(cb_id_in1);
     experimental::Noc noc;
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_src;
-
     uint32_t ublock_size_tiles = 1;
-    uint32_t ublock_size_bytes_0 = cb0.get_tile_size() * ublock_size_tiles;
-    uint32_t ublock_size_bytes_1 = cb1.get_tile_size() * ublock_size_tiles;
+
+    // single-tile ublocks
+    #ifdef ARCH_QUASAR
+        experimental::DataflowBuffer dfb0(0);
+        experimental::DataflowBuffer dfb1(1);
+        uint32_t ublock_size_bytes_0 = dfb0.get_entry_size() * ublock_size_tiles;
+        uint32_t ublock_size_bytes_1 = dfb1.get_entry_size() * ublock_size_tiles;
+    #else
+        constexpr uint32_t cb_id_in0 = 0;
+        constexpr uint32_t cb_id_in1 = 1;
+        experimental::CircularBuffer cb0(cb_id_in0);
+        experimental::CircularBuffer cb1(cb_id_in1);
+        uint32_t ublock_size_bytes_0 = cb0.get_tile_size() * ublock_size_tiles;
+        uint32_t ublock_size_bytes_1 = cb1.get_tile_size() * ublock_size_tiles;
+    #endif
 
     // read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
     for (uint32_t i=0; i<num_tiles; i += ublock_size_tiles) {
         uint64_t src0_noc_addr = get_noc_addr_from_bank_id<true>(src0_bank_id, src0_addr);
         uint64_t src1_noc_addr = get_noc_addr_from_bank_id<true>(src1_bank_id, src1_addr);
 
-        cb0.reserve_back(ublock_size_tiles);
-        cb1.reserve_back(ublock_size_tiles);
-        noc.async_read(dram_src, cb0, ublock_size_bytes_0, {.bank_id = src0_bank_id, .addr = src0_addr}, {});
-        noc.async_read(dram_src, cb1, ublock_size_bytes_1, {.bank_id = src1_bank_id, .addr = src1_addr}, {});
-        noc.async_read_barrier();
-        cb0.push_back(ublock_size_tiles);
-        cb1.push_back(ublock_size_tiles);
+        #ifdef ARCH_QUASAR
+            dfb0.reserve_back(ublock_size_tiles);
+            dfb1.reserve_back(ublock_size_tiles);
+            noc.async_read(dram_src, dfb0, ublock_size_bytes_0, {.bank_id = src0_bank_id, .addr = src0_addr}, {});
+            noc.async_read(dram_src, dfb1, ublock_size_bytes_1, {.bank_id = src1_bank_id, .addr = src1_addr}, {});
+            noc.async_read_barrier();
+            dfb0.push_back(ublock_size_tiles);
+            dfb1.push_back(ublock_size_tiles);
+        #else
+            cb0.reserve_back(ublock_size_tiles);
+            cb1.reserve_back(ublock_size_tiles);
+            noc.async_read(dram_src, cb0, ublock_size_bytes_0, {.bank_id = src0_bank_id, .addr = src0_addr}, {});
+            noc.async_read(dram_src, cb1, ublock_size_bytes_1, {.bank_id = src1_bank_id, .addr = src1_addr}, {});
+            noc.async_read_barrier();
+            cb0.push_back(ublock_size_tiles);
+            cb1.push_back(ublock_size_tiles);
+        #endif
         src0_addr += ublock_size_bytes_0;
         src1_addr += ublock_size_bytes_1;
     }
@@ -52,17 +72,28 @@ void kernel_main() {
     uint32_t src2_addr = get_arg_val<uint32_t>(5);
     uint32_t src2_bank_id = get_arg_val<uint32_t>(6);
 
-    constexpr uint32_t cb_id_in2 = 2;
-    experimental::CircularBuffer cb2(cb_id_in2);
-    uint32_t ublock_size_bytes_2 = cb2.get_tile_size() * ublock_size_tiles;
+    #ifdef ARCH_QUASAR
+        experimental::DataflowBuffer dfb2(2);
+        uint32_t ublock_size_bytes_2 = dfb2.get_entry_size() * ublock_size_tiles;
+    #else
+        constexpr uint32_t cb_id_in2 = 2;
+        experimental::CircularBuffer cb2(cb_id_in2);
+        uint32_t ublock_size_bytes_2 = cb2.get_tile_size() * ublock_size_tiles;
+    #endif
 
     for (uint32_t i=0; i<num_tiles; i += ublock_size_tiles) {
         uint64_t src2_noc_addr = get_noc_addr_from_bank_id<true>(src2_bank_id, src2_addr);
-
-        cb2.reserve_back(ublock_size_tiles);
-        noc.async_read(dram_src, cb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
-        noc.async_read_barrier();
-        cb2.push_back(ublock_size_tiles);
+        #ifdef ARCH_QUASAR
+            dfb2.reserve_back(ublock_size_tiles);
+            noc.async_read(dram_src, dfb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
+            noc.async_read_barrier();
+            dfb2.push_back(ublock_size_tiles);
+        #else
+            cb2.reserve_back(ublock_size_tiles);
+            noc.async_read(dram_src, cb2, ublock_size_bytes_2, {.bank_id = src2_bank_id, .addr = src2_addr}, {});
+            noc.async_read_barrier();
+            cb2.push_back(ublock_size_tiles);
+        #endif
         src2_addr += ublock_size_bytes_2;
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp
@@ -25,8 +25,10 @@ void kernel_main() {
 
     // single-tile ublocks
     #ifdef ARCH_QUASAR
-        experimental::DataflowBuffer dfb0(0);
-        experimental::DataflowBuffer dfb1(1);
+        constexpr uint32_t dfb_in0_id = get_compile_time_arg_val(0);
+        constexpr uint32_t dfb_in1_id = get_compile_time_arg_val(1);
+        experimental::DataflowBuffer dfb0(dfb_in0_id);
+        experimental::DataflowBuffer dfb1(dfb_in1_id);
         uint32_t ublock_size_bytes_0 = dfb0.get_entry_size() * ublock_size_tiles;
         uint32_t ublock_size_bytes_1 = dfb1.get_entry_size() * ublock_size_tiles;
     #else

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -20,20 +20,18 @@
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
  *     when input is Tf32 format. Only applicable to ELWMUL.
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
- * @tparam enable_direct_indexing: When true, uses direct indexing eltwise instructions
  * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool enable_direct_indexing = false>
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
 
     // TODO: Once runtime asserts are added for Quasar, assert that acc_to_dest is unused
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE);
 }
 
 /**
@@ -45,7 +43,6 @@ inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t ac
  * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
  *     when input is Tf32 format. Only applicable to ELWMUL.
  * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
- * @tparam enable_direct_indexing: When true, uses direct indexing eltwise instructions
  * @param operand_A: Logical dataflow buffer id for input A, used to derive the tensor shape
  * @param operand_B: Unused on Quasar. Present for API compatibility.
  * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
@@ -54,8 +51,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     MathFidelity math_fidelity,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
-    bool enable_direct_indexing = false>
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init_with_operands(
     const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, [[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
     static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
@@ -64,7 +60,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(tensor_shape_A);
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, false /* enable_direct_indexing */, binary_reuse_dest>(tensor_shape_A);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -11,7 +11,18 @@
  * LLK ELTWISE BINARY
  *************************************************************************/
 
-// Version with no operand (assumes default 32x32 tile)
+/**
+ * @brief Initialize FPU to perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ * Assumes default 32x32 tile shape.
+ * SrcA/SrcB contain 1 tile each, and output is 1 tile in destination register
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>
+ * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ *     when input is Tf32 format. Only applicable to ELWMUL.
+ * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
+ * @tparam enable_direct_indexing: When true, uses direct indexing eltwise instructions
+ * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
@@ -25,7 +36,20 @@ inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t ac
     _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE);
 }
 
-// Version with operands
+/**
+ * @brief Initialize FPU to perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ * Derives the tensor shape from operand_A to support non-default tile dimensions.
+ * SrcA/SrcB contain 1 tile each, and output is 1 tile in destination register
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>
+ * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ *     when input is Tf32 format. Only applicable to ELWMUL.
+ * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB
+ * @tparam enable_direct_indexing: When true, uses direct indexing eltwise instructions
+ * @param operand_A: Logical dataflow buffer id for input A, used to derive the tensor shape
+ * @param operand_B: Unused on Quasar. Present for API compatibility.
+ * @param acc_to_dest: Currently unused on Quasar. Will be adding support for accumulation to dest.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
@@ -43,6 +67,22 @@ inline void llk_math_eltwise_binary_init_with_operands(
     _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(tensor_shape_A);
 }
 
+/**
+ * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ * SrcA/SrcB contain 1 tile each, and output is 1 tile in the destination register.
+ * Assumes default tile shape (32x32) or 4 faces.
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API compatibiliy.
+ * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @tparam is_fp32_dest_acc_en: Unused tparam; only for API compatibiliy.
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ *     when input is Tf32 format. Unused tparam; only for API compatibiliy.
+ * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB.
+ *     The MOVD2A/B instruction copies a face from dest to the source register before each MOP run.
+ * @param dst_index: Tile index into the destination register
+ * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
+ * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
+ * @param clear_fp32_dst_acc: Unused param; only for API compatibiliy.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
@@ -58,6 +98,24 @@ inline void llk_math_eltwise_binary(uint dst_index, [[maybe_unused]] const bool 
     WAYPOINT("MBID");
 }
 
+/**
+ * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ * SrcA/SrcB contain 1 tile each, and output is 1 tile in the destination register.
+ * Derives num_faces from operand_A to support non-default tile dimensions.
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>. Unused tparam; only for API compatibiliy.
+ * @tparam src_b_bcast_type: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @tparam is_fp32_dest_acc_en: Unused tparam; only for API compatibiliy.
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ *     when input is Tf32 format. Unused tparam; only for API compatibiliy.
+ * @tparam binary_reuse_dest: When not NONE, reuses the destination register as SrcA or SrcB.
+ *     The MOVD2A/B instruction copies a face from dest to the source register before each MOP run.
+ * @param operand_A: Logical dataflow buffer id for input A, used to derive the number of faces
+ * @param operand_B: Unused param; only for API compatibiliy.
+ * @param dst_index: Tile index into the destination register
+ * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
+ * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
+ * @param clear_fp32_dst_acc: Unused param; only for API compatibiliy.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "llk_math_eltwise_binary.h"
+#include "tensor_shape.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY
+ *************************************************************************/
+
+// Version with no operand (assumes default 32x32 tile)
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool enable_direct_indexing = false>
+inline void llk_math_eltwise_binary_init([[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
+    static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
+
+    // TODO: Once runtime asserts are added for Quasar, assert that acc_to_dest is unused
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE);
+}
+
+// Version with operands
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool enable_direct_indexing = false>
+inline void llk_math_eltwise_binary_init_with_operands(
+    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, [[maybe_unused]] const std::uint32_t acc_to_dest = 0) {
+    static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
+
+    // TODO: Once runtime asserts are added for Quasar, assert that acc_to_dest is unused
+    const std::uint32_t operand_id = get_operand_id(operand_A);
+    const ckernel::TensorShape tensor_shape_A = get_operand_tensor_shape(operand_id);
+
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, math_fidelity, enable_direct_indexing, binary_reuse_dest>(tensor_shape_A);
+}
+
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary(uint dst_index, [[maybe_unused]] const bool clear_fp32_dst_acc = true) {
+    static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
+
+    // TODO: Once runtime asserts are added for Quasar, assert that clear_fp32_dst_acc is unused
+    WAYPOINT("MBIW");
+    _llk_math_eltwise_binary_<binary_reuse_dest>(dst_index);
+    WAYPOINT("MBID");
+}
+
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary(
+    const std::uint32_t operand_A, [[maybe_unused]] const std::uint32_t operand_B, uint dst_index, [[maybe_unused]] const bool clear_fp32_dst_acc) {
+    static_assert(src_b_bcast_type == BroadcastType::NONE, "Broadcast types will be added in a future update");
+
+    // TODO: Once runtime asserts are added for Quasar, assert that clear_fp32_dst_acc is unused
+    const std::uint32_t operand_id = get_operand_id(operand_A);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    WAYPOINT("MBIW");
+    _llk_math_eltwise_binary_<binary_reuse_dest>(dst_index, num_faces);
+    WAYPOINT("MBID");
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -11,6 +11,16 @@
  * LLK UNPACK AB
  *************************************************************************/
 
+/**
+ * @brief Initialization for unpack of binary operations, uses SrcA & SrcB
+ * @details Sets up MOP for unpacking binary operands
+ * operandA will be used for UNPACKER0 -> SRCA
+ * operandB will be used for UNPACKER1 -> SRCB
+ * @tparam BType: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @param operandA: The input operand dataflow buffer for source A
+ * @param operandB: The input operand dataflow buffer for source B
+ * @param transpose: Unused param; only for API compatibiliy.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, [[maybe_unused]] const std::uint32_t transpose = 0) {
@@ -24,6 +34,15 @@ inline void llk_unpack_AB_init(
     _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1);
 }
 
+/**
+ * @brief Unpacks binary operands for SrcA & SrcB
+ * @tparam BType: Broadcast type for SrcB. Currently only BroadcastType::NONE is supported on Quasar.
+ * @param operandA: The logical dataflow buffer id for source A. Used to derive L1 addresses for SrcA unpacking.
+ * @param operandB: The logical dataflow buffer id for source B. Used to derive L1 addresses for SrcB unpacking.
+ * @param tile_index_a: Tile index within the operandA dataflow buffer to read from
+ * @param tile_index_b: Tile index within the operandB dataflow buffer to read from
+ * @param bcast_row_idx: Unused param; only for API compatibiliy.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB(
     const std::uint32_t operandA,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_unpack_binary_operands.h"
+#include "llk_unpack_common_api.h"
+#include "experimental/dataflow_buffer.h"
+
+/*************************************************************************
+ * LLK UNPACK AB
+ *************************************************************************/
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(
+    const std::uint32_t operandA, const std::uint32_t operandB, [[maybe_unused]] const std::uint32_t transpose = 0) {
+    static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
+
+    // TODO: Once runtime asserts are added for Quasar, assert that transpose is unused
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+
+    // num_tiles set to 1 for back-compatibility with existing APIs, can be increased in the future for better performance.
+    _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1); 
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
+
+    static_assert(BType == BroadcastType::NONE, "Broadcast types will be added in a future update");
+    // TODO: Once runtime asserts are added for Quasar, assert that bcast_row_idx is unused
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+
+    const std::uint32_t l1_tile_idx_a = g_dfb_interface[operandA_id].rd_entry_idx + tile_index_a;
+    const std::uint32_t l1_tile_idx_b = g_dfb_interface[operandB_id].rd_entry_idx + tile_index_b;
+
+    WAYPOINT("UABW");
+    _llk_unpack_binary_operands_(l1_tile_idx_a, l1_tile_idx_b);
+    WAYPOINT("UABD");
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -21,7 +21,7 @@ inline void llk_unpack_AB_init(
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
     // num_tiles set to 1 for back-compatibility with existing APIs, can be increased in the future for better performance.
-    _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1); 
+    _llk_unpack_binary_operands_init_(operandA_id, operandB_id, 1);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -29,6 +29,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+#ifndef ARCH_QUASAR
     state_configure(icb0, icb1, ocb, call_line);
 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
@@ -40,6 +41,16 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
+#else
+    UNPACK((llk_unpack_hw_configure(icb0, icb1)));
+    UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
+
+    MATH((llk_math_pack_sync_init()));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
+
+    PACK((llk_pack_hw_configure(ocb)));
+    PACK((llk_pack_init(ocb)));
+#endif
 }
 
 // clang-format off
@@ -62,11 +73,11 @@ ALWI void binary_tiles_init(
     uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1, call_line);
 
-    if constexpr (eltwise_binary_type == ELWMUL) {
-        MATH((llk_math_eltwise_binary_init_with_operands<eltwise_binary_type, NONE, MATH_FIDELITY>(
+    if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL) {
+        MATH((llk_math_eltwise_binary_init_with_operands<eltwise_binary_type, BroadcastType::NONE, MATH_FIDELITY>(
             icb0, icb1, acc_to_dest)));
     } else {
-        MATH((llk_math_eltwise_binary_init_with_operands<eltwise_binary_type, NONE, MathFidelity::LoFi>(
+        MATH((llk_math_eltwise_binary_init_with_operands<eltwise_binary_type, BroadcastType::NONE, MathFidelity::LoFi>(
             icb0, icb1, acc_to_dest)));
     }
 
@@ -86,7 +97,7 @@ ALWI void binary_tiles_init(
  */
 // clang-format on
 ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, ELWMUL>(icb0, icb1, false, call_line);
+    binary_tiles_init<true, EltwiseBinaryType::ELWMUL>(icb0, icb1, false, call_line);
 }
 
 // clang-format off
@@ -102,7 +113,7 @@ ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1, uint32_t call_line = __bu
 // clang-format on
 ALWI void add_tiles_init(
     uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, ELWADD>(icb0, icb1, acc_to_dest, call_line);
+    binary_tiles_init<true, EltwiseBinaryType::ELWADD>(icb0, icb1, acc_to_dest, call_line);
 }
 
 // clang-format off
@@ -118,7 +129,7 @@ ALWI void add_tiles_init(
 // clang-format on
 ALWI void sub_tiles_init(
     uint32_t icb0, uint32_t icb1, bool acc_to_dest = false, uint32_t call_line = __builtin_LINE()) {
-    binary_tiles_init<true, ELWSUB>(icb0, icb1, acc_to_dest, call_line);
+    binary_tiles_init<true, EltwiseBinaryType::ELWSUB>(icb0, icb1, acc_to_dest, call_line);
 }
 
 // clang-format off
@@ -150,7 +161,7 @@ ALWI void mul_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
     // first = false;
 
     UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
-    MATH((llk_math_eltwise_binary<ELWMUL, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
+    MATH((llk_math_eltwise_binary<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
         icb0, icb1, idst, true)));
 }
 
@@ -174,7 +185,7 @@ ALWI void mul_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
 // clang-format on
 ALWI void add_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
     UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
-    MATH((llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
+    MATH((llk_math_eltwise_binary<EltwiseBinaryType::ELWADD, BroadcastType::NONE, DST_ACCUM_MODE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
         icb0, icb1, idst, true)));
 }
 
@@ -198,7 +209,7 @@ ALWI void add_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
 // clang-format on
 ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
     UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
-    MATH((llk_math_eltwise_binary<ELWSUB, NONE, DST_ACCUM_MODE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
+    MATH((llk_math_eltwise_binary<EltwiseBinaryType::ELWSUB, BroadcastType::NONE, DST_ACCUM_MODE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
         icb0, icb1, idst, true)));
 }
 
@@ -206,15 +217,15 @@ ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
  * Please refer to documentation for any_init.
  */
 template <
-    EltwiseBinaryType eltwise_binary_type = ELWADD,
+    EltwiseBinaryType eltwise_binary_type = EltwiseBinaryType::ELWADD,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 ALWI void binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, binary_reuse_dest>(false, false, icb0)));
-    if constexpr (eltwise_binary_type == ELWMUL) {
-        MATH((llk_math_eltwise_binary_init<eltwise_binary_type, NONE, MATH_FIDELITY, binary_reuse_dest>(false)));
+    if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL) {
+        MATH((llk_math_eltwise_binary_init<eltwise_binary_type, BroadcastType::NONE, MATH_FIDELITY, binary_reuse_dest>(false)));
     } else {
-        MATH((llk_math_eltwise_binary_init<eltwise_binary_type, NONE, MathFidelity::LoFi, binary_reuse_dest>(false)));
+        MATH((llk_math_eltwise_binary_init<eltwise_binary_type, BroadcastType::NONE, MathFidelity::LoFi, binary_reuse_dest>(false)));
     }
 }
 
@@ -243,17 +254,19 @@ ALWI void binary_dest_reuse_tiles_init(uint32_t icb0, uint32_t call_line = __bui
  */
 // clang-format on
 template <
-    EltwiseBinaryType eltwise_binary_type = ELWADD,
+    EltwiseBinaryType eltwise_binary_type = EltwiseBinaryType::ELWADD,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 ALWI void binary_dest_reuse_tiles(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile_index) {
+#ifndef ARCH_QUASAR
     UNPACK((llk_unpack_A<BroadcastType::NONE, true, binary_reuse_dest>(in_cb_id, in_tile_index)));
-    if constexpr (eltwise_binary_type == ELWMUL) {
-        MATH((llk_math_eltwise_binary<eltwise_binary_type, NONE, DST_ACCUM_MODE, MATH_FIDELITY, binary_reuse_dest>(
+    if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL) {
+        MATH((llk_math_eltwise_binary<eltwise_binary_type, BroadcastType::NONE, DST_ACCUM_MODE, MATH_FIDELITY, binary_reuse_dest>(
             in_cb_id, in_cb_id, dst_tile_index, true)));
     } else {
-        MATH((llk_math_eltwise_binary<eltwise_binary_type, NONE, DST_ACCUM_MODE, MathFidelity::LoFi, binary_reuse_dest>(
+        MATH((llk_math_eltwise_binary<eltwise_binary_type, BroadcastType::NONE, DST_ACCUM_MODE, MathFidelity::LoFi, binary_reuse_dest>(
             in_cb_id, in_cb_id, dst_tile_index, true)));
     }
+#endif  // TODO (GS): Add Quasar dest reuse implementation
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -38,16 +38,18 @@ ALWI void copy_tile_to_dst_init_short(
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, transpose_within_16x16_face, cbid)));
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(cbid)));
-#endif  // TODO: AM; add Quasar implementation
+#else
+    // TODO: Once runtime asserts are added for Quasar, assert that transpose and transpose_within_16x16_face are unused
+    UNPACK((llk_unpack_A_init<false, DST_ACCUM_MODE>(cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE>(cbid)));
+#endif
 }
 /**
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset
  * registers.
  */
 ALWI void copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
-#ifndef ARCH_QUASAR
     copy_tile_to_dst_init_short(cbid, 0, false, call_line);
-#endif  // TODO: AM; add Quasar implementation
 }
 
 // clang-format off

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -9,67 +9,120 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/tile_move_copy.h"
 
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
+#include "experimental/circular_buffer.h"
+#endif
+
 void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
     uint32_t acc_to_dst = get_arg_val<uint32_t>(2);
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in1 = tt::CBIndex::c_1;
-    constexpr auto cb_inp0 = cb_in0;
-    constexpr auto cb_inp1 = cb_in1;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
 
-    constexpr auto cb_in2 = tt::CBIndex::c_2;
-
-    binary_op_init_common(cb_inp0, cb_inp1, cb_out0);
-
-#if not defined ELTWISE_DEST_REUSE_TYPE
-#ifdef FULL_INIT
-    binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
-#else
-    binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
-#endif
-#endif
+    #ifdef ARCH_QUASAR
+        experimental::DataflowBuffer dfb_in0(0);
+        experimental::DataflowBuffer dfb_in1(1);
+        experimental::DataflowBuffer dfb_in2(2);
+        experimental::DataflowBuffer dfb_out(3);
+        binary_op_init_common(dfb_in0.get_id(), dfb_in1.get_id(), dfb_out.get_id());
+        #if not defined ELTWISE_DEST_REUSE_TYPE
+            #ifdef FULL_INIT
+                binary_tiles_init<true, ELTWISE_OP_TYPE>(dfb_in0.get_id(), dfb_in1.get_id());
+            #else
+                binary_tiles_init<false, ELTWISE_OP_TYPE>(dfb_in0.get_id(), dfb_in1.get_id());
+            #endif
+        #endif
+    #else
+        constexpr auto cb_in0 = tt::CBIndex::c_0;   
+        constexpr auto cb_in1 = tt::CBIndex::c_1;
+        constexpr auto cb_inp0 = cb_in0;
+        constexpr auto cb_inp1 = cb_in1;
+        constexpr auto cb_out0 = tt::CBIndex::c_16;
+        constexpr auto cb_in2 = tt::CBIndex::c_2;
+        binary_op_init_common(cb_inp0, cb_inp1, cb_out0);
+        #if not defined ELTWISE_DEST_REUSE_TYPE
+            #ifdef FULL_INIT
+                binary_tiles_init<true, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
+            #else
+                binary_tiles_init<false, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
+            #endif
+        #endif
+    #endif
 
 #ifdef PACK_RELU
     PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
 #endif
 
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
-        cb_wait_front(cb_inp0, per_core_block_size);
-        cb_wait_front(cb_inp1, per_core_block_size);
-        cb_reserve_back(cb_out0, per_core_block_size);
-
+        #ifdef ARCH_QUASAR
+            dfb_in0.wait_front(per_core_block_size);
+            dfb_in1.wait_front(per_core_block_size);
+            dfb_out.reserve_back(per_core_block_size);
+        #else
+            cb_wait_front(cb_inp0, per_core_block_size);
+            cb_wait_front(cb_inp1, per_core_block_size);
+            cb_reserve_back(cb_out0, per_core_block_size);
+        #endif
         tile_regs_acquire();
 
 #if defined(DST_ACCUM_MODE) || defined(ELTWISE_DEST_REUSE_TYPE)
-        cb_wait_front(cb_in2, per_core_block_size);
-        copy_tile_to_dst_init_short(cb_in2);
-        for (uint32_t i = 0; i < per_core_block_size; ++i) {
-            copy_tile(cb_in2, i, i);  // copy from c_in[0] to DST[0]
-        }
-        cb_pop_front(cb_in2, per_core_block_size);
+    #ifdef ARCH_QUASAR
+            dfb_in2.wait_front(per_core_block_size);
+            copy_tile_to_dst_init_short(dfb_in2.get_id());
+            for (uint32_t i = 0; i < per_core_block_size; ++i) {
+                copy_tile(dfb_in2.get_id(), i, i);  // copy from c_in[0] to DST[0]
+            }
+            dfb_in2.pop_front(per_core_block_size);
+    #else
+            cb_wait_front(cb_in2, per_core_block_size);
+            copy_tile_to_dst_init_short(cb_in2);
+            for (uint32_t i = 0; i < per_core_block_size; ++i) {
+                copy_tile(cb_in2, i, i);  // copy from c_in[0] to DST[0]
+            }
+            cb_pop_front(cb_in2, per_core_block_size);
+    #endif
 #endif
 
 #ifdef DST_ACCUM_MODE
 // The following define is needed if mul_tiles/_init is used
 #ifdef MUL_TILES_WITH_DST_ACCUM
+    #ifdef ARCH_QUASAR
+        ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id());
+    #else
         ELTWISE_OP_INIT(cb_inp0, cb_inp1);
+    #endif
 #else
+    #ifdef ARCH_QUASAR
+        ELTWISE_OP_INIT(dfb_in0.get_id(), dfb_in1.get_id(), true);
+    #else
         ELTWISE_OP_INIT(cb_inp0, cb_inp1, true);
+    #endif
 #endif
 #endif
 
 #ifdef ELTWISE_DEST_REUSE_TYPE
+    #ifdef ARCH_QUASAR
+        binary_dest_reuse_tiles_init<ELTWISE_OP_TYPE, ELTWISE_DEST_REUSE_TYPE>(dfb_in0.get_id());
+    #else
         binary_dest_reuse_tiles_init<ELTWISE_OP_TYPE, ELTWISE_DEST_REUSE_TYPE>(cb_inp0);
+    #endif
 #endif
 
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
 #ifdef ELTWISE_DEST_REUSE_TYPE
+    #ifdef ARCH_QUASAR
+            binary_dest_reuse_tiles<ELTWISE_OP_TYPE, ELTWISE_DEST_REUSE_TYPE>(dfb_in0.get_id(), i, i);
+    #else
             binary_dest_reuse_tiles<ELTWISE_OP_TYPE, ELTWISE_DEST_REUSE_TYPE>(cb_inp0, i, i);
+    #endif
 #else
+    #ifdef ARCH_QUASAR
+            ELTWISE_OP(dfb_in0.get_id(), dfb_in1.get_id(), i, i, i);
+    #else
             ELTWISE_OP(cb_inp0, cb_inp1, i, i, i);
+    #endif
 #endif
 
 #ifdef SFPU_OP_CHAIN_0
@@ -80,12 +133,22 @@ void kernel_main() {
 
         tile_regs_wait();
         for (uint32_t i = 0; i < per_core_block_size; ++i) {
+        #ifdef ARCH_QUASAR
+            pack_tile(i, dfb_out.get_id());
+        #else
             pack_tile(i, cb_out0);
+        #endif
         }
         tile_regs_release();
 
-        cb_pop_front(cb_inp0, per_core_block_size);
-        cb_pop_front(cb_inp1, per_core_block_size);
-        cb_push_back(cb_out0, per_core_block_size);
+        #ifdef ARCH_QUASAR
+            dfb_in0.pop_front(per_core_block_size);
+            dfb_in1.pop_front(per_core_block_size);
+            dfb_out.push_back(per_core_block_size);
+        #else
+            cb_pop_front(cb_inp0, per_core_block_size);
+            cb_pop_front(cb_inp1, per_core_block_size);
+            cb_push_back(cb_out0, per_core_block_size);
+        #endif
     }
 }

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
             #endif
         #endif
     #else
-        constexpr auto cb_in0 = tt::CBIndex::c_0;   
+        constexpr auto cb_in0 = tt::CBIndex::c_0;
         constexpr auto cb_in1 = tt::CBIndex::c_1;
         constexpr auto cb_inp0 = cb_in0;
         constexpr auto cb_inp1 = cb_in1;

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -22,10 +22,14 @@ void kernel_main() {
 
 
     #ifdef ARCH_QUASAR
-        experimental::DataflowBuffer dfb_in0(0);
-        experimental::DataflowBuffer dfb_in1(1);
-        experimental::DataflowBuffer dfb_in2(2);
-        experimental::DataflowBuffer dfb_out(3);
+        constexpr uint32_t dfb_in0_id = get_compile_time_arg_val(0);
+        constexpr uint32_t dfb_in1_id = get_compile_time_arg_val(1);
+        constexpr uint32_t dfb_in2_id = get_compile_time_arg_val(2);
+        constexpr uint32_t dfb_out_id = get_compile_time_arg_val(3);
+        experimental::DataflowBuffer dfb_in0(dfb_in0_id);
+        experimental::DataflowBuffer dfb_in1(dfb_in1_id);
+        experimental::DataflowBuffer dfb_in2(dfb_in2_id);
+        experimental::DataflowBuffer dfb_out(dfb_out_id);
         binary_op_init_common(dfb_in0.get_id(), dfb_in1.get_id(), dfb_out.get_id());
         #if not defined ELTWISE_DEST_REUSE_TYPE
             #ifdef FULL_INIT


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/39753

### Problem description
Provide context for the problem.
Need to propagate LLK implementations for Eltwise Binary for Quasar to metal.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.
Propagated LLK implementations for Eltwise Binary for Quasar to metal

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/qsr-eltwise-binary-bringup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/qsr-eltwise-binary-bringup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/qsr-eltwise-binary-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/qsr-eltwise-binary-bringup)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
