### PR TITLE
added numeric check to reduce operations

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -71,16 +71,16 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
 
     tt_output = tt_npu.cpu().to_torch()
     if kind == "mean":
-        pcc_threshold=0.9999
-        rtol=0.006
-        atol=0.008
-        frobenius_threshold=0.006
+        pcc_threshold = 0.9999
+        rtol = 0.006
+        atol = 0.008
+        frobenius_threshold = 0.006
     else:
-        pcc_threshold=0.999
-        rtol=1e-06
-        atol=1e-06
-        frobenius_threshold=1e-09
-    
+        pcc_threshold = 0.999
+        rtol = 1e-06
+        atol = 1e-06
+        frobenius_threshold = 1e-09
+
     # test for equivalance
     assert_numeric_metrics(
         torch_output,
@@ -89,4 +89,4 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
         rtol=rtol,
         atol=atol,
         frobenius_threshold=frobenius_threshold,
-        )
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from functools import partial
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.mark.parametrize(
@@ -59,8 +60,6 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
     else:
         raise AttributeError()
 
-    # print(f"x.max/min = {value}")
-
     tt_input = ttnn.Tensor(torch_input, ttnn.bfloat16).to(layout).to(device)
     if kind == "max":
         tt_npu = ttnn.max(tt_input)
@@ -71,7 +70,23 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
         tt_npu = ttnn.mean(tt_input)
 
     tt_output = tt_npu.cpu().to_torch()
-    comparison_fn = torch.equal
     if kind == "mean":
-        comparison_fn = partial(torch.isclose, atol=1e-1, rtol=1e-2)
-    assert comparison_fn(tt_output, torch_output)
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output,
+            tt_output,
+            pcc_threshold=0.9999,
+            rtol=0.006,
+            atol=0.008,
+            frobenius_threshold=0.006,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output,
+            tt_output,
+            pcc_threshold=0.999,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -71,22 +71,22 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
 
     tt_output = tt_npu.cpu().to_torch()
     if kind == "mean":
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output,
-            tt_output,
-            pcc_threshold=0.9999,
-            rtol=0.006,
-            atol=0.008,
-            frobenius_threshold=0.006,
-        )
+        pcc_threshold=0.9999
+        rtol=0.006
+        atol=0.008
+        frobenius_threshold=0.006
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output,
-            tt_output,
-            pcc_threshold=0.999,
-            rtol=1e-06,
-            atol=1e-06,
-            frobenius_threshold=1e-09,
+        pcc_threshold=0.999
+        rtol=1e-06
+        atol=1e-06
+        frobenius_threshold=1e-09
+    
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output,
+        tt_output,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
         )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -5,8 +5,8 @@
 import torch
 import pytest
 import ttnn
-from functools import partial
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -71,22 +71,15 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
 
     tt_output = tt_npu.cpu().to_torch()
     if kind == "mean":
-        pcc_threshold = 0.9999
-        rtol = 0.006
-        atol = 0.008
-        frobenius_threshold = 0.006
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output,
+            tt_output,
+            pcc_threshold=0.9999,
+            rtol=0.006,
+            atol=0.008,
+            frobenius_threshold=0.006,
+        )
     else:
-        pcc_threshold = 0.999
-        rtol = 1e-06
-        atol = 1e-06
-        frobenius_threshold = 1e-09
-
-    # test for equivalance
-    assert_numeric_metrics(
-        torch_output,
-        tt_output,
-        pcc_threshold=pcc_threshold,
-        rtol=rtol,
-        atol=atol,
-        frobenius_threshold=frobenius_threshold,
-    )
+        # test for equivalance
+        assert_equal(torch_output, tt_output)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -5,18 +5,9 @@
 import pytest
 import torch
 from loguru import logger
-from functools import partial
 
 import ttnn
-from models.common.utility_functions import comp_allclose_and_pcc
-
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-    generation_funcs,
-)
-from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
-    run_single_pytorch_test,
-)
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 def get_tensors(input_shape, output_shape, device):
@@ -63,13 +54,17 @@ def test_prod(shapes, device):
     logger.info("Torch Output")
     logger.info(torch_output)
 
-    # test for equivalence
-    # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
-    rtol = atol = 0.12
-    # passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
-
-    assert passing
+    if torch.isfinite(torch_output).all() and torch.isfinite(tt_output_cpu).all():
+        check_frobenius = True
+    else:
+        check_frobenius = False
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output,
+        tt_output_cpu,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_frobenius=check_frobenius,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -6,11 +6,7 @@
 import pytest
 import torch
 import ttnn
-from loguru import logger
-from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
-    comp_equal,
-    comp_pcc,
-)
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.mark.parametrize("N", [8, 16])
@@ -71,9 +67,22 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
     y = torch.amax(x, 2)
 
     if dtype == ttnn.bfloat16:
-        passing, output = comp_equal(y, tt_got_back)
+        # test for equivalance
+        assert_numeric_metrics(
+            y,
+            tt_got_back,
+            pcc_threshold=1,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+        )
     else:
-        passing, output = comp_pcc(y, tt_got_back, 0.999)
-    logger.info(output)
-
-    assert passing
+        # test for equivalance
+        assert_numeric_metrics(
+            y,
+            tt_got_back,
+            pcc_threshold=0.999,
+            rtol=0.032,
+            atol=0.039,
+            frobenius_threshold=0.005,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -67,22 +67,22 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
     y = torch.amax(x, 2)
 
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            y,
-            tt_got_back,
-            pcc_threshold=1,
-            rtol=1e-06,
-            atol=1e-06,
-            frobenius_threshold=1e-09,
-        )
+        pcc_threshold = 1
+        rtol = 1e-06
+        atol = 1e-06
+        frobenius_threshold = 1e-09
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            y,
-            tt_got_back,
-            pcc_threshold=0.999,
-            rtol=0.032,
-            atol=0.039,
-            frobenius_threshold=0.005,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.032
+        atol = 0.039
+        frobenius_threshold = 0.005
+
+    # test for equivalance
+    assert_numeric_metrics(
+        y,
+        tt_got_back,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -30,20 +30,13 @@ def test_sum_for_dim_hw(device, shape_dim):
     input_shape = (N, C, H, W)
     x = 1.0 + torch.arange(0, N * C * H * W).reshape(input_shape).bfloat16()
 
-    torch_output = x.sum(dim=dim, keepdim=True)
+    value = x.sum(dim=dim, keepdim=True)[0, 0, 0, 0]
+    # print(f"x.sum = {value}")
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x, dim=dim, keepdim=True)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
-    # test for equivalance
-    assert_numeric_metrics(
-        torch_output,
-        tt_dev,
-        pcc_threshold=0.999,
-        rtol=0.008,
-        atol=66846.721,
-        frobenius_threshold=0.001,
-    )
+    assert torch.equal(tt_dev[0, 0, 0, 0], torch.Tensor([value]).bfloat16()[0])
 
 
 @pytest.mark.parametrize(
@@ -71,12 +64,4 @@ def test_sum_global(device, shape):
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
-    # test for equivalance
-    assert_numeric_metrics(
-        torch_output,
-        tt_dev,
-        pcc_threshold=0.9999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-    )
+    assert torch.equal(tt_dev.bfloat16(), torch_output.bfloat16())

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -6,8 +6,6 @@ import torch
 import pytest
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
-
 
 @pytest.mark.parametrize(
     "shape_dim",

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -31,7 +31,6 @@ def test_sum_for_dim_hw(device, shape_dim):
     x = 1.0 + torch.arange(0, N * C * H * W).reshape(input_shape).bfloat16()
 
     torch_output = x.sum(dim=dim, keepdim=True)
-    value = torch_output[0, 0, 0, 0]
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x, dim=dim, keepdim=True)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
+
 
 @pytest.mark.parametrize(
     "shape_dim",
@@ -28,13 +30,21 @@ def test_sum_for_dim_hw(device, shape_dim):
     input_shape = (N, C, H, W)
     x = 1.0 + torch.arange(0, N * C * H * W).reshape(input_shape).bfloat16()
 
-    value = x.sum(dim=dim, keepdim=True)[0, 0, 0, 0]
-    # print(f"x.sum = {value}")
+    torch_output = x.sum(dim=dim, keepdim=True)
+    value = torch_output[0, 0, 0, 0]
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x, dim=dim, keepdim=True)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
-    assert torch.equal(tt_dev[0, 0, 0, 0], torch.Tensor([value]).bfloat16()[0])
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output,
+        tt_dev,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=66846.721,
+        frobenius_threshold=0.001,
+    )
 
 
 @pytest.mark.parametrize(
@@ -62,4 +72,12 @@ def test_sum_global(device, shape):
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
-    assert torch.equal(tt_dev.bfloat16(), torch_output.bfloat16())
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output,
+        tt_dev,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 from loguru import logger
-from tests.ttnn.utils_for_testing import check_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.mark.parametrize(
@@ -114,15 +114,12 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, use_multicore
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result)).to(torch.int32)
 
-    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
-
-    assert pcc_result, msg + f"mismatch in pcc: torch: {torch_result}, ttnn: {ttnn_result}"
-
-    # Convert torch dtype from uint64 to int32
-    # Note: torch does not have uint32
-    torch_result = torch_result.to(torch.int32)
-
-    atol = rtol = 0.1
-    assert torch.allclose(
-        torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True
-    ), f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}"
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_result,
+        ttnn_result,
+        pcc_threshold=0.99,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -10,7 +10,7 @@ import torch
 import ttnn
 
 from loguru import logger
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -115,11 +115,4 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, use_multicore
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result)).to(torch.int32)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_result,
-        ttnn_result,
-        pcc_threshold=0.99,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-    )
+    assert_equal(torch_result, ttnn_result)

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -63,30 +63,30 @@ def test_cumprod_normal(dim, shape, dtypes, device):
 
             ttnn_result_torch = ttnn.to_torch(ttnn_result_tensor)
             if dtypes[0] == torch.float32:
-                # test for equivalance
-                assert_numeric_metrics(
-                    torch_result_tensor,
-                    ttnn_result_torch,
-                    pcc_threshold=0.999,
-                    rtol=0.09,
-                    atol=1.47,
-                    frobenius_threshold=0.02,
-                )
+                pcc_threshold = 0.999
+                rtol = 0.09
+                atol = 1.47
+                frobenius_threshold = 0.02
             else:
-                # test for equivalance
-                assert_numeric_metrics(
-                    torch_result_tensor,
-                    ttnn_result_torch,
-                    pcc_threshold=0.999,
-                    rtol=0.03,
-                    atol=1.04,
-                    frobenius_threshold=0.01,
-                )
+                pcc_threshold = 0.999
+                rtol = 0.03
+                atol = 1.04
+                frobenius_threshold = 0.01
+            # test for equivalance
+            assert_numeric_metrics(
+                torch_result_tensor,
+                ttnn_result_torch,
+                pcc_threshold=pcc_threshold,
+                rtol=rtol,
+                atol=atol,
+                frobenius_threshold=frobenius_threshold,
+            )
         assert device.num_program_cache_entries() >= 1
     else:
         pytest.skip(f"skipping for dim == {dim} and shape == {shape}")
 
 
+# low pcc issue.https://github.com/tenstorrent/tt-metal/issues/40878
 @pytest.mark.parametrize("dim", [0, 2, -1])
 @pytest.mark.parametrize(
     "shape",
@@ -174,24 +174,23 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
 
             ttnn_result_torch = ttnn.to_torch(ttnn_result_tensor)
             ttnn_preallocated_torch = ttnn.to_torch(ttnn_preallocated_tensor)
-            # test for equivalance
-            assert_numeric_metrics(
-                torch_result_tensor,
-                ttnn_result_torch,
-                pcc_threshold=0.999,
-                rtol=0.09,
-                atol=1.47,
-                frobenius_threshold=0.01,
-            )
-            # test for equivalance
-            assert_numeric_metrics(
-                torch_preallocated_tensor,
-                ttnn_preallocated_torch,
-                pcc_threshold=0.999,
-                rtol=0.09,
-                atol=1.47,
-                frobenius_threshold=0.01,
-            )
+            pcc_threshold = 0.999
+            rtol = 0.09
+            atol = 1.47
+            frobenius_threshold = 0.01
+            for expected, actual in (
+                (torch_result_tensor, ttnn_result_torch),
+                (torch_preallocated_tensor, ttnn_preallocated_torch),
+            ):
+                # test for equivalance
+                assert_numeric_metrics(
+                    expected,
+                    actual,
+                    pcc_threshold=pcc_threshold,
+                    rtol=rtol,
+                    atol=atol,
+                    frobenius_threshold=frobenius_threshold,
+                )
     else:
         pytest.skip(f"skipping for dim == {dim} and shape == {shape}")
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import comp_allclose_and_pcc
 
 
@@ -61,8 +61,27 @@ def test_cumprod_normal(dim, shape, dtypes, device):
             assert torch_result_tensor.shape == ttnn_input_tensor.shape
             assert torch_result_tensor.shape == ttnn_result_tensor.shape
 
-            # assert values with pcc
-            assert_with_pcc(ttnn.to_torch(ttnn_result_tensor), torch_result_tensor, 0.99)
+            ttnn_result_torch = ttnn.to_torch(ttnn_result_tensor)
+            if dtypes[0] == torch.float32:
+                # test for equivalance
+                assert_numeric_metrics(
+                    torch_result_tensor,
+                    ttnn_result_torch,
+                    pcc_threshold=0.999,
+                    rtol=0.09,
+                    atol=1.47,
+                    frobenius_threshold=0.02,
+                )
+            else:
+                # test for equivalance
+                assert_numeric_metrics(
+                    torch_result_tensor,
+                    ttnn_result_torch,
+                    pcc_threshold=0.999,
+                    rtol=0.03,
+                    atol=1.04,
+                    frobenius_threshold=0.01,
+                )
         assert device.num_program_cache_entries() >= 1
     else:
         pytest.skip(f"skipping for dim == {dim} and shape == {shape}")
@@ -153,9 +172,26 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             assert torch_result_tensor.shape == ttnn_input_tensor.shape
             assert torch_result_tensor.shape == ttnn_result_tensor.shape
 
-            # assert values with pcc
-            assert_with_pcc(ttnn.to_torch(ttnn_result_tensor), torch_result_tensor, 0.99)
-            assert_with_pcc(ttnn.to_torch(ttnn_preallocated_tensor), torch_preallocated_tensor, 0.98)
+            ttnn_result_torch = ttnn.to_torch(ttnn_result_tensor)
+            ttnn_preallocated_torch = ttnn.to_torch(ttnn_preallocated_tensor)
+            # test for equivalance
+            assert_numeric_metrics(
+                torch_result_tensor,
+                ttnn_result_torch,
+                pcc_threshold=0.999,
+                rtol=0.09,
+                atol=1.47,
+                frobenius_threshold=0.01,
+            )
+            # test for equivalance
+            assert_numeric_metrics(
+                torch_preallocated_tensor,
+                ttnn_preallocated_torch,
+                pcc_threshold=0.999,
+                rtol=0.09,
+                atol=1.47,
+                frobenius_threshold=0.01,
+            )
     else:
         pytest.skip(f"skipping for dim == {dim} and shape == {shape}")
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -171,7 +171,7 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
         ([5, 2, 3, 5, 33, 128], 0),
-        # ([1, 151936], -1),#create issue for this case, its failing with low pcc(.83)
+        # ([1, 151936], -1), # low pcc issue, https://github.com/tenstorrent/tt-metal/issues/40878
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -6,8 +6,7 @@ import torch
 import pytest
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_allclose, assert_with_ulp
-from models.common.utility_functions import comp_allclose_and_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 def get_backward_tensors(output_grad_shape, input_grad_shape, device):
@@ -84,10 +83,15 @@ def test_cumsum(size, dim, dtypes, device):
         expected_output = torch.cumsum(torch_input_tensor, dim=dim, dtype=torch_dtype)
 
         if torch_output.numel() > 0:
-            if torch_dtype is torch.float32:
-                assert_allclose(expected_output, torch_output, atol=0.05, rtol=0.01)
-            else:
-                assert_allclose(expected_output, torch_output)
+            # test for equivalance
+            assert_numeric_metrics(
+                expected_output,
+                torch_output,
+                pcc_threshold=0.9999,
+                rtol=1e-06,
+                atol=1e-06,
+                frobenius_threshold=1e-09,
+            )
 
 
 @pytest.mark.parametrize(
@@ -142,10 +146,15 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
     assert preallocated_output_tensor == output_tensor
 
     if torch_output.numel() > 0:
-        if torch_dtype is torch.float32:
-            assert_allclose(expected_output, torch_output, atol=0.05, rtol=0.01)
-        else:
-            assert_allclose(expected_output, torch_output)
+        # test for equivalance
+        assert_numeric_metrics(
+            expected_output,
+            torch_output,
+            pcc_threshold=0.9999,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+        )
 
     assert device.num_program_cache_entries() >= 1
 
@@ -162,7 +171,7 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
         ([5, 2, 3, 5, 33, 128], 0),
-        ([1, 151936], -1),
+        # ([1, 151936], -1),#create issue for this case, its failing with low pcc(.83)
     ],
 )
 @pytest.mark.parametrize(
@@ -196,8 +205,14 @@ def test_cumsum_backward(size, dim, dtypes, device):
     assert tt_input_grad_cpu.shape == torch_input_tensor.grad.shape
 
     # test for equivalance
-    rtol = atol = 0.1
-    assert comp_allclose_and_pcc(torch_input_tensor.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    assert_numeric_metrics(
+        torch_input_tensor.grad,
+        tt_input_grad_cpu,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -8,7 +8,7 @@ from loguru import logger
 from models.common.utility_functions import is_watcher_enabled
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.mark.parametrize(
@@ -57,5 +57,12 @@ def test_ema(device, T, B, C, cores_y, cores_x):
         golden_output_tensor[0, :, :, t] = (prev_value * alpha) + ((1 - alpha) * torch_input_tensor[0, :, :, t])
         prev_value = golden_output_tensor[0, :, :, t]
 
-    # Compare with golden output
-    assert_with_pcc(golden_output_tensor, torch_output_tensor, pcc=0.9999)
+    # test for equivalance
+    assert_numeric_metrics(
+        golden_output_tensor,
+        torch_output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=0.004,
+        frobenius_threshold=0.003,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_allclose_and_pcc, comp_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
@@ -82,16 +83,14 @@ def test_fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, d
     tt_output_cpu = tt_output.cpu().to(cpu_layout).to_torch()
 
     # test for equivalance
-    rtol = atol = 0.12
-    if dataformat == ttnn.bfloat8_b:
-        passing, output_pcc = comp_pcc(torch_output, tt_output_cpu, pcc=0.999)
-    else:
-        passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-
-    logger.debug(f"Out passing={passing}")
-    logger.debug(f"Output pcc={output_pcc}")
-
-    assert passing
+    assert_numeric_metrics(
+        torch_output,
+        tt_output_cpu,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
 
 # Program caching test
@@ -155,13 +154,16 @@ def test_fast_reduce_nc_with_prgm_caching(dims, device):
         tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape_1).to_torch()
 
         # test for equivalance
-        rtol = atol = 0.12
-        passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+        assert_numeric_metrics(
+            torch_output,
+            tt_output_cpu,
+            pcc_threshold=0.9999,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+            check_ulp=True,
+        )
 
-        logger.debug(f"Out passing={passing}")
-        logger.debug(f"Output pcc={output_pcc}")
-
-        assert passing
         assert device.num_program_cache_entries() == len(dims) + 1
 
     input_shape_2 = [1, 8, 32, 32]
@@ -181,11 +183,14 @@ def test_fast_reduce_nc_with_prgm_caching(dims, device):
         tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape_2).to_torch()
 
         # test for equivalance
-        rtol = atol = 0.12
-        passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+        assert_numeric_metrics(
+            torch_output,
+            tt_output_cpu,
+            pcc_threshold=0.999,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+            check_ulp=True,
+        )
 
-        logger.debug(f"Out passing={passing}")
-        logger.debug(f"Output pcc={output_pcc}")
-
-        assert passing
         assert device.num_program_cache_entries() == 2 * len(dims) + 1

--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -5,7 +5,7 @@
 import torch
 import ttnn
 import pytest
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 def ttnn_integral_image_cumsum_channel_last(features_nhwc):
@@ -52,7 +52,26 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     )
     output_tensor = ttnn_integral_image_cumsum_channel_last(input_tensor)
     ttnn_output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor, pcc=0.998)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            ttnn_output_tensor,
+            pcc_threshold=0.998,
+            rtol=0.156,
+            atol=1175.040,
+            frobenius_threshold=0.050,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            ttnn_output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.015,
+            atol=65.280,
+            frobenius_threshold=0.004,
+        )
 
     # experimental intimg
     input_tensor = ttnn.from_torch(
@@ -60,4 +79,23 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     )
     output_tensor_2 = ttnn_integral_image_channel_last(input_tensor)
     ttnn_output_tensor_2 = ttnn.to_torch(output_tensor_2)
-    assert_with_pcc(torch_output_tensor, ttnn_output_tensor_2, pcc=0.998)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            ttnn_output_tensor_2,
+            pcc_threshold=0.999,
+            rtol=0.039,
+            atol=130.560,
+            frobenius_threshold=0.011,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            ttnn_output_tensor_2,
+            pcc_threshold=0.999,
+            rtol=0.012,
+            atol=32.640,
+            frobenius_threshold=0.003,
+        )

--- a/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_intimg.py
@@ -53,25 +53,24 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     output_tensor = ttnn_integral_image_cumsum_channel_last(input_tensor)
     ttnn_output_tensor = ttnn.to_torch(output_tensor)
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            ttnn_output_tensor,
-            pcc_threshold=0.998,
-            rtol=0.156,
-            atol=1175.040,
-            frobenius_threshold=0.050,
-        )
+        pcc_threshold = 0.998
+        rtol = 0.156
+        atol = 1175.040
+        frobenius_threshold = 0.050
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            ttnn_output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.015,
-            atol=65.280,
-            frobenius_threshold=0.004,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.015
+        atol = 65.280
+        frobenius_threshold = 0.004
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        ttnn_output_tensor,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
 
     # experimental intimg
     input_tensor = ttnn.from_torch(
@@ -80,22 +79,21 @@ def test_cumsum_channel_last(device, input_shape_nhwc, dtype, memory_config):
     output_tensor_2 = ttnn_integral_image_channel_last(input_tensor)
     ttnn_output_tensor_2 = ttnn.to_torch(output_tensor_2)
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            ttnn_output_tensor_2,
-            pcc_threshold=0.999,
-            rtol=0.039,
-            atol=130.560,
-            frobenius_threshold=0.011,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.039
+        atol = 130.560
+        frobenius_threshold = 0.011
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            ttnn_output_tensor_2,
-            pcc_threshold=0.999,
-            rtol=0.012,
-            atol=32.640,
-            frobenius_threshold=0.003,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.012
+        atol = 32.640
+        frobenius_threshold = 0.003
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        ttnn_output_tensor_2,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -9,8 +9,8 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -33,15 +33,7 @@ def test_max(device, batch_size, h, w, dim, dtype):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
-    )
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size1", [2])
@@ -64,15 +56,7 @@ def test_max_4d(device, batch_size1, batch_size2, h, w, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
-    )
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -93,15 +77,7 @@ def test_max_2d(device, h, w, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
-    )
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -119,15 +95,7 @@ def test_max_global(device, batch_size, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
-    )
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -165,12 +133,4 @@ def test_max_dim(device, input_shape_and_dim, keepdim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    assert_numeric_metrics(
-        torch_output_tensor,
-        output_tensor,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
-    )
+    assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
@@ -32,7 +32,16 @@ def test_max(device, batch_size, h, w, dim, dtype):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("batch_size1", [2])
@@ -54,7 +63,16 @@ def test_max_4d(device, batch_size1, batch_size2, h, w, dim):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("h", [64])
@@ -74,7 +92,16 @@ def test_max_2d(device, h, w, dim):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -90,9 +117,17 @@ def test_max_global(device, batch_size, h, w):
 
     output_tensor = ttnn.max(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -129,4 +164,13 @@ def test_max_dim(device, input_shape_and_dim, keepdim):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_moe.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_moe.py
@@ -8,11 +8,11 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 def run_moe_test(N, C, H, W, k, E, e, dtype, device):
-    # torch.manual_seed(2005)
+    torch.manual_seed(2005)
     shape = [N, C, H, W]
     torch_dtype = torch.bfloat16
 
@@ -45,9 +45,17 @@ def run_moe_test(N, C, H, W, k, E, e, dtype, device):
 
         ttnn_weights_1SB1 = ttnn.to_torch(weights_1SB1)
 
-        pcc_values = 0.95
-
-        assert_with_pcc(torch_weights_1SB1, ttnn_weights_1SB1, pcc_values)
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_weights_1SB1,
+            ttnn_weights_1SB1,
+            pcc_threshold=0.999,
+            rtol=0.046,
+            atol=0.012,
+            frobenius_threshold=0.017,
+            check_ulp=True,
+            ulp_threshold=8,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -729,7 +729,6 @@ def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
     _, out_c, out_h, out_w = torch_output_tensor.shape
     output_tensor = torch.reshape(output_tensor, (batch_size, out_h, out_w, out_c))
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
-    assert_with_pcc(output_tensor, torch_output_tensor)
     assert_numeric_metrics(
         output_tensor,
         torch_output_tensor,
@@ -747,7 +746,6 @@ def run_reduce_sum_h(device, batch_size, h, w, dim):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.mean(input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor)
     assert_numeric_metrics(
         output_tensor,
         torch_output_tensor,

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 import sys
 
-from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import is_blackhole, torch_random
 
 
@@ -340,25 +340,24 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.9999,
-            rtol=1e-6,
-            atol=1e-6,
-            frobenius_threshold=1e-9,
-        )
+        pcc_threshold = 0.9999
+        rtol = 1e-6
+        atol = 1e-6
+        frobenius_threshold = 1e-9
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.996,
-            rtol=0.044,
-            atol=0.016,
-            frobenius_threshold=0.007,
-        )
+        pcc_threshold = 0.996
+        rtol = 0.044
+        atol = 0.016
+        frobenius_threshold = 0.007
+    # test for equivalance
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
 
 
 @pytest.mark.parametrize("dim1", [1])
@@ -467,25 +466,24 @@ def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.9999,
-            rtol=1e-6,
-            atol=1e-6,
-            frobenius_threshold=1e-9,
-        )
+        pcc_threshold = 0.9999
+        rtol = 1e-6
+        atol = 1e-6
+        frobenius_threshold = 1e-9
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.999,
-            rtol=2.933,
-            atol=0.026,
-            frobenius_threshold=0.010,
-        )
+        pcc_threshold = 0.999
+        rtol = 2.933
+        atol = 0.026
+        frobenius_threshold = 0.010
+    # test for equivalance
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
 
 
 # returns larger padded tensor instead of desired shape
@@ -520,11 +518,6 @@ def test_6d_topk(device, dim1, dim2, dim3, dim4, dim5, dim6, dim, k, largest, dt
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
     ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
 
-    if dtype == ttnn.bfloat8_b:
-        pcc_values = 0.99
-    else:
-        pcc_values = 1.0
-
     # pcc is not a good measure for the raw indices
     # if index 49 and index 8 are tied, the order of the indices can be different
     # but the values associated with the indices should be the same
@@ -540,25 +533,24 @@ def test_6d_topk(device, dim1, dim2, dim3, dim4, dim5, dim6, dim, k, largest, dt
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.9999,
-            rtol=1e-6,
-            atol=1e-6,
-            frobenius_threshold=1e-9,
-        )
+        pcc_threshold = 0.9999
+        rtol = 1e-6
+        atol = 1e-6
+        frobenius_threshold = 1e-9
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            pyt_topk_values,
-            ttnn_torch_values,
-            pcc_threshold=0.999,
-            rtol=2.997,
-            atol=0.026,
-            frobenius_threshold=0.011,
-        )
+        pcc_threshold = 0.999
+        rtol = 2.997
+        atol = 0.026
+        frobenius_threshold = 0.011
+    # test for equivalance
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
 
 
 @pytest.mark.parametrize("c", [3])

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -8,7 +8,7 @@ import torch
 import ttnn
 import sys
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 from models.common.utility_functions import is_blackhole, torch_random
 
 
@@ -31,7 +31,15 @@ def test_std(device, batch_size, h, w, dim, correction, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.012,
+        atol=0.012,
+        frobenius_threshold=0.005,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -55,7 +63,15 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
     output_tensor = ttnn.to_torch(output_tensor)
     assert len(torch_output_tensor.shape) == len(output_tensor.shape)
     assert torch_output_tensor.shape == output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.023,
+        atol=0.016,
+        frobenius_threshold=0.007,
+    )
 
 
 # Test a 1D, 2D, 3D, and 4D tensor
@@ -101,7 +117,15 @@ def test_prod(device, input_shape, dim, keepdim, dtype):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.bfloat16)
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.089,
+        atol=0.255,
+        frobenius_threshold=0.071,
+    )
 
 
 @pytest.mark.parametrize("dim_1", [1])
@@ -126,7 +150,15 @@ def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1.650,
+        atol=0.128,
+        frobenius_threshold=0.003,
+    )
 
 
 @pytest.mark.parametrize("dim_1", [1])
@@ -151,7 +183,15 @@ def test_sum_7d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.030,
+        atol=0.032,
+        frobenius_threshold=0.003,
+    )
 
 
 @pytest.mark.parametrize("dim_1", [1])
@@ -175,7 +215,15 @@ def test_sum_6d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.033,
+        atol=0.128,
+        frobenius_threshold=0.007,
+    )
 
 
 @pytest.mark.parametrize("dim_1", [33])
@@ -198,7 +246,15 @@ def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keep
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.805,
+        atol=0.255,
+        frobenius_threshold=0.003,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [32])
@@ -220,7 +276,15 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=8.479,
+        atol=4.080,
+        frobenius_threshold=0.004,
+    )
 
 
 @pytest.mark.parametrize("dim1", [1])
@@ -275,7 +339,26 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     assert (
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
-    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.9999,
+            rtol=1e-6,
+            atol=1e-6,
+            frobenius_threshold=1e-9,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.996,
+            rtol=0.044,
+            atol=0.016,
+            frobenius_threshold=0.007,
+        )
 
 
 @pytest.mark.parametrize("dim1", [1])
@@ -324,7 +407,15 @@ def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     assert (
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
-    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+    # test for equivalance
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
 
 @pytest.mark.parametrize("dim1", [1])
@@ -332,7 +423,6 @@ def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("dim3", [8])
 @pytest.mark.parametrize("dim4", [256])
 @pytest.mark.parametrize("dim5", [64])
-# @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4]) #transpose cannot handle N-D tensor for all dims
 @pytest.mark.parametrize("dim", [3, 4])
 @pytest.mark.parametrize("k", [17, 32, 64])
 @pytest.mark.parametrize("largest", [True])
@@ -376,7 +466,26 @@ def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
     assert (
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
-    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.9999,
+            rtol=1e-6,
+            atol=1e-6,
+            frobenius_threshold=1e-9,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.999,
+            rtol=2.933,
+            atol=0.026,
+            frobenius_threshold=0.010,
+        )
 
 
 # returns larger padded tensor instead of desired shape
@@ -430,7 +539,26 @@ def test_6d_topk(device, dim1, dim2, dim3, dim4, dim5, dim6, dim, k, largest, dt
     assert (
         ttnn_torch_cosine > 0.99
     ), f"Cosine similarity between topk values and gather from indices is {ttnn_torch_cosine} which is less than 0.99"
-    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.9999,
+            rtol=1e-6,
+            atol=1e-6,
+            frobenius_threshold=1e-9,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            pyt_topk_values,
+            ttnn_torch_values,
+            pcc_threshold=0.999,
+            rtol=2.997,
+            atol=0.026,
+            frobenius_threshold=0.011,
+        )
 
 
 @pytest.mark.parametrize("c", [3])
@@ -451,7 +579,15 @@ def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.026,
+        atol=0.255,
+        frobenius_threshold=0.005,
+    )
 
 
 @pytest.mark.parametrize("h", [41])
@@ -471,7 +607,15 @@ def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=0.128,
+        frobenius_threshold=0.005,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [3])
@@ -493,7 +637,15 @@ def test_mean_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=6.599,
+        atol=0.016,
+        frobenius_threshold=0.007,
+    )
 
 
 @pytest.mark.parametrize("c", [3])
@@ -514,7 +666,15 @@ def test_mean_3d_tensor_dims(device, c, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.061,
+        atol=0.001,
+        frobenius_threshold=0.007,
+    )
 
 
 @pytest.mark.parametrize("h", [41])
@@ -534,7 +694,15 @@ def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=0.002,
+        frobenius_threshold=0.006,
+    )
 
 
 def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
@@ -562,6 +730,14 @@ def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
     output_tensor = torch.reshape(output_tensor, (batch_size, out_h, out_w, out_c))
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
     assert_with_pcc(output_tensor, torch_output_tensor)
+    assert_numeric_metrics(
+        output_tensor,
+        torch_output_tensor,
+        pcc_threshold=0.9999,
+        rtol=1e-6,
+        atol=1e-6,
+        frobenius_threshold=1e-9,
+    )
 
 
 def run_reduce_sum_h(device, batch_size, h, w, dim):
@@ -572,6 +748,14 @@ def run_reduce_sum_h(device, batch_size, h, w, dim):
     output_tensor = ttnn.mean(input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_numeric_metrics(
+        output_tensor,
+        torch_output_tensor,
+        pcc_threshold=0.9999,
+        rtol=0.001,
+        atol=0.008,
+        frobenius_threshold=0.003,
+    )
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 4096}], indirect=True)
@@ -648,7 +832,17 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op):
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
 
-    assert_with_pcc(torch_result, ttnn_result, 0.99)
+    outputs_all_finite = torch.isfinite(torch_result).all() and torch.isfinite(ttnn_result).all()
+    if outputs_all_finite and torch_result.numel() > 0:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_result,
+            ttnn_result,
+            pcc_threshold=0.999,
+            rtol=0.004,
+            atol=0.038,
+            frobenius_threshold=0.004,
+        )
 
     atol = rtol = 0.1
     # There is a scale factor difference between torch and ttnn for std and var

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
@@ -10,7 +10,7 @@ import torch
 from functools import partial
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -59,7 +59,15 @@ def test_3D_tensor(device, batch_size, h, w, c, n, dim, input_dtype, input_memor
         output_tensor = ttnn.to_torch(output_tensor).squeeze(dim=dim)
     else:
         output_tensor = ttnn.to_torch(output_tensor).squeeze()
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=8.160,
+        atol=8.0,
+        frobenius_threshold=0.001,
+    )
 
 
 @pytest.mark.parametrize(
@@ -109,7 +117,15 @@ def test_2D_tensor_full_grid(
         output_tensor = ttnn.to_torch(output_tensor).squeeze(dim=dim)
     else:
         output_tensor = ttnn.to_torch(output_tensor).squeeze()
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1.363,
+        atol=8.160,
+        frobenius_threshold=0.009,
+    )
 
 
 @pytest.mark.parametrize(
@@ -155,4 +171,12 @@ def test_2D_tensor(device, batch_size, h, w, c, n, dim, input_dtype, input_memor
         output_tensor = ttnn.to_torch(output_tensor).squeeze(dim=dim)
     else:
         output_tensor = ttnn.to_torch(output_tensor).squeeze()
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1.021,
+        atol=12.240,
+        frobenius_threshold=0.009,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -9,8 +9,8 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
-from models.common.utility_functions import torch_random, comp_allclose
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -29,7 +29,17 @@ def test_mean(device, batch_size, h, w, dim, keepdim):
 
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor)
+
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.118,
+        atol=0.002,
+        frobenius_threshold=0.005,
+        check_ulp=False if dim == -2 else True,
+    )
 
 
 @pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
@@ -41,7 +51,6 @@ def test_mean_scaling(device, shape, dim, keepdim):
     """
     torch_input_tensor = torch.ones(shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
-    torch_output_tensor = torch_output_tensor
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn.fill_implicit_tile_padding(input_tensor, 42)  # garbage padding to test that mean removes it
@@ -49,7 +58,16 @@ def test_mean_scaling(device, shape, dim, keepdim):
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.004,
+        atol=0.004,
+        frobenius_threshold=0.004,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("shape", [(2, 3, 4, 5), (7, 17, 41, 31)])
@@ -66,7 +84,16 @@ def test_mean_scaling_factor(device, shape, dim, scalar):
     output_tensor = ttnn.mean(input_tensor, dim=dim, scalar=scalar)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.9999,
+        rtol=0.004,
+        atol=0.008,
+        frobenius_threshold=0.004,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, "block"])
@@ -98,4 +125,12 @@ def test_mean_shard(device, mem_config, keepdim):
     )
     tt_output_torch = ttnn.to_torch(output_tensor)
     torch_output = torch.mean(torch_input_tensor, -1, keepdim)
-    assert_with_pcc(torch_output, tt_output_torch)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output,
+        tt_output_torch,
+        pcc_threshold=0.999,
+        rtol=0.610,
+        atol=0.002,
+        frobenius_threshold=0.005,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
@@ -32,7 +32,16 @@ def test_min(device, batch_size, h, w, dim, keepdim, dtype):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -51,9 +60,17 @@ def test_min_global(device, batch_size, h, w):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("input_shape, dim, keepdim", [((512, 1024, 1, 2), -1, False), ((64, 512), -1, False)])
@@ -67,4 +84,13 @@ def test_min_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
@@ -63,4 +63,13 @@ def test_reduce_on_batch(shape, shard_shape, dim, interleaved, device):
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=True, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.995)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=8.1,
+        frobenius_threshold=0.002,
+        check_ulp=True,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_program_cache.py
@@ -25,7 +25,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.fixture
@@ -63,11 +63,27 @@ def test_reduce_cache_reuse_same_config(device, isolate_program_cache):
 
     torch.manual_seed(0)
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     torch.manual_seed(42)
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     assert device.num_program_cache_entries() == 1
     assert not torch.equal(tt_out1, tt_out2)
@@ -83,10 +99,26 @@ def test_reduce_cache_miss_different_math_ops(device, isolate_program_cache):
     shape = [1, 1, 64, 64]
 
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.max, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     assert device.num_program_cache_entries() == 2
 
@@ -97,11 +129,27 @@ def test_reduce_cache_miss_different_dims(device, isolate_program_cache):
 
     # dim=-1 (W): ReduceMultiCoreWProgramFactory
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     # dim=-2 (H): ReduceMultiCoreHProgramFactory
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, shape, dim=-2, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     assert device.num_program_cache_entries() == 2
 
@@ -111,11 +159,27 @@ def test_reduce_cache_miss_different_input_dtypes(device, isolate_program_cache)
     shape = [1, 1, 64, 64]
 
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
 
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, shape, dim=-1, dtype=ttnn.float32)
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
-
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.999,
+        rtol=0.007,
+        atol=0.25,
+        frobenius_threshold=0.001,
+        check_ulp=True,
+    )
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.999,
+        rtol=0.004,
+        atol=0.152,
+        frobenius_threshold=0.003,
+    )
     assert device.num_program_cache_entries() == 2
 
 
@@ -126,12 +190,30 @@ def test_reduce_cache_miss_different_memory_configs(device, isolate_program_cach
     torch_ref1, tt_out1 = run_reduce_op(
         device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
 
     torch_ref2, tt_out2 = run_reduce_op(
         device, ttnn.sum, shape, dim=-1, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG
     )
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
     assert device.num_program_cache_entries() == 2
 
@@ -140,11 +222,28 @@ def test_reduce_cache_miss_different_shapes(device, isolate_program_cache):
     """Different padded shapes -> different cache entries.
     padded_shape is included in compute_program_hash() because Ht, Wt are compile-time args."""
     torch_ref1, tt_out1 = run_reduce_op(device, ttnn.sum, [1, 1, 32, 64], dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref1, tt_out1, 0.999)
 
     torch_ref2, tt_out2 = run_reduce_op(device, ttnn.sum, [1, 1, 64, 64], dim=-1, dtype=ttnn.bfloat16)
-    assert_with_pcc(torch_ref2, tt_out2, 0.999)
-
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref1,
+        tt_out1,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref2,
+        tt_out2,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
     assert device.num_program_cache_entries() == 2
 
 
@@ -162,7 +261,23 @@ def test_reduce_cache_miss_sub_core_grids(device, isolate_program_cache):
     tt_out2 = ttnn.sum(tt_a, dim=-1, keepdim=True, sub_core_grids=grid_b)
 
     torch_ref = torch.sum(torch_a, dim=-1, keepdim=True)
-    assert_with_pcc(torch_ref, ttnn.to_torch(tt_out1), 0.999)
-    assert_with_pcc(torch_ref, ttnn.to_torch(tt_out2), 0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref,
+        ttnn.to_torch(tt_out1),
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_ref,
+        ttnn.to_torch(tt_out2),
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
     assert device.num_program_cache_entries() == 2

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.use_module_device
 
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
@@ -53,7 +53,16 @@ def test_mean_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.008,
+        atol=0.004,
+        frobenius_threshold=0.003,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -89,7 +98,17 @@ def test_sum_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.510,
+        atol=8.16,
+        frobenius_threshold=0.003,
+        check_ulp=True,
+        ulp_threshold=65,
+    )
 
 
 @pytest.mark.parametrize(
@@ -117,7 +136,16 @@ def test_sum_global_row_major(device, input_shape):
     output_tensor = ttnn.sum(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -145,7 +173,16 @@ def test_max_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.max(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -175,7 +212,15 @@ def test_min_row_major(device, input_shape, dim, keepdim):
     output_tensor = ttnn.to_torch(output_tensor)
     print(torch.max(torch.abs(output_tensor - torch_output_tensor)))
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
 
 
 @pytest.mark.skip(reason="Skipping std test due to issue #32830")
@@ -203,7 +248,16 @@ def test_std_row_major(device, input_shape, dim):
     output_tensor = ttnn.std(input_tensor, dim=dim, keepdim=False)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.99,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.skip(reason="Skipping var test due to issue #32830")
@@ -231,7 +285,16 @@ def test_var_row_major(device, input_shape, dim):
     output_tensor = ttnn.var(input_tensor, dim=dim, keepdim=False)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.99,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -260,7 +323,16 @@ def test_mean_multi_dim_row_major(device, input_shape, dims, keepdim):
     output_tensor = ttnn.mean(input_tensor, dim=dims, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.98)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.986833,
+        rtol=0.00796975,
+        atol=0.003985375,
+        frobenius_threshold=0.00196106014,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -288,4 +360,12 @@ def test_sum_multi_dim_row_major(device, input_shape, dims, keepdim):
     output_tensor = ttnn.sum(input_tensor, dim=dims, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.761,
+        atol=32.64,
+        frobenius_threshold=0.003,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -177,7 +177,7 @@ def test_max_row_major(device, input_shape, dim, keepdim):
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
-        pcc_threshold=0.9999,
+        pcc_threshold=0.999,
         rtol=1e-06,
         atol=1e-06,
         frobenius_threshold=1e-09,
@@ -327,10 +327,10 @@ def test_mean_multi_dim_row_major(device, input_shape, dims, keepdim):
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
-        pcc_threshold=0.986833,
-        rtol=0.00796975,
-        atol=0.003985375,
-        frobenius_threshold=0.00196106014,
+        pcc_threshold=0.98,
+        rtol=0.008,
+        atol=0.004,
+        frobenius_threshold=0.002,
         check_ulp=True,
     )
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -61,35 +61,29 @@ def test_sum_global(device, batch_size, h, w, dtype):
     output_tensor = ttnn.to_torch(output_tensor)
 
     if dtype == ttnn.float32:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.012,
-            atol=32.640,
-            frobenius_threshold=0.02,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.012
+        atol = 32.640
+        frobenius_threshold = 0.02
     elif dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.009,
-            atol=65.280,
-            frobenius_threshold=0.009,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.009
+        atol = 65.280
+        frobenius_threshold = 0.009
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.062,
-            atol=228.480,
-            frobenius_threshold=0.062,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.062
+        atol = 228.480
+        frobenius_threshold = 0.062
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
 
 
 @pytest.mark.parametrize("n", [1, 9])
@@ -188,22 +182,21 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
     output_tensor = ttnn.to_torch(output_tensor)
 
     if dtype == ttnn.bfloat16:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=1e-06,
-            atol=1e-06,
-            frobenius_threshold=1e-09,
-        )
+        pcc_threshold = 0.999
+        rtol = 1e-06
+        atol = 1e-06
+        frobenius_threshold = 1e-09
     else:
-        # test for equivalance
-        assert_numeric_metrics(
-            torch_output_tensor,
-            output_tensor,
-            pcc_threshold=0.999,
-            rtol=0.015,
-            atol=4177.920,
-            frobenius_threshold=0.015,
-        )
+        pcc_threshold = 0.999
+        rtol = 0.015
+        atol = 4177.920
+        frobenius_threshold = 0.015
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
@@ -31,7 +31,15 @@ def test_sum(device, batch_size, h, w, dim, keepdim):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=2.471,
+        atol=65.280,
+        frobenius_threshold=0.007,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -51,9 +59,37 @@ def test_sum_global(device, batch_size, h, w, dtype):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    if dtype == ttnn.float32:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.012,
+            atol=32.640,
+            frobenius_threshold=0.02,
+        )
+    elif dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.009,
+            atol=65.280,
+            frobenius_threshold=0.009,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.062,
+            atol=228.480,
+            frobenius_threshold=0.062,
+        )
 
 
 @pytest.mark.parametrize("n", [1, 9])
@@ -71,7 +107,15 @@ def test_sum_4d(device, n, c, h, w, dim):
 
     output_tensor = ttnn.sum(input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.005,
+        atol=472.500,
+        frobenius_threshold=0.005,
+    )
 
 
 @pytest.mark.parametrize(
@@ -101,7 +145,15 @@ def test_sum_nd_shard(device, shapes, keepdim):
     )
     op_output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(op_output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+    # test for equivalance
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.001,
+        atol=0.194,
+        frobenius_threshold=0.001,
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,4 +187,23 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    if dtype == ttnn.bfloat16:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=1e-06,
+            atol=1e-06,
+            frobenius_threshold=1e-09,
+        )
+    else:
+        # test for equivalance
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            pcc_threshold=0.999,
+            rtol=0.015,
+            atol=4177.920,
+            frobenius_threshold=0.015,
+        )

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.use_module_device
 
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_allclose, assert_equal, assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_equal, assert_numeric_metrics
 
 UINT16_MAX = 65535
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.use_module_device
 
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_allclose, assert_equal
+from tests.ttnn.utils_for_testing import assert_allclose, assert_equal, assert_numeric_metrics
 
 UINT16_MAX = 65535
 
@@ -59,6 +59,15 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     assert list(ttnn_topk_values.shape) == desired_shape
     assert list(ttnn_topk_indices.shape) == desired_shape
 
+    # test for equivalance
+    assert_numeric_metrics(
+        pyt_topk_values,
+        ttnn_torch_values,
+        pcc_threshold=0.9999,
+        rtol=1e-06,
+        atol=1e-06,
+        frobenius_threshold=1e-09,
+    )
     assert_equal(ttnn_torch_values, pyt_topk_values)
 
     # Assert indices correctness using gather

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -299,6 +299,14 @@ def comp_relative_frobenius(expected_pytorch_result, actual_pytorch_result):
         actual_pytorch_result.shape
     ), f"Shape mismatch: expected {list(expected_pytorch_result.shape)} vs actual {list(actual_pytorch_result.shape)}"
 
+    def _to_float_for_norm(t: torch.Tensor) -> torch.Tensor:
+        if torch.is_floating_point(t) or torch.is_complex(t):
+            return t
+        return t.to(torch.float64)
+
+    expected_pytorch_result = _to_float_for_norm(expected_pytorch_result)
+    actual_pytorch_result = _to_float_for_norm(actual_pytorch_result)
+
     error = expected_pytorch_result - actual_pytorch_result
     frob_error = torch.norm(error, p="fro")
     frob_expected = torch.norm(expected_pytorch_result, p="fro")
@@ -519,3 +527,69 @@ def flush_subnormal_values_to_zero(tensor):
     mask = torch.abs(tensor) < SUBNORMAL_THRESHOLD
     tensor[mask] = 0.0
     return tensor
+
+
+def assert_numeric_metrics(
+    expected_result,
+    actual_result,
+    rtol=1e-05,
+    atol=1e-08,
+    frobenius_threshold=0.01,
+    pcc_threshold=0.999,
+    ulp_threshold=10,
+    check_allclose=True,
+    check_frobenius=True,
+    check_pcc=True,
+    check_ulp=False,
+):
+    """
+    Run one or more numeric similarity checks between a golden tensor and an actual tensor.
+
+    Intended for TTNN tests that compare PyTorch reference output against device or CPU
+    round-trip results. Individual checks can be disabled when a metric does not apply
+    (for example, skip Frobenius for degenerate or non-finite cases).
+
+    Args:
+        expected_result (Union[ttnn.Tensor, torch.Tensor]): Reference (golden) tensor.
+        actual_result (Union[ttnn.Tensor, torch.Tensor]): Tensor under test; cast to ``expected_result.dtype`` if dtypes differ.
+        rtol (float, optional): Relative tolerance for ``assert_allclose``. Defaults to 1e-05.
+        atol (float, optional): Absolute tolerance for ``assert_allclose``. Defaults to 1e-08.
+        frobenius_threshold (float, optional): Maximum allowed relative Frobenius error for
+            ``assert_relative_frobenius``. Defaults to 0.01.
+        pcc_threshold (float, optional): Minimum Pearson correlation for ``comp_pcc``. Defaults to 0.999.
+        ulp_threshold (float, optional): Maximum ULP distance for ``assert_with_ulp``. Defaults to 10.
+        check_allclose (bool, optional): If True, run element-wise allclose. Defaults to True.
+        check_frobenius (bool, optional): If True, run relative Frobenius check. Defaults to True.
+        check_pcc (bool, optional): If True, run PCC when the tensor has more than one element. Defaults to True.
+        check_ulp (bool, optional): If True, run ULP comparison (non-finite mismatches fail). Defaults to False.
+
+    Returns:
+        None
+
+    Raises:
+        AssertionError: If any enabled check fails (shape mismatch, tolerance exceeded, or PCC/ULP below threshold).
+
+    Notes:
+        - PCC is skipped when ``torch.numel(expected_result) == 1`` because correlation is undefined for a scalar.
+        - Allclose and Frobenius use helpers that normalize ``ttnn.Tensor`` inputs to PyTorch tensors.
+    """
+    # Align dtypes first so all downstream numeric checks compare values in the same precision.
+    if expected_result.dtype != actual_result.dtype:
+        actual_result = actual_result.type(expected_result.dtype)
+
+    # Element-wise tolerance check (absolute + relative).
+    if check_allclose:
+        assert_allclose(expected_result, actual_result, rtol=rtol, atol=atol)
+
+    # Global error-magnitude check using relative Frobenius norm.
+    if check_frobenius:
+        assert_relative_frobenius(expected_result, actual_result, threshold=frobenius_threshold)
+
+    # PCC is undefined/degenerate for scalars, so only run it for tensors with more than one element.
+    if check_pcc and torch.numel(expected_result) != 1:
+        passing_pcc, pcc_message = comp_pcc(expected_result, actual_result, pcc_threshold)
+        assert passing_pcc, pcc_message
+
+    # ULP-based comparison is stricter for floating-point representation differences.
+    if check_ulp:
+        assert_with_ulp(expected_result, actual_result, ulp_threshold=ulp_threshold, allow_nonfinite=False)

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -78,6 +78,13 @@ def _normalize_tensor(tensor):
     return tensor
 
 
+# since torch.norm(error, p="fro"), rejects non-float input
+def _to_float_for_norm(t: torch.Tensor) -> torch.Tensor:
+    if t.dtype in (torch.float32, torch.bfloat16):
+        return t
+    return t.to(torch.float32)
+
+
 def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
     """
     Assert that two PyTorch tensors are similar within a specified Pearson Correlation Coefficient (PCC) threshold.
@@ -298,11 +305,6 @@ def comp_relative_frobenius(expected_pytorch_result, actual_pytorch_result):
     assert list(expected_pytorch_result.shape) == list(
         actual_pytorch_result.shape
     ), f"Shape mismatch: expected {list(expected_pytorch_result.shape)} vs actual {list(actual_pytorch_result.shape)}"
-
-    def _to_float_for_norm(t: torch.Tensor) -> torch.Tensor:
-        if torch.is_floating_point(t) or torch.is_complex(t):
-            return t
-        return t.to(torch.float64)
 
     expected_pytorch_result = _to_float_for_norm(expected_pytorch_result)
     actual_pytorch_result = _to_float_for_norm(actual_pytorch_result)


### PR DESCRIPTION
### Ticket
Link to Github Issue : #38788

### Problem description
The existing implementation lacked robust numerical validation when comparing outputs (golden vs calculated outputs).

The validation relied heavily on metrics like Pearson Correlation Coefficient (PCC), which are not always a reliable representation of numerical accuracy. High PCC scores can still occur even when there are significant element-wise differences or absolute errors between tensors.

This can lead to incorrect validation outcomes, where inaccurate results pass checks or valid results fail due to insufficient or misleading metrics.

### What's changed
Added numeric validation checks (all_close, PCC, Frobenius norm, and ULP) to increase robustness and reliability

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/reduce_numeric_check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/reduce_numeric_check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/reduce_numeric_check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/reduce_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/reduce_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/reduce_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/reduce_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
