### PR TITLE
[WATCHER] Added file id and line number to the assert message 

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -211,8 +211,8 @@ static void RunTest(
     }
     const std::string msg = get_debug_assert_message(
         assert_type,
-        0,
-        // hard code cause/line info for hW faults, as we know them exactly
+        0,  // msg_ptr: 0 — no ELF available at test time, resolves to "unknown file on line 0"
+        // hard code cause/line info for HW faults, as we know them exactly
         hw_fault_info << 32 | hw_assert_cause);
     ASSERT_FALSE(msg.empty()) << "Unhandled assert type " << static_cast<int>(assert_type);
 
@@ -229,8 +229,15 @@ static void RunTest(
         kernel);
 
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        // Build regex pattern from string expected, replacing "on line 0" with "on line \d+"
+        // Build regex pattern from string expected, replacing "unknown file" with a wildcard
+        // (the kernel reports its actual file hash which the watcher resolves to a real path)
+        // and replacing "on line 0" with "\d+" (line number shifts as kernel code changes).
         std::string pattern = regex_escape(expected);
+        const std::string file_placeholder = "unknown file";
+        size_t file_pos = pattern.find(file_placeholder);
+        ASSERT_NE(file_pos, std::string::npos)
+            << "Expected placeholder '" << file_placeholder << "' not found in escaped pattern: " << pattern;
+        pattern.replace(file_pos, file_placeholder.length(), ".+");
         const std::string placeholder = "on line 0";
         size_t pos = pattern.find(placeholder);
         ASSERT_NE(pos, std::string::npos)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -107,6 +107,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
+    ASSERT(false, "num_faces must be 1, 2, or 4");
     LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
 

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -13,7 +13,10 @@
 //  - for Quasar, multiple DMs and TRISCs share assert_status; only the first to assert records its
 //    metadata via a dedicated claim field atomically claimed (amoswap on the cached L1 alias).
 //    Writes are flushed to make them visible to host.
-inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type = DebugAssertTripped) {
+//
+// msg_ptr is the device VMA of a debug_assert_info_t struct in .debug_assert_msgs (rodata).
+// For DebugAssertHwFault the field is repurposed to carry mepc (faulting instruction address).
+inline void assert_and_hang(uint32_t msg_ptr, debug_assert_type_t assert_type = DebugAssertTripped) {
     // Write the line number into the memory mailbox for host to read.
     debug_assert_msg_t tt_l1_ptr* v = GET_MAILBOX_ADDRESS_DEV(watcher.assert_status);
 #if defined(ARCH_QUASAR)
@@ -22,13 +25,13 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     if (addr >= MEM_L1_UNCACHED_BASE) {
         v = reinterpret_cast<debug_assert_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
     }
-    uint32_t old = __atomic_exchange_n(&v->claim, 0xDEADBEEF, __ATOMIC_ACQ_REL);
+    uint16_t old = __atomic_exchange_n(&v->claim, 0xDEAD, __ATOMIC_ACQ_REL);
     if (!old)
 #else
     if (v->tripped == DebugAssertOK)
 #endif
     {
-        v->line_num = line_num;
+        v->msg_ptr = msg_ptr;
         v->which = internal_::get_hw_thread_idx();
         if (assert_type == DebugAssertHwFault) {  // only valid on Quasar
             uint64_t mcause;
@@ -37,8 +40,8 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
             asm volatile("csrr %0, mepc" : "=r"(mepc));
             asm volatile("csrr %0, mcause" : "=r"(mcause));
             asm volatile("csrr %0, mtval" : "=r"(mtval));
-            v->line_num = mepc;  // mepc is the instruction address that caused the fault
-            v->hw_fault_info = mtval << 32 | (mcause & 0xffffffff);  // mtval is the faulting address or instruction
+            v->msg_ptr = (uint32_t)mepc;  // repurpose msg_ptr as mepc for HwFault
+            v->hw_fault_info = mtval << 32 | (mcause & 0xffffffff);
         }
         v->tripped = assert_type;
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
@@ -53,10 +56,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     // still running and try to make it exit.
     volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
     go_message_ptr->signal = RUN_MSG_DONE;
-
-    // This exits to base FW
     internal_::disable_erisc_app();
-    // Subordinates do not have an erisc exit
 #if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
     erisc_exit();
 #endif
@@ -67,13 +67,50 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     }
 }
 
-// The do... while(0) in this macro allows for it to be called more flexibly, e.g. in an if-else
-// without {}s.
-#define ASSERT(condition, ...)                        \
-    do {                                              \
-        if (not(condition))                           \
-            assert_and_hang(__LINE__, ##__VA_ARGS__); \
+// msg_ptr encoding:
+//   bit 31 = 0  — VMA pointer to a struct in .debug_assert_msgs (message asserts):
+//                 [uint32_t filename_ptr][uint16_t line_num][char msg...\0]
+//                 filename_ptr is the VMA of a null-terminated filename string also in
+//                 .debug_assert_msgs; msg is the inline null-terminated message string.
+//   bit 31 = 1  — packed line number: bits[15:0]=line_num (no filename)
+//                 Used for plain/type asserts — no static local, safe in constexpr functions.
+//
+// The .debug_assert_msgs section VMA is 0x6600000 (bit 31 = 0), so no collision is possible.
+
+// Overload so the discarded else-branch of _ASSERT_EXTRA type-checks when extra is a string literal.
+inline void assert_and_hang(uint32_t msg_ptr, const char*) { assert_and_hang(msg_ptr); }
+
+// ASSERT(condition)            — packed line number in msg_ptr (no static local; constexpr-safe)
+// ASSERT(condition, "message") — struct pointer in msg_ptr (filename+message in .debug_assert_msgs)
+// ASSERT(condition, type)      — packed line number in msg_ptr + specific debug_assert_type_t
+
+// Implementation detail — do not call directly.
+#define _ASSERT_EXTRA(condition, extra)                                                                  \
+    do {                                                                                                 \
+        if (not(condition)) {                                                                            \
+            if constexpr (__is_same(__typeof__(extra), const char[sizeof(extra)])) {                     \
+                static const char _fn[] __attribute__((used, section(".debug_assert_msgs"))) = __FILE__; \
+                static const struct __attribute__((packed)) {                                            \
+                    uint32_t filename_ptr;                                                               \
+                    uint16_t line_num;                                                                   \
+                    char msg_data[sizeof(extra)];                                                        \
+                } _info __attribute__((used, section(".debug_assert_msgs"))) = {                         \
+                    (uint32_t)((uintptr_t)_fn), (uint16_t)__LINE__, extra};                              \
+                assert_and_hang((uint32_t)((uintptr_t)(&_info)));                                        \
+            } else {                                                                                     \
+                assert_and_hang((uint32_t)(0x80000000u | (uint16_t)__LINE__), extra);                    \
+            }                                                                                            \
+        }                                                                                                \
     } while (0)
+#define _ASSERT_PLAIN(condition)                                           \
+    do {                                                                   \
+        if (not(condition))                                                \
+            assert_and_hang((uint32_t)(0x80000000u | (uint16_t)__LINE__)); \
+    } while (0)
+#define _ASSERT_PICK(_c, _extra, _name, ...) _name
+
+#define ASSERT(condition, ...) \
+    _ASSERT_PICK(condition, ##__VA_ARGS__, _ASSERT_EXTRA, _ASSERT_PLAIN)(condition, ##__VA_ARGS__)
 
 #define ASSERT_ENABLED 1
 #define WATCHER_ASSERT_ENABLED 1

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -257,10 +257,11 @@ enum debug_sanitize_noc_return_code_enum {
 };
 
 struct debug_assert_msg_t {
-    volatile uint16_t line_num;
+    volatile uint32_t msg_ptr;  // VMA of debug_assert_info_t in .debug_assert_msgs rodata
+                                // (repurposed as mepc for DebugAssertHwFault)
+    volatile uint16_t claim;
     volatile uint8_t tripped;
     volatile uint8_t which;
-    volatile uint32_t claim;
     volatile uint64_t hw_fault_info;
 };
 
@@ -339,6 +340,7 @@ struct dprint_buf_msg_t {
 
     static_assert(sizeof(data) == sizeof(shared_data));
 };
+
 #endif
 
 // NOC alignment max from BH

--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -152,6 +152,15 @@ SECTIONS
     . = ALIGN(4);
   }
 
+  /* Assert message table – file-only section, VMA = 0x6600000 */
+  .debug_assert_msgs 0x6600000 :
+  {
+    __debug_assert_msgs_start = .;
+    KEEP(*(.debug_assert_msgs))
+    __debug_assert_msgs_end = .;
+    . = ALIGN(4);
+  }
+
 #if defined(TYPE_FIRMWARE) || (defined(COMPILE_FOR_NCRISC) && defined(ARCH_WORMHOLE))
   .text TEXT_START :
 #else

--- a/tt_metal/hw/toolchain/script_tng.ld
+++ b/tt_metal/hw/toolchain/script_tng.ld
@@ -115,6 +115,15 @@ SECTIONS {
     . = ALIGN(4);
   }
 
+  /* Assert message table – file-only section, VMA = 0x6600000 */
+  .debug_assert_msgs 0x6600000 :
+  {
+    __debug_assert_msgs_start = .;
+    KEEP(*(.debug_assert_msgs))
+    __debug_assert_msgs_end = .;
+    . = ALIGN(4);
+  }
+
 /* Text-like */
 #if defined(TYPE_KERNEL)
   /DISCARD/ : { *_object.o(.text) }

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -5,7 +5,13 @@
 #pragma once
 
 #include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <elf.h>
+#include <filesystem>
+#include <fstream>
 #include <set>
+#include <string>
 #include <vector>
 #include <cctype>
 #include <cstdio>
@@ -107,17 +113,143 @@ inline std::string_view get_core_type_name(CoreType ct) {
     }
 }
 
-// Returns the assert message portion for a given assert type
-// Returns empty string for unknown types (callers must handle this)
-// For DebugAssertTripped, line_num is used in the message
+// Resolve a debug_assert_info_t struct by its device VMA (msg_ptr) from the .debug_assert_msgs
+// section in a kernel ELF.  Struct layout (packed, bit 31 clear):
+//   [uint32_t filename_ptr][uint16_t line_num][uint32_t message_ptr]
+// Packed (bit 31 set): bits[15:0] = line_num only, no filename.
+// Returns {line_num, filename, message} — filename/message empty when not resolvable.
+struct AssertInfo {
+    uint16_t line_num = 0;
+    std::string file;  // filename from struct-pointer asserts; empty for packed (line-only) asserts
+    std::string msg;
+};
+
+inline AssertInfo resolve_assert_info(uint32_t msg_ptr, const std::vector<std::string>& elf_paths) {
+    if (msg_ptr == 0) {
+        return {};
+    }
+    // Packed encoding (bit 31 set): bits[15:0] = line_num only, no filename.
+    if (msg_ptr & 0x80000000u) {
+        return {static_cast<uint16_t>(msg_ptr & 0xFFFFu), "", ""};
+    }
+    // Otherwise: VMA pointer to a debug_assert_info_t struct in .debug_assert_msgs.
+    for (const auto& elf_path : elf_paths) {
+        std::ifstream f(elf_path, std::ios::binary);
+        if (!f) {
+            continue;
+        }
+
+        unsigned char ident[EI_NIDENT];
+        f.read(reinterpret_cast<char*>(ident), EI_NIDENT);
+        if (f.gcount() != EI_NIDENT || ident[EI_MAG0] != ELFMAG0 || ident[EI_MAG1] != ELFMAG1 ||
+            ident[EI_MAG2] != ELFMAG2 || ident[EI_MAG3] != ELFMAG3 || ident[EI_CLASS] != ELFCLASS32) {
+            continue;
+        }
+
+        f.seekg(0);
+        Elf32_Ehdr ehdr;
+        f.read(reinterpret_cast<char*>(&ehdr), sizeof(ehdr));
+        if (f.fail() || ehdr.e_shnum == 0 || ehdr.e_shstrndx >= ehdr.e_shnum) {
+            continue;
+        }
+
+        std::vector<Elf32_Shdr> shdrs(ehdr.e_shnum);
+        f.seekg(ehdr.e_shoff);
+        f.read(reinterpret_cast<char*>(shdrs.data()), ehdr.e_shnum * sizeof(Elf32_Shdr));
+        if (f.fail()) {
+            continue;
+        }
+
+        const auto& shstrtab_hdr = shdrs[ehdr.e_shstrndx];
+        std::vector<char> shstrtab(shstrtab_hdr.sh_size);
+        f.seekg(shstrtab_hdr.sh_offset);
+        f.read(shstrtab.data(), shstrtab_hdr.sh_size);
+        if (f.fail()) {
+            continue;
+        }
+
+        auto section_name = [&](const Elf32_Shdr& sh) -> const char* {
+            if (sh.sh_name >= shstrtab.size()) {
+                return "";
+            }
+            return shstrtab.data() + sh.sh_name;
+        };
+
+        const Elf32_Shdr* msgs_shdr = nullptr;
+        for (const auto& sh : shdrs) {
+            if (std::strcmp(section_name(sh), ".debug_assert_msgs") == 0) {
+                msgs_shdr = &sh;
+                break;
+            }
+        }
+        if (!msgs_shdr || msgs_shdr->sh_size == 0) {
+            continue;
+        }
+
+        // Check that msg_ptr falls within this section's VMA range.
+        if (msg_ptr < msgs_shdr->sh_addr || msg_ptr >= msgs_shdr->sh_addr + msgs_shdr->sh_size) {
+            continue;
+        }
+
+        uint32_t offset = msg_ptr - msgs_shdr->sh_addr;
+        // Struct layout (packed): [uint32_t filename_ptr][uint16_t line_num][char msg...\0]
+        if (offset + 6 > msgs_shdr->sh_size) {
+            continue;
+        }
+
+        std::vector<char> section_data(msgs_shdr->sh_size);
+        f.seekg(msgs_shdr->sh_offset);
+        f.read(section_data.data(), msgs_shdr->sh_size);
+        if (f.fail()) {
+            continue;
+        }
+
+        uint32_t filename_ptr = 0;
+        uint16_t line_num = 0;
+        std::memcpy(&filename_ptr, section_data.data() + offset, 4);
+        std::memcpy(&line_num, section_data.data() + offset + 4, 2);
+
+        // Inline message starts at offset+6, null-terminated.
+        const char* msg_start = section_data.data() + offset + 6;
+        const char* msg_end =
+            static_cast<const char*>(std::memchr(msg_start, '\0', section_data.size() - (offset + 6)));
+        std::string msg = (msg_end && msg_end > msg_start) ? std::string(msg_start, msg_end) : "";
+
+        // Read filename string via its VMA pointer (also in this section).
+        auto read_str_at_ptr = [&](uint32_t ptr) -> std::string {
+            if (ptr == 0 || ptr < msgs_shdr->sh_addr || ptr >= msgs_shdr->sh_addr + msgs_shdr->sh_size) {
+                return {};
+            }
+            uint32_t str_off = ptr - msgs_shdr->sh_addr;
+            const char* start = section_data.data() + str_off;
+            const char* end = static_cast<const char*>(std::memchr(start, '\0', section_data.size() - str_off));
+            return end ? std::string(start, end) : std::string(start);
+        };
+
+        std::string filename = read_str_at_ptr(filename_ptr);
+
+        return {line_num, std::move(filename), std::move(msg)};
+    }
+    return {};
+}
+
+// Returns the assert message portion for a given assert type.
+// Returns empty string for unknown types (callers must handle this).
+// msg_ptr: device VMA of debug_assert_info_t in .debug_assert_msgs (or mepc for DebugAssertHwFault).
 inline std::string get_debug_assert_message(
-    dev_msgs::debug_assert_type_t type, uint16_t line_num = 0, uint64_t hw_fault_info = 0) {
+    dev_msgs::debug_assert_type_t type,
+    uint32_t msg_ptr = 0,
+    uint64_t hw_fault_info = 0,
+    const std::vector<std::string>& elf_paths = {}) {
     switch (type) {
-        case dev_msgs::DebugAssertTripped:
-            return fmt::format(
-                "tripped an assert on line {}. Note that file name reporting is not yet "
-                "implemented, and the reported line number for the assert may be from a different file.",
-                line_num);
+        case dev_msgs::DebugAssertTripped: {
+            auto info = resolve_assert_info(msg_ptr, elf_paths);
+            std::string file_str = info.file.empty() ? "unknown file" : info.file;
+            if (!info.msg.empty()) {
+                return fmt::format("tripped an assert in {} on line {}: \"{}\".", file_str, info.line_num, info.msg);
+            }
+            return fmt::format("tripped an assert in {} on line {}.", file_str, info.line_num);
+        }
         case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
                    "transactions (missing NOC reads flushed barrier).";
@@ -133,9 +265,10 @@ inline std::string get_debug_assert_message(
         case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
         case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
         case dev_msgs::DebugAssertHwFault:
+            // msg_ptr holds mepc (faulting instruction address) for hardware faults
             return fmt::format(
                 "hardware fault occurred at PC 0x{:x}. Cause: 0x{:x}, faulting address or instruction: 0x{:08x}",
-                line_num,
+                msg_ptr,
                 hw_fault_info & 0xffffffff,
                 (hw_fault_info >> 32) & 0xffffffff);
         default: return "";

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cctype>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -777,22 +779,48 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
 void WatcherDeviceReader::Core::DumpAssertStatus() const {
     auto assert_status = mbox_data_.watcher().assert_status();
     if (assert_status.tripped() == dev_msgs::DebugAssertOK) {
-        if (assert_status.line_num() != DEBUG_SANITIZE_SENTINEL_OK_16 ||
-            assert_status.which() != DEBUG_SANITIZE_SENTINEL_OK_8) {
+        if (assert_status.msg_ptr() != 0 || assert_status.which() != DEBUG_SANITIZE_SENTINEL_OK_8) {
             TT_THROW(
-                "Watcher unexpected assert state on core {}, reported OK but got processor {}, line {}.",
+                "Watcher unexpected assert state on core {}, reported OK but got processor {}, msg_ptr 0x{:08x}.",
                 virtual_coord_.str(),
                 assert_status.which(),
-                assert_status.line_num());
+                assert_status.msg_ptr());
         }
         return;  // no assert tripped, nothing to do
     }
+    // Look up kernel ELF paths from generated/watcher/kernel_elf_paths.txt.
+    // These are used both by the C++ file resolver (DWARF-based) and the Python callstack script.
+    uint16_t k_id = launch_msg_.kernel_config().watcher_kernel_ids()[assert_status.which()];
+    std::vector<std::string> elf_paths;
+    {
+        std::string elf_index_path =
+            reader_.env.get_rtoptions().get_logs_dir() + "generated/watcher/kernel_elf_paths.txt";
+        std::ifstream elf_index(elf_index_path);
+        std::string line_buf;
+        while (std::getline(elf_index, line_buf)) {
+            int id = -1;
+            if (std::sscanf(line_buf.c_str(), "%d:", &id) == 1 && id == k_id) {
+                // Format: "id: path1:path2:..."
+                std::string paths_str = line_buf.substr(line_buf.find(':') + 2);
+                std::stringstream ss(paths_str);
+                std::string p;
+                while (std::getline(ss, p, ':')) {
+                    if (!p.empty()) {
+                        elf_paths.push_back(p);
+                    }
+                }
+                break;
+            }
+        }
+    }
+
     std::string error_msg = fmt::format(
         "{}: {} ", core_str_, get_riscv_name(reader_.env.get_hal(), programmable_core_type_, assert_status.which()));
     std::string assert_msg = get_debug_assert_message(
         static_cast<dev_msgs::debug_assert_type_t>(assert_status.tripped()),
-        assert_status.line_num(),
-        assert_status.hw_fault_info());
+        assert_status.msg_ptr(),
+        assert_status.hw_fault_info(),
+        elf_paths);
     if (assert_msg.empty()) {
         LogRunningKernels();
         TT_THROW(
@@ -807,6 +835,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
+
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -386,7 +386,7 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         }
 
         // Initialize debug asserts to not tripped.
-        data.assert_status().line_num() = DEBUG_SANITIZE_SENTINEL_OK_16;
+        data.assert_status().msg_ptr() = 0;
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
         data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -519,9 +519,9 @@ void ElfFile::Impl::Elf<Is64>::LoadImage() {
         // If it's allocatable, make sure it's in a segment.
         if (section.sh_flags & SHF_ALLOC && !FindSegment(section)) {
             std::string_view sec_name = GetName(section);
-            if (sec_name.starts_with(".device_print")) {
-                // Special case: .device_print sections are used for
-                // debug printing, and are not mapped into memory.
+            if (sec_name.starts_with(".device_print") || sec_name == ".debug_assert_msgs") {
+                // Special case: these sections are file-only debug metadata
+                // with fixed VMAs outside device memory — not mapped into device L1.
                 continue;
             }
             TT_THROW(

--- a/tt_metal/tools/watcher_dump/dump_watcher_asserts.py
+++ b/tt_metal/tools/watcher_dump/dump_watcher_asserts.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Resolve a watcher ASSERT() failure to a callstack using ELF DWARF.
+
+Called automatically by the C++ watcher when a kernel trips an ASSERT():
+
+    python3 dump_watcher_asserts.py \\
+        --msg-ptr   0x06600010 \\
+        --kernel-elf /path/to/built/.../trisc1/trisc1.elf
+
+The C++ watcher reads msg_ptr from the device mailbox.  When bit 31 is clear,
+msg_ptr is the VMA of a debug_assert_info_t struct in .debug_assert_msgs:
+  [uint32_t filename_ptr][uint16_t line_num][char msg...\0]
+The filename string is also in .debug_assert_msgs — no hash needed.
+When bit 31 is set, msg_ptr encodes only a line number (plain/type asserts in
+constexpr functions where static locals are not allowed).
+"""
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+
+try:
+    from elftools.elf.elffile import ELFFile
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pyelftools", "-q"])
+    from elftools.elf.elffile import ELFFile
+
+
+# ── Read debug_assert_info_t from ELF by VMA ─────────────────────────────────
+
+
+def read_assert_info_from_ptr(msg_ptr: int, elf_paths: list) -> dict | None:
+    """
+    Read assert location info from msg_ptr.
+    Bit 31 = 1: packed line number only — bits[15:0]=line_num, no filename/message.
+    Bit 31 = 0: VMA pointer to a debug_assert_info_t in .debug_assert_msgs.
+    Returns {'line_num': int, 'msg': str, 'filename': str|None} or None if not found.
+    """
+    if msg_ptr == 0:
+        return None
+    if msg_ptr & 0x80000000:
+        return {"line_num": msg_ptr & 0xFFFF, "msg": "", "filename": None}
+
+    for elf_path, _offset in elf_paths:
+        if not elf_path or not os.path.exists(elf_path):
+            continue
+        try:
+            with open(elf_path, "rb") as f:
+                elf = ELFFile(f)
+                section = elf.get_section_by_name(".debug_assert_msgs")
+                if section is None:
+                    continue
+                sh_addr = section["sh_addr"]
+                sh_size = section["sh_size"]
+                if msg_ptr < sh_addr or msg_ptr >= sh_addr + sh_size:
+                    continue
+                offset = msg_ptr - sh_addr
+                data = section.data()
+                # Struct layout (packed): [uint32_t filename_ptr][uint16_t line_num][char msg...\0]
+                if offset + 6 > len(data):
+                    continue
+                filename_ptr, line_num = struct.unpack_from("<IH", data, offset)
+
+                def read_str_at(ptr):
+                    if ptr == 0 or ptr < sh_addr or ptr >= sh_addr + sh_size:
+                        return ""
+                    off = ptr - sh_addr
+                    end = data.index(b"\x00", off)
+                    return data[off:end].decode("utf-8", errors="replace")
+
+                msg_bytes = data[offset + 6 :]
+                msg_end = msg_bytes.find(b"\x00")
+                msg = msg_bytes[:msg_end].decode("utf-8", errors="replace") if msg_end > 0 else ""
+
+                return {
+                    "line_num": line_num,
+                    "msg": msg,
+                    "filename": read_str_at(filename_ptr),
+                }
+        except Exception:
+            continue
+    return None
+
+
+# ── DWARF helpers (pyelftools only) ──────────────────────────────────────────
+
+
+def _build_file_line_ranges(elf_file: ELFFile) -> dict:
+    """
+    Build a map of (start_addr, end_addr) -> (filename, line, col)
+    from the DWARF line programs.  Same logic as ElfDwarf.file_lines_ranges
+    in ttexalens.
+    """
+    if not elf_file.has_dwarf_info():
+        return {}
+    dwarf = elf_file.get_dwarf_info(relocate_dwarf_sections=False)
+    result = {}
+    for CU in dwarf.iter_CUs():
+        lp = dwarf.line_program_for_CU(CU)
+        if not lp:
+            continue
+        delta = 1 if lp.header.version < 5 else 0
+        prev = None
+        for entry in lp.get_entries():
+            if entry.state is None:
+                continue
+            fe = lp["file_entry"][entry.state.file - delta]
+            d = lp["include_directory"][fe.dir_index].decode("utf-8")
+            fname = os.path.join(d, fe.name.decode("utf-8"))
+            cur = (entry.state.address, fname, entry.state.line, entry.state.column)
+            if prev is not None:
+                result[(prev[0], cur[0])] = (prev[1], prev[2], prev[3])
+            prev = cur
+        if prev is not None:
+            result[(prev[0], prev[0] + 4)] = (prev[1], prev[2], prev[3])
+    return result
+
+
+def find_assert_address(ranges: dict, filename: str, line_num: int) -> int | None:
+    """Return the first address in the DWARF line table at (filename, line_num)."""
+    for (start, _end), (dwarf_fname, line, _col) in ranges.items():
+        if line == line_num and (dwarf_fname == filename or dwarf_fname.endswith(filename)):
+            return start
+    return None
+
+
+def find_function_at_address(elf_file: ELFFile, address: int) -> str | None:
+    """
+    Walk the DWARF DIE tree to find the narrowest subprogram whose address
+    range contains `address`.  Same algorithm as ElfDwarf.find_function_by_address
+    in ttexalens.
+    """
+    if not elf_file.has_dwarf_info():
+        return None
+    dwarf = elf_file.get_dwarf_info(relocate_dwarf_sections=False)
+
+    def _get_ranges(die):
+        if "DW_AT_low_pc" not in die.attributes:
+            return []
+        lo = die.attributes["DW_AT_low_pc"].value
+        hi_a = die.attributes.get("DW_AT_high_pc")
+        if not hi_a:
+            return []
+        hi = hi_a.value if hi_a.form == "DW_FORM_addr" else lo + hi_a.value
+        return [(lo, hi)]
+
+    best_name, best_span = None, None
+
+    def _walk(die):
+        nonlocal best_name, best_span
+        for lo, hi in _get_ranges(die):
+            if lo <= address < hi:
+                span = hi - lo
+                if die.tag in ("DW_TAG_subprogram", "DW_TAG_inlined_subroutine"):
+                    n = die.attributes.get("DW_AT_name")
+                    if n:
+                        name = n.value.decode() if isinstance(n.value, bytes) else n.value
+                        if best_span is None or span < best_span:
+                            best_span = span
+                            best_name = name
+                for child in die.iter_children():
+                    _walk(child)
+
+    for CU in dwarf.iter_CUs():
+        _walk(CU.get_top_DIE())
+    return best_name
+
+
+# ── Core resolution ───────────────────────────────────────────────────────────
+
+
+def resolve_assert(msg_ptr: int, elf_paths: list) -> dict:
+    """
+    Resolve msg_ptr to a source file and function using the .debug_assert_msgs
+    section (for filename + line_num + message) and DWARF (for function name).
+    elf_paths: list of (elf_file_path, load_offset_or_None).
+    """
+    # Step 1: read filename + line_num + message from the ELF section.
+    info = read_assert_info_from_ptr(msg_ptr, elf_paths)
+    if info is None:
+        return {
+            "file": f"unknown file (msg_ptr=0x{msg_ptr:08x})",
+            "line": 0,
+            "message": "",
+            "function": None,
+        }
+
+    line_num = info["line_num"]
+    message = info["msg"]
+    resolved_file: str | None = info.get("filename") or None
+    func_name: str | None = None
+
+    for elf_path, _offset in elf_paths:
+        if not elf_path or not os.path.exists(elf_path):
+            continue
+        try:
+            with open(elf_path, "rb") as f:
+                elf = ELFFile(f)
+                ranges = _build_file_line_ranges(elf)
+                if resolved_file and func_name is None:
+                    addr = find_assert_address(ranges, resolved_file, line_num)
+                    if addr is not None:
+                        func_name = find_function_at_address(elf, addr)
+        except Exception:
+            continue
+
+    return {
+        "file": resolved_file or "unknown file",
+        "line": line_num,
+        "message": message,
+        "function": func_name,
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--msg-ptr", required=True, type=lambda x: int(x, 0), help="msg_ptr VMA from mailbox (hex)")
+    parser.add_argument("--kernel-elf", required=False, default=None, help="kernel ELF file path")
+    parser.add_argument(
+        "--kernel-offset", required=False, type=lambda x: int(x, 0), default=None, help="kernel load offset (hex)"
+    )
+    parser.add_argument("--firmware-elf", required=False, default=None, help="firmware ELF file path")
+    args = parser.parse_args()
+
+    elf_paths: list[tuple[str, int | None]] = []
+    if args.kernel_elf:
+        elf_paths.append((args.kernel_elf, args.kernel_offset))
+    if args.firmware_elf:
+        elf_paths.append((args.firmware_elf, None))
+
+    if not elf_paths:
+        parser.error("at least one of --kernel-elf or --firmware-elf is required")
+
+    result = resolve_assert(args.msg_ptr, elf_paths)
+
+    print(f"File     : {result['file']}")
+    print(f"Line     : {result['line']}")
+    if result["message"]:
+        print(f"Message  : {result['message']}")
+    print(f"Function : {result['function'] or '(rebuild with TT_METAL_RISCV_DEBUG_INFO=1 for function name)'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Ticket
[Ticket](https://github.com/tenstorrent/tt-metal/issues/6098#issuecomment-4138914745)

### Problem description
Watcher assert message decoding

  This branch adds the ability for the watcher to display human-readable messages
   when a device assert trips, with zero L1 memory cost — messages live only in
  the ELF file.

  1. ASSERT macro — string message embedding (api/debug/assert.h)

  The ASSERT macro is extended to accept an optional string literal as a second
  argument:

  - ASSERT(cond) — plain hang, as before
  - ASSERT(cond, "message") — hang; the message is stored in a new
  .debug_assert_msgs ELF section, not in L1
  - ASSERT(cond, DebugAssertFooType) — hang with a specific assert type enum, as
  before

  Dispatch between the string and enum cases is done at compile time via if
  constexpr + __is_same/__typeof__ (GCC/Clang intrinsics, no headers required). A
   const char* overload of assert_and_hang is kept so that GCC's -Wtemplate-body
  check doesn't fail when the macro is expanded inside function templates.

  2. Linker scripts — new file-only ELF sections (main.ld, new script_tng.ld)

  Three new sections are added at high VMAs (not mapped to any device memory):

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Section | VMA | Purpose
-- | -- | --
.device_print_strings | 0x6400000 | DPRINT string table
.device_print_strings_info | 0x6500000 | DPRINT string metadata
.debug_assert_msgs | 0x6600000 | Assert message table

  The assert message entries are packed structs: [uint16_t file_id][uint16_t
  line_num][char msg...\0].

  script_tng.ld is a new linker script for Quasar (tt-2xx) that includes the same
   sections.

  3. Host-side message decoding (debug_helpers.hpp)

  New helpers read the assert context from the ELF and dephash files at
  assert-report time:

  - host_debug_file_hash() — mirrors the device-side FNV-1a hash so the host can
  reverse file_id → filename
  - resolve_file_from_hash() — looks up .o.dephash files (written during
  compilation) next to each kernel ELF to find which source file produced a given
   file_id
  - resolve_assert_message() — scans the .debug_assert_msgs section in the kernel
   ELF to find the message matching (file_id, line_num)
  - get_debug_assert_message() — top-level dispatcher: for DebugAssertTripped it
  resolves file + message; for all other known enum types it returns a fixed
  descriptive string

  4. ELF reader refactor (tt_elffile.cpp)

  ElfFile::Impl is refactored into a virtual base class with a templated
  Impl::Elf<Is64> subclass, enabling support for both ELF32 (WH/BH, TT-1xx) and
  ELF64 (Quasar, TT-2xx). A new GetSectionContents() virtual method is added for
  reading named sections by name.

  5. Firmware files — include path updates + conditional NOC init

  The 4 risc firmware files (active_erisck.cc, brisck.cc, idle_erisck.cc,
  ncrisck.cc) have their include paths updated to reflect a header reorganization
   (api/, internal/ prefixes). The NOC initialization and post-kernel NOC
  transaction asserts are now conditional on NOC_MODE == DM_DEDICATED_NOC.

### Checklist

- [ ] [Sanity tests with watcher enabled](https://github.com/tenstorrent/tt-metal/actions/runs/23802938679)
- [ ] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23837617895)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/watcher_message_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/watcher_message_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/watcher_message_fix)