### PR TITLE
[Blaze DS] Optimize prefill-by-decode to fully utilize pipeline stages

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -89,6 +89,7 @@ class ModelPipeline:
                 write_fn=self.pipeline.write_token,
                 read_fn=self.pipeline.read_output,
                 batch_size=1,
+                pipeline_depth=config.num_stages,
             )
         logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
 

--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -28,7 +28,8 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
 
 # Global constants used by multiple stage kinds (and exported to pipeline/cli)
 TOKEN_PAGE_SIZE_BYTES = 64
-TOKEN_FIFO_SIZE = 1024
+TOKEN_FIFO_NUM_PAGES = 64
+TOKEN_FIFO_SIZE = TOKEN_PAGE_SIZE_BYTES * TOKEN_FIFO_NUM_PAGES
 ACTIVATION_DIM = 7168
 ACTIVATION_PAGE_SIZE_BYTES = ACTIVATION_DIM * 2
 ACTIVATION_FIFO_SIZE = ACTIVATION_PAGE_SIZE_BYTES * 1

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -11,11 +11,10 @@ read_fn(output_tensor); e.g. Pipeline.write_token / Pipeline.read_output.
 
 Algorithm (prefill-by-decode then generation):
   - Prefill: for i = 0..S-1, call with input_ids = x[i] (B, 1); device uses/updates
-    cache; ignore logits for i < S-1. prefill() returns the last step output (logits
-    in real decoder) so caller can sample y0.
-  - Start generation: last_logits = prefill(prompt_tokens); y0 = sample(last_logits).
-  - Generation loop: for t = 0,1,..., feed y[t] (B, 1) via decode_step(), get logits,
-    sample y[t+1], repeat.
+    cache; ignore outputs for i < S-1. prefill() returns the last output token.
+  - Start generation: y0 = prefill(prompt_tokens).
+  - Generation loop: for t = 0,1,..., feed y[t] (B, 1) via decode_step(), get y[t+1],
+    repeat.
 
 Input tensor shape (H2D):
   - Only (B, 1) is supported: one token per batch element per step. The embedding layer
@@ -84,6 +83,7 @@ class DeepSeekV3:
         write_fn: Callable[[ttnn.Tensor], None],
         read_fn: Callable[[ttnn.Tensor], None],
         batch_size: int = 1,
+        pipeline_depth: int = 1,
     ) -> None:
         """
         Args:
@@ -91,12 +91,18 @@ class DeepSeekV3:
             read_fn: Called with an output tensor; implementation fills it (e.g. Pipeline.read_output).
             batch_size: Batch size B. Current implementation supports only B=1;
                 payload size is B * TOKEN_ID_BYTES (int32).
+            pipeline_depth: Number of pipeline stages between host write and readable
+                output. Prefill queues this many tokens before overlapping writes with
+                readback. Use 1 for direct loopback/no pipeline.
         """
         if batch_size != 1:
             raise ValueError(f"DeepSeekV3 currently supports only batch_size=1, got {batch_size}")
+        if pipeline_depth <= 0:
+            raise ValueError(f"pipeline_depth must be > 0, got {pipeline_depth}")
         self._write_fn = write_fn
         self._read_fn = read_fn
         self.batch_size = batch_size
+        self._pipeline_depth = pipeline_depth
         payload_bytes: int = batch_size * TOKEN_ID_BYTES
         logger.debug(f"Payload bytes: {payload_bytes} bytes")
         self._tensor_size_bytes: int = align_up(payload_bytes, PCIE_PAGE_ALIGNMENT_BYTES)
@@ -107,9 +113,9 @@ class DeepSeekV3:
 
     def prefill(self, prompt_tokens: list[ttnn.Tensor]) -> ttnn.Tensor:
         """
-        Prefill-by-decode: for i = 0..S-1, send input_ids = x[i], get logits
-        (and device updates cache). Outputs for i < S-1 are discarded. Returns the
-        last step output so the caller can sample y0 (first generated token).
+        Prefill-by-decode with overlapped I/O: enqueue tokens until the pipeline is
+        saturated, then overlap one readback per additional write, and finally drain
+        the remaining in-flight outputs. Returns the last output token.
 
         Args:
             prompt_tokens: List of ttnn.Tensor, each already padded for the socket
@@ -117,19 +123,26 @@ class DeepSeekV3:
                 Caller is responsible for padding; use to_padded_input() if needed.
 
         Returns:
-            Last step output tensor; valid data is first batch_size elements (logits
-            (B, V) in real decoder). None if prompt_tokens is empty. Caller uses this
-            to sample(logits) -> y0 for the generation loop.
+            Last step output tensor; valid data is first batch_size elements.
         """
         if len(prompt_tokens) == 0:
             raise ValueError("Expected at least one prompt token")
 
         last_output: ttnn.Tensor | None = None
-        for token in prompt_tokens:
-            self._write_fn(token)
-            self._read_fn(self._output_buffer)
-            last_output = self._output_buffer
-            self._position += 1
+        num_writes_before_readback = min(self._pipeline_depth, len(prompt_tokens))
+        # Schedules exactly len(prompt_tokens) writes and len(prompt_tokens) reads.
+        total_iterations = len(prompt_tokens) + num_writes_before_readback - 1
+
+        for i in range(total_iterations):
+            if i < len(prompt_tokens):
+                self._write_fn(prompt_tokens[i])
+
+            # Start draining once the pipeline is full or all prompt tokens have been written.
+            if i >= num_writes_before_readback - 1:
+                self._read_fn(self._output_buffer)
+                last_output = self._output_buffer
+                self._position += 1
+
         assert last_output is not None, "Last output tensor is None"
         return last_output
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
@@ -18,6 +18,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
+from models.demos.deepseek_v3_b1.model import DeepSeekV3
 
 
 @pytest.mark.parametrize("batch_size", [1])
@@ -61,3 +62,38 @@ def test_prefill_and_decode(
         ), f"Position after decode: expected {prompt_length + num_decode_steps}, got {model.position}"
 
     logger.info("Prefill and decode test passed")
+
+
+def create_event_logging_model(*, pipeline_depth: int) -> tuple[DeepSeekV3, list[str]]:
+    event_log: list[str] = []
+
+    def write_fn(token: object) -> None:
+        del token
+        event_log.append("write")
+
+    def read_fn(output_tensor: ttnn.Tensor) -> None:
+        del output_tensor
+        event_log.append("read")
+
+    model = DeepSeekV3(write_fn=write_fn, read_fn=read_fn, batch_size=1, pipeline_depth=pipeline_depth)
+    return model, event_log
+
+
+def test_prefill_starts_readback_once_pipeline_is_saturated() -> None:
+    model, event_log = create_event_logging_model(pipeline_depth=4)
+
+    _ = model.prefill([object() for _ in range(6)])
+
+    assert event_log[:5] == ["write", "write", "write", "write", "read"]
+    assert event_log.count("write") == 6
+    assert event_log.count("read") == 6
+    assert model.position == 6
+
+
+def test_prefill_drains_tail_when_prompt_shorter_than_pipeline_depth() -> None:
+    model, event_log = create_event_logging_model(pipeline_depth=8)
+
+    _ = model.prefill([object() for _ in range(3)])
+
+    assert event_log == ["write", "write", "write", "read", "read", "read"]
+    assert model.position == 3


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-blaze/issues/152

### Problem description
- Currently blaze-ds-b1 prefill is done by iterating over prompt-tokens and doing write + read for each, which underutilizes the pipeline by a factor of num stages.

### What's changed
- Now for prefill, enqueue tokens until the pipeline is saturated (or sent all prompt tokens), then issue one readback per additional write, and finally drain the remaining in-flight outputs.
- Increase token FIFO capacity to 64 pages (4096 bytes).
- Add unit tests covering prefill readback timing once the pipeline is saturated and tail draining when the prompt is shorter than the pipeline depth (`python -m pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py -k "prefill_starts_readback or prefill_drains_tail"`).
