### PR TITLE
Fix ttnn::pad segfault with interleaved input and sharded output memory_config

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -327,13 +327,19 @@ ttnn::Tensor invoke_tile(
     }
     if (output_tensor.memory_config().shard_spec().has_value() !=
         memory_config_arg.value_or(input_tensor.memory_config()).shard_spec().has_value()) {
-        const auto sharded_mem_config = create_sharded_memory_config(
-            ttnn::Shape{requested_logical_shape},
-            input_tensor.shard_spec()->grid,
-            ShardStrategy::HEIGHT,
-            ShardOrientation::ROW_MAJOR);
-        output_tensor =
-            ttnn::to_memory_config(output_tensor, memory_config_arg.value_or(sharded_mem_config), std::nullopt);
+        if (memory_config_arg.has_value()) {
+            output_tensor = ttnn::to_memory_config(output_tensor, memory_config_arg.value(), std::nullopt);
+        } else {
+            // memory_config_arg is nullopt → condition can only be true if input is sharded
+            // (interleaved input + nullopt config → both sides false → condition false)
+            // so input_tensor.shard_spec()->grid is safe here.
+            const auto sharded_mem_config = create_sharded_memory_config(
+                ttnn::Shape{requested_logical_shape},
+                input_tensor.shard_spec()->grid,
+                ShardStrategy::HEIGHT,
+                ShardOrientation::ROW_MAJOR);
+            output_tensor = ttnn::to_memory_config(output_tensor, sharded_mem_config, std::nullopt);
+        }
     }
     return output_tensor;
 }


### PR DESCRIPTION
## Summary
- Fix segfault in `invoke_tile` (`pad.cpp:328-336`) when `ttnn::pad` is called with an interleaved TILE_LAYOUT input and a sharded output `memory_config`
- The old code unconditionally built a fallback sharded config from `input_tensor.shard_spec()->grid`, which is `nullopt` for interleaved inputs — but when `memory_config_arg` is provided, the fallback was dead code anyway (`value_or` always returned `memory_config_arg`)
- Split the branch: use `memory_config_arg` directly when present, only fall back to input shard grid when nullopt (which is safe since the condition requires a sharded input in that case)

Closes #40898

## Test plan
- [x] Reproducer script (`repro_pad_sharded_output.py` from #40898) no longer segfaults
- [x] Existing pad unit tests pass: `pytest tests/ttnn/unit_tests/operations/data_movement/test_pad.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)