### PR TITLE
#40877: add missing barrier and change code to use device 2.0 api in matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -21,7 +21,7 @@ void kernel_main() {
     constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
     constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(3);
     // in0 mcast args
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
+    constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(6);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(7);
     // block args
@@ -32,7 +32,7 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(12);
     // in0 semaphore always valid
-    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(13));
+    constexpr uint32_t in0_mcast_sender_valid_semaphore_id = get_compile_time_arg_val(13);
 
     constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(14);
     constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;
@@ -61,7 +61,7 @@ void kernel_main() {
     experimental::CircularBuffer cb_in0(cb_id_in0);
     experimental::CircularBuffer cb_in2(cb_id_in2);
     experimental::Semaphore<> sender_sem(get_compile_time_arg_val(4));
-    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+    experimental::Semaphore<> receiver_sem(in0_mcast_receiver_semaphore_id);
 
     uint32_t l1_write_addr_in0;
 
@@ -69,13 +69,6 @@ void kernel_main() {
     receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-
-    const uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
 
     uint32_t local_read_addr = cb_in2.get_read_ptr();
 
@@ -185,8 +178,14 @@ void kernel_main() {
                      .addr = l1_write_addr_in0},
                     true);
 #endif
-                noc_semaphore_set_multicast_loopback_src(
-                    in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
+                receiver_sem.set(VALID);
+                receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                    noc,
+                    in0_mcast_dest_noc_start_x,
+                    in0_mcast_dest_noc_start_y,
+                    in0_mcast_dest_noc_end_x,
+                    in0_mcast_dest_noc_end_y,
+                    in0_mcast_num_cores);
 
                 local_read_addr += in0_block_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -154,7 +154,12 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < in0_B; ++b) {
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(
+                s_sparsity,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_sparsity),
+                sparsity_pagesize,
+                {.page_id = b},
+                {});
             noc.async_read_barrier();
         }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -28,8 +28,8 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(7);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(8);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
+    constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(9);
+    constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(10);
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(12);
     constexpr uint32_t num_x = get_compile_time_arg_val(13);
@@ -72,19 +72,9 @@ void kernel_main() {
     experimental::CircularBuffer cb_in2(cb_id_in2);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-    experimental::Semaphore<> sender_sem(get_compile_time_arg_val(9));
+    experimental::Semaphore<> sender_sem(in0_mcast_sender_semaphore_id);
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(10));
-
-    // L1 array for valid semaphore value
-    constexpr uint32_t cb_l1_array = get_named_compile_time_arg_val("cb_l1_array");
-    experimental::CircularBuffer cb_l1(cb_l1_array);
-    uint32_t in0_mcast_sender_semaphore_valid_addr = cb_l1.get_write_ptr();
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_valid_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_valid_addr);
-    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    in0_mcast_sender_semaphore_valid_addr_ptr[0] =
-        VALID;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
+    experimental::Semaphore<> receiver_sem(in0_mcast_receiver_semaphore_id);
 
     constexpr uint32_t num_remote_senders = (num_blocks_inner_dim + num_blocks_per_shard - 1) / num_blocks_per_shard;
     uint32_t remote_sender_noc_x[num_remote_senders];
@@ -112,13 +102,6 @@ void kernel_main() {
             }
         }
     }
-    uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
-
     receiver_sem.set(VALID);
 
     cb_in2.reserve_back(batch * in0_block_num_tiles);
@@ -291,9 +274,13 @@ void kernel_main() {
                                 // Data needs to be written directly in the core.
                                 receiver_sem.set(VALID);
                             } else {
-                                noc_semaphore_set_multicast_loopback_src(
-                                    in0_mcast_sender_semaphore_valid_addr,
-                                    in0_mcast_receiver_semaphore_noc_addr,
+                                receiver_sem.set(VALID);
+                                receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                    noc,
+                                    in0_mcast_dest_noc_start_x,
+                                    in0_mcast_dest_noc_start_y,
+                                    in0_mcast_dest_noc_end_x,
+                                    in0_mcast_dest_noc_end_y,
                                     in0_mcast_num_cores);
                             }
                         } else {
@@ -314,9 +301,13 @@ void kernel_main() {
                                 true);
 
                             // We should also multicast the flag to destinations
-                            noc_semaphore_set_multicast(
-                                in0_mcast_sender_semaphore_valid_addr,
-                                in0_mcast_receiver_semaphore_noc_addr,
+                            receiver_sem.set(VALID);
+                            receiver_sem.set_multicast(
+                                noc,
+                                in0_mcast_dest_noc_start_x,
+                                in0_mcast_dest_noc_start_y,
+                                in0_mcast_dest_noc_end_x,
+                                in0_mcast_dest_noc_end_y,
                                 in0_mcast_num_cores);
                         }
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -11,6 +11,7 @@
 #include "api/debug/dprint_tile.h"
 #include "experimental/noc.h"
 #include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
 #include "experimental/noc_semaphore.h"
 #include "experimental/tensor.h"
 
@@ -45,7 +46,6 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
     experimental::Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
@@ -55,15 +55,16 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
         const uint32_t multicast_end_x = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
-        const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        const uint64_t signalling_semaphore_address =
-            get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
-            signalling_semaphore;
+        const uint32_t signalling_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        experimental::Semaphore<> signalling_sem(signalling_semaphore_id);
         pv_sem.wait(target_sem_value);
         pv_sem.set(1);
-        noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        signalling_sem.set(1);
+        signalling_sem.set_multicast(
+            noc, multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, num_signalling_semaphores);
     } else {
         pv_sem.up(noc, pv_core_x, pv_core_y, 1);
+        noc.async_atomic_barrier();
     }
 }
 
@@ -121,11 +122,11 @@ void kernel_main() {
     experimental::CircularBuffer cb_in1(cb_id_in1);
     experimental::CircularBuffer cb_sync(sync_cb);
     experimental::CircularBuffer cb_sync2(sync_cb2);
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
 
     uint32_t in1_shard_width_offset_bytes = 0;
     uint32_t in1_dram_shard_block_size_bytes = 0;
     uint32_t dram_read_offset_bytes = 0;
-    uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
 
     if constexpr (in1_is_dram_sharded) {
@@ -161,24 +162,29 @@ void kernel_main() {
             }
         } else if constexpr (in1_is_dram_sharded) {  // when in1 is sharded in DRAM, each core reads from its own bank,
                                                      // two cores on the same row share one bank.
+            constexpr uint32_t max_page =
+                in1_block_page_size > in1_block_page_size_last ? in1_block_page_size : in1_block_page_size_last;
             for (uint32_t block = 0; block < num_blocks; ++block) {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
                 l1_read_addr_in1 = block_idx * in1_dram_shard_block_size_bytes + dram_read_offset_bytes;
                 // Operand 1
                 cb_in1.reserve_back(in1_block_num_tiles);
-                l1_write_addr_in1 = cb_in1.get_write_ptr();
+                uint32_t cb_write_offset = 0;
 
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
-                        noc_async_read_one_packet_with_state<true, true>(
-                            in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
+                        noc.async_read<Noc::TxnIdMode::DISABLED, max_page>(
+                            dram_bank,
+                            cb_in1,
+                            curr_page_size,
+                            {.bank_id = dram_bank_id, .addr = in1_tensor_addr + curr_l1_read_addr_in1},
+                            {.offset_bytes = cb_write_offset},
+                            vc);
                         curr_l1_read_addr_in1 += curr_page_size;
-                        l1_write_addr_in1 += curr_page_size;
+                        cb_write_offset += curr_page_size;
                     }
                     l1_read_addr_in1 += in1_shard_width_offset_bytes;
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -176,7 +176,7 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        noc.async_read<Noc::TxnIdMode::DISABLED, max_page>(
+                        noc.async_read<experimental::Noc::TxnIdMode::DISABLED, max_page>(
                             dram_bank,
                             cb_in1,
                             curr_page_size,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -68,23 +68,29 @@ void kernel_main() {
 #endif
 
     //  READER
-    uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
-
-    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc);
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
 
 #ifdef ARCH_GRAYSKULL
+    noc.set_async_read_state<Noc::VcSelection::CUSTOM, in1_page_size>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
+
     for (uint32_t block = 0; block < num_blocks; ++block) {
         // Operand 1
         cb_in1.reserve_back(in1_block_num_tiles);
-        l1_write_addr_in1 = cb_in1.get_write_ptr();
+        uint32_t cb_write_offset = 0;
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
+            noc.async_read_with_state<Noc::VcSelection::CUSTOM, in1_page_size>(
+                dram_bank,
+                cb_in1,
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {.offset_bytes = cb_write_offset},
+                vc);
             l1_read_addr_in1 += in1_page_size;
-            l1_write_addr_in1 += in1_page_size;
+            cb_write_offset += in1_page_size;
         }
 
         noc.async_read_barrier();
@@ -100,19 +106,23 @@ void kernel_main() {
     cb_in1.reserve_back(in1_block_num_tiles);
     uint32_t l1_write_addr_in1_offset = 0;
     uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
-    l1_write_addr_in1 = l1_write_addr_in1_start;
+    uint32_t l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        noc_async_read_set_trid(curr_block_trid);
-
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state_with_trid(
-                in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
+            noc.async_read<Noc::TxnIdMode::ENABLED, in1_page_size>(
+                dram_bank,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                vc,
+                curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
 
         if (num_free_blocks_in_buffer == 2) {
-            noc_async_read_barrier_with_trid(block_trid_to_wait);
+            noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
             cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
@@ -132,23 +142,26 @@ void kernel_main() {
         l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
     }
     // last block to wait
-    noc_async_read_barrier_with_trid(block_trid_to_wait);
+    noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
     cb_in1.push_back(in1_block_num_tiles);
 #endif
 
 #ifdef FUSE_BIAS
     // Operand 1
     cb_in3.reserve_back(in1_block_w);
-    uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
     uint32_t l1_read_addr_in3 = 0;
-
-    uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc);
+    uint32_t cb_write_offset_in3 = 0;
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc_async_read_one_packet_with_state<true, true>(in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+        noc.async_read<Noc::TxnIdMode::DISABLED, in3_page_size>(
+            dram_bank,
+            cb_in3,
+            in3_page_size,
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr + l1_read_addr_in3},
+            {.offset_bytes = cb_write_offset_in3},
+            vc);
         l1_read_addr_in3 += in3_page_size;
-        l1_write_addr_in3 += in3_page_size;
+        cb_write_offset_in3 += in3_page_size;
     }
 
     // Barrier! make sure the reads are done

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -73,7 +73,7 @@ void kernel_main() {
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
 
 #ifdef ARCH_GRAYSKULL
-    noc.set_async_read_state<Noc::VcSelection::CUSTOM, in1_page_size>(
+    noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, in1_page_size>(
         dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -82,7 +82,7 @@ void kernel_main() {
         uint32_t cb_write_offset = 0;
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc.async_read_with_state<Noc::VcSelection::CUSTOM, in1_page_size>(
+            noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, in1_page_size>(
                 dram_bank,
                 cb_in1,
                 in1_page_size,
@@ -109,7 +109,7 @@ void kernel_main() {
     uint32_t l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc.async_read<Noc::TxnIdMode::ENABLED, in1_page_size>(
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED, in1_page_size>(
                 dram_bank,
                 experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
                 in1_page_size,
@@ -122,7 +122,7 @@ void kernel_main() {
         }
 
         if (num_free_blocks_in_buffer == 2) {
-            noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
+            noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
             cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
@@ -142,7 +142,7 @@ void kernel_main() {
         l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
     }
     // last block to wait
-    noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
+    noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
     cb_in1.push_back(in1_block_num_tiles);
 #endif
 
@@ -153,7 +153,7 @@ void kernel_main() {
     uint32_t cb_write_offset_in3 = 0;
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc.async_read<Noc::TxnIdMode::DISABLED, in3_page_size>(
+        noc.async_read<experimental::Noc::TxnIdMode::DISABLED, in3_page_size>(
             dram_bank,
             cb_in3,
             in3_page_size,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -245,7 +245,12 @@ void kernel_main() {
 #endif  // IN1_DRAM_HEIGHT_SHARDED
 
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(
+                s_sparsity,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_sparsity),
+                sparsity_pagesize,
+                {.page_id = b},
+                {});
             noc.async_read_barrier();
         }
 
@@ -290,32 +295,34 @@ void kernel_main() {
                         uint32_t l1_write_addr_in1_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in1_tensor_addr);
-
-                            if (i == 0) {
-                                in1_base_addr += dram_tensor_start_offset;
-                            }
-                            noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_single_tile_size_bytes, vc);
+                            uint32_t shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t shard_base_offset = (i == 0) ? dram_tensor_start_offset : 0;
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
-                            uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
+                            uint32_t cb_write_offset_in1 = l1_write_addr_in1_offset;
                             uint32_t in1_block_w_dram =
                                 in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t m = 0; m < in1_block_h; ++m) {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
-                                uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
+                                uint32_t cb_write_offset_temp = cb_write_offset_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc_async_read_one_packet_with_state<true, true>(
-                                        in1_base_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
+                                    noc.async_read<Noc::TxnIdMode::DISABLED, in1_single_tile_size_bytes>(
+                                        dram_bank,
+                                        cb_in1,
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = shard_bank_id,
+                                         .addr = in1_tensor_addr + shard_base_offset + l1_read_addr_in1_temp},
+                                        {.offset_bytes = cb_write_offset_temp},
+                                        vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
-                                    l1_write_addr_in1_temp += in1_single_tile_size_bytes;
+                                    cb_write_offset_temp += in1_single_tile_size_bytes;
                                 }
                                 l1_read_addr_in1 += in1_block_w_dram_bytes;
-                                l1_write_addr_in1 += in1_block_w_bytes;
+                                cb_write_offset_in1 += in1_block_w_bytes;
                             }
                             l1_write_addr_in1_offset +=
                                 in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index];
@@ -476,21 +483,18 @@ void kernel_main() {
                         uint32_t l1_write_addr_in3_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank_bias;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
-
-                            if (i == 0) {
-                                // dram_tensor_start_offset is in in1 tile bytes; convert to
-                                // bias tile bytes since bias_dtype may differ from in1_dtype.
-                                in3_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
-                                                 bias_single_tile_size_bytes;
-                            }
-
-                            noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
+                            uint32_t bias_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            // dram_tensor_start_offset is in in1 tile bytes; convert to
+                            // bias tile bytes since bias_dtype may differ from in1_dtype.
+                            uint32_t bias_base_offset = (i == 0)
+                                                            ? (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                                  bias_single_tile_size_bytes
+                                                            : 0;
 
                             uint32_t l1_read_addr_in3 = 0;
-                            l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
+                            uint32_t cb_write_offset_in3 = l1_write_addr_in3_offset;
                             // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
                             // by in1_single_tile_size_bytes (not bias) to get the tile count.
                             uint32_t in3_block_w_dram =
@@ -498,10 +502,16 @@ void kernel_main() {
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc_async_read_one_packet_with_state<true, true>(
-                                    in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+                                noc.async_read<Noc::TxnIdMode::DISABLED, bias_single_tile_size_bytes>(
+                                    dram_bank_bias,
+                                    cb_in3,
+                                    bias_single_tile_size_bytes,
+                                    {.bank_id = bias_bank_id,
+                                     .addr = in3_tensor_addr + bias_base_offset + l1_read_addr_in3},
+                                    {.offset_bytes = cb_write_offset_in3},
+                                    vc);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
-                                l1_write_addr_in3 += bias_single_tile_size_bytes;
+                                cb_write_offset_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;
                             }
                             // Advance L1 offset in bias tile bytes, not in1 stride bytes.

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -310,7 +310,7 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t cb_write_offset_temp = cb_write_offset_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc.async_read<Noc::TxnIdMode::DISABLED, in1_single_tile_size_bytes>(
+                                    noc.async_read<experimental::Noc::TxnIdMode::DISABLED, in1_single_tile_size_bytes>(
                                         dram_bank,
                                         cb_in1,
                                         in1_single_tile_size_bytes,
@@ -502,7 +502,7 @@ void kernel_main() {
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc.async_read<Noc::TxnIdMode::DISABLED, bias_single_tile_size_bytes>(
+                                noc.async_read<experimental::Noc::TxnIdMode::DISABLED, bias_single_tile_size_bytes>(
                                     dram_bank_bias,
                                     cb_in3,
                                     bias_single_tile_size_bytes,


### PR DESCRIPTION
### Ticket
#40877

### Problem description
- a barrier was missing
- when fixing this, it was found that the device 2.0 api migration was not fully completed

### What's changed
- add in the barrier
- complete the migration

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-40877_mm_m20_barrier)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-40877_mm_m20_barrier)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-40877_mm_m20_barrier)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-40877_mm_m20_barrier)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-40877_mm_m20_barrier)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-40877_mm_m20_barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-40877_mm_m20_barrier)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
