### PR TITLE
SDPA Cache fix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -483,15 +483,15 @@ def test_sdpa_decode_perf(device):
     "b, nh, nkv, s, d",
     ([16, 8, 1, 8192, 128],),  # Llama2-70B
 )
-def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype):
+def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, reset_seeds):
     import torch
 
     dummy_tensors = []
+    # One cur_pos vector for both outer passes: compute_program_hash includes cur_pos, so resampling
+    # per iteration would compile extra programs for cur_pos_tensor=False paths (expected cache size 4).
+    start_indices = np.random.randint(0, s - 1, b).tolist()
+    start_indices[0] = s - 1
     for i in range(2):
-        # generate random start indices from 0 to s-1
-        start_indices = np.random.randint(0, s - 1, b).tolist()
-        start_indices[0] = s - 1
-
         dummy_tensors.append(
             ttnn.as_tensor(
                 torch.zeros(32, 32),

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -16,9 +16,19 @@ from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
 )
 
 
-def test_mask_dtype_bf16_then_bfp8(device):
+@pytest.fixture
+def device_with_program_cache(device):
+    # Enable program cache for the tests andd reset device cache on exit.
     device.enable_program_cache()
     device.clear_program_cache()
+    try:
+        yield device
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+def test_mask_dtype_bf16_then_bfp8(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s, d = 2, 8, 1, 1024, 64
     grid_size = (8, 4)
@@ -125,13 +135,10 @@ def test_mask_dtype_bf16_then_bfp8(device):
         ok, pcc = comp_pcc(ref, tt_data, min_pcc)
         assert ok, f"{label}: output vs PyTorch PCC failed ({pcc}); possible wrong cached program."
 
-    device.disable_and_clear_program_cache()
-
 
 # Share_cache must be part of compute_program_hash
-def test_share_cache_false_then_true_program_cache_distinct(device):
-    device.enable_program_cache()
-    device.clear_program_cache()
+def test_share_cache_false_then_true_program_cache_distinct(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s, d = 1, 8, 1, 512, 64
     grid_size = (8, 4)
@@ -206,8 +213,6 @@ def test_share_cache_false_then_true_program_cache_distinct(device):
         f"Got {device.num_program_cache_entries()}."
     )
 
-    device.disable_and_clear_program_cache()
-
 
 def _run_decode_non_causal_with_bkv_variant(device, *, b: int, nh: int, nkv: int, s: int, d: int):
     grid_size = (8, 4)
@@ -278,9 +283,8 @@ def _run_decode_non_causal_with_bkv_variant(device, *, b: int, nh: int, nkv: int
     return comp_pcc(ref, out_torch, 0.97)
 
 
-def test_share_cache_nullopt_bkv_relation_change(device):
-    device.disable_and_clear_program_cache()
-    device.enable_program_cache()
+def test_share_cache_nullopt_bkv_relation_change(device_with_program_cache):
+    device = device_with_program_cache
 
     torch.manual_seed(20250325)
 
@@ -297,13 +301,10 @@ def test_share_cache_nullopt_bkv_relation_change(device):
         f"(got {device.num_program_cache_entries()})."
     )
 
-    device.disable_and_clear_program_cache()
-
 
 # Operation_attributes.cur_pos must be in compute_program_hash when cur_pos_tensor is None.
-def test_cur_pos_list_values_change_program_cache_distinct(device):
-    device.enable_program_cache()
-    device.clear_program_cache()
+def test_cur_pos_list_values_change_program_cache_distinct(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s, d = 2, 8, 1, 512, 64
     grid_size = (8, 4)
@@ -381,12 +382,9 @@ def test_cur_pos_list_values_change_program_cache_distinct(device):
         "compute_program_hash may omit operation_attributes.cur_pos."
     )
 
-    device.disable_and_clear_program_cache()
 
-
-def test_mla_head_dim_v_change_program_cache_distinct(device):
-    device.enable_program_cache()
-    device.clear_program_cache()
+def test_mla_head_dim_v_change_program_cache_distinct(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s = 2, 8, 1, 512
     d_qk = 128
@@ -476,12 +474,9 @@ def test_mla_head_dim_v_change_program_cache_distinct(device):
         "compute_program_hash may omit tensor_args.v, head_dim_v, or use_mla."
     )
 
-    device.disable_and_clear_program_cache()
 
-
-def test_q_shard_height_diff_same_logical_program_cache_distinct(device):
-    device.enable_program_cache()
-    device.clear_program_cache()
+def test_q_shard_height_diff_same_logical_program_cache_distinct(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s, d = 1, 8, 1, 512, 64
     grid_size = (8, 4)
@@ -586,12 +581,9 @@ def test_q_shard_height_diff_same_logical_program_cache_distinct(device):
         "compute_program_hash likely fails to distinguish Q padded geometry (see also qkv_logical_padded_shape_key)."
     )
 
-    device.disable_and_clear_program_cache()
 
-
-def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device):
-    device.enable_program_cache()
-    device.clear_program_cache()
+def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device_with_program_cache):
+    device = device_with_program_cache
 
     b, nh, nkv, s, d = 2, 4, 1, 64, 64
     grid_size = (4, 2)
@@ -693,5 +685,3 @@ def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device
         f"with identical Q/K/V (DRAM). Got {device.num_program_cache_entries()}. "
         "If cur_pos_tensor is dropped from compute_program_hash, entries can stay at 1."
     )
-
-    device.disable_and_clear_program_cache()

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -129,7 +129,6 @@ def test_mask_dtype_bf16_then_bfp8(device):
 
 
 # Share_cache must be part of compute_program_hash
-@pytest.mark.timeout(600)
 def test_share_cache_false_then_true_program_cache_distinct(device):
     device.enable_program_cache()
     device.clear_program_cache()
@@ -279,7 +278,6 @@ def _run_decode_non_causal_with_bkv_variant(device, *, b: int, nh: int, nkv: int
     return comp_pcc(ref, out_torch, 0.97)
 
 
-@pytest.mark.timeout(600)
 def test_share_cache_nullopt_bkv_relation_change(device):
     device.disable_and_clear_program_cache()
     device.enable_program_cache()
@@ -303,7 +301,6 @@ def test_share_cache_nullopt_bkv_relation_change(device):
 
 
 # Operation_attributes.cur_pos must be in compute_program_hash when cur_pos_tensor is None.
-@pytest.mark.timeout(600)
 def test_cur_pos_list_values_change_program_cache_distinct(device):
     device.enable_program_cache()
     device.clear_program_cache()
@@ -387,7 +384,6 @@ def test_cur_pos_list_values_change_program_cache_distinct(device):
     device.disable_and_clear_program_cache()
 
 
-@pytest.mark.timeout(600)
 def test_mla_head_dim_v_change_program_cache_distinct(device):
     device.enable_program_cache()
     device.clear_program_cache()
@@ -483,7 +479,6 @@ def test_mla_head_dim_v_change_program_cache_distinct(device):
     device.disable_and_clear_program_cache()
 
 
-@pytest.mark.timeout(600)
 def test_q_shard_height_diff_same_logical_program_cache_distinct(device):
     device.enable_program_cache()
     device.clear_program_cache()
@@ -594,7 +589,6 @@ def test_q_shard_height_diff_same_logical_program_cache_distinct(device):
     device.disable_and_clear_program_cache()
 
 
-@pytest.mark.timeout(300)
 def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device):
     device.enable_program_cache()
     device.clear_program_cache()

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -18,7 +18,7 @@ from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
 
 @pytest.fixture
 def device_with_program_cache(device):
-    # Enable program cache for the tests andd reset device cache on exit.
+    # Enable program cache for the tests and reset device cache on exit.
     device.enable_program_cache()
     device.clear_program_cache()
     try:

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -222,11 +222,10 @@ def test_sdpa_decode_sharded(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype
     "b, nh, nkv, s, d",
     ([16, 8, 1, 8192, 128],),  # Llama2-70B
 )
-def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype):
+def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, reset_seeds):
     dummy_tensors = []
     # One cur_pos vector for both outer passes: compute_program_hash includes cur_pos, so resampling
     # per iteration would compile extra programs for cur_pos_tensor=False paths (expected cache size 4).
-    np.random.seed(213919)
     start_indices = np.random.randint(0, s - 1, b).tolist()
     start_indices[0] = s - 1
     for i in range(2):

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -224,11 +224,12 @@ def test_sdpa_decode_sharded(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype
 )
 def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype):
     dummy_tensors = []
+    # One cur_pos vector for both outer passes: compute_program_hash includes cur_pos, so resampling
+    # per iteration would compile extra programs for cur_pos_tensor=False paths (expected cache size 4).
+    np.random.seed(213919)
+    start_indices = np.random.randint(0, s - 1, b).tolist()
+    start_indices[0] = s - 1
     for i in range(2):
-        # generate random start indices from 0 to s-1
-        start_indices = np.random.randint(0, s - 1, b).tolist()
-        start_indices[0] = s - 1
-
         dummy_tensors.append(
             ttnn.as_tensor(
                 torch.zeros(32, 32),

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode_cache.py
@@ -1,0 +1,703 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
+    comp_pcc,
+    fa_rand,
+    get_chunk_size,
+    nearest_n,
+    nearest_pow_2,
+    num_to_corerange,
+)
+
+
+def test_mask_dtype_bf16_then_bfp8(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s, d = 2, 8, 1, 1024, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(20250322)
+
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat8_b
+    k_chunk_size = get_chunk_size(s // 4 + 1, s)
+    scale = d**-0.5
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    tt_k = ttnn.as_tensor(k, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    mask_torch = torch.bernoulli(torch.full((b, nh, 1, s), 0.25)) * torch.finfo(torch.float32).min
+    q = fa_rand(1, b, nh, d)
+    tt_q = ttnn.as_tensor(
+        q[:, :, :nh],
+        device=device,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+
+    q_s = q[:, :, :nh, :].permute(1, 2, 0, 3)
+    k_s = k[:, :, :s, :]
+    k_s = torch.cat([k_s[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    v_s = v[:, :, :s, :]
+    v_s = torch.cat([v_s[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    m_s = mask_torch[:, :nh, :, :]
+    ref = (
+        torch.nn.functional.scaled_dot_product_attention(q_s, k_s, v_s, m_s, scale=scale, is_causal=False)
+        .squeeze(2)
+        .unsqueeze(0)
+    )
+
+    tt_mask_bf16 = ttnn.as_tensor(
+        mask_torch.transpose(1, 2).contiguous(),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+    out_bf16 = ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=False,
+        attn_mask=tt_mask_bf16,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    data_bf16 = ttnn.to_torch(out_bf16)[:, :, :nh, :]
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after first decode (BFLOAT16 mask), got {device.num_program_cache_entries()}"
+
+    tt_mask_bfp8 = ttnn.as_tensor(
+        mask_torch.transpose(1, 2).contiguous(),
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+    out_bfp8 = ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=False,
+        attn_mask=tt_mask_bfp8,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    data_bfp8 = ttnn.to_torch(out_bfp8)[:, :, :nh, :]
+    assert device.num_program_cache_entries() == 2, (
+        "Expected 2 cache entries after BFLOAT8_B mask (compile-time mask dtype differs); "
+        f"got {device.num_program_cache_entries()}."
+    )
+
+    min_pcc = 0.97
+    for label, tt_data in (("BFLOAT16 mask", data_bf16), ("BFLOAT8_B mask", data_bfp8)):
+        ok, pcc = comp_pcc(ref, tt_data, min_pcc)
+        assert ok, f"{label}: output vs PyTorch PCC failed ({pcc}); possible wrong cached program."
+
+    device.disable_and_clear_program_cache()
+
+
+# Share_cache must be part of compute_program_hash
+@pytest.mark.timeout(600)
+def test_share_cache_false_then_true_program_cache_distinct(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s, d = 1, 8, 1, 512, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(42)
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    scale = d**-0.5
+    cur_pos = [min(127, s - 1)]
+    k_chunk_size = get_chunk_size(cur_pos[0] + 1, s)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    q = fa_rand(1, b, nh, d)
+
+    tt_k = ttnn.as_tensor(k, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_q = ttnn.as_tensor(
+        q[:, :, :nh],
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+        share_cache=False,
+    )
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after share_cache=False, got {device.num_program_cache_entries()}"
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+        share_cache=True,
+    )
+    assert device.num_program_cache_entries() == 2, (
+        "Expected a second program-cache entry when share_cache toggles (same B=1 K/V shapes). "
+        f"Got {device.num_program_cache_entries()}."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
+def _run_decode_non_causal_with_bkv_variant(device, *, b: int, nh: int, nkv: int, s: int, d: int):
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat8_b
+    k_chunk_size = get_chunk_size(s // 4 + 1, s)
+    scale = d**-0.5
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    q = fa_rand(1, b, nh, d)
+    mask_torch = torch.bernoulli(torch.full((b, nh, 1, s), 0.25)) * torch.finfo(torch.float32).min
+
+    tt_q = ttnn.as_tensor(q[:, :, :nh], device=device, dtype=q_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_k = ttnn.as_tensor(k, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_mask = ttnn.as_tensor(
+        mask_torch.transpose(1, 2).contiguous(),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+
+    out = ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=False,
+        attn_mask=tt_mask,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    out_torch = ttnn.to_torch(out)[:, :, :nh, :]
+
+    q_s = q[:, :, :nh, :].permute(1, 2, 0, 3)
+    k_s = k[:, :, :s, :]
+    k_s = torch.cat([k_s[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    v_s = v[:, :, :s, :]
+    v_s = torch.cat([v_s[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    ref = (
+        torch.nn.functional.scaled_dot_product_attention(
+            q_s, k_s, v_s, mask_torch[:, :nh, :, :], scale=scale, is_causal=False
+        )
+        .squeeze(2)
+        .unsqueeze(0)
+    )
+    return comp_pcc(ref, out_torch, 0.97)
+
+
+@pytest.mark.timeout(600)
+def test_share_cache_nullopt_bkv_relation_change(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+    torch.manual_seed(20250325)
+
+    ok1, pcc1 = _run_decode_non_causal_with_bkv_variant(device, b=8, nh=8, nkv=8, s=256, d=64)
+    assert ok1, f"Run1 PCC too low: {pcc1}"
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after run1 (B=8,Bkv=8, share_cache=None), got {device.num_program_cache_entries()}"
+
+    ok2, pcc2 = _run_decode_non_causal_with_bkv_variant(device, b=8, nh=8, nkv=1, s=256, d=64)
+    assert ok2, f"Run2 PCC too low: {pcc2}"
+    assert device.num_program_cache_entries() == 2, (
+        "Expected cache split when Bkv relation changes under share_cache=None "
+        f"(got {device.num_program_cache_entries()})."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
+# Operation_attributes.cur_pos must be in compute_program_hash when cur_pos_tensor is None.
+@pytest.mark.timeout(600)
+def test_cur_pos_list_values_change_program_cache_distinct(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s, d = 2, 8, 1, 512, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(43)
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    padded_heads = nearest_pow_2(nearest_n(nh, n=32))
+    scale = d**-0.5
+
+    cur_pos_a = [10, 20]
+    cur_pos_b = [min(300, s - 1), min(310, s - 1)]
+    max_pos = max(max(cur_pos_a), max(cur_pos_b))
+    k_chunk_size = get_chunk_size(max_pos + 1, s)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    q = fa_rand(1, b, nh, d)
+
+    tt_k = ttnn.as_tensor(k, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_q = ttnn.as_tensor(
+        q[:, :, :nh],
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos_a,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    assert device.num_program_cache_entries() == 1, (
+        f"Expected 1 cache entry after first causal decode (cur_pos={cur_pos_a}), "
+        f"got {device.num_program_cache_entries()}"
+    )
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos_b,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    assert device.num_program_cache_entries() == 2, (
+        "Causal decode with cur_pos=list (no cur_pos_tensor) must not reuse cache when "
+        f"cur_pos values change. Got {device.num_program_cache_entries()} entries; "
+        "compute_program_hash may omit operation_attributes.cur_pos."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
+@pytest.mark.timeout(600)
+def test_mla_head_dim_v_change_program_cache_distinct(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s = 2, 8, 1, 512
+    d_qk = 128
+    head_dim_v_a, head_dim_v_b = 32, 64
+    torch.manual_seed(402)
+
+    grid = device.compute_with_storage_grid_size()
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat8_b
+
+    cur_pos = [min(200, s - 1), min(250, s - 1)]
+    k_chunk_size = get_chunk_size(max(cur_pos) + 1, s)
+    assert k_chunk_size % 32 == 0 and s % k_chunk_size == 0, f"adjust s/k_chunk_size (got k_chunk_size={k_chunk_size})"
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=(grid.x, grid.y),
+        q_chunk_size=0,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+        max_cores_per_head_batch=4,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+    scale = d_qk**-0.5
+
+    q = fa_rand(b, nh, 1, d_qk)
+    k = fa_rand(b, nkv, s, d_qk)
+    v_a = fa_rand(b, nkv, s, head_dim_v_a)
+    v_b = fa_rand(b, nkv, s, head_dim_v_b)
+
+    tt_q = ttnn.as_tensor(
+        q.permute(2, 0, 1, 3),
+        device=device,
+        dtype=q_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+    tt_k = ttnn.as_tensor(k, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v_a = ttnn.as_tensor(v_a, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v_b = ttnn.as_tensor(v_b, device=device, dtype=kv_dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+
+    try:
+        ttnn.transformer.flash_multi_latent_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v_a,
+            head_dim_v_a,
+            is_causal=True,
+            cur_pos=cur_pos,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+    except (RuntimeError, TypeError) as e:
+        pytest.skip(f"MLA decode baseline not supported in this environment: {e}")
+
+    assert device.num_program_cache_entries() == 1, (
+        f"Expected 1 cache entry after first MLA decode (head_dim_v={head_dim_v_a}), "
+        f"got {device.num_program_cache_entries()}"
+    )
+
+    try:
+        ttnn.transformer.flash_multi_latent_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v_b,
+            head_dim_v_b,
+            is_causal=True,
+            cur_pos=cur_pos,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+    except RuntimeError as e:
+        pytest.fail(f"Second MLA decode (head_dim_v={head_dim_v_b}) failed: {e}")
+
+    assert device.num_program_cache_entries() == 2, (
+        "MLA decode must not reuse cached program when head_dim_v / V width changes "
+        f"(shared Q/K). Got {device.num_program_cache_entries()} entries; "
+        "compute_program_hash may omit tensor_args.v, head_dim_v, or use_mla."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
+@pytest.mark.timeout(600)
+def test_q_shard_height_diff_same_logical_program_cache_distinct(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s, d = 1, 8, 1, 512, 64
+    grid_size = (8, 4)
+    grid = device.compute_with_storage_grid_size()
+    if grid_size[0] > grid.x or grid_size[1] > grid.y:
+        pytest.skip(f"Need compute grid at least {grid_size}, got {grid}")
+
+    torch.manual_seed(46)
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    padded_heads_lo = nearest_pow_2(nearest_n(nh, n=32))
+    padded_heads_hi = padded_heads_lo * 2
+    logical_q = (1, b, nh, d)
+    padded_q_lo = (1, b, padded_heads_lo, d)
+    padded_q_hi = (1, b, padded_heads_hi, d)
+
+    cur_pos = [min(127, s - 1)]
+    k_chunk_size = get_chunk_size(cur_pos[0] + 1, s)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_heads_hi,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+    scale = d**-0.5
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    tt_k = ttnn.as_tensor(k, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+
+    q = fa_rand(1, b, nh, d)
+    q_bf16 = q[:, :, :nh].to(torch.bfloat16)
+    q_lo_host = torch.zeros(1, b, padded_heads_lo, d, dtype=torch.bfloat16)
+    q_lo_host[:, :, :nh, :] = q_bf16
+    q_hi_host = torch.zeros(1, b, padded_heads_hi, d, dtype=torch.bfloat16)
+    q_hi_host[:, :, :nh, :] = q_bf16
+
+    tt_q_raw_a = ttnn.as_tensor(
+        q_lo_host,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+    tt_q_raw_b = ttnn.as_tensor(
+        q_hi_host,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=dram,
+    )
+    try:
+        tt_q_a = ttnn.reshape(tt_q_raw_a, logical_q, padded_shape=padded_q_lo)
+        tt_q_b = ttnn.reshape(tt_q_raw_b, logical_q, padded_shape=padded_q_hi)
+    except RuntimeError as e:
+        pytest.skip(f"reshape with explicit padded_shape not supported for this Q setup: {e}")
+
+    if tt_q_a.shape != tt_q_b.shape:
+        pytest.fail("Setup bug: Q logical shapes (.shape) must match for Bug #6 isolation.")
+    if tt_q_a.padded_shape == tt_q_b.padded_shape:
+        pytest.skip(
+            "Q padded_shape still identical after host-padded upload; "
+            f"got {tt_q_a.padded_shape} for both — cannot validate Bug #6 runtime path on this build."
+        )
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q_a,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    assert device.num_program_cache_entries() == 1, (
+        f"Expected 1 cache entry after first decode (Q padded heads {padded_heads_lo}), "
+        f"got {device.num_program_cache_entries()}"
+    )
+
+    ttnn.transformer.scaled_dot_product_attention_decode(
+        tt_q_b,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        cur_pos=cur_pos,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        memory_config=dram,
+    )
+    assert device.num_program_cache_entries() == 2, (
+        "Same Q logical + K/V + program_config must not reuse cache when Q padded_shape differs "
+        f"({padded_heads_lo} vs {padded_heads_hi} head padding). Got {device.num_program_cache_entries()} entries; "
+        "compute_program_hash likely fails to distinguish Q padded geometry (see also qkv_logical_padded_shape_key)."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
+@pytest.mark.timeout(300)
+def test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache(device):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    b, nh, nkv, s, d = 2, 4, 1, 64, 64
+    grid_size = (4, 2)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need grid {grid_size}, device has {compute_grid_size}")
+
+    torch.manual_seed(204)
+    padded_num_heads = nearest_pow_2(nearest_n(nh, n=32))
+    dram = ttnn.DRAM_MEMORY_CONFIG
+
+    shard_grid = ttnn.CoreRangeSet({num_to_corerange(b)})
+    shard_spec_q = ttnn.ShardSpec(shard_grid, (padded_num_heads, d), ttnn.ShardOrientation.ROW_MAJOR)
+    height_sharded_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec_q)
+
+    k = fa_rand(b, nkv, s, d)
+    v = fa_rand(b, nkv, s, d)
+    tt_k = ttnn.as_tensor(k, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+    tt_v = ttnn.as_tensor(v, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, memory_config=dram)
+
+    start_indices = [min(s // 4 + i, s - 1) for i in range(b)]
+    max_start_idx = max(start_indices)
+    scale = d**-0.5
+    k_chunk_size = get_chunk_size(max_start_idx + 1, s)
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        q_chunk_size=padded_num_heads,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    q = fa_rand(1, b, nh, d)
+    tt_q = ttnn.as_tensor(
+        q[:, :, :nh],
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=height_sharded_memcfg,
+    )
+
+    pos_1d = torch.tensor(start_indices, dtype=torch.int32)
+    tt_pos_1d = ttnn.from_torch(
+        pos_1d,
+        device=device,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=dram,
+    )
+
+    try:
+        ttnn.transformer.scaled_dot_product_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v,
+            cur_pos_tensor=tt_pos_1d,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+    except RuntimeError as e:
+        pytest.skip(f"cur_pos rank-1 baseline failed: {e}")
+
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after rank-1 cur_pos_tensor, got {device.num_program_cache_entries()}"
+
+    pos_2d = pos_1d.reshape(b, 1)
+    tt_pos_2d = ttnn.from_torch(
+        pos_2d,
+        device=device,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=dram,
+    )
+
+    try:
+        ttnn.transformer.scaled_dot_product_attention_decode(
+            tt_q,
+            tt_k,
+            tt_v,
+            cur_pos_tensor=tt_pos_2d,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            memory_config=dram,
+        )
+    except RuntimeError as e:
+        pytest.skip(f"Rank-2 cur_pos on DRAM not supported for this decode path (acceptable): {e}")
+
+    assert device.num_program_cache_entries() == 2, (
+        "Expected 2 program-cache entries when cur_pos_tensor logical shape changes 1D [B] -> 2D [B,1] "
+        f"with identical Q/K/V (DRAM). Got {device.num_program_cache_entries()}. "
+        "If cur_pos_tensor is dropped from compute_program_hash, entries can stay at 1."
+    )
+
+    device.disable_and_clear_program_cache()

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -11,6 +11,8 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
+#include <tt_stl/reflection.hpp>
+
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -403,8 +405,25 @@ Tensor SdpaDecodeDeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    bool has_cur_pos = tensor_args.cur_pos_tensor.has_value();
-    bool has_attn_mask = tensor_args.attn_mask.has_value();
+    // TensorSpec hashing uses logical_shape + tensor_layout only, not cached_padded_shape_
+    const ttsl::hash::hash_t qkv_logical_padded_shape_key = [&] {
+        ttsl::hash::hash_t h = ttsl::hash::hash_objects_with_default_seed(
+            tensor_args.q.logical_shape(),
+            tensor_args.q.padded_shape(),
+            tensor_args.k.logical_shape(),
+            tensor_args.k.padded_shape());
+        if (tensor_args.v.has_value()) {
+            h = ttsl::hash::hash_objects(h, tensor_args.v->logical_shape(), tensor_args.v->padded_shape());
+        }
+        return h;
+    }();
+
+    // Hash the full optional Tensor for layout/memory/placement; hash logical_shape separately
+    // so rank and extents always contribute to the program-cache key
+    const ttsl::hash::hash_t cur_pos_tensor_logical_shape_key =
+        tensor_args.cur_pos_tensor.has_value()
+            ? ttsl::hash::hash_objects_with_default_seed(tensor_args.cur_pos_tensor->logical_shape())
+            : ttsl::hash::hash_t{0};
 
     return operation::hash_operation<SdpaDecodeDeviceOperation>(
         operation_attributes.scale,
@@ -414,17 +433,20 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
         operation_attributes.k_chunk_size,
         operation_attributes.paged_attention,
         operation_attributes.is_causal,
+        operation_attributes.share_cache,
+        operation_attributes.cur_pos,
         operation_attributes.use_mla,
         operation_attributes.head_dim_v,
         operation_attributes.sliding_window_size,
-        has_attn_mask,
-        has_cur_pos,
         tensor_args.q,
         tensor_args.k,
         tensor_args.v,
-        // Hash on page_table_tensor to properly size page table CB
+        qkv_logical_padded_shape_key,
         tensor_args.page_table_tensor,
-        tensor_args.attention_sink);
+        tensor_args.attention_sink,
+        tensor_args.attn_mask,
+        tensor_args.cur_pos_tensor,
+        cur_pos_tensor_logical_shape_key);
 }
 
 Tensor sdpa_decode(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -422,8 +422,8 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
     // so rank and extents always contribute to the program-cache key
     const ttsl::hash::hash_t cur_pos_tensor_logical_shape_key =
         tensor_args.cur_pos_tensor.has_value()
-            ? ttsl::hash::hash_objects_with_default_seed(tensor_args.cur_pos_tensor->logical_shape())
-            : ttsl::hash::hash_t{0};
+            ? ttsl::hash::hash_objects_with_default_seed(true, tensor_args.cur_pos_tensor->logical_shape())
+            : ttsl::hash::hash_objects_with_default_seed(false);
 
     return operation::hash_operation<SdpaDecodeDeviceOperation>(
         operation_attributes.scale,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 
 #include <cmath>
+#include <cstdint>
 
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -425,6 +426,11 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
             ? ttsl::hash::hash_objects_with_default_seed(true, tensor_args.cur_pos_tensor->logical_shape())
             : ttsl::hash::hash_objects_with_default_seed(false);
 
+    // Encode optional share_cache as 0 = unset, 1 = false, 2 = true so all three differ in the program hash.
+    const uint8_t share_cache_hash_tag = operation_attributes.share_cache.has_value()
+                                             ? (operation_attributes.share_cache.value() ? uint8_t{2} : uint8_t{1})
+                                             : uint8_t{0};
+
     return operation::hash_operation<SdpaDecodeDeviceOperation>(
         operation_attributes.scale,
         operation_attributes.output_mem_config,
@@ -433,7 +439,7 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
         operation_attributes.k_chunk_size,
         operation_attributes.paged_attention,
         operation_attributes.is_causal,
-        operation_attributes.share_cache,
+        share_cache_hash_tag,
         operation_attributes.cur_pos,
         operation_attributes.use_mla,
         operation_attributes.head_dim_v,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -45,7 +45,8 @@ ttnn::Tensor scaled_dot_product_attention_decode(
     std::optional<uint32_t> sliding_window_size,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<bool> share_cache) {
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
@@ -86,7 +87,7 @@ ttnn::Tensor scaled_dot_product_attention_decode(
         program_config,
         kernel_config_val,
         k_chunk_size,
-        std::nullopt,
+        share_cache,
         std::nullopt,
         std::nullopt);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -23,7 +23,8 @@ ttnn::Tensor scaled_dot_product_attention_decode(
     std::optional<uint32_t> sliding_window_size = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<operations::transformer::SDPAProgramConfig> program_config = std::nullopt,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<bool> share_cache = std::nullopt);
 
 ttnn::Tensor paged_scaled_dot_product_attention_decode(
     const ttnn::Tensor& input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -44,7 +44,7 @@ void bind_sdpa_decode(nb::module_& mod) {
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
             sliding_window_size (int, optional): The size of sliding window for sliding window attention. Defaults to `None`.
-            share_cache (bool, optional): KV cache sharing across batch for decode. Defaults to `None` (same as False).
+            share_cache (bool, optional): KV cache sharing across batch for decode. `True` enables, `False` disables. Defaults to `None` (distinct program-cache key).
 
 
         Returns:

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -44,6 +44,7 @@ void bind_sdpa_decode(nb::module_& mod) {
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
             sliding_window_size (int, optional): The size of sliding window for sliding window attention. Defaults to `None`.
+            share_cache (bool, optional): KV cache sharing across batch for decode. Defaults to `None` (same as False).
 
 
         Returns:
@@ -71,7 +72,8 @@ void bind_sdpa_decode(nb::module_& mod) {
         nb::arg("sliding_window_size") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("program_config") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("share_cache") = nb::none());
 
     ttnn::bind_function<"paged_scaled_dot_product_attention_decode", "ttnn.transformer.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -44,7 +44,7 @@ void bind_sdpa_decode(nb::module_& mod) {
             program_config (SDPAProgramConfig, optional): Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
             sliding_window_size (int, optional): The size of sliding window for sliding window attention. Defaults to `None`.
-            share_cache (bool, optional): KV cache sharing across batch for decode. `True` enables, `False` disables. Defaults to `None` (distinct program-cache key).
+            share_cache (bool, optional): KV cache sharing across batch for decode. `True` enables, `False` disables. Defaults to `None` (distinct program-cache key from explicit `False`).
 
 
         Returns:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37168

### Problem description
Fix the mentioned cache bugs as mentioned in  https://drive.google.com/file/d/1a1qf2sYc5DyMNMzcc65vdn8uMTXhbyAj/view

### What's changed

- Fixed the bug.
- Atatched the details
- Test file : tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode_cache.py

| Bug | Issue description | Fix | Test(s) (`test_sdpa_decode_cache.py`) | Test Description |
| --- | --- | --- | --- | --- | 
| **1** | `share_cache` missing from hash → wrong K/V layout reuse | `operation_attributes.share_cache` in `hash_operation` | `test_share_cache_false_then_true_program_cache_distinct`; `test_share_cache_nullopt_bkv_relation_change` | **`test_share_cache_false_then_true_program_cache_distinct`:** two **causal** decodes, **same** Q/K/V; **only** `share_cache` false → true. **`test_share_cache_nullopt_bkv_relation_change`:** two **non-causal** decodes with **`share_cache` never passed** (C++ `nullopt`); **only** `nkv` changes (`8` → `1`) with `b=nh=8`, fresh random K/V each run—program cache must go **1 → 2** so Bkv / layout cannot collide under the default path. | 
| **2** | Only “has `cur_pos`” risk; **`cur_pos` list values** must matter | `operation_attributes.cur_pos` (full vector) in `hash_operation` | `test_cur_pos_list_values_change_program_cache_distinct` | Two causal decodes with **`cur_pos` as a Python list** (no `cur_pos_tensor`), **same** Q/K/V and config; **`cur_pos` values** differ between runs. Expectation: second run **must not** reuse the first program when positions change. |
| **3** | Mask as boolean vs **tensor** (shape, dtype, …) | `tensor_args.attn_mask` optional tensor in `hash_operation` (tensor hash carries spec fields) | `test_mask_dtype_bf16_then_bfp8` | Non-causal decode; **fixed** Q, K, V and config; **same** mask values uploaded as **BFLOAT16** then **BFLOAT8_B**. Expectation: **dtype** alone splits cache; outputs checked vs PyTorch (PCC). | 
| **4** | MLA: V / `head_dim_v` geometry → CB mismatch if omitted | `operation_attributes.use_mla`, `operation_attributes.head_dim_v`, optional `tensor_args.v`, plus **`qkv_logical_padded_shape_key`** (Q/K/V logical + padded when V present) | `test_mla_head_dim_v_change_program_cache_distinct` | Two **`flash_multi_latent_attention_decode`** calls: **shared** Q and K, **same** MLA config and positions; **`head_dim_v` and V tensor** change (narrow vs wide). Expectation: **two** programs; skips if MLA unsupported. | 
| **5** | `cur_pos_tensor` logical shape and **placement** must affect the key | `tensor_args.cur_pos_tensor` + **`cur_pos_tensor_logical_shape_key`** | `test_cur_pos_tensor_rank1_then_rank2_same_dram_same_qkv_program_cache` | Causal decode with **fixed** Q (height-sharded L1), K/V on DRAM, **fixed** batch; `cur_pos_tensor` is the **same** indices as **`[B]`** then **`[B,1]`** on **DRAM**—only **rank / logical shape** changes. Expectation: **two** programs. **DRAM vs L1-sharded** `cur_pos_tensor` placement (cache-only and PCC variants) remains in **`test_sdpa_decode_program_cache_audit.py`** (`test_cur_pos_dram_then_sharded_smaller`, `test_cur_pos_dram_then_sharded_program_cache_bug4_proxy`). | 
| **6** | Q/K/V **padded** geometry may drive CB/tile layout; may not live in tensor hash alone | Explicit **`qkv_logical_padded_shape_key`** | `test_q_shard_height_diff_same_logical_program_cache_distinct` | Two causal decodes: **identical** logical Q shape, K/V, and config; Q built so **padded head dimension differs** (host padding 32 vs 64 rows, then **reshape** to same logical `[1,B,Nh,D]`). Expectation: **no silent** program reuse. **Caveat:** end-to-end check; other hash inputs might also differ—**explicit C++ key** is still the authoritative fix. | 
| **7** | K/V sequence / paged structure tied to padded extents | Same strand as 6: **K/V padded** in `qkv_logical_padded_shape_key` | **No separate test:** treated as the **same padded-shape / K–V geometry strand as bug 6**; `qkv_logical_padded_shape_key` already hashes K/V logical + padded. A **paged-attention-only** repro would be extra scope, not a distinct hash gap in `compute_program_hash`. | — | 
| **8** | `attention_sink` placement / memory config | `tensor_args.attention_sink` optional tensor in `hash_operation` | **No separate test:** the full optional **`attention_sink` tensor** is already an argument to `hash_operation`, so **buffer type / `MemoryConfig`** are included via the normal tensor hash path; a DRAM-vs-L1 integration test is optional hardening, not required to prove this operand is absent from the key. | — | 
| **9** | `program_config` variant / fields might not hash fully | `operation_attributes.program_config` in `hash_operation` | **No separate test:** `program_config` is passed **whole** into `hash_operation`; confirming that **`SDPAProgramConfig` serialization includes every field** is a **generic hashing / reflection** concern, not a second decode-row repro here. Any gap belongs in **config-hash unit tests or code review**, not another row in this file. | — |

Additional test file changes

- Failed with `assert device.num_program_cache_entries() == 4` → actual count was 6 (program-cache size assertioN)
  - **Files**
    - `tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py::test_sdpa_decode_program_cache`
    - `tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_decode.py::test_sdpa_decode_program_cache`
  - **Issue**
    - The test runs two outer iterations. Inside each iteration it sampled a new random `start_indices` and then ran four decode configurations (`sharded_in` (Q) / `sharded_out` (output) / `cur_pos_tensor` (decode positions as a tensor vs Python list)).
    - For paths with `cur_pos_tensor=False`, the decode uses the Python `cur_pos` list, which is part of the program hash (`operation_attributes.cur_pos`), so different per-batch positions → different compiled programs.
    - The first iteration built four distinct programs (one per layout variant). The second iteration would reuse those four only if all hash inputs matched. Because `start_indices` was regenerated each loop, `cur_pos` changed, so the two list-driven variants compiled again → two extra cache entries → 6 total instead of 4.
    - This failure is a test assumption bug, not a cache implementation bug.
  - **Fix (both files)**
    - Generate `start_indices` **once** before the outer loop (same `cur_pos` for both passes so list-based decodes reuse programs; `cur_pos` is in `compute_program_hash`).
    - Set **`np.random.seed(213919)`** before `np.random.randint` for reproducible `start_indices`.

- 


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/sdpa_cache)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/sdpa_cache)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/sdpa_cache)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/sdpa_cache)

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/sdpa_cache)

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/sdpa_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/sdpa_cache)
