### PR TITLE
Removed slice/concat from tt_routed_expert forward pass

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -12,6 +12,8 @@ Unlike TtSharedExpert, this module:
 - Each device holds weights for `experts_per_chip` local experts
 """
 
+from typing import Optional
+
 import torch
 from loguru import logger
 from tracy import signpost
@@ -246,20 +248,29 @@ class TtRoutedExpert(LightweightModule):
         return tt_weight
 
     def _expert_ffn(
-        self, x: ttnn.Tensor, gate_proj: ttnn.Tensor, up_proj: ttnn.Tensor, down_proj: ttnn.Tensor, out: ttnn.Tensor
+        self,
+        x: ttnn.Tensor,
+        gate_proj: ttnn.Tensor,
+        up_proj: ttnn.Tensor,
+        down_proj: ttnn.Tensor,
+        out: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """
         Single expert FFN computation.
 
         Args:
-            x: Input tensor (1, tokens, emb_dim)
+            x: Input tensor. Shape is (1, tokens, emb_dim) for the Blackhole path
+                (after ttnn.narrow) or (tokens, emb_dim) for the Wormhole path
+                (after tensor indexing).
             gate_proj: Gate projection weight (emb_dim, hidden_dim)
             up_proj: Up projection weight (emb_dim, hidden_dim)
             down_proj: Down projection weight (hidden_dim, emb_dim)
-            out: Output tensor for matmul result (1, tokens, emb_dim)
+            out: Optional pre-allocated output tensor for in-place matmul result.
+                When provided, the final matmul writes directly into this buffer.
+                When None, a new tensor is allocated for the output.
 
         Returns:
-            Output tensor (1, tokens, emb_dim)
+            Output tensor matching the shape of ``x``.
         """
         # gate_out = x @ gate_proj
         gate_out = ttnn.matmul(
@@ -280,7 +291,7 @@ class TtRoutedExpert(LightweightModule):
             down_proj,
             program_config=self.down_program_config,
             compute_kernel_config=self.compute_kernel_config,
-            optional_output_tensor=out,
+            **({"optional_output_tensor": out} if out is not None else {}),
         )
 
         return output
@@ -323,7 +334,7 @@ class TtRoutedExpert(LightweightModule):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")
 
             # Extract tokens for this expert
-            # Shape: (max_tokens, emb_dim)
+            # Shape: (1, max_tokens, emb_dim)
             tokens = ttnn.narrow(dispatched_buffer, dim=0, start=local_expert, length=1)
             logger.debug(f"Expert {local_expert}: input shape {tokens.shape}")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -245,23 +245,20 @@ class TtRoutedExpert(LightweightModule):
         return tt_weight
 
     def _expert_ffn(
-        self,
-        x: ttnn.Tensor,
-        gate_proj: ttnn.Tensor,
-        up_proj: ttnn.Tensor,
-        down_proj: ttnn.Tensor,
+        self, x: ttnn.Tensor, gate_proj: ttnn.Tensor, up_proj: ttnn.Tensor, down_proj: ttnn.Tensor, out: ttnn.Tensor
     ) -> ttnn.Tensor:
         """
         Single expert FFN computation.
 
         Args:
-            x: Input tensor (batch, tokens, emb_dim)
+            x: Input tensor (1, tokens, emb_dim)
             gate_proj: Gate projection weight (emb_dim, hidden_dim)
             up_proj: Up projection weight (emb_dim, hidden_dim)
             down_proj: Down projection weight (hidden_dim, emb_dim)
+            out: Output tensor for matmul result (1, tokens, emb_dim)
 
         Returns:
-            Output tensor (batch, tokens, emb_dim)
+            Output tensor (1, tokens, emb_dim)
         """
         # gate_out = x @ gate_proj
         gate_out = ttnn.matmul(
@@ -282,6 +279,7 @@ class TtRoutedExpert(LightweightModule):
             down_proj,
             program_config=self.down_program_config,
             compute_kernel_config=self.compute_kernel_config,
+            optional_output_tensor=out,
         )
 
         return output
@@ -315,13 +313,14 @@ class TtRoutedExpert(LightweightModule):
         # dispatched_buffer: (experts_per_chip, max_tokens, emb_dim)
         # We process expert by expert and reassemble
 
-        expert_outputs_list = []
+        # expert_outputs = ttnn.empty_like(dispatched_buffer)
+        expert_outputs = ttnn.clone(dispatched_buffer)
         for local_expert in range(self.experts_per_chip):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")
 
             # Extract tokens for this expert
             # Shape: (max_tokens, emb_dim)
-            tokens = dispatched_buffer[local_expert, :, :]
+            tokens = ttnn.narrow(dispatched_buffer, dim=0, start=local_expert, length=1)
             logger.debug(f"Expert {local_expert}: input shape {tokens.shape}")
 
             # Run FFN
@@ -330,17 +329,11 @@ class TtRoutedExpert(LightweightModule):
                 self.gate_projs[local_expert],
                 self.up_projs[local_expert],
                 self.down_projs[local_expert],
+                out=ttnn.narrow(expert_outputs, dim=0, start=local_expert, length=1),
             )
             logger.debug(f"Expert {local_expert}: output shape {output.shape}")
 
-            # Add expert dimension back
-            # Shape: (1, max_tokens, emb_dim)
-            output = ttnn.unsqueeze(output, dim=0)
-            expert_outputs_list.append(output)
-
-        # Concatenate along expert dimension
         # Shape: (experts_per_chip, max_tokens, emb_dim)
-        expert_outputs = ttnn.concat(expert_outputs_list, dim=0)
         logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
 
         return expert_outputs

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -291,7 +291,7 @@ class TtRoutedExpert(LightweightModule):
             down_proj,
             program_config=self.down_program_config,
             compute_kernel_config=self.compute_kernel_config,
-            **({"optional_output_tensor": out} if out is not None else {}),
+            optional_output_tensor=out,
         )
 
         return output

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -18,6 +18,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
 
 COMPUTE_KERNEL_CONFIG_LOFI = ttnn.WormholeComputeKernelConfig(
@@ -284,13 +285,17 @@ class TtRoutedExpert(LightweightModule):
 
         return output
 
-    def forward(
+    def _bh_forward_impl(
         self,
         dispatched_buffer: ttnn.Tensor,
         expert_token_counts: ttnn.Tensor = None,  # Unused for now, can reduce compute
     ) -> ttnn.Tensor:
         """
-        Process dispatched tokens through local experts.
+        Blackhole forward implementation using narrow and in-place writes.
+
+        Pre-allocates the output tensor with empty_like and uses narrow to extract
+        per-expert slices and write FFN results directly into the output buffer,
+        avoiding extra allocations from unsqueeze/concat.
 
         Args:
             dispatched_buffer: Dispatched tokens
@@ -336,3 +341,95 @@ class TtRoutedExpert(LightweightModule):
         logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
 
         return expert_outputs
+
+    def _wh_forward_impl(
+        self,
+        dispatched_buffer: ttnn.Tensor,
+        expert_token_counts: ttnn.Tensor = None,  # Unused for now, can reduce compute
+    ) -> ttnn.Tensor:
+        """
+        Wormhole forward implementation using indexing, unsqueeze, and concat.
+
+        Extracts per-expert tokens via tensor indexing, runs the FFN, then
+        reassembles the output by unsqueezing and concatenating along the expert
+        dimension.
+
+        Args:
+            dispatched_buffer: Dispatched tokens
+                shape: (experts_per_chip, max_tokens, emb_dim)
+            expert_token_counts: Optional token counts per expert per chip
+                If provided, only processes tokens up to the count (currently unused,
+                all tokens are processed for simplicity)
+
+        Returns:
+            expert_outputs: Expert output tensor, same shape as dispatched_buffer
+        """
+        logger.debug(f"Forward pass: dispatched_buffer shape={dispatched_buffer.shape}")
+
+        # Convert input to activations dtype if needed
+        if dispatched_buffer.dtype != self.activations_dtype:
+            logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
+            dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
+
+        # Process each local expert
+        # dispatched_buffer: (experts_per_chip, max_tokens, emb_dim)
+        # We process expert by expert and reassemble
+
+        expert_outputs_list = []
+        for local_expert in range(self.experts_per_chip):
+            signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")
+
+            # Extract tokens for this expert
+            # Shape: (max_tokens, emb_dim)
+            tokens = dispatched_buffer[local_expert, :, :]
+            logger.debug(f"Expert {local_expert}: input shape {tokens.shape}")
+
+            # Run FFN
+            output = self._expert_ffn(
+                tokens,
+                self.gate_projs[local_expert],
+                self.up_projs[local_expert],
+                self.down_projs[local_expert],
+                out=None,  # Let the FFN allocate output since we will concatenate later
+            )
+            logger.debug(f"Expert {local_expert}: output shape {output.shape}")
+
+            # Add expert dimension back
+            # Shape: (1, max_tokens, emb_dim)
+            output = ttnn.unsqueeze(output, dim=0)
+            expert_outputs_list.append(output)
+
+        # Concatenate along expert dimension
+        # Shape: (experts_per_chip, max_tokens, emb_dim)
+        expert_outputs = ttnn.concat(expert_outputs_list, dim=0)
+        logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
+
+        return expert_outputs
+
+    def forward(
+        self,
+        dispatched_buffer: ttnn.Tensor,
+        expert_token_counts: ttnn.Tensor = None,  # Unused for now, can reduce compute
+    ) -> ttnn.Tensor:
+        """
+        Process dispatched tokens through local experts.
+
+        Dispatches to the architecture-specific implementation based on the
+        current device type (Wormhole or Blackhole).
+
+        Args:
+            dispatched_buffer: Dispatched tokens
+                shape: (experts_per_chip, max_tokens, emb_dim)
+            expert_token_counts: Optional token counts per expert per chip
+                If provided, only processes tokens up to the count (currently unused,
+                all tokens are processed for simplicity)
+
+        Returns:
+            expert_outputs: Expert output tensor, same shape as dispatched_buffer
+        """
+        if is_wormhole_b0():
+            return self._wh_forward_impl(dispatched_buffer, expert_token_counts)
+        elif is_blackhole():
+            return self._bh_forward_impl(dispatched_buffer, expert_token_counts)
+        else:
+            raise ValueError("Unsupported device architecture")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -313,8 +313,7 @@ class TtRoutedExpert(LightweightModule):
         # dispatched_buffer: (experts_per_chip, max_tokens, emb_dim)
         # We process expert by expert and reassemble
 
-        # expert_outputs = ttnn.empty_like(dispatched_buffer)
-        expert_outputs = ttnn.clone(dispatched_buffer)
+        expert_outputs = ttnn.empty_like(dispatched_buffer)
         for local_expert in range(self.experts_per_chip):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")
 


### PR DESCRIPTION
### Ticket
#40572 

### Problem description
There were unnecessary slice and concat ops that were influencing perf.

### What's changed
Unnecessary slice and concat ops are replaced with `ttnn.narrow` op on the Blackhole path, using pre-allocated output buffers and `optional_output_tensor` for in-place matmul writes.

The following results are based on this pytest
`pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_routed_expert.py -k "deepseek-v3-dims-skip-pcc and linear-4"`:

- before: 9,423.96 us
- after: 8,480.63 us

### Checklist
- <a href="https://github.com/tenstorrent/tt-metal/actions/runs/23900233013"> [(Blackhole) e2e tests]</a>
- <a href="https://github.com/tenstorrent/tt-metal/actions/runs/23900261860"> [(Galaxy) DeepSeek Prefill tests]</a>
- <a href="https://github.com/tenstorrent/tt-metal/actions/runs/23900282305"> [(T3K) T3000 e2e tests]</a>