### PR TITLE
[codex] Invalidate stale L1 position reads in DeepSeek B1 decode

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -241,6 +241,7 @@ void kernel_main() {
     uint32_t position_ids_addr = get_common_arg_val<uint32_t>(1);
 
     volatile tt_l1_ptr uint32_t* position_ids_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(position_ids_addr);
+    invalidate_l1_cache();
     uint32_t kv_cache_start_tile_id = position_ids_ptr[0];
 
     // Create TensorAccessor for DRAM interleaved tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -859,6 +859,7 @@ uint32_t per_core_rta_arg_idx = 0;
     // local_cur_pos is used for kv cache update and flash mla.
     // ========================================================================
     volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
+    invalidate_l1_cache();
     uint32_t cur_pos = pos_ptr[0];
 
     const auto [skip_attention, skip_kv_cache_update, local_cur_pos] = get_device_mla_work_assignment(

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
@@ -155,6 +155,7 @@ void kernel_main() {
 
     deepseek_b1_ops::FlashMLADecode::Op<FlashMLACTArgs, true> op;
     volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);
+    invalidate_l1_cache();
     op.set_local_cur_pos(args, pos_ptr[0]);
     op(args);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -61,6 +61,7 @@ void kernel_main() {
     {
         uint32_t pos_addr = get_common_arg_val<uint32_t>(1);
         volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pos_addr);
+        invalidate_l1_cache();
         op.set_local_cur_pos(args, pos_ptr[0]);
     }
 #endif

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -106,6 +106,9 @@ struct Rope {
         void impl(const RTArgs& args) {
 #if defined(COMPILE_FOR_NCRISC)
 
+            // The persistent decoder updates position_ids in-place on BRISC between
+            // iterations, so refresh the local L1 view before reading it here.
+            invalidate_l1_cache();
             volatile tt_l1_ptr uint32_t* position_ids_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.position_ids_tensor_address);
             uint32_t position_id = position_ids_ptr[0];

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -628,6 +628,7 @@ struct SdpaReduceWorker {
 
             if constexpr (CTArgs::position_enabled) {
                 volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
+                invalidate_l1_cache();
                 uint32_t position_id = pos_ptr[0];
                 constexpr uint32_t chunk = CTArgs::per_device_chunk_size;
                 r1_neighbor_valid = (position_id >= args.r1_neighbor_device_idx * chunk);
@@ -774,6 +775,7 @@ struct SdpaReduceWorker {
                 r2_neighbor_device_idx = args.r2_neighbor_device_idx;
 
                 volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
+                invalidate_l1_cache();
                 position_id = pos_ptr[0];
 
                 constexpr uint32_t chunk = CTArgs::per_device_chunk_size;


### PR DESCRIPTION
## What changed
This refreshes the local L1 view before reading mutable `position_id` / `position_ids` tensors in the DeepSeek B1 decode path.

The change adds `invalidate_l1_cache()` at each direct read site touched by the persistent decode flow:
- `unified_kernels/sdpa_reduce_worker.hpp`
- `unified_kernels/rope.hpp`
- `fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp`
- `micro_ops/flash_mla/kernels/flash_mla_kernel.cpp`
- `micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp`
- `fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp`

## Why
The persistent decoder updates position state in-place between iterations. Some downstream kernels were rereading that mutable state without invalidating their local L1 view first.

That can leave a one-iteration-stale `position_id`, which becomes especially harmful at the first SP chunk boundary (`per_device_chunk_size = 1024`) where the SDPA validity mask changes and an additional device/ring participant must become active.

## Impact
This makes position-dependent masking and lookup logic consistent across the DeepSeek B1 decode stack and is intended to fix bad token generation once decode crosses 1024 tokens.

## Root cause
Top-level decoder and attention kernels already invalidated L1 before reading position. The bug was that sibling/subordinate ops were not doing the same, so they could observe stale position state during persistent decode.

## Validation
- `git diff --check`
- Static code audit of the persistent decode position-read path

I did not run hardware-backed decode tests in this environment.
