### PR TITLE
Fix concatenate_heads hang with sharded input and interleaved output

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_concatenate_heads.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_concatenate_heads.py
@@ -26,3 +26,42 @@ def test_concatenate_heads(device, batch, sequence, height, width):
     output = ttnn.to_torch(output)
 
     assert_with_pcc(torch_output_tensor, output, 0.9999)
+
+
+def test_concatenate_heads_sharded_input_interleaved_output(device):
+    """Regression test for hang when input is height-sharded L1 and output is DRAM interleaved.
+    See https://github.com/tenstorrent/tt-metal/issues/40925
+    """
+    torch_input_tensor = torch.randn(32, 32, 18, 64, dtype=torch.bfloat16)
+
+    golden_function = ttnn.get_golden_function(ttnn.transformer.concatenate_heads)
+    torch_output_tensor = golden_function(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+    )
+
+    input_tensor = ttnn.to_memory_config(
+        input_tensor,
+        ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))]),
+                [512, 64],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    output = ttnn.transformer.concatenate_heads(
+        input_tensor,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+    )
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_output_tensor, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
@@ -38,7 +38,8 @@ ttnn::Tensor concatenate_heads(const Tensor& input_tensor, const std::optional<M
     const auto& resolved_mem_config = memory_config.value_or(input_tensor.memory_config());
     const auto& actual_input =
         (input_tensor.is_sharded() && !resolved_mem_config.is_sharded())
-            ? ttnn::to_memory_config(input_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM})
+            ? ttnn::to_memory_config(
+                  input_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, resolved_mem_config.buffer_type()})
             : input_tensor;
 
     auto output = ttnn::prim::nlp_concat_heads(actual_input, memory_config);

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.hpp"
 #include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
+#include "ttnn/operations/core/core.hpp"
 
 using namespace tt::tt_metal;
 
@@ -31,7 +32,16 @@ ttnn::Tensor concatenate_heads(const Tensor& input_tensor, const std::optional<M
         "Head size ({}) cannot have tile padding. Ensure that the head size is not padded.",
         head_size);
 
-    auto output = ttnn::prim::nlp_concat_heads(input_tensor, memory_config);
+    // The sharded program path only supports sharded-to-sharded operation.
+    // When input is sharded but output is interleaved, fall back to the interleaved path
+    // by converting the input to DRAM interleaved first.
+    const auto& resolved_mem_config = memory_config.value_or(input_tensor.memory_config());
+    const auto& actual_input =
+        (input_tensor.is_sharded() && !resolved_mem_config.is_sharded())
+            ? ttnn::to_memory_config(input_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM})
+            : input_tensor;
+
+    auto output = ttnn::prim::nlp_concat_heads(actual_input, memory_config);
 
     return ttnn::squeeze(output, 1);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.cpp
@@ -34,7 +34,7 @@ ttnn::Tensor concatenate_heads(const Tensor& input_tensor, const std::optional<M
 
     // The sharded program path only supports sharded-to-sharded operation.
     // When input is sharded but output is interleaved, fall back to the interleaved path
-    // by converting the input to DRAM interleaved first.
+    // by converting the input to DRAM/L1 interleaved first.
     const auto& resolved_mem_config = memory_config.value_or(input_tensor.memory_config());
     const auto& actual_input =
         (input_tensor.is_sharded() && !resolved_mem_config.is_sharded())


### PR DESCRIPTION
## Summary
- `ttnn.transformer.concatenate_heads` hangs when called with height-sharded L1 input and DRAM interleaved output
- Root cause: the sharded program path only creates the output circular buffer (CB 16) when output is also sharded — when output is DRAM interleaved, the kernel hangs on `cb_reserve_back` for a non-existent CB
- Fix: fall back to the interleaved program path by converting sharded input to DRAM interleaved when the requested output is not sharded

## Test plan
- [x] Run repro script from #40925 — should print `PASSED` instead of hanging
- [x] Run existing concatenate_heads tests: `pytest tests/ttnn/unit_tests/operations/transformers/test_transformer.py -k  "concatenate_heads" -v`

Resolves #40925

🤖 Generated with [Claude Code](https://claude.com/claude-code)