### PR TITLE
Add package compatibility check to docker and venv

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -341,6 +341,15 @@ uv pip install --extra-index-url "$PYTORCH_INDEX" \
     --no-build-isolation \
     -r "$(pwd)/tt_metal/python_env/requirements-dev.txt"
 
+echo "Installing tt-triage dependiencies"
+uv pip install --index-strategy unsafe-best-match -r "$(pwd)/tools/triage/requirements.txt"
+
+echo "Checking packages are compatible"
+if ! uv pip check; then
+    echo -e "\033[1;31mERROR: Package compatibility check failed. See above for details.\033[0m" >&2
+    exit 1
+fi
+
 echo "Installing tt-metal"
 uv pip install -e .
 

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -22,6 +22,7 @@ OPTIONS:
     --bundle-python       Deep-copy the Python interpreter into the venv instead of
                           using symlinks. This makes the venv fully self-contained
                           and portable, at the cost of increased disk space.
+    --skip-compat-check   Skip the package compatibility check (uv pip check).
     --help, -h            Show this help message and exit
 
 ENVIRONMENT VARIABLES:
@@ -61,6 +62,7 @@ ARG_PYTHON_VERSION=""
 ARG_ENV_DIR=""
 FORCE_OVERWRITE="false"
 BUNDLE_PYTHON="false"
+SKIP_COMPAT_CHECK="false"
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -91,6 +93,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --bundle-python)
             BUNDLE_PYTHON="true"
+            shift
+            ;;
+        --skip-compat-check)
+            SKIP_COMPAT_CHECK="true"
             shift
             ;;
         --help|-h)
@@ -344,10 +350,14 @@ uv pip install --extra-index-url "$PYTORCH_INDEX" \
 echo "Installing tt-triage dependiencies"
 uv pip install --index-strategy unsafe-best-match -r "$(pwd)/tools/triage/requirements.txt"
 
-echo "Checking packages are compatible"
-if ! uv pip check; then
-    echo -e "\033[1;31mERROR: Package compatibility check failed. See above for details.\033[0m" >&2
-    exit 1
+if [[ "$SKIP_COMPAT_CHECK" == "true" ]]; then
+    echo "Skipping package compatibility check (--skip-compat-check)"
+else
+    echo "Checking packages are compatible"
+    if ! uv pip check; then
+        echo -e "\033[1;31mERROR: Package compatibility check failed. See above for details.\033[0m" >&2
+        exit 1
+    fi
 fi
 
 echo "Installing tt-metal"

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -350,6 +350,9 @@ uv pip install --extra-index-url "$PYTORCH_INDEX" \
 echo "Installing tt-triage dependencies"
 uv pip install --index-strategy unsafe-best-match -r "$(pwd)/tools/triage/requirements.txt"
 
+echo "Installing tt-metal"
+uv pip install -e .
+
 if [[ "$SKIP_COMPAT_CHECK" == "true" ]]; then
     echo "Skipping package compatibility check (--skip-compat-check)"
 else
@@ -359,9 +362,6 @@ else
         exit 1
     fi
 fi
-
-echo "Installing tt-metal"
-uv pip install -e .
 
 # Create .pth files for ttml
 # This allows using pre-built ttml from build_metal.sh --build-tt-train

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -347,7 +347,7 @@ uv pip install --extra-index-url "$PYTORCH_INDEX" \
     --no-build-isolation \
     -r "$(pwd)/tt_metal/python_env/requirements-dev.txt"
 
-echo "Installing tt-triage dependiencies"
+echo "Installing tt-triage dependencies"
 uv pip install --index-strategy unsafe-best-match -r "$(pwd)/tools/triage/requirements.txt"
 
 if [[ "$SKIP_COMPAT_CHECK" == "true" ]]; then

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -170,7 +170,8 @@ RUN umask 000 && \
     uv pip install --no-cache --index-url https://download.pytorch.org/whl/cpu torch && \
     uv pip install --index-strategy unsafe-best-match --no-cache --no-build-isolation -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
     uv pip install --index-strategy unsafe-best-match --no-cache -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt && \
-    uv pip install --index-strategy unsafe-best-match --no-cache -r ${TT_METAL_INFRA_DIR}/tools/triage/requirements.txt
+    uv pip install --index-strategy unsafe-best-match --no-cache -r ${TT_METAL_INFRA_DIR}/tools/triage/requirements.txt && \
+    uv pip check
 
 #############################################################
 


### PR DESCRIPTION
### Ticket
/

### Problem description
Adding `uv pip check` when creating dockerfile as well as when creating a virtual environment to ensure all dependencies and packages are compatible and avoid breaking changes.

Dockerfile change will ensure we don't commit a breaking change while venv change will ensure catching it locally.

Also, adding tt-triage dependency installation in venv.

Recent example:
Bump of `tt-smi` to `4.1.2` pulled `tt-umd 0.9.4`, while `tt-triage` pulled `tt-umd 0.9.3.x` and caused `tt-smi` to stop working and broke CI and merge gates.

That bump would be caught with this output:
<img width="565" height="89" alt="image" src="https://github.com/user-attachments/assets/2c9b24d9-0894-44b3-9a9b-1eef8b410a4a" />
 
### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/package-check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/package-check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/package-check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/package-check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/package-check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/package-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/package-check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
