### PR TITLE
[Feature]: Add support for DFBs on multiple nodes

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -122,8 +122,12 @@ void run_single_dfb_program(
     log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
 
     uint32_t num_entries_per_producer = entries_per_core / dfb_config.num_producers;
+    const bool is_blocked = (dfb_config.cap == dfb::AccessPattern::BLOCKED);
     std::vector<uint32_t> producer_cta = {
-        (uint32_t)in_buffer->address(), num_entries_per_producer, (uint32_t)dfb_config.enable_implicit_sync};
+        (uint32_t)in_buffer->address(),
+        num_entries_per_producer,
+        (uint32_t)dfb_config.enable_implicit_sync,
+        (uint32_t)is_blocked};
     tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
 
     KernelHandle producer_kernel;
@@ -142,7 +146,7 @@ void run_single_dfb_program(
             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     }
 
-    const bool is_blocked = (dfb_config.cap == dfb::AccessPattern::BLOCKED);
+    // is_blocked is already defined above
     uint32_t num_entries_per_consumer = is_blocked ? entries_per_core : entries_per_core / dfb_config.num_consumers;
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
@@ -236,6 +240,18 @@ void run_single_dfb_program(
                 std::vector<uint32_t> expected(
                     input.begin() + co * entry_size / sizeof(uint32_t),
                     input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                if (expected != l1_data) {
+                    std::cout << "expected: ";
+                    for (const auto& e : expected) {
+                        std::cout << e << " ";
+                    }
+                    std::cout << std::endl;
+                    std::cout << "l1_data: ";
+                    for (const auto& l : l1_data) {
+                        std::cout << l << " ";
+                    }
+                    std::cout << std::endl;
+                }
                 EXPECT_EQ(expected, l1_data)
                     << "DFB L1 mismatch on core (" << core.x << "," << core.y << ")";
             }
@@ -739,7 +755,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1B) { // mismatching
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) { // mismatching
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -33,14 +33,6 @@ namespace tt::tt_metal {
 
 enum class DFBPorCType : uint8_t { DM, TENSIX };
 
-static void skip_single_core_compute_grid(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    const CoreCoord grid = mesh_device->compute_with_storage_grid_size();
-    if (grid.x * grid.y == 1) {
-        GTEST_SKIP() << "Multi-core DFB tests require more than a single node but grid size is (" << grid.x
-                     << "x" << grid.y << ")";
-    }
-}
-
 class DFBImplicitSyncParamFixture : public MeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
 
 static std::string ImplicitSyncParamName(const ::testing::TestParamInfo<bool>& info) {
@@ -53,9 +45,8 @@ void execute_program_and_verify(
     const std::shared_ptr<distributed::MeshBuffer>& in_buffer,
     const std::shared_ptr<distributed::MeshBuffer>& out_buffer,
     distributed::MeshCoordinate& zero_coord,
-    uint32_t buffer_size,
+    std::vector<uint32_t>& input,
     bool verify_output = true) {
-    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, buffer_size / sizeof(uint32_t));
     distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
 
     // TODO #38042: Need to wait for data to be written, the barrier needs to be uplifted for Quasar
@@ -184,14 +175,22 @@ void run_single_dfb_program(
     const uint32_t producer_mask = dfb->config.producer_risc_mask;
     const uint32_t consumer_mask = dfb->config.consumer_risc_mask;
 
-    // Single-core: one iteration, chunk_offset = 0.
-    // Multi-core:  each core gets a disjoint page window via chunk_offset.
+    // Build a per-core chunk-offset map (used for both runtime args and L1 pre-fill/verify).
+    std::map<CoreCoord, uint32_t> core_to_chunk_offset;
     uint32_t core_idx = 0;
     for (const CoreRange& cr : core_range_set.ranges()) {
         for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
             for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
-                const uint32_t chunk_offset = core_idx++ * entries_per_core;
+                core_to_chunk_offset[CoreCoord(x, y)] = core_idx++ * entries_per_core;
+            }
+        }
+    }
+
+    for (const CoreRange& cr : core_range_set.ranges()) {
+        for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+            for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
                 const CoreCoord core(x, y);
+                const uint32_t chunk_offset = core_to_chunk_offset.at(core);
                 SetRuntimeArgs(program, producer_kernel, core, {producer_mask, chunk_offset});
                 SetRuntimeArgs(
                     program, consumer_kernel, core,
@@ -200,10 +199,48 @@ void run_single_dfb_program(
         }
     }
 
+    // Generate input once; shared by in_buffer write, L1 pre-fill, and verification.
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_buffer_size / sizeof(uint32_t));
+
+    IDevice* device = mesh_device->get_devices()[0];
+    const uint32_t words_per_core = entries_per_core * entry_size / sizeof(uint32_t);
+
+    // For Tensix → DM: pre-fill each core's DFB L1 with its input chunk so the
+    // Tensix producer kernel can read from L1 while DM consumer drains to DRAM.
+    if (producer_type == DFBPorCType::TENSIX) {
+        for (const auto& group : dfb->groups) {
+            for (const auto& [core, alloc_addr] : group.l1_by_core) {
+                const uint32_t co = core_to_chunk_offset.at(core);
+                std::vector<uint32_t> slice(
+                    input.begin() + co * entry_size / sizeof(uint32_t),
+                    input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                detail::WriteToDeviceL1(device, core, alloc_addr, slice);
+            }
+        }
+    }
+
+    // Launch program; verify out_buffer only for DM → DM paths (Tensix consumer
+    // does not write to DRAM, so out_buffer verification is skipped there).
     execute_program_and_verify(
         mesh_device, program, in_buffer, out_buffer, zero_coord,
-        total_buffer_size,
-        (producer_type == DFBPorCType::DM && consumer_type == DFBPorCType::DM));
+        input,
+        /*verify_output=*/(consumer_type == DFBPorCType::DM));
+
+    // For DM → Tensix: verify each core's DFB L1 against the expected input chunk.
+    if (consumer_type == DFBPorCType::TENSIX) {
+        for (const auto& group : dfb->groups) {
+            for (const auto& [core, alloc_addr] : group.l1_by_core) {
+                const uint32_t co = core_to_chunk_offset.at(core);
+                std::vector<uint32_t> l1_data;
+                detail::ReadFromDeviceL1(device, core, alloc_addr, dfb->total_size(), l1_data);
+                std::vector<uint32_t> expected(
+                    input.begin() + co * entry_size / sizeof(uint32_t),
+                    input.begin() + co * entry_size / sizeof(uint32_t) + words_per_core);
+                EXPECT_EQ(expected, l1_data)
+                    << "DFB L1 mismatch on core (" << core.x << "," << core.y << ")";
+            }
+        }
+    }
 }
 
 void run_in_dfb_out_dfb_program(
@@ -279,7 +316,8 @@ void run_in_dfb_out_dfb_program(
         {(uint32_t)input_dfb_id, (uint32_t)output_dfb_id});
     SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)output_dfb->config.consumer_risc_mask, (uint32_t)output_dfb_id, 0u});
 
-    execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, buffer_size);
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, buffer_size / sizeof(uint32_t));
+    execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, input);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
@@ -330,80 +368,80 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixDMTest2xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig dm2tensix_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+// TEST_F(MeshDeviceFixture, DMTensixDMTest2xDFB1Sx1S) {
+//     if (devices_.at(0)->arch() != ARCH::QUASAR) {
+//         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+//     }
+//     experimental::dfb::DataflowBufferConfig dm2tensix_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 1,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 1,
+//         .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    experimental::dfb::DataflowBufferConfig tensix2dm_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-            .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+//     experimental::dfb::DataflowBufferConfig tensix2dm_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 1,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 1,
+//             .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
-}
+//     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
+// }
 
-TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB2Sx1S1xDFB1Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig dm2tensix_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 2,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+// TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB2Sx1S1xDFB1Sx2S) {
+//     if (devices_.at(0)->arch() != ARCH::QUASAR) {
+//         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+//     }
+//     experimental::dfb::DataflowBufferConfig dm2tensix_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 2,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 1,
+//         .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    experimental::dfb::DataflowBufferConfig tensix2dm_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 2,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+//     experimental::dfb::DataflowBufferConfig tensix2dm_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 1,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 2,
+//         .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
-}
+//     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
+// }
 
-TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB4Sx1S1xDFB1Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
-    }
-    experimental::dfb::DataflowBufferConfig dm2tensix_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 4,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 1,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+// TEST_F(MeshDeviceFixture, DMTensixDMTest1xDFB4Sx1S1xDFB1Sx4S) {
+//     if (devices_.at(0)->arch() != ARCH::QUASAR) {
+//         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+//     }
+//     experimental::dfb::DataflowBufferConfig dm2tensix_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 4,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 1,
+//         .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    experimental::dfb::DataflowBufferConfig tensix2dm_config{
-        .entry_size = 1024,
-        .num_entries = 16,
-        .num_producers = 1,
-        .pap = dfb::AccessPattern::STRIDED,
-        .num_consumers = 4,
-        .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+//     experimental::dfb::DataflowBufferConfig tensix2dm_config{
+//         .entry_size = 1024,
+//         .num_entries = 16,
+//         .num_producers = 1,
+//         .pap = dfb::AccessPattern::STRIDED,
+//         .num_consumers = 4,
+//         .cap = dfb::AccessPattern::STRIDED,
+//         .enable_implicit_sync = false};
 
-    run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
-}
+//     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
+// }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
@@ -701,7 +739,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx1B) { // mismatching
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
 }
 
-TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) {
+TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx1B) { // mismatching
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -873,17 +911,10 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB2Sx4B) {
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ImplicitSync,
-    DFBImplicitSyncParamFixture,
-    ::testing::Bool(),
-    ImplicitSyncParamName);
-
 TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx1S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
-    skip_single_core_compute_grid(this->devices_.at(0));
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
         .num_entries = 16,
@@ -893,16 +924,14 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx1S) {
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
-    // 2 cores in the x-direction; each reads/writes 16 x 1024 B of DRAM.
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
 }
 
-TEST_F(MeshDeviceFixture, MultiCoreDMTest2Core_2Sx2S) {
+TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_2Sx2S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
-    skip_single_core_compute_grid(this->devices_.at(0));
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
         .num_entries = 16,
@@ -910,7 +939,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDMTest2Core_2Sx2S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_implicit_sync = GetParam()};
 
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
@@ -920,7 +949,6 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4B) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
-    skip_single_core_compute_grid(this->devices_.at(0));
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
         .num_entries = 16,
@@ -933,5 +961,11 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4B) {
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ImplicitSync,
+    DFBImplicitSyncParamFixture,
+    ::testing::Bool(),
+    ImplicitSyncParamName);
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -33,6 +33,14 @@ namespace tt::tt_metal {
 
 enum class DFBPorCType : uint8_t { DM, TENSIX };
 
+static void skip_single_core_compute_grid(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    const CoreCoord grid = mesh_device->compute_with_storage_grid_size();
+    if (grid.x * grid.y == 1) {
+        GTEST_SKIP() << "Multi-core DFB tests require more than a single node but grid size is (" << grid.x
+                     << "x" << grid.y << ")";
+    }
+}
+
 class DFBImplicitSyncParamFixture : public MeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
 
 static std::string ImplicitSyncParamName(const ::testing::TestParamInfo<bool>& info) {
@@ -67,11 +75,6 @@ void execute_program_and_verify(
     std::vector<uint32_t> output;
     distributed::ReadShard(mesh_device->mesh_command_queue(), output, out_buffer, zero_coord, true);
 
-    // first CB would get allocated at L1 unreserved base
-    uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    std::vector<uint32_t> intermediate(buffer_size / sizeof(uint32_t));
-    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), l1_unreserved_base, buffer_size, intermediate);
-
     if (verify_output) {
         if (input != output) {
             log_info(tt::LogTest, "Printing input");
@@ -83,45 +86,53 @@ void execute_program_and_verify(
             for (auto i : output) {
                 std::cout << i << " ";
             }
-            std::cout << std::endl;
-            if (intermediate != input) {
-                log_info(tt::LogTest, "Printing intermediate");
-                for (auto i : intermediate) {
-                    std::cout << i << " ";
-                }
-                std::cout << std::endl;
-            }
         }
         EXPECT_EQ(input, output);
     }
 }
 
+// Runs a single DFB program on one or more cores and verifies output == input.
+//
+// When core_range_set contains N > 1 cores the global DRAM buffers are sized
+// N x entries_per_core x entry_size and each core receives a unique
+// chunk_offset (= core_idx * entries_per_core) so it accesses a disjoint
+// slice of the buffer.  Multi-core use requires DM producer and consumer.
 void run_single_dfb_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     experimental::dfb::DataflowBufferConfig& dfb_config,
     DFBPorCType producer_type,
-    DFBPorCType consumer_type) {
+    DFBPorCType consumer_type,
+    const CoreRangeSet& core_range_set = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)))) {
 
     TT_FATAL(
         !(producer_type == DFBPorCType::TENSIX && consumer_type == DFBPorCType::TENSIX),
         "Both producer and consumer cannot be Tensix. At least one must be a DM kernel for NOC transfers.");
+    TT_FATAL(
+        core_range_set.num_cores() == 1 ||
+            (producer_type == DFBPorCType::DM && consumer_type == DFBPorCType::DM),
+        "Multi-core DFB programs only support DM producer and consumer.");
 
     Program program = CreateProgram();
-
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    uint32_t buffer_size = dfb_config.entry_size * dfb_config.num_entries;
-    distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = buffer_size, .buffer_type = BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+
+    const uint32_t num_cores = core_range_set.num_cores();
+    const uint32_t entries_per_core = dfb_config.num_entries;
+    const uint32_t entry_size = dfb_config.entry_size;
+    // page_size = entry_size makes every entry independently addressable by
+    // page_id.  For single-core this is equivalent to page_size = buffer_size
+    // because chunk_offset = 0 and page_ids 0..num_entries-1 stay in range.
+    const uint32_t total_buffer_size = num_cores * entries_per_core * entry_size;
+    distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = entry_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = total_buffer_size};
     auto in_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
     auto out_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
 
-    log_info(tt::LogTest, "In Buffer: [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
+    log_info(tt::LogTest, "In Buffer:  [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
     log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
 
-    CoreCoord logical_core = CoreCoord(0, 0);
-
-    uint32_t num_entries_per_producer = dfb_config.num_entries / dfb_config.num_producers;
-    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address(), num_entries_per_producer, (uint32_t)dfb_config.enable_implicit_sync};
+    uint32_t num_entries_per_producer = entries_per_core / dfb_config.num_producers;
+    std::vector<uint32_t> producer_cta = {
+        (uint32_t)in_buffer->address(), num_entries_per_producer, (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
 
     KernelHandle producer_kernel;
@@ -129,24 +140,23 @@ void run_single_dfb_program(
         producer_kernel = experimental::quasar::CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
-            logical_core,
+            core_range_set,
             experimental::quasar::QuasarDataMovementConfig{
                 .num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     } else {
         producer_kernel = CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
-            logical_core,
+            core_range_set,
             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     }
 
-    uint32_t num_entries_per_consumer = dfb_config.cap == dfb::AccessPattern::STRIDED
-                                            ? dfb_config.num_entries / dfb_config.num_consumers
-                                            : dfb_config.num_entries;
+    const bool is_blocked = (dfb_config.cap == dfb::AccessPattern::BLOCKED);
+    uint32_t num_entries_per_consumer = is_blocked ? entries_per_core : entries_per_core / dfb_config.num_consumers;
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
         num_entries_per_consumer,
-        (uint32_t)dfb_config.cap == dfb::AccessPattern::BLOCKED,
+        (uint32_t)is_blocked,
         (uint32_t)dfb_config.enable_implicit_sync};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
 
@@ -155,36 +165,45 @@ void run_single_dfb_program(
         consumer_kernel = experimental::quasar::CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
-            logical_core,
+            core_range_set,
             experimental::quasar::QuasarDataMovementConfig{
                 .num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
     } else {
         consumer_kernel = CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
-            logical_core,
+            core_range_set,
             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
     }
 
-    auto logical_dfb_id = experimental::dfb::CreateDataflowBuffer(program, logical_core, dfb_config);
-
+    auto logical_dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, dfb_config);
     experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
         program, logical_dfb_id, producer_kernel, consumer_kernel);
 
     auto dfb = program.impl().get_dataflow_buffer(logical_dfb_id);
+    const uint32_t producer_mask = dfb->config.producer_risc_mask;
+    const uint32_t consumer_mask = dfb->config.consumer_risc_mask;
 
-    SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)dfb->config.producer_risc_mask});
-    SetRuntimeArgs(
-        program, consumer_kernel, logical_core, {(uint32_t)dfb->config.consumer_risc_mask, (uint32_t)logical_dfb_id});
+    // Single-core: one iteration, chunk_offset = 0.
+    // Multi-core:  each core gets a disjoint page window via chunk_offset.
+    uint32_t core_idx = 0;
+    for (const CoreRange& cr : core_range_set.ranges()) {
+        for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+            for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+                const uint32_t chunk_offset = core_idx++ * entries_per_core;
+                const CoreCoord core(x, y);
+                SetRuntimeArgs(program, producer_kernel, core, {producer_mask, chunk_offset});
+                SetRuntimeArgs(
+                    program, consumer_kernel, core,
+                    {consumer_mask, (uint32_t)logical_dfb_id, chunk_offset});
+            }
+        }
+    }
 
     execute_program_and_verify(
-        mesh_device,
-        program,
-        in_buffer,
-        out_buffer,
-        zero_coord,
-        buffer_size,
-        (producer_type == DFBPorCType::DM and consumer_type == DFBPorCType::DM));
+        mesh_device, program, in_buffer, out_buffer, zero_coord,
+        total_buffer_size,
+        (producer_type == DFBPorCType::DM && consumer_type == DFBPorCType::DM));
 }
 
 void run_in_dfb_out_dfb_program(
@@ -252,13 +271,13 @@ void run_in_dfb_out_dfb_program(
     auto input_dfb = program.impl().get_dataflow_buffer(input_dfb_id);
     auto output_dfb = program.impl().get_dataflow_buffer(output_dfb_id);
 
-    SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)input_dfb->config.producer_risc_mask});
+    SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)input_dfb->config.producer_risc_mask, 0u});
     SetRuntimeArgs(
         program,
         compute_kernel,
         logical_core,
         {(uint32_t)input_dfb_id, (uint32_t)output_dfb_id});
-    SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)output_dfb->config.consumer_risc_mask, (uint32_t)output_dfb_id});
+    SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)output_dfb->config.consumer_risc_mask, (uint32_t)output_dfb_id, 0u});
 
     execute_program_and_verify(mesh_device, program, in_buffer, out_buffer, zero_coord, buffer_size);
 }
@@ -859,5 +878,60 @@ INSTANTIATE_TEST_SUITE_P(
     DFBImplicitSyncParamFixture,
     ::testing::Bool(),
     ImplicitSyncParamName);
+
+TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    skip_single_core_compute_grid(this->devices_.at(0));
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = GetParam()};
+
+    // 2 cores in the x-direction; each reads/writes 16 x 1024 B of DRAM.
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
+}
+
+TEST_F(MeshDeviceFixture, MultiCoreDMTest2Core_2Sx2S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    skip_single_core_compute_grid(this->devices_.at(0));
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 2,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = 2,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
+}
+
+TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    skip_single_core_compute_grid(this->devices_.at(0));
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = dfb::AccessPattern::BLOCKED,
+        .enable_implicit_sync = GetParam()};
+
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
+}
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -56,13 +56,16 @@ void validate_dfb_tile_counters(
     const auto& dfb = dfbs[0];
 
     ASSERT_EQ(dfb->risc_mask, config.producer_risc_mask | config.consumer_risc_mask);
-    ASSERT_EQ(dfb->risc_configs.size(), config.num_producers + config.num_consumers);
+    ASSERT_FALSE(dfb->groups.empty()) << "DFB has no groups (configs not finalized?)";
+    // All single-core tests produce exactly one DfbGroup.
+    const auto& hw_risc_configs = dfb->groups[0].hw_risc_configs;
+    ASSERT_EQ(hw_risc_configs.size(), config.num_producers + config.num_consumers);
 
     // risc ID to risc config maps
     std::map<uint8_t, const experimental::dfb::detail::DFBRiscConfig*> producer_configs;
     std::map<uint8_t, const experimental::dfb::detail::DFBRiscConfig*> consumer_configs;
 
-    for (const auto& rc : dfb->risc_configs) {
+    for (const auto& rc : hw_risc_configs) {
         if (rc.is_producer) {
             producer_configs[rc.risc_id] = &rc;
         } else {
@@ -683,6 +686,175 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4BConfig) {
         }};
 
     validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-core DFB tests
+// ---------------------------------------------------------------------------
+
+// Helper: validate that a multi-core DFB has the expected number of DfbGroups
+// and that each core's hw_risc_configs matches a single reference group
+// (i.e. all cores have identical TC/remapper assignments).
+static void validate_multicore_dfb_groups(
+    Program& program,
+    const CoreRangeSet& core_range_set,
+    uint32_t expected_num_groups,
+    uint32_t expected_cores_per_group) {
+    // Collect DFBs from the first core; they should all be on every core.
+    CoreCoord first_core = core_range_set.ranges()[0].start_coord;
+    auto dfbs = program.impl().dataflow_buffers_on_core(first_core);
+    ASSERT_EQ(dfbs.size(), 1) << "Expected exactly 1 DFB on core";
+    const auto& dfb = dfbs[0];
+
+    ASSERT_EQ(dfb->groups.size(), expected_num_groups)
+        << "Expected " << expected_num_groups << " DfbGroup(s)";
+
+    for (const auto& grp : dfb->groups) {
+        EXPECT_EQ(grp.l1_by_core.size(), expected_cores_per_group)
+            << "DfbGroup should have " << expected_cores_per_group << " core(s)";
+    }
+
+    // All cores in the core_range_set should appear somewhere in l1_by_core.
+    std::set<CoreCoord> accounted_cores;
+    for (const auto& grp : dfb->groups) {
+        for (const auto& [c, _] : grp.l1_by_core) {
+            accounted_cores.insert(c);
+        }
+    }
+    for (const CoreRange& cr : core_range_set.ranges()) {
+        for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+            for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+                EXPECT_EQ(accounted_cores.count(CoreCoord(x, y)), 1u)
+                    << "Core (" << x << "," << y << ") not found in any DfbGroup";
+            }
+        }
+    }
+}
+
+// Multi-core DFB, no implicit sync: 2 cores, 1 producer, 1 consumer, STRIDED.
+// Expected: 1 DfbGroup (homogeneous HW config) with 2 cores.
+TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));  // 2 cores: (0,0) and (1,0)
+    experimental::dfb::CreateDataflowBuffer(program, core_range_set, config);
+
+    // Finalize configs explicitly (normally done during compile/ConfigureDeviceWithProgram).
+    program.impl().finalize_dataflow_buffer_configs();
+
+    // Both cores have identical TC config → 1 group with 2 cores.
+    validate_multicore_dfb_groups(program, core_range_set, /*expected_num_groups=*/1, /*expected_cores_per_group=*/2);
+
+    // Each core should have TC index 0 (independent per-core allocator starting from 0).
+    for (const CoreRange& cr : core_range_set.ranges()) {
+        for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+            for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+                CoreCoord core(x, y);
+                auto dfbs = program.impl().dataflow_buffers_on_core(core);
+                ASSERT_EQ(dfbs.size(), 1);
+                const auto& dfb = dfbs[0];
+                // Find this core's group
+                const experimental::dfb::detail::DfbGroup* found_grp = nullptr;
+                for (const auto& grp : dfb->groups) {
+                    for (const auto& [c, _] : grp.l1_by_core) {
+                        if (c == core) { found_grp = &grp; break; }
+                    }
+                    if (found_grp) {
+                        break;
+                    }
+                }
+                ASSERT_NE(found_grp, nullptr) << "Core (" << x << "," << y << ") not found in any DfbGroup";
+
+                // Validate TC index is 0 (first allocation from fresh per-core allocator).
+                for (const auto& rc : found_grp->hw_risc_configs) {
+                    for (uint8_t tc = 0; tc < rc.config.num_tcs_to_rr; tc++) {
+                        auto ptc = rc.config.packed_tile_counter[tc];
+                        EXPECT_EQ(dfb::get_counter_id(ptc), tc)
+                            << "Core (" << x << "," << y << ") RISC " << (int)rc.risc_id
+                            << " TC[" << (int)tc << "] should have counter_id=" << (int)tc;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Multi-core DFB, with implicit sync: 2 cores, 1 producer, 1 consumer, STRIDED.
+// Txn IDs should be allocated once (core-invariant) and identical across cores.
+TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true};
+
+    Program program = CreateProgram();
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));  // 2 cores
+    experimental::dfb::CreateDataflowBuffer(program, core_range_set, config);
+
+    program.impl().finalize_dataflow_buffer_configs();
+
+    // Should still produce 1 group (identical HW config on both cores).
+    validate_multicore_dfb_groups(program, core_range_set, /*expected_num_groups=*/1, /*expected_cores_per_group=*/2);
+
+    // Txn ID descriptors are core-invariant: allocated once during finalization.
+    CoreCoord first_core(0, 0);
+    auto dfbs = program.impl().dataflow_buffers_on_core(first_core);
+    ASSERT_EQ(dfbs.size(), 1);
+    const auto& dfb = dfbs[0];
+
+    EXPECT_EQ(dfb->producer_txn_descriptor.num_txn_ids, 2u)
+        << "Expected 2 producer txn IDs (double-buffering)";
+    EXPECT_EQ(dfb->consumer_txn_descriptor.num_txn_ids, 2u)
+        << "Expected 2 consumer txn IDs (double-buffering)";
+}
+
+// Identical-config multi-core: assert one DfbGroup is produced (multicast-ready).
+TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 512,
+        .num_entries = 8,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    // 4 cores in a 2x2 grid — all identical config → should produce 1 DfbGroup.
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 1)));
+    experimental::dfb::CreateDataflowBuffer(program, core_range_set, config);
+
+    program.impl().finalize_dataflow_buffer_configs();
+
+    // All 4 cores have the same HW config → 1 DfbGroup with 4 cores.
+    validate_multicore_dfb_groups(program, core_range_set, /*expected_num_groups=*/1, /*expected_cores_per_group=*/4);
 }
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
@@ -31,5 +31,6 @@ void kernel_main() {
         dfb.pop_front(1);
         // DPRINT << "pfd" << ENDL();
     }
+    // dfb.finish();
     DPRINT << "CBWD" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -52,6 +52,7 @@ void kernel_main() {
             dfb.pop_front(1);
         }
     }
+    dfb.finish();
     DPRINT << "CBW" << ENDL();
     noc.async_write_barrier();
     DPRINT << "CBWD" << ENDL();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -16,6 +16,9 @@ void kernel_main() {
 
     uint32_t consumer_mask = get_arg_val<uint32_t>(0);
     uint32_t logical_dfb_id = get_arg_val<uint32_t>(1);
+    // Base page offset for this core's slice of the global buffer.
+    // Single-core callers pass 0; multi-core callers pass core_idx * entries_per_core.
+    const uint32_t chunk_offset = get_arg_val<uint32_t>(2);
     const uint32_t num_consumers = static_cast<uint32_t>(__builtin_popcount(consumer_mask));
 
     experimental::DataflowBuffer dfb(logical_dfb_id);
@@ -35,9 +38,9 @@ void kernel_main() {
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
         uint32_t page_id = 0;
         if constexpr (blocked_consumer) {
-            page_id = tile_id;
+            page_id = chunk_offset + tile_id;
         } else {
-            page_id = tile_id * num_consumers + consumer_idx;
+            page_id = chunk_offset + tile_id * num_consumers + consumer_idx;
         }
         DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
         if constexpr (implicit_sync) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -14,6 +14,9 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<3>();
 
     uint32_t producer_mask = get_arg_val<uint32_t>(0);
+    // Base page offset for this core's slice of the global buffer.
+    // Single-core callers pass 0; multi-core callers pass core_idx * entries_per_core.
+    const uint32_t chunk_offset = get_arg_val<uint32_t>(1);
     const uint32_t num_producers = static_cast<uint32_t>(__builtin_popcount(producer_mask));
 
     experimental::DataflowBuffer dfb(0);
@@ -31,12 +34,13 @@ void kernel_main() {
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        // DPRINT << "producer tile id " << tile_id << " page id " << ((tile_id * num_producers) + producer_idx) << ENDL();
+        const uint32_t page_id = chunk_offset + tile_id * num_producers + producer_idx;
+        // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         if constexpr (implicit_sync) {
-            dfb.read_in(noc, tensor_accessor, {.page_id = tile_id * num_producers + producer_idx});
+            dfb.read_in(noc, tensor_accessor, {.page_id = page_id});
         } else {
             dfb.reserve_back(1);
-            noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id * num_producers + producer_idx}, {});
+            noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = page_id}, {});
             noc.async_read_barrier();
             dfb.push_back(1);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -11,7 +11,13 @@ void kernel_main() {
     const uint32_t src_addr_base = get_compile_time_arg_val(0);
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
     constexpr uint32_t implicit_sync = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    // BLOCKED consumer does block reads (TC0 fully exhausted before TC1, etc.), so the DFB
+    // uses a contiguous layout per producer. Producer i must write pages [i*N .. i*N+(N-1)]
+    // so that each consumer TC sees a contiguous, in-order slice.
+    // STRIDED consumer reads in round-robin (TC0, TC1, ..., TC0, ...), so the DFB uses an
+    // interleaved layout and producer i writes pages [i, i+P, i+2P, ...].
+    constexpr uint32_t blocked_consumer = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4>();
 
     uint32_t producer_mask = get_arg_val<uint32_t>(0);
     // Base page offset for this core's slice of the global buffer.
@@ -34,7 +40,9 @@ void kernel_main() {
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        const uint32_t page_id = chunk_offset + tile_id * num_producers + producer_idx;
+        const uint32_t page_id = blocked_consumer
+                                     ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
+                                     : chunk_offset + tile_id * num_producers + producer_idx;
         // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         if constexpr (implicit_sync) {
             dfb.read_in(noc, tensor_accessor, {.page_id = page_id});

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -86,13 +86,14 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
 
 namespace detail {
 
-::dfb::PackedTileCounter TileCounterAllocator::allocate(uint8_t tensix_id) {
+::dfb::PackedTileCounter TileCounterAllocator::allocate(const CoreCoord& core, uint8_t tensix_id) {
     TT_FATAL(tensix_id < ::dfb::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
+    auto& tc_ids = next_tc_id_[core];
     TT_FATAL(
-        next_tc_id_[tensix_id] < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
-        "Out of tile counters for tensix {}",
-        tensix_id);
-    uint8_t tc_id = next_tc_id_[tensix_id]++;
+        tc_ids[tensix_id] < ::dfb::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
+        "Out of tile counters for tensix {} on core ({}, {})",
+        tensix_id, core.x, core.y);
+    uint8_t tc_id = tc_ids[tensix_id]++;
     return static_cast<::dfb::PackedTileCounter>(
         (tensix_id << ::dfb::PACKED_TC_COUNTER_ID_BITS) | tc_id);
 }
@@ -274,13 +275,22 @@ struct TileCounterGroup {
 };
 
 uint32_t DataflowBufferImpl::serialized_size() const {
-    // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc
+    // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc.
+    // All groups have the same number of RISC configs
+    TT_FATAL(!groups.empty(), "DFB {} has no groups (configs not finalized?)", id);
     return sizeof(dfb_initializer_t) +
-           (risc_configs.size() * sizeof(dfb_initializer_per_risc_t));
+           (groups[0].hw_risc_configs.size() * sizeof(dfb_initializer_per_risc_t));
 }
 
-std::vector<uint8_t> DataflowBufferImpl::serialize() const {
+std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
     TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
+
+    auto it = this->core_lookup_.find(core);
+    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
+    const auto& [group_idx, alloc_addr] = it->second;
+    const DfbGroup* core_group = &this->groups[group_idx];
+
+    const auto& hw_risc_configs = core_group->hw_risc_configs;
 
     std::vector<uint8_t> data;
     data.reserve(serialized_size());
@@ -299,8 +309,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
 
     log_info(
         tt::LogMetal,
-        "Serializing DFB {} with {} producers and {} consumers. risc_mask: 0x{:x} use_remapper: {}",
+        "Serializing DFB {} for core ({},{}) with {} producers and {} consumers. risc_mask: 0x{:x} use_remapper: {}",
         this->id,
+        core.x,
+        core.y,
         this->config.num_producers,
         this->config.num_consumers,
         this->risc_mask,
@@ -324,19 +336,64 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     const auto* init_bytes = reinterpret_cast<const uint8_t*>(&init);
     data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
 
+    const uint32_t entry_size = this->config.entry_size;
+    const uint32_t max_prod_cons = std::max(this->config.num_producers, this->config.num_consumers);
+
+    // Find num_producer_tcs and num_consumer_tcs from the HW config.
+    uint8_t num_producer_tcs = 0;
+    uint8_t num_consumer_tcs = 0;
+    for (const auto& rc : hw_risc_configs) {
+        if (rc.is_producer) {
+            num_producer_tcs = std::max(num_producer_tcs, rc.config.num_tcs_to_rr);
+        } else {
+            num_consumer_tcs = std::max(num_consumer_tcs, rc.config.num_tcs_to_rr);
+        }
+    }
+
+    std::vector<DFBRiscConfig> per_core_rc = hw_risc_configs;
+    uint32_t base = alloc_addr;
+    for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
+        for (auto& rc : per_core_rc) {
+            if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
+                rc.config.base_addr[tc] = base;
+                rc.config.limit[tc] =
+                    rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (this->capacity - 1)) + entry_size;
+                if (!rc.config.broadcast_tc) {
+                    base += entry_size;
+                }
+            }
+        }
+    }
+    base = alloc_addr;
+    for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
+        for (auto& rc : per_core_rc) {
+            if (rc.is_producer) {
+                continue;
+            }
+            rc.config.base_addr[tc] = base;
+            rc.config.limit[tc] =
+                rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (this->capacity - 1)) + entry_size;
+            if ((this->config.cap == dfb::AccessPattern::STRIDED ||
+                 (this->config.cap == dfb::AccessPattern::BLOCKED && this->config.num_producers > 1)) &&
+                tc < rc.config.num_tcs_to_rr) {
+                base += entry_size;
+            }
+        }
+    }
+
     // Write one dfb_initializer_per_risc_t per risc, in risc_mask order
     for (int bit = 0; bit < 16; bit++) {
         if (!(this->risc_mask & (1 << bit))) {
             continue;
         }
         const DFBRiscConfig* rc = nullptr;
-        for (const auto& c : risc_configs) {
+        for (const auto& c : per_core_rc) {
             if (c.risc_id == static_cast<uint8_t>(bit)) {
                 rc = &c;
                 break;
             }
         }
-        TT_FATAL(rc != nullptr, "DFB {}: no risc_config for risc_id {} (bit {})", this->id, bit, bit);
+        TT_FATAL(rc != nullptr, "DFB {}: no risc_config for risc_id {} on core ({},{})", this->id, bit, core.x, core.y);
 
         log_info(tt::LogMetal, "New risc config (risc_id={}, is_producer={})", rc->risc_id, rc->is_producer);
         dfb_initializer_per_risc_t per_risc = {};
@@ -376,7 +433,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
         data.insert(data.end(), cfg_bytes, cfg_bytes + sizeof(per_risc));
     }
 
-    log_info(tt::LogMetal, "Serialized DFB {} size: {}", this->id, data.size());
+    log_info(tt::LogMetal, "Serialized DFB {} for core ({},{}) size: {}", this->id, core.x, core.y, data.size());
 
     return data;
 }
@@ -455,11 +512,6 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     TT_FATAL(config.pap != dfb::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
 
     TT_FATAL(
-        core_range_set.num_cores() == 1,
-        "DFB only supports single core, but CoreRangeSet contains {} cores: {}",
-        core_range_set.num_cores(),
-        core_range_set.str());
-    TT_FATAL(
         config.cap != dfb::AccessPattern::BLOCKED || config.num_consumers <= 4,
         "Blocked consumer pattern supports at most 4 consumers, but {} were specified",
         config.num_consumers);
@@ -533,20 +585,26 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     return dfb->id;
 }
 
-// Allocates TCs and remapper indices
+// Allocates TCs and remapper indices, per (dfb, core).
 void ProgramImpl::finalize_dataflow_buffer_configs() {
     if (this->dataflow_buffers_.empty()) {
         return;
     }
 
-    // Group DFBs by core
+    // Collect all (dfb, core) pairs that need finalization, grouped by core so that
+    // remapper need can be determined per logical core
     std::unordered_map<CoreCoord, std::vector<std::shared_ptr<DataflowBufferImpl>>> dfbs_by_core;
     for (auto& dfb : this->dataflow_buffers_) {
         if (dfb->configs_finalized) {
             continue;
         }
-        CoreCoord core = dfb->core_ranges.ranges()[0].start_coord;
-        dfbs_by_core[core].push_back(dfb);
+        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                    dfbs_by_core[CoreCoord(x, y)].push_back(dfb);
+                }
+            }
+        }
     }
 
     // Process each core's DFBs together
@@ -554,7 +612,6 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
         bool core_needs_remapper = false;
         for (const auto& dfb : core_dfbs) {
             if (dfb->config.cap == dfb::AccessPattern::BLOCKED) {
-                // DM-DM BLOCKED uses software broadcast (no remapper needed)
                 bool dm_dm_blocked = !has_tensix_risc(dfb->config.producer_risc_mask) &&
                                      !has_tensix_risc(dfb->config.consumer_risc_mask);
                 if (!dm_dm_blocked) {
@@ -576,11 +633,18 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
             finalize_single_dfb_config(dfb, core, core_needs_remapper);
         }
     }
+
+    for (auto& dfb : this->dataflow_buffers_) {
+        if (!dfb->configs_finalized && !dfb->groups.empty()) {
+            dfb->configs_finalized = true;
+        }
+    }
 }
 
 void ProgramImpl::finalize_single_dfb_config(
     std::shared_ptr<DataflowBufferImpl>& dfb, const CoreCoord& core, bool core_has_remapper) {
     const auto& config = dfb->config;
+    std::vector<DFBRiscConfig> new_hw_risc_configs;
 
     TT_FATAL(config.producer_risc_mask != 0, "producer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
     TT_FATAL(config.consumer_risc_mask != 0, "consumer_risc_mask must be set before program launch. Either set it in DataflowBufferConfig or call BindDataflowBufferToProducerConsumerKernels after creating kernels");
@@ -707,14 +771,14 @@ void ProgramImpl::finalize_single_dfb_config(
                 uint8_t consumer_risc_id = consumer_risc_ids[consumer_idx];
                 uint8_t tensix_id = get_tensix_id_for_pair(producer_risc_id, consumer_risc_id, pair_counter++);
 
-                group.producer_tc = tile_counter_allocator_.allocate(tensix_id);
+                group.producer_tc = tile_counter_allocator_.allocate(core, tensix_id);
 
                 if (use_remapper) {
                     // With remapper: allocate separate consumer TC
                     uint8_t consumer_tensix_id =
                         ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
                     dfb::PackedTileCounter consumer_tc =
-                        tile_counter_allocator_.allocate(consumer_tensix_id);
+                        tile_counter_allocator_.allocate(core, consumer_tensix_id);
                     group.consumer_tcs.push_back(consumer_tc);
                 } else {
                     // Without remapper: shared TC
@@ -737,7 +801,7 @@ void ProgramImpl::finalize_single_dfb_config(
                     // DM-DM BLOCKED: allocate one TC per consumer (tc_slot == consumer_idx).
                     // The TC is shared between producer and consumer i -- no remapper needed.
                     uint8_t tensix_id = get_dm_tensix_id_for_pair(pair_counter++);
-                    group.producer_tc = tile_counter_allocator_.allocate(tensix_id);
+                    group.producer_tc = tile_counter_allocator_.allocate(core, tensix_id);
                     group.consumer_tcs.push_back(group.producer_tc);  // shared
 
                     log_info(
@@ -750,13 +814,13 @@ void ProgramImpl::finalize_single_dfb_config(
                 } else {
                     // Tensix-involved BLOCKED: use remapper for 1-to-many
                     uint8_t producer_tensix_id = producer_risc_ids[producer_idx] % 4;
-                    group.producer_tc = tile_counter_allocator_.allocate(producer_tensix_id);
+                    group.producer_tc = tile_counter_allocator_.allocate(core, producer_tensix_id);
 
                     for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
                         uint8_t consumer_tensix_id =
                             ClientTypeAllocator::get_tensix_id(consumer_client_types[consumer_idx]);
                         dfb::PackedTileCounter consumer_tc =
-                            tile_counter_allocator_.allocate(consumer_tensix_id);
+                            tile_counter_allocator_.allocate(core, consumer_tensix_id);
                         group.consumer_tcs.push_back(consumer_tc);
                     }
 
@@ -837,7 +901,7 @@ void ProgramImpl::finalize_single_dfb_config(
                 risc_config.config.remapper_consumer_ids_mask);
         }
 
-        dfb->risc_configs.push_back(risc_config);
+        new_hw_risc_configs.push_back(risc_config);
     }
 
     // Create consumer risc_configs and assign TCs from groups
@@ -904,12 +968,13 @@ void ProgramImpl::finalize_single_dfb_config(
         }
         risc_config.config.num_tcs_to_rr = num_consumer_tcs;
 
-        dfb->risc_configs.push_back(risc_config);
+        new_hw_risc_configs.push_back(risc_config);
     }
 
     // Allocate transaction IDs and compute ISR descriptor fields when implicit sync is enabled.
+    // Only done on the first core processed for this DFB because txn IDs are core-invariant
     // Two txn IDs per side for double buffering.
-    if (config.enable_implicit_sync) {
+    if (config.enable_implicit_sync && dfb->groups.empty()) {
         constexpr uint8_t TXN_IDS_PER_SIDE = 2;
 
         if (!producer_is_tensix_only) {
@@ -954,10 +1019,62 @@ void ProgramImpl::finalize_single_dfb_config(
         }
     }
 
-    dfb->configs_finalized = true;
     dfb->use_remapper = use_remapper;
     log_info(
         tt::LogMetal, "DFB {} finalized risc_mask: 0x{:x} use_remapper: {}", dfb->id, dfb->risc_mask, use_remapper);
+
+    // Bin this core into a DfbGroup with matching HW config (TC/remapper fields).
+    // base_addr/limit are not set here; they are derived per-core in DataflowBufferImpl::serialize_for_core()
+    // from each core's alloc_addr, so they are intentionally ignored in this HW config equality check.
+    auto hw_risc_configs_equal = [](const std::vector<DFBRiscConfig>& a, const std::vector<DFBRiscConfig>& b) -> bool {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < a.size(); i++) {
+            if (a[i].risc_id != b[i].risc_id || a[i].is_producer != b[i].is_producer) {
+                return false;
+            }
+            const auto& ca = a[i].config;
+            const auto& cb = b[i].config;
+            if (ca.num_tcs_to_rr != cb.num_tcs_to_rr ||
+                ca.broadcast_tc != cb.broadcast_tc ||
+                ca.remapper_pair_index != cb.remapper_pair_index ||
+                ca.consumer_tcs != cb.consumer_tcs ||
+                ca.remapper_consumer_ids_mask != cb.remapper_consumer_ids_mask ||
+                ca.producer_client_type != cb.producer_client_type) {
+                return false;
+            }
+            for (int j = 0; j < ca.num_tcs_to_rr; j++) {
+                if (ca.packed_tile_counter[j] != cb.packed_tile_counter[j]) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    };
+
+    DfbGroup* matching_group = nullptr;
+    for (auto& grp : dfb->groups) {
+        if (hw_risc_configs_equal(grp.hw_risc_configs, new_hw_risc_configs)) {
+            matching_group = &grp;
+            break;
+        }
+    }
+    if (matching_group == nullptr) {
+        DfbGroup new_group;
+        new_group.hw_risc_configs = new_hw_risc_configs;
+        dfb->groups.push_back(std::move(new_group));
+        matching_group = &dfb->groups.back();
+    }
+
+    // Extend core_ranges to include this core.
+    CoreRange core_as_range(core, core);
+    if (matching_group->core_ranges.ranges().empty()) {
+        matching_group->core_ranges = CoreRangeSet(core_as_range);
+    } else {
+        matching_group->core_ranges = matching_group->core_ranges.merge(CoreRangeSet(core_as_range));
+    }
+    matching_group->l1_by_core.emplace_back(core, 0u);
 }
 
 void ProgramImpl::invalidate_dataflow_buffer_allocation() {
@@ -1002,57 +1119,14 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
                 }
             }
         }
-        dfb->allocated_address = computed_addr;
-
-        // Populate base_addr[] and limit[] arrays for each risc config.
-        // Layout is column-major by (tile_counter, producer/consumer): all producers' tc0 first, then all tc1, etc.
-        uint32_t entry_size = dfb->config.entry_size;
-        uint32_t max_prod_cons = std::max(dfb->config.num_producers, dfb->config.num_consumers);
-
-        uint8_t num_producer_tcs = 0;
-        for (const auto& rc : dfb->risc_configs) {
-            if (rc.is_producer) {
-                num_producer_tcs = rc.config.num_tcs_to_rr;
-                break;
-            }
-        }
-        uint32_t base_addr = static_cast<uint32_t>(computed_addr);
-        for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
-            for (auto& rc : dfb->risc_configs) {
-                if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
-                    rc.config.base_addr[tc] = base_addr;
-                    rc.config.limit[tc] =
-                        rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
-                    // DM-DM BLOCKED broadcast: all producer TC slots map to the same physical buffer,
-                    // so base_addr must not advance between slots.
-                    if (!rc.config.broadcast_tc) {
-                        base_addr += entry_size;
-                    }
-                }
-            }
-        }
-
-        uint8_t num_consumer_tcs = 0;
-        for (const auto& rc : dfb->risc_configs) {
-            if (!rc.is_producer) {
-                num_consumer_tcs = rc.config.num_tcs_to_rr;
-                break;
-            }
-        }
-        base_addr = static_cast<uint32_t>(computed_addr);
-        for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
-            for (auto& rc : dfb->risc_configs) {
-                if (rc.is_producer) {
-                    continue;
-                }
-                rc.config.base_addr[tc] = base_addr;
-                rc.config.limit[tc] =
-                    rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
-                if ((dfb->config.cap == dfb::AccessPattern::STRIDED ||
-                     (dfb->config.cap == dfb::AccessPattern::BLOCKED && dfb->config.num_producers > 1)) &&
-                    tc < rc.config.num_tcs_to_rr) {
-                    base_addr += entry_size;
-                }
+        // Fill alloc_addr per core in each group.  All cores of a DFB get the same computed_addr so the L1 buffer is at a uniform
+        // absolute address on every physical core.
+        uint32_t alloc_addr = static_cast<uint32_t>(computed_addr);
+        dfb->core_lookup_.clear();
+        for (size_t gi = 0; gi < dfb->groups.size(); gi++) {
+            for (auto& [core, addr] : dfb->groups[gi].l1_by_core) {
+                addr = alloc_addr;
+                dfb->core_lookup_.emplace(core, std::make_pair(gi, alloc_addr));
             }
         }
     }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -337,7 +337,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
     data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
 
     const uint32_t entry_size = this->config.entry_size;
-    const uint32_t max_prod_cons = std::max(this->config.num_producers, this->config.num_consumers);
+    // const uint32_t max_prod_cons = std::max(this->config.num_producers, this->config.num_consumers);
 
     // Find num_producer_tcs and num_consumer_tcs from the HW config.
     uint8_t num_producer_tcs = 0;
@@ -350,6 +350,17 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         }
     }
 
+    // Address arithmetic for L1 base/limit/step:
+    //   - STRIDED (stride_in_entries = max_prod_cons): interleaved layout.
+    //     Each producer occupies 1 slot per round → base step = entry_size.
+    //   - BLOCKED (stride_in_entries = 1): contiguous block per producer/TC.
+    //     Each producer occupies `capacity` consecutive slots → base step = capacity * entry_size.
+    //     This applies to both DM-DM BLOCKED (broadcast_tc) and Tensix-involved BLOCKED (remapper).
+    //     The hardware derives the per-pop stride from (limit - base - entry_size) / (capacity - 1),
+    //     which equals entry_size for BLOCKED and max_prod_cons * entry_size for STRIDED.
+    const uint32_t effective_stride = this->stride_in_entries;
+    const uint32_t base_step = (effective_stride > 1) ? entry_size : (this->capacity * entry_size);
+
     std::vector<DFBRiscConfig> per_core_rc = hw_risc_configs;
     uint32_t base = alloc_addr;
     for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
@@ -357,10 +368,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
             if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
                 rc.config.base_addr[tc] = base;
                 rc.config.limit[tc] =
-                    rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (this->capacity - 1)) + entry_size;
-                if (!rc.config.broadcast_tc) {
-                    base += entry_size;
-                }
+                    rc.config.base_addr[tc] + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
+                // Always advance base so each producer/TC gets its own L1 slot range.
+                // broadcast_tc only governs device-side credit posting, not L1 addressing.
+                base += base_step;
             }
         }
     }
@@ -372,11 +383,11 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
             }
             rc.config.base_addr[tc] = base;
             rc.config.limit[tc] =
-                rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (this->capacity - 1)) + entry_size;
+                rc.config.base_addr[tc] + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
             if ((this->config.cap == dfb::AccessPattern::STRIDED ||
                  (this->config.cap == dfb::AccessPattern::BLOCKED && this->config.num_producers > 1)) &&
                 tc < rc.config.num_tcs_to_rr) {
-                base += entry_size;
+                base += base_step;
             }
         }
     }

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -41,6 +41,14 @@ struct DFBRiscConfig {
     LocalDFBInterfaceHost config;
 };
 
+// One group of cores that share the same HW config (TC/remapper assignments).
+// l1_by_core stores the allocated L1 base address per core (same formula fills base_addr/limit at serialize time).
+struct DfbGroup {
+    CoreRangeSet core_ranges;
+    std::vector<DFBRiscConfig> hw_risc_configs;            // base_addr/limit intentionally zeroed
+    std::vector<std::pair<CoreCoord, uint32_t>> l1_by_core; // (core, alloc_addr)
+};
+
 struct DataflowBufferImpl {
     uint32_t id{};
     CoreRangeSet core_ranges;
@@ -49,9 +57,14 @@ struct DataflowBufferImpl {
     uint16_t risc_mask = 0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
     uint8_t tensix_trisc_mask = 0;  // bits 0-3: which TRISC(s) use DFB (producer=bit2, consumer=bit0 or bit3)
     uint16_t capacity = 0;
-    std::vector<DFBRiscConfig> risc_configs;
 
-    // Shared config fields (written to dfb_initializer_t)
+    // Per-CoreRangeSet groups of cores sharing identical HW config (TC/remapper).
+    std::vector<DfbGroup> groups;
+
+    // Maps each CoreCoord to {group_index, alloc_addr}
+    std::unordered_map<CoreCoord, std::pair<size_t, uint32_t>> core_lookup_;
+
+    // Shared config fields (written to dfb_initializer_t, same for all cores)
     uint32_t entry_size = 0;
     uint32_t stride_in_entries = 0;
     dfb_txn_id_descriptor_t producer_txn_descriptor = {};
@@ -62,20 +75,19 @@ struct DataflowBufferImpl {
     // Flag to track if this DFB uses remapper (set during finalization)
     bool use_remapper = false;
 
-    std::optional<uint32_t> allocated_address;
-
     uint32_t total_size() const { return config.entry_size * config.num_entries; }
     uint32_t serialized_size() const;
-    std::vector<uint8_t> serialize() const;  // returns config to write to device
+    std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;
 };
 
 class TileCounterAllocator {
 public:
-    ::dfb::PackedTileCounter allocate(uint8_t tensix_id);
-    void reset() { next_tc_id_.fill(0); }
+    // Allocate a tile counter for (core, tensix_id). Each core has an independent counter sequence
+    ::dfb::PackedTileCounter allocate(const CoreCoord& core, uint8_t tensix_id);
+    void reset() { next_tc_id_.clear(); }
 
 private:
-    std::array<uint8_t, 4> next_tc_id_ = {0};
+    std::unordered_map<CoreCoord, std::array<uint8_t, 4>> next_tc_id_;
 };
 
 class RemapperIndexAllocator {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -718,7 +718,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                         // KernelGroup to hold value of number of dfbs
                         auto local_dfb_val = per_core_num_dfbs_.find(core);
                         if (local_dfb_val != per_core_num_dfbs_.end()) {
-                            num_dfbs += local_dfb_val->second;
+                            num_dfbs = local_dfb_val->second;
                         }
                     }
                 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -940,7 +940,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         program.impl().get_program_config(index).dfb_size / sizeof(uint8_t));
                     uint32_t offset = 0;
                     for (const auto& dfb : dfbs_on_core) {
-                        auto serialized = dfb->serialize();
+                        auto serialized = dfb->serialize_for_core(logical_core);
                         std::memcpy(dfb_config_vec.data() + offset, serialized.data(), serialized.size());
                         offset += serialized.size();
                     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38191

### What's changed
Cores are going to be denoted as nodes. 

Need changes to allow DFBs to be specified on multiple nodes. A DFB over a node range may potentially have different tile counters allocated depending on other DFBs on that node so the tile counter allocator and remapper config are updated to be made per node. 

The producer and consumer txn id can be shared for all nodes because txn id assignment comes from a global pool. The thresholds for txn id isrs are based on the number of transactions a single node would need to see because each node keeps track of the issued transactions and its txn ids  

Added a DfbGroup concept similar to KernelGroups so common configs could be grouped and mcasted together. Currently follow the same allocation as CBs i.e. DFB on multiple nodes share the same l1 address 

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/mc-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/mc-dfb)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
ge.svg?branch=abhullar/mc-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/mc-dfb)