### PR TITLE
Fix error in ttnn.expand padding input processing

### DIFF
--- a/models/demos/qwen3_vl/tt/common.py
+++ b/models/demos/qwen3_vl/tt/common.py
@@ -197,8 +197,11 @@ def preprocess_inputs_prefill_ttnn(
         prefill_seq_len = min(max_prefill_len, max(2 ** math.ceil(math.log(input_embed.shape[0], 2)), 128))
 
         # Initialize prefill tensors full of pad tokens
-        input_padding = ttnn.expand(pad_embedding, (prefill_seq_len - actual_prompt_len, -1))
-        input_prefill_i = ttnn.concat([input_embed[:actual_prompt_len, :], input_padding], dim=0)
+        if prefill_seq_len - actual_prompt_len > 0:
+            input_padding = ttnn.expand(pad_embedding, (prefill_seq_len - actual_prompt_len, -1))
+            input_prefill_i = ttnn.concat([input_embed[:actual_prompt_len, :], input_padding], dim=0)
+        else:
+            input_prefill_i = input_embed[:actual_prompt_len, :]
         input_prefill.append(input_prefill_i)
         deepstack_visual_embeds_i = (
             [

--- a/models/demos/qwen3_vl/tt/common.py
+++ b/models/demos/qwen3_vl/tt/common.py
@@ -196,8 +196,9 @@ def preprocess_inputs_prefill_ttnn(
         # Prefill size is nearest power of 2 - FIXME: *really*? power of 2? surely we only need it to be a multiple of 1024 or whatever?
         prefill_seq_len = min(max_prefill_len, max(2 ** math.ceil(math.log(input_embed.shape[0], 2)), 128))
 
-        # Initialize prefill tensors full of pad tokens
+        # check if padding is required and if not just skip it
         if prefill_seq_len - actual_prompt_len > 0:
+            # Initialize prefill tensors full of pad tokens
             input_padding = ttnn.expand(pad_embedding, (prefill_seq_len - actual_prompt_len, -1))
             input_prefill_i = ttnn.concat([input_embed[:actual_prompt_len, :], input_padding], dim=0)
         else:


### PR DESCRIPTION
### Ticket
#40537 

### Problem description
`ttnn.expand` fails for cases where no padding is required.

### What's changed
Added a check for if padding is needed otherwise skip it

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssanjay/qwen3-vl-expand-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssanjay/qwen3-vl-expand-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
