### PR TITLE
Improve asin, acos accuracy

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -349,6 +349,35 @@ def test_acos(device, h, w, layout):
     run_unary_test(device, h, w, ttnn.acos, layout=layout, pcc=0.999)
 
 
+def run_unary_inverse_trig_bf16_test(device, h, w, ttnn_function, ulp_threshold, layout=ttnn.TILE_LAYOUT):
+    """Explicit bfloat16 I/O and dense samples in [-1, 1] for asin/acos domain coverage."""
+    torch.manual_seed(0)
+    torch_input_tensor = torch.linspace(-1.0, 1.0, steps=h * w, dtype=torch.bfloat16).reshape(h, w)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=layout, device=device)
+    output_tensor = ttnn_function(input_tensor)
+    assert output_tensor.layout == layout, f"Output layout {output_tensor.layout} should match input layout {layout}"
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold)
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_asin_bf16(device, h, w, layout):
+    run_unary_inverse_trig_bf16_test(device, h, w, ttnn.asin, 3, layout=layout)
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_acos_bf16(device, h, w, layout):
+    run_unary_inverse_trig_bf16_test(device, h, w, ttnn.acos, 3, layout=layout)
+
+
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -111,7 +111,7 @@ def test_relu_fp32(device, ttnn_function):
     assert status
 
 
-def test_atan_fp32(device):
+def run_unary_fp32_test_with_ulp(device, ttnn_function, torch_function, max_ulp):
     all_bf16_values = generate_all_bfloat16_bitpatterns(torch.float32)
 
     # Flush subnormal inputs
@@ -121,9 +121,8 @@ def test_atan_fp32(device):
 
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    # Execute atan operation
-    y_tt = ttnn.atan(x_tt)
-    y_torch = torch.atan(x_torch)
+    y_tt = ttnn_function(x_tt)
+    y_torch = torch_function(x_torch)
 
     # Compare results
     tt_out = ttnn.to_torch(y_tt)
@@ -132,7 +131,19 @@ def test_atan_fp32(device):
     # Thus, we flush golden output to 0.0 as well to verify this behavior
     y_torch = flush_subnormal_values_to_zero(y_torch)
 
-    assert_with_ulp(y_torch, tt_out, 3, allow_nonfinite=True)
+    assert_with_ulp(y_torch, tt_out, max_ulp, allow_nonfinite=True)
+
+
+def test_atan_fp32(device):
+    run_unary_fp32_test_with_ulp(device, ttnn.atan, torch.atan, max_ulp=3)
+
+
+def test_asin_fp32(device):
+    run_unary_fp32_test_with_ulp(device, ttnn.asin, torch.asin, max_ulp=100)
+
+
+def test_acos_fp32(device):
+    run_unary_fp32_test_with_ulp(device, ttnn.acos, torch.acos, max_ulp=100)
 
 
 def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
@@ -184,18 +195,6 @@ def test_silu(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_log(device, h, w):
     run_unary_test(device, h, w, ttnn.log)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_asin(device, h, w):
-    run_unary_test(device, h, w, ttnn.asin, pcc=0.998)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_acos(device, h, w):
-    run_unary_test(device, h, w, ttnn.acos, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -7,30 +7,12 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "ckernel_sfpu_sqrt_custom.h"
 
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
-    sfpi::vFloat val = in;
-    sfpi::vFloat out;
-    v_if(val != 0.0f) {
-        // Magic number 0x5f37 is used as an approximation constant in the fast inverse square root algorithm.
-        // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
-        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
-        sfpi::vFloat neg_half_val = val * -0.5f;
-        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
-        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
-        out = approx * val;
-    }
-    v_else { out = val; }
-    v_endif;
-    return out;
-}
 
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
@@ -58,11 +40,11 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
 
     // calculated_value = temp + sqrt( temp^2 - log_value / a)
     sfpi::vFloat calculated_value = (temp * temp) - (log_value * OneDivA);
-    sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
+    sfpi::vFloat intermediate_result = sfpu_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
 
     // result = sqrt(calculated_value)
-    sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
+    sfpi::vFloat result = sfpu_sqrt_custom<false>(calculated_value);
 
     return result;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -14,7 +14,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat val = in;
-    sfpi::vFloat out;
+    sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
@@ -24,7 +24,6 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         out = approx * val;
     }
-    v_else { out = val; }
     v_endif;
     return out;
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE>
+sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
+    sfpi::vFloat val = in;
+    sfpi::vFloat out;
+    v_if(val != 0.0f) {
+        // Fast inverse square-root seed + two Newton-Raphson refinements.
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+        sfpi::vFloat neg_half_val = val * -0.5f;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        out = approx * val;
+    }
+    v_else { out = val; }
+    v_endif;
+    return out;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -390,66 +390,54 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     // Use symmetry + range transform for better accuracy near |x| ~= 1:
     // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
     sfpi::vFloat abs_v = sfpi::abs(val);
-    sfpi::vFloat asin_abs;
+    sfpi::vFloat asin_abs = PI_2;
 
-    v_if(abs_v == sfpi::vConst1) { asin_abs = PI_2; }
+    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
     v_else {
-        v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
-        v_else {
-            sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
-            sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
-            sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-            asin_abs = PI_2 - 2.0f * asin_root;
-        }
-        v_endif;
+        sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
+        sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
+        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+        asin_abs -= 2.0f * asin_root;
     }
     v_endif;
 
     return sfpi::setsgn(asin_abs, val);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_asin() {
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
+inline void calculate_asin_acos_impl() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
+        sfpi::vFloat result;
+        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { result = std::numeric_limits<float>::quiet_NaN(); }
+        v_else {
+            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
+            if constexpr (IS_ACOS) {
+                result = PI_2 - a;
+            } else {
+                result = a;
+            }
+        }
         v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_asin() {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_acos() {
-    // SFPU microcode
-    // Use identities to reduce cancellation near +/-1:
-    //  x >  0.5: acos(x) = 2*asin(sqrt((1-x)/2))
-    //  x < -0.5: acos(x) = pi - 2*asin(sqrt((1+x)/2))
-    //  else    : acos(x) = pi/2 - asin(x)
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else {
-            sfpi::vFloat result;
-            v_if(v > 0.5f) {
-                sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f - v) * 0.5f);
-                result = 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-            }
-            v_else {
-                v_if(v < -0.5f) {
-                    sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f + v) * 0.5f);
-                    result = PI - 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-                }
-                v_else { result = PI_2 - sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
-                v_endif;
-            }
-            v_endif;
-            sfpi::dst_reg[0] = result;
-        }
-        v_endif;
-        sfpi::dst_reg++;
-    }
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
 }
 
 // cosh = (exp(x) + exp(-x)) / 2

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_sqrt_custom.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
@@ -16,11 +17,11 @@ using namespace sfpi;
 
 namespace ckernel::sfpu {
 
-static const float PI = 3.1415927f;
-static const float PI_2 = 1.5707964f;
-static const float PI_4 = 0.7853982f;
-static const float FRAC_1_PI = 0.31830987f;
-static const float FRAC_2_PI = 0.636619747f;
+static const float PI = 3.1415927410125732f;
+static const float PI_2 = 1.5707963705062866f;
+static const float PI_4 = 0.7853981852531433f;
+static const float FRAC_1_PI = 0.31830987334251404f;
+static const float FRAC_2_PI = 0.6366197466850281f;
 
 template <bool is_fp32_dest_acc_en>
 static sfpi::vFloat sfpu_tan(sfpi::vFloat x, sfpi::vInt i);
@@ -365,37 +366,46 @@ inline void calculate_atan() {
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline sfpi::vFloat sfpu_asine_maclaurin_series(sfpi::vFloat val) {
-    // Valid for x in [-1, 1].
-    // Maclaurin series
-    // arcsin(x) = x + [(1/2) *x^3/3] + [(1 * 3) / (2 * 4) * x^5 / 5] + [(1 * 3 * 5) / (2 * 4 * 6) * x^7 / 7 ] + ...
-    // arcsin(x) ≈ x + (1/6) * x^3 + (3/40) * x^5 + (5/112) * x^7 + (35/1152) * x^9 + (63/2816) * x^11
+sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
+    // Polynomial in Horner form for asin(z)/z, evaluated over reduced intervals.
+    // asin(z) = z * (1 + c1*z^2 + c2*z^4 + ...).
+    sfpi::vFloat z2 = val * val;
+    sfpi::vFloat ratio = PolynomialEvaluator::eval(
+        z2,
+        sfpi::vConst1,
+        0.16666666666666666f,
+        0.075f,
+        0.044642857142857144f,
+        0.030381944444444444f,
+        0.022372159090909091f,
+        0.017352764423076923f,
+        0.01396484375f,
+        0.011551800896139705f,
+        0.009761609529194078f);
+    return val * ratio;
+}
 
-    sfpi::vFloat tmp = val;
-    sfpi::vFloat val_square = val * val;
-    // x
-    sfpi::vFloat output = tmp;
-    // (1/6) * x^3
-    tmp = tmp * val_square;
-    output += 0.166666666 * tmp;
-    // (3/40) * x^5
-    tmp = tmp * val_square;
-    output += 0.075 * tmp;
+template <bool APPROXIMATION_MODE>
+sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
+    // Use symmetry + range transform for better accuracy near |x| ~= 1:
+    // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
+    sfpi::vFloat abs_v = sfpi::abs(val);
+    sfpi::vFloat asin_abs;
 
-    //(5/112) * x^7
-    tmp = tmp * val_square;
-    output += 0.044642857 * tmp;
+    v_if(abs_v == sfpi::vConst1) { asin_abs = PI_2; }
+    v_else {
+        v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
+        v_else {
+            sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
+            sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
+            sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+            asin_abs = PI_2 - 2.0f * asin_root;
+        }
+        v_endif;
+    }
+    v_endif;
 
-    // (35/1152) *x^9
-    tmp = tmp * val_square;
-    output += 0.03038194 * tmp;
-
-    //(63/2816) * x^11
-    tmp = tmp * val_square;
-    output += 0.02237216 * tmp;
-
-    // Write out output
-    return output;
+    return sfpi::setsgn(asin_abs, val);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
@@ -404,7 +414,7 @@ inline void calculate_asin() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_else { sfpi::dst_reg[0] = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
         v_endif;
         sfpi::dst_reg++;
     }
@@ -413,11 +423,30 @@ inline void calculate_asin() {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_acos() {
     // SFPU microcode
-    // acos(x) = PI/2 - asin(x)
+    // Use identities to reduce cancellation near +/-1:
+    //  x >  0.5: acos(x) = 2*asin(sqrt((1-x)/2))
+    //  x < -0.5: acos(x) = pi - 2*asin(sqrt((1+x)/2))
+    //  else    : acos(x) = pi/2 - asin(x)
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = PI_2 - sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_else {
+            sfpi::vFloat result;
+            v_if(v > 0.5f) {
+                sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f - v) * 0.5f);
+                result = 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+            }
+            v_else {
+                v_if(v < -0.5f) {
+                    sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f + v) * 0.5f);
+                    result = PI - 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+                }
+                v_else { result = PI_2 - sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
+                v_endif;
+            }
+            v_endif;
+            sfpi::dst_reg[0] = result;
+        }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -365,38 +365,52 @@ inline void calculate_atan() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
-    // Polynomial in Horner form for asin(z)/z, evaluated over reduced intervals.
-    // asin(z) = z * (1 + c1*z^2 + c2*z^4 + ...).
+    // Polynomial in Horner form for asin(z)/z in u=z^2, evaluated over reduced intervals.
+    // asin(z) = z * P(u).
     sfpi::vFloat z2 = val * val;
-    sfpi::vFloat ratio = PolynomialEvaluator::eval(
-        z2,
-        sfpi::vConst1,
-        0.16666666666666666f,
-        0.075f,
-        0.044642857142857144f,
-        0.030381944444444444f,
-        0.022372159090909091f,
-        0.017352764423076923f,
-        0.01396484375f,
-        0.011551800896139705f,
-        0.009761609529194078f);
+    sfpi::vFloat ratio;
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Low-degree polynomial for reduced-precision destination path; |z| <= 5/8 => u=z^2 <= (5/8)^2.
+        // Single-precision fit to asin(sqrt(u))/sqrt(u) (same Horner depth as atan low path). Regenerate with:
+        // > fpminimax(asin(sqrt(x))/sqrt(x), [|0,1,2,3|], [|single...|], [2^(-40); (5/8)^2], relative);
+        ratio = PolynomialEvaluator::eval(
+            z2,
+            0.999978601932525634765625f,
+            0.16771225631237030029296875f,
+            0.06381262838840484619140625f,
+            0.083148844540119171142578125f);
+    } else {
+        // Higher-degree series coefficients for fp32 destination path.
+        ratio = PolynomialEvaluator::eval(
+            z2,
+            sfpi::vConst1,
+            0.16666666666666666f,
+            0.075f,
+            0.044642857142857144f,
+            0.030381944444444444f,
+            0.022372159090909091f,
+            0.017352764423076923f,
+            0.01396484375f,
+            0.011551800896139705f,
+            0.009761609529194078f);
+    }
     return val * ratio;
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     // Use symmetry + range transform for better accuracy near |x| ~= 1:
     // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
     sfpi::vFloat abs_v = sfpi::abs(val);
     sfpi::vFloat asin_abs = PI_2;
 
-    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
+    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE, is_fp32_dest_acc_en>(abs_v); }
     v_else {
         sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
         sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
-        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE, is_fp32_dest_acc_en>(root);
         asin_abs -= 2.0f * asin_root;
     }
     v_endif;
@@ -411,7 +425,7 @@ inline void calculate_asin_acos_impl() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
         v_if(sfpi::abs(v) <= sfpi::vConst1) {
-            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
+            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE, is_fp32_dest_acc_en>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;
             } else {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -409,9 +409,8 @@ inline void calculate_asin_acos_impl() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::vFloat result;
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { result = std::numeric_limits<float>::quiet_NaN(); }
-        v_else {
+        sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
+        v_if(sfpi::abs(v) <= sfpi::vConst1) {
             sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -7,30 +7,12 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_log.h"
+#include "ckernel_sfpu_sqrt_custom.h"
 
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline sfpi::vFloat calculate_sqrt_custom(sfpi::vFloat in) {
-    sfpi::vFloat val = in;
-    sfpi::vFloat out;
-    v_if(val != 0.0f) {
-        // Magic number 0x5f37 is used as an approximation constant in the fast inverse square root algorithm.
-        // See: https://en.wikipedia.org/wiki/Fast_inverse_square_root
-        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
-        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
-        sfpi::vFloat neg_half_val = val * -0.5f;
-        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
-        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
-        out = approx * val;
-    }
-    v_else { out = val; }
-    v_endif;
-    return out;
-}
 
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
@@ -58,11 +40,11 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
 
     // calculated_value = temp + sqrt( temp^2 - log_value / a)
     sfpi::vFloat calculated_value = (temp * temp) - (log_value * OneDivA);
-    sfpi::vFloat intermediate_result = calculate_sqrt_custom<false>(calculated_value);
+    sfpi::vFloat intermediate_result = sfpu_sqrt_custom<false>(calculated_value);
     calculated_value = temp + intermediate_result;
 
     // result = sqrt(calculated_value)
-    sfpi::vFloat result = calculate_sqrt_custom<false>(calculated_value);
+    sfpi::vFloat result = sfpu_sqrt_custom<false>(calculated_value);
 
     return result;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -14,7 +14,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE>
 sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
     sfpi::vFloat val = in;
-    sfpi::vFloat out;
+    sfpi::vFloat out = val;
     v_if(val != 0.0f) {
         // Fast inverse square-root seed + two Newton-Raphson refinements.
         sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
@@ -24,7 +24,6 @@ sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
         approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
         out = approx * val;
     }
-    v_else { out = val; }
     v_endif;
     return out;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt_custom.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE>
+sfpi_inline sfpi::vFloat sfpu_sqrt_custom(sfpi::vFloat in) {
+    sfpi::vFloat val = in;
+    sfpi::vFloat out;
+    v_if(val != 0.0f) {
+        // Fast inverse square-root seed + two Newton-Raphson refinements.
+        sfpi::vUInt magic = sfpi::reinterpret<sfpi::vUInt>(sfpi::vFloat(sfpi::s2vFloat16b(0x5f37)));
+        sfpi::vFloat approx = sfpi::reinterpret<sfpi::vFloat>(magic - (sfpi::reinterpret<sfpi::vUInt>(val) >> 1));
+        sfpi::vFloat neg_half_val = val * -0.5f;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        approx = ((approx * approx) * neg_half_val + 1.5f) * approx;
+        out = approx * val;
+    }
+    v_else { out = val; }
+    v_endif;
+    return out;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -385,38 +385,52 @@ inline void calculate_atan() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
-    // Polynomial in Horner form for asin(z)/z, evaluated over reduced intervals.
-    // asin(z) = z * (1 + c1*z^2 + c2*z^4 + ...).
+    // Polynomial in Horner form for asin(z)/z in u=z^2, evaluated over reduced intervals.
+    // asin(z) = z * P(u).
     sfpi::vFloat z2 = val * val;
-    sfpi::vFloat ratio = PolynomialEvaluator::eval(
-        z2,
-        sfpi::vConst1,
-        0.16666666666666666f,
-        0.075f,
-        0.044642857142857144f,
-        0.030381944444444444f,
-        0.022372159090909091f,
-        0.017352764423076923f,
-        0.01396484375f,
-        0.011551800896139705f,
-        0.009761609529194078f);
+    sfpi::vFloat ratio;
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Low-degree polynomial for reduced-precision destination path; |z| <= 5/8 => u=z^2 <= (5/8)^2.
+        // Single-precision fit to asin(sqrt(u))/sqrt(u) (same Horner depth as atan low path). Regenerate with:
+        // > fpminimax(asin(sqrt(x))/sqrt(x), [|0,1,2,3|], [|single...|], [2^(-40); (5/8)^2], relative);
+        ratio = PolynomialEvaluator::eval(
+            z2,
+            0.999978601932525634765625f,
+            0.16771225631237030029296875f,
+            0.06381262838840484619140625f,
+            0.083148844540119171142578125f);
+    } else {
+        // Higher-degree series coefficients for fp32 destination path.
+        ratio = PolynomialEvaluator::eval(
+            z2,
+            sfpi::vConst1,
+            0.16666666666666666f,
+            0.075f,
+            0.044642857142857144f,
+            0.030381944444444444f,
+            0.022372159090909091f,
+            0.017352764423076923f,
+            0.01396484375f,
+            0.011551800896139705f,
+            0.009761609529194078f);
+    }
     return val * ratio;
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     // Use symmetry + range transform for better accuracy near |x| ~= 1:
     // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
     sfpi::vFloat abs_v = sfpi::abs(val);
     sfpi::vFloat asin_abs = PI_2;
 
-    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
+    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE, is_fp32_dest_acc_en>(abs_v); }
     v_else {
         sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
         sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
-        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE, is_fp32_dest_acc_en>(root);
         asin_abs -= 2.0f * asin_root;
     }
     v_endif;
@@ -431,7 +445,7 @@ inline void calculate_asin_acos_impl() {
         sfpi::vFloat v = sfpi::dst_reg[0];
         sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
         v_if(sfpi::abs(v) <= sfpi::vConst1) {
-            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
+            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE, is_fp32_dest_acc_en>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;
             } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_sqrt_custom.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
@@ -16,11 +17,11 @@ using namespace sfpi;
 
 namespace ckernel::sfpu {
 
-static const float PI = 3.1415927f;
-static const float PI_2 = 1.5707964f;
-static const float PI_4 = 0.7853982f;
-static const float FRAC_1_PI = 0.31830987f;
-static const float FRAC_2_PI = 0.636619747f;
+static const float PI = 3.14159274101257324f;
+static const float PI_2 = 1.5707963705062866f;
+static const float PI_4 = 0.7853981852531433f;
+static const float FRAC_1_PI = 0.31830987334251404f;
+static const float FRAC_2_PI = 0.6366197466850281f;
 
 template <bool is_fp32_dest_acc_en>
 static sfpi::vFloat sfpu_tan(sfpi::vFloat x, sfpi::vInt i);
@@ -385,37 +386,46 @@ inline void calculate_atan() {
 }
 
 template <bool APPROXIMATION_MODE>
-sfpi_inline sfpi::vFloat sfpu_asine_maclaurin_series(sfpi::vFloat val) {
-    // Valid for x in [-1, 1].
-    // Maclaurin series
-    // arcsin(x) = x + [(1/2) *x^3/3] + [(1 * 3) / (2 * 4) * x^5 / 5] + [(1 * 3 * 5) / (2 * 4 * 6) * x^7 / 7 ] + ...
-    // arcsin(x) ≈ x + (1/6) * x^3 + (3/40) * x^5 + (5/112) * x^7 + (35/1152) * x^9 + (63/2816) * x^11
+sfpi_inline sfpi::vFloat sfpu_asin_ratio_poly_direct(sfpi::vFloat val) {
+    // Polynomial in Horner form for asin(z)/z, evaluated over reduced intervals.
+    // asin(z) = z * (1 + c1*z^2 + c2*z^4 + ...).
+    sfpi::vFloat z2 = val * val;
+    sfpi::vFloat ratio = PolynomialEvaluator::eval(
+        z2,
+        sfpi::vConst1,
+        0.16666666666666666f,
+        0.075f,
+        0.044642857142857144f,
+        0.030381944444444444f,
+        0.022372159090909091f,
+        0.017352764423076923f,
+        0.01396484375f,
+        0.011551800896139705f,
+        0.009761609529194078f);
+    return val * ratio;
+}
 
-    sfpi::vFloat tmp = val;
-    sfpi::vFloat val_square = val * val;
-    // x
-    sfpi::vFloat output = tmp;
-    // (1/6) * x^3
-    tmp = tmp * val_square;
-    output += 0.166666666 * tmp;
-    // (3/40) * x^5
-    tmp = tmp * val_square;
-    output += 0.075 * tmp;
+template <bool APPROXIMATION_MODE>
+sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
+    // Use symmetry + range transform for better accuracy near |x| ~= 1:
+    // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
+    sfpi::vFloat abs_v = sfpi::abs(val);
+    sfpi::vFloat asin_abs;
 
-    //(5/112) * x^7
-    tmp = tmp * val_square;
-    output += 0.044642857 * tmp;
+    v_if(abs_v == sfpi::vConst1) { asin_abs = PI_2; }
+    v_else {
+        v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
+        v_else {
+            sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
+            sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
+            sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+            asin_abs = PI_2 - 2.0f * asin_root;
+        }
+        v_endif;
+    }
+    v_endif;
 
-    // (35/1152) *x^9
-    tmp = tmp * val_square;
-    output += 0.03038194 * tmp;
-
-    //(63/2816) * x^11
-    tmp = tmp * val_square;
-    output += 0.02237216 * tmp;
-
-    // Write out output
-    return output;
+    return sfpi::setsgn(asin_abs, val);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
@@ -424,7 +434,7 @@ inline void calculate_asin() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_else { sfpi::dst_reg[0] = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
         v_endif;
         sfpi::dst_reg++;
     }
@@ -433,11 +443,30 @@ inline void calculate_asin() {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_acos() {
     // SFPU microcode
-    // acos(x) = PI/2 - asin(x)
+    // Use identities to reduce cancellation near +/-1:
+    //  x >  0.5: acos(x) = 2*asin(sqrt((1-x)/2))
+    //  x < -0.5: acos(x) = pi - 2*asin(sqrt((1+x)/2))
+    //  else    : acos(x) = pi/2 - asin(x)
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = PI_2 - sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v); }
+        v_else {
+            sfpi::vFloat result;
+            v_if(v > 0.5f) {
+                sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f - v) * 0.5f);
+                result = 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+            }
+            v_else {
+                v_if(v < -0.5f) {
+                    sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f + v) * 0.5f);
+                    result = PI - 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+                }
+                v_else { result = PI_2 - sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
+                v_endif;
+            }
+            v_endif;
+            sfpi::dst_reg[0] = result;
+        }
         v_endif;
         sfpi::dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -410,66 +410,54 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
     // Use symmetry + range transform for better accuracy near |x| ~= 1:
     // asin(x) = sign(x) * [pi/2 - 2*asin(sqrt((1-|x|)/2))].
     sfpi::vFloat abs_v = sfpi::abs(val);
-    sfpi::vFloat asin_abs;
+    sfpi::vFloat asin_abs = PI_2;
 
-    v_if(abs_v == sfpi::vConst1) { asin_abs = PI_2; }
+    v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
     v_else {
-        v_if(abs_v <= 0.625f) { asin_abs = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(abs_v); }
-        v_else {
-            sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
-            sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
-            sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-            asin_abs = PI_2 - 2.0f * asin_root;
-        }
-        v_endif;
+        sfpi::vFloat t = (1.0f - abs_v) * 0.5f;
+        sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>(t);
+        sfpi::vFloat asin_root = sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
+        asin_abs -= 2.0f * asin_root;
     }
     v_endif;
 
     return sfpi::setsgn(asin_abs, val);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_asin() {
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
+inline void calculate_asin_acos_impl() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else { sfpi::dst_reg[0] = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
+        sfpi::vFloat result;
+        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { result = std::numeric_limits<float>::quiet_NaN(); }
+        v_else {
+            sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
+            if constexpr (IS_ACOS) {
+                result = PI_2 - a;
+            } else {
+                result = a;
+            }
+        }
         v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_asin() {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_acos() {
-    // SFPU microcode
-    // Use identities to reduce cancellation near +/-1:
-    //  x >  0.5: acos(x) = 2*asin(sqrt((1-x)/2))
-    //  x < -0.5: acos(x) = pi - 2*asin(sqrt((1+x)/2))
-    //  else    : acos(x) = pi/2 - asin(x)
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_else {
-            sfpi::vFloat result;
-            v_if(v > 0.5f) {
-                sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f - v) * 0.5f);
-                result = 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-            }
-            v_else {
-                v_if(v < -0.5f) {
-                    sfpi::vFloat root = sfpu_sqrt_custom<APPROXIMATION_MODE>((1.0f + v) * 0.5f);
-                    result = PI - 2.0f * sfpu_asin_ratio_poly_direct<APPROXIMATION_MODE>(root);
-                }
-                v_else { result = PI_2 - sfpu_asin_range_reduced<APPROXIMATION_MODE>(v); }
-                v_endif;
-            }
-            v_endif;
-            sfpi::dst_reg[0] = result;
-        }
-        v_endif;
-        sfpi::dst_reg++;
-    }
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
 }
 
 // cosh = (exp(x) + exp(-x)) / 2

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -429,9 +429,8 @@ inline void calculate_asin_acos_impl() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::vFloat result;
-        v_if(v < sfpi::vConstNeg1 || v > sfpi::vConst1) { result = std::numeric_limits<float>::quiet_NaN(); }
-        v_else {
+        sfpi::vFloat result = std::numeric_limits<float>::quiet_NaN();
+        v_if(sfpi::abs(v) <= sfpi::vConst1) {
             sfpi::vFloat a = sfpu_asin_range_reduced<APPROXIMATION_MODE>(v);
             if constexpr (IS_ACOS) {
                 result = PI_2 - a;

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -165,7 +165,9 @@ ALWI void atanh_tile(uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void asin_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_asin, RC, true, idst)); }
+ALWI void asin_tile(uint32_t idst) {
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -209,7 +211,9 @@ ALWI void atan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atan, sfpu::atan_init, t
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void acos_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_acos, RC, true, idst)); }
+ALWI void acos_tile(uint32_t idst) {
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
None

### Problem description
asin and acos accuracy is poor.

### What's changed
Change test from PCC to ULP.
Suggest new implementation using Horner's method + split range at 0.625 + custom square root.
Didn't reuse available square root because that one is less precise and requires changes in LLK submodule.

### Accuracy
ULP difference before change: 1720368.0
ULP difference after change: <100 (86 for acos, 52 for asin)

### Performance
|    | OP CODE              | OP TYPE       |   GLOBAL CALL COUNT |   DEVICE ID | DEVICE ARCH   | ATTRIBUTES                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | MATH FIDELITY   |   CORE COUNT |   AVAILABLE WORKER CORE COUNT |   PARALLELIZATION STRATEGY |   HOST START TS |   HOST END TS |   HOST DURATION [ns] |   DEVICE FW START CYCLE |   DEVICE FW END CYCLE |   OP TO OP LATENCY [ns] |   OP TO OP LATENCY BR/NRISC START [ns] |   DEVICE FW DURATION [ns] |   DEVICE KERNEL DURATION [ns] |   DEVICE KERNEL DURATION DM START [ns] |   DEVICE KERNEL DURATION PER CORE MIN [ns] |   DEVICE KERNEL DURATION PER CORE MAX [ns] |   DEVICE KERNEL DURATION PER CORE AVG [ns] |   DEVICE KERNEL FIRST TO LAST START [ns] |   DEVICE BRISC KERNEL DURATION [ns] |   DEVICE NCRISC KERNEL DURATION [ns] |   DEVICE TRISC0 KERNEL DURATION [ns] |   DEVICE TRISC1 KERNEL DURATION [ns] |   DEVICE TRISC2 KERNEL DURATION [ns] |   DEVICE ERISC KERNEL DURATION [ns] |   DEVICE COMPUTE CB WAIT FRONT [ns] |   DEVICE COMPUTE CB RESERVE BACK [ns] |   DISPATCH TOTAL CQ CMD OP TIME [ns] |   DISPATCH GO SEND WAIT TIME [ns] | INPUT_0_W_PAD[LOGICAL]   | INPUT_0_Z_PAD[LOGICAL]   | INPUT_0_Y_PAD[LOGICAL]   | INPUT_0_X_PAD[LOGICAL]   | INPUT_0_LAYOUT   | INPUT_0_DATATYPE   | INPUT_0_MEMORY         | OUTPUT_0_W_PAD[LOGICAL]   | OUTPUT_0_Z_PAD[LOGICAL]   | OUTPUT_0_Y_PAD[LOGICAL]   | OUTPUT_0_X_PAD[LOGICAL]   | OUTPUT_0_LAYOUT   | OUTPUT_0_DATATYPE   | OUTPUT_0_MEMORY        |   METAL TRACE ID |   METAL TRACE REPLAY SESSION ID | COMPUTE KERNEL SOURCE                                                               | COMPUTE KERNEL HASH                   | DATA MOVEMENT KERNEL SOURCE                                                                                                                                                                                      | DATA MOVEMENT KERNEL HASH                                                                                            |        PROGRAM HASH | PROGRAM CACHE HIT   |   TENSIX DM 0 MAX KERNEL SIZE [B] |   TENSIX DM 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 0 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 1 MAX KERNEL SIZE [B] |   TENSIX COMPUTE 2 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 0 MAX KERNEL SIZE [B] |   ACTIVE ETH DM 1 MAX KERNEL SIZE [B] |   IDLE ETH DM 0 MAX KERNEL SIZE [B] |   IDLE ETH DM 1 MAX KERNEL SIZE [B] |   PM IDEAL [ns] |   PM COMPUTE [ns] |   PM BANDWIDTH [ns] | PM REQ I BW   | PM REQ O BW   |   PM FPU UTIL (%) |   NOC UTIL (%) |   MULTICAST NOC UTIL (%) |   DRAM BW UTIL (%) |   ETH BW UTIL (%) |   NPE CONG IMPACT (%) |
|---:|:---------------------|:--------------|--------------------:|------------:|:--------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------|-------------:|------------------------------:|---------------------------:|----------------:|--------------:|---------------------:|------------------------:|----------------------:|------------------------:|---------------------------------------:|--------------------------:|------------------------------:|---------------------------------------:|-------------------------------------------:|-------------------------------------------:|-------------------------------------------:|-----------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|-------------------------------------:|------------------------------------:|------------------------------------:|--------------------------------------:|-------------------------------------:|----------------------------------:|:-------------------------|:-------------------------|:-------------------------|:-------------------------|:-----------------|:-------------------|:-----------------------|:--------------------------|:--------------------------|:--------------------------|:--------------------------|:------------------|:--------------------|:-----------------------|-----------------:|--------------------------------:|:------------------------------------------------------------------------------------|:--------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|--------------------:|:--------------------|----------------------------------:|----------------------------------:|---------------------------------------:|---------------------------------------:|---------------------------------------:|--------------------------------------:|--------------------------------------:|------------------------------------:|------------------------------------:|----------------:|------------------:|--------------------:|:--------------|:--------------|------------------:|---------------:|-------------------------:|-------------------:|------------------:|----------------------:|
|  0 | main | tt_dnn_device |                1024 |           0 | wormhole_b0   | {'bfp8_pack_precise': 'false'; 'fp32_dest_acc_en': 'true'; 'op_chain': '{BasicUnaryWithParam<float; int; unsigned int>(base=BasicUnaryWithParam<float>(op_type=UnaryOpType::ASIN;param={}))}'; 'output_dtype': 'DataType::FLOAT32'; 'output_memory_config': 'MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED;buffer_type=BufferType::DRAM;shard_spec=std::nullopt;nd_shard_spec=std::nullopt;created_with_nd_shard_spec=0)'; 'preserve_fp32_precision': 'true'; 'sub_core_grids': 'std::nullopt'} | HiFi4           |            8 |                            64 |                        nan |     29685702575 |   29686289811 |               587236 |          17174842029088 |        17174842034530 |                       0 |                                      0 |                      5442 |                          4826 |                                   4346 |                                        nan |                                        nan |                                        nan |                                      606 |                                4328 |                                 1390 |                                 1894 |                                 3584 |                                  409 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 1[1]                     | 1[1]                     | 64[64]                   | 128[128]                 | TILE             | FLOAT32            | DEV_1_DRAM_INTERLEAVED | 1[1]                      | 1[1]                      | 64[64]                    | 128[128]                  | TILE              | FLOAT32             | DEV_1_DRAM_INTERLEAVED |              nan |                             nan | ['ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute//eltwise_sfpu.cpp'] | ['eltwise_sfpu/3841396480945331342/'] | ['ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp'; 'ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp'] | ['writer_unary_interleaved_start_id/7153240009947149406/'; 'reader_unary_interleaved_start_id/4651828238444297836/'] | 9788982343552622585 | False               |                              2604 |                              2520 |                                   1344 |                                   1096 |                                   1228 |                                     0 |                                     0 |                                   0 |                                   0 |               1 |                 1 |                   1 | []            | []            |             0.021 |            nan |                      nan |                nan |               nan |                   nan |
|  1 | current PR | tt_dnn_device |                1024 |           0 | wormhole_b0   | {'bfp8_pack_precise': 'false'; 'fp32_dest_acc_en': 'true'; 'op_chain': '{BasicUnaryWithParam<float; int; unsigned int>(base=BasicUnaryWithParam<float>(op_type=UnaryOpType::ASIN;param={}))}'; 'output_dtype': 'DataType::FLOAT32'; 'output_memory_config': 'MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED;buffer_type=BufferType::DRAM;shard_spec=std::nullopt;nd_shard_spec=std::nullopt;created_with_nd_shard_spec=0)'; 'preserve_fp32_precision': 'true'; 'sub_core_grids': 'std::nullopt'} | HiFi4           |           64 |                            64 |                        nan |     31797666019 |   31798216495 |               550476 |           4505309971355 |         4505309980873 |                       0 |                                      0 |                      9518 |                          8905 |                                   8417 |                                        nan |                                        nan |                                        nan |                                      724 |                                8399 |                                 2121 |                                 2629 |                                 6990 |                                  511 |                                 nan |                                 nan |                                   nan |                                  nan |                               nan | 1[1]                     | 1[1]                     | 256[256]                 | 256[256]                 | TILE             | FLOAT32            | DEV_1_DRAM_INTERLEAVED | 1[1]                      | 1[1]                      | 256[256]                  | 256[256]                  | TILE              | FLOAT32             | DEV_1_DRAM_INTERLEAVED |              nan |                             nan | ['ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute//eltwise_sfpu.cpp'] | ['eltwise_sfpu/3841396480945331342/'] | ['ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp'; 'ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp'] | ['writer_unary_interleaved_start_id/7153240009947149406/'; 'reader_unary_interleaved_start_id/4651828238444297836/'] | 9788982343558391801 | False               |                              2604 |                              2520 |                                   1344 |                                   1672 |                                   1228 |                                     0 |                                     0 |                                   0 |                                   0 |               1 |                 1 |                   1 | []            | []            |             0.011 |            nan |                      nan |                nan |               nan |                   nan |

### Required for
https://github.com/tenstorrent/tt-lang/pull/414

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/improve-asin-acos-accuracy)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/improve-asin-acos-accuracy)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/improve-asin-acos-accuracy)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) - https://github.com/tenstorrent/tt-metal/actions/runs/23662405981


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/improve-asin-acos-accuracy)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/improve-asin-acos-accuracy)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/improve-asin-acos-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/improve-asin-acos-accuracy)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
