### PR TITLE
fix wo output projection sharding for MHA models on N300

### DIFF
--- a/models/tt_transformers/tests/test_mha_wo_sharding.py
+++ b/models/tt_transformers/tests/test_mha_wo_sharding.py
@@ -55,9 +55,7 @@ def test_mha_wo_sharding(mesh_device):
     )
 
     expected_sharded_dim = (n_heads * head_dim) // num_devices
-    assert wo.shape[-2] == expected_sharded_dim, (
-        f"wo dim 2 should be {expected_sharded_dim}, got {wo.shape[-2]}"
-    )
+    assert wo.shape[-2] == expected_sharded_dim, f"wo dim 2 should be {expected_sharded_dim}, got {wo.shape[-2]}"
 
     attn_output = ttnn.as_tensor(
         torch.randn(1, 1, seq_len, qkv_inner),

--- a/models/tt_transformers/tests/test_mha_wo_sharding.py
+++ b/models/tt_transformers/tests/test_mha_wo_sharding.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify that the wo output projection weight is correctly sharded for MHA
+models (n_heads == n_kv_heads) on multi-device meshes.
+
+Regression test for: ShardTensor2dMesh producing incorrect weight shapes
+when n_heads == n_kv_heads on N300 (1x2 mesh).
+"""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
+def test_mha_wo_sharding(mesh_device):
+    """On a multi-device mesh, wo sharded via ShardTensorToMesh(dim=2) must
+    produce per-device shape [1, 1, n_heads*head_dim // num_devices, dim]
+    and the subsequent ttnn.linear must not crash."""
+
+    num_devices = mesh_device.get_num_devices()
+    if num_devices < 2:
+        pytest.skip("MHA sharding test requires >= 2 devices")
+
+    n_heads = 16
+    head_dim = 128
+    dim = 2048
+    seq_len = 128
+    n_local_heads = n_heads // num_devices
+    qkv_inner = n_local_heads * head_dim
+
+    pt_wo = torch.randn(1, 1, n_heads * head_dim, dim)
+    wo = ttnn.as_tensor(
+        pt_wo,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=2),
+    )
+
+    expected_sharded_dim = (n_heads * head_dim) // num_devices
+    assert wo.shape[-2] == expected_sharded_dim, (
+        f"wo dim 2 should be {expected_sharded_dim}, got {wo.shape[-2]}"
+    )
+
+    attn_output = ttnn.as_tensor(
+        torch.randn(1, 1, seq_len, qkv_inner),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    output = ttnn.linear(
+        attn_output,
+        wo,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    assert output.shape[-1] == dim, f"output width should be {dim}, got {output.shape[-1]}"
+    assert output.shape[-2] == seq_len, f"output seq_len should be {seq_len}, got {output.shape[-2]}"
+
+    ttnn.deallocate(wo)
+    ttnn.deallocate(attn_output)
+    ttnn.deallocate(output)

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -360,7 +360,7 @@ class Attention(LightweightModule):
             memory_config=get_wo_memory_config(),
             mesh_mapper=get_wo_mesh_mapper(),
             cache_file_name=(
-                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo_dim2_sharded")
+                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo")
             ),
         )
         if not use_paged_kv_cache:

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -325,7 +325,6 @@ class Attention(LightweightModule):
             (configuration.n_heads * configuration.head_dim) // configuration.num_devices, configuration.dim
         )
 
-        self.shard_wo_dims = (2, 3) if (self.use_fused_all_gather_matmul or self.TG) else (3, 2)
 
         def get_wo_mesh_mapper():
             if self.use_fused_all_gather_matmul or self.TG:
@@ -361,9 +360,7 @@ class Attention(LightweightModule):
             memory_config=get_wo_memory_config(),
             mesh_mapper=get_wo_mesh_mapper(),
             cache_file_name=(
-                cache_name("wo_width_sharded_2d")
-                if (self.use_fused_all_gather_matmul or self.TG)
-                else cache_name("wo_dim2_sharded")
+                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo_dim2_sharded")
             ),
         )
         if not use_paged_kv_cache:

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -361,7 +361,9 @@ class Attention(LightweightModule):
             memory_config=get_wo_memory_config(),
             mesh_mapper=get_wo_mesh_mapper(),
             cache_file_name=(
-                cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo")
+                cache_name("wo_width_sharded_2d")
+                if (self.use_fused_all_gather_matmul or self.TG)
+                else cache_name("wo_dim2_sharded")
             ),
         )
         if not use_paged_kv_cache:

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -327,6 +327,15 @@ class Attention(LightweightModule):
 
         self.shard_wo_dims = (2, 3) if (self.use_fused_all_gather_matmul or self.TG) else (3, 2)
 
+        def get_wo_mesh_mapper():
+            if self.use_fused_all_gather_matmul or self.TG:
+                return ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=(2, 3),
+                    mesh_shape=configuration.cluster_shape,
+                )
+            return ttnn.ShardTensorToMesh(self.mesh_device, dim=2)
+
         if self.prefetcher is not None:
             self.wo_sharded_ring = ttnn.as_tensor(
                 pt_wo,
@@ -334,11 +343,7 @@ class Attention(LightweightModule):
                 layout=ttnn.TILE_LAYOUT,
                 device=self.mesh_device,
                 memory_config=self.args.get_sharded_wo_ring_mem_config(),
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device,
-                    dims=self.shard_wo_dims,
-                    mesh_shape=configuration.cluster_shape,
-                ),
+                mesh_mapper=get_wo_mesh_mapper(),
                 cache_file_name=(cache_name("wo_sharded_ring")),
             )
 
@@ -354,11 +359,7 @@ class Attention(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
             device=self.mesh_device,
             memory_config=get_wo_memory_config(),
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device,
-                dims=self.shard_wo_dims,
-                mesh_shape=configuration.cluster_shape,
-            ),
+            mesh_mapper=get_wo_mesh_mapper(),
             cache_file_name=(
                 cache_name("wo_width_sharded_2d") if (self.use_fused_all_gather_matmul or self.TG) else cache_name("wo")
             ),

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -325,7 +325,6 @@ class Attention(LightweightModule):
             (configuration.n_heads * configuration.head_dim) // configuration.num_devices, configuration.dim
         )
 
-
         def get_wo_mesh_mapper():
             if self.use_fused_all_gather_matmul or self.TG:
                 return ttnn.ShardTensor2dMesh(


### PR DESCRIPTION
# **TL:DR**

Running an MHA model (`n_heads == n_kv_heads`) on N300 via vLLM crashes at the `wo` matmul in `attention.forward_prefill`:

```
TT_FATAL: width=1024 height=2048
```

The `wo` output projection weight loaded via `ShardTensor2dMesh(dims=(3,2), mesh_shape=[1,2])` has the wrong shape on each device. For `deepseek-coder-1.3b` (16 heads, 16 kv_heads, head_dim=128, hidden=2048):

```
attn_output_11SH.shape = Shape([1, 1, 128, 1024])   # 8 local heads * 128 — correct
self.wo.shape           = Shape([1, 1, 2048, 4096])  # expected [1, 1, 1024, 2048]
```

**Fix:** Replace `ShardTensor2dMesh(dims=(3,2))` with `ShardTensorToMesh(dim=2)` for the non-fused, non-TG code path. This correctly row-shards the weight across the 2 devices.

GQA models (Llama 3.x, Qwen, Mistral) are not affected eg Qwen3-8B on N300 works with the original code. T3K and TG use separate sharding paths and are also unaffected.

### Test (N300 + vLLM)

```bash
MESH_DEVICE=N300 ARCH_NAME=wormhole_b0 \
  python -m vllm.entrypoints.openai.api_server \
    --model deepseek-ai/deepseek-coder-1.3b-base --device tt --max-model-len 4096

curl -s http://localhost:8000/v1/completions \
  -d '{"model":"deepseek-ai/deepseek-coder-1.3b-base","prompt":"def fib(n):","max_tokens":50}'
```

______


## How I found it

Trying to run `deepseek-coder-1.3b` (16 heads, 16 kv_heads, head_dim=128) via vLLM on N300, the `wo` matmul in `attention.forward_prefill` crashes. Adding a debug print before the `ttnn.linear` call:

```
attn_output_11SH.shape = Shape([1, 1, 128, 1024])   # correct: 8 local heads * 128
self.wo.shape           = Shape([1, 1, 2048, 4096])  # wrong: doubled in both dims
```

Expected `wo` per device: `[1,1,1024,2048]`. The `ShardTensor2dMesh` mapper produces `[1,1,2048,4096]` — replicating+concatenating rather than sharding. GQA models (Llama, Qwen) don't hit this because their larger Q head count produces shard dimensions that happen to work.


## How to test

### On N300 with vLLM (end-to-end)

```bash
# Download an MHA model
huggingface-cli download deepseek-ai/deepseek-coder-1.3b-base

# Run via vLLM with TT backend
MESH_DEVICE=N300 ARCH_NAME=wormhole_b0 \
  python -m vllm.entrypoints.openai.api_server \
    --model deepseek-ai/deepseek-coder-1.3b-base \
    --device tt \
    --max-model-len 4096

# Test completion
curl -s http://localhost:8000/v1/completions \
  -d '{"model":"deepseek-ai/deepseek-coder-1.3b-base","prompt":"def fib(n):","max_tokens":50}'
```

### Unit test (shape verification)

Any N300 test that loads an MHA model (n_heads == n_kv_heads) through `tt_transformers` and runs prefill should now pass instead of hitting the `a_shape[-1] == b_shape[-2]` assertion.

