### PR TITLE
Fix race condition in post sdpa scatter CB overlap

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -2626,13 +2626,14 @@ class AttentionBlock:
         )
         matmul4_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             matmul4_in0_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset_post_sdpa,
+            ref_input_tensor,
+            address_offset=input_running_offset,
             total_size=matmul4_k_num_tiles * tile_1x32_size,
             core_ranges=full_device_grid,
         )
         matmul4_in0_cb_descriptor.format_descriptors = [matmul4_in0_cb_format]
-        sdpa_kv_cache_running_offset_post_sdpa += matmul4_in0_cb_descriptor.total_size
+        input_running_offset += matmul4_in0_cb_descriptor.total_size
+        scatter_dest_l1_addr = ttnn.get_cb_address(matmul4_in0_cb_descriptor)
 
         # CB 2: Matmul4 output (4 tiles of 1x32 per core, kv_b2 grid)
         # When kv_cache buffer is available, overlap into it. Otherwise standalone.
@@ -2644,15 +2645,17 @@ class AttentionBlock:
             tile=matmul4_out_tile_descriptor,
         )
 
+        # Overlapping matmul4 output with input tensor, but it's likely safe to have this overlap with kv cache buffer
+        # Only matmul4 input is unsafe to overlap with kv cache buffer
         matmul4_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             matmul4_out_cb,
-            ref_sdpa_kv_cache_buffer,
-            address_offset=sdpa_kv_cache_running_offset_post_sdpa,
+            ref_input_tensor,
+            address_offset=input_running_offset,
             total_size=matmul4_out_w_per_core * tile_1x32_size,
             core_ranges=full_device_grid,
         )
         matmul4_out_cb_descriptor.format_descriptors = [matmul4_out_cb_format]
-        sdpa_kv_cache_running_offset_post_sdpa += matmul4_out_cb_descriptor.total_size
+        input_running_offset += matmul4_out_cb_descriptor.total_size
 
         # CB 3: Gather2 output = Mcast3 source (from sharded tensor, gather core)
         gather2_dst_cb_format = ttnn.CBFormatDescriptor(
@@ -3297,7 +3300,6 @@ class AttentionBlock:
         # ========================================================================
         # Pre-compute device-invariant SDPA addresses
         # ========================================================================
-        scatter_dest_l1_addr = ref_sdpa_kv_cache_buffer.buffer_address() + matmul4_in0_cb_descriptor.address_offset
         forwarder_buffer_base = ref_sdpa_forwarder_scratch.buffer_address()
         ncrisc_buffer_offset = sdpa_fwd_slots_per_round * sdpa_fwd_slot_size * 2  # After BRISC R1+R2
         r1_recv_buffer_addr = ref_sdpa_intermediate_recv.buffer_address()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Post sdpa scatter had an unlikely race condition in that it's possible for some cores out of the 8 sdpa output cores to finish ahead of others and then scatter their output. Originally the scatter dest was the kv cache buffer, which meant it could corrupt data of sdpa cores that were behind/not finished.

### What's changed
Overlap scatter output with the input tensor, which guarantees sdpa output cores that finish earlier don't corrupt the data of other sdpa cores.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
