### PR TITLE
ttsim BH skip list: remove typecast and bfloat8_b tests

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -142,11 +142,13 @@ blackhole:
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
 

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -142,18 +142,15 @@ blackhole:
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
   - tests/ttnn/unit_tests/operations/eltwise/test_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
 
   # Core tests
-  - tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
   - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
   - tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
   - tests/ttnn/unit_tests/base_functionality/test_cpp_logging.py


### PR DESCRIPTION
## Summary

Removes 3 tests from the BH ttsim skip list, following recent tt-llk changes that have now landed in tt-metal main.

**`test_eltwise_typecast.py` and `test_typecast_int.py`**: tt-llk PRs [#1510](https://github.com/tenstorrent/tt-llk/pull/1510) and [#1534](https://github.com/tenstorrent/tt-llk/pull/1534) implemented `DISABLE_SFPLOADMACRO` paths for the full set of typecast operations (fp32↔uint16/fp16b/uint32, uint16↔fp32/uint32, int32↔fp16b/fp32/uint16, uint32↔fp16b/fp32). These tests directly exercise those paths.

**`test_untilize_bfloat8_b.py`**: tt-llk PR [#1496](https://github.com/tenstorrent/tt-llk/pull/1496) introduced a BH-specific workaround for int8/uint8/fp8 tilize operations.

Candidate removals — waiting for CI to confirm they now pass on BH.