### PR TITLE
Fixing row and col naming masked_bincount test

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py
@@ -167,10 +167,10 @@ def test_masked_bincount(
     for device_id in range(len(device_tensors)):
         tt_hist = ttnn.to_torch(device_tensors[device_id]).flatten().to(torch.int32)
 
-        row_idx = device_id // n_cols
-        group_idx = device_id % n_cols
+        row = device_id // n_cols
+        col = device_id % n_cols
 
-        ref_hist = torch_histograms[(group_idx, row_idx)]
+        ref_hist = torch_histograms[(col, row)]
 
         matches = torch.equal(tt_hist[:n_routed_experts], ref_hist)
         if not matches:


### PR DESCRIPTION
Finxing a naming bug in test_masked_bincount.py

`FAILED models/demos/deepseek_v3_d_p/tests/pcc/test_masked_bincount.py::test_masked_bincount[blackhole-linear-1x4-4096-8-256] - NameError: name 'row' is not defined`

- [ ] [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23637551545)