### PR TITLE
update ttnn.fill_cache for non zero idx

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -135,6 +135,110 @@ class TestUpdateCache:
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("head_dim", [64])
+@pytest.mark.parametrize("max_seq_len", [4096])
+@pytest.mark.parametrize("num_users", [8, 32])
+@pytest.mark.parametrize("num_heads", [1, 2])
+@pytest.mark.parametrize("in_sharded", [True, False])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+class TestFillCacheWithOffset:
+    @pytest.mark.parametrize("seq_len", [32, 128])
+    @pytest.mark.parametrize("update_idx", [32, 64, 512])
+    def test_fill_cache_with_update_idx(
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, update_idx, device
+    ):
+        cache_dtype = input_dtype
+        input_shape = [1, num_heads, seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+
+        cache = torch.randn(cache_shape).bfloat16().float()
+        cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+        for i in range(num_users):
+            x = torch.randn(input_shape).bfloat16().float()
+            xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT)
+            if in_sharded:
+                compute_grid_size = device.compute_with_storage_grid_size()
+                num_cores = min(seq_len // 32 * num_heads, 32)
+                shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+                input_shard_spec = ttnn.ShardSpec(
+                    shard_grid,
+                    [
+                        xt.volume() // xt.padded_shape[-1] // num_cores,
+                        xt.padded_shape[-1],
+                    ],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                )
+                input_mem_config = ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+                )
+                xt = xt.to(device, input_mem_config)
+            else:
+                xt = xt.to(device)
+
+            cachett = ttnn.fill_cache(cachett, xt, i, update_idx=update_idx)
+            cache[i : i + 1, :, update_idx : update_idx + x.shape[-2], :] = x
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
+        assert eq
+
+    @pytest.mark.parametrize("seq_len", [128])
+    def test_fill_cache_continuation(
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device
+    ):
+        """Simulates continuation chat: fill at 0, then fill more at seq_len offset."""
+        cache_dtype = input_dtype
+        input_shape = [1, num_heads, seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+
+        cache = torch.randn(cache_shape).bfloat16().float()
+        cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+        for i in range(num_users):
+            x1 = torch.randn(input_shape).bfloat16().float()
+            x2 = torch.randn(input_shape).bfloat16().float()
+
+            def to_device(x):
+                xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT)
+                if in_sharded:
+                    compute_grid_size = device.compute_with_storage_grid_size()
+                    num_cores = min(seq_len // 32 * num_heads, 32)
+                    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+                    input_shard_spec = ttnn.ShardSpec(
+                        shard_grid,
+                        [
+                            xt.volume() // xt.padded_shape[-1] // num_cores,
+                            xt.padded_shape[-1],
+                        ],
+                        ttnn.ShardOrientation.ROW_MAJOR,
+                    )
+                    input_mem_config = ttnn.MemoryConfig(
+                        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+                    )
+                    return xt.to(device, input_mem_config)
+                return xt.to(device)
+
+            cachett = ttnn.fill_cache(cachett, to_device(x1), i)
+            cache[i : i + 1, :, :seq_len, :] = x1
+
+            cachett = ttnn.fill_cache(cachett, to_device(x2), i, update_idx=seq_len)
+            cache[i : i + 1, :, seq_len : 2 * seq_len, :] = x2
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
+        assert eq
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [8, 16, 32, 64])
 @pytest.mark.parametrize("num_heads", [1, 2])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -239,6 +239,78 @@ class TestFillCacheWithOffset:
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("head_dim", [64])
+@pytest.mark.parametrize("max_seq_len", [4096])
+@pytest.mark.parametrize("num_users", [8, 32])
+@pytest.mark.parametrize("num_heads", [1, 2])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+class TestFillCacheSubTileOffset:
+    """Tests fill_cache with non-tile-aligned update_idx (sub-tile offsets).
+    Only interleaved input is supported for non-aligned offsets."""
+
+    @pytest.mark.parametrize("seq_len", [32, 128])
+    @pytest.mark.parametrize("update_idx", [1, 10, 16, 25, 31])
+    def test_fill_cache_subtile_offset(
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, input_dtype, update_idx, device
+    ):
+        cache_dtype = input_dtype
+        input_shape = [1, num_heads, seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+
+        cache = torch.randn(cache_shape).bfloat16().float()
+        cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+        for i in range(num_users):
+            x = torch.randn(input_shape).bfloat16().float()
+            xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+            cachett = ttnn.fill_cache(cachett, xt, i, update_idx=update_idx)
+            cache[i : i + 1, :, update_idx : update_idx + x.shape[-2], :] = x
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
+        assert eq
+
+    @pytest.mark.parametrize("seq_len", [128])
+    @pytest.mark.parametrize("decode_tokens", [5, 17])
+    def test_fill_cache_continuation_subtile(
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, input_dtype, decode_tokens, device
+    ):
+        """Simulates continuation after decode: prefill at 0, then fill at seq_len + decode_tokens (non-aligned)."""
+        cache_dtype = input_dtype
+        input_shape = [1, num_heads, seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+        continuation_offset = seq_len + decode_tokens
+
+        cache = torch.randn(cache_shape).bfloat16().float()
+        cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+        for i in range(num_users):
+            x1 = torch.randn(input_shape).bfloat16().float()
+            x2 = torch.randn(input_shape).bfloat16().float()
+
+            xt1 = ttnn.Tensor(x1, input_dtype).to(ttnn.TILE_LAYOUT).to(device)
+            cachett = ttnn.fill_cache(cachett, xt1, i)
+            cache[i : i + 1, :, :seq_len, :] = x1
+
+            xt2 = ttnn.Tensor(x2, input_dtype).to(ttnn.TILE_LAYOUT).to(device)
+            cachett = ttnn.fill_cache(cachett, xt2, i, update_idx=continuation_offset)
+            cache[i : i + 1, :, continuation_offset : continuation_offset + seq_len, :] = x2
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
+        assert eq
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [8, 16, 32, 64])
 @pytest.mark.parametrize("num_heads", [1, 2])

--- a/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/kv_cache/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
     PRIVATE
         device/update_cache_device_operation.cpp
         device/fill_cache_multi_core_program_factory.cpp
+        device/fill_cache_offset_program_factory.cpp
         device/update_cache_multi_core_program_factory.cpp
         kv_cache.cpp
 )

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_offset_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_offset_program_factory.cpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "fill_cache_offset_program_factory.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+using namespace tt::constants;
+
+FillCacheOffsetProgramFactory::cached_program_t FillCacheOffsetProgramFactory::create(
+    const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& /*output_tensor*/) {
+    const auto& cache_tensor = tensor_args.cache;
+    const auto& input_tensor = tensor_args.input;
+    const auto batch_idx = operation_attributes.batch_idx;
+    const auto update_idx = operation_attributes.update_idx;
+    const uint32_t sub_offset = update_idx % TILE_HEIGHT;
+    Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t input_Ht = input_tensor.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t num_heads = input_tensor.padded_shape()[1];
+    uint32_t cache_HtWt = cache_tensor.padded_shape()[-2] * Wt / TILE_HEIGHT;
+    uint32_t cache_CHtWt = num_heads * cache_HtWt;
+    uint32_t input_HtWt = input_Ht * Wt;
+    uint32_t aligned_start_tile = update_idx / TILE_HEIGHT;
+
+    uint32_t num_output_tiles_per_head = input_Ht + (sub_offset > 0 ? 1 : 0);
+    uint32_t num_blocks_of_work = num_output_tiles_per_head * num_heads;
+
+    uint32_t cache_batch_start = batch_idx * cache_CHtWt + aligned_start_tile * Wt;
+
+    uint32_t elem_size = (input_tensor.dtype() == DataType::FLOAT32) ? 4 : 2;
+    uint32_t face_row_bytes = 16 * elem_size;
+    uint32_t face_bytes = 16 * 16 * elem_size;
+
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    bool row_major = true;
+    uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    std::tie(
+        num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks_of_work, row_major);
+
+    // CB 0: output tiles (double-buffered, Wt tiles per block)
+    uint32_t cb_out_index = 0;
+    uint32_t num_out_tiles = 2 * Wt;
+    tt::tt_metal::CircularBufferConfig cb_out_config =
+        tt::tt_metal::CircularBufferConfig(num_out_tiles * single_tile_size, {{cb_out_index, cb_data_format}})
+            .set_page_size(cb_out_index, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+
+    // CB 1: scratch buffer for input tiles (2 tile rows = 2 * Wt tiles)
+    uint32_t cb_scratch_index = 1;
+    uint32_t num_scratch_tiles = 2 * Wt;
+    tt::tt_metal::CircularBufferConfig cb_scratch_config =
+        tt::tt_metal::CircularBufferConfig(num_scratch_tiles * single_tile_size, {{cb_scratch_index, cb_data_format}})
+            .set_page_size(cb_scratch_index, single_tile_size);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scratch_config);
+
+    auto* src_buffer = input_tensor.buffer();
+    auto* dst_buffer = cache_tensor.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {cb_out_index, cb_scratch_index, face_row_bytes, face_bytes};
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {cb_out_index};
+    tt::tt_metal::TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_offset.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_fill_cache_offset.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    uint32_t block_start = 0;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_blocks_per_core = (i < g1_numcores) ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {dst_buffer->address(),
+             src_buffer->address(),
+             Wt,
+             sub_offset,
+             num_output_tiles_per_head,
+             input_Ht,
+             cache_batch_start,
+             cache_HtWt,
+             input_HtWt,
+             num_blocks_per_core,
+             block_start});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {dst_buffer->address(),
+             Wt,
+             num_output_tiles_per_head,
+             cache_batch_start,
+             cache_HtWt,
+             num_blocks_per_core,
+             block_start});
+
+        block_start += num_blocks_per_core;
+    }
+
+    return cached_program_t{
+        std::move(program),
+        shared_variables_t{
+            .reader_kernel_id = reader_kernel_id,
+            .writer_kernel_id = writer_kernel_id,
+            .cores = cores,
+            .g1_numcores = g1_numcores,
+            .num_blocks_per_core_group_1 = num_blocks_per_core_group_1,
+            .num_blocks_per_core_group_2 = num_blocks_per_core_group_2,
+            .Wt = Wt,
+            .cache_HtWt = cache_HtWt,
+            .input_HtWt = input_HtWt,
+            .input_Ht = input_Ht,
+            .num_output_tiles_per_head = num_output_tiles_per_head,
+        }};
+}
+
+void FillCacheOffsetProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const KvCacheParams& operation_attributes,
+    const KvCacheInputs& tensor_args,
+    Tensor& /*output_tensor*/) {
+    auto& program = cached_program.program;
+    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    const auto& cores = cached_program.shared_variables.cores;
+    const auto Wt = cached_program.shared_variables.Wt;
+    const auto cache_HtWt = cached_program.shared_variables.cache_HtWt;
+
+    const auto batch_idx = operation_attributes.batch_idx;
+    const auto update_idx = operation_attributes.update_idx;
+    const uint32_t sub_offset = update_idx % TILE_HEIGHT;
+    const uint32_t aligned_start_tile = update_idx / TILE_HEIGHT;
+    const uint32_t num_heads = tensor_args.input.padded_shape()[1];
+    const uint32_t cache_CHtWt = num_heads * cache_HtWt;
+    const uint32_t cache_batch_start = batch_idx * cache_CHtWt + aligned_start_tile * Wt;
+
+    auto* src_buffer = tensor_args.input.buffer();
+    auto* dst_buffer = tensor_args.cache.buffer();
+
+    for (uint32_t i = 0; i < cores.size(); i++) {
+        const CoreCoord& core = cores.at(i);
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+            runtime_args[1] = src_buffer->address();
+            runtime_args[3] = sub_offset;
+            runtime_args[6] = cache_batch_start;
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+            runtime_args[3] = cache_batch_start;
+        }
+    }
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_offset_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_offset_program_factory.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "update_cache_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+
+struct FillCacheOffsetProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        std::vector<CoreCoord> cores;
+        uint32_t g1_numcores = 0;
+        uint32_t num_blocks_per_core_group_1 = 0;
+        uint32_t num_blocks_per_core_group_2 = 0;
+        uint32_t Wt = 0;
+        uint32_t cache_HtWt = 0;
+        uint32_t input_HtWt = 0;
+        uint32_t input_Ht = 0;
+        uint32_t num_output_tiles_per_head = 0;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const KvCacheParams& operation_attributes,
+        const KvCacheInputs& tensor_args,
+        Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_offset.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_offset.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+inline uint32_t min(uint32_t a, uint32_t b) { return a < b ? a : b; }
+
+// Copy rows between tiles in L1 using face-aware batched NOC reads.
+// Rows within the same source and destination face pair are copied in a single NOC operation.
+// Each tile has 4 faces of 16x16 elements:
+//   Face 0: rows 0-15 cols 0-15,  Face 1: rows 0-15 cols 16-31
+//   Face 2: rows 16-31 cols 0-15, Face 3: rows 16-31 cols 16-31
+inline void copy_tile_rows(
+    uint32_t dst_l1,
+    uint32_t dst_row_start,
+    uint32_t src_l1,
+    uint32_t src_row_start,
+    uint32_t num_rows,
+    uint32_t face_row_bytes,
+    uint32_t face_bytes) {
+    uint32_t rows_done = 0;
+    while (rows_done < num_rows) {
+        uint32_t sr = src_row_start + rows_done;
+        uint32_t dr = dst_row_start + rows_done;
+
+        uint32_t src_remaining = (sr < 16) ? (16 - sr) : (32 - sr);
+        uint32_t dst_remaining = (dr < 16) ? (16 - dr) : (32 - dr);
+        uint32_t chunk = min(min(src_remaining, dst_remaining), num_rows - rows_done);
+
+        uint32_t src_face0 = (sr < 16) ? 0 : 2;
+        uint32_t src_rif = sr & 15;
+        uint32_t dst_face0 = (dr < 16) ? 0 : 2;
+        uint32_t dst_rif = dr & 15;
+
+        uint32_t copy_bytes = chunk * face_row_bytes;
+
+        uint64_t src_noc = get_noc_addr(src_l1 + src_face0 * face_bytes + src_rif * face_row_bytes);
+        noc_async_read(src_noc, dst_l1 + dst_face0 * face_bytes + dst_rif * face_row_bytes, copy_bytes);
+
+        src_noc = get_noc_addr(src_l1 + (src_face0 + 1) * face_bytes + src_rif * face_row_bytes);
+        noc_async_read(src_noc, dst_l1 + (dst_face0 + 1) * face_bytes + dst_rif * face_row_bytes, copy_bytes);
+
+        rows_done += chunk;
+    }
+}
+
+void kernel_main() {
+    const uint32_t cache_addr = get_arg_val<uint32_t>(0);
+    const uint32_t input_addr = get_arg_val<uint32_t>(1);
+    const uint32_t Wt = get_arg_val<uint32_t>(2);
+    const uint32_t sub_offset = get_arg_val<uint32_t>(3);
+    const uint32_t num_output_tiles_per_head = get_arg_val<uint32_t>(4);
+    const uint32_t input_Ht = get_arg_val<uint32_t>(5);
+    const uint32_t cache_batch_start = get_arg_val<uint32_t>(6);
+    const uint32_t cache_HtWt = get_arg_val<uint32_t>(7);
+    const uint32_t input_HtWt = get_arg_val<uint32_t>(8);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(9);
+    const uint32_t block_start = get_arg_val<uint32_t>(10);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t face_row_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t face_bytes = get_compile_time_arg_val(3);
+    constexpr auto cache_ta_args = TensorAccessorArgs<4>();
+    constexpr auto input_ta_args = TensorAccessorArgs<cache_ta_args.next_compile_time_args_offset()>();
+
+    const uint32_t tile_bytes = get_tile_size(cb_out);
+    const auto cache_s = TensorAccessor(cache_ta_args, cache_addr, tile_bytes);
+    const auto input_s = TensorAccessor(input_ta_args, input_addr, tile_bytes);
+
+    // Reserve scratch space once (never pushed, reused each iteration)
+    cb_reserve_back(cb_scratch, 2 * Wt);
+    const uint32_t scratch_base = get_write_ptr(cb_scratch);
+
+    for (uint32_t b = 0; b < num_blocks; b++) {
+        const uint32_t global_block = block_start + b;
+        const uint32_t head = global_block / num_output_tiles_per_head;
+        const uint32_t t = global_block % num_output_tiles_per_head;
+        const bool is_first = (t == 0);
+        const bool is_last = (t == num_output_tiles_per_head - 1);
+
+        // Compute cache tile start ID for this output tile
+        const uint32_t cache_tile_id = cache_batch_start + head * cache_HtWt + t * Wt;
+
+        // Read cache tile into output CB
+        cb_reserve_back(cb_out, Wt);
+        uint32_t out_addr = get_write_ptr(cb_out);
+        for (uint32_t w = 0; w < Wt; w++) {
+            noc_async_read_tile(cache_tile_id + w, cache_s, out_addr + w * tile_bytes);
+        }
+        noc_async_read_barrier();
+
+        // Determine what to copy for this output tile
+        uint32_t cache_row_dst;        // destination row in cache tile
+        uint32_t num_rows_part_a;      // rows from first input tile
+        uint32_t src_row_a;            // starting row in first input tile
+        uint32_t input_tile_row_a;     // which input tile row (along seq_len)
+        uint32_t num_rows_part_b = 0;  // rows from second input tile
+        uint32_t input_tile_row_b = 0;
+
+        if (is_first) {
+            cache_row_dst = sub_offset;
+            num_rows_part_a = 32 - sub_offset;
+            src_row_a = 0;
+            input_tile_row_a = 0;
+        } else if (is_last) {
+            cache_row_dst = 0;
+            num_rows_part_a = sub_offset;
+            src_row_a = 32 - sub_offset;
+            input_tile_row_a = input_Ht - 1;
+        } else {
+            // Middle tile: rows from two input tiles
+            cache_row_dst = 0;
+            num_rows_part_a = sub_offset;
+            src_row_a = 32 - sub_offset;
+            input_tile_row_a = t - 1;
+            num_rows_part_b = 32 - sub_offset;
+            input_tile_row_b = t;
+        }
+
+        // Read input tile(s) into scratch
+        const uint32_t input_base_a = head * input_HtWt + input_tile_row_a * Wt;
+        for (uint32_t w = 0; w < Wt; w++) {
+            noc_async_read_tile(input_base_a + w, input_s, scratch_base + w * tile_bytes);
+        }
+        if (num_rows_part_b > 0) {
+            const uint32_t input_base_b = head * input_HtWt + input_tile_row_b * Wt;
+            for (uint32_t w = 0; w < Wt; w++) {
+                noc_async_read_tile(input_base_b + w, input_s, scratch_base + (Wt + w) * tile_bytes);
+            }
+        }
+        noc_async_read_barrier();
+
+        // Merge rows into output tile using face-aware copies
+        for (uint32_t w = 0; w < Wt; w++) {
+            const uint32_t out_tile = out_addr + w * tile_bytes;
+            const uint32_t scratch_tile_a = scratch_base + w * tile_bytes;
+
+            copy_tile_rows(
+                out_tile, cache_row_dst, scratch_tile_a, src_row_a, num_rows_part_a, face_row_bytes, face_bytes);
+
+            if (num_rows_part_b > 0) {
+                const uint32_t scratch_tile_b = scratch_base + (Wt + w) * tile_bytes;
+                copy_tile_rows(
+                    out_tile,
+                    cache_row_dst + num_rows_part_a,
+                    scratch_tile_b,
+                    0,
+                    num_rows_part_b,
+                    face_row_bytes,
+                    face_bytes);
+            }
+        }
+        noc_async_read_barrier();
+
+        cb_push_back(cb_out, Wt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_fill_cache_offset.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_fill_cache_offset.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t cache_addr = get_arg_val<uint32_t>(0);
+    const uint32_t Wt = get_arg_val<uint32_t>(1);
+    const uint32_t num_output_tiles_per_head = get_arg_val<uint32_t>(2);
+    const uint32_t cache_batch_start = get_arg_val<uint32_t>(3);
+    const uint32_t cache_HtWt = get_arg_val<uint32_t>(4);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(5);
+    const uint32_t block_start = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr auto cache_ta_args = TensorAccessorArgs<1>();
+
+    const uint32_t tile_bytes = get_tile_size(cb_out);
+    const auto cache_s = TensorAccessor(cache_ta_args, cache_addr, tile_bytes);
+
+    for (uint32_t b = 0; b < num_blocks; b++) {
+        const uint32_t global_block = block_start + b;
+        const uint32_t head = global_block / num_output_tiles_per_head;
+        const uint32_t t = global_block % num_output_tiles_per_head;
+
+        const uint32_t cache_tile_id = cache_batch_start + head * cache_HtWt + t * Wt;
+
+        cb_wait_front(cb_out, Wt);
+        uint32_t l1_read_addr = get_read_ptr(cb_out);
+        for (uint32_t w = 0; w < Wt; w++) {
+            noc_async_write_tile(cache_tile_id + w, cache_s, l1_read_addr + w * tile_bytes);
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_out, Wt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -12,6 +12,9 @@ using namespace tt::constants;
 UpdateKVCacheOperation::program_factory_t UpdateKVCacheOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& /*tensor_args*/) {
     if (args.op_type == UpdateCacheOpType::FILL) {
+        if (args.update_idx % TILE_HEIGHT != 0) {
+            return FillCacheOffsetProgramFactory{};
+        }
         return FillCacheMultiCoreProgramFactory{};
     }
     return UpdateCacheMultiCoreProgramFactory{};
@@ -64,11 +67,14 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
 
-        TT_FATAL(
-            args.update_idx % TILE_HEIGHT == 0,
-            "update_idx ({}) must be a multiple of TILE_HEIGHT ({}) for fill cache",
-            args.update_idx,
-            TILE_HEIGHT);
+        if (args.update_idx % TILE_HEIGHT != 0) {
+            TT_FATAL(
+                !input_tensor.is_sharded(), "Non-tile-aligned update_idx requires interleaved (non-sharded) input");
+            TT_FATAL(
+                input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32,
+                "Non-tile-aligned update_idx requires BFLOAT16 or FLOAT32 dtype, got {}",
+                input_tensor.dtype());
+        }
 
         if (input_tensor.is_sharded()) {
             TT_FATAL(
@@ -152,8 +158,9 @@ Tensor UpdateKVCacheOperation::create_output_tensors(
 
 tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    bool is_sub_tile_offset = (args.op_type == UpdateCacheOpType::FILL) && (args.update_idx % TILE_HEIGHT != 0);
     return tt::tt_metal::operation::hash_operation<UpdateKVCacheOperation>(
-        args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
+        args.op_type, is_sub_tile_offset, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
 }
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -64,6 +64,12 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
 
+        TT_FATAL(
+            args.update_idx % TILE_HEIGHT == 0,
+            "update_idx ({}) must be a multiple of TILE_HEIGHT ({}) for fill cache",
+            args.update_idx,
+            TILE_HEIGHT);
+
         if (input_tensor.is_sharded()) {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
@@ -86,8 +92,9 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
             args.batch_idx,
             cache_tensor.padded_shape()[0]);
         TT_FATAL(
-            input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
-            "Input tensor height ({}) must be <= cache tensor height ({})",
+            args.update_idx + input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
+            "update_idx ({}) + input seq len ({}) must be <= cache seq len ({})",
+            args.update_idx,
             input_tensor.padded_shape()[-2],
             cache_tensor.padded_shape()[-2]);
     } else if (args.op_type == UpdateCacheOpType::UPDATE) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/global_circular_buffer.hpp>
 #include "update_cache_device_operation_types.hpp"
 #include "fill_cache_multi_core_program_factory.hpp"
+#include "fill_cache_offset_program_factory.hpp"
 #include "update_cache_multi_core_program_factory.hpp"
 
 namespace ttnn::prim {
@@ -21,7 +22,8 @@ struct UpdateKVCacheOperation {
     using tensor_args_t = KvCacheInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
-    using program_factory_t = std::variant<UpdateCacheMultiCoreProgramFactory, FillCacheMultiCoreProgramFactory>;
+    using program_factory_t = std::
+        variant<UpdateCacheMultiCoreProgramFactory, FillCacheMultiCoreProgramFactory, FillCacheOffsetProgramFactory>;
 
     static program_factory_t select_program_factory(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
@@ -21,8 +21,8 @@ ttnn::Tensor update_cache_for_token_(
 }
 
 ttnn::Tensor fill_cache_for_user_(
-    const ttnn::Tensor& cache, const ttnn::Tensor& input, const uint32_t batch_index) {
-    ttnn::prim::update_cache(cache, input, batch_index, 0, 0, ttnn::prim::UpdateCacheOpType::FILL);
+    const ttnn::Tensor& cache, const ttnn::Tensor& input, const uint32_t batch_index, const uint32_t update_idx) {
+    ttnn::prim::update_cache(cache, input, batch_index, update_idx, 0, ttnn::prim::UpdateCacheOpType::FILL);
     return cache;
 }
 
@@ -39,8 +39,11 @@ ttnn::Tensor update_cache(
 }
 
 ttnn::Tensor fill_cache(
-    const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, const uint32_t batch_idx) {
-    ttnn::prim::update_cache(cache_tensor, input_tensor, batch_idx, 0, 0, ttnn::prim::UpdateCacheOpType::FILL);
+    const ttnn::Tensor& cache_tensor,
+    const ttnn::Tensor& input_tensor,
+    const uint32_t batch_idx,
+    const uint32_t update_idx) {
+    ttnn::prim::update_cache(cache_tensor, input_tensor, batch_idx, update_idx, 0, ttnn::prim::UpdateCacheOpType::FILL);
     return cache_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
@@ -9,7 +9,8 @@
 
 namespace ttnn {
 
-ttnn::Tensor fill_cache_for_user_(const ttnn::Tensor& cache, const ttnn::Tensor& input, uint32_t batch_index);
+ttnn::Tensor fill_cache_for_user_(
+    const ttnn::Tensor& cache, const ttnn::Tensor& input, uint32_t batch_index, uint32_t update_idx = 0);
 
 ttnn::Tensor update_cache_for_token_(
     const ttnn::Tensor& cache,
@@ -25,6 +26,7 @@ ttnn::Tensor update_cache(
     uint32_t batch_offset = 0,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
-ttnn::Tensor fill_cache(const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, uint32_t batch_idx);
+ttnn::Tensor fill_cache(
+    const ttnn::Tensor& cache_tensor, const ttnn::Tensor& input_tensor, uint32_t batch_idx, uint32_t update_idx = 0);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache_nanobind.cpp
@@ -30,6 +30,7 @@ void bind_fill_cache_for_user_(nb::module_& mod) {
             cache (ttnn.Tensor): the cache tensor to be written to.
             input_tensor (ttnn.Tensor): the input tensor to be written to the cache.
             batch_index (int): the index into the cache tensor.
+            update_idx (int): the starting position along the sequence dimension. Must be a multiple of 32 (tile-aligned). Default = 0.
 
 
         Returns:
@@ -39,7 +40,13 @@ void bind_fill_cache_for_user_(nb::module_& mod) {
         )doc";
 
     ttnn::bind_function<"fill_cache_for_user_", "ttnn.kv_cache.">(
-        mod, doc, &ttnn::fill_cache_for_user_, nb::arg("cache"), nb::arg("input"), nb::arg("batch_index"));
+        mod,
+        doc,
+        &ttnn::fill_cache_for_user_,
+        nb::arg("cache"),
+        nb::arg("input"),
+        nb::arg("batch_index"),
+        nb::arg("update_idx") = 0);
 }
 
 void bind_update_cache_for_token_(nb::module_& mod) {
@@ -105,22 +112,29 @@ void bind_update_cache(nb::module_& mod) {
 
 void bind_fill_cache(nb::module_& mod) {
     const auto* doc = R"doc(
-        Fills the cache tensor in place with the values from input at the specified batch_idx.
+        Fills the cache tensor in place with the values from input at the specified batch_idx, starting at position update_idx along the sequence dimension.
 
         Args:
             * :attr:`cache_tensor` (ttnn.Tensor): The cache tensor to be written to.
             * :attr:`input_tensor` (ttnn.Tensor): The token tensor to be written to the cache.
             * :attr:`batch_idx` (int): The index into the cache tensor.
+            * :attr:`update_idx` (int): The starting position along the sequence dimension. Must be a multiple of 32 (tile-aligned). Default = 0.
 
         Example:
             >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
             >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = ttnn.update_cache(tensor1, tensor2, batch_idx)
+            >>> output = ttnn.fill_cache(tensor1, tensor2, batch_idx)
 
     )doc";
 
     ttnn::bind_function<"fill_cache">(
-        mod, doc, &ttnn::fill_cache, nb::arg("cache_tensor"), nb::arg("input_tensor"), nb::arg("batch_idx"));
+        mod,
+        doc,
+        &ttnn::fill_cache,
+        nb::arg("cache_tensor"),
+        nb::arg("input_tensor"),
+        nb::arg("batch_idx"),
+        nb::arg("update_idx") = 0);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR extends the TTNN KV-cache fill path to support writing the input sequence into the cache starting at a non-zero sequence offset (update_idx), enabling continuation-style prefill/updates without rewriting from position 0.

Changes:

Add an optional update_idx parameter (default 0) to ttnn.fill_cache and ttnn.fill_cache_for_user_ (C++ + Python bindings).
Enforce fill-cache offset constraints in device-op validation (tile alignment and bounds within cache sequence length).
Add unit tests covering fill_cache(..., update_idx=...) for both interleaved and sharded inputs.