### PR TITLE
[QSR] Converted DFB indices to compile-time args for matmul_block

### DIFF
--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -369,10 +369,8 @@ void matmul_tile(
             tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
 
         // Build compute_cta from compute_kernel_args followed by dataflow buffer ids
-        std::vector<uint32_t> compute_dfb_ids = {src0_dfb, src1_dfb, dst_dfb};
         std::vector<uint32_t> compute_cta = cfg.compute_kernel_args;
-        compute_cta.insert(compute_cta.end(), compute_dfb_ids.begin(), compute_dfb_ids.end());
-
+        compute_cta.insert(compute_cta.end(), {src0_dfb, src1_dfb, dst_dfb});
         compute_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             cfg.compute_kernel,

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -368,9 +368,10 @@ void matmul_tile(
             core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
 
-        // Add dataflow buffer ids as compile args and prepend test-passed flags to compute_cta vector
-        std::vector<uint32_t> compute_cta = {src0_dfb, src1_dfb, dst_dfb};
-        compute_cta.insert(compute_cta.begin(), cfg.compute_kernel_args.begin(), cfg.compute_kernel_args.end());
+        // Build compute_cta from compute_kernel_args followed by dataflow buffer ids
+        std::vector<uint32_t> compute_dfb_ids = {src0_dfb, src1_dfb, dst_dfb};
+        std::vector<uint32_t> compute_cta = cfg.compute_kernel_args;
+        compute_cta.insert(compute_cta.end(), compute_dfb_ids.begin(), compute_dfb_ids.end());
 
         compute_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -360,14 +360,14 @@ void matmul_tile(
             cfg.reader_kernel,
             core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = reader_cta});
-        
+
         std::vector<uint32_t> writer_cta = {dst_dfb};
         unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
             core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
-        
+
         // Add dataflow buffer ids as compile args and prepend test-passed flags to compute_cta vector
         std::vector<uint32_t> compute_cta = {src0_dfb, src1_dfb, dst_dfb};
         compute_cta.insert(compute_cta.begin(), cfg.compute_kernel_args.begin(), cfg.compute_kernel_args.end());

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -354,17 +354,23 @@ void matmul_tile(
     KernelHandle unary_writer_kernel;
     KernelHandle compute_kernel;
     if (is_quasar) {
+        std::vector<uint32_t> reader_cta = {src0_dfb, src1_dfb};
         mm_reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             cfg.reader_kernel,
             core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
-
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = reader_cta});
+        
+        std::vector<uint32_t> writer_cta = {dst_dfb};
         unary_writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tt_metal/kernels/dataflow/writer_unary.cpp",
             core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
+            tt_metal::experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = writer_cta});
+        
+        // Add dataflow buffer ids as compile args and prepend test-passed flags to compute_cta vector
+        std::vector<uint32_t> compute_cta = {src0_dfb, src1_dfb, dst_dfb};
+        compute_cta.insert(compute_cta.begin(), cfg.compute_kernel_args.begin(), cfg.compute_kernel_args.end());
 
         compute_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
@@ -375,7 +381,7 @@ void matmul_tile(
                 .math_fidelity = cfg.math_fidelity,
                 .fp32_dest_acc_en = cfg.fp32_dest_acc_en,
                 .dst_full_sync_en = cfg.dst_full_sync_en,
-                .compile_args = cfg.compute_kernel_args,
+                .compile_args = compute_cta,
                 .defines = compute_defines});
 
         tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -19,9 +19,12 @@ void kernel_main() {
     uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
 
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb0(0);
-    experimental::DataflowBuffer dfb1(1);
-    experimental::DataflowBuffer dfb_out(2);
+    constexpr uint32_t dfb0_id = get_compile_time_arg_val(7);
+    constexpr uint32_t dfb1_id = get_compile_time_arg_val(8);
+    constexpr uint32_t dfb_out_id = get_compile_time_arg_val(9);
+    experimental::DataflowBuffer dfb0(dfb0_id);
+    experimental::DataflowBuffer dfb1(dfb1_id);
+    experimental::DataflowBuffer dfb_out(dfb_out_id);
 #endif
 
 #if (TEST_INIT_SHORT == 1)

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp
@@ -40,8 +40,10 @@ void kernel_main() {
     }
 
 #ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb_in0(0);
-    experimental::DataflowBuffer dfb_in1(1);
+    constexpr uint32_t dfb_in0_id = get_compile_time_arg_val(0);
+    constexpr uint32_t dfb_in1_id = get_compile_time_arg_val(1);
+    experimental::DataflowBuffer dfb_in0(dfb_in0_id);
+    experimental::DataflowBuffer dfb_in1(dfb_in1_id);
     experimental::Noc noc;
     experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram;
 #else

--- a/tt_metal/kernels/dataflow/writer_unary.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary.cpp
@@ -27,8 +27,8 @@ void kernel_main() {
         ublock_size_bytes = dfb_out.get_entry_size();
     #else
         constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
-        ublock_size_bytes = get_tile_size(cb_out_id);
         experimental::CircularBuffer cb(cb_out_id);
+        ublock_size_bytes = get_tile_size(cb_out_id);
     #endif
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {

--- a/tt_metal/kernels/dataflow/writer_unary.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary.cpp
@@ -21,38 +21,38 @@ void kernel_main() {
     uint32_t ublock_size_bytes;
 
     // single-tile ublocks
-    #ifdef ARCH_QUASAR
-        constexpr uint32_t dfb_out_id = get_compile_time_arg_val(0);
-        experimental::DataflowBuffer dfb_out(dfb_out_id);
-        ublock_size_bytes = dfb_out.get_entry_size();
-    #else
-        constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
-        experimental::CircularBuffer cb(cb_out_id);
-        ublock_size_bytes = get_tile_size(cb_out_id);
-    #endif
+#ifdef ARCH_QUASAR
+    constexpr uint32_t dfb_out_id = get_compile_time_arg_val(0);
+    experimental::DataflowBuffer dfb_out(dfb_out_id);
+    ublock_size_bytes = dfb_out.get_entry_size();
+#else
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+    experimental::CircularBuffer cb(cb_out_id);
+    ublock_size_bytes = get_tile_size(cb_out_id);
+#endif
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        #ifdef ARCH_QUASAR
-            dfb_out.wait_front(ublock_size_tiles);
-            noc.async_write(
-                dfb_out,
-                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
-                ublock_size_bytes,
-                {},
-                {.bank_id = bank_id, .addr = dst_addr});
-            noc.async_write_barrier();
-            dfb_out.pop_front(ublock_size_tiles);
-        #else
-            cb.wait_front(ublock_size_tiles);
-            noc.async_write(
-                cb,
-                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
-                ublock_size_bytes,
-                {},
-                {.bank_id = bank_id, .addr = dst_addr});
-            noc.async_write_barrier();
-            cb.pop_front(ublock_size_tiles);
-        #endif
+#ifdef ARCH_QUASAR
+        dfb_out.wait_front(ublock_size_tiles);
+        noc.async_write(
+            dfb_out,
+            experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
+            ublock_size_bytes,
+            {},
+            {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
+        dfb_out.pop_front(ublock_size_tiles);
+#else
+        cb.wait_front(ublock_size_tiles);
+        noc.async_write(
+            cb,
+            experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
+            ublock_size_bytes,
+            {},
+            {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
+        cb.pop_front(ublock_size_tiles);
+#endif
         dst_addr += ublock_size_bytes;
     }
 }

--- a/tt_metal/kernels/dataflow/writer_unary.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary.cpp
@@ -3,57 +3,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/endpoints.h"
+
 #ifdef ARCH_QUASAR
 #include "experimental/dataflow_buffer.h"
 #else
 #include "experimental/circular_buffer.h"
 #endif
-#include "experimental/endpoints.h"
 
 void kernel_main() {
     uint32_t dst_addr  = get_arg_val<uint32_t>(0);
     uint32_t bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
-#ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb_out(2);
-#else
-    constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
-    experimental::CircularBuffer cb(cb_id_out0);
-#endif
+    experimental::Noc noc;
+    uint32_t ublock_size_tiles = 1;
+    uint32_t ublock_size_bytes;
 
     // single-tile ublocks
-#ifdef ARCH_QUASAR
-    uint32_t ublock_size_bytes = dfb_out.get_entry_size();
-#else
-    uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
-#endif
-    uint32_t ublock_size_tiles = 1;
-
-    experimental::Noc noc;
+    #ifdef ARCH_QUASAR
+        constexpr uint32_t dfb_out_id = get_compile_time_arg_val(0);
+        experimental::DataflowBuffer dfb_out(dfb_out_id);
+        ublock_size_bytes = dfb_out.get_entry_size();
+    #else
+        constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+        ublock_size_bytes = get_tile_size(cb_out_id);
+        experimental::CircularBuffer cb(cb_out_id);
+    #endif
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-#ifdef ARCH_QUASAR
-        dfb_out.wait_front(ublock_size_tiles);
-        noc.async_write(
-            dfb_out,
-            experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
-            ublock_size_bytes,
-            {},
-            {.bank_id = bank_id, .addr = dst_addr});
-        noc.async_write_barrier();
-        dfb_out.pop_front(ublock_size_tiles);
-#else
-        cb.wait_front(ublock_size_tiles);
-        noc.async_write(
-            cb,
-            experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
-            ublock_size_bytes,
-            {},
-            {.bank_id = bank_id, .addr = dst_addr});
-        noc.async_write_barrier();
-        cb.pop_front(ublock_size_tiles);
-#endif
+        #ifdef ARCH_QUASAR
+            dfb_out.wait_front(ublock_size_tiles);
+            noc.async_write(
+                dfb_out,
+                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
+                ublock_size_bytes,
+                {},
+                {.bank_id = bank_id, .addr = dst_addr});
+            noc.async_write_barrier();
+            dfb_out.pop_front(ublock_size_tiles);
+        #else
+            cb.wait_front(ublock_size_tiles);
+            noc.async_write(
+                cb,
+                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
+                ublock_size_bytes,
+                {},
+                {.bank_id = bank_id, .addr = dst_addr});
+            noc.async_write_barrier();
+            cb.pop_front(ublock_size_tiles);
+        #endif
         dst_addr += ublock_size_bytes;
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Kernels for matmul_block bringup were using hardcoded dfb indices which could cause conflicting dfb index implementations for writer_unary.cpp.

### What's changed
Made DFP indices passable as compile-time args

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/matmul-block-compile-time-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/matmul-block-compile-time-dfb)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs