### PR TITLE
fix for failing bevformer test

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -4,10 +4,7 @@
 """
 Regression test for matmul with batch dimension mismatch (in0_B > 1, in1_B = 1).
 
-This tests the reuse_in0_in_CB optimization path that was previously causing hangs
-when the input tensor had batch > 1 and the weight tensor had batch = 1.
-
-GitHub Issue: Fixed hang in BEVFormer spatial cross attention with batch=6
+This tests the path that was previously causing hangs when the input tensor had batch > 1 and the weight tensor had batch = 1.
 """
 
 import pytest
@@ -19,7 +16,7 @@ from models.common.utility_functions import comp_pcc
 @pytest.mark.parametrize(
     "batch, M, K, N",
     [
-        (6, 30125, 256, 256),
+        (6, 3000, 256, 256),
     ],
 )
 def test_matmul_batch_mismatch(batch, M, K, N, device):
@@ -30,8 +27,7 @@ def test_matmul_batch_mismatch(batch, M, K, N, device):
     - Input: [batch, M, K]
     - Weight: [K, N] (no batch dimension, implicitly batch=1)
 
-    Previously, batch=6 would hang in the matmul kernel due to incorrect handling
-    of the reuse_in0_in_CB optimization in the 1D mcast reuse program factory.
+    Previously, batch=6 would hang in the matmul kernel due to incorrect argument passed to the in1 reader receiver kernel.
     """
     # Create input tensor [batch, M, K]
     input_torch = torch.randn(batch, M, K)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -13,14 +13,13 @@ GitHub Issue: Fixed hang in BEVFormer spatial cross attention with batch=6
 import pytest
 import torch
 import ttnn
+from models.common.utility_functions import comp_pcc
 
 
 @pytest.mark.parametrize(
     "batch, M, K, N",
     [
-        (6, 30125, 256, 256),  # Exact failing case from BEVFormer SCA
-        (2, 1000, 256, 256),  # Smaller case with batch=2
-        (1, 30125, 256, 256),  # Baseline batch=1 case
+        (6, 30125, 256, 256),
     ],
 )
 def test_matmul_batch_mismatch(batch, M, K, N, device):
@@ -61,5 +60,6 @@ def test_matmul_batch_mismatch(batch, M, K, N, device):
     # Compute reference
     expected = torch.matmul(input_torch, weight_torch) + bias_torch
 
-    # Verify correctness (allow for numerical differences due to bfloat16)
-    assert torch.allclose(output_torch, expected, rtol=1e-2, atol=1e-1)
+    # Verify correctness using PCC (allow for numerical differences due to bfloat16)
+    pcc_passed, pcc_message = comp_pcc(expected, output_torch, 0.99)
+    assert pcc_passed, f"PCC check failed: {pcc_message}"

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_batch_mismatch.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for matmul with batch dimension mismatch (in0_B > 1, in1_B = 1).
+
+This tests the reuse_in0_in_CB optimization path that was previously causing hangs
+when the input tensor had batch > 1 and the weight tensor had batch = 1.
+
+GitHub Issue: Fixed hang in BEVFormer spatial cross attention with batch=6
+"""
+
+import pytest
+import torch
+import ttnn
+
+
+@pytest.mark.parametrize(
+    "batch, M, K, N",
+    [
+        (6, 30125, 256, 256),  # Exact failing case from BEVFormer SCA
+        (2, 1000, 256, 256),  # Smaller case with batch=2
+        (1, 30125, 256, 256),  # Baseline batch=1 case
+    ],
+)
+def test_matmul_batch_mismatch(batch, M, K, N, device):
+    """
+    Test ttnn.linear with batch dimension mismatch (input batch >= 1, weight batch = 1).
+
+    This specifically tests the case where:
+    - Input: [batch, M, K]
+    - Weight: [K, N] (no batch dimension, implicitly batch=1)
+
+    Previously, batch=6 would hang in the matmul kernel due to incorrect handling
+    of the reuse_in0_in_CB optimization in the 1D mcast reuse program factory.
+    """
+    # Create input tensor [batch, M, K]
+    input_torch = torch.randn(batch, M, K)
+    input_ttnn = ttnn.from_torch(input_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    # Create weight tensor [K, N]
+    weight_torch = torch.randn(K, N)
+    weight_ttnn = ttnn.from_torch(weight_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    # Create bias tensor [N]
+    bias_torch = torch.randn(N)
+    bias_ttnn = ttnn.from_torch(bias_torch, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    # Run ttnn.linear (internally uses matmul)
+    output = ttnn.linear(input_ttnn, weight_ttnn, bias=bias_ttnn)
+
+    # Ensure operation completes (this was the hang point for batch=6)
+    ttnn.synchronize_device(device)
+
+    # Verify output shape
+    assert list(output.shape) == [batch, M, N]
+
+    # Convert back to torch for correctness check
+    output_torch = ttnn.to_torch(output).to(torch.float32)
+
+    # Compute reference
+    expected = torch.matmul(input_torch, weight_torch) + bias_torch
+
+    # Verify correctness (allow for numerical differences due to bfloat16)
+    assert torch.allclose(output_torch, expected, rtol=1e-2, atol=1e-1)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -367,6 +367,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
             (std::uint32_t)M * K,  // MtKt
             (std::uint32_t)B,      // batch
             (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
             // sparsity args
             (std::uint32_t)0,     // batchB
             (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
@@ -1270,9 +1271,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)0,  // in0_mcast_num_dests
         (std::uint32_t)0,  // in0_mcast_num_cores
         // batch args
-        (std::uint32_t)M * K,  // MtKt
-        (std::uint32_t)in0_B,  // batch
-        (std::uint32_t)in1_B,  // batch
+        (std::uint32_t)M * K,            // MtKt
+        (std::uint32_t)in0_B,            // batch
+        (std::uint32_t)in1_B,            // batch
+        (std::uint32_t)reuse_in0_in_CB,  // reuse_in0_in_CB
         // sparsity args
         (std::uint32_t)0,     // batchB
         (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1132,7 +1132,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     uint32_t in0_block_tiles = in0_block_h * in0_block_w;
     uint32_t in0_CB_tiles = in0_block_tiles;
 
-    if (in0_B == 1 && in1_B > 1) {
+    bool reuse_in0_in_CB =
+        ((in0_B == 1 && in1_B > 1) && !in0_is_sharded && !output_is_sharded && !bcast_batch &&
+         !fused_activation.has_value());
+
+    if (reuse_in0_in_CB) {
         in0_CB_tiles = per_core_M * num_blocks * in0_block_w;
     } else if (in0_is_sharded) {
         in0_CB_tiles = num_blocks * per_core_M * in0_block_w * in0_B;
@@ -1177,6 +1181,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     if (in1_B * num_blocks > 1) {
         in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
     }
+
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
 
     uint32_t out_block_tiles = out_block_h * out_block_w;
@@ -1268,7 +1273,6 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)M * K,  // MtKt
         (std::uint32_t)in0_B,  // batch
         (std::uint32_t)in1_B,  // batch
-
         // sparsity args
         (std::uint32_t)0,     // batchB
         (std::uint32_t)0,     // sparsity_pagesize (placeholder since sparsity not used in this case)
@@ -1300,9 +1304,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
         (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
         // batch args
-        (std::uint32_t)K * N,                                        // KtNt
-        (std::uint32_t)((in0_B == 1 && in1_B > 1) ? in1_B : in0_B),  // batch
-        (std::uint32_t)bcast_batch,                                  // bcast_B
+        (std::uint32_t)K * N,                              // KtNt
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        (std::uint32_t)bcast_batch,                        // bcast_B
         // sparsity args
         (std::uint32_t)0,  // batchB
         (std::uint32_t)0,  // sparsity_pagesize (placeholder since sparsity not used in this case)
@@ -1352,7 +1356,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         (std::uint32_t)in1_mcast_sender_semaphore_id,
         (std::uint32_t)in1_mcast_receiver_semaphore_id,
         // batch args
-        (std::uint32_t)in1_B,  // batch
+        (std::uint32_t)(reuse_in0_in_CB ? in1_B : in0_B),  // batch
 
         // WRITER
         // out tensor args
@@ -1542,11 +1546,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         out_num_blocks_x,  // out_num_blocks_x
         out_num_blocks_y,  // out_num_blocks_y
 
-        out_subblock_h,               // out_subblock_h
-        out_subblock_w,               // out_subblock_w
-        out_subblock_num_tiles,       // out_subblock_num_tiles
-        bcast_batch ? in0_B : in1_B,  // batch (use in0_B when broadcasting in1, otherwise in1_B)
-        out_block_tiles,              // out_block_num_tiles
+        out_subblock_h,                     // out_subblock_h
+        out_subblock_w,                     // out_subblock_w
+        out_subblock_num_tiles,             // out_subblock_num_tiles
+        (reuse_in0_in_CB ? in1_B : in0_B),  // batch
+        out_block_tiles,                    // out_block_num_tiles
 
         untilize_out,  // untilize_out
         false,         // get_batch_from_reader

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -417,6 +417,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
             (std::uint32_t)M * K,  // MtKt
             (std::uint32_t)B,      // batch
             (std::uint32_t)B,      // batch
+            (std::uint32_t)false,  // reuse_in0_in_CB
 
             // sparsity args
             (std::uint32_t)0,      // batchB

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -60,24 +60,22 @@ void kernel_main() {
     constexpr uint32_t MtKt = get_compile_time_arg_val(19);  // if 0
     constexpr uint32_t in0_B = get_compile_time_arg_val(20);
     constexpr uint32_t in1_B = get_compile_time_arg_val(21);
+    constexpr uint32_t in0_reuse_in_CB = get_compile_time_arg_val(22);
 
     // sparsity args
 
-    constexpr uint32_t batchB = get_compile_time_arg_val(22);
-    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(23);
+    constexpr uint32_t batchB = get_compile_time_arg_val(23);
+    constexpr uint32_t sparsity_pagesize = get_compile_time_arg_val(24);
     // Boolean that is set when input A is sparse. If set, both input A and B are assumed to be sparse.
     // Based on the sparsity tensor, the corresponding batch in input A and B are skipped.
-    constexpr bool bcast_A = (bool)get_compile_time_arg_val(24);
+    constexpr bool bcast_A = (bool)get_compile_time_arg_val(25);
     // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
-    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(25);
+    constexpr bool get_batch_from_reader = (bool)get_compile_time_arg_val(26);
 
-    constexpr bool fuse_op = (bool)get_compile_time_arg_val(26);
+    constexpr bool fuse_op = (bool)get_compile_time_arg_val(27);
 
-    constexpr auto in0_args = TensorAccessorArgs<27>();
+    constexpr auto in0_args = TensorAccessorArgs<28>();
 
-    // Optimization for when in0 is [1, 1, M, K] and in1 is [1, H, K, N]
-    // In this case we reuse the in0 data in CB for all batches instead of re-reading
-    constexpr bool reuse_in0_in_CB = (in0_B == 1 && in1_B > 1);
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
     // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
@@ -388,7 +386,7 @@ void kernel_main() {
         // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
         // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
         // CB so compute kernel thinks it has new data
-        if (reuse_in0_in_CB) {
+        if (in0_reuse_in_CB) {
             for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
                 for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
                     cb_in0.reserve_back(in0_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -74,6 +74,10 @@ void kernel_main() {
     constexpr bool fuse_op = (bool)get_compile_time_arg_val(26);
 
     constexpr auto in0_args = TensorAccessorArgs<27>();
+
+    // Optimization for when in0 is [1, 1, M, K] and in1 is [1, H, K, N]
+    // In this case we reuse the in0 data in CB for all batches instead of re-reading
+    constexpr bool reuse_in0_in_CB = (in0_B == 1 && in1_B > 1);
     constexpr auto sparsity_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
     // 0 is used to specify "INVALID" state, i.e. when the multicasted data has not been received by the receiver.
@@ -384,7 +388,7 @@ void kernel_main() {
         // optimization we just read the tensor slice once into each core's L1 and keep it there for all weight
         // batches since the needed in0 data is already in L1 after batch 0, we can just move read pointer for this
         // CB so compute kernel thinks it has new data
-        if (in0_B == 1 && in1_B > 1) {
+        if (reuse_in0_in_CB) {
             for (uint32_t fake_batch = 0; fake_batch < in1_B - in0_B; ++fake_batch) {
                 for (uint32_t blk = 0; blk < num_blocks_inner_dim; ++blk) {
                     cb_in0.reserve_back(in0_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -247,7 +247,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         // 2. Shape requirements: must be rank-4 tensors (to ensure dim 1 is the batch dimension)
         // 3. Batch dimension requirement: input A must have batch size 1 on dim 1
         // 4. Memory layout requirement: inputs must not be sharded
-        auto can_use_in0_reuse = [&]() {
+        auto in0_reuse = [&]() {
             if (!std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>(
                     chosen_program_config)) {
                 return false;
@@ -271,7 +271,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
 
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
-                a_shape[i] == b_shape[i] || (i == 1 && can_use_in0_reuse()),
+                a_shape[i] == b_shape[i] || (i == 1 && in0_reuse()),
                 "bmm (non-bcast matmul) expects input tensors of shapes "
                 "BCMK*BCKN=BCMN or batch dimension {} mismatch: a={} vs b={} (dimension mismatch only allowed on dim 1 "
                 "for rank-4 tensors when a[1]=1 and using MatmulMultiCoreReuseMultiCast1DProgramConfig with "

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -290,6 +290,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         (std::uint32_t)Mt * Kt,  // MtKt
         (std::uint32_t)batchA,   // batchA
         (std::uint32_t)batchA,   // batchA
+        (std::uint32_t)false,    // reuse_in0_in_CB
         // sparsity args
         (std::uint32_t)batchB,                                  // batchB
         (std::uint32_t)sparsity.buffer()->aligned_page_size(),  // sparsity_pagesize


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/37416)

### Problem description
[previous PR](https://github.com/tenstorrent/tt-metal/pull/40172) caused bevformer model to [hang ](https://github.com/tenstorrent/tt-metal/actions/runs/23584135071/job/68674126350) during e2e blackhole tests 

### What's changed
* bug was -> [in1_receiver kernels always used in1_B instead of only when optimization should be applied](https://github.com/tenstorrent/tt-metal/pull/40172/changes#diff-4097baacb0bbab7989474f26176012c593ebaa0711b714b34013f1af31c14f67), this got triggered in bevformer with in1_B=6 and in1_B=1
* updated how in0_reuse optimization is used during kernel argument passing - made it uniform and fixed the bug 
* added a regression test to make sure this issue doesn't come up again

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/bevformer-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/bevformer-test-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/bevformer-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/bevformer-test-fix)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/bevformer-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/bevformer-test-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)