### PR TITLE
Restrict profiler to only search local cluster eth cores

### DIFF
--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -368,24 +368,10 @@ void syncDeviceDevice(ChipId device_id_sender, ChipId device_id_receiver) {
         constexpr std::uint16_t sample_size = 16;
         constexpr std::uint16_t channel_count = 1;
 
-        const auto& active_eth_cores = device_sender->get_active_ethernet_cores(false);
-        auto eth_sender_core_iter = active_eth_cores.begin();
-        tt_xy_pair eth_receiver_core;
-        tt_xy_pair eth_sender_core;
+        const auto& connected_chips =
+            MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(device_id_sender);
 
-        ChipId device_id_receiver_curr = std::numeric_limits<ChipId>::max();
-        while ((device_id_receiver != device_id_receiver_curr) and (eth_sender_core_iter != active_eth_cores.end())) {
-            eth_sender_core = *eth_sender_core_iter;
-            if (not MetalContext::instance().get_cluster().is_ethernet_link_up(device_sender->id(), eth_sender_core)) {
-                eth_sender_core_iter++;
-                continue;
-            }
-            std::tie(device_id_receiver_curr, eth_receiver_core) =
-                device_sender->get_connected_ethernet_core(eth_sender_core);
-            eth_sender_core_iter++;
-        }
-
-        if (device_id_receiver != device_id_receiver_curr) {
+        if (!connected_chips.contains(device_id_receiver) || connected_chips.at(device_id_receiver).empty()) {
             log_warning(
                 tt::LogMetal,
                 "No eth connection could be found between device {} and {}",
@@ -393,6 +379,11 @@ void syncDeviceDevice(ChipId device_id_sender, ChipId device_id_receiver) {
                 device_id_receiver);
             return;
         }
+
+        CoreCoord eth_sender_core = connected_chips.at(device_id_receiver)[0];
+        auto [connected_chip_id, eth_receiver_core] =
+            MetalContext::instance().get_cluster().get_connected_ethernet_core(
+                std::make_tuple(device_id_sender, eth_sender_core));
 
         const std::vector<uint32_t>& ct_args = {
             channel_count, static_cast<uint32_t>(sample_count), static_cast<uint32_t>(sample_size)};
@@ -639,20 +630,12 @@ void ProfilerSync(ProfilerSyncState state) {
                 if (!MetalContext::instance().device_manager()->is_device_active(sender_device_id)) {
                     continue;
                 }
-                auto* sender_device = MetalContext::instance().device_manager()->get_active_device(sender_device_id);
-                const auto& active_eth_cores = sender_device->get_active_ethernet_cores(false);
 
-                ChipId receiver_device_id;
-                tt_xy_pair receiver_eth_core;
-                for (const auto& sender_eth_core : active_eth_cores) {
-                    if (not MetalContext::instance().get_cluster().is_ethernet_link_up(
-                            sender_device_id, sender_eth_core)) {
-                        continue;
-                    }
+                const auto& connected_chips =
+                    MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
+                        sender_device_id);
 
-                    std::tie(receiver_device_id, receiver_eth_core) =
-                        sender_device->get_connected_ethernet_core(sender_eth_core);
-
+                for (const auto& [receiver_device_id, eth_cores] : connected_chips) {
                     if (visited.contains(receiver_device_id) && !visited[receiver_device_id]) {
                         visited[receiver_device_id] = true;
                         num_connected_devices[*root_device]++;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -381,9 +381,8 @@ void syncDeviceDevice(ChipId device_id_sender, ChipId device_id_receiver) {
         }
 
         CoreCoord eth_sender_core = connected_chips.at(device_id_receiver)[0];
-        auto [connected_chip_id, eth_receiver_core] =
-            MetalContext::instance().get_cluster().get_connected_ethernet_core(
-                std::make_tuple(device_id_sender, eth_sender_core));
+        auto eth_receiver_core = std::get<1>(MetalContext::instance().get_cluster().get_connected_ethernet_core(
+            std::make_tuple(device_id_sender, eth_sender_core)));
 
         const std::vector<uint32_t>& ct_args = {
             channel_count, static_cast<uint32_t>(sample_count), static_cast<uint32_t>(sample_size)};
@@ -635,7 +634,8 @@ void ProfilerSync(ProfilerSyncState state) {
                     MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
                         sender_device_id);
 
-                for (const auto& [receiver_device_id, eth_cores] : connected_chips) {
+                for (const auto& connected_chip : connected_chips) {
+                    ChipId receiver_device_id = connected_chip.first;
                     if (visited.contains(receiver_device_id) && !visited[receiver_device_id]) {
                         visited[receiver_device_id] = true;
                         num_connected_devices[*root_device]++;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
On machines where there are eth connections to other hosts/devices outside of our cluster, if we enable set `TT_METAL_PROFILER_SYNC=1`, then profiler will try and query eth cores of the remote clusters using APIs that assert if the connection is not within the local cluster.

### What's changed
Change profiler to only iterate over local eth connections.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/eth)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/eth)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/eth)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/eth)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/eth)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/eth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/eth)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
