### PR TITLE
[DS Blaze] Fix LM head sampling

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -57,6 +57,14 @@ struct Core {
         get_named_compile_time_arg_val("is_argmax_mesh_sender_core") == 1;
     static constexpr bool is_rmsnorm_core = get_named_compile_time_arg_val("is_rmsnorm_core") == 1;
     static constexpr bool persistent_mode = get_named_compile_time_arg_val("persistent_mode") == 1;
+    static constexpr uint32_t fabric_gate_bcast_turn_semaphore_id =
+        get_named_compile_time_arg_val("fabric_gate_bcast_turn_semaphore_id");
+    static constexpr uint32_t fabric_gate_argmax_turn_semaphore_id =
+        get_named_compile_time_arg_val("fabric_gate_argmax_turn_semaphore_id");
+    static constexpr uint32_t fabric_gate_bcast_noc_x = get_named_compile_time_arg_val("fabric_gate_bcast_noc_x");
+    static constexpr uint32_t fabric_gate_bcast_noc_y = get_named_compile_time_arg_val("fabric_gate_bcast_noc_y");
+    static constexpr uint32_t fabric_gate_argmax_noc_x = get_named_compile_time_arg_val("fabric_gate_argmax_noc_x");
+    static constexpr uint32_t fabric_gate_argmax_noc_y = get_named_compile_time_arg_val("fabric_gate_argmax_noc_y");
     static constexpr uint32_t mesh_row = get_named_compile_time_arg_val("mesh_row");
     static constexpr uint32_t mesh_col = get_named_compile_time_arg_val("mesh_col");
     static_assert(input_socket_mode != 1, "lm_head_sampling input socket mode=1 is invalid");
@@ -322,13 +330,22 @@ void kernel_main() {
         // Phase 0: broadcast_rms-style combined path.
         // ====================================================================
 #if defined(COMPILE_FOR_BRISC) && !defined(SKIP_CCL)
-        // Persistent-mode sender/input core waits for host signal before each iteration.
         constexpr bool is_root = get_named_compile_time_arg_val("bcast_is_root") == 1;
         if constexpr (Core::persistent_mode && is_root && Core::is_input_core) {
             auto next_iteration_semaphore =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(persistent_next_iter_global_sem_addr);
             noc_semaphore_wait(next_iteration_semaphore, 1);
             noc_semaphore_set(next_iteration_semaphore, 0);
+        }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC)
+        // Device-local fabric gate (pre-bcast acquire).
+        if constexpr (Core::is_input_core && !Core::skip_ccl) {
+            auto* bcast_turn_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_semaphore(Core::fabric_gate_bcast_turn_semaphore_id));
+            noc_semaphore_wait(bcast_turn_sem, 1);
+            noc_semaphore_set(bcast_turn_sem, 0);
         }
 #endif
 
@@ -341,6 +358,18 @@ void kernel_main() {
                 DeviceZoneScopedN("CCL_BROADCAST");
                 bcast(bcast_args);
             }
+        }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC)
+        // Device-local fabric gate (post-bcast release to argmax side).
+        if constexpr (Core::is_input_core && !Core::skip_ccl) {
+            auto argmax_turn_sem_noc_addr = get_noc_addr(
+                Core::fabric_gate_argmax_noc_x,
+                Core::fabric_gate_argmax_noc_y,
+                get_semaphore(Core::fabric_gate_argmax_turn_semaphore_id));
+            noc_semaphore_inc(argmax_turn_sem_noc_addr, 1);
+            noc_async_atomic_barrier();
         }
 #endif
 
@@ -369,10 +398,32 @@ void kernel_main() {
             matmul(matmul_args);
         }
 
+#if defined(COMPILE_FOR_BRISC)
+        // Device-local fabric gate (pre-sampling acquire on argmax final core).
+        if constexpr (Core::is_argmax_final_core && !Core::skip_ccl) {
+            auto* argmax_turn_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                get_semaphore(Core::fabric_gate_argmax_turn_semaphore_id));
+            noc_semaphore_wait(argmax_turn_sem, 1);
+            noc_semaphore_set(argmax_turn_sem, 0);
+        }
+#endif
+
         {
             DeviceZoneScopedN("ARGMAX");
             sampling_op(sampling_args);
         }
+
+#if defined(COMPILE_FOR_BRISC)
+        // Device-local fabric gate (post-sampling release back to bcast side).
+        if constexpr (Core::is_argmax_final_core && !Core::skip_ccl) {
+            auto bcast_turn_sem_noc_addr = get_noc_addr(
+                Core::fabric_gate_bcast_noc_x,
+                Core::fabric_gate_bcast_noc_y,
+                get_semaphore(Core::fabric_gate_bcast_turn_semaphore_id));
+            noc_semaphore_inc(bcast_turn_sem_noc_addr, 1);
+            noc_async_atomic_barrier();
+        }
+#endif
 
         if constexpr (!Core::persistent_mode) {
             break;

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
@@ -330,6 +330,8 @@ class LMHeadSampling:
         mcast_data_receiver_semaphore_id = 1
         argmax_receiver_semaphore_id = 2
         argmax_local_ready_semaphore_id = 3
+        fabric_gate_bcast_turn_semaphore_id = 4
+        fabric_gate_argmax_turn_semaphore_id = 5
         bcast_config = DeepseekMinimalBroadcast.configure(
             mesh_device=mesh_device,
             input_tensor_mesh=input_tensor_mesh,
@@ -365,6 +367,7 @@ class LMHeadSampling:
 
                 # Broadcast worker core from config (root/non-root consistent).
                 worker_core = bcast_config.get_worker_core(coord)
+                bcast_worker_core_phys = device.worker_core_from_logical_core(worker_core)
 
                 # ================================================================
                 # Core grid configuration (per-device)
@@ -558,6 +561,7 @@ class LMHeadSampling:
                             )
 
                     argmax_socket_mode = socket_mode_selected if emit_socket_on_this_device else socket_mode_none
+                    final_core_phys = device.worker_core_from_logical_core(argmax_final_core)
 
                 # Determine if sender is part of the mcast rectangle
                 is_part_of_receiver_grid = mcast_grid.contains(mcast_sender_core)
@@ -624,6 +628,12 @@ class LMHeadSampling:
                     ("argmax_socket_cb", argmax_socket_cb if enable_socket_output else 0),
                     ("argmax_socket_page_size_bytes", socket_page_size_bytes if enable_socket_output else 0),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
+                    ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
+                    ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),
+                    ("fabric_gate_bcast_noc_y", int(bcast_worker_core_phys.y)),
+                    ("fabric_gate_argmax_noc_x", int(final_core_phys.x)),
+                    ("fabric_gate_argmax_noc_y", int(final_core_phys.y)),
                     ("mesh_row", row),
                     ("mesh_col", col),
                 ]
@@ -657,6 +667,12 @@ class LMHeadSampling:
                     ("argmax_socket_cb", argmax_socket_cb if enable_socket_output else 0),
                     ("argmax_socket_page_size_bytes", socket_page_size_bytes if enable_socket_output else 0),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
+                    ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
+                    ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),
+                    ("fabric_gate_bcast_noc_y", int(bcast_worker_core_phys.y)),
+                    ("fabric_gate_argmax_noc_x", int(final_core_phys.x)),
+                    ("fabric_gate_argmax_noc_y", int(final_core_phys.y)),
                     ("mesh_row", row),
                     ("mesh_col", col),
                 ]
@@ -681,6 +697,12 @@ class LMHeadSampling:
                     ("matmul_k_num_tiles", num_tiles_k),
                     ("matmul_out_w", out_w_per_core),
                     ("persistent_mode", 1 if persistent_mode else 0),
+                    ("fabric_gate_bcast_turn_semaphore_id", fabric_gate_bcast_turn_semaphore_id),
+                    ("fabric_gate_argmax_turn_semaphore_id", fabric_gate_argmax_turn_semaphore_id),
+                    ("fabric_gate_bcast_noc_x", int(bcast_worker_core_phys.x)),
+                    ("fabric_gate_bcast_noc_y", int(bcast_worker_core_phys.y)),
+                    ("fabric_gate_argmax_noc_x", int(final_core_phys.x)),
+                    ("fabric_gate_argmax_noc_y", int(final_core_phys.y)),
                     ("mesh_row", row),
                     ("mesh_col", col),
                 ]
@@ -688,7 +710,6 @@ class LMHeadSampling:
                 # ================================================================
                 # CCL Broadcast common runtime args
                 # ================================================================
-                final_core_phys = device.worker_core_from_logical_core(argmax_final_core)
                 argmax_scratch_addr = (
                     int(scratch_tensors_per_device[device_idx].buffer_address()) if not skip_ccl else 0
                 )
@@ -858,6 +879,16 @@ class LMHeadSampling:
                             ttnn.SemaphoreDescriptor(
                                 id=argmax_local_ready_semaphore_id,
                                 core_ranges=argmax_core_grid,
+                                initial_value=0,
+                            ),
+                            ttnn.SemaphoreDescriptor(
+                                id=fabric_gate_bcast_turn_semaphore_id,
+                                core_ranges=ttnn.CoreRangeSet([ttnn.CoreRange(worker_core, worker_core)]),
+                                initial_value=1,
+                            ),
+                            ttnn.SemaphoreDescriptor(
+                                id=fabric_gate_argmax_turn_semaphore_id,
+                                core_ranges=ttnn.CoreRangeSet([ttnn.CoreRange(argmax_final_core, argmax_final_core)]),
                                 initial_value=0,
                             ),
                         ]


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/40837

### Problem description
Race b/w argmax and bcast core in connecting to fabric router

### What's changed
Added a two-way fabric sync sem to serialize fabric connections on a device

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aagarwal/lm-head-op-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/lm-head-op-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/lm-head-op-fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/lm-head-op-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/lm-head-op-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/lm-head-op-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/lm-head-op-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
