### PR TITLE
[skip ci] Remove falcon7b from model perf test workflows

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -71,12 +71,6 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run falcon7b model_perf test
-        timeout-minutes: ${{ matrix.test-info.timeout }}
-        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
-        with:
-          commands: pytest models/demos/falcon7b_common/tests -m models_performance_bare_metal
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'llm_javelin' && (inputs.model == 'all' || inputs.model == 'falcon7b') }}
       - name: Run vanilla_unet model_perf test
         timeout-minutes: ${{ matrix.test-info.timeout }}
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - all
-          - falcon7b
           - functional_unet
           - stable_diffusion
           - sentence_bert
@@ -56,7 +55,7 @@ on:
   workflow_call:
     inputs:
       model:
-        description: "Select model to test (all, falcon7b, functional_unet, stable_diffusion, etc.)"
+        description: "Select model to test (all, functional_unet, stable_diffusion, etc.)"
         required: false
         type: string
         default: "all"


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-metal/issues/40015

Falcon-7B is a tier-3 model, and as such it doesn't require model device perf testing.

## Summary
- Remove `falcon7b` from the model selection options in `perf-models.yaml`
- Remove the `Run falcon7b model_perf test` step from `perf-models-impl.yaml`
- Update workflow_call input description to no longer reference falcon7b
