### PR TITLE
[Cleanup] Move deprecated `CreateSemaphore(CoreType)` from public API to internal

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -85,8 +85,8 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferNonBlockingAPIs) {
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
-        const auto master_semaphore = CreateSemaphore(program_, worker_core, 0, tt::CoreType::WORKER);
-        const auto subordinate_semaphore = CreateSemaphore(program_, worker_core, 0, tt::CoreType::WORKER);
+        const auto master_semaphore = CreateSemaphore(program_, worker_core, 0);
+        const auto subordinate_semaphore = CreateSemaphore(program_, worker_core, 0);
 
         std::vector<CBHandle> cbs;
         cbs.reserve(n_cbs);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -32,9 +32,11 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
-// Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size, Eth, EthernetConfig
+// Access to internal API: ProgramImpl::get_cb_base_addr, ProgramImpl::get_cb_size, Eth, EthernetConfig,
+// CreateSemaphore with CoreType
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
+#include "impl/buffers/semaphore.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -28,6 +28,7 @@
 #include "mesh_dispatch_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
+#include "impl/buffers/semaphore.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -291,16 +291,6 @@ void UpdateDynamicCircularBufferAddress(Program& program, CBHandle cb_handle, co
 void UpdateDynamicCircularBufferAddressAndTotalSize(
     Program& program, CBHandle cb_handle, const Buffer& buffer, uint32_t total_size);
 
-[[deprecated(
-    "tt::tt_metal::CreateSemaphore(Program& program, const std::variant<CoreRange, CoreRangeSet>& core_spec, uint32_t "
-    "initial_value, CoreType core_type) is deprecated. Use tt::tt_metal::CreateSemaphore(Program& program, const "
-    "std::variant<CoreRange, CoreRangeSet>& core_spec, uint32_t initial_value) instead.")]]
-uint32_t CreateSemaphore(
-    Program& program,
-    const std::variant<CoreRange, CoreRangeSet>& core_spec,
-    uint32_t initial_value,
-    CoreType core_type);
-
 // clang-format off
 /**
  * Initializes semaphore on all cores within core range (inclusive). Each core can have up to eight 4B semaphores aligned to L1_ALIGNMENT.

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -134,12 +134,9 @@ void append_fabric_vc2_connection_rt_args(
             .core_ranges = CoreRangeSet(CoreRange(worker_core, worker_core)),
             .initial_value = 0});
     } else {
-        worker_teardown_semaphore_id =
-            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
-        worker_buffer_index_semaphore_id =
-            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
-        worker_flow_control_semaphore_id =
-            tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0, CoreType::WORKER);
+        worker_teardown_semaphore_id = tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0);
+        worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0);
+        worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(worker_program_or_desc, {worker_core}, 0);
     }
 
     // Resolve VC2 sender channel addresses via explicit SenderWorkerAdapterSpec

--- a/tt_metal/impl/buffers/semaphore.hpp
+++ b/tt_metal/impl/buffers/semaphore.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <variant>
 
 #include <tt-metalium/core_coord.hpp>
 #include <umd/device/soc_descriptor.hpp>
@@ -46,5 +47,13 @@ private:
     uint32_t initial_value_;  // Initial value of semaphore
     CoreType core_type_;
 };
+
+class Program;
+
+uint32_t CreateSemaphore(
+    Program& program,
+    const std::variant<CoreRange, CoreRangeSet>& core_spec,
+    uint32_t initial_value,
+    CoreType core_type);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -4,9 +4,9 @@
 
 #include "dispatch.hpp"
 
-#include <host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
+#include "impl/buffers/semaphore.hpp"
 #include <map>
 #include <string>
 #include <variant>

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "dispatch_s.hpp"
 
-#include <host_api.hpp>
 #include <tt_metal.hpp>
+#include "impl/buffers/semaphore.hpp"
 #include <map>
 #include <string>
 #include <variant>

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -8,6 +8,7 @@
 #include <host_api.hpp>
 #include <utility>
 #include <variant>
+#include "impl/buffers/semaphore.hpp"
 
 #include "device.hpp"
 #include "dispatch.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -4,8 +4,8 @@
 
 #include "prefetch.hpp"
 
-#include <host_api.hpp>
 #include <tt_metal.hpp>
+#include "impl/buffers/semaphore.hpp"
 #include <array>
 #include <map>
 #include <string>


### PR DESCRIPTION
#36536 

Removes the deprecated 4-param `CreateSemaphore` (with `CoreType`) from the public API in `host_api.hpp` and moves its declaration to `impl/buffers/semaphore.hpp` for internal-only use. Call sites that passed `CoreType::WORKER` (the default) are migrated to the 3-param version, and unnecessary `#include <host_api.hpp>` includes are cleaned up from files that only needed the 4-param overload.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/delete_create_sem_coretype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/delete_create_sem_coretype)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/delete_create_sem_coretype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/delete_create_sem_coretype)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/delete_create_sem_coretype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/delete_create_sem_coretype)
- [x] New/Existing tests provide coverage for changes
- [x] Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early