### PR TITLE
Update mcast teardown to mcast using the sender semaphore to avoid signalling receivers

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -1559,6 +1559,6 @@ void kernel_main() {
     // ====================================================================
     {
         DeviceZoneScopedN("MCAST_TEARDOWN");
-        mcast.teardown();
+        mcast.teardown(mcast_args);
     }
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -181,9 +181,9 @@ class AttentionBlock:
 
     @staticmethod
     def get_num_semaphores(num_links=1):
-        # 15 from pre/post-SDPA pipeline internals (includes ccl_sync),
+        # 16 from pre/post-SDPA pipeline internals (includes ccl_sync),
         # plus broadcast semaphores.
-        non_bcast_num_semaphores = 15
+        non_bcast_num_semaphores = 16
         bcast_num_semaphores = DeepseekMinimalBroadcast.get_num_semaphores(num_links=num_links)
         return non_bcast_num_semaphores + bcast_num_semaphores
 
@@ -770,7 +770,8 @@ class AttentionBlock:
         # Phase 1: QNOPE first halves, Phase 2: QNOPE second halves, Phase 3: QROPE
         nope_phase1_semaphore_addr = gather_noc0_receiver_semaphore_addr  # ID 2
         nope_phase2_semaphore_addr = gather_noc1_receiver_semaphore_addr  # ID 3
-        rope_semaphore_addr = mcast_data_sender_semaphore_addr  # ID 0 (mcast completed before CreateQHeads)
+        rope_semaphore_addr = ttnn.get_global_semaphore_address(attention_block_semaphores[semaphore_index])
+        semaphore_index += 1
 
         # Semaphore IDs for MLA
         mla_reducer_semaphore_addr = ttnn.get_global_semaphore_address(attention_block_semaphores[semaphore_index])

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2745,6 +2745,6 @@ void kernel_main() {
     // ====================================================================
     {
         DeviceZoneScopedN("MCAST_TEARDOWN");
-        mcast.teardown();
+        mcast.teardown(mcast_args);
     }
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -232,7 +232,7 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST2");
         mcast2(mcast2_args);
     }
-    mcast.teardown();
+    mcast.teardown(mcast_args);
 
     // ========================================================================
     // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -355,7 +355,7 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST2");
         mcast2(mcast2_args);
     }
-    mcast.teardown();
+    mcast.teardown(mcast_args);
 
     // ========================================================================
     // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -429,5 +429,5 @@ void kernel_main() {
             break;
         }
     }
-    mcast.teardown();
+    mcast.teardown(mcast_args);
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -1347,7 +1347,7 @@ void kernel_main() {
     }
 
     // Teardown (one teardown since all mcasts reuse the same semaphores)
-    residual_mcast.teardown();
+    residual_mcast.teardown(moe.routed.residual_mcast_args);
 
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
     noc_async_write_barrier();

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
@@ -771,7 +771,7 @@ void kernel_main() {
     }
 #endif
     // Only need one teardown since all mcasts reuse the same semaphores
-    mcast.teardown();
+    mcast.teardown(mcast_args);
 
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
     noc_async_write_barrier();

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -519,7 +519,7 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST3");
         mcast3(mcast3_args);
     }
-    mcast3.teardown();
+    mcast3.teardown(mcast3_args);
 
     // ========================================================================
     // Matmul5: [1, 8192] x [8192, 64] -> [1, 64] per core (112 active cores)

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -1038,6 +1038,6 @@ if constexpr (!Core::skip_ccl) {
     // ====================================================================
     {
         DeviceZoneScopedN("MCAST_TEARDOWN");
-        mcast.teardown();
+        mcast.teardown(mcast_args);
     }
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -162,8 +162,8 @@ class PreSDPA:
     @staticmethod
     def get_num_semaphores(skip_ccl=False, num_links=1):
         if skip_ccl:
-            return 10
-        return 10 + DeepseekMinimalBroadcast.get_num_semaphores(num_links)
+            return 11
+        return 11 + DeepseekMinimalBroadcast.get_num_semaphores(num_links)
 
     @staticmethod
     def create_semaphores(mesh_device, skip_ccl=False, num_links=1):
@@ -495,7 +495,8 @@ class PreSDPA:
         # Phase 1: QNOPE first halves, Phase 2: QNOPE second halves, Phase 3: QROPE
         nope_phase1_semaphore_addr = gather_noc0_receiver_semaphore_addr  # ID 2
         nope_phase2_semaphore_addr = gather_noc1_receiver_semaphore_addr  # ID 3
-        rope_semaphore_addr = mcast_data_sender_semaphore_addr  # ID 0 (mcast completed before CreateQHeads)
+        rope_semaphore_addr = ttnn.get_global_semaphore_address(semaphores[semaphore_index])
+        semaphore_index += 1
 
         # Semaphore IDs for MLA
         mla_reducer_semaphore_addr = ttnn.get_global_semaphore_address(semaphores[semaphore_index])

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -444,7 +444,7 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST2");
         mcast(mcast2_args);
     }
-    act_mcast.teardown();
+    act_mcast.teardown(act_mcast_args);
 
     // ========================================================================
     // Phase 7: Down Proj Matmul — [1, K_down] x [K_down, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
@@ -95,5 +95,5 @@ void kernel_main() {
     Mcast::Op<McastCTArgs, Core::is_sender_core, Core::is_receiver_core, Core::is_receiver_core, true> mcast;
     mcast.init(mcast_args);
     mcast(mcast_args);
-    mcast.teardown();
+    mcast.teardown(mcast_args);
 }

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -719,6 +719,7 @@ struct FlashMLADecode {
             }
             cb_push_back(sdpa_output_cb, out_chunk_tiles);
             tile_regs_commit();
+            tile_regs_wait();
             tile_regs_release();
             sdpa_custom_mm_block_uninit();
             MATH(t6_semaphore_wait_on_max<p_stall::STALL_SFPU>(semaphore::FPU_SFPU));

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -164,7 +164,7 @@ FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uin
 }
 
 template <uint32_t mcast_num_cores, bool loopback, bool is_part_of_receiver_grid>
-FORCE_INLINE void teardown_persistent_mcast_sender() {
+FORCE_INLINE void teardown_persistent_mcast_sender(uint32_t data_sender_semaphore_addr) {
     mcast_send_set_state<
         mcast_num_cores,
         loopback,
@@ -181,11 +181,11 @@ FORCE_INLINE void teardown_persistent_mcast_sender() {
         is_part_of_receiver_grid,
         false,
         false,
-        false,
-        false,
-        write_reg_cmd_buf>(0, 0, 0);
+        true,
+        mcast_is_shared_write_cmd_buf,
+        write_reg_cmd_buf>(data_sender_semaphore_addr, data_sender_semaphore_addr, 4);
     noc_async_write_barrier();
-    riscv_wait(1000);  // This is just to guarantee safety due to posted mcast hw bug
+    riscv_wait(10000);  // This is just to guarantee safety due to posted mcast hw bug
 }
 
 #endif  // defined(COMPILE_FOR_BRISC)
@@ -276,7 +276,7 @@ struct Mcast {
     //   Op op;
     //   op.init(args);      // Initialize persistent mcast sender (call once)
     //   op(args);           // Send data (can be called multiple times)
-    //   op.teardown();      // Teardown persistent mcast sender (call once)
+    //   op.teardown(args);  // Teardown persistent mcast sender (call once)
     //
     // Or use the legacy all-in-one call:
     //   op.init_send_teardown(args);  // Does init + send + teardown
@@ -330,14 +330,14 @@ struct Mcast {
         // Must be called after all operator() calls on sender core
         // No-op for NCRISC/TRISC
         // ====================================================================
-        void teardown() {
+        void teardown([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_BRISC)
             if constexpr (IsSenderCore) {
                 // Teardown persistent mcast sender
                 teardown_persistent_mcast_sender<
                     CTArgsT::mcast_num_cores,
                     CTArgsT::loopback,
-                    CTArgsT::is_part_of_receiver_grid>();
+                    CTArgsT::is_part_of_receiver_grid>(args.data_sender_semaphore_addr);
             }
 #endif
         }

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -654,6 +654,21 @@ struct SdpaReduceWorker {
                 cb_reserve_back(CTArgs::cb_neighbor_l, CTArgs::out_tiles);
                 cb_push_back(CTArgs::cb_neighbor_l, CTArgs::out_tiles);
             }
+
+            // Clear the semaphores if the neighbor is not valid
+            if (!r1_neighbor_valid) {
+                volatile tt_l1_ptr uint32_t* sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r1_neighbor_sem_addr);
+                noc_semaphore_wait(sem_ptr, CTArgs::L_SEM_BASE_THRESHOLD + CTArgs::num_l_chunks - 1);
+                noc_semaphore_set(sem_ptr, 0);
+            }
+
+            if (!r2_neighbor_r1_valid) {
+                volatile tt_l1_ptr uint32_t* sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r2_neighbor_sem_addr);
+                noc_semaphore_wait(sem_ptr, CTArgs::L_SEM_BASE_THRESHOLD + CTArgs::num_l_chunks - 1);
+                noc_semaphore_set(sem_ptr, 0);
+            }
         }
 #endif  // COMPILE_FOR_NCRISC
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
If we're using global semaphores to mcast to, then if we manually loop the op on host those global semaphores will be incremented by the teardown mcast, so the next iteration might race ahead.

### What's changed
Use the sender semaphore for now as the destination to mcast to during teardown.
Fix sdpa_reduce_worker to clear semaphores when receiving garbage data.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/mcast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mcast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mcast)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
