### PR TITLE
#35247: fix up batch transpose matmul

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -260,3 +260,106 @@ def test_matmul_2d_interleaved_sharded_dtype_bias_sweep(
         num_dram_banks=num_dram_banks,
         expected_pcc=expected_pcc,
     )
+
+
+@pytest.mark.parametrize(
+    "batch, m, k, n, program_config",
+    [
+        pytest.param(
+            256,
+            32,
+            128,
+            128,
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=1,
+                out_subblock_h=2,
+                out_subblock_w=2,
+                per_core_M=8,
+                per_core_N=4,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=False,
+            ),
+            id="1d_mcast_in1_fuse_batch",
+        ),
+        pytest.param(
+            8,
+            32,
+            128,
+            128,
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(2, 1),
+                in0_block_w=1,
+                out_subblock_h=2,
+                out_subblock_w=2,
+                per_core_M=8,
+                per_core_N=2,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            id="1d_mcast_in0_fuse_batch",
+        ),
+        pytest.param(
+            64,
+            32,
+            128,
+            128,
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(2, 8),
+                in0_block_w=1,
+                out_subblock_h=2,
+                out_subblock_w=2,
+                per_core_M=8,
+                per_core_N=2,
+                transpose_mcast=False,
+                fuse_batch=True,
+            ),
+            id="2d_mcast_fuse_batch",
+        ),
+    ],
+)
+@pytest.mark.timeout(120)
+def test_matmul_transpose_a_fuse_batch(device, batch, m, k, n, program_config):
+    """
+    Regression test for transpose_a stride calculation with fuse_batch enabled
+    in 1D mcast (both mcast_in0 and mcast_in1) and 2D mcast program configs.
+
+    When batches are fused into M and transpose_a is True, the reader kernel
+    strides must use M_per_batch (not the fused M) to correctly traverse tiles.
+    Program configs are specified explicitly to guard against future changes in
+    automatic config selection.
+    """
+    torch.manual_seed(0)
+
+    torch_a = torch.randn((batch, m, k), dtype=torch.bfloat16)
+    torch_b = torch.randn((1, k, n), dtype=torch.bfloat16)
+    torch_out = torch.matmul(torch_a, torch_b)
+
+    torch_a_phys = torch_a.transpose(-1, -2)
+    torch_b_phys = torch_b.transpose(-1, -2)
+
+    a = ttnn.from_torch(torch_a_phys, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b_phys, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    output = ttnn.matmul(
+        a,
+        b,
+        transpose_a=True,
+        transpose_b=True,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+    output = ttnn.to_torch(output)
+
+    assert output.shape == torch_out.shape
+    assert_with_pcc(torch_out, output, pcc=0.999)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -293,8 +293,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         in0_last_ktile_w,
         in0_last_ktile_h);
 
-    const auto in0_tensor_stride_w = transpose_a ? M : 1;
-    const auto in0_tensor_stride_h = transpose_a ? 1 : K;
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const bool batch_fused = (M != M_per_batch);
+    TT_FATAL(
+        !(transpose_a && batch_fused && M_per_batch > 1),
+        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
+        M_per_batch,
+        M);
+    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
+    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
@@ -1223,8 +1231,16 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
-    const auto in0_tensor_stride_w = transpose_a ? M : 1;
-    const auto in0_tensor_stride_h = transpose_a ? 1 : K;
+    const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
+    const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
+    const bool batch_fused = (M != M_per_batch);
+    TT_FATAL(
+        !(transpose_a && batch_fused && M_per_batch > 1),
+        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
+        M_per_batch,
+        M);
+    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
+    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -295,14 +295,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
     const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
-    const bool batch_fused = (M != M_per_batch);
-    TT_FATAL(
-        !(transpose_a && batch_fused && M_per_batch > 1),
-        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
-        M_per_batch,
-        M);
-    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
-    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
@@ -1233,14 +1227,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
     const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
     const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
-    const bool batch_fused = (M != M_per_batch);
-    TT_FATAL(
-        !(transpose_a && batch_fused && M_per_batch > 1),
-        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
-        M_per_batch,
-        M);
-    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
-    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -35,6 +35,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     bool packer_l1_acc,
     uint32_t B,
     uint32_t M,
+    uint32_t M_per_batch,
     uint32_t N,
     uint32_t K,
     bool bcast_batch,
@@ -339,8 +340,14 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         }
     }
 
-    const auto in0_tensor_stride_w = transpose_a ? M : 1;
-    const auto in0_tensor_stride_h = transpose_a ? 1 : K;
+    const bool batch_fused = (M != M_per_batch);
+    TT_FATAL(
+        !(transpose_a && batch_fused && M_per_batch > 1),
+        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
+        M_per_batch,
+        M);
+    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
+    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;
@@ -1670,6 +1677,7 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
     const auto B = fuse_batch ? 1 : get_batch_size(a_shape_padded);
     const auto Mt = get_M_dim(a_shape_padded, in0_tile, fuse_batch);
+    const auto Mt_per_batch = get_M_dim(a_shape_padded, in0_tile, false);
     const auto Kt = get_K_dim(a_shape_padded, in0_tile);
     const auto Nt = get_N_dim(b_shape_padded, in1_tile);
 
@@ -1728,6 +1736,7 @@ static MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t matmul_multi_
         packer_l1_acc,
         B,
         Mt,
+        Mt_per_batch,
         Nt,
         Kt,
         bcast_batch,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -340,14 +340,8 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
         }
     }
 
-    const bool batch_fused = (M != M_per_batch);
-    TT_FATAL(
-        !(transpose_a && batch_fused && M_per_batch > 1),
-        "transpose_a with fuse_batch is not supported when M_per_batch > 1 (M_per_batch={}, M={})",
-        M_per_batch,
-        M);
-    const auto in0_tensor_stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1;
-    const auto in0_tensor_stride_h = (transpose_a && !batch_fused) ? 1 : K;
+    const auto [in0_tensor_stride_w, in0_tensor_stride_h] =
+        operations::matmul::utilities::get_in0_transpose_strides(M, M_per_batch, transpose_a, K);
     const auto in0_tensor_next_block_stride = in0_block_w * in0_tensor_stride_w;
     const auto in0_tensor_next_h_dim_block_stride = in0_block_h * in0_tensor_stride_h;
     const auto in0_tensor_start_tile_id_stride = per_core_M * in0_tensor_stride_h;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -391,6 +391,15 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         get_batch_size(b_shape_padded) == 1,
                         "Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
                         "or equivalent. Please change the second input tensor or adjust the program config.");
+                    if (attributes.transpose_a) {
+                        uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
+                        TT_FATAL(
+                            M_per_batch <= 1,
+                            "transpose_a with fuse_batch is not supported when M_per_batch > 1 "
+                            "(M_per_batch={}, a_shape_padded={})",
+                            M_per_batch,
+                            a_shape_padded);
+                    }
                 }
             }
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -107,6 +107,35 @@ inline uint32_t get_N_dim(const tt::tt_metal::Shape& padded_shape, const std::op
     return padded_shape[-1] / (tile.has_value() ? tile.value().get_width() : 1);
 }
 
+struct In0TransposeStrides {
+    uint32_t stride_w;
+    uint32_t stride_h;
+};
+
+/**
+ * @brief Compute in0 tensor strides for the reader kernel, handling transpose_a with fuse_batch.
+ *
+ * When transpose_a is true and batches are not fused (M == M_per_batch), the tile traversal
+ * order must be transposed: stride_w = M_per_batch, stride_h = 1. When batches are fused
+ * (M != M_per_batch) or transpose_a is false, normal strides apply: stride_w = 1, stride_h = K.
+ *
+ * The caller must ensure that transpose_a + fuse_batch + M_per_batch > 1 is not used; this
+ * unsupported combination is validated in MatmulDeviceOperation::validate_on_program_cache_miss.
+ *
+ * @param M Total M dimension in tiles (possibly fused across batches)
+ * @param M_per_batch M dimension in tiles for a single batch
+ * @param transpose_a Whether the A tensor is logically transposed
+ * @param K K dimension in tiles
+ * @return In0TransposeStrides with stride_w and stride_h
+ */
+inline In0TransposeStrides get_in0_transpose_strides(uint32_t M, uint32_t M_per_batch, bool transpose_a, uint32_t K) {
+    const bool batch_fused = (M != M_per_batch);
+    return {
+        .stride_w = (transpose_a && !batch_fused) ? M_per_batch : 1u,
+        .stride_h = (transpose_a && !batch_fused) ? 1u : K,
+    };
+}
+
 /**
  * @brief Get the padded shape of a tensor, with optional transpose.
  *


### PR DESCRIPTION
### Ticket
Link to Github Issue #35247

### Problem description
Some tests with fused transpose with matmul were failing.

### What's changed
- There was a bug when fused transpose with batch was used.
- This has been fixed, some extra asserts added, and tests added to nightly.
- Tested locally that with changes the test pass and without they fail.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-35247_mm_tr_batch)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-35247_mm_tr_batch)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-35247_mm_tr_batch)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-35247_mm_tr_batch)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-35247_mm_tr_batch)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-35247_mm_tr_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-35247_mm_tr_batch)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
