### PR TITLE
Use ReluConfig in pack_relu_config for Quasar type safety

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -28,7 +28,11 @@ void kernel_main() {
 #endif
 
 #ifdef PACK_RELU
+#ifdef ARCH_QUASAR
+    pack_relu_config(ReluConfig::from_packed(get_arg_val<uint32_t>(0)));
+#else
     pack_relu_config(get_arg_val<uint32_t>(0));
+#endif
 #endif
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -271,4 +271,4 @@ ALWI void pack_rows_uninit() {
  }
  #endif
 
- }  // namespace ckernel
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -257,17 +257,18 @@ ALWI void pack_rows_uninit() {
 /**
  * Configures packer ReLU activation at runtime.
  *
- * The packed config encodes the ReLU mode in bits [1:0] and a bfloat16
- * threshold in bits [31:16].
- *
  * Return value: None
  *
- * | Param Type | Name   | Description                                          | Type     | Valid Range | Required |
- * |------------|--------|------------------------------------------------------|----------|-------------|----------|
- * | Function   | config | Packed ReLU config (mode in [1:0], threshold [31:16])| uint32_t | Any         | True     |
+ * | Param Type | Name   | Description                                                         | Type                  | Valid Range | Required |
+ * |------------|--------|---------------------------------------------------------------------|-----------------------|-------------|----------|
+ * | Function   | config | ReLU configuration (ReluConfig on Quasar, packed uint32_t on WH/BH) | ReluConfig / uint32_t | Any         | True     |
  */
-ALWI void pack_relu_config(const uint32_t config) {
-    PACK((llk_pack_relu_config(config)));
-}
+ #ifdef ARCH_QUASAR
+ ALWI void pack_relu_config(const ReluConfig& config) { PACK((llk_pack_relu_config(config))); }
+ #else
+ ALWI void pack_relu_config(const uint32_t config) {
+     PACK((llk_pack_relu_config(config)));
+ }
+ #endif
 
-}  // namespace ckernel
+ }  // namespace ckernel


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/pull/40648#discussion_r3000664998

### What's changed

- On Quasar, pack_relu_config now accepts const ReluConfig& instead of a raw uint32_t, leveraging the existing type-safe struct with factory methods (ReluConfig::none(), ReluConfig::zero(), ReluConfig::min_threshold(t), etc.) to prevent incorrectly encoded bit patterns
- Wormhole/Blackhole retain the uint32_t parameter since ReluConfig is Quasar-specific and there are no other consumers in wh/bh that would benefit from it — adding it there would be unused code bloat
- The kernel-side callsite (eltwise_copy.cpp) converts the runtime arg via ReluConfig::from_packed() on Quasar
