### PR TITLE
Fix runtime arg out-of-bounds in reshard_same_width kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp
@@ -18,6 +18,9 @@ void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t write_offset = get_arg_val<uint32_t>(1);
     uint32_t num_reads = get_arg_val<uint32_t>(2);
+    if (num_reads == 0) {
+        return;
+    }
     tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
     uint32_t args_idx = 0;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
@@ -18,6 +18,9 @@ void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t read_offset = get_arg_val<uint32_t>(1);
     uint32_t num_writes = get_arg_val<uint32_t>(2);
+    if (num_writes == 0) {
+        return;
+    }
     tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
     uint32_t args_idx = 0;
 


### PR DESCRIPTION
Add early return guards in reshard_same_width_reader.cpp and reshard_same_width_writer.cpp to prevent accessing runtime argument index 3 when num_reads/num_writes is 0.

When cores are idle (assigned no work), the program factory only passes 3 runtime arguments (indices 0-2). The kernels were unconditionally accessing index 3 to get the variable args pointer, causing NCRISC accessed unique runtime arg index out of bounds watcher errors when TT_METAL_WATCHER=1 is enabled.

This issue was exposed by commit 981042032d which added strict runtime argument bounds checking.

The fix adds a check for num_reads/num_writes == 0 and returns early before attempting to access the args pointer. This is safe because the args pointer is only used in loops that iterate num_reads/num_writes times.

Tested: Reproduced error on main, verified fix resolves it.
- Before: NCRISC accessed unique runtime arg index out of bounds
- After: 12 tests pass, no watcher errors

Thank you claude!

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/fix-reshard-same-width-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/fix-reshard-same-width-runtime-args)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/fix-reshard-same-width-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/fix-reshard-same-width-runtime-args)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/fix-reshard-same-width-runtime-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/fix-reshard-same-width-runtime-args)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early