### PR TITLE
[skip ci] Create new workflow for tt-deploy model testing

### DIFF
--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -124,7 +124,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           # Source T3K test scripts if needed (for run_t3000_* functions)
-          if [[ "${{ matrix.test-group.cmd }}" == *"run_t3000"* ]]; then
+          if echo "${{ matrix.test-group.cmd }}" | grep -q "run_t3000"; then
             source tests/scripts/t3000/run_t3000_demo_tests.sh
             source tests/scripts/t3000/run_t3000_perf_tests.sh
             source tests/scripts/t3000/run_t3000_integration_tests.sh

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -1,0 +1,158 @@
+name: "[internal] Demo SP Release tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      enabled-skus:
+        required: true
+        type: string
+      model:
+        required: false
+        type: string
+        default: "all"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
+      job-prefix:
+        required: false
+        type: string
+        default: ""
+        description: "Optional prefix for job names"
+
+jobs:
+  load-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.apply-model-filter.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/demo_sp_release_tests.yaml
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "demo"
+      - name: Build unified test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
+      - name: Apply model filter
+        id: apply-model-filter
+        run: |
+          MATRIX='${{ steps.build-matrix.outputs.matrix }}'
+          if [ "${{ inputs.model }}" = "all" ]; then
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$MATRIX" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            FILTERED=$(echo "$MATRIX" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model == $m)]')
+            if [ "$FILTERED" = "[]" ]; then
+              echo "::error::No tests found for model '${{ inputs.model }}'. Ensure the model is defined in the test matrix (TESTS_YAML_PATH=${TESTS_YAML_PATH})."
+              exit 1
+            fi
+            echo "matrix<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+  demo-sp-release-tests:
+    needs: load-test-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ inputs.job-prefix }}${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        LOGURU_LEVEL: INFO
+        HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: Mark repository as safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          echo "${{ matrix.test-group.cmd }}"
+          ${{ matrix.test-group.cmd }}
+      - name: Save environment data
+        id: save-environment-data
+        if: ${{ !cancelled() && matrix.test-group.save-perf-data }}
+        run: |
+          if [ -d "generated/benchmark_data" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py "${{ matrix.test-group.sku }}"
+          else
+            echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload benchmark data
+        if: ${{ !cancelled() && matrix.test-group.save-perf-data && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: ${{ matrix.test-group.owner_id }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -62,8 +62,9 @@ jobs:
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter
+        env:
+          MATRIX: ${{ steps.build-matrix.outputs.matrix }}
         run: |
-          MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           if [ "${{ inputs.model }}" = "all" ]; then
             echo "matrix<<EOF" >> $GITHUB_OUTPUT
             echo "$MATRIX" >> $GITHUB_OUTPUT

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -122,6 +122,12 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
+          # Source T3K test scripts if needed (for run_t3000_* functions)
+          if [[ "${{ matrix.test-group.cmd }}" == *"run_t3000"* ]]; then
+            source tests/scripts/t3000/run_t3000_demo_tests.sh
+            source tests/scripts/t3000/run_t3000_perf_tests.sh
+            source tests/scripts/t3000/run_t3000_integration_tests.sh
+          fi
           echo "${{ matrix.test-group.cmd }}"
           ${{ matrix.test-group.cmd }}
       - name: Save environment data

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -123,14 +123,21 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
+          # Store command safely using heredoc
+          CMD=$(cat << 'EOF'
+          ${{ matrix.test-group.cmd }}
+          EOF
+          )
+
           # Source T3K test scripts if needed (for run_t3000_* functions)
-          if echo "${{ matrix.test-group.cmd }}" | grep -q "run_t3000"; then
+          if [[ "$CMD" == *"run_t3000"* ]]; then
             source tests/scripts/t3000/run_t3000_demo_tests.sh
             source tests/scripts/t3000/run_t3000_perf_tests.sh
             source tests/scripts/t3000/run_t3000_integration_tests.sh
           fi
-          echo "${{ matrix.test-group.cmd }}"
-          ${{ matrix.test-group.cmd }}
+
+          echo "$CMD"
+          eval "$CMD"
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() && matrix.test-group.save-perf-data }}

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -1,4 +1,4 @@
-name: "(Demo) Model Status for Deploy"
+name: "(Demo) Model Status for Console Deployment"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -1,4 +1,4 @@
-name: "(Demo) Model Status for Console Deployment"
+name: "(Release) Model Status for Console Deployment"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -43,8 +43,8 @@ on:
           - wan22
 
   schedule:
-    # Run daily at 5 AM UTC
-    - cron: "0 5 * * *"
+    # Run daily at 4 AM UTC
+    - cron: "0 4 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -43,8 +43,8 @@ on:
           - wan22
 
   schedule:
-    # Run daily at 9 AM UTC
-    - cron: "0 9 * * *"
+    # Run daily at 5 AM UTC
+    - cron: "0 5 * * *"
 
 permissions:
   contents: write

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -1,0 +1,95 @@
+name: "(Demo) Model Status for Deploy"
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        required: false
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+        description: "Platform to build and test"
+      build-type:
+        required: false
+        type: choice
+        default: Release
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - ASan
+          - TSan
+        description: "Build type configuration"
+      enable-lto:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
+      test-group:
+        description: "Select which test group to run"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - deepseek_prefill
+          - wan22
+
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: write
+  packages: write
+  actions: write
+  id-token: write
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
+      enable-lto: ${{ inputs.enable-lto || false }}
+      build-wheel: true
+
+  deepseek-prefill-tests:
+    name: "DeepSeek Prefill Tests"
+    needs: build-artifact
+    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'deepseek_prefill' || github.event_name == 'schedule' }}
+    secrets: inherit
+    uses: ./.github/workflows/demo-sp-release-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: bh_galaxy,wh_llmbox,bh_loudbox,bh_qb
+      model: deepseek_prefill
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      job-prefix: "[DeepSeek] "
+
+  wan22-tests:
+    name: "Wan 2.2 Tests"
+    needs: build-artifact
+    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'wan22' || github.event_name == 'schedule' }}
+    secrets: inherit
+    uses: ./.github/workflows/demo-sp-release-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: wh_galaxy_perf,wh_galaxy,wh_llmbox_perf,wh_llmbox
+      model: wan22
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      job-prefix: "[Wan2.2] "

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -43,7 +43,7 @@ on:
           - wan22
 
   schedule:
-    # Run daily at 2 AM UTC
+    # Run daily at 9 AM UTC
     - cron: "0 9 * * *"
 
 permissions:

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -74,7 +74,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,wh_llmbox,bh_loudbox,bh_qb
+      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_llmbox
       model: deepseek_prefill
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[DeepSeek] "
@@ -89,7 +89,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy_perf,wh_galaxy,wh_llmbox_perf,wh_llmbox
+      enabled-skus: wh_galaxy_perf,wh_llmbox_perf
       model: wan22
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[Wan2.2] "

--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -1,17 +1,8 @@
 name: "(Galaxy) DeepSeek Prefill tests"
 
 on:
-
   workflow_dispatch:
     inputs:
-      test-type:
-        description: 'Select which tests to run'
-        required: true
-        type: choice
-        options:
-          - all
-          - module
-        default: 'all'
       platform:
         required: false
         type: choice
@@ -36,6 +27,30 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
+      test-group:
+        description: "Select which test group to run"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - deepseek_prefill
+          - wan22
+
+  schedule:
+    # Run daily at 9 AM UTC
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: write
+  packages: write
+  actions: write
+  id-token: write
 
 jobs:
   build-artifact:
@@ -45,16 +60,36 @@ jobs:
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-  Galaxy-DeepSeek-Prefill-tests:
+      build-wheel: true
+
+  deepseek-prefill-tests:
+    name: "DeepSeek Prefill Tests"
     needs: build-artifact
+    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'deepseek_prefill' || github.event_name == 'schedule' }}
     secrets: inherit
-    uses: ./.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+    uses: ./.github/workflows/demo-sp-release-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enabled-skus: bh_galaxy
-      test-type: ${{ inputs.test-type || 'all' }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_llmbox
+      model: deepseek_prefill
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      job-prefix: "[DeepSeek] "
+
+  wan22-tests:
+    name: "Wan 2.2 Tests"
+    needs: build-artifact
+    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'wan22' || github.event_name == 'schedule' }}
+    secrets: inherit
+    uses: ./.github/workflows/demo-sp-release-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      enabled-skus: wh_galaxy_perf,wh_llmbox_perf
+      model: wan22
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      job-prefix: "[Wan2.2] "

--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -1,8 +1,17 @@
 name: "(Galaxy) DeepSeek Prefill tests"
 
 on:
+
   workflow_dispatch:
     inputs:
+      test-type:
+        description: 'Select which tests to run'
+        required: true
+        type: choice
+        options:
+          - all
+          - module
+        default: 'all'
       platform:
         required: false
         type: choice
@@ -27,30 +36,6 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-      mlperf-read-only:
-        required: false
-        type: boolean
-        default: true
-        description: "Set to false to allow write access to MLPerf mount"
-      test-group:
-        description: "Select which test group to run"
-        required: false
-        default: "all"
-        type: choice
-        options:
-          - all
-          - deepseek_prefill
-          - wan22
-
-  schedule:
-    # Run daily at 9 AM UTC
-    - cron: "0 9 * * *"
-
-permissions:
-  contents: write
-  packages: write
-  actions: write
-  id-token: write
 
 jobs:
   build-artifact:
@@ -60,36 +45,16 @@ jobs:
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      build-wheel: true
-
-  deepseek-prefill-tests:
-    name: "DeepSeek Prefill Tests"
+  Galaxy-DeepSeek-Prefill-tests:
     needs: build-artifact
-    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'deepseek_prefill' || github.event_name == 'schedule' }}
     secrets: inherit
-    uses: ./.github/workflows/demo-sp-release-impl.yaml
+    uses: ./.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_llmbox
-      model: deepseek_prefill
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
-      job-prefix: "[DeepSeek] "
-
-  wan22-tests:
-    name: "Wan 2.2 Tests"
-    needs: build-artifact
-    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'wan22' || github.event_name == 'schedule' }}
-    secrets: inherit
-    uses: ./.github/workflows/demo-sp-release-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy_perf,wh_llmbox_perf
-      model: wan22
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
-      job-prefix: "[Wan2.2] "
+      enabled-skus: bh_galaxy
+      test-type: ${{ inputs.test-type || 'all' }}

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -113,7 +113,7 @@
   model: wan22
   skus:
     wh_llmbox_perf:
-      timeout: 25
+      timeout: 45
   owner_id: U03FJB5TM5Y
   team: models
   model-name: wan22

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -1,0 +1,141 @@
+# This file defines the test matrix for the SP Demo Release pipeline.
+# This pipeline includes tests for:
+#   - Galaxy DeepSeek Prefill
+#   - Wan 2.2 (across Galaxy and T3K)
+
+# Each entry represents a parallel job with the following keys:
+#   name: The display name for the job in GitHub Actions.
+#   cmd: The exact command to run (env vars must be inlined).
+#   skus: A mapping of SKU names to their configuration (each SKU has timeout in minutes).
+#   owner_id: The Slack user ID to notify on failure.
+#   team: The team that owns the test.
+#   model: Model identifier for filtering tests.
+
+# For max allowed timeout refer to .github/time_budget.yaml
+
+# ============================================================================
+# Galaxy DeepSeek Prefill Tests
+# ============================================================================
+
+- name: "(Galaxy) DeepSeek Prefill module tests"
+  cmd: export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG && uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt && pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
+  model: deepseek_prefill
+  skus:
+    bh_galaxy:
+      timeout: 30
+  owner_id: U08RL15T4N8
+  team: models
+
+- name: "t3k_DeepSeek_PREFILL"
+  cmd: |
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py -vvv  --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4)"
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py -vvv --tb=short -k "mesh-4x2"
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+  model: deepseek_prefill
+  skus:
+    wh_llmbox:
+      timeout: 45
+  owner_id: U08E1JCMAJF
+  team: shield
+
+- name: bh_lb_DeepSeek_PREFILL
+  cmd: |
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc"
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
+  model: deepseek_prefill
+  skus:
+    bh_loudbox:
+      timeout: 45
+  owner_id: U08E1JCMAJF
+  team: shield
+
+- name: bh_qb_DeepSeek_PREFILL
+  cmd: |
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc"
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2' -vvv --tb=short
+  model: deepseek_prefill
+  skus:
+    bh_qb:
+      timeout: 40
+  owner_id: U08E1JCMAJF
+  team: shield
+
+# ============================================================================
+# Wan 2.2 Tests (Galaxy)
+# ============================================================================
+
+- name: Galaxy Wan2.2 demo tests
+  cmd: |
+    export TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE NO_PROMPT=1
+    pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "wh_4x8sp1tp0 and resolution_720p" --timeout 1500
+  model: wan22
+  skus:
+    wh_galaxy_perf:
+      timeout: 20
+  owner_id: U03FJB5TM5Y
+  team: models
+
+- name: Galaxy DiT Wan2.2 model perf tests
+  cmd: |
+    export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
+    pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8sp1tp0 and resolution_720p and t2v" --timeout=1200
+  model: wan22
+  skus:
+    wh_galaxy_perf:
+      timeout: 25
+  owner_id: U03FJB5TM5Y
+  team: models
+  arch: wormhole_b0
+  save-perf-data: true
+  model-type: Wan2.2
+
+- name: Galaxy Wan2.2 integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
+  model: wan22
+  skus:
+    wh_galaxy:
+      timeout: 40
+  owner_id: U03FJB5TM5Y
+  team: ttnn
+
+# ============================================================================
+# Wan 2.2 Tests (T3K)
+# ============================================================================
+
+- name: t3k_wan2.2_tests_demo
+  cmd: run_t3000_wan22_tests
+  model: wan22
+  skus:
+    wh_llmbox_perf:
+      timeout: 25
+  owner_id: U03FJB5TM5Y
+  team: models
+  model-name: wan22
+
+- name: t3k_DiT_Wan2.2_model_perf_tests
+  cmd: run_t3000_wan22_tests
+  model: wan22
+  skus:
+    wh_llmbox_perf:
+      timeout: 45
+  owner_id: U03FJB5TM5Y
+  team: models
+  model-name: wan22
+  model-type: DiT
+  save-perf-data: true
+
+- name: t3k_wan2.2_tests_integration
+  cmd: run_t3000_wan22_tests
+  model: wan22
+  skus:
+    wh_llmbox:
+      timeout: 45
+  owner_id: U03FJB5TM5Y
+  team: models
+  model-name: wan2.2

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -37,10 +37,10 @@
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla -k "2x4 and random and scaled_sl and check_pcc" -vvv --tb=short
   model: deepseek_prefill
   skus:
-    wh_llmbox:
+    wh_llmbox_perf:
       timeout: 45
   owner_id: U08E1JCMAJF
-  team: shield
+  team: models
 
 - name: bh_lb_DeepSeek_PREFILL
   cmd: |
@@ -53,7 +53,7 @@
     bh_loudbox:
       timeout: 45
   owner_id: U08E1JCMAJF
-  team: shield
+  team: models
 
 - name: bh_qb_DeepSeek_PREFILL
   cmd: |
@@ -61,10 +61,10 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2' -vvv --tb=short
   model: deepseek_prefill
   skus:
-    bh_qb:
+    bh_llmbox:
       timeout: 40
   owner_id: U08E1JCMAJF
-  team: shield
+  team: models
 
 # ============================================================================
 # Wan 2.2 Tests (Galaxy)
@@ -99,10 +99,10 @@
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
   model: wan22
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 40
   owner_id: U03FJB5TM5Y
-  team: ttnn
+  team: models
 
 # ============================================================================
 # Wan 2.2 Tests (T3K)
@@ -134,7 +134,7 @@
   cmd: run_t3000_wan22_tests
   model: wan22
   skus:
-    wh_llmbox:
+    wh_llmbox_perf:
       timeout: 45
   owner_id: U03FJB5TM5Y
   team: models


### PR DESCRIPTION
### Ticket
[Link to slack thread](https://tenstorrent.slack.com/archives/C09SFA6NTUY/p1773849643602289)

### Problem description
Currently we don't have unified workflow for models that are for tt-deploy event/tenstorrent console
Also we need a workflow where we will run models on exabox

### What's changed
Added a new workflow that currently has

- Deepseek prefill tests (t3k bh/wh, galaxy)
- Wan 2.2 (t3k bh/wh, galaxy)