### PR TITLE
#35247: update fatal check for matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -395,7 +395,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         uint32_t batch_size_a = get_batch_size(a_shape_padded);
                         uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
                         TT_FATAL(
-                            batch_size_a <= 1 || M_per_batch <= 1,
+                            batch_size_a == 1 || M_per_batch == 1,
                             "transpose_a with fuse_batch is not supported when batch dimensions "
                             "exist and M_per_batch > 1 (batch_size={}, M_per_batch={}, a_shape_padded={})",
                             batch_size_a,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -392,11 +392,13 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         "Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
                         "or equivalent. Please change the second input tensor or adjust the program config.");
                     if (attributes.transpose_a) {
+                        uint32_t batch_size_a = get_batch_size(a_shape_padded);
                         uint32_t M_per_batch = a_shape_padded[-2] / in0_tile.get_height();
                         TT_FATAL(
-                            M_per_batch <= 1,
-                            "transpose_a with fuse_batch is not supported when M_per_batch > 1 "
-                            "(M_per_batch={}, a_shape_padded={})",
+                            batch_size_a <= 1 || M_per_batch <= 1,
+                            "transpose_a with fuse_batch is not supported when batch dimensions "
+                            "exist and M_per_batch > 1 (batch_size={}, M_per_batch={}, a_shape_padded={})",
+                            batch_size_a,
                             M_per_batch,
                             a_shape_padded);
                     }


### PR DESCRIPTION
### Ticket
#35247

### Problem description
AI messed up the refactor of a fatal and that wasn't caught.

### What's changed
Update the fatal.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-35247_mm_fatal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-35247_mm_fatal)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-35247_mm_fatal)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-35247_mm_fatal)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-35247_mm_fatal)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-35247_mm_fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-35247_mm_fatal)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
