### PR TITLE
Migrate EXP2 to tt-llk

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -4,34 +4,18 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_exp2.h"
 
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_exp2() {
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-
-        v = v * sfpi::vConstFloatPrgm0;
-        sfpi::vFloat result;
-
-        if constexpr (is_fp32_dest_acc_en) {
-            result = _sfpu_exp_fp32_accurate_(v);
-        } else {
-            result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-        }
-
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
-    }
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    sfpi::vConstFloatPrgm0 = 0.6931471805f;
+    _init_exp2_<APPROXIMATION_MODE>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -4,34 +4,18 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_exp2.h"
 
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void calculate_exp2() {
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-
-        v = v * sfpi::vConstFloatPrgm0;
-        sfpi::vFloat result;
-
-        if constexpr (is_fp32_dest_acc_en) {
-            result = _sfpu_exp_fp32_accurate_(v);
-        } else {
-            result = _sfpu_exp_21f_bf16_<true>(v);
-            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-        }
-
-        sfpi::dst_reg[0] = result;
-        sfpi::dst_reg++;
-    }
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    sfpi::vConstFloatPrgm0 = 0.6931471805f;
+    _init_exp2_<APPROXIMATION_MODE>();
 }
 
 }  // namespace ckernel::sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40952

### Problem description
Metal implementation and tt-llk implementation differ. Metal side has the updated code , and tt-llk uses exp-approx appraoch. Hence exp2 requires to be migrated to tt-llk as part of exp-approx task.

### What's changed
Migrated Metal EXP2 implemengtation to tt-llk

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/exp2_migrate)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/exp2_migrate)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/exp2_migrate)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/exp2_migrate)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/exp2_migrate)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/exp2_migrate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/exp2_migrate)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
