### PR TITLE
#38406: Generalized overlap function

### DIFF
--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -132,6 +132,7 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             raw_tensor_shape=(1536, 12288),
             dtype=ttnn.DataType.BFLOAT8_B,
+            tp_dim=(None, 0),
         )
     )
     kv_a_shard_spec: OverlappedShardSpec = field(
@@ -165,18 +166,6 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     def packed_w(self) -> int:
         return self.q_a_proj_shape[1] * 2
 
-    @property
-    def q_a_tiles_per_shard(self) -> int:
-        return self.q_a_shard_spec.tiles_per_shard
-
-    @property
-    def q_b_tiles_per_shard(self) -> int:
-        return self.q_b_shard_spec.tiles_per_shard
-
-    @property
-    def kv_tiles_per_shard(self) -> int:
-        return self.kv_a_shard_spec.tiles_per_shard
-
     # --- weight shuffles ------------------------------------------------------
 
     @staticmethod
@@ -196,17 +185,17 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
             heads_per_row=self.heads_per_row,
         )
 
-    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int) -> torch.Tensor:
+    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int, mesh_shape: tuple[int, int]) -> torch.Tensor:
         """Extract the per-device q_b_proj slice for a given TP index.
 
         The full q_b_proj tensor is laid out as ``[all_qnope | all_qrope]``
-        across ``q_b_shard_spec.tp`` devices.  This method splits qnope and
-        qrope, takes the ``tp_idx``-th chunk of each, and stitches them into
-        the single-device ``(K, qnope_dim + qrope_dim)`` slice.
+        across TP devices.  This method splits qnope and qrope, takes the
+        ``tp_idx``-th chunk of each, and stitches them into the single-device
+        ``(K, qnope_dim + qrope_dim)`` slice.
         """
         per_tp_qnope_dim = self.num_qnope_heads * self.qnope_head_dim
         per_tp_qrope_dim = self.num_qrope_heads * self.qrope_head_dim
-        total_qnope_dim = self.q_b_shard_spec.tp * per_tp_qnope_dim
+        total_qnope_dim = self.q_b_shard_spec.tp(mesh_shape) * per_tp_qnope_dim
 
         full_qnope = q_b_proj_weights[:, :total_qnope_dim]
         full_qrope = q_b_proj_weights[:, total_qnope_dim:]
@@ -239,7 +228,7 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
 
     Fuses the following into a single WIDTH_SHARDED raw buffer:
 
-    * **o_proj** — BFP8, (16384, 7168) full / (8192, 7168) per-device at tp=2,
+    * **o_proj** — BFP8, (16384, 7168) full, TP along mesh columns (tp_dim=(None, 0)),
       WIDTH_SHARDED on 112 cores.
     * **gate_mm** — BFP16, (7168, 256), WIDTH_SHARDED on 8 cores.
     * **attn_norm** — BFP16, (1, 7168), on core (12, 9).
@@ -271,7 +260,7 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             ),
             raw_tensor_shape=(16384, 7168),
             dtype=ttnn.DataType.BFLOAT8_B,
-            tp=2,
+            tp_dim=(None, 0),
         )
     )
     gate_mm: OverlappedShardSpec = field(
@@ -617,11 +606,11 @@ class BlitzDecodeWeights:
             self.moe_tp = 1
         else:
             mesh_shape = (device.shape[0], device.shape[1])
-            assert mesh_shape == (
-                4,
-                2,
-            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
-            self.mla_tp = 2
+            # assert mesh_shape == (
+            #     4,
+            #     2,
+            # ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
+            self.mla_tp = 2 if device.shape[1] == 2 else 1
             self.moe_tp = 8
 
     # ------------------------------------------------------------------
@@ -674,7 +663,8 @@ class BlitzDecodeWeights:
             underlying fused device buffer.
         """
         cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-        cfg.q_b_shard_spec.tp = self.mla_tp
+        mesh_shape = (self._device.shape[0], self._device.shape[1])
+        q_b_tp = cfg.q_b_shard_spec.tp(mesh_shape)
 
         # -- Validate device grid ----------------------------------------
         device_grid = self._device.compute_with_storage_grid_size()
@@ -689,7 +679,7 @@ class BlitzDecodeWeights:
         assert (
             q_a_proj_weights.shape == cfg.q_a_proj_shape
         ), f"q_a_proj_weights must be {cfg.q_a_proj_shape}, got {tuple(q_a_proj_weights.shape)}"
-        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * cfg.q_b_shard_spec.tp)
+        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * q_b_tp)
         assert (
             tuple(q_b_proj_weights.shape) == expected_q_b_shape
         ), f"q_b_proj_weights must be {expected_q_b_shape}, got {tuple(q_b_proj_weights.shape)}"
@@ -708,8 +698,8 @@ class BlitzDecodeWeights:
 
         # -- Step 3: build per-TP fused tensors -------------------------
         per_tp_combined = []
-        for tp_idx in range(cfg.q_b_shard_spec.tp):
-            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx)
+        for tp_idx in range(q_b_tp):
+            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mesh_shape)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
             q_ab_fused, q_ab_shard_shape = stitch_width_sharded(packed, shuffled, q_ab_num_cores)
@@ -728,7 +718,7 @@ class BlitzDecodeWeights:
             assert combined_tp.shape == (fused_shard_h, target_w * total_cores)
             per_tp_combined.append(combined_tp)
 
-        combined = torch.cat(per_tp_combined, dim=1) if cfg.q_b_shard_spec.tp > 1 else per_tp_combined[0]
+        combined = torch.cat(per_tp_combined, dim=1) if q_b_tp > 1 else per_tp_combined[0]
 
         # -- Step 4: place on device as WIDTH_SHARDED -------------------
         shard_spec = ttnn.ShardSpec(
@@ -742,10 +732,9 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
-        if cfg.q_b_shard_spec.tp == 1:
+        if q_b_tp == 1:
             mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
         else:
-            mesh_shape = (self._device.shape[0], self._device.shape[1])
             mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 1))
         device_for_torch = self._device if move_to_device else None
 
@@ -785,8 +774,7 @@ class BlitzDecodeWeights:
                 core_range_set=cfg.q_ab_core_range_set,
                 dtype=ttnn.bfloat8_b,
                 tile_shape=ts,
-                byte_offset=cfg.q_a_tiles_per_shard * tile_bytes,
-                total_size=cfg.q_b_tiles_per_shard * tile_bytes,
+                byte_offset=cfg.q_a_shard_spec.tiles_per_shard(mesh_shape) * tile_bytes,
             ),
             OverlappedTensor(
                 fused_tensor=fused,
@@ -837,7 +825,6 @@ class BlitzDecodeWeights:
             ``[o_proj, gate_mm, attn_norm, q_norm, ffn_norm, kv_norm]``.
         """
         cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
-        cfg.o_proj.tp = self.mla_tp
 
         return overlap_tensors(
             [

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -522,11 +522,11 @@ class BlitzDecodeWeights:
             self.moe_tp = 1
         else:
             mesh_shape = (device.shape[0], device.shape[1])
-            # assert mesh_shape == (
-            #     4,
-            #     2,
-            # ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
-            self.mla_tp = 2 if device.shape[1] == 2 else 1
+            assert mesh_shape == (
+                4,
+                2,
+            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
+            self.mla_tp = 2
             self.moe_tp = 8
 
     # ------------------------------------------------------------------

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -539,6 +539,7 @@ class BlitzDecodeWeights:
         q_b_proj_weights: torch.Tensor,
         kv_a_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat8_b,
         move_to_device: bool = True,
     ) -> dict[str, OverlappedTensor]:
         """Fuse q_a_proj, q_b_proj, and kv_a_proj via ``overlap_tensors``.
@@ -614,7 +615,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=q_ab_cores,
                             raw_tensor_shape=tuple(q_a_packed.shape),
-                            dtype=ttnn.bfloat8_b,
+                            dtype=dtype,
                         ),
                     ),
                     (
@@ -623,7 +624,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=q_ab_cores,
                             raw_tensor_shape=tuple(q_b_preprocessed.shape),
-                            dtype=ttnn.bfloat8_b,
+                            dtype=dtype,
                             tp_dim=(None, 1),
                         ),
                     ),
@@ -635,7 +636,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=kv_cores,
                             raw_tensor_shape=tuple(kv_reordered.shape),
-                            dtype=ttnn.bfloat8_b,
+                            dtype=dtype,
                         ),
                     ),
                 ],
@@ -653,6 +654,7 @@ class BlitzDecodeWeights:
         kv_norm: torch.Tensor,
         ffn_norm: torch.Tensor,
         *,
+        o_proj_dtype: ttnn.DataType = ttnn.bfloat8_b,
         move_to_device: bool = True,
     ) -> dict[str, OverlappedTensor]:
         """Fuse o_proj, gate_mm, and 4 RMSNorm gammas into one WIDTH_SHARDED tensor.
@@ -685,7 +687,13 @@ class BlitzDecodeWeights:
 
         return overlap_tensors(
             [
-                [("o_proj", o_proj_weights, replace(cfg.o_proj, raw_tensor_shape=tuple(o_proj_weights.shape)))],
+                [
+                    (
+                        "o_proj",
+                        o_proj_weights,
+                        replace(cfg.o_proj, raw_tensor_shape=tuple(o_proj_weights.shape), dtype=o_proj_dtype),
+                    )
+                ],
                 [("gate_mm", gate_mm_weights, cfg.gate_mm)],
                 [
                     ("attn_norm", attn_norm, cfg.attn_norm),
@@ -703,6 +711,7 @@ class BlitzDecodeWeights:
         kv_b1_proj_weights: torch.Tensor,
         kv_b2_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat8_b,
         move_to_device: bool = True,
     ) -> dict[str, OverlappedTensor]:
         """Fuse kv_b1_proj and kv_b2_proj via ``overlap_tensors``.
@@ -761,7 +770,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=cfg.kv_b1_core_range_set,
                             raw_tensor_shape=tuple(kv_b1_proj_weights.shape),
-                            dtype=ttnn.bfloat8_b,
+                            dtype=dtype,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(None, 0),
                         ),
@@ -774,7 +783,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=cfg.kv_b2_core_range_set,
                             raw_tensor_shape=tuple(kv_b2_preprocessed.shape),
-                            dtype=ttnn.bfloat8_b,
+                            dtype=dtype,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(None, 0),
                             logical_tensor_shape=cfg.kv_b2_proj_shape,
@@ -796,6 +805,7 @@ class BlitzDecodeWeights:
         up_proj_weights: torch.Tensor,
         down_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat4_b,
         move_to_device: bool = True,
     ) -> tuple[OverlappedTensor, OverlappedTensor, ttnn.Tensor]:
         """Create all shared-expert weight tensors in one call.
@@ -895,7 +905,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=cfg.gate_core_range_set,
                             raw_tensor_shape=tuple(gate_preprocessed.shape),
-                            dtype=ttnn.bfloat4_b,
+                            dtype=dtype,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(0, 1),
                             logical_tensor_shape=cfg.gate_proj_shape,
@@ -909,7 +919,7 @@ class BlitzDecodeWeights:
                         OverlappedShardSpec(
                             core_range_set=cfg.up_core_range_set,
                             raw_tensor_shape=tuple(up_preprocessed.shape),
-                            dtype=ttnn.bfloat4_b,
+                            dtype=dtype,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(0, 1),
                             logical_tensor_shape=cfg.up_proj_shape,
@@ -959,7 +969,7 @@ class BlitzDecodeWeights:
 
         down_tensor = ttnn.from_torch(
             dp_combined,
-            dtype=ttnn.bfloat4_b,
+            dtype=dtype,
             layout=ttnn.TILE_LAYOUT,
             device=device_dp,
             memory_config=dp_mem,
@@ -975,6 +985,7 @@ class BlitzDecodeWeights:
         up_proj_weights: torch.Tensor,
         down_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat4_b,
         move_to_device: bool = True,
     ) -> tuple[list[ttnn.Tensor], list[ttnn.Tensor], list[ttnn.Tensor]]:
         """Create DRAM WIDTH_SHARDED expert weight tensors for routed MoE.
@@ -1048,7 +1059,7 @@ class BlitzDecodeWeights:
                 tensors.append(
                     ttnn.from_torch(
                         w_shuffled.contiguous(),
-                        dtype=ttnn.bfloat4_b,
+                        dtype=dtype,
                         layout=ttnn.TILE_LAYOUT,
                         device=device_for_torch,
                         memory_config=mem_config,
@@ -1071,6 +1082,7 @@ class BlitzDecodeWeights:
         up_proj_weights: torch.Tensor,
         down_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat4_b,
         move_to_device: bool = True,
     ) -> tuple[OverlappedTensor, OverlappedTensor, ttnn.Tensor]:
         """Create MLP shared-expert weights (SRAM) from full projection tensors.
@@ -1093,6 +1105,7 @@ class BlitzDecodeWeights:
             gate_proj_weights[:, :shared_n],
             up_proj_weights[:, :shared_n],
             down_proj_weights[:shared_n, :],
+            dtype=dtype,
             move_to_device=move_to_device,
         )
 
@@ -1102,6 +1115,7 @@ class BlitzDecodeWeights:
         up_proj_weights: torch.Tensor,
         down_proj_weights: torch.Tensor,
         *,
+        dtype: ttnn.DataType = ttnn.bfloat4_b,
         move_to_device: bool = True,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         """Create MLP per-device routed expert weights (DRAM).
@@ -1180,7 +1194,7 @@ class BlitzDecodeWeights:
 
             return ttnn.from_torch(
                 stacked.contiguous(),
-                dtype=ttnn.bfloat4_b,
+                dtype=dtype,
                 layout=ttnn.TILE_LAYOUT,
                 device=device_for_torch,
                 memory_config=mem_config,

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -6,11 +6,10 @@
 Blitz decode weight overlapping infrastructure.
 
 "Overlapping" means fusing multiple weight tensors into a single
-width-sharded tensor so they share the same L1 base address on each core.
-For each core the individual shards are stitched together vertically,
-with tile-reshape applied when shard widths differ, producing one
-contiguous buffer per core.  Kernels locate each sub-weight at a known
-row offset within the fused shard.
+L1 buffer so they share the same base address on each core.
+For each core the individual shards are concatenated into one contiguous
+buffer, zero-padded to a common maximum byte size.  Kernels locate
+each sub-weight at a known byte offset within the fused shard.
 """
 
 from __future__ import annotations
@@ -191,8 +190,6 @@ QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = QAB_KVA_PROJ_SingleDeviceOverlapSpec()
 
 _GAMMA_CORE = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(12, 9), ttnn.CoreCoord(12, 9))])
 _KV_NORM_CORE = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 8))])
-_ATTN_NORM_BYTES = 7168 * 2
-_Q_NORM_BYTES = 1536 * 2
 
 
 @dataclass(frozen=True)
@@ -248,7 +245,6 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
-            byte_offset=0,
             tile_h=1,
             tile_w=32,
         )
@@ -258,7 +254,6 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 1536),
             dtype=ttnn.DataType.BFLOAT16,
-            byte_offset=_ATTN_NORM_BYTES,
             tile_h=1,
             tile_w=32,
         )
@@ -268,7 +263,6 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             core_range_set=_KV_NORM_CORE,
             raw_tensor_shape=(1, 512),
             dtype=ttnn.DataType.BFLOAT16,
-            byte_offset=0,
             tile_h=1,
             tile_w=32,
         )
@@ -278,7 +272,6 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
-            byte_offset=_ATTN_NORM_BYTES + _Q_NORM_BYTES,
             tile_h=1,
             tile_w=32,
         )
@@ -512,8 +505,9 @@ class BlitzDecodeWeights:
     """Fuses weight tensors to share the same L1 base address per core.
 
     Methods take raw torch weight tensors, apply any required preprocessing
-    (packing, shuffling), stitch per-core shards, and return the result as
-    a device-resident ttnn.Tensor with WIDTH_SHARDED placement.
+    (packing, shuffling), and fuse them via ``overlap_tensors`` into a
+    single L1 buffer.  Each method returns a list of
+    ``OverlappedTensor`` views into the fused buffer.
 
     Args:
         device: The ttnn device (or MeshDevice) to place tensors on.
@@ -547,27 +541,17 @@ class BlitzDecodeWeights:
         *,
         move_to_device: bool = True,
     ) -> list[OverlappedTensor]:
-        """Fuse q_a_proj, q_b_proj, and kv_a_proj into one WIDTH_SHARDED tensor.
+        """Fuse q_a_proj, q_b_proj, and kv_a_proj via ``overlap_tensors``.
 
-        The fused tensor spans two core regions that share the same shard
-        width, giving every core a single base address:
+        The fused buffer spans two core regions (lanes):
 
-        * **Top region** (8x12 = 96 cores): q_a_proj packed + q_b_proj
-          shuffled, stitched per core.
-        * **Bottom region** (2x9 = 18 cores at offset (8,0)): kv_a_proj
-          with shard reordering, zero-padded to the same shard height as
-          the top region.
+        * **Lane 0** (8×12 = 96 cores): q_a_proj (packed) and q_b_proj
+          (shuffled) back-to-back within each core's shard.
+        * **Lane 1** (2×9 = 18 cores at offset (8,0)): kv_a_proj
+          with shard reordering, zero-padded to the same max byte size.
 
-        For multi-device (4x2 mesh, TP=2) the q_b_proj weights span all
-        TP devices (width ``mla_tp * per_device_width``).  Per-TP slices are
-        shuffled independently and stitched with the (replicated)
-        q_a_proj into separate per-TP fused tensors, which are
-        concatenated along width and distributed via
-        ``ShardTensor2dMesh`` across mesh columns.  q_a_proj and
-        kv_a_proj are replicated on every device.
-
-        MLA TP is inferred from the device topology: single-device ->
-        mla_tp=1, 4x2 mesh -> mla_tp=2.
+        q_b_proj is TP-sharded along mesh columns (``tp_dim=(None, 1)``).
+        q_a_proj and kv_a_proj are replicated on every device.
 
         Args:
             q_a_proj_weights: Raw q_a_proj tensor, shape ``(7168, 1536)``.
@@ -713,9 +697,9 @@ class BlitzDecodeWeights:
         *,
         move_to_device: bool = True,
     ) -> list[OverlappedTensor]:
-        """Fuse kv_b1_proj and kv_b2_proj into one HEIGHT_SHARDED tensor.
+        """Fuse kv_b1_proj and kv_b2_proj via ``overlap_tensors``.
 
-        Stitches ``kv_b1_proj (8192, 512)`` onto 64 cores and
+        Fuses ``kv_b1_proj (8192, 512)`` onto 64 cores and
         ``kv_b2_proj (512, 8192)`` (pre-transposed to ``(8192, 512)``)
         onto another 64 cores.  Both lanes are HEIGHT_SHARDED with
         shard ``(128, 512)`` as BFP8.

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -14,7 +14,7 @@ each sub-weight at a known byte offset within the fused shard.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import torch
 from loguru import logger
@@ -667,8 +667,9 @@ class BlitzDecodeWeights:
         * **kv_norm** — BFP16 (1×32 tiles) on dedicated core (0, 8).
 
         Args:
-            o_proj_weights:     Raw o_proj tensor, shape ``(16384, 7168)``.
-                TP-sharded on the height dim across ``mla_tp`` devices.
+            o_proj_weights:     Raw o_proj tensor, shape
+                ``(8192 * mla_tp, 7168)``.  TP-sharded on the height
+                dim across mesh columns.
             gate_mm_weights:    Raw gate_mm tensor, shape (7168, 256).
                 Replicated across TP devices.
             attn_norm:      Pre-SDPA attention-input RMSNorm gamma, shape (1, 7168).
@@ -684,7 +685,7 @@ class BlitzDecodeWeights:
 
         return overlap_tensors(
             [
-                [("o_proj", o_proj_weights, cfg.o_proj)],
+                [("o_proj", o_proj_weights, replace(cfg.o_proj, raw_tensor_shape=tuple(o_proj_weights.shape)))],
                 [("gate_mm", gate_mm_weights, cfg.gate_mm)],
                 [
                     ("attn_norm", attn_norm, cfg.attn_norm),

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -540,7 +540,7 @@ class BlitzDecodeWeights:
         kv_a_proj_weights: torch.Tensor,
         *,
         move_to_device: bool = True,
-    ) -> list[OverlappedTensor]:
+    ) -> dict[str, OverlappedTensor]:
         """Fuse q_a_proj, q_b_proj, and kv_a_proj via ``overlap_tensors``.
 
         The fused buffer spans two core regions (lanes):
@@ -564,9 +564,9 @@ class BlitzDecodeWeights:
                 provided for layout/sharding metadata.
 
         Returns:
-            A list of three :class:`OverlappedTensor` views
-            ``[q_a_proj, q_b_proj, kv_a_proj]`` that share the same
-            underlying fused device buffer.
+            A dict of :class:`OverlappedTensor` views keyed by name
+            (``q_a_proj``, ``q_b_proj``, ``kv_a_proj``) that share the
+            same underlying fused device buffer.
         """
         cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
         mesh_shape = (self._device.shape[0], self._device.shape[1])
@@ -609,6 +609,7 @@ class BlitzDecodeWeights:
             [
                 [
                     (
+                        "q_a_proj",
                         q_a_packed,
                         OverlappedShardSpec(
                             core_range_set=q_ab_cores,
@@ -617,6 +618,7 @@ class BlitzDecodeWeights:
                         ),
                     ),
                     (
+                        "q_b_proj",
                         q_b_preprocessed,
                         OverlappedShardSpec(
                             core_range_set=q_ab_cores,
@@ -628,6 +630,7 @@ class BlitzDecodeWeights:
                 ],
                 [
                     (
+                        "kv_a_proj",
                         kv_reordered,
                         OverlappedShardSpec(
                             core_range_set=kv_cores,
@@ -651,7 +654,7 @@ class BlitzDecodeWeights:
         ffn_norm: torch.Tensor,
         *,
         move_to_device: bool = True,
-    ) -> list[OverlappedTensor]:
+    ) -> dict[str, OverlappedTensor]:
         """Fuse o_proj, gate_mm, and 4 RMSNorm gammas into one WIDTH_SHARDED tensor.
 
         The fused buffer is a UINT32 raw-byte container where each core's
@@ -674,17 +677,21 @@ class BlitzDecodeWeights:
             ffn_norm:  MoE pre-MLP RMSNorm gamma, shape (1, 7168).
 
         Returns:
-            List of six OverlappedTensors
-            ``[o_proj, gate_mm, attn_norm, q_norm, ffn_norm, kv_norm]``.
+            A dict of six OverlappedTensors keyed by name:
+            ``o_proj``, ``gate_mm``, ``attn_norm``, ``q_norm``, ``ffn_norm``, ``kv_norm``.
         """
         cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
 
         return overlap_tensors(
             [
-                [(o_proj_weights, cfg.o_proj)],
-                [(gate_mm_weights, cfg.gate_mm)],
-                [(attn_norm, cfg.attn_norm), (q_norm, cfg.q_norm), (ffn_norm, cfg.ffn_norm)],
-                [(kv_norm, cfg.kv_norm)],
+                [("o_proj", o_proj_weights, cfg.o_proj)],
+                [("gate_mm", gate_mm_weights, cfg.gate_mm)],
+                [
+                    ("attn_norm", attn_norm, cfg.attn_norm),
+                    ("q_norm", q_norm, cfg.q_norm),
+                    ("ffn_norm", ffn_norm, cfg.ffn_norm),
+                ],
+                [("kv_norm", kv_norm, cfg.kv_norm)],
             ],
             device=self._device,
             move_to_device=move_to_device,
@@ -696,7 +703,7 @@ class BlitzDecodeWeights:
         kv_b2_proj_weights: torch.Tensor,
         *,
         move_to_device: bool = True,
-    ) -> list[OverlappedTensor]:
+    ) -> dict[str, OverlappedTensor]:
         """Fuse kv_b1_proj and kv_b2_proj via ``overlap_tensors``.
 
         Fuses ``kv_b1_proj (8192, 512)`` onto 64 cores and
@@ -721,8 +728,9 @@ class BlitzDecodeWeights:
                 TP-sharded on the heads dim.
 
         Returns:
-            ``[kv_b1_proj, kv_b2_proj]`` as :class:`OverlappedTensor`
-            views sharing the same fused device buffer.
+            A dict of :class:`OverlappedTensor` views keyed by name
+            (``kv_b1_proj``, ``kv_b2_proj``) sharing the same fused
+            device buffer.
         """
         cfg = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
         mla_tp = self.mla_tp
@@ -747,6 +755,7 @@ class BlitzDecodeWeights:
             [
                 [
                     (
+                        "kv_b1_proj",
                         kv_b1_proj_weights,
                         OverlappedShardSpec(
                             core_range_set=cfg.kv_b1_core_range_set,
@@ -759,6 +768,7 @@ class BlitzDecodeWeights:
                 ],
                 [
                     (
+                        "kv_b2_proj",
                         kv_b2_preprocessed,
                         OverlappedShardSpec(
                             core_range_set=cfg.kv_b2_core_range_set,
@@ -875,10 +885,11 @@ class BlitzDecodeWeights:
                 .contiguous()
             )
 
-        gate_ov, up_ov = overlap_tensors(
+        gate_up_dict = overlap_tensors(
             [
                 [
                     (
+                        "gate_proj",
                         gate_preprocessed,
                         OverlappedShardSpec(
                             core_range_set=cfg.gate_core_range_set,
@@ -892,6 +903,7 @@ class BlitzDecodeWeights:
                 ],
                 [
                     (
+                        "up_proj",
                         up_preprocessed,
                         OverlappedShardSpec(
                             core_range_set=cfg.up_core_range_set,
@@ -907,6 +919,8 @@ class BlitzDecodeWeights:
             device=self._device,
             move_to_device=move_to_device,
         )
+        gate_ov = gate_up_dict["gate_proj"]
+        up_ov = gate_up_dict["up_proj"]
 
         # ==================================================================
         # Down (WIDTH_SHARDED in L1 on 112 matmul cores)

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import numpy as np
 import torch
 from loguru import logger
 
+import models.demos.deepseek_v3_b1.blitz_overlap_tensors as blitz_overlap_tensors
 import ttnn
 
 
@@ -92,15 +92,12 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     Shape tuples follow (height, width) convention.  All shapes describe
     the per-device layout; TP is inferred from the device topology at
     runtime (single-device -> TP=1, 4x2 mesh -> TP=2).
-    """
 
-    # Core range sets for q_ab and kv_a regions
-    q_ab_core_range_set: ttnn.CoreRangeSet = field(
-        default_factory=lambda: ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))})
-    )
-    kv_core_range_set: ttnn.CoreRangeSet = field(
-        default_factory=lambda: ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))})
-    )
+    The three sub-tensor shard specs use :class:`OverlappedShardSpec`
+    to compute per-shard tile counts and byte sizes.  ``q_a_shard_spec``
+    uses the packed shape ``(H/2, 2W)`` after the ``shuffle_q_a``
+    transform.
+    """
 
     # Head configuration
     num_qnope_heads: int = 64
@@ -111,13 +108,33 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     knope_dim: int = 512
     krope_dim: int = 64
 
-    # Raw tensor shapes (height, width)
+    # Raw tensor shapes for input validation (height, width)
     q_a_proj_shape: tuple[int, int] = (7168, 1536)
     q_b_proj_shape: tuple[int, int] = (1536, 12288)
     kv_a_proj_shape: tuple[int, int] = (7168, 576)
 
-    tile_h: int = 32
-    tile_w: int = 32
+    # Sub-tensor shard specs — q_a uses the packed shape (H/2, 2W)
+    q_a_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
+            raw_tensor_shape=(3584, 3072),
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+    )
+    q_b_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
+            raw_tensor_shape=(1536, 12288),
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+    )
+    kv_a_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))}),
+            raw_tensor_shape=(7168, 576),
+            dtype=ttnn.DataType.BFLOAT8_B,
+        )
+    )
 
     # kv_a_proj shard reorder: places the Knope-rope boundary shard so that
     # the physical core layout matches the logical split expected by the
@@ -125,6 +142,14 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     kv_a_proj_shard_order: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6, 7, 16, 8, 9, 10, 11, 12, 13, 14, 15, 17)
 
     # --- derived properties ---------------------------------------------------
+
+    @property
+    def q_ab_core_range_set(self) -> ttnn.CoreRangeSet:
+        return self.q_a_shard_spec.core_range_set
+
+    @property
+    def kv_core_range_set(self) -> ttnn.CoreRangeSet:
+        return self.kv_a_shard_spec.core_range_set
 
     @property
     def packed_h(self) -> int:
@@ -136,18 +161,15 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
 
     @property
     def q_a_tiles_per_shard(self) -> int:
-        shard_w = self.q_a_proj_shape[1] * 2 // self.q_ab_core_range_set.num_cores()
-        return (self.packed_h // self.tile_h) * (shard_w // self.tile_w)
+        return self.q_a_shard_spec.tiles_per_shard
 
     @property
     def q_b_tiles_per_shard(self) -> int:
-        shard_w = self.q_b_proj_shape[1] // self.q_ab_core_range_set.num_cores()
-        return (self.q_b_proj_shape[0] // self.tile_h) * (shard_w // self.tile_w)
+        return self.q_b_shard_spec.tiles_per_shard
 
     @property
     def kv_tiles_per_shard(self) -> int:
-        shard_w = self.kv_a_proj_shape[1] // self.kv_core_range_set.num_cores()
-        return (self.kv_a_proj_shape[0] // self.tile_h) * (shard_w // self.tile_w)
+        return self.kv_a_shard_spec.tiles_per_shard
 
     # --- weight shuffles ------------------------------------------------------
 
@@ -740,7 +762,7 @@ class BlitzDecodeWeights:
             q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mla_tp)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
-            q_ab_fused, q_ab_shard_shape = BlitzDecodeWeights._stitch_width_sharded(packed, shuffled, q_ab_num_cores)
+            q_ab_fused, q_ab_shard_shape = blitz_overlap_tensors.stitch_width_sharded(packed, shuffled, q_ab_num_cores)
             fused_shard_h, target_w = q_ab_shard_shape
 
             kv_shard_w = kv_w // kv_num_cores
@@ -899,7 +921,7 @@ class BlitzDecodeWeights:
         # gate_mm shards (bfloat16) — 8 cores
         for i in range(g_num_cores):
             shard_data = gate_mm_weights[:, i * g_shard_w : (i + 1) * g_shard_w].contiguous()
-            shard_raw = BlitzDecodeWeights._tilize_and_pack_bfloat16(shard_data, cfg.tile_h, cfg.tile_w)
+            shard_raw = blitz_overlap_tensors.tilize_and_pack_bfloat16(shard_data, cfg.tile_h, cfg.tile_w)
             assert len(shard_raw) == cfg.gate_mm_shard_bytes
             shared_packed.extend(shard_raw)
             shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
@@ -912,7 +934,7 @@ class BlitzDecodeWeights:
             (q_norm, cfg.q_norm_bytes),
             (ffn_norm, cfg.ffn_norm_bytes),
         ]:
-            raw = BlitzDecodeWeights._pack_bfloat16_1x32(gamma_tensor)
+            raw = blitz_overlap_tensors.pack_bfloat16_1x32(gamma_tensor)
             assert len(raw) == expected_bytes
             gamma_shard[offset : offset + len(raw)] = raw
             offset += len(raw)
@@ -920,7 +942,7 @@ class BlitzDecodeWeights:
 
         # kv_norm core (0, 8) — dedicated core
         kv_norm_shard = bytearray(max_shard_bytes)
-        kv_norm_raw = BlitzDecodeWeights._pack_bfloat16_1x32(kv_norm)
+        kv_norm_raw = blitz_overlap_tensors.pack_bfloat16_1x32(kv_norm)
         assert len(kv_norm_raw) == cfg.kv_norm_bytes
         kv_norm_shard[: len(kv_norm_raw)] = kv_norm_raw
         shared_packed.extend(kv_norm_shard)
@@ -936,7 +958,7 @@ class BlitzDecodeWeights:
             o_packed = bytearray()
             for i in range(o_num_cores):
                 shard_data = o_proj_slice[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
-                shard_raw = BlitzDecodeWeights._tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
+                shard_raw = blitz_overlap_tensors.tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
                 assert len(shard_raw) == cfg.o_proj_shard_bytes
                 o_packed.extend(shard_raw)
                 o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
@@ -1624,245 +1646,3 @@ class BlitzDecodeWeights:
             shuffled = shuffled[:, :, :N]
 
         return shuffled.reshape(*orig_shape)
-
-    @staticmethod
-    def _tilize_and_pack_bfp8(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
-        """Tilize a 2-D tensor and pack as BFP8_b raw bytes.
-
-        Produces the exact byte layout the hardware expects:
-        ``[16 exponent uint32 words][256 mantissa uint32 words]`` per tile,
-        with tiles in row-major order across the tensor.
-
-        Matches the C++ ``pack_as_bfp_tiles<Bfp8_b>`` with
-        ``row_major_input=false, is_exp_a=false``:
-
-        * Shared exponent = max float32 exponent in each 16-element block.
-        * Per-element mantissa = 24-bit explicit mantissa (hidden-1 + 23
-          fractional bits), right-shifted by the exponent delta *and* by
-          17 (``24 - 7``) to yield 7 bits, with round-to-nearest-even.
-        * Packed byte = ``sign(1) | mantissa(7)``, zeroed when mantissa
-          rounds to 0.
-
-        Tile layout: 4 faces (16x16) in order
-        face0 (rows 0-15, cols 0-15), face1 (rows 0-15, cols 16-31),
-        face2 (rows 16-31, cols 0-15), face3 (rows 16-31, cols 16-31).
-        Each face row of 16 elements forms one BFP8 block.
-        """
-        H, W = data_2d.shape
-        face_h, face_w = tile_h // 2, tile_w // 2
-        tr, tc = H // tile_h, W // tile_w
-        num_tiles = tr * tc
-
-        data_np = data_2d.contiguous().float().numpy()
-
-        # Reshape into tile grid -> (tr, tc, tile_h, tile_w)
-        tiles = data_np.reshape(tr, tile_h, tc, tile_w).transpose(0, 2, 1, 3)
-        tiles = tiles.reshape(num_tiles, tile_h, tile_w)
-
-        # Extract 4 faces per tile -> face-ordered (N, 1024)
-        face_ordered = np.concatenate(
-            [
-                tiles[:, :face_h, :face_w].reshape(num_tiles, -1),
-                tiles[:, :face_h, face_w:].reshape(num_tiles, -1),
-                tiles[:, face_h:, :face_w].reshape(num_tiles, -1),
-                tiles[:, face_h:, face_w:].reshape(num_tiles, -1),
-            ],
-            axis=1,
-        )
-
-        # Reshape into BFP8 blocks: (N, 64 blocks, 16 elements)
-        blocks = face_ordered.reshape(num_tiles, 64, 16)
-
-        # --- float32 field extraction (vectorised) ---
-        float_bits = blocks.view(np.uint32)
-        signs = ((float_bits >> 31) & 1).astype(np.uint8)
-        exponents = ((float_bits >> 23) & 0xFF).astype(np.int32)
-        mantissa23 = (float_bits & 0x007F_FFFF).astype(np.int32)
-
-        # 24-bit explicit mantissa with hidden 1; zero for denormals
-        explicit_mant = np.where(exponents == 0, np.int32(0), np.int32(1 << 23) | mantissa23)
-
-        # Shared exponent = max float32 exponent in each 16-element block
-        shared_exp = np.max(exponents, axis=2)  # (N, 64)
-
-        # Shift mantissa by exponent delta, then by 17 to get 7-bit result
-        delta = shared_exp[:, :, np.newaxis] - exponents
-        shifted = explicit_mant >> np.minimum(delta, 31)
-
-        MANT_SHIFT = 17  # 24 - 7
-        ROUND_MASK = (1 << MANT_SHIFT) - 1
-        TIE = np.int32(1 << (MANT_SHIFT - 1))
-
-        round_value = shifted & ROUND_MASK
-        mantissa7 = (shifted >> MANT_SHIFT).astype(np.int32)
-        guard_bit = mantissa7 & 1
-        round_up = (round_value > TIE) | ((round_value == TIE) & (guard_bit == 1))
-        mantissa7 = np.where(round_up, np.minimum(mantissa7 + 1, 127), mantissa7)
-
-        # Zero sign when mantissa is zero
-        signs = np.where(mantissa7 == 0, np.uint8(0), signs)
-        packed_mant = ((signs.astype(np.int32) << 7) | (mantissa7 & 0x7F)).astype(np.uint8)
-
-        # Assemble per-tile bytes: [exp words][mant words]
-        exp_bytes = shared_exp.astype(np.uint8)  # (N, 64)
-        exp_words = exp_bytes.view(np.uint32).reshape(num_tiles, 16)
-
-        mant_words = packed_mant.reshape(num_tiles, 1024).view(np.uint32).reshape(num_tiles, 256)
-
-        tile_words = np.concatenate([exp_words, mant_words], axis=1)  # (N, 272)
-        return tile_words.tobytes()
-
-    @staticmethod
-    def _tilize_and_pack_bfloat16(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
-        """Tilize a 2-D tensor and pack as bfloat16 (Float16_b) raw bytes.
-
-        Each tile is 2048 bytes: 1024 elements x 2 bytes, stored in
-        face order (face0, face1, face2, face3), row-major within each
-        face.  bfloat16 is the top 16 bits of IEEE-754 float32.
-        """
-        H, W = data_2d.shape
-        face_h, face_w = tile_h // 2, tile_w // 2
-        tr, tc = H // tile_h, W // tile_w
-        num_tiles = tr * tc
-
-        data_np = data_2d.contiguous().float().numpy()
-
-        tiles = data_np.reshape(tr, tile_h, tc, tile_w).transpose(0, 2, 1, 3)
-        tiles = tiles.reshape(num_tiles, tile_h, tile_w)
-
-        face_ordered = np.concatenate(
-            [
-                tiles[:, :face_h, :face_w].reshape(num_tiles, -1),
-                tiles[:, :face_h, face_w:].reshape(num_tiles, -1),
-                tiles[:, face_h:, :face_w].reshape(num_tiles, -1),
-                tiles[:, face_h:, face_w:].reshape(num_tiles, -1),
-            ],
-            axis=1,
-        )  # (N, 1024)
-
-        # bfloat16 = top 16 bits of float32
-        float_bits = face_ordered.view(np.uint32)
-        bf16_bits = (float_bits >> 16).astype(np.uint16)
-        return bf16_bits.tobytes()
-
-    @staticmethod
-    def _pack_bfloat16_1x32(data: torch.Tensor) -> bytes:
-        """Pack a 1-row tensor as raw bfloat16 bytes with 1×32 tile layout.
-
-        For 1×32 tiles there is no face reordering; elements are stored
-        sequentially in tile-width chunks.  bfloat16 is the top 16 bits
-        of IEEE-754 float32.
-        """
-        flat = data.contiguous().float().reshape(-1).numpy()
-        float_bits = flat.view(np.uint32)
-        bf16_bits = (float_bits >> 16).astype(np.uint16)
-        return bf16_bits.tobytes()
-
-    @staticmethod
-    def _stitch_width_sharded(
-        tensor1: torch.Tensor,
-        tensor2: torch.Tensor,
-        num_cores: int,
-        tile_h: int = 32,
-        tile_w: int = 32,
-    ) -> tuple[torch.Tensor, tuple[int, int]]:
-        """Stitch two width-sharded tensors into one fused tensor.
-
-        For every core the two shards are concatenated vertically.  When
-        the shard widths differ, the wider shard is tile-reshaped to match
-        the narrower one (preserving tile ordering) so the concatenation
-        is well-defined.
-
-        Args:
-            tensor1: First weight tensor (H1, W1).
-            tensor2: Second weight tensor (H2, W2).
-            num_cores: Total cores in the width-sharded grid.
-            tile_h: Tile height (default 32).
-            tile_w: Tile width (default 32).
-
-        Returns:
-            (fused_tensor, shard_shape) ready for WIDTH_SHARDED
-            placement on num_cores cores.
-        """
-        H1, W1 = tensor1.shape
-        H2, W2 = tensor2.shape
-
-        shard_w1 = W1 // num_cores
-        shard_w2 = W2 // num_cores
-
-        # Use the narrower shard width as target; tile-reshape the wider.
-        if shard_w1 <= shard_w2:
-            target_w = shard_w1
-            narrow, wide = tensor1, tensor2
-            narrow_h, wide_h = H1, H2
-            narrow_sw, wide_sw = shard_w1, shard_w2
-        else:
-            target_w = shard_w2
-            narrow, wide = tensor2, tensor1
-            narrow_h, wide_h = H2, H1
-            narrow_sw, wide_sw = shard_w2, shard_w1
-
-        # Height of each wide shard after tile-reshape to target_w
-        reshaped_h = wide_h * wide_sw // target_w
-
-        fused_shard_h = narrow_h + reshaped_h
-        fused = torch.zeros(fused_shard_h, target_w * num_cores, dtype=tensor1.dtype)
-
-        for core_idx in range(num_cores):
-            col_start = core_idx * target_w
-            col_end = col_start + target_w
-
-            # Narrow shard: already at target width, just copy.
-            n_start = core_idx * narrow_sw
-            n_end = n_start + narrow_sw
-            fused[:narrow_h, col_start:col_end] = narrow[:, n_start:n_end]
-
-            # Wide shard: tile-reshape from (wide_h, wide_sw) to
-            # (reshaped_h, target_w), then copy.
-            w_start = core_idx * wide_sw
-            w_end = w_start + wide_sw
-            w_shard = wide[:, w_start:w_end]
-            w_reshaped = BlitzDecodeWeights._tile_reshape(
-                w_shard,
-                src_shape=(wide_h, wide_sw),
-                dst_shape=(reshaped_h, target_w),
-                tile_h=tile_h,
-                tile_w=tile_w,
-            )
-            fused[narrow_h:, col_start:col_end] = w_reshaped
-
-        shard_shape = (fused_shard_h, target_w)
-        return fused, shard_shape
-
-    @staticmethod
-    def _tile_reshape(
-        tensor: torch.Tensor,
-        src_shape: tuple[int, int],
-        dst_shape: tuple[int, int],
-        tile_h: int = 32,
-        tile_w: int = 32,
-    ) -> torch.Tensor:
-        """Reshape a 2-D tensor while preserving row-major tile ordering.
-
-        Data is stored as a grid of (tile_h x tile_w) tiles in row-major
-        order.  A naive torch.reshape changes which values land in each
-        tile.  This helper keeps every tile's contents unchanged by:
-
-        1. Splitting into the source tile grid.
-        2. Flattening to a 1-D tile sequence (row-major).
-        3. Re-gridding into the destination tile dimensions.
-
-        Total tile count must be identical for source and destination.
-        """
-        src_h, src_w = src_shape
-        dst_h, dst_w = dst_shape
-        src_tr, src_tc = src_h // tile_h, src_w // tile_w
-        dst_tr, dst_tc = dst_h // tile_h, dst_w // tile_w
-        assert src_tr * src_tc == dst_tr * dst_tc, f"Tile count mismatch: {src_tr * src_tc} vs {dst_tr * dst_tc}"
-        # (H, W) -> (tile_rows, tile_h, tile_cols, tile_w)
-        #         -> (tile_rows, tile_cols, tile_h, tile_w)
-        tiles = tensor.reshape(src_tr, tile_h, src_tc, tile_w).permute(0, 2, 1, 3)
-        # Flatten to 1-D tile sequence, re-grid to destination layout
-        tiles = tiles.reshape(-1, tile_h, tile_w).reshape(dst_tr, dst_tc, tile_h, tile_w)
-        # (dst_tr, dst_tc, tile_h, tile_w) -> (dst_H, dst_W)
-        return tiles.permute(0, 2, 1, 3).reshape(dst_h, dst_w)

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -21,12 +21,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import (
-    OverlappedShardSpec,
-    OverlappedTensor,
-    max_shard_bytes,
-    overlap_tensors,
-)
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedShardSpec, OverlappedTensor, overlap_tensors
 
 
 def shuffle_weights_for_interleaved_qnope_qrope(
@@ -110,9 +105,6 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     qnope_head_dim: int = 128
     qrope_head_dim: int = 64
     heads_per_row: int = 8
-    knope_dim: int = 512
-    krope_dim: int = 64
-
     # Raw tensor shapes for input validation (height, width)
     q_a_proj_shape: tuple[int, int] = (7168, 1536)
     q_b_proj_shape: tuple[int, int] = (1536, 12288)
@@ -146,24 +138,6 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     # the physical core layout matches the logical split expected by the
     # KV cache branch kernel.
     kv_a_proj_shard_order: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6, 7, 16, 8, 9, 10, 11, 12, 13, 14, 15, 17)
-
-    # --- derived properties ---------------------------------------------------
-
-    @property
-    def q_ab_core_range_set(self) -> ttnn.CoreRangeSet:
-        return self.q_a_shard_spec.core_range_set
-
-    @property
-    def kv_core_range_set(self) -> ttnn.CoreRangeSet:
-        return self.kv_a_shard_spec.core_range_set
-
-    @property
-    def packed_h(self) -> int:
-        return self.q_a_proj_shape[0] // 2
-
-    @property
-    def packed_w(self) -> int:
-        return self.q_a_proj_shape[1] * 2
 
     # --- weight shuffles ------------------------------------------------------
 
@@ -207,7 +181,7 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     def shuffle_kv_a(self, weights: torch.Tensor) -> torch.Tensor:
         """Reorder kv_a_proj shards for the KV cache branch core layout."""
         kv_h, kv_w = weights.shape
-        kv_num_cores = self.kv_core_range_set.num_cores()
+        kv_num_cores = self.kv_a_shard_spec.core_range_set.num_cores()
         shards = weights.reshape(kv_h, kv_num_cores, kv_w // kv_num_cores)
         return shards[:, list(self.kv_a_proj_shard_order), :].reshape(kv_h, kv_w)
 
@@ -310,19 +284,6 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
         )
     )
 
-    # --- derived properties ---------------------------------------------------
-
-    @property
-    def max_shard_bytes(self) -> int:
-        return max_shard_bytes(
-            [
-                [self.o_proj],
-                [self.gate_mm],
-                [self.attn_norm, self.q_norm, self.ffn_norm],
-                [self.kv_norm],
-            ]
-        )
-
 
 O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
 
@@ -361,27 +322,6 @@ class KVB12_PROJ_SingleDeviceOverlapSpec:
 
     kv_b1_proj_shape: tuple[int, int] = (8192, 512)
     kv_b2_proj_shape: tuple[int, int] = (512, 8192)
-
-    tile_h: int = 32
-    tile_w: int = 32
-    bfp8_tile_bytes: int = 1088
-
-    # --- derived properties ---------------------------------------------------
-
-    @property
-    def shard_shape(self) -> tuple[int, int]:
-        """HEIGHT_SHARDED shard: (128, 512) -- same for both sub-tensors."""
-        num_cores = self.kv_b1_core_range_set.num_cores()
-        return (self.kv_b1_proj_shape[0] // num_cores, self.kv_b1_proj_shape[1])
-
-    @property
-    def tiles_per_shard(self) -> int:
-        sh, sw = self.shard_shape
-        return (sh // self.tile_h) * (sw // self.tile_w)
-
-    @property
-    def shard_bytes(self) -> int:
-        return self.tiles_per_shard * self.bfp8_tile_bytes
 
     # --- weight shuffles ------------------------------------------------------
 
@@ -464,10 +404,6 @@ class GATE_UP_PROJ_SingleDeviceOverlapSpec:
     k_parallel: int = 8
     n_parallel: int = 8
 
-    tile_h: int = 32
-    tile_w: int = 32
-    bfp4_tile_bytes: int = 576
-
     # --- derived properties ---------------------------------------------------
 
     @property
@@ -480,19 +416,6 @@ class GATE_UP_PROJ_SingleDeviceOverlapSpec:
         """Shape of the stacked (per-sub-tensor) representation."""
         sh, sw = self.shard_shape
         return (self.gate_core_range_set.num_cores() * sh, sw)
-
-    @property
-    def tiles_per_shard(self) -> int:
-        sh, sw = self.shard_shape
-        return (sh // self.tile_h) * (sw // self.tile_w)
-
-    @property
-    def shard_bytes(self) -> int:
-        return self.tiles_per_shard * self.bfp4_tile_bytes
-
-    @property
-    def max_shard_bytes(self) -> int:
-        return self.shard_bytes
 
     @staticmethod
     def _crs_shard_permutation(core_range_set: ttnn.CoreRangeSet) -> tuple[int, ...]:
@@ -667,8 +590,8 @@ class BlitzDecodeWeights:
 
         # -- Validate device grid ----------------------------------------
         device_grid = self._device.compute_with_storage_grid_size()
-        q_ab_bb = cfg.q_ab_core_range_set.bounding_box()
-        kv_bb = cfg.kv_core_range_set.bounding_box()
+        q_ab_bb = cfg.q_a_shard_spec.core_range_set.bounding_box()
+        kv_bb = cfg.kv_a_shard_spec.core_range_set.bounding_box()
         required_rows = max(q_ab_bb.end.y, kv_bb.end.y) + 1
         required_cols = max(q_ab_bb.end.x, kv_bb.end.x) + 1
         assert device_grid.y >= required_rows, f"Device grid needs at least {required_rows} rows, got {device_grid.y}"
@@ -695,8 +618,8 @@ class BlitzDecodeWeights:
         ]
         q_b_preprocessed = torch.cat(q_b_shuffled_slices, dim=1) if q_b_tp > 1 else q_b_shuffled_slices[0]
 
-        q_ab_cores = cfg.q_ab_core_range_set
-        kv_cores = cfg.kv_core_range_set
+        q_ab_cores = cfg.q_a_shard_spec.core_range_set
+        kv_cores = cfg.kv_a_shard_spec.core_range_set
 
         return overlap_tensors(
             [
@@ -793,8 +716,9 @@ class BlitzDecodeWeights:
         """Fuse kv_b1_proj and kv_b2_proj into one HEIGHT_SHARDED tensor.
 
         Stitches ``kv_b1_proj (8192, 512)`` onto 64 cores and
-        ``kv_b2_proj (512, 8192)`` onto another 64 cores into a
-        single HEIGHT_SHARDED buffer with shard ``(128, 512)``.
+        ``kv_b2_proj (512, 8192)`` (pre-transposed to ``(8192, 512)``)
+        onto another 64 cores.  Both lanes are HEIGHT_SHARDED with
+        shard ``(128, 512)`` as BFP8.
 
         Layout::
 
@@ -802,10 +726,9 @@ class BlitzDecodeWeights:
             kv_b1_proj (8192, 512) as bfloat8_b, shard (128, 512)
 
             -- kv_b2 region: 64 remaining cores (5x8 + 12x2) --
-            kv_b2_proj (512, 8192) as bfloat8_b, shard (512, 128)
-            tile-shuffled into (128, 512) shape
+            kv_b2_proj (8192, 512) as bfloat8_b, shard (128, 512)
 
-            combined: 128 cores, HEIGHT_SHARDED, shard (128, 512)
+            combined: 128 cores, fused buffer
 
         Args:
             kv_b1_proj_weights: shape ``(8192 * mla_tp, 512)``.
@@ -829,78 +752,43 @@ class BlitzDecodeWeights:
             tuple(kv_b2_proj_weights.shape) == expected_b2_shape
         ), f"kv_b2 expected {expected_b2_shape}, got {tuple(kv_b2_proj_weights.shape)}"
 
-        per_device_b1_h = cfg.kv_b1_proj_shape[0]
         per_device_b2_w = cfg.kv_b2_proj_shape[1]
-
-        per_tp_combined = []
+        b2_shuffled = []
         for tp_idx in range(mla_tp):
-            b1_slice = kv_b1_proj_weights[tp_idx * per_device_b1_h : (tp_idx + 1) * per_device_b1_h, :]
             b2_slice = kv_b2_proj_weights[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
-            b2_physical = cfg.shuffle_kv_b2(b2_slice)
-            per_tp_combined.append(torch.cat([b1_slice, b2_physical], dim=0))
+            b2_shuffled.append(cfg.shuffle_kv_b2(b2_slice))
+        kv_b2_preprocessed = torch.cat(b2_shuffled, dim=0) if mla_tp > 1 else b2_shuffled[0]
 
-        combined = torch.cat(per_tp_combined, dim=0) if mla_tp > 1 else per_tp_combined[0]
-
-        # -- Place on device as HEIGHT_SHARDED --------------------------
-        combined_crs = ttnn.CoreRangeSet(
-            list(cfg.kv_b1_core_range_set.ranges()) + list(cfg.kv_b2_core_range_set.ranges())
+        return overlap_tensors(
+            [
+                [
+                    (
+                        kv_b1_proj_weights,
+                        OverlappedShardSpec(
+                            core_range_set=cfg.kv_b1_core_range_set,
+                            raw_tensor_shape=tuple(kv_b1_proj_weights.shape),
+                            dtype=ttnn.bfloat8_b,
+                            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                            tp_dim=(None, 0),
+                        ),
+                    ),
+                ],
+                [
+                    (
+                        kv_b2_preprocessed,
+                        OverlappedShardSpec(
+                            core_range_set=cfg.kv_b2_core_range_set,
+                            raw_tensor_shape=tuple(kv_b2_preprocessed.shape),
+                            dtype=ttnn.bfloat8_b,
+                            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                            tp_dim=(None, 0),
+                        ),
+                    ),
+                ],
+            ],
+            device=self._device,
+            move_to_device=move_to_device,
         )
-        sh, sw = cfg.shard_shape
-        shard_spec = ttnn.ShardSpec(
-            combined_crs,
-            (sh, sw),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            shard_spec,
-        )
-
-        if mla_tp == 1:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
-        else:
-            mesh_shape = (self._device.shape[0], self._device.shape[1])
-            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 0))
-        device_for_torch = self._device if move_to_device else None
-
-        fused = ttnn.from_torch(
-            combined,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            device=device_for_torch,
-            memory_config=mem_config,
-            mesh_mapper=mesh_mapper,
-        )
-
-        # -- Build OverlappedTensor views --------------------------------
-        tile = fused.get_tile()
-        tile_shape = tuple(tile.tile_shape)
-        num_b2_cores = cfg.kv_b2_core_range_set.num_cores()
-        kv_b2_shard = (cfg.kv_b2_proj_shape[0], cfg.kv_b2_proj_shape[1] // num_b2_cores)
-
-        return [
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.kv_b1_proj_shape,
-                shard_shape=cfg.shard_shape,
-                core_range_set=cfg.kv_b1_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=tile_shape,
-                byte_offset=0,
-                total_size=cfg.shard_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.kv_b2_proj_shape,
-                shard_shape=kv_b2_shard,
-                core_range_set=cfg.kv_b2_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=tile_shape,
-                byte_offset=0,
-                total_size=cfg.shard_bytes,
-            ),
-        ]
 
     # ------------------------------------------------------------------
     # MOE weight loading
@@ -970,63 +858,67 @@ class BlitzDecodeWeights:
             tuple(up_proj_weights.shape) == expected_up_shape
         ), f"up_proj must be {expected_up_shape}, got {tuple(up_proj_weights.shape)}"
 
+        mesh_rows = self._device.shape[0]
+        mesh_cols = self._device.shape[1]
         per_device_n = cfg.gate_proj_shape[1]
-        gu_per_tp = []
+        stacked_h, stacked_w = cfg.stacked_shape
+
+        gate_stacked_list = []
+        up_stacked_list = []
         for tp_idx in range(moe_tp):
             gate_slice = gate_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
             up_slice = up_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
-            gate_stacked = cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set)
-            up_stacked = cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set)
-            gu_per_tp.append(torch.cat([gate_stacked, up_stacked], dim=0))
-
-        combined_crs = ttnn.CoreRangeSet(list(cfg.gate_core_range_set.ranges()) + list(cfg.up_core_range_set.ranges()))
-        sh, sw = cfg.shard_shape
-        gu_shard_spec = ttnn.ShardSpec(combined_crs, (sh, sw), ttnn.ShardOrientation.ROW_MAJOR)
-        gu_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gu_shard_spec)
+            gate_stacked_list.append(cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set))
+            up_stacked_list.append(cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set))
 
         if moe_tp == 1:
-            gu_combined = gu_per_tp[0]
-            gu_mapper = ttnn.ReplicateTensorToMesh(self._device)
+            gate_preprocessed = gate_stacked_list[0]
+            up_preprocessed = up_stacked_list[0]
         else:
-            mesh_rows = self._device.shape[0]
-            mesh_cols = self._device.shape[1]
-            rows = []
-            for r in range(mesh_rows):
-                rows.append(torch.cat(gu_per_tp[r * mesh_cols : (r + 1) * mesh_cols], dim=1))
-            gu_combined = torch.cat(rows, dim=0)
-            gu_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
-        device_gu = self._device if move_to_device else None
+            gate_preprocessed = (
+                torch.stack(gate_stacked_list)
+                .reshape(mesh_rows, mesh_cols, stacked_h, stacked_w)
+                .permute(0, 2, 1, 3)
+                .reshape(mesh_rows * stacked_h, mesh_cols * stacked_w)
+                .contiguous()
+            )
+            up_preprocessed = (
+                torch.stack(up_stacked_list)
+                .reshape(mesh_rows, mesh_cols, stacked_h, stacked_w)
+                .permute(0, 2, 1, 3)
+                .reshape(mesh_rows * stacked_h, mesh_cols * stacked_w)
+                .contiguous()
+            )
 
-        fused = ttnn.from_torch(
-            gu_combined,
-            dtype=ttnn.bfloat4_b,
-            layout=ttnn.TILE_LAYOUT,
-            device=device_gu,
-            memory_config=gu_mem,
-            mesh_mapper=gu_mapper,
-        )
-
-        tile = fused.get_tile()
-        ts = tuple(tile.tile_shape)
-        gate_ov = OverlappedTensor(
-            fused_tensor=fused,
-            tensor_shape=cfg.gate_proj_shape,
-            shard_shape=cfg.shard_shape,
-            core_range_set=cfg.gate_core_range_set,
-            dtype=ttnn.bfloat4_b,
-            tile_shape=ts,
-            byte_offset=0,
-            total_size=cfg.shard_bytes,
-        )
-        up_ov = OverlappedTensor(
-            fused_tensor=fused,
-            tensor_shape=cfg.up_proj_shape,
-            shard_shape=cfg.shard_shape,
-            core_range_set=cfg.up_core_range_set,
-            dtype=ttnn.bfloat4_b,
-            tile_shape=ts,
-            byte_offset=0,
-            total_size=cfg.shard_bytes,
+        gate_ov, up_ov = overlap_tensors(
+            [
+                [
+                    (
+                        gate_preprocessed,
+                        OverlappedShardSpec(
+                            core_range_set=cfg.gate_core_range_set,
+                            raw_tensor_shape=tuple(gate_preprocessed.shape),
+                            dtype=ttnn.bfloat4_b,
+                            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                            tp_dim=(0, 1),
+                        ),
+                    ),
+                ],
+                [
+                    (
+                        up_preprocessed,
+                        OverlappedShardSpec(
+                            core_range_set=cfg.up_core_range_set,
+                            raw_tensor_shape=tuple(up_preprocessed.shape),
+                            dtype=ttnn.bfloat4_b,
+                            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                            tp_dim=(0, 1),
+                        ),
+                    ),
+                ],
+            ],
+            device=self._device,
+            move_to_device=move_to_device,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -26,7 +26,6 @@ from models.demos.deepseek_v3_b1.blitz_overlap_tensors import (
     OverlappedTensor,
     max_shard_bytes,
     overlap_tensors,
-    stitch_width_sharded,
 )
 
 
@@ -687,106 +686,53 @@ class BlitzDecodeWeights:
             kv_a_proj_weights.shape == cfg.kv_a_proj_shape
         ), f"kv_a_proj_weights must be {cfg.kv_a_proj_shape}, got {tuple(kv_a_proj_weights.shape)}"
 
-        # -- Step 1: pack q_a_proj  (H, W) -> (H/2, 2W) ----------------
-        packed = cfg.shuffle_q_a(q_a_proj_weights)
-
-        # -- Step 2: reorder kv_a_proj shards ---------------------------
+        # -- Preprocess --------------------------------------------------
+        q_a_packed = cfg.shuffle_q_a(q_a_proj_weights)
         kv_reordered = cfg.shuffle_kv_a(kv_a_proj_weights)
-        kv_h, kv_w = kv_a_proj_weights.shape
-        kv_num_cores = cfg.kv_core_range_set.num_cores()
-        q_ab_num_cores = cfg.q_ab_core_range_set.num_cores()
 
-        # -- Step 3: build per-TP fused tensors -------------------------
-        per_tp_combined = []
-        for tp_idx in range(q_b_tp):
-            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mesh_shape)
-            shuffled = cfg.shuffle_q_b(q_b_slice)
-
-            q_ab_fused, q_ab_shard_shape = stitch_width_sharded(packed, shuffled, q_ab_num_cores)
-            fused_shard_h, target_w = q_ab_shard_shape
-
-            kv_shard_w = kv_w // kv_num_cores
-            assert (
-                kv_shard_w == target_w
-            ), f"kv_a_proj shard width ({kv_shard_w}) must equal q_ab fused shard width ({target_w})"
-
-            kv_padded = torch.zeros(fused_shard_h, kv_w, dtype=kv_a_proj_weights.dtype)
-            kv_padded[:kv_h, :] = kv_reordered
-
-            total_cores = q_ab_num_cores + kv_num_cores
-            combined_tp = torch.cat([q_ab_fused, kv_padded], dim=1)
-            assert combined_tp.shape == (fused_shard_h, target_w * total_cores)
-            per_tp_combined.append(combined_tp)
-
-        combined = torch.cat(per_tp_combined, dim=1) if q_b_tp > 1 else per_tp_combined[0]
-
-        # -- Step 4: place on device as WIDTH_SHARDED -------------------
-        shard_spec = ttnn.ShardSpec(
-            ttnn.CoreRangeSet({q_ab_bb, kv_bb}),
-            (fused_shard_h, target_w),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.BufferType.L1,
-            shard_spec,
-        )
-
-        if q_b_tp == 1:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
-        else:
-            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 1))
-        device_for_torch = self._device if move_to_device else None
-
-        fused = ttnn.from_torch(
-            combined,
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-            device=device_for_torch,
-            memory_config=mem_config,
-            mesh_mapper=mesh_mapper,
-        )
-
-        # -- Build OverlappedTensor views --------------------------------
-        tile = fused.get_tile()
-        ts = tuple(tile.tile_shape)
-        tile_bytes = tile.get_tile_size(ttnn.bfloat8_b)
-
-        q_a_shard_w = cfg.packed_w // q_ab_num_cores
-        q_b_shard_w = cfg.q_b_proj_shape[1] // q_ab_num_cores
-        kv_shard_w = kv_w // kv_num_cores
-
-        return [
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=(cfg.packed_h, cfg.packed_w),
-                shard_shape=(cfg.packed_h, q_a_shard_w),
-                core_range_set=cfg.q_ab_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=ts,
-                byte_offset=0,
-                total_size=cfg.q_a_tiles_per_shard * tile_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.q_b_proj_shape,
-                shard_shape=(cfg.q_b_proj_shape[0], q_b_shard_w),
-                core_range_set=cfg.q_ab_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=ts,
-                byte_offset=cfg.q_a_shard_spec.tiles_per_shard(mesh_shape) * tile_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.kv_a_proj_shape,
-                shard_shape=(cfg.kv_a_proj_shape[0], kv_shard_w),
-                core_range_set=cfg.kv_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=ts,
-                byte_offset=0,
-                total_size=cfg.kv_tiles_per_shard * tile_bytes,
-            ),
+        q_b_shuffled_slices = [
+            cfg.shuffle_q_b(cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mesh_shape)) for tp_idx in range(q_b_tp)
         ]
+        q_b_preprocessed = torch.cat(q_b_shuffled_slices, dim=1) if q_b_tp > 1 else q_b_shuffled_slices[0]
+
+        q_ab_cores = cfg.q_ab_core_range_set
+        kv_cores = cfg.kv_core_range_set
+
+        return overlap_tensors(
+            [
+                [
+                    (
+                        q_a_packed,
+                        OverlappedShardSpec(
+                            core_range_set=q_ab_cores,
+                            raw_tensor_shape=tuple(q_a_packed.shape),
+                            dtype=ttnn.bfloat8_b,
+                        ),
+                    ),
+                    (
+                        q_b_preprocessed,
+                        OverlappedShardSpec(
+                            core_range_set=q_ab_cores,
+                            raw_tensor_shape=tuple(q_b_preprocessed.shape),
+                            dtype=ttnn.bfloat8_b,
+                            tp_dim=(None, 1),
+                        ),
+                    ),
+                ],
+                [
+                    (
+                        kv_reordered,
+                        OverlappedShardSpec(
+                            core_range_set=kv_cores,
+                            raw_tensor_shape=tuple(kv_reordered.shape),
+                            dtype=ttnn.bfloat8_b,
+                        ),
+                    ),
+                ],
+            ],
+            device=self._device,
+            move_to_device=move_to_device,
+        )
 
     def get_tt_o_proj_and_gate_mm_weights(
         self,

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -20,8 +20,14 @@ from dataclasses import dataclass, field
 import torch
 from loguru import logger
 
-import models.demos.deepseek_v3_b1.blitz_overlap_tensors as blitz_overlap_tensors
 import ttnn
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import (
+    OverlappedShardSpec,
+    OverlappedTensor,
+    max_shard_bytes,
+    overlap_tensors,
+    stitch_width_sharded,
+)
 
 
 def shuffle_weights_for_interleaved_qnope_qrope(
@@ -114,22 +120,22 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     kv_a_proj_shape: tuple[int, int] = (7168, 576)
 
     # Sub-tensor shard specs — q_a uses the packed shape (H/2, 2W)
-    q_a_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    q_a_shard_spec: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             raw_tensor_shape=(3584, 3072),
             dtype=ttnn.DataType.BFLOAT8_B,
         )
     )
-    q_b_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    q_b_shard_spec: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             raw_tensor_shape=(1536, 12288),
             dtype=ttnn.DataType.BFLOAT8_B,
         )
     )
-    kv_a_shard_spec: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    kv_a_shard_spec: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))}),
             raw_tensor_shape=(7168, 576),
             dtype=ttnn.DataType.BFLOAT8_B,
@@ -233,7 +239,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
 
     Fuses the following into a single WIDTH_SHARDED raw buffer:
 
-    * **o_proj** — BFP8, (8192, 7168), WIDTH_SHARDED on 112 cores.
+    * **o_proj** — BFP8, (16384, 7168) full / (8192, 7168) per-device at tp=2,
+      WIDTH_SHARDED on 112 cores.
     * **gate_mm** — BFP16, (7168, 256), WIDTH_SHARDED on 8 cores.
     * **attn_norm** — BFP16, (1, 7168), on core (12, 9).
       Attention input norm (attn_norm / mla_norm) — applied to hidden
@@ -254,27 +261,28 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     Shape tuples follow (height, width) convention.
     """
 
-    o_proj: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    o_proj: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),  # 96 cores
                     ttnn.CoreRange(ttnn.CoreCoord(1, 8), ttnn.CoreCoord(8, 9)),  # 16 cores
                 }
             ),
-            raw_tensor_shape=(8192, 7168),
+            raw_tensor_shape=(16384, 7168),
             dtype=ttnn.DataType.BFLOAT8_B,
+            tp=2,
         )
     )
-    gate_mm: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    gate_mm: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7))}),
             raw_tensor_shape=(7168, 256),
             dtype=ttnn.DataType.BFLOAT16,
         )
     )
-    attn_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    attn_norm: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
@@ -283,8 +291,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    q_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    q_norm: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 1536),
             dtype=ttnn.DataType.BFLOAT16,
@@ -293,8 +301,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    kv_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    kv_norm: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=_KV_NORM_CORE,
             raw_tensor_shape=(1, 512),
             dtype=ttnn.DataType.BFLOAT16,
@@ -303,8 +311,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    ffn_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
-        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+    ffn_norm: OverlappedShardSpec = field(
+        default_factory=lambda: OverlappedShardSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
@@ -318,7 +326,7 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
 
     @property
     def max_shard_bytes(self) -> int:
-        return blitz_overlap_tensors.max_shard_bytes(
+        return max_shard_bytes(
             [
                 [self.o_proj],
                 [self.gate_mm],
@@ -589,29 +597,6 @@ class DOWN_PROJ_SingleDeviceSpec:
 DOWN_PROJ_SINGLE_DEVICE_SPEC = DOWN_PROJ_SingleDeviceSpec()
 
 
-@dataclass
-class OverlappedTensor:
-    """A logical view of a sub-tensor within a fused (overlapped) device buffer.
-
-    The fused tensor is a raw byte container whose own tensor properties
-    (dtype, layout, shard spec) are generally meaningless for the individual
-    sub-tensors.  This class carries the intended per-sub-tensor properties
-    alongside a shared reference to the underlying fused buffer.
-    """
-
-    fused_tensor: ttnn.Tensor
-    tensor_shape: tuple[int, int]
-    shard_shape: tuple[int, int]
-    core_range_set: ttnn.CoreRangeSet
-    dtype: ttnn.DataType
-    tile_shape: tuple[int, int]
-    byte_offset: int = 0
-    total_size: int = 0
-
-    def get_tile(self) -> ttnn.Tile:
-        return ttnn.Tile(self.tile_shape)
-
-
 class BlitzDecodeWeights:
     """Fuses weight tensors to share the same L1 base address per core.
 
@@ -727,7 +712,7 @@ class BlitzDecodeWeights:
             q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
-            q_ab_fused, q_ab_shard_shape = blitz_overlap_tensors.stitch_width_sharded(packed, shuffled, q_ab_num_cores)
+            q_ab_fused, q_ab_shard_shape = stitch_width_sharded(packed, shuffled, q_ab_num_cores)
             fused_shard_h, target_w = q_ab_shard_shape
 
             kv_shard_w = kv_w // kv_num_cores
@@ -838,8 +823,8 @@ class BlitzDecodeWeights:
         * **kv_norm** — BFP16 (1×32 tiles) on dedicated core (0, 8).
 
         Args:
-            o_proj_weights:     Raw o_proj tensor, shape
-                ``(8192 * mla_tp, 7168)``.  TP-sharded on the inner dim.
+            o_proj_weights:     Raw o_proj tensor, shape ``(16384, 7168)``.
+                TP-sharded on the height dim across ``mla_tp`` devices.
             gate_mm_weights:    Raw gate_mm tensor, shape (7168, 256).
                 Replicated across TP devices.
             attn_norm:      Pre-SDPA attention-input RMSNorm gamma, shape (1, 7168).
@@ -849,152 +834,21 @@ class BlitzDecodeWeights:
 
         Returns:
             List of six OverlappedTensors
-            ``[o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm]``.
+            ``[o_proj, gate_mm, attn_norm, q_norm, ffn_norm, kv_norm]``.
         """
         cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
         cfg.o_proj.tp = self.mla_tp
 
-        # -- Validate shapes --------------------------------------------
-        expected_o_proj_shape = (cfg.o_proj.raw_tensor_shape[0] * cfg.o_proj.tp, cfg.o_proj.raw_tensor_shape[1])
-        assert (
-            tuple(o_proj_weights.shape) == expected_o_proj_shape
-        ), f"o_proj must be {expected_o_proj_shape}, got {tuple(o_proj_weights.shape)}"
-        assert (
-            gate_mm_weights.shape == cfg.gate_mm.raw_tensor_shape
-        ), f"gate_mm must be {cfg.gate_mm.raw_tensor_shape}, got {tuple(gate_mm_weights.shape)}"
-        assert (
-            tuple(attn_norm.shape) == cfg.attn_norm.raw_tensor_shape
-        ), f"attn_norm must be {cfg.attn_norm.raw_tensor_shape}, got {tuple(attn_norm.shape)}"
-        assert (
-            tuple(q_norm.shape) == cfg.q_norm.raw_tensor_shape
-        ), f"q_norm must be {cfg.q_norm.raw_tensor_shape}, got {tuple(q_norm.shape)}"
-        assert (
-            tuple(kv_norm.shape) == cfg.kv_norm.raw_tensor_shape
-        ), f"kv_norm must be {cfg.kv_norm.raw_tensor_shape}, got {tuple(kv_norm.shape)}"
-        assert (
-            tuple(ffn_norm.shape) == cfg.ffn_norm.raw_tensor_shape
-        ), f"ffn_norm must be {cfg.ffn_norm.raw_tensor_shape}, got {tuple(ffn_norm.shape)}"
-
-        o_num_cores = cfg.o_proj.core_range_set.num_cores()
-        g_num_cores = cfg.gate_mm.core_range_set.num_cores()
-        o_shard_w = cfg.o_proj.raw_tensor_shape[1] // o_num_cores
-        g_shard_w = cfg.gate_mm.raw_tensor_shape[1] // g_num_cores
-        max_shard_bytes = cfg.max_shard_bytes
-        assert max_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
-
-        # -- Pack shared portion (gate_mm + gammas, replicated) ----------
-        shared_packed = bytearray()
-
-        # gate_mm shards (bfloat16) — 8 cores
-        for i in range(g_num_cores):
-            shard_data = gate_mm_weights[:, i * g_shard_w : (i + 1) * g_shard_w].contiguous()
-            shard_raw = blitz_overlap_tensors.tilize_and_pack(shard_data, cfg.gate_mm)
-            assert len(shard_raw) == cfg.gate_mm.shard_bytes
-            shared_packed.extend(shard_raw)
-            shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm.shard_bytes))
-
-        # Gamma core (12, 9) — attn_norm + q_norm + ffn_norm
-        gamma_shard = bytearray(max_shard_bytes)
-        offset = 0
-        for gamma_tensor, expected_bytes in [
-            (attn_norm, cfg.attn_norm.shard_bytes),
-            (q_norm, cfg.q_norm.shard_bytes),
-            (ffn_norm, cfg.ffn_norm.shard_bytes),
-        ]:
-            raw = blitz_overlap_tensors.tilize_and_pack(gamma_tensor, cfg.attn_norm)
-            assert len(raw) == expected_bytes
-            gamma_shard[offset : offset + len(raw)] = raw
-            offset += len(raw)
-        shared_packed.extend(gamma_shard)
-
-        # kv_norm core (0, 8) — dedicated core
-        kv_norm_shard = bytearray(max_shard_bytes)
-        kv_norm_raw = blitz_overlap_tensors.tilize_and_pack(kv_norm, cfg.kv_norm)
-        assert len(kv_norm_raw) == cfg.kv_norm.shard_bytes
-        kv_norm_shard[: len(kv_norm_raw)] = kv_norm_raw
-        shared_packed.extend(kv_norm_shard)
-
-        # -- Pack per-TP o_proj shards and combine -----------------------
-        total_cores = o_num_cores + g_num_cores + 2  # +1 gamma core, +1 kv_norm core
-        uint32_per_shard = max_shard_bytes // 4
-        per_device_o_h = cfg.o_proj.raw_tensor_shape[0]
-
-        per_tp_raw = []
-        for tp_idx in range(cfg.o_proj.tp):
-            o_proj_slice = o_proj_weights[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
-            o_packed = bytearray()
-            for i in range(o_num_cores):
-                shard_data = o_proj_slice[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
-                shard_raw = blitz_overlap_tensors.tilize_and_pack(shard_data, cfg.o_proj)
-                assert len(shard_raw) == cfg.o_proj.shard_bytes
-                o_packed.extend(shard_raw)
-                o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj.shard_bytes))
-            per_tp_raw.append(torch.frombuffer(bytes(o_packed + shared_packed), dtype=torch.int32).clone())
-
-        # -- Build UINT32 tensor on device ------------------------------
-        if cfg.o_proj.tp == 1:
-            combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
-        else:
-            combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
-
-        combined_crs_ranges = (
-            list(cfg.o_proj.core_range_set.ranges())
-            + list(cfg.gate_mm.core_range_set.ranges())
-            + list(cfg.attn_norm.core_range_set.ranges())
-            + list(cfg.kv_norm.core_range_set.ranges())
+        return overlap_tensors(
+            [
+                [(o_proj_weights, cfg.o_proj)],
+                [(gate_mm_weights, cfg.gate_mm)],
+                [(attn_norm, cfg.attn_norm), (q_norm, cfg.q_norm), (ffn_norm, cfg.ffn_norm)],
+                [(kv_norm, cfg.kv_norm)],
+            ],
+            device=self._device,
+            move_to_device=move_to_device,
         )
-        combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
-        shard_spec = ttnn.ShardSpec(
-            combined_crs,
-            (1, uint32_per_shard),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.BufferType.L1,
-            shard_spec,
-        )
-
-        if cfg.o_proj.tp == 1:
-            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
-        else:
-            mesh_shape = (self._device.shape[0], self._device.shape[1])
-            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 1))
-        device_for_torch = self._device if move_to_device else None
-
-        fused = ttnn.from_torch(
-            combined,
-            dtype=ttnn.uint32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device_for_torch,
-            memory_config=mem_config,
-            mesh_mapper=mesh_mapper,
-        )
-
-        # -- Build OverlappedTensor views --------------------------------
-        def _ov(
-            spec: blitz_overlap_tensors.OverlappedShardSpec, shard_w_override: int | None = None
-        ) -> OverlappedTensor:
-            shape = spec.raw_tensor_shape
-            shard_shape = (shape[0], shard_w_override) if shard_w_override is not None else shape
-            return OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=shape,
-                shard_shape=shard_shape,
-                core_range_set=spec.core_range_set,
-                dtype=spec.dtype,
-                tile_shape=(spec.tile_h, spec.tile_w),
-                byte_offset=spec.byte_offset,
-            )
-
-        return [
-            _ov(cfg.o_proj, shard_w_override=o_shard_w),
-            _ov(cfg.gate_mm, shard_w_override=g_shard_w),
-            _ov(cfg.attn_norm),
-            _ov(cfg.q_norm),
-            _ov(cfg.kv_norm),
-            _ov(cfg.ffn_norm),
-        ]
 
     def get_tt_kv_b12_proj_weights(
         self,

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -329,7 +329,7 @@ class KVB12_PROJ_SingleDeviceOverlapSpec:
         kv_dim, n_heads = self.kv_b2_proj_shape
         n_cores = self.kv_b2_core_range_set.num_cores()
         head_dim = n_heads // n_cores
-        t = self.tile_h
+        t = 32
 
         k_tiles = kv_dim // t
         n_tiles = head_dim // t
@@ -766,6 +766,7 @@ class BlitzDecodeWeights:
                             dtype=ttnn.bfloat8_b,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(None, 0),
+                            logical_tensor_shape=cfg.kv_b2_proj_shape,
                         ),
                     ),
                 ],
@@ -885,6 +886,7 @@ class BlitzDecodeWeights:
                             dtype=ttnn.bfloat4_b,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(0, 1),
+                            logical_tensor_shape=cfg.gate_proj_shape,
                         ),
                     ),
                 ],
@@ -897,6 +899,7 @@ class BlitzDecodeWeights:
                             dtype=ttnn.bfloat4_b,
                             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                             tp_dim=(0, 1),
+                            logical_tensor_shape=cfg.up_proj_shape,
                         ),
                     ),
                 ],

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -190,17 +190,17 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
             heads_per_row=self.heads_per_row,
         )
 
-    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int, mla_tp: int) -> torch.Tensor:
+    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int) -> torch.Tensor:
         """Extract the per-device q_b_proj slice for a given TP index.
 
         The full q_b_proj tensor is laid out as ``[all_qnope | all_qrope]``
-        across ``mla_tp`` devices.  This method splits qnope and qrope,
-        takes the ``tp_idx``-th chunk of each, and stitches them into the
-        single-device ``(K, qnope_dim + qrope_dim)`` slice.
+        across ``q_b_shard_spec.tp`` devices.  This method splits qnope and
+        qrope, takes the ``tp_idx``-th chunk of each, and stitches them into
+        the single-device ``(K, qnope_dim + qrope_dim)`` slice.
         """
         per_tp_qnope_dim = self.num_qnope_heads * self.qnope_head_dim
         per_tp_qrope_dim = self.num_qrope_heads * self.qrope_head_dim
-        total_qnope_dim = mla_tp * per_tp_qnope_dim
+        total_qnope_dim = self.q_b_shard_spec.tp * per_tp_qnope_dim
 
         full_qnope = q_b_proj_weights[:, :total_qnope_dim]
         full_qrope = q_b_proj_weights[:, total_qnope_dim:]
@@ -219,6 +219,12 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
 
 
 QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = QAB_KVA_PROJ_SingleDeviceOverlapSpec()
+
+
+_GAMMA_CORE = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(12, 9), ttnn.CoreCoord(12, 9))])
+_KV_NORM_CORE = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(0, 8))])
+_ATTN_NORM_BYTES = 7168 * 2
+_Q_NORM_BYTES = 1536 * 2
 
 
 @dataclass(frozen=True)
@@ -248,118 +254,77 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     Shape tuples follow (height, width) convention.
     """
 
-    # Core range sets for o_proj and gate_mm regions
-    o_proj_core_range_set: ttnn.CoreRangeSet = field(
-        default_factory=lambda: ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),  # 96 cores
-                ttnn.CoreRange(ttnn.CoreCoord(1, 8), ttnn.CoreCoord(8, 9)),  # 16 cores
-            }
+    o_proj: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),  # 96 cores
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 8), ttnn.CoreCoord(8, 9)),  # 16 cores
+                }
+            ),
+            raw_tensor_shape=(8192, 7168),
+            dtype=ttnn.DataType.BFLOAT8_B,
         )
     )
-    gate_mm_core_range_set: ttnn.CoreRangeSet = field(
-        default_factory=lambda: ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7))})
+    gate_mm: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7))}),
+            raw_tensor_shape=(7168, 256),
+            dtype=ttnn.DataType.BFLOAT16,
+        )
     )
-
-    # Gamma core (12, 9): hosts attn_norm, q_norm, ffn_norm
-    gamma_core: ttnn.CoreCoord = field(default_factory=lambda: ttnn.CoreCoord(12, 9))
-
-    # Raw tensor shapes (height, width)
-    o_proj_shape: tuple[int, int] = (8192, 7168)
-    gate_mm_shape: tuple[int, int] = (7168, 256)
-
-    # Gamma shapes — all (1, W) bfloat16 with 1×32 tiles
-    attn_norm_shape: tuple[int, int] = (1, 7168)
-    q_norm_shape: tuple[int, int] = (1, 1536)
-    kv_norm_shape: tuple[int, int] = (1, 512)
-    ffn_norm_shape: tuple[int, int] = (1, 7168)
-
-    # kv_norm lives on its own dedicated core (0, 8)
-    kv_norm_core: ttnn.CoreCoord = field(default_factory=lambda: ttnn.CoreCoord(0, 8))
-
-    tile_h: int = 32
-    tile_w: int = 32
-    gamma_tile_h: int = 1
-    gamma_tile_w: int = 32
-    bfp8_tile_bytes: int = 1088
-    bfp16_tile_bytes: int = 2048
-    bf16_1x32_tile_bytes: int = 64  # 1 × 32 × 2 bytes
+    attn_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=_GAMMA_CORE,
+            raw_tensor_shape=(1, 7168),
+            dtype=ttnn.DataType.BFLOAT16,
+            byte_offset=0,
+            tile_h=1,
+            tile_w=32,
+        )
+    )
+    q_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=_GAMMA_CORE,
+            raw_tensor_shape=(1, 1536),
+            dtype=ttnn.DataType.BFLOAT16,
+            byte_offset=_ATTN_NORM_BYTES,
+            tile_h=1,
+            tile_w=32,
+        )
+    )
+    kv_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=_KV_NORM_CORE,
+            raw_tensor_shape=(1, 512),
+            dtype=ttnn.DataType.BFLOAT16,
+            byte_offset=0,
+            tile_h=1,
+            tile_w=32,
+        )
+    )
+    ffn_norm: blitz_overlap_tensors.OverlappedShardSpec = field(
+        default_factory=lambda: blitz_overlap_tensors.OverlappedShardSpec(
+            core_range_set=_GAMMA_CORE,
+            raw_tensor_shape=(1, 7168),
+            dtype=ttnn.DataType.BFLOAT16,
+            byte_offset=_ATTN_NORM_BYTES + _Q_NORM_BYTES,
+            tile_h=1,
+            tile_w=32,
+        )
+    )
 
     # --- derived properties ---------------------------------------------------
 
     @property
-    def o_proj_tiles_per_shard(self) -> int:
-        shard_w = self.o_proj_shape[1] // self.o_proj_core_range_set.num_cores()
-        return (self.o_proj_shape[0] // self.tile_h) * (shard_w // self.tile_w)
-
-    @property
-    def gate_mm_tiles_per_shard(self) -> int:
-        shard_w = self.gate_mm_shape[1] // self.gate_mm_core_range_set.num_cores()
-        return (self.gate_mm_shape[0] // self.tile_h) * (shard_w // self.tile_w)
-
-    @property
-    def o_proj_shard_bytes(self) -> int:
-        return self.o_proj_tiles_per_shard * self.bfp8_tile_bytes
-
-    @property
-    def gate_mm_shard_bytes(self) -> int:
-        return self.gate_mm_tiles_per_shard * self.bfp16_tile_bytes
-
-    # Gamma byte sizes (bfloat16: 2 bytes per element)
-    @property
-    def attn_norm_bytes(self) -> int:
-        return self.attn_norm_shape[1] * 2
-
-    @property
-    def q_norm_bytes(self) -> int:
-        return self.q_norm_shape[1] * 2
-
-    @property
-    def kv_norm_bytes(self) -> int:
-        return self.kv_norm_shape[1] * 2
-
-    @property
-    def ffn_norm_bytes(self) -> int:
-        return self.ffn_norm_shape[1] * 2
-
-    @property
-    def gamma_core_total_bytes(self) -> int:
-        """Total bytes for the three gammas on the gamma core (12, 9)."""
-        return self.attn_norm_bytes + self.q_norm_bytes + self.ffn_norm_bytes
-
-    # Byte offsets within each core's shard
-    @property
-    def attn_norm_byte_offset(self) -> int:
-        return 0
-
-    @property
-    def q_norm_byte_offset(self) -> int:
-        return self.attn_norm_bytes
-
-    @property
-    def ffn_norm_byte_offset(self) -> int:
-        return self.attn_norm_bytes + self.q_norm_bytes
-
-    @property
-    def kv_norm_byte_offset(self) -> int:
-        """kv_norm is the only occupant of core (0, 8)."""
-        return 0
-
-    @property
-    def gamma_core_range_set(self) -> ttnn.CoreRangeSet:
-        return ttnn.CoreRangeSet([ttnn.CoreRange(self.gamma_core, self.gamma_core)])
-
-    @property
-    def kv_norm_core_range_set(self) -> ttnn.CoreRangeSet:
-        return ttnn.CoreRangeSet([ttnn.CoreRange(self.kv_norm_core, self.kv_norm_core)])
-
-    @property
     def max_shard_bytes(self) -> int:
-        return max(
-            self.o_proj_shard_bytes,
-            self.gate_mm_shard_bytes,
-            self.gamma_core_total_bytes,
-            self.kv_norm_bytes,
+        return blitz_overlap_tensors.max_shard_bytes(
+            [
+                [self.o_proj],
+                [self.gate_mm],
+                [self.attn_norm, self.q_norm, self.ffn_norm],
+                [self.kv_norm],
+            ]
         )
 
 
@@ -724,7 +689,7 @@ class BlitzDecodeWeights:
             underlying fused device buffer.
         """
         cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-        mla_tp = self.mla_tp
+        cfg.q_b_shard_spec.tp = self.mla_tp
 
         # -- Validate device grid ----------------------------------------
         device_grid = self._device.compute_with_storage_grid_size()
@@ -739,7 +704,7 @@ class BlitzDecodeWeights:
         assert (
             q_a_proj_weights.shape == cfg.q_a_proj_shape
         ), f"q_a_proj_weights must be {cfg.q_a_proj_shape}, got {tuple(q_a_proj_weights.shape)}"
-        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp)
+        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * cfg.q_b_shard_spec.tp)
         assert (
             tuple(q_b_proj_weights.shape) == expected_q_b_shape
         ), f"q_b_proj_weights must be {expected_q_b_shape}, got {tuple(q_b_proj_weights.shape)}"
@@ -758,8 +723,8 @@ class BlitzDecodeWeights:
 
         # -- Step 3: build per-TP fused tensors -------------------------
         per_tp_combined = []
-        for tp_idx in range(mla_tp):
-            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mla_tp)
+        for tp_idx in range(cfg.q_b_shard_spec.tp):
+            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
             q_ab_fused, q_ab_shard_shape = blitz_overlap_tensors.stitch_width_sharded(packed, shuffled, q_ab_num_cores)
@@ -778,7 +743,7 @@ class BlitzDecodeWeights:
             assert combined_tp.shape == (fused_shard_h, target_w * total_cores)
             per_tp_combined.append(combined_tp)
 
-        combined = torch.cat(per_tp_combined, dim=1) if mla_tp > 1 else per_tp_combined[0]
+        combined = torch.cat(per_tp_combined, dim=1) if cfg.q_b_shard_spec.tp > 1 else per_tp_combined[0]
 
         # -- Step 4: place on device as WIDTH_SHARDED -------------------
         shard_spec = ttnn.ShardSpec(
@@ -792,7 +757,7 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
-        if mla_tp == 1:
+        if cfg.q_b_shard_spec.tp == 1:
             mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
         else:
             mesh_shape = (self._device.shape[0], self._device.shape[1])
@@ -887,31 +852,33 @@ class BlitzDecodeWeights:
             ``[o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm]``.
         """
         cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
-        mla_tp = self.mla_tp
+        cfg.o_proj.tp = self.mla_tp
 
         # -- Validate shapes --------------------------------------------
-        expected_o_proj_shape = (cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1])
+        expected_o_proj_shape = (cfg.o_proj.raw_tensor_shape[0] * cfg.o_proj.tp, cfg.o_proj.raw_tensor_shape[1])
         assert (
             tuple(o_proj_weights.shape) == expected_o_proj_shape
         ), f"o_proj must be {expected_o_proj_shape}, got {tuple(o_proj_weights.shape)}"
         assert (
-            gate_mm_weights.shape == cfg.gate_mm_shape
-        ), f"gate_mm must be {cfg.gate_mm_shape}, got {tuple(gate_mm_weights.shape)}"
+            gate_mm_weights.shape == cfg.gate_mm.raw_tensor_shape
+        ), f"gate_mm must be {cfg.gate_mm.raw_tensor_shape}, got {tuple(gate_mm_weights.shape)}"
         assert (
-            tuple(attn_norm.shape) == cfg.attn_norm_shape
-        ), f"attn_norm must be {cfg.attn_norm_shape}, got {tuple(attn_norm.shape)}"
-        assert tuple(q_norm.shape) == cfg.q_norm_shape, f"q_norm must be {cfg.q_norm_shape}, got {tuple(q_norm.shape)}"
+            tuple(attn_norm.shape) == cfg.attn_norm.raw_tensor_shape
+        ), f"attn_norm must be {cfg.attn_norm.raw_tensor_shape}, got {tuple(attn_norm.shape)}"
         assert (
-            tuple(kv_norm.shape) == cfg.kv_norm_shape
-        ), f"kv_norm must be {cfg.kv_norm_shape}, got {tuple(kv_norm.shape)}"
+            tuple(q_norm.shape) == cfg.q_norm.raw_tensor_shape
+        ), f"q_norm must be {cfg.q_norm.raw_tensor_shape}, got {tuple(q_norm.shape)}"
         assert (
-            tuple(ffn_norm.shape) == cfg.ffn_norm_shape
-        ), f"ffn_norm must be {cfg.ffn_norm_shape}, got {tuple(ffn_norm.shape)}"
+            tuple(kv_norm.shape) == cfg.kv_norm.raw_tensor_shape
+        ), f"kv_norm must be {cfg.kv_norm.raw_tensor_shape}, got {tuple(kv_norm.shape)}"
+        assert (
+            tuple(ffn_norm.shape) == cfg.ffn_norm.raw_tensor_shape
+        ), f"ffn_norm must be {cfg.ffn_norm.raw_tensor_shape}, got {tuple(ffn_norm.shape)}"
 
-        o_num_cores = cfg.o_proj_core_range_set.num_cores()
-        g_num_cores = cfg.gate_mm_core_range_set.num_cores()
-        o_shard_w = cfg.o_proj_shape[1] // o_num_cores
-        g_shard_w = cfg.gate_mm_shape[1] // g_num_cores
+        o_num_cores = cfg.o_proj.core_range_set.num_cores()
+        g_num_cores = cfg.gate_mm.core_range_set.num_cores()
+        o_shard_w = cfg.o_proj.raw_tensor_shape[1] // o_num_cores
+        g_shard_w = cfg.gate_mm.raw_tensor_shape[1] // g_num_cores
         max_shard_bytes = cfg.max_shard_bytes
         assert max_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
 
@@ -921,20 +888,20 @@ class BlitzDecodeWeights:
         # gate_mm shards (bfloat16) — 8 cores
         for i in range(g_num_cores):
             shard_data = gate_mm_weights[:, i * g_shard_w : (i + 1) * g_shard_w].contiguous()
-            shard_raw = blitz_overlap_tensors.tilize_and_pack_bfloat16(shard_data, cfg.tile_h, cfg.tile_w)
-            assert len(shard_raw) == cfg.gate_mm_shard_bytes
+            shard_raw = blitz_overlap_tensors.tilize_and_pack(shard_data, cfg.gate_mm)
+            assert len(shard_raw) == cfg.gate_mm.shard_bytes
             shared_packed.extend(shard_raw)
-            shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
+            shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm.shard_bytes))
 
         # Gamma core (12, 9) — attn_norm + q_norm + ffn_norm
         gamma_shard = bytearray(max_shard_bytes)
         offset = 0
         for gamma_tensor, expected_bytes in [
-            (attn_norm, cfg.attn_norm_bytes),
-            (q_norm, cfg.q_norm_bytes),
-            (ffn_norm, cfg.ffn_norm_bytes),
+            (attn_norm, cfg.attn_norm.shard_bytes),
+            (q_norm, cfg.q_norm.shard_bytes),
+            (ffn_norm, cfg.ffn_norm.shard_bytes),
         ]:
-            raw = blitz_overlap_tensors.pack_bfloat16_1x32(gamma_tensor)
+            raw = blitz_overlap_tensors.tilize_and_pack(gamma_tensor, cfg.attn_norm)
             assert len(raw) == expected_bytes
             gamma_shard[offset : offset + len(raw)] = raw
             offset += len(raw)
@@ -942,39 +909,39 @@ class BlitzDecodeWeights:
 
         # kv_norm core (0, 8) — dedicated core
         kv_norm_shard = bytearray(max_shard_bytes)
-        kv_norm_raw = blitz_overlap_tensors.pack_bfloat16_1x32(kv_norm)
-        assert len(kv_norm_raw) == cfg.kv_norm_bytes
+        kv_norm_raw = blitz_overlap_tensors.tilize_and_pack(kv_norm, cfg.kv_norm)
+        assert len(kv_norm_raw) == cfg.kv_norm.shard_bytes
         kv_norm_shard[: len(kv_norm_raw)] = kv_norm_raw
         shared_packed.extend(kv_norm_shard)
 
         # -- Pack per-TP o_proj shards and combine -----------------------
         total_cores = o_num_cores + g_num_cores + 2  # +1 gamma core, +1 kv_norm core
         uint32_per_shard = max_shard_bytes // 4
-        per_device_o_h = cfg.o_proj_shape[0]
+        per_device_o_h = cfg.o_proj.raw_tensor_shape[0]
 
         per_tp_raw = []
-        for tp_idx in range(mla_tp):
+        for tp_idx in range(cfg.o_proj.tp):
             o_proj_slice = o_proj_weights[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
             o_packed = bytearray()
             for i in range(o_num_cores):
                 shard_data = o_proj_slice[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
-                shard_raw = blitz_overlap_tensors.tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
-                assert len(shard_raw) == cfg.o_proj_shard_bytes
+                shard_raw = blitz_overlap_tensors.tilize_and_pack(shard_data, cfg.o_proj)
+                assert len(shard_raw) == cfg.o_proj.shard_bytes
                 o_packed.extend(shard_raw)
-                o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
+                o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj.shard_bytes))
             per_tp_raw.append(torch.frombuffer(bytes(o_packed + shared_packed), dtype=torch.int32).clone())
 
         # -- Build UINT32 tensor on device ------------------------------
-        if mla_tp == 1:
+        if cfg.o_proj.tp == 1:
             combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
         else:
             combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
 
         combined_crs_ranges = (
-            list(cfg.o_proj_core_range_set.ranges())
-            + list(cfg.gate_mm_core_range_set.ranges())
-            + list(cfg.gamma_core_range_set.ranges())
-            + list(cfg.kv_norm_core_range_set.ranges())
+            list(cfg.o_proj.core_range_set.ranges())
+            + list(cfg.gate_mm.core_range_set.ranges())
+            + list(cfg.attn_norm.core_range_set.ranges())
+            + list(cfg.kv_norm.core_range_set.ranges())
         )
         combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
         shard_spec = ttnn.ShardSpec(
@@ -988,7 +955,7 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
-        if mla_tp == 1:
+        if cfg.o_proj.tp == 1:
             mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
         else:
             mesh_shape = (self._device.shape[0], self._device.shape[1])
@@ -1005,70 +972,28 @@ class BlitzDecodeWeights:
         )
 
         # -- Build OverlappedTensor views --------------------------------
-        tile_32x32 = (cfg.tile_h, cfg.tile_w)
-        tile_1x32 = (cfg.gamma_tile_h, cfg.gamma_tile_w)
+        def _ov(
+            spec: blitz_overlap_tensors.OverlappedShardSpec, shard_w_override: int | None = None
+        ) -> OverlappedTensor:
+            shape = spec.raw_tensor_shape
+            shard_shape = (shape[0], shard_w_override) if shard_w_override is not None else shape
+            return OverlappedTensor(
+                fused_tensor=fused,
+                tensor_shape=shape,
+                shard_shape=shard_shape,
+                core_range_set=spec.core_range_set,
+                dtype=spec.dtype,
+                tile_shape=(spec.tile_h, spec.tile_w),
+                byte_offset=spec.byte_offset,
+            )
 
         return [
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.o_proj_shape,
-                shard_shape=(cfg.o_proj_shape[0], o_shard_w),
-                core_range_set=cfg.o_proj_core_range_set,
-                dtype=ttnn.bfloat8_b,
-                tile_shape=tile_32x32,
-                byte_offset=0,
-                total_size=cfg.o_proj_shard_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.gate_mm_shape,
-                shard_shape=(cfg.gate_mm_shape[0], g_shard_w),
-                core_range_set=cfg.gate_mm_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_32x32,
-                byte_offset=0,
-                total_size=cfg.gate_mm_shard_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.attn_norm_shape,
-                shard_shape=cfg.attn_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.attn_norm_byte_offset,
-                total_size=cfg.attn_norm_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.q_norm_shape,
-                shard_shape=cfg.q_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.q_norm_byte_offset,
-                total_size=cfg.q_norm_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.kv_norm_shape,
-                shard_shape=cfg.kv_norm_shape,
-                core_range_set=cfg.kv_norm_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.kv_norm_byte_offset,
-                total_size=cfg.kv_norm_bytes,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.ffn_norm_shape,
-                shard_shape=cfg.ffn_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.ffn_norm_byte_offset,
-                total_size=cfg.ffn_norm_bytes,
-            ),
+            _ov(cfg.o_proj, shard_w_override=o_shard_w),
+            _ov(cfg.gate_mm, shard_w_override=g_shard_w),
+            _ov(cfg.attn_norm),
+            _ov(cfg.q_norm),
+            _ov(cfg.kv_norm),
+            _ov(cfg.ffn_norm),
         ]
 
     def get_tt_kv_b12_proj_weights(

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -20,7 +20,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlapEntry, OverlappedTensorSpec, overlap_tensors
 
 OverlappedTensor = ttnn.OverlappedTensor
 
@@ -611,7 +611,7 @@ class BlitzDecodeWeights:
         return overlap_tensors(
             [
                 [
-                    (
+                    OverlapEntry(
                         "q_a_proj",
                         q_a_packed,
                         OverlappedTensorSpec(
@@ -620,7 +620,7 @@ class BlitzDecodeWeights:
                             dtype=dtype,
                         ),
                     ),
-                    (
+                    OverlapEntry(
                         "q_b_proj",
                         q_b_preprocessed,
                         OverlappedTensorSpec(
@@ -632,7 +632,7 @@ class BlitzDecodeWeights:
                     ),
                 ],
                 [
-                    (
+                    OverlapEntry(
                         "kv_a_proj",
                         kv_reordered,
                         OverlappedTensorSpec(
@@ -690,19 +690,19 @@ class BlitzDecodeWeights:
         return overlap_tensors(
             [
                 [
-                    (
+                    OverlapEntry(
                         "o_proj",
                         o_proj_weights,
                         replace(cfg.o_proj, raw_tensor_shape=tuple(o_proj_weights.shape), dtype=o_proj_dtype),
                     )
                 ],
-                [("gate_mm", gate_mm_weights, cfg.gate_mm)],
+                [OverlapEntry("gate_mm", gate_mm_weights, cfg.gate_mm)],
                 [
-                    ("attn_norm", attn_norm, cfg.attn_norm),
-                    ("q_norm", q_norm, cfg.q_norm),
-                    ("ffn_norm", ffn_norm, cfg.ffn_norm),
+                    OverlapEntry("attn_norm", attn_norm, cfg.attn_norm),
+                    OverlapEntry("q_norm", q_norm, cfg.q_norm),
+                    OverlapEntry("ffn_norm", ffn_norm, cfg.ffn_norm),
                 ],
-                [("kv_norm", kv_norm, cfg.kv_norm)],
+                [OverlapEntry("kv_norm", kv_norm, cfg.kv_norm)],
             ],
             device=self._device,
             move_to_device=move_to_device,
@@ -766,7 +766,7 @@ class BlitzDecodeWeights:
         return overlap_tensors(
             [
                 [
-                    (
+                    OverlapEntry(
                         "kv_b1_proj",
                         kv_b1_proj_weights,
                         OverlappedTensorSpec(
@@ -779,7 +779,7 @@ class BlitzDecodeWeights:
                     ),
                 ],
                 [
-                    (
+                    OverlapEntry(
                         "kv_b2_proj",
                         kv_b2_preprocessed,
                         OverlappedTensorSpec(
@@ -901,7 +901,7 @@ class BlitzDecodeWeights:
         gate_up_dict = overlap_tensors(
             [
                 [
-                    (
+                    OverlapEntry(
                         "gate_proj",
                         gate_preprocessed,
                         OverlappedTensorSpec(
@@ -915,7 +915,7 @@ class BlitzDecodeWeights:
                     ),
                 ],
                 [
-                    (
+                    OverlapEntry(
                         "up_proj",
                         up_preprocessed,
                         OverlappedTensorSpec(

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -20,7 +20,9 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensor, OverlappedTensorSpec, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, overlap_tensors
+
+OverlappedTensor = ttnn.OverlappedTensor
 
 
 def shuffle_weights_for_interleaved_qnope_qrope(

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -20,7 +20,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedShardSpec, OverlappedTensor, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensor, OverlappedTensorSpec, overlap_tensors
 
 
 def shuffle_weights_for_interleaved_qnope_qrope(
@@ -92,7 +92,7 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     the per-device layout; TP is inferred from the device topology at
     runtime (single-device -> TP=1, 4x2 mesh -> TP=2).
 
-    The three sub-tensor shard specs use :class:`OverlappedShardSpec`
+    The three sub-tensor shard specs use :class:`OverlappedTensorSpec`
     to compute per-shard tile counts and byte sizes.  ``q_a_shard_spec``
     uses the packed shape ``(H/2, 2W)`` after the ``shuffle_q_a``
     transform.
@@ -110,23 +110,23 @@ class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     kv_a_proj_shape: tuple[int, int] = (7168, 576)
 
     # Sub-tensor shard specs — q_a uses the packed shape (H/2, 2W)
-    q_a_shard_spec: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    q_a_shard_spec: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             raw_tensor_shape=(3584, 3072),
             dtype=ttnn.DataType.BFLOAT8_B,
         )
     )
-    q_b_shard_spec: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    q_b_shard_spec: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             raw_tensor_shape=(1536, 12288),
             dtype=ttnn.DataType.BFLOAT8_B,
             tp_dim=(None, 0),
         )
     )
-    kv_a_shard_spec: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    kv_a_shard_spec: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(8, 9))}),
             raw_tensor_shape=(7168, 576),
             dtype=ttnn.DataType.BFLOAT8_B,
@@ -220,8 +220,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     Shape tuples follow (height, width) convention.
     """
 
-    o_proj: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    o_proj: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),  # 96 cores
@@ -233,15 +233,15 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tp_dim=(None, 0),
         )
     )
-    gate_mm: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    gate_mm: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7))}),
             raw_tensor_shape=(7168, 256),
             dtype=ttnn.DataType.BFLOAT16,
         )
     )
-    attn_norm: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    attn_norm: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
@@ -249,8 +249,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    q_norm: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    q_norm: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 1536),
             dtype=ttnn.DataType.BFLOAT16,
@@ -258,8 +258,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    kv_norm: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    kv_norm: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=_KV_NORM_CORE,
             raw_tensor_shape=(1, 512),
             dtype=ttnn.DataType.BFLOAT16,
@@ -267,8 +267,8 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
             tile_w=32,
         )
     )
-    ffn_norm: OverlappedShardSpec = field(
-        default_factory=lambda: OverlappedShardSpec(
+    ffn_norm: OverlappedTensorSpec = field(
+        default_factory=lambda: OverlappedTensorSpec(
             core_range_set=_GAMMA_CORE,
             raw_tensor_shape=(1, 7168),
             dtype=ttnn.DataType.BFLOAT16,
@@ -612,7 +612,7 @@ class BlitzDecodeWeights:
                     (
                         "q_a_proj",
                         q_a_packed,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=q_ab_cores,
                             raw_tensor_shape=tuple(q_a_packed.shape),
                             dtype=dtype,
@@ -621,7 +621,7 @@ class BlitzDecodeWeights:
                     (
                         "q_b_proj",
                         q_b_preprocessed,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=q_ab_cores,
                             raw_tensor_shape=tuple(q_b_preprocessed.shape),
                             dtype=dtype,
@@ -633,7 +633,7 @@ class BlitzDecodeWeights:
                     (
                         "kv_a_proj",
                         kv_reordered,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=kv_cores,
                             raw_tensor_shape=tuple(kv_reordered.shape),
                             dtype=dtype,
@@ -767,7 +767,7 @@ class BlitzDecodeWeights:
                     (
                         "kv_b1_proj",
                         kv_b1_proj_weights,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=cfg.kv_b1_core_range_set,
                             raw_tensor_shape=tuple(kv_b1_proj_weights.shape),
                             dtype=dtype,
@@ -780,7 +780,7 @@ class BlitzDecodeWeights:
                     (
                         "kv_b2_proj",
                         kv_b2_preprocessed,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=cfg.kv_b2_core_range_set,
                             raw_tensor_shape=tuple(kv_b2_preprocessed.shape),
                             dtype=dtype,
@@ -902,7 +902,7 @@ class BlitzDecodeWeights:
                     (
                         "gate_proj",
                         gate_preprocessed,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=cfg.gate_core_range_set,
                             raw_tensor_shape=tuple(gate_preprocessed.shape),
                             dtype=dtype,
@@ -916,7 +916,7 @@ class BlitzDecodeWeights:
                     (
                         "up_proj",
                         up_preprocessed,
-                        OverlappedShardSpec(
+                        OverlappedTensorSpec(
                             core_range_set=cfg.up_core_range_set,
                             raw_tensor_shape=tuple(up_preprocessed.shape),
                             dtype=dtype,

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -5,6 +5,14 @@ import torch
 
 import ttnn
 
+_DTYPE_ELEMENT_BYTES = {
+    ttnn.bfloat16: 2,
+    ttnn.float32: 4,
+    ttnn.uint16: 2,
+    ttnn.uint32: 4,
+    ttnn.int32: 4,
+}
+
 
 @dataclass
 class OverlappedShardSpec:
@@ -34,15 +42,16 @@ class OverlappedShardSpec:
     bfp8_tile_bytes: int = 1088
     bfp4_tile_bytes: int = 576
 
+    tp: int = 1
+
     def _tile_bytes(self) -> int:
         num_elements = self.tile_h * self.tile_w
-        if self.dtype in (ttnn.DataType.BFLOAT8_B, ttnn.DataType.BFLOAT4_B):
+        if self.dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b):
             num_blocks = num_elements // 16
             exponent_bytes = (num_blocks + 3) // 4 * 4
-            mantissa_bytes = num_elements if self.dtype == ttnn.DataType.BFLOAT8_B else num_elements // 2
+            mantissa_bytes = num_elements if self.dtype == ttnn.bfloat8_b else num_elements // 2
             return exponent_bytes + mantissa_bytes
-        else:
-            return num_elements * self.dtype.size()
+        return num_elements * _DTYPE_ELEMENT_BYTES[self.dtype]
 
     @property
     def tiles_per_shard(self) -> int:
@@ -58,95 +67,32 @@ class OverlappedShardSpec:
         return self.shard_bytes * self.core_range_set.num_cores()
 
 
-def max_shard_bytes(shard_specs: list[OverlappedShardSpec]) -> int:
-    return max(spec.shard_bytes for spec in shard_specs)
+def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]]) -> int:
+    return max(sum(spec.shard_bytes for spec in lane) for lane in shard_specs)
+
+
+def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedShardSpec) -> bytes:
+    match spec.dtype:
+        case ttnn.bfloat8_b:
+            return tilize_and_pack_bfp8(data_2d, spec.tile_h, spec.tile_w)
+        case ttnn.bfloat4_b:
+            return tilize_and_pack_bfp4(data_2d, spec.tile_h, spec.tile_w)
+        case ttnn.bfloat16:
+            if spec.tile_h == 1 and spec.tile_w == 32:
+                return pack_bfloat16_1x32(data_2d)
+            return tilize_and_pack_bfloat16(data_2d, spec.tile_h, spec.tile_w)
+        case _:
+            raise ValueError(f"Unsupported dtype: {spec.dtype}")
 
 
 def tilize_and_pack_bfp8(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
     """Tilize a 2-D tensor and pack as BFP8_b raw bytes.
 
-    Produces the exact byte layout the hardware expects:
-    ``[16 exponent uint32 words][256 mantissa uint32 words]`` per tile,
-    with tiles in row-major order across the tensor.
-
-    Matches the C++ ``pack_as_bfp_tiles<Bfp8_b>`` with
-    ``row_major_input=false, is_exp_a=false``:
-
-    * Shared exponent = max float32 exponent in each 16-element block.
-    * Per-element mantissa = 24-bit explicit mantissa (hidden-1 + 23
-        fractional bits), right-shifted by the exponent delta *and* by
-        17 (``24 - 7``) to yield 7 bits, with round-to-nearest-even.
-    * Packed byte = ``sign(1) | mantissa(7)``, zeroed when mantissa
-        rounds to 0.
-
-    Tile layout: 4 faces (16x16) in order
-    face0 (rows 0-15, cols 0-15), face1 (rows 0-15, cols 16-31),
-    face2 (rows 16-31, cols 0-15), face3 (rows 16-31, cols 16-31).
-    Each face row of 16 elements forms one BFP8 block.
+    Delegates to the C++ ``pack_as_bfp8_tiles`` via nanobind.
     """
     H, W = data_2d.shape
-    face_h, face_w = tile_h // 2, tile_w // 2
-    tr, tc = H // tile_h, W // tile_w
-    num_tiles = tr * tc
-
     data_np = data_2d.contiguous().float().numpy()
-
-    # Reshape into tile grid -> (tr, tc, tile_h, tile_w)
-    tiles = data_np.reshape(tr, tile_h, tc, tile_w).transpose(0, 2, 1, 3)
-    tiles = tiles.reshape(num_tiles, tile_h, tile_w)
-
-    # Extract 4 faces per tile -> face-ordered (N, 1024)
-    face_ordered = np.concatenate(
-        [
-            tiles[:, :face_h, :face_w].reshape(num_tiles, -1),
-            tiles[:, :face_h, face_w:].reshape(num_tiles, -1),
-            tiles[:, face_h:, :face_w].reshape(num_tiles, -1),
-            tiles[:, face_h:, face_w:].reshape(num_tiles, -1),
-        ],
-        axis=1,
-    )
-
-    # Reshape into BFP8 blocks: (N, 64 blocks, 16 elements)
-    blocks = face_ordered.reshape(num_tiles, 64, 16)
-
-    # --- float32 field extraction (vectorised) ---
-    float_bits = blocks.view(np.uint32)
-    signs = ((float_bits >> 31) & 1).astype(np.uint8)
-    exponents = ((float_bits >> 23) & 0xFF).astype(np.int32)
-    mantissa23 = (float_bits & 0x007F_FFFF).astype(np.int32)
-
-    # 24-bit explicit mantissa with hidden 1; zero for denormals
-    explicit_mant = np.where(exponents == 0, np.int32(0), np.int32(1 << 23) | mantissa23)
-
-    # Shared exponent = max float32 exponent in each 16-element block
-    shared_exp = np.max(exponents, axis=2)  # (N, 64)
-
-    # Shift mantissa by exponent delta, then by 17 to get 7-bit result
-    delta = shared_exp[:, :, np.newaxis] - exponents
-    shifted = explicit_mant >> np.minimum(delta, 31)
-
-    MANT_SHIFT = 17  # 24 - 7
-    ROUND_MASK = (1 << MANT_SHIFT) - 1
-    TIE = np.int32(1 << (MANT_SHIFT - 1))
-
-    round_value = shifted & ROUND_MASK
-    mantissa7 = (shifted >> MANT_SHIFT).astype(np.int32)
-    guard_bit = mantissa7 & 1
-    round_up = (round_value > TIE) | ((round_value == TIE) & (guard_bit == 1))
-    mantissa7 = np.where(round_up, np.minimum(mantissa7 + 1, 127), mantissa7)
-
-    # Zero sign when mantissa is zero
-    signs = np.where(mantissa7 == 0, np.uint8(0), signs)
-    packed_mant = ((signs.astype(np.int32) << 7) | (mantissa7 & 0x7F)).astype(np.uint8)
-
-    # Assemble per-tile bytes: [exp words][mant words]
-    exp_bytes = shared_exp.astype(np.uint8)  # (N, 64)
-    exp_words = exp_bytes.view(np.uint32).reshape(num_tiles, 16)
-
-    mant_words = packed_mant.reshape(num_tiles, 1024).view(np.uint32).reshape(num_tiles, 256)
-
-    tile_words = np.concatenate([exp_words, mant_words], axis=1)  # (N, 272)
-    return tile_words.tobytes()
+    return ttnn._ttnn.core.tilize_and_pack_bfp8_b(data_np, H, W, tile_h, tile_w)
 
 
 def tilize_and_pack_bfloat16(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
@@ -176,10 +122,19 @@ def tilize_and_pack_bfloat16(data_2d: torch.Tensor, tile_h: int = 32, tile_w: in
         axis=1,
     )  # (N, 1024)
 
-    # bfloat16 = top 16 bits of float32
     float_bits = face_ordered.view(np.uint32)
     bf16_bits = (float_bits >> 16).astype(np.uint16)
     return bf16_bits.tobytes()
+
+
+def tilize_and_pack_bfp4(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
+    """Tilize a 2-D tensor and pack as BFP4_b raw bytes.
+
+    Delegates to the C++ ``pack_as_bfp4_tiles`` via nanobind.
+    """
+    H, W = data_2d.shape
+    data_np = data_2d.contiguous().float().numpy()
+    return ttnn._ttnn.core.tilize_and_pack_bfp4_b(data_np, H, W, tile_h, tile_w)
 
 
 def pack_bfloat16_1x32(data: torch.Tensor) -> bytes:

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -1,0 +1,304 @@
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+import ttnn
+
+
+@dataclass
+class OverlappedShardSpec:
+    """Describes one sub-tensor within a fused WIDTH_SHARDED raw-byte buffer.
+
+    Multiple ``OverlappedShardSpec`` instances share a single device
+    allocation whose per-core shard is zero-padded to a common maximum
+    byte size.  Each spec carries the core range, logical tensor shape,
+    dtype, tile dimensions, and byte offset needed to address its
+    portion of the shard.
+
+    Tile byte sizes for BFP formats are computed from ``tile_h`` and
+    ``tile_w`` rather than stored as constants, so non-standard tile
+    shapes (e.g. 1x32, 16x32) are handled automatically.
+
+    Shape tuples follow (height, width) convention.
+    """
+
+    core_range_set: ttnn.CoreRangeSet
+    raw_tensor_shape: tuple[int, int]
+    dtype: ttnn.DataType
+    # byte offset within a core shard
+    byte_offset: int = 0
+
+    tile_h: int = 32
+    tile_w: int = 32
+    bfp8_tile_bytes: int = 1088
+    bfp4_tile_bytes: int = 576
+
+    def _tile_bytes(self) -> int:
+        num_elements = self.tile_h * self.tile_w
+        if self.dtype in (ttnn.DataType.BFLOAT8_B, ttnn.DataType.BFLOAT4_B):
+            num_blocks = num_elements // 16
+            exponent_bytes = (num_blocks + 3) // 4 * 4
+            mantissa_bytes = num_elements if self.dtype == ttnn.DataType.BFLOAT8_B else num_elements // 2
+            return exponent_bytes + mantissa_bytes
+        else:
+            return num_elements * self.dtype.size()
+
+    @property
+    def tiles_per_shard(self) -> int:
+        shard_w = self.raw_tensor_shape[1] // self.core_range_set.num_cores()
+        return (self.raw_tensor_shape[0] // self.tile_h) * (shard_w // self.tile_w)
+
+    @property
+    def shard_bytes(self) -> int:
+        return self.tiles_per_shard * self._tile_bytes()
+
+    @property
+    def total_bytes(self) -> int:
+        return self.shard_bytes * self.core_range_set.num_cores()
+
+
+def max_shard_bytes(shard_specs: list[OverlappedShardSpec]) -> int:
+    return max(spec.shard_bytes for spec in shard_specs)
+
+
+def tilize_and_pack_bfp8(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
+    """Tilize a 2-D tensor and pack as BFP8_b raw bytes.
+
+    Produces the exact byte layout the hardware expects:
+    ``[16 exponent uint32 words][256 mantissa uint32 words]`` per tile,
+    with tiles in row-major order across the tensor.
+
+    Matches the C++ ``pack_as_bfp_tiles<Bfp8_b>`` with
+    ``row_major_input=false, is_exp_a=false``:
+
+    * Shared exponent = max float32 exponent in each 16-element block.
+    * Per-element mantissa = 24-bit explicit mantissa (hidden-1 + 23
+        fractional bits), right-shifted by the exponent delta *and* by
+        17 (``24 - 7``) to yield 7 bits, with round-to-nearest-even.
+    * Packed byte = ``sign(1) | mantissa(7)``, zeroed when mantissa
+        rounds to 0.
+
+    Tile layout: 4 faces (16x16) in order
+    face0 (rows 0-15, cols 0-15), face1 (rows 0-15, cols 16-31),
+    face2 (rows 16-31, cols 0-15), face3 (rows 16-31, cols 16-31).
+    Each face row of 16 elements forms one BFP8 block.
+    """
+    H, W = data_2d.shape
+    face_h, face_w = tile_h // 2, tile_w // 2
+    tr, tc = H // tile_h, W // tile_w
+    num_tiles = tr * tc
+
+    data_np = data_2d.contiguous().float().numpy()
+
+    # Reshape into tile grid -> (tr, tc, tile_h, tile_w)
+    tiles = data_np.reshape(tr, tile_h, tc, tile_w).transpose(0, 2, 1, 3)
+    tiles = tiles.reshape(num_tiles, tile_h, tile_w)
+
+    # Extract 4 faces per tile -> face-ordered (N, 1024)
+    face_ordered = np.concatenate(
+        [
+            tiles[:, :face_h, :face_w].reshape(num_tiles, -1),
+            tiles[:, :face_h, face_w:].reshape(num_tiles, -1),
+            tiles[:, face_h:, :face_w].reshape(num_tiles, -1),
+            tiles[:, face_h:, face_w:].reshape(num_tiles, -1),
+        ],
+        axis=1,
+    )
+
+    # Reshape into BFP8 blocks: (N, 64 blocks, 16 elements)
+    blocks = face_ordered.reshape(num_tiles, 64, 16)
+
+    # --- float32 field extraction (vectorised) ---
+    float_bits = blocks.view(np.uint32)
+    signs = ((float_bits >> 31) & 1).astype(np.uint8)
+    exponents = ((float_bits >> 23) & 0xFF).astype(np.int32)
+    mantissa23 = (float_bits & 0x007F_FFFF).astype(np.int32)
+
+    # 24-bit explicit mantissa with hidden 1; zero for denormals
+    explicit_mant = np.where(exponents == 0, np.int32(0), np.int32(1 << 23) | mantissa23)
+
+    # Shared exponent = max float32 exponent in each 16-element block
+    shared_exp = np.max(exponents, axis=2)  # (N, 64)
+
+    # Shift mantissa by exponent delta, then by 17 to get 7-bit result
+    delta = shared_exp[:, :, np.newaxis] - exponents
+    shifted = explicit_mant >> np.minimum(delta, 31)
+
+    MANT_SHIFT = 17  # 24 - 7
+    ROUND_MASK = (1 << MANT_SHIFT) - 1
+    TIE = np.int32(1 << (MANT_SHIFT - 1))
+
+    round_value = shifted & ROUND_MASK
+    mantissa7 = (shifted >> MANT_SHIFT).astype(np.int32)
+    guard_bit = mantissa7 & 1
+    round_up = (round_value > TIE) | ((round_value == TIE) & (guard_bit == 1))
+    mantissa7 = np.where(round_up, np.minimum(mantissa7 + 1, 127), mantissa7)
+
+    # Zero sign when mantissa is zero
+    signs = np.where(mantissa7 == 0, np.uint8(0), signs)
+    packed_mant = ((signs.astype(np.int32) << 7) | (mantissa7 & 0x7F)).astype(np.uint8)
+
+    # Assemble per-tile bytes: [exp words][mant words]
+    exp_bytes = shared_exp.astype(np.uint8)  # (N, 64)
+    exp_words = exp_bytes.view(np.uint32).reshape(num_tiles, 16)
+
+    mant_words = packed_mant.reshape(num_tiles, 1024).view(np.uint32).reshape(num_tiles, 256)
+
+    tile_words = np.concatenate([exp_words, mant_words], axis=1)  # (N, 272)
+    return tile_words.tobytes()
+
+
+def tilize_and_pack_bfloat16(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:
+    """Tilize a 2-D tensor and pack as bfloat16 (Float16_b) raw bytes.
+
+    Each tile is 2048 bytes: 1024 elements x 2 bytes, stored in
+    face order (face0, face1, face2, face3), row-major within each
+    face.  bfloat16 is the top 16 bits of IEEE-754 float32.
+    """
+    H, W = data_2d.shape
+    face_h, face_w = tile_h // 2, tile_w // 2
+    tr, tc = H // tile_h, W // tile_w
+    num_tiles = tr * tc
+
+    data_np = data_2d.contiguous().float().numpy()
+
+    tiles = data_np.reshape(tr, tile_h, tc, tile_w).transpose(0, 2, 1, 3)
+    tiles = tiles.reshape(num_tiles, tile_h, tile_w)
+
+    face_ordered = np.concatenate(
+        [
+            tiles[:, :face_h, :face_w].reshape(num_tiles, -1),
+            tiles[:, :face_h, face_w:].reshape(num_tiles, -1),
+            tiles[:, face_h:, :face_w].reshape(num_tiles, -1),
+            tiles[:, face_h:, face_w:].reshape(num_tiles, -1),
+        ],
+        axis=1,
+    )  # (N, 1024)
+
+    # bfloat16 = top 16 bits of float32
+    float_bits = face_ordered.view(np.uint32)
+    bf16_bits = (float_bits >> 16).astype(np.uint16)
+    return bf16_bits.tobytes()
+
+
+def pack_bfloat16_1x32(data: torch.Tensor) -> bytes:
+    """Pack a 1-row tensor as raw bfloat16 bytes with 1×32 tile layout.
+
+    For 1×32 tiles there is no face reordering; elements are stored
+    sequentially in tile-width chunks.  bfloat16 is the top 16 bits
+    of IEEE-754 float32.
+    """
+    flat = data.contiguous().float().reshape(-1).numpy()
+    float_bits = flat.view(np.uint32)
+    bf16_bits = (float_bits >> 16).astype(np.uint16)
+    return bf16_bits.tobytes()
+
+
+def stitch_width_sharded(
+    tensor1: torch.Tensor,
+    tensor2: torch.Tensor,
+    num_cores: int,
+    tile_h: int = 32,
+    tile_w: int = 32,
+) -> tuple[torch.Tensor, tuple[int, int]]:
+    """Stitch two width-sharded tensors into one fused tensor.
+
+    For every core the two shards are concatenated vertically.  When
+    the shard widths differ, the wider shard is tile-reshaped to match
+    the narrower one (preserving tile ordering) so the concatenation
+    is well-defined.
+
+    Args:
+        tensor1: First weight tensor (H1, W1).
+        tensor2: Second weight tensor (H2, W2).
+        num_cores: Total cores in the width-sharded grid.
+        tile_h: Tile height (default 32).
+        tile_w: Tile width (default 32).
+
+    Returns:
+        (fused_tensor, shard_shape) ready for WIDTH_SHARDED
+        placement on num_cores cores.
+    """
+    H1, W1 = tensor1.shape
+    H2, W2 = tensor2.shape
+
+    shard_w1 = W1 // num_cores
+    shard_w2 = W2 // num_cores
+
+    # Use the narrower shard width as target; tile-reshape the wider.
+    if shard_w1 <= shard_w2:
+        target_w = shard_w1
+        narrow, wide = tensor1, tensor2
+        narrow_h, wide_h = H1, H2
+        narrow_sw, wide_sw = shard_w1, shard_w2
+    else:
+        target_w = shard_w2
+        narrow, wide = tensor2, tensor1
+        narrow_h, wide_h = H2, H1
+        narrow_sw, wide_sw = shard_w2, shard_w1
+
+    # Height of each wide shard after tile-reshape to target_w
+    reshaped_h = wide_h * wide_sw // target_w
+
+    fused_shard_h = narrow_h + reshaped_h
+    fused = torch.zeros(fused_shard_h, target_w * num_cores, dtype=tensor1.dtype)
+
+    for core_idx in range(num_cores):
+        col_start = core_idx * target_w
+        col_end = col_start + target_w
+
+        # Narrow shard: already at target width, just copy.
+        n_start = core_idx * narrow_sw
+        n_end = n_start + narrow_sw
+        fused[:narrow_h, col_start:col_end] = narrow[:, n_start:n_end]
+
+        # Wide shard: tile-reshape from (wide_h, wide_sw) to
+        # (reshaped_h, target_w), then copy.
+        w_start = core_idx * wide_sw
+        w_end = w_start + wide_sw
+        w_shard = wide[:, w_start:w_end]
+        w_reshaped = tile_reshape(
+            w_shard,
+            src_shape=(wide_h, wide_sw),
+            dst_shape=(reshaped_h, target_w),
+            tile_h=tile_h,
+            tile_w=tile_w,
+        )
+        fused[narrow_h:, col_start:col_end] = w_reshaped
+
+    shard_shape = (fused_shard_h, target_w)
+    return fused, shard_shape
+
+
+def tile_reshape(
+    tensor: torch.Tensor,
+    src_shape: tuple[int, int],
+    dst_shape: tuple[int, int],
+    tile_h: int = 32,
+    tile_w: int = 32,
+) -> torch.Tensor:
+    """Reshape a 2-D tensor while preserving row-major tile ordering.
+
+    Data is stored as a grid of (tile_h x tile_w) tiles in row-major
+    order.  A naive torch.reshape changes which values land in each
+    tile.  This helper keeps every tile's contents unchanged by:
+
+    1. Splitting into the source tile grid.
+    2. Flattening to a 1-D tile sequence (row-major).
+    3. Re-gridding into the destination tile dimensions.
+
+    Total tile count must be identical for source and destination.
+    """
+    src_h, src_w = src_shape
+    dst_h, dst_w = dst_shape
+    src_tr, src_tc = src_h // tile_h, src_w // tile_w
+    dst_tr, dst_tc = dst_h // tile_h, dst_w // tile_w
+    assert src_tr * src_tc == dst_tr * dst_tc, f"Tile count mismatch: {src_tr * src_tc} vs {dst_tr * dst_tc}"
+    # (H, W) -> (tile_rows, tile_h, tile_cols, tile_w)
+    #         -> (tile_rows, tile_cols, tile_h, tile_w)
+    tiles = tensor.reshape(src_tr, tile_h, src_tc, tile_w).permute(0, 2, 1, 3)
+    # Flatten to 1-D tile sequence, re-grid to destination layout
+    tiles = tiles.reshape(-1, tile_h, tile_w).reshape(dst_tr, dst_tc, tile_h, tile_w)
+    # (dst_tr, dst_tc, tile_h, tile_w) -> (dst_H, dst_W)
+    return tiles.permute(0, 2, 1, 3).reshape(dst_h, dst_w)

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -18,11 +18,10 @@ _DTYPE_ELEMENT_BYTES = {
 class OverlappedShardSpec:
     """Describes one sub-tensor within a fused raw-byte buffer.
 
-    Multiple ``OverlappedShardSpec`` instances share a single device
-    allocation whose per-core shard is zero-padded to a common maximum
+    Multiple ``OverlappedShardSpec`` instances share a single L1
+    buffer whose per-core shard is zero-padded to a common maximum
     byte size.  Each spec carries the core range, logical tensor shape,
-    dtype, tile dimensions, and byte offset needed to address its
-    portion of the shard.
+    dtype, and tile dimensions needed to pack its portion of the shard.
 
     Tile byte sizes for BFP formats are computed from ``tile_h`` and
     ``tile_w`` rather than stored as constants, so non-standard tile
@@ -42,13 +41,9 @@ class OverlappedShardSpec:
     raw_tensor_shape: tuple[int, int]
     dtype: ttnn.DataType
     sharding: ttnn.TensorMemoryLayout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-    # byte offset within a core shard
-    byte_offset: int = 0
 
     tile_h: int = 32
     tile_w: int = 32
-    bfp8_tile_bytes: int = 1088
-    bfp4_tile_bytes: int = 576
 
     tp_dim: tuple[int | None, int | None] = (None, None)
 
@@ -105,9 +100,6 @@ class OverlappedShardSpec:
 
     def shard_bytes(self, mesh_shape: tuple[int, int]) -> int:
         return self.tiles_per_shard(mesh_shape) * self._tile_bytes()
-
-    def total_bytes(self, mesh_shape: tuple[int, int]) -> int:
-        return self.shard_bytes(mesh_shape) * self.core_range_set.num_cores()
 
 
 def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]], mesh_shape: tuple[int, int]) -> int:
@@ -374,112 +366,3 @@ def pack_bfloat16_1x32(data: torch.Tensor) -> bytes:
     float_bits = flat.view(np.uint32)
     bf16_bits = (float_bits >> 16).astype(np.uint16)
     return bf16_bits.tobytes()
-
-
-def stitch_width_sharded(
-    tensor1: torch.Tensor,
-    tensor2: torch.Tensor,
-    num_cores: int,
-    tile_h: int = 32,
-    tile_w: int = 32,
-) -> tuple[torch.Tensor, tuple[int, int]]:
-    """Stitch two width-sharded tensors into one fused tensor.
-
-    For every core the two shards are concatenated vertically.  When
-    the shard widths differ, the wider shard is tile-reshaped to match
-    the narrower one (preserving tile ordering) so the concatenation
-    is well-defined.
-
-    Args:
-        tensor1: First weight tensor (H1, W1).
-        tensor2: Second weight tensor (H2, W2).
-        num_cores: Total cores in the width-sharded grid.
-        tile_h: Tile height (default 32).
-        tile_w: Tile width (default 32).
-
-    Returns:
-        (fused_tensor, shard_shape) ready for WIDTH_SHARDED
-        placement on num_cores cores.
-    """
-    H1, W1 = tensor1.shape
-    H2, W2 = tensor2.shape
-
-    shard_w1 = W1 // num_cores
-    shard_w2 = W2 // num_cores
-
-    # Use the narrower shard width as target; tile-reshape the wider.
-    if shard_w1 <= shard_w2:
-        target_w = shard_w1
-        narrow, wide = tensor1, tensor2
-        narrow_h, wide_h = H1, H2
-        narrow_sw, wide_sw = shard_w1, shard_w2
-    else:
-        target_w = shard_w2
-        narrow, wide = tensor2, tensor1
-        narrow_h, wide_h = H2, H1
-        narrow_sw, wide_sw = shard_w2, shard_w1
-
-    # Height of each wide shard after tile-reshape to target_w
-    reshaped_h = wide_h * wide_sw // target_w
-
-    fused_shard_h = narrow_h + reshaped_h
-    fused = torch.zeros(fused_shard_h, target_w * num_cores, dtype=tensor1.dtype)
-
-    for core_idx in range(num_cores):
-        col_start = core_idx * target_w
-        col_end = col_start + target_w
-
-        # Narrow shard: already at target width, just copy.
-        n_start = core_idx * narrow_sw
-        n_end = n_start + narrow_sw
-        fused[:narrow_h, col_start:col_end] = narrow[:, n_start:n_end]
-
-        # Wide shard: tile-reshape from (wide_h, wide_sw) to
-        # (reshaped_h, target_w), then copy.
-        w_start = core_idx * wide_sw
-        w_end = w_start + wide_sw
-        w_shard = wide[:, w_start:w_end]
-        w_reshaped = tile_reshape(
-            w_shard,
-            src_shape=(wide_h, wide_sw),
-            dst_shape=(reshaped_h, target_w),
-            tile_h=tile_h,
-            tile_w=tile_w,
-        )
-        fused[narrow_h:, col_start:col_end] = w_reshaped
-
-    shard_shape = (fused_shard_h, target_w)
-    return fused, shard_shape
-
-
-def tile_reshape(
-    tensor: torch.Tensor,
-    src_shape: tuple[int, int],
-    dst_shape: tuple[int, int],
-    tile_h: int = 32,
-    tile_w: int = 32,
-) -> torch.Tensor:
-    """Reshape a 2-D tensor while preserving row-major tile ordering.
-
-    Data is stored as a grid of (tile_h x tile_w) tiles in row-major
-    order.  A naive torch.reshape changes which values land in each
-    tile.  This helper keeps every tile's contents unchanged by:
-
-    1. Splitting into the source tile grid.
-    2. Flattening to a 1-D tile sequence (row-major).
-    3. Re-gridding into the destination tile dimensions.
-
-    Total tile count must be identical for source and destination.
-    """
-    src_h, src_w = src_shape
-    dst_h, dst_w = dst_shape
-    src_tr, src_tc = src_h // tile_h, src_w // tile_w
-    dst_tr, dst_tc = dst_h // tile_h, dst_w // tile_w
-    assert src_tr * src_tc == dst_tr * dst_tc, f"Tile count mismatch: {src_tr * src_tc} vs {dst_tr * dst_tc}"
-    # (H, W) -> (tile_rows, tile_h, tile_cols, tile_w)
-    #         -> (tile_rows, tile_cols, tile_h, tile_w)
-    tiles = tensor.reshape(src_tr, tile_h, src_tc, tile_w).permute(0, 2, 1, 3)
-    # Flatten to 1-D tile sequence, re-grid to destination layout
-    tiles = tiles.reshape(-1, tile_h, tile_w).reshape(dst_tr, dst_tc, tile_h, tile_w)
-    # (dst_tr, dst_tc, tile_h, tile_w) -> (dst_H, dst_W)
-    return tiles.permute(0, 2, 1, 3).reshape(dst_h, dst_w)

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -56,7 +56,7 @@ class OverlappedShardSpec:
     @property
     def tiles_per_shard(self) -> int:
         shard_w = self.raw_tensor_shape[1] // self.core_range_set.num_cores()
-        return (self.raw_tensor_shape[0] // self.tile_h) * (shard_w // self.tile_w)
+        return (self.per_device_height // self.tile_h) * (shard_w // self.tile_w)
 
     @property
     def shard_bytes(self) -> int:
@@ -65,6 +65,10 @@ class OverlappedShardSpec:
     @property
     def total_bytes(self) -> int:
         return self.shard_bytes * self.core_range_set.num_cores()
+
+    @property
+    def per_device_height(self) -> int:
+        return self.raw_tensor_shape[0] // self.tp
 
 
 def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]]) -> int:
@@ -83,6 +87,163 @@ def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedShardSpec) -> bytes:
             return tilize_and_pack_bfloat16(data_2d, spec.tile_h, spec.tile_w)
         case _:
             raise ValueError(f"Unsupported dtype: {spec.dtype}")
+
+
+@dataclass
+class OverlappedTensor:
+    """A logical view of a sub-tensor within a fused (overlapped) device buffer.
+
+    The fused tensor is a raw byte container whose own tensor properties
+    (dtype, layout, shard spec) are generally meaningless for the individual
+    sub-tensors.  This class carries the intended per-sub-tensor properties
+    alongside a shared reference to the underlying fused buffer.
+    """
+
+    fused_tensor: ttnn.Tensor
+    tensor_shape: tuple[int, int]
+    shard_shape: tuple[int, int]
+    core_range_set: ttnn.CoreRangeSet
+    dtype: ttnn.DataType
+    tile_shape: tuple[int, int]
+    byte_offset: int = 0
+    total_size: int = 0
+
+    def get_tile(self) -> ttnn.Tile:
+        return ttnn.Tile(self.tile_shape)
+
+
+def overlap_tensors(
+    tensors: list[list[tuple[torch.Tensor, OverlappedShardSpec]]],
+    device: ttnn.Device,
+    move_to_device: bool = True,
+) -> list[OverlappedTensor]:
+    """Overlap a list of tensors into a single fused WIDTH_SHARDED tensor.
+
+    Args:
+        tensors: A list of "lanes".  Each lane is a list of
+            ``(torch.Tensor, OverlappedShardSpec)`` tuples that share
+            the same core range set and are packed back-to-back within
+            each core's shard.  Lanes must occupy disjoint core ranges.
+        device: The mesh device to place the fused tensor on.
+        move_to_device: If True (default), place the result on device.
+
+    Returns:
+        A flat list of ``OverlappedTensor`` views, one per
+        ``(tensor, spec)`` pair across all lanes, in input order.
+    """
+
+    for lane in tensors:
+        assert len(lane) > 0, "Lane must contain at least one tensor"
+        for tensor, spec in lane:
+            assert (
+                tuple(tensor.shape) == spec.raw_tensor_shape
+            ), f"Tensor shape {tuple(tensor.shape)} does not match spec shape {spec.raw_tensor_shape}"
+            assert spec.core_range_set == lane[0][1].core_range_set, (
+                f"Core range set {spec.core_range_set} does not match {lane[0][1].core_range_set}, "
+                "all core range sets must be the same within a lane"
+            )
+            assert spec.tp > 0 and (spec.tp & (spec.tp - 1)) == 0, "TP must be a positive power of 2"
+
+    def _core_set(crs: ttnn.CoreRangeSet) -> set[tuple[int, int]]:
+        cores = set()
+        for cr in crs.ranges():
+            for x in range(cr.start.x, cr.end.x + 1):
+                for y in range(cr.start.y, cr.end.y + 1):
+                    cores.add((x, y))
+        return cores
+
+    for i, lane_a in enumerate(tensors):
+        cores_a = _core_set(lane_a[0][1].core_range_set)
+        for lane_b in tensors[i + 1 :]:
+            cores_b = _core_set(lane_b[0][1].core_range_set)
+            assert not cores_a & cores_b, "Lanes must have separate core range sets"
+
+    needed_shard_bytes = max_shard_bytes([[spec for _, spec in lane] for lane in tensors])
+    assert needed_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
+    uint32_per_shard = needed_shard_bytes // 4
+
+    max_tp = max(spec.tp for lane in tensors for _, spec in lane)
+    total_cores = sum(lane[0][1].core_range_set.num_cores() for lane in tensors)
+
+    byte_offsets: dict[int, int] = {}
+
+    per_tp_raw = []
+    for tp_idx in range(max_tp):
+        tp_packed = bytearray()
+        for lane in tensors:
+            num_cores = lane[0][1].core_range_set.num_cores()
+            for core_idx in range(num_cores):
+                shard_data = bytearray()
+                for tensor, spec in lane:
+                    slice_idx = tp_idx * spec.tp // max_tp
+                    per_dev_h = spec.per_device_height
+                    device_slice = tensor[slice_idx * per_dev_h : (slice_idx + 1) * per_dev_h, :]
+                    shard_w = spec.raw_tensor_shape[1] // num_cores
+                    shard_col = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w].contiguous()
+                    shard_raw = tilize_and_pack(shard_col, spec)
+                    assert len(shard_raw) == spec.shard_bytes
+                    byte_offsets[id(spec)] = len(shard_data)
+                    shard_data.extend(shard_raw)
+
+                if len(shard_data) < needed_shard_bytes:
+                    shard_data.extend(b"\x00" * (needed_shard_bytes - len(shard_data)))
+                tp_packed.extend(shard_data)
+
+        per_tp_raw.append(torch.frombuffer(bytes(tp_packed), dtype=torch.int32).clone())
+
+    if max_tp == 1:
+        combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
+    else:
+        combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
+
+    combined_crs_ranges = [cr for lane in tensors for cr in lane[0][1].core_range_set.ranges()]
+    combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
+    shard_spec = ttnn.ShardSpec(
+        combined_crs,
+        (1, uint32_per_shard),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+
+    if max_tp == 1:
+        mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+    else:
+        mesh_shape = (device.shape[0], device.shape[1])
+        mesh_mapper = ttnn.ShardTensor2dMesh(device, mesh_shape=mesh_shape, dims=(None, 1))
+    device_for_torch = device if move_to_device else None
+
+    fused = ttnn.from_torch(
+        combined,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device_for_torch,
+        memory_config=mem_config,
+        mesh_mapper=mesh_mapper,
+    )
+
+    result = []
+    for lane in tensors:
+        num_cores = lane[0][1].core_range_set.num_cores()
+        for tensor, spec in lane:
+            shard_w = spec.raw_tensor_shape[1] // num_cores
+            result.append(
+                OverlappedTensor(
+                    fused_tensor=fused,
+                    tensor_shape=(spec.per_device_height, spec.raw_tensor_shape[1]),
+                    shard_shape=(spec.per_device_height, shard_w),
+                    core_range_set=spec.core_range_set,
+                    dtype=spec.dtype,
+                    tile_shape=(spec.tile_h, spec.tile_w),
+                    byte_offset=byte_offsets[id(spec)],
+                    total_size=spec.shard_bytes,
+                )
+            )
+
+    return result
 
 
 def tilize_and_pack_bfp8(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -61,8 +61,9 @@ class OverlappedShardSpec:
     def _tile_bytes(self) -> int:
         num_elements = self.tile_h * self.tile_w
         if self.dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b):
-            num_blocks = num_elements // 16
-            exponent_bytes = (num_blocks + 3) // 4 * 4
+            _L1_ALIGNMENT = 16
+            num_exponents = num_elements // 16
+            exponent_bytes = (num_exponents + _L1_ALIGNMENT - 1) // _L1_ALIGNMENT * _L1_ALIGNMENT
             mantissa_bytes = num_elements if self.dtype == ttnn.bfloat8_b else num_elements // 2
             return exponent_bytes + mantissa_bytes
         return num_elements * _DTYPE_ELEMENT_BYTES[self.dtype]

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -16,7 +16,7 @@ _DTYPE_ELEMENT_BYTES = {
 
 @dataclass
 class OverlappedShardSpec:
-    """Describes one sub-tensor within a fused WIDTH_SHARDED raw-byte buffer.
+    """Describes one sub-tensor within a fused raw-byte buffer.
 
     Multiple ``OverlappedShardSpec`` instances share a single device
     allocation whose per-core shard is zero-padded to a common maximum
@@ -29,11 +29,19 @@ class OverlappedShardSpec:
     shapes (e.g. 1x32, 16x32) are handled automatically.
 
     Shape tuples follow (height, width) convention.
+
+    ``sharding`` controls how cores partition the per-device tensor:
+
+    - ``WIDTH_SHARDED``: each core gets a column slice (full height,
+      partial width).  ``num_cores`` divides the width.
+    - ``HEIGHT_SHARDED``: each core gets a row slice (partial height,
+      full width).  ``num_cores`` divides the height.
     """
 
     core_range_set: ttnn.CoreRangeSet
     raw_tensor_shape: tuple[int, int]
     dtype: ttnn.DataType
+    sharding: ttnn.TensorMemoryLayout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
     # byte offset within a core shard
     byte_offset: int = 0
 
@@ -82,10 +90,18 @@ class OverlappedShardSpec:
     def per_device_width(self, mesh_shape: tuple[int, int]) -> int:
         return self.raw_tensor_shape[1] // self._dim_tp(1, mesh_shape)
 
-    def tiles_per_shard(self, mesh_shape: tuple[int, int]) -> int:
+    def shard_shape(self, mesh_shape: tuple[int, int]) -> tuple[int, int]:
+        pdh = self.per_device_height(mesh_shape)
         pdw = self.per_device_width(mesh_shape)
-        shard_w = pdw // self.core_range_set.num_cores()
-        return (self.per_device_height(mesh_shape) // self.tile_h) * (shard_w // self.tile_w)
+        num_cores = self.core_range_set.num_cores()
+        if self.sharding == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+            return (pdh, pdw // num_cores)
+        else:
+            return (pdh // num_cores, pdw)
+
+    def tiles_per_shard(self, mesh_shape: tuple[int, int]) -> int:
+        sh, sw = self.shard_shape(mesh_shape)
+        return (sh // self.tile_h) * (sw // self.tile_w)
 
     def shard_bytes(self, mesh_shape: tuple[int, int]) -> int:
         return self.tiles_per_shard(mesh_shape) * self._tile_bytes()
@@ -140,7 +156,13 @@ def overlap_tensors(
     device: ttnn.Device,
     move_to_device: bool = True,
 ) -> list[OverlappedTensor]:
-    """Overlap a list of tensors into a single fused WIDTH_SHARDED tensor.
+    """Overlap a list of tensors into a single fused tensor.
+
+    The fused tensor is always stored as WIDTH_SHARDED on the device
+    (one flat shard per core).  Individual sub-tensors within the fused
+    buffer can be either WIDTH_SHARDED or HEIGHT_SHARDED — the
+    ``sharding`` field on each ``OverlappedShardSpec`` controls how the
+    per-device tensor is sliced across cores before tilization.
 
     Args:
         tensors: A list of "lanes".  Each lane is a list of
@@ -168,6 +190,10 @@ def overlap_tensors(
             assert len(spec.tp_dim) == 2 and all(
                 d is None or d in (0, 1) for d in spec.tp_dim
             ), "tp_dim must be a 2-tuple of None, 0, or 1"
+            assert spec.sharding in (
+                ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ), f"sharding must be WIDTH_SHARDED or HEIGHT_SHARDED, got {spec.sharding}"
 
     def _core_set(crs: ttnn.CoreRangeSet) -> set[tuple[int, int]]:
         cores = set()
@@ -212,9 +238,13 @@ def overlap_tensors(
                             h_idx * per_dev_h : (h_idx + 1) * per_dev_h,
                             w_idx * per_dev_w : (w_idx + 1) * per_dev_w,
                         ]
-                        shard_w = per_dev_w // num_cores
-                        shard_col = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w].contiguous()
-                        shard_raw = tilize_and_pack(shard_col, spec)
+                        if spec.sharding == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+                            shard_w = per_dev_w // num_cores
+                            core_slice = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w]
+                        else:
+                            shard_h = per_dev_h // num_cores
+                            core_slice = device_slice[core_idx * shard_h : (core_idx + 1) * shard_h, :]
+                        shard_raw = tilize_and_pack(core_slice.contiguous(), spec)
                         assert len(shard_raw) == spec.shard_bytes(mesh_shape)
                         byte_offsets[id(spec)] = len(shard_data)
                         shard_data.extend(shard_raw)
@@ -262,16 +292,14 @@ def overlap_tensors(
 
     result = []
     for lane in tensors:
-        num_cores = lane[0][1].core_range_set.num_cores()
         for tensor, spec in lane:
             pdh = spec.per_device_height(mesh_shape)
             pdw = spec.per_device_width(mesh_shape)
-            shard_w = pdw // num_cores
             result.append(
                 OverlappedTensor(
                     fused_tensor=fused,
                     tensor_shape=(pdh, pdw),
-                    shard_shape=(pdh, shard_w),
+                    shard_shape=spec.shard_shape(mesh_shape),
                     core_range_set=spec.core_range_set,
                     dtype=spec.dtype,
                     tile_shape=(spec.tile_h, spec.tile_w),

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -151,10 +151,10 @@ class OverlappedTensor:
 
 
 def overlap_tensors(
-    tensors: list[list[tuple[torch.Tensor, OverlappedShardSpec]]],
+    tensors: list[list[tuple[str, torch.Tensor, OverlappedShardSpec]]],
     device: ttnn.Device,
     move_to_device: bool = True,
-) -> list[OverlappedTensor]:
+) -> dict[str, OverlappedTensor]:
     """Overlap a list of tensors into a single fused tensor.
 
     The fused tensor is always stored as WIDTH_SHARDED on the device
@@ -165,25 +165,24 @@ def overlap_tensors(
 
     Args:
         tensors: A list of "lanes".  Each lane is a list of
-            ``(torch.Tensor, OverlappedShardSpec)`` tuples that share
+            ``(name, tensor, spec)`` tuples that share
             the same core range set and are packed back-to-back within
             each core's shard.  Lanes must occupy disjoint core ranges.
         device: The mesh device to place the fused tensor on.
         move_to_device: If True (default), place the result on device.
 
     Returns:
-        A flat list of ``OverlappedTensor`` views, one per
-        ``(tensor, spec)`` pair across all lanes, in input order.
+        A dict of ``OverlappedTensor`` views, keyed by tensor name.
     """
 
     for lane in tensors:
         assert len(lane) > 0, "Lane must contain at least one tensor"
-        for tensor, spec in lane:
+        for _name, tensor, spec in lane:
             assert (
                 tuple(tensor.shape) == spec.raw_tensor_shape
             ), f"Tensor shape {tuple(tensor.shape)} does not match spec shape {spec.raw_tensor_shape}"
-            assert spec.core_range_set == lane[0][1].core_range_set, (
-                f"Core range set {spec.core_range_set} does not match {lane[0][1].core_range_set}, "
+            assert spec.core_range_set == lane[0][2].core_range_set, (
+                f"Core range set {spec.core_range_set} does not match {lane[0][2].core_range_set}, "
                 "all core range sets must be the same within a lane"
             )
             assert len(spec.tp_dim) == 2 and all(
@@ -203,20 +202,20 @@ def overlap_tensors(
         return cores
 
     for i, lane_a in enumerate(tensors):
-        cores_a = _core_set(lane_a[0][1].core_range_set)
+        cores_a = _core_set(lane_a[0][2].core_range_set)
         for lane_b in tensors[i + 1 :]:
-            cores_b = _core_set(lane_b[0][1].core_range_set)
+            cores_b = _core_set(lane_b[0][2].core_range_set)
             assert not cores_a & cores_b, "Lanes must have separate core range sets"
 
     mesh_shape = (device.shape[0], device.shape[1])
     mesh_rows, mesh_cols = mesh_shape
     num_devices = mesh_rows * mesh_cols
 
-    needed_shard_bytes = max_shard_bytes([[spec for _, spec in lane] for lane in tensors], mesh_shape)
+    needed_shard_bytes = max_shard_bytes([[spec for _, _, spec in lane] for lane in tensors], mesh_shape)
     assert needed_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
     uint32_per_shard = needed_shard_bytes // 4
 
-    total_cores = sum(lane[0][1].core_range_set.num_cores() for lane in tensors)
+    total_cores = sum(lane[0][2].core_range_set.num_cores() for lane in tensors)
 
     byte_offsets: dict[int, int] = {}
 
@@ -225,10 +224,10 @@ def overlap_tensors(
         for col in range(mesh_cols):
             dev_packed = bytearray()
             for lane in tensors:
-                num_cores = lane[0][1].core_range_set.num_cores()
+                num_cores = lane[0][2].core_range_set.num_cores()
                 for core_idx in range(num_cores):
                     shard_data = bytearray()
-                    for tensor, spec in lane:
+                    for _name, tensor, spec in lane:
                         h_idx = spec._dim_slice_idx(0, row, col, mesh_shape)
                         w_idx = spec._dim_slice_idx(1, row, col, mesh_shape)
                         per_dev_h = spec.per_device_height(mesh_shape)
@@ -261,7 +260,7 @@ def overlap_tensors(
         row_tensors = [torch.cat([t.reshape(1, -1) for t in row_list], dim=1) for row_list in per_device_raw]
         combined = torch.cat(row_tensors, dim=0)
 
-    combined_crs_ranges = [cr for lane in tensors for cr in lane[0][1].core_range_set.ranges()]
+    combined_crs_ranges = [cr for lane in tensors for cr in lane[0][2].core_range_set.ranges()]
     combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
     shard_spec = ttnn.ShardSpec(
         combined_crs,
@@ -289,24 +288,22 @@ def overlap_tensors(
         mesh_mapper=mesh_mapper,
     )
 
-    result = []
+    result = {}
     for lane in tensors:
-        for tensor, spec in lane:
+        for name, tensor, spec in lane:
             ts = spec.logical_tensor_shape or (
                 spec.per_device_height(mesh_shape),
                 spec.per_device_width(mesh_shape),
             )
-            result.append(
-                OverlappedTensor(
-                    fused_tensor=fused,
-                    tensor_shape=ts,
-                    shard_shape=spec.shard_shape(mesh_shape),
-                    core_range_set=spec.core_range_set,
-                    dtype=spec.dtype,
-                    tile_shape=(spec.tile_h, spec.tile_w),
-                    byte_offset=byte_offsets[id(spec)],
-                    total_size=spec.shard_bytes,
-                )
+            result[name] = OverlappedTensor(
+                fused_tensor=fused,
+                tensor_shape=ts,
+                shard_shape=spec.shard_shape(mesh_shape),
+                core_range_set=spec.core_range_set,
+                dtype=spec.dtype,
+                tile_shape=(spec.tile_h, spec.tile_w),
+                byte_offset=byte_offsets[id(spec)],
+                total_size=spec.shard_bytes(mesh_shape),
             )
 
     return result

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -42,7 +42,7 @@ class OverlappedShardSpec:
     bfp8_tile_bytes: int = 1088
     bfp4_tile_bytes: int = 576
 
-    tp: int = 1
+    tp_dim: tuple[int | None, int | None] = (None, None)
 
     def _tile_bytes(self) -> int:
         num_elements = self.tile_h * self.tile_w
@@ -53,26 +53,49 @@ class OverlappedShardSpec:
             return exponent_bytes + mantissa_bytes
         return num_elements * _DTYPE_ELEMENT_BYTES[self.dtype]
 
-    @property
-    def tiles_per_shard(self) -> int:
-        shard_w = self.raw_tensor_shape[1] // self.core_range_set.num_cores()
-        return (self.per_device_height // self.tile_h) * (shard_w // self.tile_w)
+    def _dim_tp(self, tensor_dim: int, mesh_shape: tuple[int, int]) -> int:
+        """TP factor for a single tensor dimension (0=height, 1=width)."""
+        result = 1
+        for mesh_dim, d in enumerate(self.tp_dim):
+            if d == tensor_dim:
+                result *= mesh_shape[mesh_dim]
+        return result
 
-    @property
-    def shard_bytes(self) -> int:
-        return self.tiles_per_shard * self._tile_bytes()
+    def _dim_slice_idx(self, tensor_dim: int, row: int, col: int, mesh_shape: tuple[int, int]) -> int:
+        """Slice index for a single tensor dimension at mesh coordinate (row, col)."""
+        idx = 0
+        stride = 1
+        mesh_coord = (row, col)
+        for mesh_dim in reversed(range(2)):
+            if self.tp_dim[mesh_dim] == tensor_dim:
+                idx += mesh_coord[mesh_dim] * stride
+                stride *= mesh_shape[mesh_dim]
+        return idx
 
-    @property
-    def total_bytes(self) -> int:
-        return self.shard_bytes * self.core_range_set.num_cores()
+    def tp(self, mesh_shape: tuple[int, int]) -> int:
+        """Total TP factor (product of all non-None mesh dimensions)."""
+        return self._dim_tp(0, mesh_shape) * self._dim_tp(1, mesh_shape)
 
-    @property
-    def per_device_height(self) -> int:
-        return self.raw_tensor_shape[0] // self.tp
+    def per_device_height(self, mesh_shape: tuple[int, int]) -> int:
+        return self.raw_tensor_shape[0] // self._dim_tp(0, mesh_shape)
+
+    def per_device_width(self, mesh_shape: tuple[int, int]) -> int:
+        return self.raw_tensor_shape[1] // self._dim_tp(1, mesh_shape)
+
+    def tiles_per_shard(self, mesh_shape: tuple[int, int]) -> int:
+        pdw = self.per_device_width(mesh_shape)
+        shard_w = pdw // self.core_range_set.num_cores()
+        return (self.per_device_height(mesh_shape) // self.tile_h) * (shard_w // self.tile_w)
+
+    def shard_bytes(self, mesh_shape: tuple[int, int]) -> int:
+        return self.tiles_per_shard(mesh_shape) * self._tile_bytes()
+
+    def total_bytes(self, mesh_shape: tuple[int, int]) -> int:
+        return self.shard_bytes(mesh_shape) * self.core_range_set.num_cores()
 
 
-def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]]) -> int:
-    return max(sum(spec.shard_bytes for spec in lane) for lane in shard_specs)
+def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]], mesh_shape: tuple[int, int]) -> int:
+    return max(sum(spec.shard_bytes(mesh_shape) for spec in lane) for lane in shard_specs)
 
 
 def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedShardSpec) -> bytes:
@@ -142,7 +165,9 @@ def overlap_tensors(
                 f"Core range set {spec.core_range_set} does not match {lane[0][1].core_range_set}, "
                 "all core range sets must be the same within a lane"
             )
-            assert spec.tp > 0 and (spec.tp & (spec.tp - 1)) == 0, "TP must be a positive power of 2"
+            assert len(spec.tp_dim) == 2 and all(
+                d is None or d in (0, 1) for d in spec.tp_dim
+            ), "tp_dim must be a 2-tuple of None, 0, or 1"
 
     def _core_set(crs: ttnn.CoreRangeSet) -> set[tuple[int, int]]:
         cores = set()
@@ -158,43 +183,54 @@ def overlap_tensors(
             cores_b = _core_set(lane_b[0][1].core_range_set)
             assert not cores_a & cores_b, "Lanes must have separate core range sets"
 
-    needed_shard_bytes = max_shard_bytes([[spec for _, spec in lane] for lane in tensors])
+    mesh_shape = (device.shape[0], device.shape[1])
+    mesh_rows, mesh_cols = mesh_shape
+    num_devices = mesh_rows * mesh_cols
+
+    needed_shard_bytes = max_shard_bytes([[spec for _, spec in lane] for lane in tensors], mesh_shape)
     assert needed_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
     uint32_per_shard = needed_shard_bytes // 4
 
-    max_tp = max(spec.tp for lane in tensors for _, spec in lane)
     total_cores = sum(lane[0][1].core_range_set.num_cores() for lane in tensors)
 
     byte_offsets: dict[int, int] = {}
 
-    per_tp_raw = []
-    for tp_idx in range(max_tp):
-        tp_packed = bytearray()
-        for lane in tensors:
-            num_cores = lane[0][1].core_range_set.num_cores()
-            for core_idx in range(num_cores):
-                shard_data = bytearray()
-                for tensor, spec in lane:
-                    slice_idx = tp_idx * spec.tp // max_tp
-                    per_dev_h = spec.per_device_height
-                    device_slice = tensor[slice_idx * per_dev_h : (slice_idx + 1) * per_dev_h, :]
-                    shard_w = spec.raw_tensor_shape[1] // num_cores
-                    shard_col = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w].contiguous()
-                    shard_raw = tilize_and_pack(shard_col, spec)
-                    assert len(shard_raw) == spec.shard_bytes
-                    byte_offsets[id(spec)] = len(shard_data)
-                    shard_data.extend(shard_raw)
+    per_device_raw: list[list[torch.Tensor]] = [[] for _ in range(mesh_rows)]
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            dev_packed = bytearray()
+            for lane in tensors:
+                num_cores = lane[0][1].core_range_set.num_cores()
+                for core_idx in range(num_cores):
+                    shard_data = bytearray()
+                    for tensor, spec in lane:
+                        h_idx = spec._dim_slice_idx(0, row, col, mesh_shape)
+                        w_idx = spec._dim_slice_idx(1, row, col, mesh_shape)
+                        per_dev_h = spec.per_device_height(mesh_shape)
+                        per_dev_w = spec.per_device_width(mesh_shape)
+                        device_slice = tensor[
+                            h_idx * per_dev_h : (h_idx + 1) * per_dev_h,
+                            w_idx * per_dev_w : (w_idx + 1) * per_dev_w,
+                        ]
+                        shard_w = per_dev_w // num_cores
+                        shard_col = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w].contiguous()
+                        shard_raw = tilize_and_pack(shard_col, spec)
+                        assert len(shard_raw) == spec.shard_bytes(mesh_shape)
+                        byte_offsets[id(spec)] = len(shard_data)
+                        shard_data.extend(shard_raw)
 
-                if len(shard_data) < needed_shard_bytes:
-                    shard_data.extend(b"\x00" * (needed_shard_bytes - len(shard_data)))
-                tp_packed.extend(shard_data)
+                    if len(shard_data) < needed_shard_bytes:
+                        shard_data.extend(b"\x00" * (needed_shard_bytes - len(shard_data)))
+                    dev_packed.extend(shard_data)
 
-        per_tp_raw.append(torch.frombuffer(bytes(tp_packed), dtype=torch.int32).clone())
+            per_device_raw[row].append(torch.frombuffer(bytes(dev_packed), dtype=torch.int32).clone())
 
-    if max_tp == 1:
-        combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
+    shard_elems = uint32_per_shard * total_cores
+    if num_devices == 1:
+        combined = per_device_raw[0][0].reshape(1, shard_elems)
     else:
-        combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
+        row_tensors = [torch.cat([t.reshape(1, -1) for t in row_list], dim=1) for row_list in per_device_raw]
+        combined = torch.cat(row_tensors, dim=0)
 
     combined_crs_ranges = [cr for lane in tensors for cr in lane[0][1].core_range_set.ranges()]
     combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
@@ -209,11 +245,10 @@ def overlap_tensors(
         shard_spec,
     )
 
-    if max_tp == 1:
+    if num_devices == 1:
         mesh_mapper = ttnn.ReplicateTensorToMesh(device)
     else:
-        mesh_shape = (device.shape[0], device.shape[1])
-        mesh_mapper = ttnn.ShardTensor2dMesh(device, mesh_shape=mesh_shape, dims=(None, 1))
+        mesh_mapper = ttnn.ShardTensor2dMesh(device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
     device_for_torch = device if move_to_device else None
 
     fused = ttnn.from_torch(
@@ -229,12 +264,14 @@ def overlap_tensors(
     for lane in tensors:
         num_cores = lane[0][1].core_range_set.num_cores()
         for tensor, spec in lane:
-            shard_w = spec.raw_tensor_shape[1] // num_cores
+            pdh = spec.per_device_height(mesh_shape)
+            pdw = spec.per_device_width(mesh_shape)
+            shard_w = pdw // num_cores
             result.append(
                 OverlappedTensor(
                     fused_tensor=fused,
-                    tensor_shape=(spec.per_device_height, spec.raw_tensor_shape[1]),
-                    shard_shape=(spec.per_device_height, shard_w),
+                    tensor_shape=(pdh, pdw),
+                    shard_shape=(pdh, shard_w),
                     core_range_set=spec.core_range_set,
                     dtype=spec.dtype,
                     tile_shape=(spec.tile_h, spec.tile_w),

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 
 import numpy as np

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -35,6 +35,11 @@ class OverlappedShardSpec:
       partial width).  ``num_cores`` divides the width.
     - ``HEIGHT_SHARDED``: each core gets a row slice (partial height,
       full width).  ``num_cores`` divides the height.
+
+    When data is preprocessed (shuffled / block-sharded) before
+    overlapping, ``raw_tensor_shape`` reflects the physical layout
+    while ``logical_tensor_shape`` preserves the original per-device
+    shape for downstream consumers.
     """
 
     core_range_set: ttnn.CoreRangeSet
@@ -46,6 +51,8 @@ class OverlappedShardSpec:
     tile_w: int = 32
 
     tp_dim: tuple[int | None, int | None] = (None, None)
+
+    logical_tensor_shape: tuple[int, int] | None = None
 
     def _tile_bytes(self) -> int:
         num_elements = self.tile_h * self.tile_w
@@ -285,12 +292,14 @@ def overlap_tensors(
     result = []
     for lane in tensors:
         for tensor, spec in lane:
-            pdh = spec.per_device_height(mesh_shape)
-            pdw = spec.per_device_width(mesh_shape)
+            ts = spec.logical_tensor_shape or (
+                spec.per_device_height(mesh_shape),
+                spec.per_device_width(mesh_shape),
+            )
             result.append(
                 OverlappedTensor(
                     fused_tensor=fused,
-                    tensor_shape=(pdh, pdw),
+                    tensor_shape=ts,
                     shard_shape=spec.shard_shape(mesh_shape),
                     core_range_set=spec.core_range_set,
                     dtype=spec.dtype,

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -222,17 +222,17 @@ def overlap_tensors(
 
     total_cores = sum(lane[0][2].core_range_set.num_cores() for lane in tensors)
 
-    byte_offsets: dict[int, int] = {}
+    byte_offsets: dict[tuple[int, int], int] = {}
 
     per_device_raw: list[list[torch.Tensor]] = [[] for _ in range(mesh_rows)]
     for row in range(mesh_rows):
         for col in range(mesh_cols):
             dev_packed = bytearray()
-            for lane in tensors:
+            for lane_idx, lane in enumerate(tensors):
                 num_cores = lane[0][2].core_range_set.num_cores()
                 for core_idx in range(num_cores):
                     shard_data = bytearray()
-                    for _name, tensor, spec in lane:
+                    for spec_idx, (_name, tensor, spec) in enumerate(lane):
                         h_idx = spec._dim_slice_idx(0, row, col, mesh_shape)
                         w_idx = spec._dim_slice_idx(1, row, col, mesh_shape)
                         per_dev_h = spec.per_device_height(mesh_shape)
@@ -249,7 +249,7 @@ def overlap_tensors(
                             core_slice = device_slice[core_idx * shard_h : (core_idx + 1) * shard_h, :]
                         shard_raw = tilize_and_pack(core_slice.contiguous(), spec)
                         assert len(shard_raw) == spec.shard_bytes(mesh_shape)
-                        byte_offsets[id(spec)] = len(shard_data)
+                        byte_offsets[(lane_idx, spec_idx)] = len(shard_data)
                         shard_data.extend(shard_raw)
 
                     if len(shard_data) < needed_shard_bytes:
@@ -294,8 +294,8 @@ def overlap_tensors(
     )
 
     result = {}
-    for lane in tensors:
-        for name, tensor, spec in lane:
+    for lane_idx, lane in enumerate(tensors):
+        for spec_idx, (name, tensor, spec) in enumerate(lane):
             ts = spec.logical_tensor_shape or (
                 spec.per_device_height(mesh_shape),
                 spec.per_device_width(mesh_shape),
@@ -307,7 +307,7 @@ def overlap_tensors(
                 core_range_set=spec.core_range_set,
                 dtype=spec.dtype,
                 tile_shape=(spec.tile_h, spec.tile_w),
-                byte_offset=byte_offsets[id(spec)],
+                byte_offset=byte_offsets[(lane_idx, spec_idx)],
                 total_size=spec.shard_bytes(mesh_shape),
             )
 

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -132,15 +132,31 @@ def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedTensorSpec) -> bytes:
             raise ValueError(f"Unsupported dtype: {spec.dtype}")
 
 
+@dataclass
+class OverlapEntry:
+    """A named tensor paired with its overlap spec for use in ``overlap_tensors``."""
+
+    name: str
+    tensor: torch.Tensor
+    spec: OverlappedTensorSpec
+
+
 OverlappedTensor = ttnn.OverlappedTensor
 
 
 def overlap_tensors(
-    tensors: list[list[tuple[str, torch.Tensor, OverlappedTensorSpec]]],
+    tensors: list[list[OverlapEntry]],
     device: ttnn.Device,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
     """Overlap a list of tensors into a single fused tensor.
+
+    On tenstorrent devices, all L1 allocations are lockstep. This means that
+    if tensor is used only on subset of cores, the memory for it is still
+    allocated on all cores. To avoid wasting memory, this function allows to
+    overlapp multiple tensors into a single fused tensor.
+    When the fused tensor is sharded over cores, each core gets a
+    shard of the fused tensor, corresponding to the desired origianal tensor.
 
     The fused tensor is always stored as WIDTH_SHARDED on the device
     (one flat shard per core).  Individual sub-tensors within the fused
@@ -150,9 +166,9 @@ def overlap_tensors(
 
     Args:
         tensors: A list of "lanes".  Each lane is a list of
-            ``(name, tensor, spec)`` tuples that share
-            the same core range set and are packed back-to-back within
-            each core's shard.  Lanes must occupy disjoint core ranges.
+            ``OverlapEntry`` instances that share the same core range
+            set and are packed back-to-back within each core's shard.
+            Lanes must occupy disjoint core ranges.
         device: The mesh device to place the fused tensor on.
         move_to_device: If True (default), place the result on device.
 
@@ -162,21 +178,21 @@ def overlap_tensors(
 
     for lane in tensors:
         assert len(lane) > 0, "Lane must contain at least one tensor"
-        for _name, tensor, spec in lane:
+        for entry in lane:
             assert (
-                tuple(tensor.shape) == spec.raw_tensor_shape
-            ), f"Tensor shape {tuple(tensor.shape)} does not match spec shape {spec.raw_tensor_shape}"
-            assert spec.core_range_set == lane[0][2].core_range_set, (
-                f"Core range set {spec.core_range_set} does not match {lane[0][2].core_range_set}, "
+                tuple(entry.tensor.shape) == entry.spec.raw_tensor_shape
+            ), f"Tensor shape {tuple(entry.tensor.shape)} does not match spec shape {entry.spec.raw_tensor_shape}"
+            assert entry.spec.core_range_set == lane[0].spec.core_range_set, (
+                f"Core range set {entry.spec.core_range_set} does not match {lane[0].spec.core_range_set}, "
                 "all core range sets must be the same within a lane"
             )
-            assert len(spec.tp_dim) == 2 and all(
-                d is None or d in (0, 1) for d in spec.tp_dim
+            assert len(entry.spec.tp_dim) == 2 and all(
+                d is None or d in (0, 1) for d in entry.spec.tp_dim
             ), "tp_dim must be a 2-tuple of None, 0, or 1"
-            assert spec.sharding in (
+            assert entry.spec.sharding in (
                 ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ), f"sharding must be WIDTH_SHARDED or HEIGHT_SHARDED, got {spec.sharding}"
+            ), f"sharding must be WIDTH_SHARDED or HEIGHT_SHARDED, got {entry.spec.sharding}"
 
     def _core_set(crs: ttnn.CoreRangeSet) -> set[tuple[int, int]]:
         cores = set()
@@ -187,20 +203,20 @@ def overlap_tensors(
         return cores
 
     for i, lane_a in enumerate(tensors):
-        cores_a = _core_set(lane_a[0][2].core_range_set)
+        cores_a = _core_set(lane_a[0].spec.core_range_set)
         for lane_b in tensors[i + 1 :]:
-            cores_b = _core_set(lane_b[0][2].core_range_set)
+            cores_b = _core_set(lane_b[0].spec.core_range_set)
             assert not cores_a & cores_b, "Lanes must have separate core range sets"
 
     mesh_shape = (device.shape[0], device.shape[1])
     mesh_rows, mesh_cols = mesh_shape
     num_devices = mesh_rows * mesh_cols
 
-    needed_shard_bytes = max_shard_bytes([[spec for _, _, spec in lane] for lane in tensors], mesh_shape)
+    needed_shard_bytes = max_shard_bytes([[entry.spec for entry in lane] for lane in tensors], mesh_shape)
     assert needed_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
     uint32_per_shard = needed_shard_bytes // 4
 
-    total_cores = sum(lane[0][2].core_range_set.num_cores() for lane in tensors)
+    total_cores = sum(lane[0].spec.core_range_set.num_cores() for lane in tensors)
 
     byte_offsets: dict[tuple[int, int], int] = {}
 
@@ -209,26 +225,26 @@ def overlap_tensors(
         for col in range(mesh_cols):
             dev_packed = bytearray()
             for lane_idx, lane in enumerate(tensors):
-                num_cores = lane[0][2].core_range_set.num_cores()
+                num_cores = lane[0].spec.core_range_set.num_cores()
                 for core_idx in range(num_cores):
                     shard_data = bytearray()
-                    for spec_idx, (_name, tensor, spec) in enumerate(lane):
-                        h_idx = spec._dim_slice_idx(0, row, col, mesh_shape)
-                        w_idx = spec._dim_slice_idx(1, row, col, mesh_shape)
-                        per_dev_h = spec.per_device_height(mesh_shape)
-                        per_dev_w = spec.per_device_width(mesh_shape)
-                        device_slice = tensor[
+                    for spec_idx, entry in enumerate(lane):
+                        h_idx = entry.spec._dim_slice_idx(0, row, col, mesh_shape)
+                        w_idx = entry.spec._dim_slice_idx(1, row, col, mesh_shape)
+                        per_dev_h = entry.spec.per_device_height(mesh_shape)
+                        per_dev_w = entry.spec.per_device_width(mesh_shape)
+                        device_slice = entry.tensor[
                             h_idx * per_dev_h : (h_idx + 1) * per_dev_h,
                             w_idx * per_dev_w : (w_idx + 1) * per_dev_w,
                         ]
-                        if spec.sharding == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+                        if entry.spec.sharding == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
                             shard_w = per_dev_w // num_cores
                             core_slice = device_slice[:, core_idx * shard_w : (core_idx + 1) * shard_w]
                         else:
                             shard_h = per_dev_h // num_cores
                             core_slice = device_slice[core_idx * shard_h : (core_idx + 1) * shard_h, :]
-                        shard_raw = tilize_and_pack(core_slice.contiguous(), spec)
-                        assert len(shard_raw) == spec.shard_bytes(mesh_shape)
+                        shard_raw = tilize_and_pack(core_slice.contiguous(), entry.spec)
+                        assert len(shard_raw) == entry.spec.shard_bytes(mesh_shape)
                         byte_offsets[(lane_idx, spec_idx)] = len(shard_data)
                         shard_data.extend(shard_raw)
 
@@ -245,7 +261,7 @@ def overlap_tensors(
         row_tensors = [torch.cat([t.reshape(1, -1) for t in row_list], dim=1) for row_list in per_device_raw]
         combined = torch.cat(row_tensors, dim=0)
 
-    combined_crs_ranges = [cr for lane in tensors for cr in lane[0][2].core_range_set.ranges()]
+    combined_crs_ranges = [cr for lane in tensors for cr in lane[0].spec.core_range_set.ranges()]
     combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
     shard_spec = ttnn.ShardSpec(
         combined_crs,
@@ -275,20 +291,22 @@ def overlap_tensors(
 
     result = {}
     for lane_idx, lane in enumerate(tensors):
-        for spec_idx, (name, tensor, spec) in enumerate(lane):
-            ts = spec.logical_tensor_shape or (
-                spec.per_device_height(mesh_shape),
-                spec.per_device_width(mesh_shape),
+        for spec_idx, entry in enumerate(lane):
+            ts = entry.spec.logical_tensor_shape or (
+                entry.spec.per_device_height(mesh_shape),
+                entry.spec.per_device_width(mesh_shape),
             )
-            result[name] = OverlappedTensor(
+            result[entry.name] = OverlappedTensor(
+                # fused tensor is just a reference to the underlying fused tensor, that
+                # stores all overlapped tensors.
                 fused_tensor=fused,
                 tensor_shape=ts,
-                shard_shape=spec.shard_shape(mesh_shape),
-                core_range_set=spec.core_range_set,
-                dtype=spec.dtype,
-                tile_shape=(spec.tile_h, spec.tile_w),
+                shard_shape=entry.spec.shard_shape(mesh_shape),
+                core_range_set=entry.spec.core_range_set,
+                dtype=entry.spec.dtype,
+                tile_shape=(entry.spec.tile_h, entry.spec.tile_w),
                 byte_offset=byte_offsets[(lane_idx, spec_idx)],
-                total_size=spec.shard_bytes(mesh_shape),
+                total_size=entry.spec.shard_bytes(mesh_shape),
             )
 
     return result

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -132,27 +132,7 @@ def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedTensorSpec) -> bytes:
             raise ValueError(f"Unsupported dtype: {spec.dtype}")
 
 
-@dataclass
-class OverlappedTensor:
-    """A logical view of a sub-tensor within a fused (overlapped) device buffer.
-
-    The fused tensor is a raw byte container whose own tensor properties
-    (dtype, layout, shard spec) are generally meaningless for the individual
-    sub-tensors.  This class carries the intended per-sub-tensor properties
-    alongside a shared reference to the underlying fused buffer.
-    """
-
-    fused_tensor: ttnn.Tensor
-    tensor_shape: tuple[int, int]
-    shard_shape: tuple[int, int]
-    core_range_set: ttnn.CoreRangeSet
-    dtype: ttnn.DataType
-    tile_shape: tuple[int, int]
-    byte_offset: int = 0
-    total_size: int = 0
-
-    def get_tile(self) -> ttnn.Tile:
-        return ttnn.Tile(self.tile_shape)
+OverlappedTensor = ttnn.OverlappedTensor
 
 
 def overlap_tensors(

--- a/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
+++ b/models/demos/deepseek_v3_b1/blitz_overlap_tensors.py
@@ -19,10 +19,10 @@ _DTYPE_ELEMENT_BYTES = {
 
 
 @dataclass
-class OverlappedShardSpec:
+class OverlappedTensorSpec:
     """Describes one sub-tensor within a fused raw-byte buffer.
 
-    Multiple ``OverlappedShardSpec`` instances share a single L1
+    Multiple ``OverlappedTensorSpec`` instances share a single L1
     buffer whose per-core shard is zero-padded to a common maximum
     byte size.  Each spec carries the core range, logical tensor shape,
     dtype, and tile dimensions needed to pack its portion of the shard.
@@ -114,11 +114,11 @@ class OverlappedShardSpec:
         return self.tiles_per_shard(mesh_shape) * self._tile_bytes()
 
 
-def max_shard_bytes(shard_specs: list[list[OverlappedShardSpec]], mesh_shape: tuple[int, int]) -> int:
+def max_shard_bytes(shard_specs: list[list[OverlappedTensorSpec]], mesh_shape: tuple[int, int]) -> int:
     return max(sum(spec.shard_bytes(mesh_shape) for spec in lane) for lane in shard_specs)
 
 
-def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedShardSpec) -> bytes:
+def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedTensorSpec) -> bytes:
     match spec.dtype:
         case ttnn.bfloat8_b:
             return tilize_and_pack_bfp8(data_2d, spec.tile_h, spec.tile_w)
@@ -156,7 +156,7 @@ class OverlappedTensor:
 
 
 def overlap_tensors(
-    tensors: list[list[tuple[str, torch.Tensor, OverlappedShardSpec]]],
+    tensors: list[list[tuple[str, torch.Tensor, OverlappedTensorSpec]]],
     device: ttnn.Device,
     move_to_device: bool = True,
 ) -> dict[str, OverlappedTensor]:
@@ -165,7 +165,7 @@ def overlap_tensors(
     The fused tensor is always stored as WIDTH_SHARDED on the device
     (one flat shard per core).  Individual sub-tensors within the fused
     buffer can be either WIDTH_SHARDED or HEIGHT_SHARDED — the
-    ``sharding`` field on each ``OverlappedShardSpec`` controls how the
+    ``sharding`` field on each ``OverlappedTensorSpec`` controls how the
     per-device tensor is sliced across cores before tilization.
 
     Args:

--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import ttnn
 
 if TYPE_CHECKING:
-    from models.demos.deepseek_v3_b1.blitz_decode_weights import OverlappedTensor
+    from ttnn import OverlappedTensor
 
 
 class CircularBufferIdManager:

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -559,7 +559,7 @@ class AttentionBlock:
 
         # Active Matmul5 cores: o_proj cores (12×8 + 8×2 = 112 cores)
         o_proj_spec = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
-        matmul5_active_core_grid = o_proj_spec.o_proj_core_range_set
+        matmul5_active_core_grid = o_proj_spec.o_proj.core_range_set
         num_matmul5_cores = matmul5_active_core_grid.num_cores()  # 112
 
         # Per-core gather3 sender index: contiguous 0..111 in row-major order.

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -29,7 +29,7 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
 )
 
 if TYPE_CHECKING:
-    from models.demos.deepseek_v3_b1.blitz_decode_weights import OverlappedTensor
+    from ttnn import OverlappedTensor
 
 # Device roles for ReduceToOneB1
 MESH_LEAF = 0

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -297,7 +297,7 @@ class PostSDPA:
 
         # Active Matmul5 cores: o_proj cores (12×8 + 8×2 = 112 cores)
         o_proj_spec = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
-        matmul5_active_core_grid = o_proj_spec.o_proj_core_range_set
+        matmul5_active_core_grid = o_proj_spec.o_proj.core_range_set
         num_matmul5_cores = matmul5_active_core_grid.num_cores()  # 112
 
         # Per-core gather3 sender index: contiguous 0..111 in row-major order.

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -26,13 +26,9 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
-from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
-from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, ShardMeshMapper, SourceTensorSelection, TensorTarget
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 
-# Bump when any standalone tensor preprocessing logic changes to invalidate caches.
-CURRENT_TRANSFORM_VERSION = 1
-
+OverlappedTensor = ttnn.OverlappedTensor
 
 # Serialization: manifest version and dtype name mapping
 _MANIFEST_VERSION = 1

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -27,6 +27,8 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
+from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, ShardMeshMapper, SourceTensorSelection, TensorTarget
 
 OverlappedTensor = ttnn.OverlappedTensor
 
@@ -633,11 +635,25 @@ def prepare_attention_weights(
         q_norm_ot = o_norms["q_norm"]
         ffn_norm_ot = o_norms["ffn_norm"]
         kv_norm_ot = o_norms["kv_norm"]
-        gate_bias_tt = create_gate_bias_tensor(
-            state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
-            bdw._device,
-            move_to_device=move_to_device,
-        )
+        _gate_bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
+        if cache_config is not None:
+            target = _gate_bias_target(layer_idx)
+            fingerprint = cache_config.context.fingerprint(
+                source=SourceTensorSelection(names=(_gate_bias_key,)),
+                target=target,
+            )
+            gate_bias_tt = cache_config.cache.get_or_create(
+                fingerprint,
+                bdw._device,
+                preprocess=lambda t: {target.name: t[_gate_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
+                raw_tensors=lambda: {_gate_bias_key: state_dict[_gate_bias_key]},
+            )
+        else:
+            gate_bias_tt = create_gate_bias_tensor(
+                state_dict[_gate_bias_key],
+                bdw._device,
+                move_to_device=move_to_device,
+            )
         logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -1321,14 +1321,10 @@ _OVERLAPPED_SERIALIZED_FIELDS = {
     "byte_offset",
     "total_size",
 }
-_OVERLAPPED_SKIP_FIELDS = {"fused_tensor"}
 
 
 def _overlapped_tensor_to_json(ot: OverlappedTensor) -> dict:
     """Serialize one OverlappedTensor's metadata to a JSON-serializable dict."""
-    all_fields = {f.name for f in fields(OverlappedTensor)}
-    missing = all_fields - _OVERLAPPED_SERIALIZED_FIELDS - _OVERLAPPED_SKIP_FIELDS
-    assert not missing, f"OverlappedTensor has new fields not serialized: {missing}"
     dtype_str = _DTYPE_TO_STR.get(ot.dtype)
     if dtype_str is None:
         dtype_str = str(ot.dtype)
@@ -1415,18 +1411,20 @@ def _dump_overlapped_fusion_groups(
     layer_dir: Path,
     field_tuples: list[tuple[str, OverlappedTensor]],
 ) -> dict:
-    """Dump fused tensors for the given (field_name, OverlappedTensor) pairs; return fusion_groups dict."""
-    by_fused: dict[int, list[tuple[str, OverlappedTensor]]] = {}
+    """Dump fused tensors for the given (field_name, OverlappedTensor) pairs; return fusion_groups dict.
+
+    Groups fields by their fusion group name (from ``_FIELD_TO_FUSION_GROUP``)
+    rather than by Python object identity, because the C++ OverlappedTensor may
+    return a fresh wrapper from ``.fused_tensor`` on each access.
+    """
+    by_group: dict[str, list[tuple[str, OverlappedTensor]]] = {}
     for name, ot in field_tuples:
-        fid = id(ot.fused_tensor)
-        if fid not in by_fused:
-            by_fused[fid] = []
-        by_fused[fid].append((name, ot))
-    fusion_groups: dict[str, dict] = {}
-    for fid, group_fields in by_fused.items():
-        group_name = _FIELD_TO_FUSION_GROUP.get(group_fields[0][0])
+        group_name = _FIELD_TO_FUSION_GROUP.get(name)
         if group_name is None:
-            raise KeyError(f"Unknown field for fusion group: {group_fields[0][0]}")
+            raise KeyError(f"Unknown field for fusion group: {name}")
+        by_group.setdefault(group_name, []).append((name, ot))
+    fusion_groups: dict[str, dict] = {}
+    for group_name, group_fields in by_group.items():
         tensorbin_name = f"{group_name}.tensorbin"
         ttnn.dump_tensor(layer_dir / tensorbin_name, group_fields[0][1].fused_tensor)
         fusion_groups[group_name] = {

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -631,29 +631,13 @@ def prepare_attention_weights(
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
             o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
-        o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-
-        _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
-        if cache_config is not None:
-            target = _gate_bias_target(layer_idx)
-            fingerprint = cache_config.context.fingerprint(
-                source=SourceTensorSelection(names=(_bias_key,)),
-                target=target,
-            )
-            gate_bias_tt = cache_config.cache.get_or_create(
-                fingerprint,
-                bdw._device,
-                preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
-                raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
-            )
-        else:
-            gate_bias_tt = create_gate_bias_tensor(
-                state_dict[_bias_key],
-                bdw._device,
-                move_to_device=move_to_device,
-            )
-
-        logger.debug("Converted o_proj_gate_mm_norms (MoE) in {:.3f}s", time.perf_counter() - t0)
+        o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, ffn_norm_ot, kv_norm_ot = o_norms
+        gate_bias_tt = create_gate_bias_tensor(
+            state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
+            bdw._device,
+            move_to_device=move_to_device,
+        )
+        logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
@@ -675,8 +659,8 @@ def prepare_attention_weights(
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
             o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
-        o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-        logger.debug("Converted o_proj_gate_mm_norms (dense) in {:.3f}s", time.perf_counter() - t0)
+        o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, ffn_norm_ot, kv_norm_ot = o_norms
+        logger.debug("  convert o_proj_gate_mm_norms (dense): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -620,18 +620,23 @@ def prepare_attention_weights(
     logger.debug("Loaded raw tensors in {:.3f}s", time.perf_counter() - t0)
     logger.debug("Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)", layer_idx)
     t0 = time.perf_counter()
-    q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
-        q_a, q_b, kv_a, move_to_device=move_to_device
-    )
-    kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2, move_to_device=move_to_device)
-    logger.debug("Converted q_ab_kv_a + kv_b12 in {:.3f}s", time.perf_counter() - t0)
+    qab_kva = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a, move_to_device=move_to_device)
+    q_a_proj, q_b_proj, kv_a_proj = qab_kva["q_a_proj"], qab_kva["q_b_proj"], qab_kva["kv_a_proj"]
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2, move_to_device=move_to_device)
+    kv_b1_proj, kv_b2_proj = kv_b12["kv_b1_proj"], kv_b12["kv_b2_proj"]
+    logger.debug("  convert q_ab_kv_a + kv_b12: {:.3f}s", time.perf_counter() - t0)
 
     if is_moe:
         gate_mm = state_dict[_key(layer_idx, "mlp.gate.weight")].T.contiguous()
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
             o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
-        o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, ffn_norm_ot, kv_norm_ot = o_norms
+        o_proj_ot = o_norms["o_proj"]
+        gate_mm_ot = o_norms["gate_mm"]
+        attn_norm_ot = o_norms["attn_norm"]
+        q_norm_ot = o_norms["q_norm"]
+        ffn_norm_ot = o_norms["ffn_norm"]
+        kv_norm_ot = o_norms["kv_norm"]
         gate_bias_tt = create_gate_bias_tensor(
             state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
             bdw._device,
@@ -659,7 +664,11 @@ def prepare_attention_weights(
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
             o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
-        o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, ffn_norm_ot, kv_norm_ot = o_norms
+        o_proj_ot = o_norms["o_proj"]
+        attn_norm_ot = o_norms["attn_norm"]
+        q_norm_ot = o_norms["q_norm"]
+        ffn_norm_ot = o_norms["ffn_norm"]
+        kv_norm_ot = o_norms["kv_norm"]
         logger.debug("  convert o_proj_gate_mm_norms (dense): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -277,7 +277,7 @@ def _verify_layer_on_4x2_grid(
     # q_ab_kv_a
     if not _check_on_device(loaded.q_a_proj.fused_tensor, "q_a_proj.fused_tensor"):
         return False
-    fid = id(loaded.q_a_proj.fused_tensor)
+    fid = loaded.q_a_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         if not _check_topology(loaded.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "q_ab_kv_a"):
@@ -285,7 +285,7 @@ def _verify_layer_on_4x2_grid(
     # o_proj_gate_mm_norms
     if not _check_on_device(loaded.o_proj.fused_tensor, "o_proj.fused_tensor"):
         return False
-    fid = id(loaded.o_proj.fused_tensor)
+    fid = loaded.o_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         if not _check_topology(loaded.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "o_proj_gate_mm_norms"):
@@ -293,7 +293,7 @@ def _verify_layer_on_4x2_grid(
     # kv_b12
     if not _check_on_device(loaded.kv_b1_proj.fused_tensor, "kv_b1_proj.fused_tensor"):
         return False
-    fid = id(loaded.kv_b1_proj.fused_tensor)
+    fid = loaded.kv_b1_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         if not _check_topology(loaded.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0, "kv_b12"):
@@ -301,7 +301,7 @@ def _verify_layer_on_4x2_grid(
     # gate_up
     if not _check_on_device(loaded.shared_gate_proj.fused_tensor, "shared_gate_proj.fused_tensor"):
         return False
-    fid = id(loaded.shared_gate_proj.fused_tensor)
+    fid = loaded.shared_gate_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         if not _check_topology(loaded.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1, "gate_up"):

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -174,7 +174,8 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused q_ab_proj + kv_a_proj weights ...")
-    q_a, q_b, kv = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw)
+    qab_kva = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw)
+    q_a, q_b, kv = qab_kva["q_a_proj"], qab_kva["q_b_proj"], qab_kva["kv_a_proj"]
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
     composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
@@ -308,7 +309,7 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused o_proj + gate_mm + rmsnorm gamma weights ...")
-    o_proj, gate_mm, attn_norm_g, q_norm_g, ffn_norm_g, kv_norm_g = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         o_proj_raw,
         gate_mm_raw,
         attn_norm_raw,
@@ -316,6 +317,12 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
         kv_norm_raw,
         ffn_norm_raw,
     )
+    o_proj = o_norms["o_proj"]
+    gate_mm = o_norms["gate_mm"]
+    attn_norm_g = o_norms["attn_norm"]
+    q_norm_g = o_norms["q_norm"]
+    ffn_norm_g = o_norms["ffn_norm"]
+    kv_norm_g = o_norms["kv_norm"]
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
     composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
@@ -467,7 +474,8 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused kv_b1 + kv_b2 weights ...")
-    kv_b1, kv_b2 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw)
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw)
+    kv_b1, kv_b2 = kv_b12["kv_b1_proj"], kv_b12["kv_b2_proj"]
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
     composer = ttnn.ConcatMeshToTensor(submesh, dim=0)

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -258,7 +258,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
-@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (2, 2), (1, 2)])
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -257,7 +257,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
-@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
@@ -296,9 +296,7 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
     tile_1x32 = ttnn.Tile([1, 32])
 
     torch.manual_seed(42)
-    o_proj_raw = torch.randn(
-        cfg.o_proj.raw_tensor_shape[0] * cfg.o_proj.tp, cfg.o_proj.raw_tensor_shape[1], dtype=torch.bfloat16
-    )
+    o_proj_raw = torch.randn(*cfg.o_proj.raw_tensor_shape, dtype=torch.bfloat16)
     gate_mm_raw = torch.randn(cfg.gate_mm.raw_tensor_shape, dtype=torch.bfloat16)
     attn_norm_raw = torch.randn(cfg.attn_norm.raw_tensor_shape, dtype=torch.bfloat16)
     q_norm_raw = torch.randn(cfg.q_norm.raw_tensor_shape, dtype=torch.bfloat16)
@@ -307,7 +305,7 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused o_proj + gate_mm + rmsnorm gamma weights ...")
-    o_proj, gate_mm, attn_norm_g, q_norm_g, kv_norm_g, ffn_norm_g = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_proj, gate_mm, attn_norm_g, q_norm_g, ffn_norm_g, kv_norm_g = bdw.get_tt_o_proj_and_gate_mm_weights(
         o_proj_raw,
         gate_mm_raw,
         attn_norm_raw,
@@ -364,7 +362,7 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     # -- Build references (dtype round-trip on single device) ----------------
     logger.info("Building o_proj per-TP round-trip references ...")
-    per_device_o_h = cfg.o_proj.raw_tensor_shape[0]
+    per_device_o_h = cfg.o_proj.per_device_height
     o_tp_refs = []
     for tp_idx in range(cfg.o_proj.tp):
         o_slice = o_proj_raw[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -162,12 +162,12 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         pytest.skip("Test requires more devices than are available on this platform")
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
-    mla_tp = mesh_cols
     cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+    cfg.q_b_shard_spec.tp = mesh_cols
 
     torch.manual_seed(42)
     q_a_raw = torch.randn(cfg.q_a_proj_shape, dtype=torch.bfloat16)
-    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp, dtype=torch.bfloat16)
+    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * cfg.q_b_shard_spec.tp, dtype=torch.bfloat16)
     kv_raw = torch.randn(cfg.kv_a_proj_shape, dtype=torch.bfloat16)
 
     bdw = BlitzDecodeWeights(submesh)
@@ -223,8 +223,8 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     logger.info("Building q_b_proj per-TP round-trip references ...")
     q_b_tp_refs = []
-    for tp_idx in range(mla_tp):
-        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx, mla_tp)
+    for tp_idx in range(cfg.q_b_shard_spec.tp):
+        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx)
         ref = _get_roundtrip_reference(
             cfg.shuffle_q_b(q_b_slice),
             q_b.core_range_set,
@@ -291,17 +291,19 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
         pytest.skip("Test requires more devices than are available on this platform")
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
-    mla_tp = mesh_cols
     cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
+    cfg.o_proj.tp = mesh_cols
     tile_1x32 = ttnn.Tile([1, 32])
 
     torch.manual_seed(42)
-    o_proj_raw = torch.randn(cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1], dtype=torch.bfloat16)
-    gate_mm_raw = torch.randn(cfg.gate_mm_shape, dtype=torch.bfloat16)
-    attn_norm_raw = torch.randn(cfg.attn_norm_shape, dtype=torch.bfloat16)
-    q_norm_raw = torch.randn(cfg.q_norm_shape, dtype=torch.bfloat16)
-    kv_norm_raw = torch.randn(cfg.kv_norm_shape, dtype=torch.bfloat16)
-    ffn_norm_raw = torch.randn(cfg.ffn_norm_shape, dtype=torch.bfloat16)
+    o_proj_raw = torch.randn(
+        cfg.o_proj.raw_tensor_shape[0] * cfg.o_proj.tp, cfg.o_proj.raw_tensor_shape[1], dtype=torch.bfloat16
+    )
+    gate_mm_raw = torch.randn(cfg.gate_mm.raw_tensor_shape, dtype=torch.bfloat16)
+    attn_norm_raw = torch.randn(cfg.attn_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    q_norm_raw = torch.randn(cfg.q_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    kv_norm_raw = torch.randn(cfg.kv_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    ffn_norm_raw = torch.randn(cfg.ffn_norm.raw_tensor_shape, dtype=torch.bfloat16)
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused o_proj + gate_mm + rmsnorm gamma weights ...")
@@ -362,9 +364,9 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     # -- Build references (dtype round-trip on single device) ----------------
     logger.info("Building o_proj per-TP round-trip references ...")
-    per_device_o_h = cfg.o_proj_shape[0]
+    per_device_o_h = cfg.o_proj.raw_tensor_shape[0]
     o_tp_refs = []
-    for tp_idx in range(mla_tp):
+    for tp_idx in range(cfg.o_proj.tp):
         o_slice = o_proj_raw[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
         ref = _get_roundtrip_reference(
             o_slice,

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -5,9 +5,12 @@
 """
 Device tests for overlapped (fused) weight extraction.
 
+All tests are parameterized by dtype (bfloat4_b, bfloat8_b, bfloat16)
+to verify correctness across data type configurations.
+
 Tests all three constituents of get_tt_q_ab_proj_and_kv_a_proj_weights
 (using an NCRISC kernel to extract each sub-tensor, then verifying
-against an independently preprocessed + bfp8 round-tripped reference):
+against an independently preprocessed + dtype round-tripped reference):
   - q_a_proj (packed)
   - q_b_proj (shuffled)
   - kv_a_proj (shard-reordered)
@@ -15,7 +18,7 @@ against an independently preprocessed + bfp8 round-tripped reference):
 Tests all constituents of get_tt_o_proj_and_gate_mm_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
 against a dtype round-tripped reference):
-  - o_proj  (BFP8)
+  - o_proj  (parameterized dtype)
   - gate_mm (BFP16)
   - attn_norm (BFP16, 1x32 tile)
   - q_norm (BFP16, 1x32 tile)
@@ -25,15 +28,15 @@ against a dtype round-tripped reference):
 Tests both constituents of get_tt_kv_b12_proj_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
 against a dtype round-tripped reference):
-  - kv_b1_proj (HEIGHT_SHARDED, BFP8)
-  - kv_b2_proj (WIDTH_SHARDED, BFP8) — extracted in original shape
+  - kv_b1_proj (HEIGHT_SHARDED)
+  - kv_b2_proj (WIDTH_SHARDED) — extracted in original shape
     since shuffle_kv_b2 preserves per-tile data and linear tile order
 
 Tests both constituents of get_tt_moe_shared_expert_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
 against a dtype round-tripped reference):
-  - gate_proj (block-sharded HEIGHT_SHARDED, BFP4)
-  - up_proj   (block-sharded HEIGHT_SHARDED, BFP4)
+  - gate_proj (block-sharded HEIGHT_SHARDED)
+  - up_proj   (block-sharded HEIGHT_SHARDED)
 """
 
 import pytest
@@ -131,13 +134,14 @@ def _get_roundtrip_reference(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
+def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols, dtype):
     """Verify all three constituents of the q_ab_proj + kv_a_proj overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
@@ -174,7 +178,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused q_ab_proj + kv_a_proj weights ...")
-    qab_kva = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw)
+    qab_kva = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw, dtype=dtype)
     q_a, q_b, kv = qab_kva["q_a_proj"], qab_kva["q_b_proj"], qab_kva["kv_a_proj"]
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
@@ -260,13 +264,14 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
+@pytest.mark.parametrize("o_proj_dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
+def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols, o_proj_dtype):
     """Verify all constituents of the o_proj + gate_mm + rmsnorm gamma overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
@@ -316,6 +321,7 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
         q_norm_raw,
         kv_norm_raw,
         ffn_norm_raw,
+        o_proj_dtype=o_proj_dtype,
     )
     o_proj = o_norms["o_proj"]
     gate_mm = o_norms["gate_mm"]
@@ -432,13 +438,14 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
         logger.info(f"Device {device_idx} (TP={tp_group}): o_proj, gate_mm, gammas overlap passed")
 
 
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
+def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols, dtype):
     """Verify both constituents of the kv_b1 + kv_b2 overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
@@ -474,7 +481,7 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused kv_b1 + kv_b2 weights ...")
-    kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw)
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw, dtype=dtype)
     kv_b1, kv_b2 = kv_b12["kv_b1_proj"], kv_b12["kv_b2_proj"]
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
@@ -567,13 +574,14 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         logger.info(f"Device {device_idx} (TP={tp_group}): kv_b1_proj, kv_b2_proj overlap passed")
 
 
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_gate_up_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
+def test_gate_up_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols, dtype):
     """Verify both constituents of the gate + up projection overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
@@ -613,7 +621,7 @@ def test_gate_up_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     bdw = BlitzDecodeWeights(submesh)
     logger.info("Building fused gate + up proj weights ...")
-    gate, up, _ = bdw.get_tt_moe_shared_expert_weights(gate_raw, up_raw, down_raw)
+    gate, up, _ = bdw.get_tt_moe_shared_expert_weights(gate_raw, up_raw, down_raw, dtype=dtype)
 
     # -- Extract gate (block-sharded BFP4) while fused buffer is alive -------
     logger.info("Extracting gate_proj from fused buffer ...")

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -163,11 +163,12 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
     cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-    cfg.q_b_shard_spec.tp = mesh_cols
+    mesh_shape = (mesh_rows, mesh_cols)
+    q_b_tp = cfg.q_b_shard_spec.tp(mesh_shape)
 
     torch.manual_seed(42)
     q_a_raw = torch.randn(cfg.q_a_proj_shape, dtype=torch.bfloat16)
-    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * cfg.q_b_shard_spec.tp, dtype=torch.bfloat16)
+    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * q_b_tp, dtype=torch.bfloat16)
     kv_raw = torch.randn(cfg.kv_a_proj_shape, dtype=torch.bfloat16)
 
     bdw = BlitzDecodeWeights(submesh)
@@ -223,8 +224,8 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     logger.info("Building q_b_proj per-TP round-trip references ...")
     q_b_tp_refs = []
-    for tp_idx in range(cfg.q_b_shard_spec.tp):
-        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx)
+    for tp_idx in range(q_b_tp):
+        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx, mesh_shape)
         ref = _get_roundtrip_reference(
             cfg.shuffle_q_b(q_b_slice),
             q_b.core_range_set,
@@ -257,7 +258,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
-@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2)])
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (2, 2), (1, 2)])
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
@@ -292,7 +293,8 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
     cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
-    cfg.o_proj.tp = mesh_cols
+    mesh_shape = (mesh_rows, mesh_cols)
+    o_proj_tp = cfg.o_proj.tp(mesh_shape)
     tile_1x32 = ttnn.Tile([1, 32])
 
     torch.manual_seed(42)
@@ -362,9 +364,9 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh
 
     # -- Build references (dtype round-trip on single device) ----------------
     logger.info("Building o_proj per-TP round-trip references ...")
-    per_device_o_h = cfg.o_proj.per_device_height
+    per_device_o_h = cfg.o_proj.per_device_height(mesh_shape)
     o_tp_refs = []
-    for tp_idx in range(cfg.o_proj.tp):
+    for tp_idx in range(o_proj_tp):
         o_slice = o_proj_raw[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
         ref = _get_roundtrip_reference(
             o_slice,

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -26,7 +26,8 @@ Tests both constituents of get_tt_kv_b12_proj_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
 against a dtype round-tripped reference):
   - kv_b1_proj (HEIGHT_SHARDED, BFP8)
-  - kv_b2_proj (HEIGHT_SHARDED, BFP8)
+  - kv_b2_proj (WIDTH_SHARDED, BFP8) — extracted in original shape
+    since shuffle_kv_b2 preserves per-tile data and linear tile order
 
 Tests both constituents of get_tt_moe_shared_expert_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
@@ -445,8 +446,9 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         kv_b1_proj (8192, 512) as bfloat8_b
           HEIGHT_SHARDED on 64 cores (8x8 Qnope grid), shard (128, 512)
 
-        kv_b2_proj (512, 8192) pre-transposed to (8192, 512) as bfloat8_b
-          HEIGHT_SHARDED on 64 cores, shard (128, 512)
+        kv_b2_proj (512, 8192) as bfloat8_b
+          Extracted as WIDTH_SHARDED on 64 cores, shard (512, 128)
+          (byte-identical to the HEIGHT_SHARDED (128, 512) shard after shuffle)
 
     For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
     both tensors are TP-sharded on the 8192 (heads) dim.
@@ -485,14 +487,19 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     kv_b1_result = ttnn.to_torch(kv_b1_out, mesh_composer=composer)
     ttnn.deallocate(kv_b1_out)
 
-    # -- Extract kv_b2 (HEIGHT_SHARDED, BFP8) while fused buffer is alive -----
+    # -- Extract kv_b2 (WIDTH_SHARDED, BFP8) while fused buffer is alive -----
+    # The shuffle_kv_b2 rearrangement preserves per-tile element data and
+    # linear tile order, so each core's (128, 512) HEIGHT_SHARDED shard is
+    # byte-identical to the original (512, 128) WIDTH_SHARDED shard.
+    # Extracting as WIDTH_SHARDED lets us compare directly against the
+    # unshuffled reference without calling shuffle_kv_b2.
     logger.info("Extracting kv_b2_proj from fused buffer ...")
     kv_b2_out = _create_output_device_tensor(
-        *cfg.kv_b1_proj_shape,
+        *cfg.kv_b2_proj_shape,
         kv_b2.core_range_set,
         submesh,
         dtype=kv_b2.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        sharding=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         mesh_mapper=replicate,
     )
     kv_b2_out = CopyToOutput.op(kv_b2.fused_tensor, kv_b2_out, byte_offset=kv_b2.byte_offset)
@@ -521,19 +528,19 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
         logger.info(f"Building kv_b2_proj round-trip reference (TP={tp_idx}) ...")
         b2_slice = kv_b2_raw[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
-        b2_physical = cfg.shuffle_kv_b2(b2_slice)
         ref = _get_roundtrip_reference(
-            b2_physical,
+            b2_slice,
             kv_b2.core_range_set,
             single_device,
             dtype=kv_b2.dtype,
-            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            sharding=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         )
         kv_b2_tp_refs.append(ref)
 
     ttnn.close_mesh_device(single_device)
 
     kv_b1_h = kv_b1.tensor_shape[0]
+    kv_b2_h = cfg.kv_b2_proj_shape[0]
 
     logger.info("Verifying per-device results ...")
     for device_idx in range(num_devices):
@@ -544,7 +551,7 @@ def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
             b1_slice, kv_b1_tp_refs[tp_group]
         ), f"kv_b1_proj mismatch on device {device_idx} (TP={tp_group})"
 
-        b2_slice = kv_b2_result[device_idx * kv_b1_h : (device_idx + 1) * kv_b1_h]
+        b2_slice = kv_b2_result[device_idx * kv_b2_h : (device_idx + 1) * kv_b2_h]
         assert torch.equal(
             b2_slice, kv_b2_tp_refs[tp_group]
         ), f"kv_b2_proj mismatch on device {device_idx} (TP={tp_group})"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -622,7 +622,7 @@ def test_attention_block(
     num_matmul1_cores = matmul1_grid.num_cores()  # 64
 
     # Active Matmul2 cores: o_proj cores (12×8 + 8×2 = 112 cores)
-    matmul2_grid = o_proj_cfg.o_proj_core_range_set
+    matmul2_grid = o_proj_cfg.o_proj.core_range_set
     num_matmul2_cores = matmul2_grid.num_cores()  # 112
 
     # SDPA configuration (matching original sdpa_reduce_to_all test)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -125,14 +125,7 @@ def test_moe_routed_expert(device, use_hardcoded_expert_index):
     torch_q_norm = torch.zeros((1, 1536), dtype=torch.bfloat16)
     torch_kv_norm = torch.zeros((1, 512), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
-    (
-        _,  # o_proj
-        ttnn_gate_mm_weights,  # gate_mm overlapped tensor on (12,0)-(12,7)
-        _,  # attn_norm
-        _,  # q_norm
-        _,  # kv_norm
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_attn_norm,
@@ -140,6 +133,7 @@ def test_moe_routed_expert(device, use_hardcoded_expert_index):
         torch_kv_norm,
         torch_ffn_norm,
     )
+    ttnn_gate_mm_weights = o_norms["gate_mm"]
     compute_core_grid = ttnn_gate_mm_weights.core_range_set
     logger.info(f"Created gate matmul weights as overlapped tensor on {compute_core_grid.num_cores()} cores")
 
@@ -651,14 +645,7 @@ def test_moe_routed_expert_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_i
     torch_q_norm = torch.zeros((1, 1536), dtype=torch.bfloat16)
     torch_kv_norm = torch.zeros((1, 512), dtype=torch.bfloat16)
     torch_ffn_norm = torch.zeros((1, K), dtype=torch.bfloat16)
-    (
-        _,  # o_proj
-        ttnn_gate_mm_weights,  # gate_mm overlapped tensor on (12,0)-(12,7)
-        _,  # attn_norm
-        _,  # q_norm
-        _,  # kv_norm
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_attn_norm,
@@ -666,6 +653,7 @@ def test_moe_routed_expert_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_i
         torch_kv_norm,
         torch_ffn_norm,
     )
+    ttnn_gate_mm_weights = o_norms["gate_mm"]
     compute_core_grid = ttnn_gate_mm_weights.core_range_set
     logger.info(f"Created gate matmul weights as overlapped tensor on {compute_core_grid.num_cores()} cores")
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -130,7 +130,7 @@ def test_post_sdpa(
     num_mcast_cores = MCAST_GRID_X * MCAST_GRID_Y  # 130
 
     # Active Matmul2 cores: o_proj cores (12×8 + 8×2 = 112 cores)
-    matmul2_grid = o_proj_cfg.o_proj_core_range_set
+    matmul2_grid = o_proj_cfg.o_proj.core_range_set
     num_matmul2_cores = matmul2_grid.num_cores()  # 112
 
     # Per-core dimensions
@@ -568,7 +568,7 @@ def test_post_sdpa_with_sdpa_phase(
     num_mcast_cores = MCAST_GRID_X * MCAST_GRID_Y  # 130
 
     # Active Matmul2 cores: o_proj cores (12×8 + 8×2 = 112 cores)
-    matmul2_grid = o_proj_cfg.o_proj_core_range_set
+    matmul2_grid = o_proj_cfg.o_proj.core_range_set
     num_matmul2_cores = matmul2_grid.num_cores()  # 112
 
     # SDPA configuration (matching original sdpa_reduce_to_all test)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -245,20 +245,14 @@ def test_post_sdpa(
     bdw = BlitzDecodeWeights(submesh)
 
     # Weights1 = kv_b2_proj (second half of fused kv_b12 buffer)
-    _, kv_b2_overlapped = bdw.get_tt_kv_b12_proj_weights(torch_kv_b1_proj_dummy, torch_kv_b2_proj_weights)
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(torch_kv_b1_proj_dummy, torch_kv_b2_proj_weights)
+    kv_b2_overlapped = kv_b12["kv_b2_proj"]
     logger.info(
         f"Created kv_b2 overlapped tensor: shard {kv_b2_overlapped.shard_shape} on {matmul1_grid.num_cores()} cores"
     )
 
     # Weights2 = o_proj (first element of fused o_proj/gate/gamma buffer)
-    (
-        o_proj_overlapped,
-        _,  # gate_mm
-        _,  # attn_norm
-        _,  # q_norm
-        _,  # kv_norm
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_dummy,
         torch_attn_norm_dummy,
@@ -266,6 +260,7 @@ def test_post_sdpa(
         torch_kv_norm_dummy,
         torch_ffn_norm_dummy,
     )
+    o_proj_overlapped = o_norms["o_proj"]
     logger.info(
         f"Created o_proj overlapped tensor: shard {o_proj_overlapped.shard_shape} on {matmul2_grid.num_cores()} cores"
     )
@@ -772,19 +767,13 @@ def test_post_sdpa_with_sdpa_phase(
     single_device = ttnn.get_device_tensors(ttnn_input)[0].device()
     bdw = BlitzDecodeWeights(submesh)
 
-    _, kv_b2_overlapped = bdw.get_tt_kv_b12_proj_weights(torch_kv_b1_proj_dummy, torch_kv_b2_proj_weights)
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(torch_kv_b1_proj_dummy, torch_kv_b2_proj_weights)
+    kv_b2_overlapped = kv_b12["kv_b2_proj"]
     logger.info(
         f"Created kv_b2 overlapped tensor: shard {kv_b2_overlapped.shard_shape} on {matmul1_grid.num_cores()} cores"
     )
 
-    (
-        o_proj_overlapped,
-        _,  # gate_mm
-        _,  # attn_norm
-        _,  # q_norm
-        _,  # kv_norm
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_dummy,
         torch_attn_norm_dummy,
@@ -792,6 +781,7 @@ def test_post_sdpa_with_sdpa_phase(
         torch_kv_norm_dummy,
         torch_ffn_norm_dummy,
     )
+    o_proj_overlapped = o_norms["o_proj"]
     logger.info(
         f"Created o_proj overlapped tensor: shard {o_proj_overlapped.shard_shape} on {matmul2_grid.num_cores()} cores"
     )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -163,11 +163,11 @@ def test_post_sdpa(
     torch_kv_b1_proj_dummy = torch.zeros(
         (kv_b12_cfg.kv_b1_proj_shape[0] * num_tp, kv_b12_cfg.kv_b1_proj_shape[1]), dtype=torch.bfloat16
     )
-    torch_gate_mm_dummy = torch.zeros(o_proj_cfg.gate_mm_shape, dtype=torch.bfloat16)
-    torch_attn_norm_dummy = torch.zeros(o_proj_cfg.attn_norm_shape, dtype=torch.bfloat16)
-    torch_q_norm_dummy = torch.zeros(o_proj_cfg.q_norm_shape, dtype=torch.bfloat16)
-    torch_kv_norm_dummy = torch.zeros(o_proj_cfg.kv_norm_shape, dtype=torch.bfloat16)
-    torch_ffn_norm_dummy = torch.zeros(o_proj_cfg.ffn_norm_shape, dtype=torch.bfloat16)
+    torch_gate_mm_dummy = torch.zeros(o_proj_cfg.gate_mm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_attn_norm_dummy = torch.zeros(o_proj_cfg.attn_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_q_norm_dummy = torch.zeros(o_proj_cfg.q_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_kv_norm_dummy = torch.zeros(o_proj_cfg.kv_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_ffn_norm_dummy = torch.zeros(o_proj_cfg.ffn_norm.raw_tensor_shape, dtype=torch.bfloat16)
 
     # One input per mesh row: [num_matmul1_cores * num_tp, K1] covers all TP columns in the row
     device_inputs = []
@@ -623,11 +623,11 @@ def test_post_sdpa_with_sdpa_phase(
     torch_kv_b1_proj_dummy = torch.zeros(
         (kv_b12_cfg.kv_b1_proj_shape[0] * num_tp, kv_b12_cfg.kv_b1_proj_shape[1]), dtype=torch.bfloat16
     )
-    torch_gate_mm_dummy = torch.zeros(o_proj_cfg.gate_mm_shape, dtype=torch.bfloat16)
-    torch_attn_norm_dummy = torch.zeros(o_proj_cfg.attn_norm_shape, dtype=torch.bfloat16)
-    torch_q_norm_dummy = torch.zeros(o_proj_cfg.q_norm_shape, dtype=torch.bfloat16)
-    torch_kv_norm_dummy = torch.zeros(o_proj_cfg.kv_norm_shape, dtype=torch.bfloat16)
-    torch_ffn_norm_dummy = torch.zeros(o_proj_cfg.ffn_norm_shape, dtype=torch.bfloat16)
+    torch_gate_mm_dummy = torch.zeros(o_proj_cfg.gate_mm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_attn_norm_dummy = torch.zeros(o_proj_cfg.attn_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_q_norm_dummy = torch.zeros(o_proj_cfg.q_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_kv_norm_dummy = torch.zeros(o_proj_cfg.kv_norm.raw_tensor_shape, dtype=torch.bfloat16)
+    torch_ffn_norm_dummy = torch.zeros(o_proj_cfg.ffn_norm.raw_tensor_shape, dtype=torch.bfloat16)
 
     # SDPA input tensors per device: L [8, 4096], MS [8, 256]
     # MS tensor layout: for each worker core c (0..7), within columns [c*32, (c+1)*32]:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -457,22 +457,22 @@ def test_pre_sdpa(
     # Fused matmul1 (q_a_proj packed), matmul2 (q_b_proj shuffled), and DKV matmul (kv_a_proj)
     # weights as overlapped tensors sharing a single L1 buffer via BlitzDecodeWeights.
     bdw = BlitzDecodeWeights(submesh)
-    (
-        matmul_weights_overlapped,
-        matmul2_weights_overlapped,
-        dkv_matmul_weights_overlapped,
-    ) = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
+    qab_kva = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
         torch_matmul_weights,
         torch_matmul2_weights_full_unshuffled,
         torch_dkv_matmul_weights,
     )
+    matmul_weights_overlapped = qab_kva["q_a_proj"]
+    matmul2_weights_overlapped = qab_kva["q_b_proj"]
+    dkv_matmul_weights_overlapped = qab_kva["kv_a_proj"]
 
     # Matmul3 / kv_b1_proj weights — fused with kv_b2_proj via BlitzDecodeWeights
     torch_matmul3_weights_flat = torch_matmul3_weights.reshape(num_tp * NUM_QNOPE_HEADS * QNOPE_HEAD_DIM, QNOPE_OUT_DIM)
-    matmul3_weights_overlapped, _ = bdw.get_tt_kv_b12_proj_weights(
+    kv_b12 = bdw.get_tt_kv_b12_proj_weights(
         torch_matmul3_weights_flat,
         torch_kv_b2_proj_weights,
     )
+    matmul3_weights_overlapped = kv_b12["kv_b1_proj"]
 
     # SDPA input tensor - height sharded on SDPA input grid (cols 0-3, rows 1-2)
     # After 3-phase CreateQHeads tilization:
@@ -572,14 +572,7 @@ def test_pre_sdpa(
     torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
 
     # Fused o_proj, gate_mm, and RMSNorm gammas — we only need the 3 gamma overlapped views.
-    (
-        _,  # o_proj
-        _,  # gate_mm
-        gamma_overlapped,
-        rmsnorm2_gamma_overlapped,
-        dkv_rmsnorm_gamma_overlapped,
-        _,  # ffn_norm
-    ) = bdw.get_tt_o_proj_and_gate_mm_weights(
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
         torch_o_proj_weights,
         torch_gate_mm_weights,
         torch_gamma,
@@ -587,6 +580,9 @@ def test_pre_sdpa(
         torch_dkv_rmsnorm_gamma,
         torch_ffn_norm,
     )
+    gamma_overlapped = o_norms["attn_norm"]
+    rmsnorm2_gamma_overlapped = o_norms["q_norm"]
+    dkv_rmsnorm_gamma_overlapped = o_norms["kv_norm"]
 
     # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
     krope_num_cores = kv_cache_branch_rope_crs.num_cores()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -80,7 +80,7 @@ def _deallocate_layer(layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWei
     ):
         ot = getattr(layer, f, None)
         if ot is not None and hasattr(ot, "fused_tensor"):
-            fid = id(ot.fused_tensor)
+            fid = ot.fused_tensor.tensor_id
             if fid not in seen:
                 seen.add(fid)
                 ttnn.deallocate(ot.fused_tensor, force=True)
@@ -169,25 +169,25 @@ def _assert_layer_on_device_with_topology(
     # Check fusion groups via one representative OverlappedTensor per group
     # q_ab_kv_a
     _assert_on_device(layer.q_a_proj.fused_tensor)
-    fid = id(layer.q_a_proj.fused_tensor)
+    fid = layer.q_a_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         _assert_topology(layer.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # o_proj_gate_mm_norms
     _assert_on_device(layer.o_proj.fused_tensor)
-    fid = id(layer.o_proj.fused_tensor)
+    fid = layer.o_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         _assert_topology(layer.o_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # kv_b12
     _assert_on_device(layer.kv_b1_proj.fused_tensor)
-    fid = id(layer.kv_b1_proj.fused_tensor)
+    fid = layer.kv_b1_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         _assert_topology(layer.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # gate_up
     _assert_on_device(layer.shared_gate_proj.fused_tensor)
-    fid = id(layer.shared_gate_proj.fused_tensor)
+    fid = layer.shared_gate_proj.fused_tensor.tensor_id
     if fid not in seen_fused:
         seen_fused.add(fid)
         _assert_topology(layer.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
@@ -805,11 +805,11 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert layer.routed_up_proj.shape == orig.routed_up_proj.shape
     assert layer.routed_down_proj.shape == orig.routed_down_proj.shape
 
-    assert id(layer.q_a_proj.fused_tensor) == id(layer.q_b_proj.fused_tensor)
-    assert id(layer.q_b_proj.fused_tensor) == id(layer.kv_a_proj.fused_tensor)
-    assert id(layer.o_proj.fused_tensor) == id(layer.attn_norm.fused_tensor)
-    assert id(layer.kv_b1_proj.fused_tensor) == id(layer.kv_b2_proj.fused_tensor)
-    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    assert layer.q_a_proj.fused_tensor.tensor_id == layer.q_b_proj.fused_tensor.tensor_id
+    assert layer.q_b_proj.fused_tensor.tensor_id == layer.kv_a_proj.fused_tensor.tensor_id
+    assert layer.o_proj.fused_tensor.tensor_id == layer.attn_norm.fused_tensor.tensor_id
+    assert layer.kv_b1_proj.fused_tensor.tensor_id == layer.kv_b2_proj.fused_tensor.tensor_id
+    assert layer.shared_gate_proj.fused_tensor.tensor_id == layer.shared_up_proj.fused_tensor.tensor_id
     _assert_layer_on_device_with_topology(layer)
 
 
@@ -957,7 +957,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
         assert layer.routed_up_proj[e].shape == orig.routed_up_proj[e].shape
         assert layer.routed_down_proj[e].shape == orig.routed_down_proj[e].shape
 
-    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    assert layer.shared_gate_proj.fused_tensor.tensor_id == layer.shared_up_proj.fused_tensor.tensor_id
     _assert_layer_on_device_with_topology(layer)
 
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -14,7 +14,6 @@ Tests for prepare_weights: per-layer prepare/save/load on 4x2 mesh.
 """
 
 import time
-from dataclasses import fields as dataclass_fields
 
 import pytest
 import torch
@@ -105,9 +104,6 @@ def _core_range_set_to_tuples(crs):
     return sorted(((r.start.x, r.start.y), (r.end.x, r.end.y)) for r in crs.ranges())
 
 
-_OVERLAPPED_TENSOR_SKIPPED_FIELDS = {"fused_tensor"}
-
-
 def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -> None:
     """Assert two OverlappedTensors have matching metadata (not fused_tensor identity)."""
     assert a.tensor_shape == b.tensor_shape
@@ -117,10 +113,6 @@ def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -
     assert a.byte_offset == b.byte_offset
     assert a.total_size == b.total_size
     assert _core_range_set_to_tuples(a.core_range_set) == _core_range_set_to_tuples(b.core_range_set)
-    checked = {"tensor_shape", "shard_shape", "dtype", "tile_shape", "byte_offset", "total_size", "core_range_set"}
-    all_fields = {f.name for f in dataclass_fields(OverlappedTensor)}
-    unchecked = all_fields - checked - _OVERLAPPED_TENSOR_SKIPPED_FIELDS
-    assert not unchecked, f"OverlappedTensor has new fields not covered by assertion: {unchecked}"
 
 
 def _assert_on_device(tensor: ttnn.Tensor) -> None:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -36,6 +36,11 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     DenseRoutedExpertWeights,
     MoERoutedExpertWeights,
     SharedExpertWeights,
+    load_dense_decoder_layer,
+    load_embedding_weights,
+    load_lm_head_weights,
+    load_moe_decoder_layer,
+    load_mtp_weights,
     prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
@@ -44,6 +49,13 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     prepare_mtp_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
+    save_attention_weights,
+    save_decoder_layer,
+    save_embedding_weights,
+    save_lm_head_weights,
+    save_mtp_weights,
+    save_routed_expert_weights,
+    save_shared_expert_weights,
 )
 from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, CacheContext, TensorCache
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -153,8 +153,6 @@ def _test_cache_context(mesh_shape: tuple[int, int] = (4, 2)) -> CacheContext:
 
 
 # Expected placements for 4x2 mesh (mla_tp=2, moe_tp=8)
-_PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]
-_PLACEMENTS_SHARD_NONE_0 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(0)]
 _PLACEMENTS_SHARD_0_1 = [ttnn.PlacementShard(0), ttnn.PlacementShard(1)]
 _PLACEMENTS_REPLICATE = [ttnn.PlacementReplicate()]
 
@@ -180,19 +178,19 @@ def _assert_layer_on_device_with_topology(
     fid = id(layer.q_a_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+        _assert_topology(layer.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # o_proj_gate_mm_norms
     _assert_on_device(layer.o_proj.fused_tensor)
     fid = id(layer.o_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+        _assert_topology(layer.o_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # kv_b12
     _assert_on_device(layer.kv_b1_proj.fused_tensor)
     fid = id(layer.kv_b1_proj.fused_tensor)
     if fid not in seen_fused:
         seen_fused.add(fid)
-        _assert_topology(layer.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0)
+        _assert_topology(layer.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
     # gate_up
     _assert_on_device(layer.shared_gate_proj.fused_tensor)
     fid = id(layer.shared_gate_proj.fused_tensor)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -27,7 +27,6 @@ from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
 OverlappedTensor = ttnn.OverlappedTensor
 from models.demos.deepseek_v3_b1.prepare_weights import (
     _MTP_LAYER_IDX,
-    CURRENT_TRANSFORM_VERSION,
     AttentionWeights,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
@@ -37,11 +36,6 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     DenseRoutedExpertWeights,
     MoERoutedExpertWeights,
     SharedExpertWeights,
-    load_dense_decoder_layer,
-    load_embedding_weights,
-    load_lm_head_weights,
-    load_moe_decoder_layer,
-    load_mtp_weights,
     prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
@@ -50,13 +44,6 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     prepare_mtp_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
-    save_attention_weights,
-    save_decoder_layer,
-    save_embedding_weights,
-    save_lm_head_weights,
-    save_mtp_weights,
-    save_routed_expert_weights,
-    save_shared_expert_weights,
 )
 from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, CacheContext, TensorCache
 
@@ -141,7 +128,7 @@ def _test_cache_context(mesh_shape: tuple[int, int] = (4, 2)) -> CacheContext:
         schema_version=1,
         hf_model_id="test-model",
         hf_revision="test-rev",
-        transform_version=CURRENT_TRANSFORM_VERSION,
+        transform_version=1,
         mesh_shape=mesh_shape,
     )
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -22,8 +22,10 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
+
+OverlappedTensor = ttnn.OverlappedTensor
 from models.demos.deepseek_v3_b1.prepare_weights import (
     _MTP_LAYER_IDX,
     CURRENT_TRANSFORM_VERSION,

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Roundtrip tests for overlapped tensor serialization
+(dump_overlapped_tensors / load_overlapped_tensors).
+
+Creates OverlappedTensor views via overlap_tensors, dumps them to disk,
+loads them back, and verifies that both the metadata (shapes, dtypes,
+core ranges, byte offsets) and raw tensor data survive the roundtrip.
+"""
+
+import pathlib
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedShardSpec, OverlappedTensor, overlap_tensors
+
+
+def _core_range_set_eq(a: ttnn.CoreRangeSet, b: ttnn.CoreRangeSet) -> bool:
+    """Compare two CoreRangeSets by their sorted range tuples."""
+
+    def _key(crs):
+        return sorted((r.start.x, r.start.y, r.end.x, r.end.y) for r in crs.ranges())
+
+    return _key(a) == _key(b)
+
+
+def _assert_overlapped_metadata_eq(original: OverlappedTensor, loaded: OverlappedTensor, idx: int):
+    """Assert all metadata fields of two OverlappedTensor views match."""
+    assert (
+        original.tensor_shape == loaded.tensor_shape
+    ), f"view[{idx}] tensor_shape: {original.tensor_shape} != {loaded.tensor_shape}"
+    assert (
+        original.shard_shape == loaded.shard_shape
+    ), f"view[{idx}] shard_shape: {original.shard_shape} != {loaded.shard_shape}"
+    assert _core_range_set_eq(original.core_range_set, loaded.core_range_set), f"view[{idx}] core_range_set mismatch"
+    assert original.dtype == loaded.dtype, f"view[{idx}] dtype: {original.dtype} != {loaded.dtype}"
+    assert (
+        original.tile_shape == loaded.tile_shape
+    ), f"view[{idx}] tile_shape: {original.tile_shape} != {loaded.tile_shape}"
+    assert (
+        original.byte_offset == loaded.byte_offset
+    ), f"view[{idx}] byte_offset: {original.byte_offset} != {loaded.byte_offset}"
+
+
+def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
+    """Roundtrip: two BFP8 sub-tensors on same cores, single lane."""
+    torch.manual_seed(0)
+
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    t1 = torch.randn(512, 512, dtype=torch.bfloat16)
+    t2 = torch.randn(256, 512, dtype=torch.bfloat16)
+
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
+    spec2 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+
+    views = overlap_tensors([[(t1, spec1), (t2, spec2)]], device=device)
+    assert len(views) == 2
+
+    file_name = str(tmp_path / "single_lane.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
+    assert len(loaded) == len(views)
+
+    for i, (orig, ld) in enumerate(zip(views, loaded)):
+        _assert_overlapped_metadata_eq(orig, ld, i)
+
+    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    assert orig_torch.shape == loaded_torch.shape
+    assert torch.equal(orig_torch, loaded_torch)
+
+
+def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device):
+    """Roundtrip: two lanes with different core ranges and dtypes."""
+    torch.manual_seed(42)
+
+    crs_a = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    crs_b = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0))})
+
+    t_bfp8 = torch.randn(512, 512, dtype=torch.bfloat16)
+    t_bf16 = torch.randn(128, 128, dtype=torch.bfloat16)
+
+    spec_bfp8 = OverlappedShardSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
+    spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=ttnn.bfloat16)
+
+    views = overlap_tensors(
+        [[(t_bfp8, spec_bfp8)], [(t_bf16, spec_bf16)]],
+        device=device,
+    )
+    assert len(views) == 2
+
+    file_name = str(tmp_path / "multi_lane.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
+    assert len(loaded) == len(views)
+
+    for i, (orig, ld) in enumerate(zip(views, loaded)):
+        _assert_overlapped_metadata_eq(orig, ld, i)
+
+    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    assert torch.equal(orig_torch, loaded_torch)
+
+
+def test_overlapped_tensor_roundtrip_to_device(tmp_path, device):
+    """Roundtrip with load-to-device: loads directly onto device."""
+    torch.manual_seed(7)
+
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    t1 = torch.randn(256, 512, dtype=torch.bfloat16)
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+
+    views = overlap_tensors([[(t1, spec1)]], device=device)
+
+    file_name = str(tmp_path / "to_device.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=device)
+    assert len(loaded) == 1
+    assert loaded[0].fused_tensor.is_allocated()
+
+    _assert_overlapped_metadata_eq(views[0], loaded[0], 0)
+
+    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    assert torch.equal(orig_torch, loaded_torch)
+
+
+def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
+    """Roundtrip with HEIGHT_SHARDED sub-tensors."""
+    torch.manual_seed(13)
+
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    t1 = torch.randn(512, 256, dtype=torch.bfloat16)
+    spec1 = OverlappedShardSpec(
+        core_range_set=crs,
+        raw_tensor_shape=(512, 256),
+        dtype=ttnn.bfloat8_b,
+        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    )
+
+    views = overlap_tensors([[(t1, spec1)]], device=device)
+
+    file_name = str(tmp_path / "height_sharded.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
+    assert len(loaded) == 1
+    _assert_overlapped_metadata_eq(views[0], loaded[0], 0)
+
+    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    assert torch.equal(orig_torch, loaded_torch)
+
+
+def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
+    """Roundtrip with mixed tile sizes (32x32 BFP8 + 1x32 BF16 gamma)."""
+    torch.manual_seed(99)
+
+    crs_main = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    crs_gamma = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(4, 0))})
+
+    t_main = torch.randn(256, 512, dtype=torch.bfloat16)
+    t_gamma = torch.randn(1, 32, dtype=torch.bfloat16)
+
+    spec_main = OverlappedShardSpec(core_range_set=crs_main, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+    spec_gamma = OverlappedShardSpec(
+        core_range_set=crs_gamma,
+        raw_tensor_shape=(1, 32),
+        dtype=ttnn.bfloat16,
+        tile_h=1,
+        tile_w=32,
+    )
+
+    views = overlap_tensors(
+        [[(t_main, spec_main)], [(t_gamma, spec_gamma)]],
+        device=device,
+    )
+    assert len(views) == 2
+
+    file_name = str(tmp_path / "mixed_tiles.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
+    assert len(loaded) == 2
+
+    for i, (orig, ld) in enumerate(zip(views, loaded)):
+        _assert_overlapped_metadata_eq(orig, ld, i)
+
+    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    assert torch.equal(orig_torch, loaded_torch)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device):
+    """Roundtrip serialization with TP on a 4x2 mesh.
+
+    Creates two sub-tensors on the same core range:
+      - t1: replicated across all devices (no TP)
+      - t2: TP-sharded along width across mesh columns (tp_dim=(None, 1))
+
+    The fused tensor has different data on each mesh column. Verifies
+    that after dump+load, each device gets back its original data.
+    """
+    mesh = bh_2d_mesh_device
+    if mesh.shape[0] * mesh.shape[1] < 8:
+        pytest.skip("Test requires 4x2 mesh (8 devices)")
+
+    submesh = mesh.create_submesh(ttnn.MeshShape((4, 2)))
+    mesh_rows, mesh_cols = 4, 2
+
+    torch.manual_seed(42)
+
+    crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+
+    t1 = torch.randn(512, 512, dtype=torch.bfloat16)
+    t2 = torch.randn(256, 1024, dtype=torch.bfloat16)
+
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
+    spec2 = OverlappedShardSpec(
+        core_range_set=crs,
+        raw_tensor_shape=(256, 1024),
+        dtype=ttnn.bfloat8_b,
+        tp_dim=(None, 1),
+    )
+
+    views = overlap_tensors([[(t1, spec1), (t2, spec2)]], device=submesh)
+    assert len(views) == 2
+
+    file_name = str(tmp_path / "tp_4x2.overlappedtensorbin")
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+
+    loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=submesh)
+    assert len(loaded) == len(views)
+
+    for i, (orig, ld) in enumerate(zip(views, loaded)):
+        _assert_overlapped_metadata_eq(orig, ld, i)
+
+    assert loaded[0].fused_tensor.is_allocated()
+
+    orig_shards = ttnn.get_device_tensors(views[0].fused_tensor)
+    loaded_shards = ttnn.get_device_tensors(loaded[0].fused_tensor)
+    assert len(orig_shards) == len(loaded_shards) == mesh_rows * mesh_cols
+
+    for dev_idx in range(len(orig_shards)):
+        orig_cpu = ttnn.to_torch(orig_shards[dev_idx])
+        loaded_cpu = ttnn.to_torch(loaded_shards[dev_idx])
+        assert torch.equal(orig_cpu, loaded_cpu), f"Data mismatch on device {dev_idx}"
+
+    ttnn.close_mesh_device(submesh)

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -45,6 +45,9 @@ def _assert_overlapped_metadata_eq(original: OverlappedTensor, loaded: Overlappe
     assert (
         original.byte_offset == loaded.byte_offset
     ), f"view[{key}] byte_offset: {original.byte_offset} != {loaded.byte_offset}"
+    assert (
+        original.total_size == loaded.total_size
+    ), f"view[{key}] total_size: {original.total_size} != {loaded.total_size}"
 
 
 def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -58,19 +58,19 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
     spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
     spec2 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
 
-    views = overlap_tensors([[(t1, spec1), (t2, spec2)]], device=device)
+    views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=device)
     assert len(views) == 2
 
     file_name = str(tmp_path / "single_lane.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == len(views)
 
-    for i, (orig, ld) in enumerate(zip(views, loaded)):
+    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
         _assert_overlapped_metadata_eq(orig, ld, i)
 
-    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
     loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
     assert orig_torch.shape == loaded_torch.shape
     assert torch.equal(orig_torch, loaded_torch)
@@ -90,21 +90,21 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device):
     spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=ttnn.bfloat16)
 
     views = overlap_tensors(
-        [[(t_bfp8, spec_bfp8)], [(t_bf16, spec_bf16)]],
+        [[("bfp8", t_bfp8, spec_bfp8)], [("bf16", t_bf16, spec_bf16)]],
         device=device,
     )
     assert len(views) == 2
 
     file_name = str(tmp_path / "multi_lane.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == len(views)
 
-    for i, (orig, ld) in enumerate(zip(views, loaded)):
+    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
         _assert_overlapped_metadata_eq(orig, ld, i)
 
-    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    orig_torch = ttnn.to_torch(views["bfp8"].fused_tensor)
     loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
@@ -117,18 +117,18 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device):
     t1 = torch.randn(256, 512, dtype=torch.bfloat16)
     spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
 
-    views = overlap_tensors([[(t1, spec1)]], device=device)
+    views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "to_device.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=device)
     assert len(loaded) == 1
     assert loaded[0].fused_tensor.is_allocated()
 
-    _assert_overlapped_metadata_eq(views[0], loaded[0], 0)
+    _assert_overlapped_metadata_eq(views["t1"], loaded[0], 0)
 
-    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
     loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
@@ -146,16 +146,16 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     )
 
-    views = overlap_tensors([[(t1, spec1)]], device=device)
+    views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "height_sharded.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == 1
-    _assert_overlapped_metadata_eq(views[0], loaded[0], 0)
+    _assert_overlapped_metadata_eq(views["t1"], loaded[0], 0)
 
-    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
     loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
@@ -180,21 +180,21 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
     )
 
     views = overlap_tensors(
-        [[(t_main, spec_main)], [(t_gamma, spec_gamma)]],
+        [[("main", t_main, spec_main)], [("gamma", t_gamma, spec_gamma)]],
         device=device,
     )
     assert len(views) == 2
 
     file_name = str(tmp_path / "mixed_tiles.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == 2
 
-    for i, (orig, ld) in enumerate(zip(views, loaded)):
+    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
         _assert_overlapped_metadata_eq(orig, ld, i)
 
-    orig_torch = ttnn.to_torch(views[0].fused_tensor)
+    orig_torch = ttnn.to_torch(views["main"].fused_tensor)
     loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
@@ -236,21 +236,21 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device):
         tp_dim=(None, 1),
     )
 
-    views = overlap_tensors([[(t1, spec1), (t2, spec2)]], device=submesh)
+    views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=submesh)
     assert len(views) == 2
 
     file_name = str(tmp_path / "tp_4x2.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=submesh)
     assert len(loaded) == len(views)
 
-    for i, (orig, ld) in enumerate(zip(views, loaded)):
+    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
         _assert_overlapped_metadata_eq(orig, ld, i)
 
     assert loaded[0].fused_tensor.is_allocated()
 
-    orig_shards = ttnn.get_device_tensors(views[0].fused_tensor)
+    orig_shards = ttnn.get_device_tensors(views["t1"].fused_tensor)
     loaded_shards = ttnn.get_device_tensors(loaded[0].fused_tensor)
     assert len(orig_shards) == len(loaded_shards) == mesh_rows * mesh_cols
 

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -93,7 +93,7 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device, dtype):
     t_bf16 = torch.randn(128, 128, dtype=torch.bfloat16)
 
     spec_primary = OverlappedShardSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=dtype)
-    spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=ttnn.bfloat16)
+    spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=dtype)
 
     views = overlap_tensors(
         [[("primary", t_primary, spec_primary)], [("bf16", t_bf16, spec_bf16)]],
@@ -184,7 +184,7 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device, dtype):
     spec_gamma = OverlappedShardSpec(
         core_range_set=crs_gamma,
         raw_tensor_shape=(1, 32),
-        dtype=ttnn.bfloat16,
+        dtype=dtype,
         tile_h=1,
         tile_w=32,
     )

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -50,16 +50,17 @@ def _assert_overlapped_metadata_eq(original: OverlappedTensor, loaded: Overlappe
     ), f"view[{key}] total_size: {original.total_size} != {loaded.total_size}"
 
 
-def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
-    """Roundtrip: two BFP8 sub-tensors on same cores, single lane."""
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device, dtype):
+    """Roundtrip: two sub-tensors on same cores, single lane."""
     torch.manual_seed(0)
 
     crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     t1 = torch.randn(512, 512, dtype=torch.bfloat16)
     t2 = torch.randn(256, 512, dtype=torch.bfloat16)
 
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
-    spec2 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
+    spec2 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
     views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=device)
     assert len(views) == 2
@@ -80,21 +81,22 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
     assert torch.equal(orig_torch, loaded_torch)
 
 
-def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device):
-    """Roundtrip: two lanes with different core ranges and dtypes."""
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device, dtype):
+    """Roundtrip: two lanes with different core ranges, primary dtype parameterized."""
     torch.manual_seed(42)
 
     crs_a = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     crs_b = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0))})
 
-    t_bfp8 = torch.randn(512, 512, dtype=torch.bfloat16)
+    t_primary = torch.randn(512, 512, dtype=torch.bfloat16)
     t_bf16 = torch.randn(128, 128, dtype=torch.bfloat16)
 
-    spec_bfp8 = OverlappedShardSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
+    spec_primary = OverlappedShardSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=dtype)
     spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=ttnn.bfloat16)
 
     views = overlap_tensors(
-        [[("bfp8", t_bfp8, spec_bfp8)], [("bf16", t_bf16, spec_bf16)]],
+        [[("primary", t_primary, spec_primary)], [("bf16", t_bf16, spec_bf16)]],
         device=device,
     )
     assert len(views) == 2
@@ -109,18 +111,19 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device):
     for name in views:
         _assert_overlapped_metadata_eq(views[name], loaded[name], name)
 
-    orig_torch = ttnn.to_torch(views["bfp8"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded["bfp8"].fused_tensor)
+    orig_torch = ttnn.to_torch(views["primary"].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["primary"].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
 
-def test_overlapped_tensor_roundtrip_to_device(tmp_path, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_to_device(tmp_path, device, dtype):
     """Roundtrip with load-to-device: loads directly onto device."""
     torch.manual_seed(7)
 
     crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     t1 = torch.randn(256, 512, dtype=torch.bfloat16)
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
     views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
@@ -138,7 +141,8 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device):
     assert torch.equal(orig_torch, loaded_torch)
 
 
-def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device, dtype):
     """Roundtrip with HEIGHT_SHARDED sub-tensors."""
     torch.manual_seed(13)
 
@@ -147,7 +151,7 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
     spec1 = OverlappedShardSpec(
         core_range_set=crs,
         raw_tensor_shape=(512, 256),
-        dtype=ttnn.bfloat8_b,
+        dtype=dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     )
 
@@ -165,8 +169,9 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
     assert torch.equal(orig_torch, loaded_torch)
 
 
-def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
-    """Roundtrip with mixed tile sizes (32x32 BFP8 + 1x32 BF16 gamma)."""
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device, dtype):
+    """Roundtrip with mixed tile sizes (32x32 parameterized dtype + 1x32 BF16 gamma)."""
     torch.manual_seed(99)
 
     crs_main = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
@@ -175,7 +180,7 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
     t_main = torch.randn(256, 512, dtype=torch.bfloat16)
     t_gamma = torch.randn(1, 32, dtype=torch.bfloat16)
 
-    spec_main = OverlappedShardSpec(core_range_set=crs_main, raw_tensor_shape=(256, 512), dtype=ttnn.bfloat8_b)
+    spec_main = OverlappedShardSpec(core_range_set=crs_main, raw_tensor_shape=(256, 512), dtype=dtype)
     spec_gamma = OverlappedShardSpec(
         core_range_set=crs_gamma,
         raw_tensor_shape=(1, 32),
@@ -210,7 +215,8 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device):
+@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device, dtype):
     """Roundtrip serialization with TP on a 4x2 mesh.
 
     Creates two sub-tensors on the same core range:
@@ -234,11 +240,11 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device):
     t1 = torch.randn(512, 512, dtype=torch.bfloat16)
     t2 = torch.randn(256, 1024, dtype=torch.bfloat16)
 
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=ttnn.bfloat8_b)
+    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
     spec2 = OverlappedShardSpec(
         core_range_set=crs,
         raw_tensor_shape=(256, 1024),
-        dtype=ttnn.bfloat8_b,
+        dtype=dtype,
         tp_dim=(None, 1),
     )
 

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -29,22 +29,22 @@ def _core_range_set_eq(a: ttnn.CoreRangeSet, b: ttnn.CoreRangeSet) -> bool:
     return _key(a) == _key(b)
 
 
-def _assert_overlapped_metadata_eq(original: OverlappedTensor, loaded: OverlappedTensor, idx: int):
+def _assert_overlapped_metadata_eq(original: OverlappedTensor, loaded: OverlappedTensor, key: str | int):
     """Assert all metadata fields of two OverlappedTensor views match."""
     assert (
         original.tensor_shape == loaded.tensor_shape
-    ), f"view[{idx}] tensor_shape: {original.tensor_shape} != {loaded.tensor_shape}"
+    ), f"view[{key}] tensor_shape: {original.tensor_shape} != {loaded.tensor_shape}"
     assert (
         original.shard_shape == loaded.shard_shape
-    ), f"view[{idx}] shard_shape: {original.shard_shape} != {loaded.shard_shape}"
-    assert _core_range_set_eq(original.core_range_set, loaded.core_range_set), f"view[{idx}] core_range_set mismatch"
-    assert original.dtype == loaded.dtype, f"view[{idx}] dtype: {original.dtype} != {loaded.dtype}"
+    ), f"view[{key}] shard_shape: {original.shard_shape} != {loaded.shard_shape}"
+    assert _core_range_set_eq(original.core_range_set, loaded.core_range_set), f"view[{key}] core_range_set mismatch"
+    assert original.dtype == loaded.dtype, f"view[{key}] dtype: {original.dtype} != {loaded.dtype}"
     assert (
         original.tile_shape == loaded.tile_shape
-    ), f"view[{idx}] tile_shape: {original.tile_shape} != {loaded.tile_shape}"
+    ), f"view[{key}] tile_shape: {original.tile_shape} != {loaded.tile_shape}"
     assert (
         original.byte_offset == loaded.byte_offset
-    ), f"view[{idx}] byte_offset: {original.byte_offset} != {loaded.byte_offset}"
+    ), f"view[{key}] byte_offset: {original.byte_offset} != {loaded.byte_offset}"
 
 
 def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
@@ -62,16 +62,17 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device):
     assert len(views) == 2
 
     file_name = str(tmp_path / "single_lane.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == len(views)
+    assert set(loaded.keys()) == set(views.keys())
 
-    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
-        _assert_overlapped_metadata_eq(orig, ld, i)
+    for name in views:
+        _assert_overlapped_metadata_eq(views[name], loaded[name], name)
 
     orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["t1"].fused_tensor)
     assert orig_torch.shape == loaded_torch.shape
     assert torch.equal(orig_torch, loaded_torch)
 
@@ -96,16 +97,17 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device):
     assert len(views) == 2
 
     file_name = str(tmp_path / "multi_lane.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == len(views)
+    assert set(loaded.keys()) == set(views.keys())
 
-    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
-        _assert_overlapped_metadata_eq(orig, ld, i)
+    for name in views:
+        _assert_overlapped_metadata_eq(views[name], loaded[name], name)
 
     orig_torch = ttnn.to_torch(views["bfp8"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["bfp8"].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
 
@@ -120,16 +122,16 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device):
     views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "to_device.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=device)
     assert len(loaded) == 1
-    assert loaded[0].fused_tensor.is_allocated()
+    assert loaded["t1"].fused_tensor.is_allocated()
 
-    _assert_overlapped_metadata_eq(views["t1"], loaded[0], 0)
+    _assert_overlapped_metadata_eq(views["t1"], loaded["t1"], "t1")
 
     orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["t1"].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
 
@@ -149,14 +151,14 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device):
     views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "height_sharded.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == 1
-    _assert_overlapped_metadata_eq(views["t1"], loaded[0], 0)
+    _assert_overlapped_metadata_eq(views["t1"], loaded["t1"], "t1")
 
     orig_torch = ttnn.to_torch(views["t1"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["t1"].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
 
@@ -186,16 +188,17 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device):
     assert len(views) == 2
 
     file_name = str(tmp_path / "mixed_tiles.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name)
     assert len(loaded) == 2
+    assert set(loaded.keys()) == set(views.keys())
 
-    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
-        _assert_overlapped_metadata_eq(orig, ld, i)
+    for name in views:
+        _assert_overlapped_metadata_eq(views[name], loaded[name], name)
 
     orig_torch = ttnn.to_torch(views["main"].fused_tensor)
-    loaded_torch = ttnn.to_torch(loaded[0].fused_tensor)
+    loaded_torch = ttnn.to_torch(loaded["main"].fused_tensor)
     assert torch.equal(orig_torch, loaded_torch)
 
 
@@ -240,18 +243,19 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device):
     assert len(views) == 2
 
     file_name = str(tmp_path / "tp_4x2.overlappedtensorbin")
-    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, list(views.values()))
+    ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
 
     loaded = ttnn._ttnn.tensor.load_overlapped_tensors(file_name, device=submesh)
     assert len(loaded) == len(views)
+    assert set(loaded.keys()) == set(views.keys())
 
-    for i, (orig, ld) in enumerate(zip(views.values(), loaded)):
-        _assert_overlapped_metadata_eq(orig, ld, i)
+    for name in views:
+        _assert_overlapped_metadata_eq(views[name], loaded[name], name)
 
-    assert loaded[0].fused_tensor.is_allocated()
+    assert loaded["t1"].fused_tensor.is_allocated()
 
     orig_shards = ttnn.get_device_tensors(views["t1"].fused_tensor)
-    loaded_shards = ttnn.get_device_tensors(loaded[0].fused_tensor)
+    loaded_shards = ttnn.get_device_tensors(loaded["t1"].fused_tensor)
     assert len(orig_shards) == len(loaded_shards) == mesh_rows * mesh_cols
 
     for dev_idx in range(len(orig_shards)):

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedShardSpec, OverlappedTensor, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, OverlappedTensor, overlap_tensors
 
 
 def _core_range_set_eq(a: ttnn.CoreRangeSet, b: ttnn.CoreRangeSet) -> bool:
@@ -59,8 +59,8 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device, dtype):
     t1 = torch.randn(512, 512, dtype=torch.bfloat16)
     t2 = torch.randn(256, 512, dtype=torch.bfloat16)
 
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
-    spec2 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
+    spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
+    spec2 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
     views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=device)
     assert len(views) == 2
@@ -92,8 +92,8 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device, dtype):
     t_primary = torch.randn(512, 512, dtype=torch.bfloat16)
     t_bf16 = torch.randn(128, 128, dtype=torch.bfloat16)
 
-    spec_primary = OverlappedShardSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=dtype)
-    spec_bf16 = OverlappedShardSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=dtype)
+    spec_primary = OverlappedTensorSpec(core_range_set=crs_a, raw_tensor_shape=(512, 512), dtype=dtype)
+    spec_bf16 = OverlappedTensorSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=dtype)
 
     views = overlap_tensors(
         [[("primary", t_primary, spec_primary)], [("bf16", t_bf16, spec_bf16)]],
@@ -123,7 +123,7 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device, dtype):
 
     crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     t1 = torch.randn(256, 512, dtype=torch.bfloat16)
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
+    spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
     views = overlap_tensors([[("t1", t1, spec1)]], device=device)
 
@@ -148,7 +148,7 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device, dtype):
 
     crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     t1 = torch.randn(512, 256, dtype=torch.bfloat16)
-    spec1 = OverlappedShardSpec(
+    spec1 = OverlappedTensorSpec(
         core_range_set=crs,
         raw_tensor_shape=(512, 256),
         dtype=dtype,
@@ -180,8 +180,8 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device, dtype):
     t_main = torch.randn(256, 512, dtype=torch.bfloat16)
     t_gamma = torch.randn(1, 32, dtype=torch.bfloat16)
 
-    spec_main = OverlappedShardSpec(core_range_set=crs_main, raw_tensor_shape=(256, 512), dtype=dtype)
-    spec_gamma = OverlappedShardSpec(
+    spec_main = OverlappedTensorSpec(core_range_set=crs_main, raw_tensor_shape=(256, 512), dtype=dtype)
+    spec_gamma = OverlappedTensorSpec(
         core_range_set=crs_gamma,
         raw_tensor_shape=(1, 32),
         dtype=dtype,
@@ -240,8 +240,8 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device, dtype):
     t1 = torch.randn(512, 512, dtype=torch.bfloat16)
     t2 = torch.randn(256, 1024, dtype=torch.bfloat16)
 
-    spec1 = OverlappedShardSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
-    spec2 = OverlappedShardSpec(
+    spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
+    spec2 = OverlappedTensorSpec(
         core_range_set=crs,
         raw_tensor_shape=(256, 1024),
         dtype=dtype,

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlapEntry, OverlappedTensorSpec, overlap_tensors
 
 OverlappedTensor = ttnn.OverlappedTensor
 
@@ -64,7 +64,7 @@ def test_overlapped_tensor_roundtrip_single_lane(tmp_path, device, dtype):
     spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(512, 512), dtype=dtype)
     spec2 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
-    views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=device)
+    views = overlap_tensors([[OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)]], device=device)
     assert len(views) == 2
 
     file_name = str(tmp_path / "single_lane.overlappedtensorbin")
@@ -98,7 +98,7 @@ def test_overlapped_tensor_roundtrip_multi_lane(tmp_path, device, dtype):
     spec_bf16 = OverlappedTensorSpec(core_range_set=crs_b, raw_tensor_shape=(128, 128), dtype=dtype)
 
     views = overlap_tensors(
-        [[("primary", t_primary, spec_primary)], [("bf16", t_bf16, spec_bf16)]],
+        [[OverlapEntry("primary", t_primary, spec_primary)], [OverlapEntry("bf16", t_bf16, spec_bf16)]],
         device=device,
     )
     assert len(views) == 2
@@ -127,7 +127,7 @@ def test_overlapped_tensor_roundtrip_to_device(tmp_path, device, dtype):
     t1 = torch.randn(256, 512, dtype=torch.bfloat16)
     spec1 = OverlappedTensorSpec(core_range_set=crs, raw_tensor_shape=(256, 512), dtype=dtype)
 
-    views = overlap_tensors([[("t1", t1, spec1)]], device=device)
+    views = overlap_tensors([[OverlapEntry("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "to_device.overlappedtensorbin")
     ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
@@ -157,7 +157,7 @@ def test_overlapped_tensor_roundtrip_height_sharded(tmp_path, device, dtype):
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     )
 
-    views = overlap_tensors([[("t1", t1, spec1)]], device=device)
+    views = overlap_tensors([[OverlapEntry("t1", t1, spec1)]], device=device)
 
     file_name = str(tmp_path / "height_sharded.overlappedtensorbin")
     ttnn._ttnn.tensor.dump_overlapped_tensors(file_name, views)
@@ -192,7 +192,7 @@ def test_overlapped_tensor_roundtrip_mixed_tiles(tmp_path, device, dtype):
     )
 
     views = overlap_tensors(
-        [[("main", t_main, spec_main)], [("gamma", t_gamma, spec_gamma)]],
+        [[OverlapEntry("main", t_main, spec_main)], [OverlapEntry("gamma", t_gamma, spec_gamma)]],
         device=device,
     )
     assert len(views) == 2
@@ -250,7 +250,7 @@ def test_overlapped_tensor_roundtrip_tp_4x2(tmp_path, bh_2d_mesh_device, dtype):
         tp_dim=(None, 1),
     )
 
-    views = overlap_tensors([[("t1", t1, spec1), ("t2", t2, spec2)]], device=submesh)
+    views = overlap_tensors([[OverlapEntry("t1", t1, spec1), OverlapEntry("t2", t2, spec2)]], device=submesh)
     assert len(views) == 2
 
     file_name = str(tmp_path / "tp_4x2.overlappedtensorbin")

--- a/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_overlapped_tensor_serialization.py
@@ -17,7 +17,9 @@ import pytest
 import torch
 
 import ttnn
-from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, OverlappedTensor, overlap_tensors
+from models.demos.deepseek_v3_b1.blitz_overlap_tensors import OverlappedTensorSpec, overlap_tensors
+
+OverlappedTensor = ttnn.OverlappedTensor
 
 
 def _core_range_set_eq(a: ttnn.CoreRangeSet, b: ttnn.CoreRangeSet) -> bool:

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -82,6 +82,7 @@ set(TENSOR_FLATBUFFER_SCHEMAS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/tensor_spec.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/tensor_topology.fbs
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/tensor.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/tensor/flatbuffer/overlapped_tensor.fbs
 )
 
 set(TENSOR_FLATBUFFER_GENERATED_HEADERS)
@@ -156,6 +157,8 @@ target_sources(
         core/reports.cpp
         core/tensor/flatbuffer/tensor_flatbuffer.cpp
         core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+        core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
+        core/tensor/overlapped_serialization.cpp
         core/tensor/host_buffer/functions.cpp
         core/tensor/serialization.cpp
         core/tensor/storage.cpp

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -22,6 +22,7 @@ struct OverlappedTensorView {
     DataType dtype;
     std::array<uint32_t, 2> tile_shape;
     uint64_t byte_offset = 0;
+    uint64_t total_size = 0;
 };
 
 void dump_overlapped_tensors(const std::string& file_name, const std::vector<OverlappedTensorView>& views);

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -14,6 +14,7 @@
 namespace tt::tt_metal {
 
 struct OverlappedTensorView {
+    std::string name;
     Tensor fused_tensor;
     std::array<uint32_t, 2> tensor_shape;
     std::array<uint32_t, 2> shard_shape;

--- a/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/overlapped_tensor.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace tt::tt_metal {
+
+struct OverlappedTensorView {
+    Tensor fused_tensor;
+    std::array<uint32_t, 2> tensor_shape;
+    std::array<uint32_t, 2> shard_shape;
+    CoreRangeSet core_range_set;
+    DataType dtype;
+    std::array<uint32_t, 2> tile_shape;
+    uint64_t byte_offset = 0;
+};
+
+void dump_overlapped_tensors(const std::string& file_name, const std::vector<OverlappedTensorView>& views);
+std::vector<OverlappedTensorView> load_overlapped_tensors(
+    const std::string& file_name, distributed::MeshDevice* device = nullptr);
+
+}  // namespace tt::tt_metal

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
@@ -14,6 +14,7 @@ table OverlappedView {
     tile_h:         uint32;
     tile_w:         uint32;
     byte_offset:    uint64;
+    total_size:     uint64;
 }
 
 table OverlappedTensors {

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
@@ -4,6 +4,7 @@ include "tensor.fbs";
 namespace ttnn.flatbuffer;
 
 table OverlappedView {
+    name:           string;
     tensor_shape_h: uint32;
     tensor_shape_w: uint32;
     shard_shape_h:  uint32;

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor.fbs
@@ -1,0 +1,23 @@
+include "tensor_spec.fbs";
+include "tensor.fbs";
+
+namespace ttnn.flatbuffer;
+
+table OverlappedView {
+    tensor_shape_h: uint32;
+    tensor_shape_w: uint32;
+    shard_shape_h:  uint32;
+    shard_shape_w:  uint32;
+    core_range_set: CoreRangeSet;
+    dtype:          DataType;
+    tile_h:         uint32;
+    tile_w:         uint32;
+    byte_offset:    uint64;
+}
+
+table OverlappedTensors {
+    fused_tensor: Tensor;
+    views: [OverlappedView];
+}
+
+root_type OverlappedTensors;

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
@@ -39,7 +39,8 @@ flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuf
             ttnn::to_flatbuffer(v.dtype),
             v.tile_shape[0],
             v.tile_shape[1],
-            v.byte_offset));
+            v.byte_offset,
+            v.total_size));
     }
 
     auto views_vec = builder.CreateVector(view_offsets);
@@ -68,6 +69,7 @@ std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuff
             .dtype = ttnn::from_flatbuffer(fb_view->dtype()),
             .tile_shape = {fb_view->tile_h(), fb_view->tile_w()},
             .byte_offset = fb_view->byte_offset(),
+            .total_size = fb_view->total_size(),
         });
     }
     return result;

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp"
+#include "tensor/flatbuffer/tensor_flatbuffer.hpp"
+#include "tensor/flatbuffer/tensor_spec_flatbuffer.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+
+#include "overlapped_tensor_generated.h"
+
+#include <vector>
+#include <cstdint>
+
+namespace ttnn {
+
+flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuffer(
+    const std::vector<tt::tt_metal::OverlappedTensorView>& views,
+    flatbuffers::FlatBufferBuilder& builder,
+    std::vector<tt::tt_metal::HostBuffer>& buffers) {
+    TT_FATAL(!views.empty(), "Need at least one OverlappedTensorView to serialize");
+
+    auto fused_offset = ttnn::to_flatbuffer(views[0].fused_tensor, builder, buffers);
+
+    std::vector<flatbuffers::Offset<flatbuffer::OverlappedView>> view_offsets;
+    view_offsets.reserve(views.size());
+    for (const auto& v : views) {
+        auto crs_offset = ttnn::to_flatbuffer(builder, v.core_range_set);
+        view_offsets.push_back(flatbuffer::CreateOverlappedView(
+            builder,
+            v.tensor_shape[0],
+            v.tensor_shape[1],
+            v.shard_shape[0],
+            v.shard_shape[1],
+            crs_offset,
+            ttnn::to_flatbuffer(v.dtype),
+            v.tile_shape[0],
+            v.tile_shape[1],
+            v.byte_offset));
+    }
+
+    auto views_vec = builder.CreateVector(view_offsets);
+    return flatbuffer::CreateOverlappedTensors(builder, fused_offset, views_vec);
+}
+
+std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuffer(
+    const flatbuffer::OverlappedTensors* fb,
+    tt::stl::Span<std::byte> tensor_data,
+    const tt::tt_metal::MemoryPin& memory_pin) {
+    TT_FATAL(fb != nullptr, "OverlappedTensors flatbuffer pointer must not be null");
+    TT_FATAL(fb->fused_tensor() != nullptr, "fused_tensor is required");
+    TT_FATAL(fb->views() != nullptr && fb->views()->size() > 0, "At least one view is required");
+
+    auto fused = ttnn::from_flatbuffer(fb->fused_tensor(), tensor_data, memory_pin);
+
+    std::vector<tt::tt_metal::OverlappedTensorView> result;
+    result.reserve(fb->views()->size());
+    for (const auto* fb_view : *fb->views()) {
+        result.push_back(tt::tt_metal::OverlappedTensorView{
+            .fused_tensor = fused,
+            .tensor_shape = {fb_view->tensor_shape_h(), fb_view->tensor_shape_w()},
+            .shard_shape = {fb_view->shard_shape_h(), fb_view->shard_shape_w()},
+            .core_range_set = ttnn::from_flatbuffer(fb_view->core_range_set()),
+            .dtype = ttnn::from_flatbuffer(fb_view->dtype()),
+            .tile_shape = {fb_view->tile_h(), fb_view->tile_w()},
+            .byte_offset = fb_view->byte_offset(),
+        });
+    }
+    return result;
+}
+
+}  // namespace ttnn

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.cpp
@@ -26,9 +26,11 @@ flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuf
     std::vector<flatbuffers::Offset<flatbuffer::OverlappedView>> view_offsets;
     view_offsets.reserve(views.size());
     for (const auto& v : views) {
+        auto name_offset = builder.CreateString(v.name);
         auto crs_offset = ttnn::to_flatbuffer(builder, v.core_range_set);
         view_offsets.push_back(flatbuffer::CreateOverlappedView(
             builder,
+            name_offset,
             v.tensor_shape[0],
             v.tensor_shape[1],
             v.shard_shape[0],
@@ -58,6 +60,7 @@ std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuff
     result.reserve(fb->views()->size());
     for (const auto* fb_view : *fb->views()) {
         result.push_back(tt::tt_metal::OverlappedTensorView{
+            .name = fb_view->name() ? fb_view->name()->str() : std::string{},
             .fused_tensor = fused,
             .tensor_shape = {fb_view->tensor_shape_h(), fb_view->tensor_shape_w()},
             .shard_shape = {fb_view->shard_shape_h(), fb_view->shard_shape_w()},

--- a/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt_stl/span.hpp>
+
+#include "overlapped_tensor_generated.h"
+
+#include "ttnn/tensor/overlapped_tensor.hpp"
+
+namespace ttnn {
+
+flatbuffers::Offset<flatbuffer::OverlappedTensors> overlapped_tensors_to_flatbuffer(
+    const std::vector<tt::tt_metal::OverlappedTensorView>& views,
+    flatbuffers::FlatBufferBuilder& builder,
+    std::vector<tt::tt_metal::HostBuffer>& buffers);
+
+std::vector<tt::tt_metal::OverlappedTensorView> overlapped_tensors_from_flatbuffer(
+    const flatbuffer::OverlappedTensors* fb,
+    tt::stl::Span<std::byte> tensor_data,
+    const tt::tt_metal::MemoryPin& memory_pin);
+
+}  // namespace ttnn

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -59,6 +59,9 @@ flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
 
 namespace {
 
+using ttnn::from_flatbuffer;
+using ttnn::to_flatbuffer;
+
 tt::tt_metal::BufferType from_flatbuffer(flatbuffer::BufferType type) {
     switch (type) {
         case flatbuffer::BufferType::DRAM: return tt::tt_metal::BufferType::DRAM;

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -5,7 +5,6 @@
 #include "tensor/flatbuffer/tensor_spec_flatbuffer.hpp"
 
 namespace ttnn {
-namespace {
 
 CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     std::vector<CoreRange> ranges;
@@ -27,6 +26,38 @@ flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
     auto ranges_vector = builder.CreateVector(range_offsets);
     return flatbuffer::CreateCoreRangeSet(builder, ranges_vector);
 }
+
+tt::tt_metal::DataType from_flatbuffer(flatbuffer::DataType type) {
+    switch (type) {
+        case flatbuffer::DataType::BFloat16: return tt::tt_metal::DataType::BFLOAT16;
+        case flatbuffer::DataType::Float32: return tt::tt_metal::DataType::FLOAT32;
+        case flatbuffer::DataType::UInt32: return tt::tt_metal::DataType::UINT32;
+        case flatbuffer::DataType::BFloat8B: return tt::tt_metal::DataType::BFLOAT8_B;
+        case flatbuffer::DataType::BFloat4B: return tt::tt_metal::DataType::BFLOAT4_B;
+        case flatbuffer::DataType::UInt8: return tt::tt_metal::DataType::UINT8;
+        case flatbuffer::DataType::UInt16: return tt::tt_metal::DataType::UINT16;
+        case flatbuffer::DataType::Int32: return tt::tt_metal::DataType::INT32;
+        case flatbuffer::DataType::Invalid: return tt::tt_metal::DataType::INVALID;
+    }
+    TT_THROW("Unsupported DataType from flatbuffer.");
+}
+
+flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
+    switch (type) {
+        case tt::tt_metal::DataType::BFLOAT16: return flatbuffer::DataType::BFloat16;
+        case tt::tt_metal::DataType::FLOAT32: return flatbuffer::DataType::Float32;
+        case tt::tt_metal::DataType::UINT32: return flatbuffer::DataType::UInt32;
+        case tt::tt_metal::DataType::BFLOAT8_B: return flatbuffer::DataType::BFloat8B;
+        case tt::tt_metal::DataType::BFLOAT4_B: return flatbuffer::DataType::BFloat4B;
+        case tt::tt_metal::DataType::UINT8: return flatbuffer::DataType::UInt8;
+        case tt::tt_metal::DataType::UINT16: return flatbuffer::DataType::UInt16;
+        case tt::tt_metal::DataType::INT32: return flatbuffer::DataType::Int32;
+        case tt::tt_metal::DataType::INVALID: return flatbuffer::DataType::Invalid;
+    }
+    TT_THROW("Unsupported DataType to flatbuffer.");
+}
+
+namespace {
 
 tt::tt_metal::BufferType from_flatbuffer(flatbuffer::BufferType type) {
     switch (type) {
@@ -50,21 +81,6 @@ tt::tt_metal::TensorMemoryLayout from_flatbuffer(flatbuffer::TensorMemoryLayout 
     TT_THROW("Unsupported TensorMemoryLayout from flatbuffer.");
 }
 
-tt::tt_metal::DataType from_flatbuffer(flatbuffer::DataType type) {
-    switch (type) {
-        case flatbuffer::DataType::BFloat16: return tt::tt_metal::DataType::BFLOAT16;
-        case flatbuffer::DataType::Float32: return tt::tt_metal::DataType::FLOAT32;
-        case flatbuffer::DataType::UInt32: return tt::tt_metal::DataType::UINT32;
-        case flatbuffer::DataType::BFloat8B: return tt::tt_metal::DataType::BFLOAT8_B;
-        case flatbuffer::DataType::BFloat4B: return tt::tt_metal::DataType::BFLOAT4_B;
-        case flatbuffer::DataType::UInt8: return tt::tt_metal::DataType::UINT8;
-        case flatbuffer::DataType::UInt16: return tt::tt_metal::DataType::UINT16;
-        case flatbuffer::DataType::Int32: return tt::tt_metal::DataType::INT32;
-        case flatbuffer::DataType::Invalid: return tt::tt_metal::DataType::INVALID;
-    }
-    TT_THROW("Unsupported DataType from flatbuffer.");
-}
-
 flatbuffer::TensorMemoryLayout to_flatbuffer(tt::tt_metal::TensorMemoryLayout layout) {
     switch (layout) {
         case tt::tt_metal::TensorMemoryLayout::INTERLEAVED: return flatbuffer::TensorMemoryLayout::Interleaved;
@@ -85,21 +101,6 @@ flatbuffer::BufferType to_flatbuffer(tt::tt_metal::BufferType type) {
         case tt::tt_metal::BufferType::TRACE: return flatbuffer::BufferType::Trace;
     }
     TT_THROW("Unsupported BufferType to flatbuffer.");
-}
-
-flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
-    switch (type) {
-        case tt::tt_metal::DataType::BFLOAT16: return flatbuffer::DataType::BFloat16;
-        case tt::tt_metal::DataType::FLOAT32: return flatbuffer::DataType::Float32;
-        case tt::tt_metal::DataType::UINT32: return flatbuffer::DataType::UInt32;
-        case tt::tt_metal::DataType::BFLOAT8_B: return flatbuffer::DataType::BFloat8B;
-        case tt::tt_metal::DataType::BFLOAT4_B: return flatbuffer::DataType::BFloat4B;
-        case tt::tt_metal::DataType::UINT8: return flatbuffer::DataType::UInt8;
-        case tt::tt_metal::DataType::UINT16: return flatbuffer::DataType::UInt16;
-        case tt::tt_metal::DataType::INT32: return flatbuffer::DataType::Int32;
-        case tt::tt_metal::DataType::INVALID: return flatbuffer::DataType::Invalid;
-    }
-    TT_THROW("Unsupported DataType to flatbuffer.");
 }
 
 tt::tt_metal::ShardOrientation from_flatbuffer(flatbuffer::ShardOrientation orientation) {

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.hpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.hpp
@@ -11,6 +11,13 @@
 
 namespace ttnn {
 
+flatbuffers::Offset<flatbuffer::CoreRangeSet> to_flatbuffer(
+    flatbuffers::FlatBufferBuilder& builder, const CoreRangeSet& core_range_set);
+CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set);
+
+flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type);
+tt::tt_metal::DataType from_flatbuffer(flatbuffer::DataType type);
+
 flatbuffers::Offset<flatbuffer::MemoryConfig> to_flatbuffer(
     const tt::tt_metal::MemoryConfig& config, flatbuffers::FlatBufferBuilder& builder);
 flatbuffers::Offset<flatbuffer::TensorSpec> to_flatbuffer(

--- a/ttnn/core/tensor/overlapped_serialization.cpp
+++ b/ttnn/core/tensor/overlapped_serialization.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/tensor/overlapped_tensor.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cerrno>
+#include <string>
+#include <string_view>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+
+#include <flatbuffers/flatbuffers.h>
+#include <flatbuffers/verifier.h>
+
+#include <tt_stl/cleanup.hpp>
+
+#include "tensor/flatbuffer/overlapped_tensor_flatbuffer.hpp"
+#include "ttnn/distributed/host_ccl.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+void safe_fwrite(const void* buffer, size_t bytes, FILE* file, const std::string& filename, std::string_view what) {
+    TT_FATAL(bytes > 0, "Expected to write > 0 bytes to file");
+    const size_t written = fwrite(buffer, 1, bytes, file);
+    TT_FATAL(
+        written == bytes,
+        "Failed to write {} to \"{}\": wrote {}/{} bytes (ferror={}, errno={} \"{}\")",
+        what,
+        filename,
+        written,
+        bytes,
+        ferror(file),
+        errno,
+        strerror(errno));
+}
+
+constexpr std::uint32_t kOverlappedFlatbufferAlignment = alignof(std::uint64_t);
+
+}  // namespace
+
+void dump_overlapped_tensors(const std::string& file_name, const std::vector<OverlappedTensorView>& views) {
+    TT_FATAL(!views.empty(), "Need at least one view to serialize");
+
+    const auto& fused_ref = views[0].fused_tensor;
+    for (size_t i = 1; i < views.size(); ++i) {
+        TT_FATAL(
+            views[i].fused_tensor.tensor_id == fused_ref.tensor_id,
+            "All OverlappedTensorViews must reference the same fused tensor (view {} differs)",
+            i);
+    }
+
+    Tensor cpu_tensor = views[0].fused_tensor.cpu();
+    cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
+
+    // Build a temporary view list with the CPU-side fused tensor for serialization.
+    std::vector<OverlappedTensorView> cpu_views = views;
+    for (auto& v : cpu_views) {
+        v.fused_tensor = cpu_tensor;
+    }
+
+    const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
+    if (ctx->rank() == distributed::multihost::Rank(0)) {
+        FILE* output_file = fopen(file_name.c_str(), "wb");
+        TT_FATAL(
+            output_file != nullptr,
+            "Cannot open \"{}\" for writing: errno={} \"{}\"",
+            file_name,
+            errno,
+            strerror(errno));
+        auto cleanup = ttsl::make_cleanup([f = output_file, &file_name]() {
+            if (f && fclose(f) != 0) {
+                log_warning(tt::LogAlways, "Failed to close \"{}\"", file_name);
+            }
+        });
+
+        std::vector<HostBuffer> buffers;
+        flatbuffers::FlatBufferBuilder builder;
+        auto root_offset = ttnn::overlapped_tensors_to_flatbuffer(cpu_views, builder, buffers);
+        builder.Align(kOverlappedFlatbufferAlignment);
+        builder.Finish(root_offset);
+
+        const uint64_t header_size = builder.GetSize();
+        safe_fwrite(&header_size, sizeof(header_size), output_file, file_name, "header size");
+        safe_fwrite(builder.GetBufferPointer(), header_size, output_file, file_name, "header");
+
+        for (const auto& buffer : buffers) {
+            auto buffer_view = buffer.view_bytes();
+            TT_FATAL(!buffer_view.empty(), "Unexpected empty buffer during serialization");
+            safe_fwrite(buffer_view.data(), buffer_view.size(), output_file, file_name, "tensor data");
+        }
+
+        TT_FATAL(
+            fflush(output_file) == 0, "Failed to flush \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
+    }
+    ctx->barrier();
+}
+
+std::vector<OverlappedTensorView> load_overlapped_tensors(
+    const std::string& file_name, distributed::MeshDevice* device) {
+    int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
+    TT_FATAL(fd != -1, "Cannot open \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
+    auto cleanup = ttsl::make_cleanup([fd]() { close(fd); });
+
+    struct stat file_stat{};
+    TT_FATAL(fstat(fd, &file_stat) == 0, "Failed to get file stats for \"{}\"", file_name);
+    size_t file_size = file_stat.st_size;
+    TT_FATAL(file_size >= sizeof(uint64_t), "File \"{}\" is too small to be valid", file_name);
+
+    void* mmap_addr = mmap(nullptr, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    TT_FATAL(mmap_addr != MAP_FAILED, "Failed to mmap file \"{}\": {}", file_name, strerror(errno));
+
+    std::shared_ptr<void> mmap_ptr(mmap_addr, [file_size](void* addr) { munmap(addr, file_size); });
+    MemoryPin memory_pin(mmap_ptr);
+
+    auto* file_data = static_cast<std::byte*>(mmap_addr);
+    uint64_t header_size = 0;
+    std::memcpy(&header_size, file_data, sizeof(header_size));
+    TT_FATAL(
+        sizeof(header_size) + header_size <= file_size,
+        "File \"{}\" is truncated or corrupt (header_size={}, file_size={})",
+        file_name,
+        header_size,
+        file_size);
+
+    const auto* header_start = reinterpret_cast<const std::uint8_t*>(file_data) + sizeof(header_size);
+    TT_FATAL(
+        header_size < flatbuffers::Verifier::Options().max_size,
+        "Header size is too large; this most likely indicates data corruption.");
+    flatbuffers::Verifier verifier(header_start, header_size);
+    TT_FATAL(
+        ttnn::flatbuffer::VerifyOverlappedTensorsBuffer(verifier),
+        "Cannot validate overlapped tensor data; this most likely indicates data corruption.");
+    const auto* fb_root = ttnn::flatbuffer::GetOverlappedTensors(header_start);
+
+    const uint64_t data_offset = sizeof(header_size) + header_size;
+    const uint64_t data_size = file_size - data_offset;
+
+    std::byte* data_region = file_data + data_offset;
+    TT_FATAL(
+        (reinterpret_cast<uintptr_t>(data_region) & (kOverlappedFlatbufferAlignment - 1)) == 0,
+        "Tensor data pointer must be 8-byte aligned!");
+
+    auto views =
+        ttnn::overlapped_tensors_from_flatbuffer(fb_root, tt::stl::Span<std::byte>(data_region, data_size), memory_pin);
+
+    if (device != nullptr) {
+        auto& fused = views[0].fused_tensor;
+        fused = fused.to_device(device, fused.tensor_spec().memory_config());
+        for (size_t i = 1; i < views.size(); ++i) {
+            views[i].fused_tensor = fused;
+        }
+    }
+
+    return views;
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn-nanobind/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/core.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
@@ -19,14 +20,40 @@
 #include <reflect>
 
 #include "ttnn/core.hpp"
+#include <tt-metalium/bfloat4.hpp>
+#include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/experimental/lightmetal/lightmetal_binary.hpp>
 #include <tt-metalium/experimental/lightmetal/lightmetal_replay.hpp>
 #include <tt-metalium/experimental/lightmetal/lightmetal_api.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tile.hpp>
 #include "tt_stl/caseless_comparison.hpp"
 #include "ttnn-nanobind/nanobind_helpers.hpp"
 #include "ttnn/config.hpp"
 #include "ttnn/distributed/types.hpp"
+
+namespace {
+
+// Rearrange a flat 2D row-major float buffer into consecutive per-tile
+// row-major blocks expected by pack_as_bfp*_tiles(row_major_input=true).
+std::vector<float> rearrange_to_tile_blocks(const float* src, int H, int W, int tile_h, int tile_w) {
+    const int tiles_r = H / tile_h;
+    const int tiles_c = W / tile_w;
+    std::vector<float> tiled(static_cast<size_t>(H) * W);
+    size_t dst_idx = 0;
+    for (int tr = 0; tr < tiles_r; ++tr) {
+        for (int tc = 0; tc < tiles_c; ++tc) {
+            for (int r = 0; r < tile_h; ++r) {
+                for (int c = 0; c < tile_w; ++c) {
+                    tiled[dst_idx++] = src[(tr * tile_h + r) * W + tc * tile_w + c];
+                }
+            }
+        }
+    }
+    return tiled;
+}
+
+}  // namespace
 
 namespace ttnn::core {
 
@@ -135,6 +162,36 @@ void py_module(nb::module_& mod) {
             >>> ttnn.set_printoptions(profile="short", sci_mode=None)
             >>> ttnn.set_printoptions(profile="short", precision=6)
         )doc");
+
+    mod.def(
+        "tilize_and_pack_bfp8_b",
+        [](nb::ndarray<float, nb::c_contig> data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
+            auto tiled = rearrange_to_tile_blocks(data.data(), H, W, tile_h, tile_w);
+            tt::tt_metal::Tile tile({static_cast<uint32_t>(tile_h), static_cast<uint32_t>(tile_w)});
+            auto packed =
+                pack_as_bfp8_tiles<float>(tt::stl::Span<const float>(tiled.data(), tiled.size()), true, false, tile);
+            return nb::bytes(reinterpret_cast<const char*>(packed.data()), packed.size() * sizeof(uint32_t));
+        },
+        nb::arg("data"),
+        nb::arg("H"),
+        nb::arg("W"),
+        nb::arg("tile_h") = 32,
+        nb::arg("tile_w") = 32);
+
+    mod.def(
+        "tilize_and_pack_bfp4_b",
+        [](nb::ndarray<float, nb::c_contig> data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
+            auto tiled = rearrange_to_tile_blocks(data.data(), H, W, tile_h, tile_w);
+            tt::tt_metal::Tile tile({static_cast<uint32_t>(tile_h), static_cast<uint32_t>(tile_w)});
+            auto packed =
+                pack_as_bfp4_tiles<float>(tt::stl::Span<const float>(tiled.data(), tiled.size()), true, false, tile);
+            return nb::bytes(reinterpret_cast<const char*>(packed.data()), packed.size() * sizeof(uint32_t));
+        },
+        nb::arg("data"),
+        nb::arg("H"),
+        nb::arg("W"),
+        nb::arg("tile_h") = 32,
+        nb::arg("tile_w") = 32);
 
     mod.def("dump_stack_trace_on_segfault", &ttnn::core::dump_stack_trace_on_segfault);
 

--- a/ttnn/cpp/ttnn-nanobind/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/core.cpp
@@ -165,7 +165,7 @@ void py_module(nb::module_& mod) {
 
     mod.def(
         "tilize_and_pack_bfp8_b",
-        [](nb::ndarray<float, nb::c_contig> data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
+        [](const nb::ndarray<float, nb::c_contig>& data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
             auto tiled = rearrange_to_tile_blocks(data.data(), H, W, tile_h, tile_w);
             tt::tt_metal::Tile tile({static_cast<uint32_t>(tile_h), static_cast<uint32_t>(tile_w)});
             auto packed =
@@ -180,7 +180,7 @@ void py_module(nb::module_& mod) {
 
     mod.def(
         "tilize_and_pack_bfp4_b",
-        [](nb::ndarray<float, nb::c_contig> data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
+        [](const nb::ndarray<float, nb::c_contig>& data, int H, int W, int tile_h, int tile_w) -> nb::bytes {
             auto tiled = rearrange_to_tile_blocks(data.data(), H, W, tile_h, tile_w);
             tt::tt_metal::Tile tile({static_cast<uint32_t>(tile_h), static_cast<uint32_t>(tile_w)});
             auto packed =

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -31,6 +31,7 @@
 #include "ttnn-nanobind/json_class.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/serialization.hpp"
+#include "ttnn/tensor/overlapped_tensor.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -621,6 +622,67 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::arg("device") = nullptr,
             R"doc(
                 Load tensor to file using FlatBuffer format with inline file storage.
+            )doc");
+
+    m_tensor
+        .def(
+            "dump_overlapped_tensors",
+            [](const std::string& file_name, nb::list py_views) {
+                constexpr std::string_view kExt = ".overlappedtensorbin";
+                if (file_name.size() < kExt.size() ||
+                    file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
+                    throw std::runtime_error("File " + file_name + " must have " + std::string(kExt) + " extension");
+                }
+                std::vector<OverlappedTensorView> views;
+                views.reserve(nb::len(py_views));
+                for (auto item : py_views) {
+                    nb::object obj = nb::borrow(item);
+                    views.push_back(OverlappedTensorView{
+                        .fused_tensor = nb::cast<Tensor>(obj.attr("fused_tensor")),
+                        .tensor_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tensor_shape")),
+                        .shard_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("shard_shape")),
+                        .core_range_set = nb::cast<CoreRangeSet>(obj.attr("core_range_set")),
+                        .dtype = nb::cast<DataType>(obj.attr("dtype")),
+                        .tile_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tile_shape")),
+                        .byte_offset = nb::cast<uint64_t>(obj.attr("byte_offset")),
+                    });
+                }
+                dump_overlapped_tensors(file_name, views);
+            },
+            nb::arg("file_name"),
+            nb::arg("views"),
+            R"doc(
+                Dump a list of OverlappedTensor to a single file using FlatBuffer format.
+                All views must reference the same fused tensor.
+            )doc")
+        .def(
+            "load_overlapped_tensors",
+            [](const std::string& file_name, MeshDevice* device) -> nb::list {
+                constexpr std::string_view kExt = ".overlappedtensorbin";
+                if (file_name.size() < kExt.size() ||
+                    file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
+                    throw std::runtime_error("File " + file_name + " must have " + std::string(kExt) + " extension");
+                }
+                auto views = load_overlapped_tensors(file_name, device);
+                nb::module_ mod = nb::module_::import_("models.demos.deepseek_v3_b1.blitz_overlap_tensors");
+                nb::object cls = mod.attr("OverlappedTensor");
+                nb::list result;
+                for (const auto& v : views) {
+                    result.append(
+                        cls(nb::cast(v.fused_tensor),
+                            nb::make_tuple(v.tensor_shape[0], v.tensor_shape[1]),
+                            nb::make_tuple(v.shard_shape[0], v.shard_shape[1]),
+                            nb::cast(v.core_range_set),
+                            nb::cast(v.dtype),
+                            nb::make_tuple(v.tile_shape[0], v.tile_shape[1]),
+                            nb::cast(v.byte_offset)));
+                }
+                return result;
+            },
+            nb::arg("file_name"),
+            nb::arg("device") = nullptr,
+            R"doc(
+                Load a list of OverlappedTensor from a file serialized with dump_overlapped_tensors.
             )doc");
 }
 

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -720,7 +720,8 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 auto views = load_overlapped_tensors(file_name, device);
                 nb::dict result;
                 for (auto& v : views) {
-                    result[nb::cast(v.name)] = nb::cast(std::move(v));
+                    auto key = nb::cast(v.name);
+                    result[key] = nb::cast(std::move(v));
                 }
                 return result;
             },

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -688,10 +688,9 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
     m_tensor
         .def(
             "dump_overlapped_tensors",
-            [](const std::string& file_name, nb::dict py_views) {
+            [](const std::string& file_name, const nb::dict& py_views) {
                 constexpr std::string_view kExt = ".overlappedtensorbin";
-                if (file_name.size() < kExt.size() ||
-                    file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
+                if (!file_name.ends_with(kExt)) {
                     throw std::runtime_error("File " + file_name + " must have " + std::string(kExt) + " extension");
                 }
                 std::vector<OverlappedTensorView> views;
@@ -713,8 +712,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             "load_overlapped_tensors",
             [](const std::string& file_name, MeshDevice* device) -> nb::dict {
                 constexpr std::string_view kExt = ".overlappedtensorbin";
-                if (file_name.size() < kExt.size() ||
-                    file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
+                if (!file_name.ends_with(kExt)) {
                     throw std::runtime_error("File " + file_name + " must have " + std::string(kExt) + " extension");
                 }
                 auto views = load_overlapped_tensors(file_name, device);

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -627,7 +627,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
     m_tensor
         .def(
             "dump_overlapped_tensors",
-            [](const std::string& file_name, nb::list py_views) {
+            [](const std::string& file_name, nb::dict py_views) {
                 constexpr std::string_view kExt = ".overlappedtensorbin";
                 if (file_name.size() < kExt.size() ||
                     file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
@@ -635,9 +635,10 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 }
                 std::vector<OverlappedTensorView> views;
                 views.reserve(nb::len(py_views));
-                for (auto item : py_views) {
-                    nb::object obj = nb::borrow(item);
+                for (auto [key, value] : py_views) {
+                    nb::object obj = nb::borrow(value);
                     views.push_back(OverlappedTensorView{
+                        .name = nb::cast<std::string>(key),
                         .fused_tensor = nb::cast<Tensor>(obj.attr("fused_tensor")),
                         .tensor_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tensor_shape")),
                         .shard_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("shard_shape")),
@@ -652,12 +653,12 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::arg("file_name"),
             nb::arg("views"),
             R"doc(
-                Dump a list of OverlappedTensor to a single file using FlatBuffer format.
+                Dump a dict of OverlappedTensor to a single file using FlatBuffer format.
                 All views must reference the same fused tensor.
             )doc")
         .def(
             "load_overlapped_tensors",
-            [](const std::string& file_name, MeshDevice* device) -> nb::list {
+            [](const std::string& file_name, MeshDevice* device) -> nb::dict {
                 constexpr std::string_view kExt = ".overlappedtensorbin";
                 if (file_name.size() < kExt.size() ||
                     file_name.compare(file_name.size() - kExt.size(), kExt.size(), kExt) != 0) {
@@ -666,23 +667,23 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 auto views = load_overlapped_tensors(file_name, device);
                 nb::module_ mod = nb::module_::import_("models.demos.deepseek_v3_b1.blitz_overlap_tensors");
                 nb::object cls = mod.attr("OverlappedTensor");
-                nb::list result;
+                nb::dict result;
                 for (const auto& v : views) {
-                    result.append(
+                    result[nb::cast(v.name)] =
                         cls(nb::cast(v.fused_tensor),
                             nb::make_tuple(v.tensor_shape[0], v.tensor_shape[1]),
                             nb::make_tuple(v.shard_shape[0], v.shard_shape[1]),
                             nb::cast(v.core_range_set),
                             nb::cast(v.dtype),
                             nb::make_tuple(v.tile_shape[0], v.tile_shape[1]),
-                            nb::cast(v.byte_offset)));
+                            nb::cast(v.byte_offset));
                 }
                 return result;
             },
             nb::arg("file_name"),
             nb::arg("device") = nullptr,
             R"doc(
-                Load a list of OverlappedTensor from a file serialized with dump_overlapped_tensors.
+                Load a dict of OverlappedTensor from a file serialized with dump_overlapped_tensors.
             )doc");
 }
 

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -664,11 +664,20 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::arg("byte_offset") = 0,
             nb::arg("total_size") = 0)
         .def_rw("fused_tensor", &OverlappedTensorView::fused_tensor)
-        .def_rw("tensor_shape", &OverlappedTensorView::tensor_shape)
-        .def_rw("shard_shape", &OverlappedTensorView::shard_shape)
+        .def_prop_rw(
+            "tensor_shape",
+            [](const OverlappedTensorView& self) { return nb::make_tuple(self.tensor_shape[0], self.tensor_shape[1]); },
+            [](OverlappedTensorView& self, std::array<uint32_t, 2> v) { self.tensor_shape = v; })
+        .def_prop_rw(
+            "shard_shape",
+            [](const OverlappedTensorView& self) { return nb::make_tuple(self.shard_shape[0], self.shard_shape[1]); },
+            [](OverlappedTensorView& self, std::array<uint32_t, 2> v) { self.shard_shape = v; })
         .def_rw("core_range_set", &OverlappedTensorView::core_range_set)
         .def_rw("dtype", &OverlappedTensorView::dtype)
-        .def_rw("tile_shape", &OverlappedTensorView::tile_shape)
+        .def_prop_rw(
+            "tile_shape",
+            [](const OverlappedTensorView& self) { return nb::make_tuple(self.tile_shape[0], self.tile_shape[1]); },
+            [](OverlappedTensorView& self, std::array<uint32_t, 2> v) { self.tile_shape = v; })
         .def_rw("byte_offset", &OverlappedTensorView::byte_offset)
         .def_rw("total_size", &OverlappedTensorView::total_size)
         .def(

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -646,6 +646,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                         .dtype = nb::cast<DataType>(obj.attr("dtype")),
                         .tile_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tile_shape")),
                         .byte_offset = nb::cast<uint64_t>(obj.attr("byte_offset")),
+                        .total_size = nb::cast<uint64_t>(obj.attr("total_size")),
                     });
                 }
                 dump_overlapped_tensors(file_name, views);
@@ -676,7 +677,8 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                             nb::cast(v.core_range_set),
                             nb::cast(v.dtype),
                             nb::make_tuple(v.tile_shape[0], v.tile_shape[1]),
-                            nb::cast(v.byte_offset));
+                            nb::cast(v.byte_offset),
+                            nb::cast(v.total_size));
                 }
                 return result;
             },

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -624,6 +624,58 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 Load tensor to file using FlatBuffer format with inline file storage.
             )doc");
 
+    nb::class_<OverlappedTensorView>(m_tensor, "OverlappedTensor", R"doc(
+        A logical view of a sub-tensor within a fused (overlapped) device buffer.
+
+        The fused tensor is a raw byte container whose own tensor properties
+        (dtype, layout, shard spec) are generally meaningless for the individual
+        sub-tensors.  This class carries the intended per-sub-tensor properties
+        alongside a shared reference to the underlying fused buffer.
+    )doc")
+        .def(
+            "__init__",
+            [](OverlappedTensorView* self,
+               Tensor fused_tensor,
+               std::array<uint32_t, 2> tensor_shape,
+               std::array<uint32_t, 2> shard_shape,
+               CoreRangeSet core_range_set,
+               DataType dtype,
+               std::array<uint32_t, 2> tile_shape,
+               uint64_t byte_offset,
+               uint64_t total_size) {
+                new (self) OverlappedTensorView{
+                    .name = "",
+                    .fused_tensor = std::move(fused_tensor),
+                    .tensor_shape = tensor_shape,
+                    .shard_shape = shard_shape,
+                    .core_range_set = std::move(core_range_set),
+                    .dtype = dtype,
+                    .tile_shape = tile_shape,
+                    .byte_offset = byte_offset,
+                    .total_size = total_size,
+                };
+            },
+            nb::arg("fused_tensor"),
+            nb::arg("tensor_shape"),
+            nb::arg("shard_shape"),
+            nb::arg("core_range_set"),
+            nb::arg("dtype"),
+            nb::arg("tile_shape"),
+            nb::arg("byte_offset") = 0,
+            nb::arg("total_size") = 0)
+        .def_rw("fused_tensor", &OverlappedTensorView::fused_tensor)
+        .def_rw("tensor_shape", &OverlappedTensorView::tensor_shape)
+        .def_rw("shard_shape", &OverlappedTensorView::shard_shape)
+        .def_rw("core_range_set", &OverlappedTensorView::core_range_set)
+        .def_rw("dtype", &OverlappedTensorView::dtype)
+        .def_rw("tile_shape", &OverlappedTensorView::tile_shape)
+        .def_rw("byte_offset", &OverlappedTensorView::byte_offset)
+        .def_rw("total_size", &OverlappedTensorView::total_size)
+        .def(
+            "get_tile",
+            [](const OverlappedTensorView& self) { return Tile(self.tile_shape); },
+            "Return a Tile object constructed from the tile_shape.");
+
     m_tensor
         .def(
             "dump_overlapped_tensors",
@@ -636,18 +688,9 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 std::vector<OverlappedTensorView> views;
                 views.reserve(nb::len(py_views));
                 for (auto [key, value] : py_views) {
-                    nb::object obj = nb::borrow(value);
-                    views.push_back(OverlappedTensorView{
-                        .name = nb::cast<std::string>(key),
-                        .fused_tensor = nb::cast<Tensor>(obj.attr("fused_tensor")),
-                        .tensor_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tensor_shape")),
-                        .shard_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("shard_shape")),
-                        .core_range_set = nb::cast<CoreRangeSet>(obj.attr("core_range_set")),
-                        .dtype = nb::cast<DataType>(obj.attr("dtype")),
-                        .tile_shape = nb::cast<std::array<uint32_t, 2>>(obj.attr("tile_shape")),
-                        .byte_offset = nb::cast<uint64_t>(obj.attr("byte_offset")),
-                        .total_size = nb::cast<uint64_t>(obj.attr("total_size")),
-                    });
+                    auto view = nb::cast<OverlappedTensorView>(value);
+                    view.name = nb::cast<std::string>(key);
+                    views.push_back(std::move(view));
                 }
                 dump_overlapped_tensors(file_name, views);
             },
@@ -666,19 +709,9 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                     throw std::runtime_error("File " + file_name + " must have " + std::string(kExt) + " extension");
                 }
                 auto views = load_overlapped_tensors(file_name, device);
-                nb::module_ mod = nb::module_::import_("models.demos.deepseek_v3_b1.blitz_overlap_tensors");
-                nb::object cls = mod.attr("OverlappedTensor");
                 nb::dict result;
-                for (const auto& v : views) {
-                    result[nb::cast(v.name)] =
-                        cls(nb::cast(v.fused_tensor),
-                            nb::make_tuple(v.tensor_shape[0], v.tensor_shape[1]),
-                            nb::make_tuple(v.shard_shape[0], v.shard_shape[1]),
-                            nb::cast(v.core_range_set),
-                            nb::cast(v.dtype),
-                            nb::make_tuple(v.tile_shape[0], v.tile_shape[1]),
-                            nb::cast(v.byte_offset),
-                            nb::cast(v.total_size));
+                for (auto& v : views) {
+                    result[nb::cast(v.name)] = nb::cast(std::move(v));
                 }
                 return result;
             },

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -227,6 +227,7 @@ from ttnn.types import (
     corerange_to_cores,
     get_optimal_worker_cores_for_sharded_tensor,
     Tile,
+    OverlappedTensor,
     Layout,
     ROW_MAJOR_LAYOUT,
     TILE_LAYOUT,

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -41,6 +41,7 @@ DEVICE_STORAGE_TYPE = StorageType.DEVICE
 TILE_SIZE = 32
 
 Tile = ttnn._ttnn.tensor.Tile
+OverlappedTensor = ttnn._ttnn.tensor.OverlappedTensor
 
 Shape = ttnn._ttnn.types.Shape
 TensorSpec = ttnn._ttnn.tensor.TensorSpec


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38406)

### Problem description
    On tenstorrent devices, all L1 allocations are lockstep. This means that
    if tensor is used only on subset of cores, the memory for it is still
    allocated on all cores. To avoid wasting memory, this function allows to
    overlap multiple tensors into a single fused tensor.
    When the fused tensor is sharded over cores, each core gets a
    shard of the fused tensor, corresponding to the desired origianal tensor.

    The fused tensor is always stored as WIDTH_SHARDED on the device
    (one flat shard per core).  Individual sub-tensors within the fused
    buffer can be either WIDTH_SHARDED or HEIGHT_SHARDED — the
    ``sharding`` field on each ``OverlappedTensorSpec`` controls how the
    per-device tensor is sliced across cores before tilization.

### What's changed
Added overlap_tensors function and port blitz_decode_weights.py

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinskiTT/38406-general_overlap_function)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinskiTT/38406-general_overlap_function)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
