### PR TITLE
Fix the missing TensorTopology copy in ttnn.empty_like op

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
@@ -436,11 +436,9 @@ def test_empty_multi_device(mesh_device, input_shapes):
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        [2, 1, 4, 4],  # 256x256
+        [2, 1, 4, 4],
         [2, 1280, 8, 8],
         [2, 640, 16, 16],
-        [2, 1280, 8, 8],  # 512x512
-        [2, 1280, 16, 16],
         [2, 1280, 16, 16],
     ],
 )
@@ -449,36 +447,128 @@ def test_empty_like(device, input_shapes):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.to_device(input_tensor, device)
-    output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.empty_like(input_tensor)
 
-    assert list(torch_input_tensor.shape) == list(output_tensor.shape)
+    assert list(input_tensor.shape) == list(output_tensor.shape)
+    assert (
+        output_tensor.dtype == input_tensor.dtype
+    ), f"dtype mismatch: input={input_tensor.dtype}, output={output_tensor.dtype}"
+    assert (
+        output_tensor.layout == input_tensor.layout
+    ), f"layout mismatch: input={input_tensor.layout}, output={output_tensor.layout}"
+    assert (
+        output_tensor.memory_config() == input_tensor.memory_config()
+    ), f"memory_config mismatch: input={input_tensor.memory_config()}, output={output_tensor.memory_config()}"
 
 
 @pytest.mark.parametrize(
     "input_shapes",
     [
-        [2, 1, 4, 4],  # 256x256
+        [2, 1, 4, 4],
         [2, 1280, 8, 8],
         [2, 640, 16, 16],
-        [2, 1280, 8, 8],  # 512x512
-        [2, 1280, 16, 16],
         [2, 1280, 16, 16],
     ],
 )
 def test_empty_like_multi_device(mesh_device, input_shapes):
-    torch_input_tensor = torch.empty((input_shapes), dtype=torch.bfloat16)
+    torch_input_tensor = torch.ones((input_shapes), dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.to_device(input_tensor, mesh_device)
+    output_tensor = ttnn.empty_like(input_tensor)
+
+    assert list(input_tensor.shape) == list(output_tensor.shape)
+    assert (
+        output_tensor.dtype == input_tensor.dtype
+    ), f"dtype mismatch: input={input_tensor.dtype}, output={output_tensor.dtype}"
+    assert (
+        output_tensor.layout == input_tensor.layout
+    ), f"layout mismatch: input={input_tensor.layout}, output={output_tensor.layout}"
+    assert (
+        output_tensor.memory_config() == input_tensor.memory_config()
+    ), f"memory_config mismatch: input={input_tensor.memory_config()}, output={output_tensor.memory_config()}"
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1, 4, 4],
+        [2, 1280, 8, 8],
+    ],
+)
+def test_empty_like_preserves_topology_replicate(mesh_device, input_shapes):
+    torch_input_tensor = torch.ones((input_shapes), dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    input_topology = input_tensor.tensor_topology()
+
     output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
-    for output_tensor in output_tensors:
-        assert list(torch_input_tensor.shape) == list(output_tensor.shape)
+
+    output_topology = output_tensor.tensor_topology()
+    assert input_topology == output_topology, f"Topology mismatch: input={input_topology}, output={output_topology}"
+
+
+@pytest.mark.parametrize(
+    "shape_suffix",
+    [
+        [1, 32, 32],
+        [8, 64, 64],
+    ],
+)
+def test_empty_like_preserves_topology_shard(mesh_device, shape_suffix):
+    num_devices = mesh_device.get_num_devices()
+    input_shapes = [num_devices] + shape_suffix
+    torch_input_tensor = torch.ones((input_shapes), dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+    input_topology = input_tensor.tensor_topology()
+
+    output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
+
+    output_topology = output_tensor.tensor_topology()
+    assert input_topology == output_topology, f"Topology mismatch: input={input_topology}, output={output_topology}"
+
+
+@pytest.mark.parametrize(
+    "mesh_shape, dims",
+    [
+        ((2, 2), (0, 1)),
+        ((2, 2), (0, 2)),
+    ],
+)
+def test_empty_like_preserves_topology_shard_2d(mesh_device, mesh_shape, dims):
+    num_devices = mesh_device.get_num_devices()
+    required = mesh_shape[0] * mesh_shape[1]
+    if num_devices < required:
+        pytest.skip(f"Need at least {required} devices, have {num_devices}")
+
+    mesh_device.reshape(ttnn.MeshShape(*mesh_shape))
+
+    input_shapes = [mesh_shape[0], mesh_shape[1], 32, 32]
+    torch_input_tensor = torch.ones(input_shapes, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=list(mesh_shape), dims=dims),
+    )
+    input_topology = input_tensor.tensor_topology()
+
+    output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
+
+    output_topology = output_tensor.tensor_topology()
+    assert input_topology == output_topology, f"Topology mismatch: input={input_topology}, output={output_topology}"
 
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -8,6 +8,7 @@
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/layout/layout.hpp"
 #include <tt_stl/optional_reference.hpp>
+#include <ttnn/distributed/tensor_topology.hpp>
 
 namespace tt::tt_metal::distributed {
 class MeshDevice;
@@ -21,7 +22,8 @@ class TensorSpec;
 // Allocates a tensor on host.
 // Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device shard.
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
-Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec, IDevice* device, std::optional<TensorTopology> tensor_topology = std::nullopt);
 
 tt::tt_metal::Tensor to_device(
     const tt::tt_metal::Tensor& input_tensor,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -23,21 +23,29 @@
 namespace {
 
 tt::tt_metal::Tensor allocate_tensor_on_device(
-    const tt::tt_metal::TensorSpec& tensor_spec, tt::tt_metal::distributed::MeshDevice* device) {
+    const tt::tt_metal::TensorSpec& tensor_spec,
+    tt::tt_metal::distributed::MeshDevice* device,
+    std::optional<tt::tt_metal::TensorTopology> topology) {
     using namespace tt::tt_metal;
     auto mesh_buffer = tensor_impl::allocate_device_buffer(device, tensor_spec);
     DeviceStorage device_storage(mesh_buffer);
-    // TODO (#25340): Implement correct logic and add test for this
-    ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
-    for (size_t i = 0; i < device->shape().dims(); i++) {
-        placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
-    }
 
-    auto tensor_topology = TensorTopology{
-        device->shape(),
-        placements,
-        std::vector<distributed::MeshCoordinate>(
-            device_storage.get_coords().begin(), device_storage.get_coords().end())};
+    TensorTopology tensor_topology;
+    if (topology.has_value()) {
+        tensor_topology = std::move(*topology);
+    } else {
+        // Default: all Replicate placements.
+        // TODO (#25340): Implement correct logic and add test for this.
+        ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
+        for (size_t i = 0; i < device->shape().dims(); i++) {
+            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+        }
+        tensor_topology = TensorTopology{
+            device->shape(),
+            placements,
+            std::vector<distributed::MeshCoordinate>(
+                device_storage.get_coords().begin(), device_storage.get_coords().end())};
+    }
     return Tensor(std::move(device_storage), tensor_spec, tensor_topology);
 }
 }  // namespace
@@ -62,7 +70,8 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
     return Tensor(HostTensor(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
 }
 
-Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
+Tensor create_device_tensor(
+    const TensorSpec& tensor_spec, IDevice* device, std::optional<TensorTopology> tensor_topology) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::create_device_tensor",
         tensor_spec.logical_shape(),
@@ -73,7 +82,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
 
     Tensor output;
     distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
-    output = allocate_tensor_on_device(tensor_spec, mesh_device);
+    output = allocate_tensor_on_device(tensor_spec, mesh_device, std::move(tensor_topology));
     output = tt::tt_metal::set_tensor_id(output);
 
     GraphTracker::instance().track_function_end(output);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -34,8 +34,7 @@ tt::tt_metal::Tensor allocate_tensor_on_device(
     if (topology.has_value()) {
         tensor_topology = std::move(*topology);
     } else {
-        // Default: all Replicate placements.
-        // TODO (#25340): Implement correct logic and add test for this.
+        // Use Replicate as default value for placements in MeshMapperConfig
         ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
         for (size_t i = 0; i < device->shape().dims(); i++) {
             placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -373,8 +373,17 @@ Tensor empty_like(
     DataType dtype_value = dtype.value_or(tensor.dtype());
     MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
     MeshDevice* device_ptr = device.has_value() ? &device->get() : tensor.device();
+
+    std::optional<tt::tt_metal::TensorTopology> topology = std::nullopt;
+    if (is_device_tensor(tensor) &&
+        device_ptr->shape().mesh_size() == tensor.tensor_topology().distribution_shape().mesh_size()) {
+        topology = tensor.tensor_topology();
+    }
+
     return create_device_tensor(
-        TensorSpec(tensor.logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)), device_ptr);
+        TensorSpec(tensor.logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)),
+        device_ptr,
+        std::move(topology));
 }
 
 Tensor arange(

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -474,10 +474,10 @@ void bind_empty_like(nb::module_& mod) {
             tensor (ttnn.Tensor): The reference tensor whose shape will be used for the output tensor.
 
         Keyword Args:
-            dtype (ttnn.DataType, optional): The desired data type of the output tensor. Defaults to `ttnn.bfloat16`.
-            layout (ttnn.Layout, optional): The desired layout of the output tensor. Defaults to `ttnn.ROW_MAJOR`.
-            device (ttnn.Device | ttnn.MeshDevice, optional): The device where the tensor will be allocated. Defaults to `None`.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+            dtype (ttnn.DataType, optional): The desired data type of the output tensor. Defaults to the input tensor's dtype.
+            layout (ttnn.Layout, optional): The desired layout of the output tensor. Defaults to the input tensor's layout.
+            device (ttnn.Device | ttnn.MeshDevice, optional): The device where the tensor will be allocated. Defaults to the input tensor's device.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to the input tensor's memory config.
 
         Returns:
             ttnn.Tensor: The output uninitialized tensor with the same shape as the input tensor.
@@ -489,10 +489,10 @@ void bind_empty_like(nb::module_& mod) {
         empty_like_impl,
         nb::arg("tensor"),
         nb::kw_only(),
-        nb::arg("dtype") = DataType::BFLOAT16,
-        nb::arg("layout") = Layout::ROW_MAJOR,
+        nb::arg("dtype") = nb::none(),
+        nb::arg("layout") = nb::none(),
         nb::arg("device") = nb::none(),
-        nb::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG);
+        nb::arg("memory_config") = nb::none());
 }
 
 Tensor from_buffer_impl(


### PR DESCRIPTION
### Ticket
#40927

### Changes
- Update create_device_tensor to accept an optional TensorTopology argument, allowing callers to propagate topology from an existing tensor
- Propagate the input tensor's TensorTopology (Replicate/Shard) in empty_like when the device mesh shape matches
- Fix `empty_like` nanobind defaults to inherit dtype, layout, device, and memory config from the input tensor (matching PyTorch torch.empty_like semantics)
- In addition to pytorch, `empty_like` op also inherits tensor topology from the parent tensor
- Updated `empty_like` pytests accordingly

### Checklist
- [ ] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/23796667550)
- [ ] [TT-metal L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23796691622)