### PR TITLE
Add support for DeepSeekV3 MTP weights

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -18,20 +18,24 @@ import torch
 import ttnn
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    _MTP_LAYER_IDX,
     NUM_ROUTED_EXPERTS,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
+    DeepSeekV3MTPWeights,
     load_dense_decoder_layer,
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
     load_moe_routed_experts,
+    load_mtp_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
+    prepare_mtp_weights,
 )
 
 
@@ -48,6 +52,9 @@ class WeightProvider(Protocol):
         ...
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
+        ...
+
+    def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
         ...
 
 
@@ -196,6 +203,18 @@ def _build_synthetic_dense_state_dict(layer_id: int) -> dict[str, torch.Tensor]:
     return state_dict
 
 
+def _build_synthetic_mtp_state_dict(mtp_layer_idx: int = _MTP_LAYER_IDX) -> dict[str, torch.Tensor]:
+    """Build a synthetic MTP state dict with only the lightweight MTP projection/norm tensors."""
+    dtype = torch.bfloat16
+    H = LogicalModelDimensions.HIDDEN_SIZE
+
+    return {
+        _layer_key(mtp_layer_idx, "hnorm.weight"): torch.ones(H, dtype=dtype),
+        _layer_key(mtp_layer_idx, "enorm.weight"): torch.ones(H, dtype=dtype),
+        _layer_key(mtp_layer_idx, "eh_proj.weight"): torch.randn(H, 2 * H, dtype=dtype),
+    }
+
+
 class CacheWeightProvider:
     """Load embedding and LM head weights from cache; each host loads only what its stage needs."""
 
@@ -218,6 +237,9 @@ class CacheWeightProvider:
 
     def load_dense_layer(self, layer_id: int, device: ttnn.MeshDevice) -> DeepSeekV3DenseLayerWeights:
         return load_dense_decoder_layer(self._path, device, layer_id)
+
+    def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
+        return load_mtp_weights(self._path, device)
 
 
 class SyntheticWeightProvider:
@@ -266,6 +288,10 @@ class SyntheticWeightProvider:
         bdw = BlitzDecodeWeights(device)
         return prepare_dense_layer_weights(bdw, sd, layer_id, move_to_device=True)
 
+    def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
+        sd = _build_synthetic_mtp_state_dict()
+        return prepare_mtp_weights(sd, device, move_to_device=True)
+
 
 class StateDictWeightProvider:
     """Load real HF safetensors via LazyStateDict and prepare weights at runtime (no tensorbin cache)."""
@@ -299,3 +325,6 @@ class StateDictWeightProvider:
 
         bdw = BlitzDecodeWeights(device)
         return prepare_dense_layer_weights(bdw, self._state_dict, layer_id, move_to_device=True)
+
+    def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
+        return prepare_mtp_weights(self._state_dict, device, move_to_device=True)

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -9,7 +9,8 @@ Takes full HuggingFace state dict tensors (full logical shapes for the target
 mesh), applies key mapping, transpose, and kv_b split, then passes to
 BlitzDecodeWeights which fuses and shards onto the mesh.
 
-Supports per-layer save/load (save_decoder_layer, load_dense_decoder_layer, load_moe_decoder_layer) and embedding/lm_head save/load for offline preparation and runtime load.
+Supports per-layer save/load (save_decoder_layer, load_dense_decoder_layer, load_moe_decoder_layer),
+embedding/lm_head save/load, and MTP weight save/load for offline preparation and runtime load.
 """
 
 from __future__ import annotations
@@ -245,8 +246,22 @@ class DeepSeekV3LMHeadWeights:
     final_norm: ttnn.Tensor  # model.norm.weight, (1, 7168)
 
 
+@dataclass
+class DeepSeekV3MTPWeights:
+    """Weights for the MTP (Multi-Token Prediction) speculative decode layer.
+
+    HF state dict keys live under ``model.layers.{mtp_layer_idx}.*`` (layer 61 for DeepSeek V3).
+    The MTP decoder block (layer 61) is a regular MoE layer loaded separately.
+    """
+
+    h_gamma: ttnn.Tensor  # model.layers.61.hnorm.weight
+    e_gamma: ttnn.Tensor  # model.layers.61.enorm.weight
+    eh_projection: ttnn.Tensor  # model.layers.61.eh_proj.weight
+
+
 # Constants for kv_b_proj split (HF stores one matrix; we split into kv_b1 and kv_b2).
 _NUM_HEADS = 64
+
 # MoE routed experts (DeepSeek V3 config: n_routed_experts=256).
 NUM_ROUTED_EXPERTS = 256
 _QK_NOPE_HEAD_DIM = 128
@@ -255,6 +270,11 @@ _V_HEAD_DIM = 128
 _KV_LORA_RANK = 512
 _KV_B_PROJ_HEAD_DIM = _QK_NOPE_HEAD_DIM + _V_HEAD_DIM  # 256
 _Q_HEAD_DIM = _QK_NOPE_HEAD_DIM + _QK_ROPE_HEAD_DIM  # 192
+
+# MTP layer constants
+_MTP_LAYER_IDX = 61
+_MTP_NUM_DRAM_BANKS = 8
+_MTP_B_TILE = ttnn.Tile([32, 32])
 
 
 def deinterleave_q_b_proj(q_b_proj: torch.Tensor, num_heads: int | None = None) -> torch.Tensor:
@@ -500,14 +520,14 @@ def prepare_attention_weights(
     )
     # Single-device (mla_tp=1) expects per-TP shapes; slice if state dict has full logical (2-TP) size
     q_b, o_proj, kv_b1, kv_b2 = _slice_attention_weights_for_mla_tp(q_b, o_proj, kv_b1, kv_b2, bdw.mla_tp)
-    logger.debug("  load raw tensors: {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Loaded raw tensors in {:.3f}s", time.perf_counter() - t0)
     logger.debug("Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)", layer_idx)
     t0 = time.perf_counter()
     q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(
         q_a, q_b, kv_a, move_to_device=move_to_device
     )
     kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2, move_to_device=move_to_device)
-    logger.debug("  convert q_ab_kv_a + kv_b12: {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Converted q_ab_kv_a + kv_b12 in {:.3f}s", time.perf_counter() - t0)
 
     if is_moe:
         gate_mm = state_dict[_key(layer_idx, "mlp.gate.weight")].T.contiguous()
@@ -520,7 +540,7 @@ def prepare_attention_weights(
             bdw._device,
             move_to_device=move_to_device,
         )
-        logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
+        logger.debug("Converted o_proj_gate_mm_norms (MoE) in {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
@@ -541,7 +561,7 @@ def prepare_attention_weights(
             o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
         o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-        logger.debug("  convert o_proj_gate_mm_norms (dense): {:.3f}s", time.perf_counter() - t0)
+        logger.debug("Converted o_proj_gate_mm_norms (dense) in {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
             q_b_proj=q_b_proj,
@@ -587,7 +607,7 @@ def prepare_shared_expert_weights(
         shared_gate_proj, shared_up_proj, shared_down_proj = bdw.get_tt_mlp_shared_expert_weights(
             mlp_gate, mlp_up, mlp_down, move_to_device=move_to_device
         )
-    logger.debug("  shared expert weights done in {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Shared expert weights done in {:.3f}s", time.perf_counter() - t0)
     return SharedExpertWeights(
         shared_gate_proj=shared_gate_proj,
         shared_up_proj=shared_up_proj,
@@ -617,12 +637,12 @@ def prepare_routed_expert_weights(
         down_list = []
         for e in range(num_routed_experts):
             if e > 0 and e % 64 == 0:
-                logger.debug("  loaded experts 0..{} from state dict", e - 1)
+                logger.debug("Loaded experts 0..{} from state dict", e - 1)
             gate_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.gate_proj.weight")].T.contiguous())
             up_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.up_proj.weight")].T.contiguous())
             down_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.down_proj.weight")].T.contiguous())
         load_elapsed = time.perf_counter() - t0
-        logger.info("  loaded {} experts from state dict in {:.3f}s", num_routed_experts, load_elapsed)
+        logger.info("Loaded {} experts from state dict in {:.3f}s", num_routed_experts, load_elapsed)
         logger.debug("Converting routed experts to device format (blitz)...")
         t0 = time.perf_counter()
         gate_stacked = torch.stack(gate_list, dim=0)
@@ -631,7 +651,7 @@ def prepare_routed_expert_weights(
         routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_moe_routed_expert_weights(
             gate_stacked, up_stacked, down_stacked, move_to_device=move_to_device
         )
-        logger.info("  converted routed experts in {:.3f}s", time.perf_counter() - t0)
+        logger.info("Converted routed experts in {:.3f}s", time.perf_counter() - t0)
         routed = MoERoutedExpertWeights(
             routed_gate_proj=routed_gate_proj,
             routed_up_proj=routed_up_proj,
@@ -668,7 +688,7 @@ def prepare_dense_layer_weights(
     shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     assert isinstance(routed, DenseRoutedExpertWeights)
-    return DeepSeekV3DenseLayerWeights(
+    result = DeepSeekV3DenseLayerWeights(
         q_a_proj=attn.q_a_proj,
         q_b_proj=attn.q_b_proj,
         kv_a_proj=attn.kv_a_proj,
@@ -686,7 +706,8 @@ def prepare_dense_layer_weights(
         routed_up_proj=routed.routed_up_proj,
         routed_down_proj=routed.routed_down_proj,
     )
-    logger.info("  dense layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    logger.info("Dense layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    return result
 
 
 def prepare_moe_layer_weights(
@@ -708,7 +729,7 @@ def prepare_moe_layer_weights(
     assert isinstance(attn.gate_mm, OverlappedTensor)
     assert attn.gate_bias is not None
     assert isinstance(routed, MoERoutedExpertWeights)
-    return DeepSeekV3MoELayerWeights(
+    result = DeepSeekV3MoELayerWeights(
         q_a_proj=attn.q_a_proj,
         q_b_proj=attn.q_b_proj,
         kv_a_proj=attn.kv_a_proj,
@@ -728,7 +749,8 @@ def prepare_moe_layer_weights(
         routed_up_proj=routed.routed_up_proj,
         routed_down_proj=routed.routed_down_proj,
     )
-    logger.info("  MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    logger.info("MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    return result
 
 
 def _to_tt_embedding(embedding_torch: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
@@ -769,9 +791,9 @@ def save_embedding_weights(
     path = Path(path)
     emb_dir = path / "embedding"
     emb_dir.mkdir(parents=True, exist_ok=True)
-    logger.info("Dump embedding weights...")
+    logger.info("Saving embedding weights...")
     ttnn.dump_tensor(emb_dir / "embedding.tensorbin", weights.embedding)
-    logger.info("Dump manifest...")
+    logger.info("Saving embedding manifest...")
     manifest = {
         "version": _MANIFEST_VERSION,
         "hf_model_name": hf_model_name,
@@ -925,6 +947,139 @@ def load_lm_head_weights(path: str | Path, device) -> DeepSeekV3LMHeadWeights:
     lm_head = ttnn.load_tensor(lm_dir / "lm_head.tensorbin", device=device)
     final_norm = ttnn.load_tensor(lm_dir / "final_norm.tensorbin", device=device)
     return DeepSeekV3LMHeadWeights(lm_head=lm_head, final_norm=final_norm)
+
+
+def _to_tt_mtp_eh_proj(eh_proj_torch: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
+    """Convert transposed eh_proj (K+embedding_dim, hidden) to TT WIDTH_SHARDED DRAM with tile shuffle.
+
+    eh_proj_torch: already transposed to (K, N) = (14336, 7168).
+    Pads N to align with _MTP_NUM_DRAM_BANKS, shuffles tiles for DRAM streaming,
+    and creates a WIDTH_SHARDED DRAM tensor.
+    """
+    K, N = eh_proj_torch.shape
+    assert N % _MTP_NUM_DRAM_BANKS == 0, f"eh_proj N={N} must be divisible by {_MTP_NUM_DRAM_BANKS} DRAM banks"
+    n_per_bank = N // _MTP_NUM_DRAM_BANKS
+    padded_N = _MTP_NUM_DRAM_BANKS * n_per_bank
+
+    eh_padded = torch.zeros((K, padded_N), dtype=eh_proj_torch.dtype)
+    eh_padded[:, :N] = eh_proj_torch
+
+    eh_shuffled = BlitzDecodeWeights._shuffle_dram_tiles(eh_padded, 32, _MTP_NUM_DRAM_BANKS)
+
+    eh_shard_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(_MTP_NUM_DRAM_BANKS - 1, 0),
+            )
+        }
+    )
+    eh_proj_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(eh_shard_grid, (K, n_per_bank), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.from_torch(
+        eh_shuffled.contiguous(),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device if move_to_device else None,
+        memory_config=eh_proj_mem_config,
+        tile=_MTP_B_TILE,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+
+def prepare_mtp_weights(
+    state_dict: dict[str, torch.Tensor],
+    device,
+    *,
+    mtp_layer_idx: int = _MTP_LAYER_IDX,
+    move_to_device: bool = False,
+) -> DeepSeekV3MTPWeights:
+    """Prepare lightweight MTP projection/norm weights from state dict.
+
+    Only the MTP-specific tensors (h_gamma, e_gamma, eh_projection) are prepared here.
+    The MTP decoder block (layer 61) is a regular MoE layer handled through the standard
+    prepare_moe_layer_weights / load_moe_decoder_layer path.
+    """
+    logger.info("Preparing MTP weights (layer {})...", mtp_layer_idx)
+    t0 = time.perf_counter()
+
+    h_gamma_w = state_dict[_key(mtp_layer_idx, "hnorm.weight")].unsqueeze(0)
+    h_gamma_tt = _to_tt_lm_head_final_norm(h_gamma_w, device, move_to_device=move_to_device)
+
+    e_gamma_w = state_dict[_key(mtp_layer_idx, "enorm.weight")].unsqueeze(0)
+    e_gamma_tt = _to_tt_lm_head_final_norm(e_gamma_w, device, move_to_device=move_to_device)
+
+    eh_proj_w = state_dict[_key(mtp_layer_idx, "eh_proj.weight")].T.contiguous()
+    eh_proj_tt = _to_tt_mtp_eh_proj(eh_proj_w, device, move_to_device=move_to_device)
+
+    logger.info("MTP weights prepared in {:.3f}s", time.perf_counter() - t0)
+    return DeepSeekV3MTPWeights(
+        h_gamma=h_gamma_tt,
+        e_gamma=e_gamma_tt,
+        eh_projection=eh_proj_tt,
+    )
+
+
+def save_mtp_weights(
+    weights: DeepSeekV3MTPWeights,
+    path: str | Path,
+    *,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save MTP projection/norm weights to <path>/mtp/.
+
+    Only the lightweight MTP tensors (h_gamma, e_gamma, eh_projection) are saved here.
+    The MTP decoder block (layer 61) is saved separately as a standard MoE layer via
+    save_decoder_layer.
+    """
+    path = Path(path)
+    mtp_dir = path / "mtp"
+    mtp_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Saving MTP projection/norm weights to {}...", mtp_dir)
+    t0 = time.perf_counter()
+    ttnn.dump_tensor(mtp_dir / "mtp_h_gamma.tensorbin", weights.h_gamma)
+    ttnn.dump_tensor(mtp_dir / "mtp_e_gamma.tensorbin", weights.e_gamma)
+    ttnn.dump_tensor(mtp_dir / "mtp_eh_projection.tensorbin", weights.eh_projection)
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "hf_model_name": hf_model_name,
+        "hf_state_dict_name": hf_state_dict_name,
+        "device_mesh_shape": list(device_mesh_shape),
+    }
+    with open(mtp_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+    logger.info("MTP weights saved in {:.3f}s", time.perf_counter() - t0)
+
+
+def load_mtp_weights(
+    path: str | Path,
+    device,
+) -> DeepSeekV3MTPWeights:
+    """Load MTP projection/norm weights from <path>/mtp/.
+
+    device must be the mesh device (same shape as used for prepare_mtp_weights).
+    The MTP decoder block (layer 61) is loaded separately via load_moe_decoder_layer.
+    """
+    path = Path(path)
+    mtp_dir = path / "mtp"
+    if not mtp_dir.is_dir():
+        raise FileNotFoundError(f"MTP dir not found: {mtp_dir}")
+    logger.info("Loading MTP weights from {}...", mtp_dir)
+    t0 = time.perf_counter()
+    h_gamma = ttnn.load_tensor(mtp_dir / "mtp_h_gamma.tensorbin", device=device)
+    e_gamma = ttnn.load_tensor(mtp_dir / "mtp_e_gamma.tensorbin", device=device)
+    eh_projection = ttnn.load_tensor(mtp_dir / "mtp_eh_projection.tensorbin", device=device)
+    logger.info("MTP weights loaded in {:.3f}s", time.perf_counter() - t0)
+    return DeepSeekV3MTPWeights(
+        h_gamma=h_gamma,
+        e_gamma=e_gamma,
+        eh_projection=eh_projection,
+    )
 
 
 def _core_range_set_to_list(crs: ttnn.CoreRangeSet) -> list[list[list[int]]]:
@@ -1118,7 +1273,7 @@ def save_attention_weights(
         manifest.setdefault("standalone_tensors", {})["gate_bias"] = "gate_bias.tensorbin"
     with open(layer_dir / "manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
-    logger.debug("  save_attention_weights: {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Saved attention weights in {:.3f}s", time.perf_counter() - t0)
 
 
 def save_shared_expert_weights(
@@ -1159,7 +1314,7 @@ def save_shared_expert_weights(
     manifest.setdefault("standalone_tensors", {})["shared_down_proj"] = name
     with open(layer_dir / "manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
-    logger.debug("  save_shared_expert_weights: {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Saved shared expert weights in {:.3f}s", time.perf_counter() - t0)
 
 
 def save_routed_expert_weights(
@@ -1196,13 +1351,13 @@ def save_routed_expert_weights(
         experts_dir.mkdir(parents=True, exist_ok=True)
         for e in range(num_experts):
             if e > 0 and e % 64 == 0:
-                logger.debug("  saved experts 0..{}", e - 1)
+                logger.debug("Saved experts 0..{}", e - 1)
             expert_dir = experts_dir / f"e_{e:03d}"
             expert_dir.mkdir(parents=True, exist_ok=True)
             ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed.routed_gate_proj[e])
             ttnn.dump_tensor(expert_dir / "up_proj.tensorbin", routed.routed_up_proj[e])
             ttnn.dump_tensor(expert_dir / "down_proj.tensorbin", routed.routed_down_proj[e])
-        logger.info("  saved {} routed experts in {:.3f}s", num_experts, time.perf_counter() - t0)
+        logger.info("Saved {} routed experts in {:.3f}s", num_experts, time.perf_counter() - t0)
     else:
         assert isinstance(routed, DenseRoutedExpertWeights)
         logger.debug("Saving dense routed MLP for layer {}...", layer_idx)
@@ -1232,7 +1387,7 @@ def save_decoder_layer(
     """
     path = Path(path)
     layer_dir = path / f"layer_{layer_idx:03d}"
-    logger.info(f"Saving layer {layer_idx} to {layer_dir}...")
+    logger.info("Saving layer {} to {}...", layer_idx, layer_dir)
     is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
     save_decoder_layer_t0 = time.perf_counter()
     attn = AttentionWeights(
@@ -1293,7 +1448,7 @@ def save_decoder_layer(
         hf_state_dict_name=hf_state_dict_name,
         device_mesh_shape=device_mesh_shape,
     )
-    logger.info(f"  save_decoder_layer total: {time.perf_counter() - save_decoder_layer_t0:.3f}s")
+    logger.info("Saved decoder layer in {:.3f}s", time.perf_counter() - save_decoder_layer_t0)
 
 
 def load_moe_routed_experts(
@@ -1333,21 +1488,21 @@ def load_moe_routed_experts(
     routed_down_proj = []
     for e in range(num_experts):
         if e > 0 and e % 64 == 0:
-            logger.debug("  loaded gate experts 0..{}", e - 1)
+            logger.debug("Loaded gate experts 0..{}", e - 1)
         expert_dir = experts_dir / f"e_{e:03d}"
         routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
     for e in range(num_experts):
         if e > 0 and e % 64 == 0:
-            logger.debug("  loaded up experts 0..{}", e - 1)
+            logger.debug("Loaded up experts 0..{}", e - 1)
         expert_dir = experts_dir / f"e_{e:03d}"
         routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
     for e in range(num_experts):
         if e > 0 and e % 64 == 0:
-            logger.debug("  loaded down experts 0..{}", e - 1)
+            logger.debug("Loaded down experts 0..{}", e - 1)
         expert_dir = experts_dir / f"e_{e:03d}"
         routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
 
-    logger.info("  routed experts for layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    logger.info("Routed experts for layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - t0)
     routed = MoERoutedExpertWeights(
         routed_gate_proj=routed_gate_proj,
         routed_up_proj=routed_up_proj,
@@ -1411,7 +1566,7 @@ def load_dense_decoder_layer(
     routed_gate_proj = ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)
     routed_up_proj = ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)
     routed_down_proj = ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)
-    logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+    logger.info("Layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
 
     return DeepSeekV3DenseLayerWeights(
         q_a_proj=q_a_proj,
@@ -1500,7 +1655,7 @@ def load_moe_decoder_layer(
     routed_gate_proj = preloaded_routed_experts.routed_gate_proj
     routed_up_proj = preloaded_routed_experts.routed_up_proj
     routed_down_proj = preloaded_routed_experts.routed_down_proj
-    logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+    logger.info("Layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
 
     return DeepSeekV3MoELayerWeights(
         q_a_proj=q_a_proj,

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -9,15 +9,17 @@ Runs in fast dispatch; weights are prepared and saved to disk (no device placeme
 
 Modes:
   dense     - Full dense layer (layers 0-2).
-  moe       - Full MoE layer (layers 3-60): attention + shared experts + routed experts.
+  moe       - Full MoE layer (layers 3-61): attention + shared experts + routed experts.
   embedding - Embedding layer (model.embed_tokens). No --layer-num needed.
   lm_head   - LM head + final RMSNorm. No --layer-num needed.
+  mtp       - MTP (Multi-Token Prediction) lightweight projection/norm weights. No --layer-num needed.
 
 Usage:
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 0 --type dense
-  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 3 4 5 6 --type moe
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 3 4 5 6 61 --type moe
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type embedding
   python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type lm_head
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --type mtp
 """
 
 from __future__ import annotations
@@ -43,20 +45,24 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
+    DeepSeekV3MTPWeights,
     load_dense_decoder_layer,
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
+    load_mtp_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
+    prepare_mtp_weights,
     save_decoder_layer,
     save_embedding_weights,
     save_lm_head_weights,
+    save_mtp_weights,
 )
 
-NUM_LAYERS = 61
+NUM_LAYERS = 62
 FIRST_K_DENSE_REPLACE = 3
 DEVICE_MESH_SHAPE = (4, 2)
 MANIFEST_VERSION = 1
@@ -91,14 +97,14 @@ def _create_parser() -> argparse.ArgumentParser:
         type=int,
         nargs="+",
         default=None,
-        help="Layer index(es) (0-60); one or more, required for dense/moe, ignored for embedding/lm_head",
+        help="Layer index(es) (0-61); one or more, required for dense/moe, ignored for embedding/lm_head/mtp",
     )
     parser.add_argument(
         "--type",
         dest="mode",
-        choices=("dense", "moe", "embedding", "lm_head"),
+        choices=("dense", "moe", "embedding", "lm_head", "mtp"),
         required=True,
-        help="Cache type: dense (layers 0-2), moe (full layer for 3-60), embedding, lm_head",
+        help="Cache type: dense (layers 0-2), moe (full layer for 3-61), embedding, lm_head, mtp",
     )
     parser.add_argument(
         "--force",
@@ -159,6 +165,11 @@ def _validate_args(args: argparse.Namespace) -> None:
             if not manifest_path.is_file():
                 logger.error("lm_head/manifest.json not found for verify: {}", manifest_path)
                 sys.exit(1)
+        elif mode == "mtp":
+            manifest_path = output_path / "mtp" / "manifest.json"
+            if not manifest_path.is_file():
+                logger.error("mtp/manifest.json not found for verify: {}", manifest_path)
+                sys.exit(1)
         else:
             for layer_num in layer_nums:
                 layer_dir = output_path / f"layer_{layer_num:03d}"
@@ -194,6 +205,11 @@ def _validate_args(args: argparse.Namespace) -> None:
             lm_dir = output_path / "lm_head"
             if lm_dir.is_dir() and (lm_dir / "manifest.json").is_file():
                 logger.error("lm_head cache already exists. Use --force to overwrite.")
+                sys.exit(1)
+        elif mode == "mtp":
+            mtp_dir = output_path / "mtp"
+            if mtp_dir.is_dir() and (mtp_dir / "manifest.json").is_file():
+                logger.error("MTP cache already exists (mtp/). Use --force to overwrite.")
                 sys.exit(1)
         else:
             for layer_num in layer_nums:
@@ -422,6 +438,59 @@ def _verify_lm_head_cache(output_path: Path) -> bool:
     return True
 
 
+def _verify_mtp_cache(output_path: Path) -> bool:
+    """Verify MTP cache: manifest, file existence, and optionally load to device. Returns True if all checks pass."""
+    mtp_dir = output_path / "mtp"
+    manifest_path = mtp_dir / "manifest.json"
+    logger.info("Verifying MTP cache (mtp/)...")
+
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.error("Failed to load manifest: {}", e)
+        return False
+    version = manifest.get("version", 0)
+    if version > MANIFEST_VERSION:
+        logger.error("Unsupported manifest version {} (max {})", version, MANIFEST_VERSION)
+        return False
+    logger.info("Manifest OK (version={})", version)
+
+    for fname in (
+        "mtp_h_gamma.tensorbin",
+        "mtp_e_gamma.tensorbin",
+        "mtp_eh_projection.tensorbin",
+    ):
+        if not _check_file(Path(fname), mtp_dir):
+            return False
+    logger.info("All MTP files present")
+
+    logger.info("Loading to device for sanity check...")
+    if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
+        os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
+    device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
+    try:
+        with bh_2d_mesh_device_context(device_params) as mesh_device:
+            submesh = mesh_device.create_submesh(ttnn.MeshShape(*DEVICE_MESH_SHAPE))
+            loaded = load_mtp_weights(output_path, submesh)
+        if not isinstance(loaded, DeepSeekV3MTPWeights):
+            logger.error("Expected DeepSeekV3MTPWeights, got {}", type(loaded).__name__)
+            return False
+        if not _check_on_device(loaded.h_gamma, "mtp.h_gamma"):
+            return False
+        if not _check_on_device(loaded.e_gamma, "mtp.e_gamma"):
+            return False
+        if not _check_on_device(loaded.eh_projection, "mtp.eh_projection"):
+            return False
+        logger.info("Device load OK (on-device checks passed)")
+    except Exception as e:
+        logger.error("Device load failed: {}", e)
+        return False
+
+    logger.info("Verify OK")
+    return True
+
+
 def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
     """Verify existing cache: manifest, file existence, and optionally load to device. Returns True if all checks pass."""
     layer_dir = output_path / f"layer_{layer_num:03d}"
@@ -572,6 +641,8 @@ def main() -> int:
             ok = _verify_embedding_cache(output_path)
         elif mode == "lm_head":
             ok = _verify_lm_head_cache(output_path)
+        elif mode == "mtp":
+            ok = _verify_mtp_cache(output_path)
         else:
             ok = True
             for layer_num in layer_nums:
@@ -672,9 +743,18 @@ def main() -> int:
                 t0 = time.perf_counter()
                 save_lm_head_weights(weights, output_path, **manifest_kw)
                 logger.info("save_lm_head_weights took {:.3f}s", time.perf_counter() - t0)
+            elif mode == "mtp":
+                logger.info("Preparing MTP weights...")
+                t0 = time.perf_counter()
+                weights = prepare_mtp_weights(state_dict, submesh)
+                logger.info("prepare_mtp_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving MTP weights...")
+                t0 = time.perf_counter()
+                save_mtp_weights(weights, output_path, **manifest_kw)
+                logger.info("save_mtp_weights took {:.3f}s", time.perf_counter() - t0)
 
     elapsed = time.perf_counter() - total_t0
-    if mode in ("embedding", "lm_head"):
+    if mode in ("embedding", "lm_head", "mtp"):
         logger.info("Cache generation complete (mode={}) in {:.3f}s", mode, elapsed)
     else:
         logger.info("Cache generation complete for layers {} (mode={}) in {:.3f}s", layer_nums, mode, elapsed)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -23,12 +23,15 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+from models.demos.deepseek_v3_b1.demo.weight_provider import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.prepare_weights import (
+    _MTP_LAYER_IDX,
     AttentionWeights,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
     DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
+    DeepSeekV3MTPWeights,
     DenseRoutedExpertWeights,
     MoERoutedExpertWeights,
     SharedExpertWeights,
@@ -36,17 +39,20 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     load_embedding_weights,
     load_lm_head_weights,
     load_moe_decoder_layer,
+    load_mtp_weights,
     prepare_attention_weights,
     prepare_dense_layer_weights,
     prepare_embedding_weights,
     prepare_lm_head_weights,
     prepare_moe_layer_weights,
+    prepare_mtp_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
     save_attention_weights,
     save_decoder_layer,
     save_embedding_weights,
     save_lm_head_weights,
+    save_mtp_weights,
     save_routed_expert_weights,
     save_shared_expert_weights,
 )
@@ -212,7 +218,7 @@ HF_KV_B_FULL_LOGICAL = (32768, 512)
 HF_SHARED_GATE_UP_FULL_LOGICAL = (2048, 7168)
 
 # Don't use all the experts in tests to avoid taking too long
-NUM_ROUTED_EXPERTS = 4
+NUM_ROUTED_EXPERTS_FOR_TESTS = 4
 
 
 def _layer_state_dict(
@@ -271,7 +277,7 @@ def _layer_state_dict(
         state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = torch.randn(
             shared_down_rows, shared_down_cols, generator=g, dtype=torch.bfloat16
         )
-        for e in range(NUM_ROUTED_EXPERTS):
+        for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
             state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
                 2048, 7168, generator=g, dtype=torch.bfloat16
             )
@@ -413,13 +419,13 @@ def test_prepare_routed_expert_weights_moe_4x2(bh_2d_mesh_device):
         state,
         0,
         is_moe=True,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS,
         move_to_device=True,
     )
     assert isinstance(routed, MoERoutedExpertWeights)
-    assert len(routed.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed.routed_down_proj) == NUM_ROUTED_EXPERTS
+    assert len(routed.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(routed.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(routed.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     routed.validate_contiguous_dram()
 
 
@@ -493,7 +499,7 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
-    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
     attn = AttentionWeights(
         q_a_proj=layer.q_a_proj,
@@ -534,7 +540,7 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
     _assert_overlapped_tensors_match(layer.gate_mm, loaded.gate_mm)
     assert loaded.gate_bias.shape == layer.gate_bias.shape
     _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
-    assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     assert loaded.routed_gate_proj[0].shape == expected_routed_expert_shape
     _assert_layer_on_device_with_topology(loaded)
 
@@ -543,9 +549,9 @@ def _moe_routed_expert_stacked_tensors(seed: int = 43):
     """Build (num_experts, K, N) stacked gate/up and (num_experts, K_down, N_down) down for get_tt_moe_routed_expert_weights."""
     g = torch.Generator().manual_seed(seed)
     # MoE expert shapes: gate/up (K=7168, N=2048), down (2048, 7168)
-    gate_stacked = torch.randn(NUM_ROUTED_EXPERTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
-    up_stacked = torch.randn(NUM_ROUTED_EXPERTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
-    down_stacked = torch.randn(NUM_ROUTED_EXPERTS, 2048, 7168, generator=g, dtype=torch.bfloat16)
+    gate_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
+    up_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
+    down_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 2048, 7168, generator=g, dtype=torch.bfloat16)
     return gate_stacked, up_stacked, down_stacked
 
 
@@ -567,15 +573,15 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
     )
 
     # Capture shapes before dump
-    expected_gate_shapes = [routed_gate_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
-    expected_up_shapes = [routed_up_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
-    expected_down_shapes = [routed_down_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
+    expected_gate_shapes = [routed_gate_proj[e].shape for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS)]
+    expected_up_shapes = [routed_up_proj[e].shape for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS)]
+    expected_down_shapes = [routed_down_proj[e].shape for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS)]
 
     # Dump only routed experts (same layout as save_layer for MoE)
     layer_dir = tmp_path / "layer_000"
     experts_dir = layer_dir / "experts"
     experts_dir.mkdir(parents=True, exist_ok=True)
-    for e in range(NUM_ROUTED_EXPERTS):
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         logger.info("Dumping expert {}...", e)
         expert_dir = experts_dir / f"e_{e:03d}"
         expert_dir.mkdir(parents=True, exist_ok=True)
@@ -592,15 +598,15 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
     t0 = time.perf_counter()
     # Same order as load_moe_routed_experts / get_tt_moe_routed_expert_weights: all gates, then ups, then downs
     # (DRAMStreamingMatmul indexes experts via base + i * stride per projection).
-    for e in range(NUM_ROUTED_EXPERTS):
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         expert_dir = experts_dir / f"e_{e:03d}"
         logger.info("Loading gate expert {}...", e)
         routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=submesh))
-    for e in range(NUM_ROUTED_EXPERTS):
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         expert_dir = experts_dir / f"e_{e:03d}"
         logger.info("Loading up expert {}...", e)
         routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=submesh))
-    for e in range(NUM_ROUTED_EXPERTS):
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         expert_dir = experts_dir / f"e_{e:03d}"
         logger.info("Loading down expert {}...", e)
         routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=submesh))
@@ -613,10 +619,10 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
         routed_down_proj=routed_down_proj,
     ).validate_contiguous_dram()
 
-    assert len(routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
+    assert len(routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         assert routed_gate_proj[e].shape == expected_gate_shapes[e]
         assert routed_up_proj[e].shape == expected_up_shapes[e]
         assert routed_down_proj[e].shape == expected_down_shapes[e]
@@ -764,7 +770,7 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     logger.info(f"State dict prepared")
     t0 = time.perf_counter()
     logger.info(f"Preparing weights...")
-    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS)
     logger.info(f"Weights prepared")
     elapsed = time.perf_counter() - t0
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
@@ -784,9 +790,9 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     assert layer.shared_gate_proj.tensor_shape == (7168, 256)
     assert layer.shared_up_proj.tensor_shape == (7168, 256)
     assert hasattr(layer, "shared_down_proj")
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
 
 
 @pytest.mark.parametrize(
@@ -804,7 +810,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
     t0 = time.perf_counter()
-    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS)
     elapsed = time.perf_counter() - t0
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
@@ -823,9 +829,9 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert orig.shared_gate_proj.tensor_shape == (7168, 256)
     assert orig.shared_up_proj.tensor_shape == (7168, 256)
     assert hasattr(orig, "shared_down_proj")
-    assert len(orig.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(orig.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(orig.routed_down_proj) == NUM_ROUTED_EXPERTS
+    assert len(orig.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(orig.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(orig.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     # Early access to q_ab_kv_a fused_tensor (same as first tensor touched in save_layer)
     logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.q_a_proj.fused_tensor)...")
     q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
@@ -846,7 +852,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert (layer_dir / "gate_bias.tensorbin").exists()
     assert (layer_dir / "shared_down_proj.tensorbin").exists()
     experts_dir = layer_dir / "experts"
-    for e in range(NUM_ROUTED_EXPERTS):
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         expert_dir = experts_dir / f"e_{e:03d}"
         assert (expert_dir / "gate_proj.tensorbin").exists()
         assert (expert_dir / "up_proj.tensorbin").exists()
@@ -874,10 +880,10 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
     _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
     assert layer.shared_down_proj.shape == orig.shared_down_proj.shape
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         assert layer.routed_gate_proj[e].shape == orig.routed_gate_proj[e].shape
         assert layer.routed_up_proj[e].shape == orig.routed_up_proj[e].shape
         assert layer.routed_down_proj[e].shape == orig.routed_down_proj[e].shape
@@ -900,7 +906,7 @@ def test_load_moe_decoder_layer_4x2(bh_2d_mesh_device, tmp_path):
 
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
-    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
     save_decoder_layer(
         orig,
@@ -923,10 +929,10 @@ def test_load_moe_decoder_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert layer.attn_norm.tensor_shape == (1, 7168)
     assert layer.shared_gate_proj.tensor_shape == (7168, 256)
     assert layer.shared_up_proj.tensor_shape == (7168, 256)
-    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
-    for e in range(NUM_ROUTED_EXPERTS):
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
+    for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
         _assert_on_device(layer.routed_gate_proj[e])
         _assert_on_device(layer.routed_up_proj[e])
         _assert_on_device(layer.routed_down_proj[e])
@@ -1020,85 +1026,81 @@ def test_save_load_embedding_and_lm_head_weights_4x2(bh_2d_mesh_device, tmp_path
     _assert_on_device(loaded_lm_head.final_norm)
 
 
-@pytest.mark.skip(reason="Too slow for CI; use for manual multi-submesh validation")
+def _mtp_state_dict(mtp_layer_idx: int = _MTP_LAYER_IDX, seed: int = 44) -> dict[str, torch.Tensor]:
+    """Build a synthetic state dict with only the lightweight MTP projection/norm tensors."""
+    g = torch.Generator().manual_seed(seed + 1000)
+    dtype = torch.bfloat16
+    H = LogicalModelDimensions.HIDDEN_SIZE
+    return {
+        f"model.layers.{mtp_layer_idx}.hnorm.weight": torch.randn(H, generator=g, dtype=dtype),
+        f"model.layers.{mtp_layer_idx}.enorm.weight": torch.randn(H, generator=g, dtype=dtype),
+        f"model.layers.{mtp_layer_idx}.eh_proj.weight": torch.randn(H, 2 * H, generator=g, dtype=dtype),
+    }
+
+
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
-    """Prepare each of 4 layers on a different 4x2 submesh, save them, then load each on the same submesh.
+def test_prepare_mtp_weights_4x2(bh_2d_mesh_device):
+    """Prepare MTP weights on 4x2 mesh; verify type and shapes."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _mtp_state_dict()
+    t0 = time.perf_counter()
+    weights = prepare_mtp_weights(state, submesh)
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_mtp_weights (4x2 mesh): {:.3f} s", elapsed)
+    H = LogicalModelDimensions.HIDDEN_SIZE
+    assert isinstance(weights, DeepSeekV3MTPWeights)
+    assert weights.h_gamma.shape == (1, H)
+    assert weights.e_gamma.shape == (1, H)
+    assert weights.eh_projection.shape == (2 * H, H)
 
-    Uses create_submeshes to get 4 disjoint (4x2) submeshes; requires 32 devices.
-    Each layer is prepared on its own submesh to avoid OOM. Layers 0,1,2 are dense, layer 3 is MoE.
-    """
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_mtp_weights_4x2(bh_2d_mesh_device, tmp_path):
+    """Save MTP weights to disk, load back, verify shapes match and tensors are on device."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_dense_decoder_layer/load_moe_decoder_layer require slow dispatch")
-    num_submeshes = 4
-    devices_per_submesh = 4 * 2
-    num_devices_required = num_submeshes * devices_per_submesh  # 32
-    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices_required:
-        pytest.skip(
-            f"Test requires {num_devices_required} devices (4 submeshes x 4x2), "
-            f"mesh has {bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
-        )
-    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape((4, 2)))
-    assert len(submeshes) >= num_submeshes, f"Expected at least {num_submeshes} submeshes"
+        pytest.skip("load_mtp_weights requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _mtp_state_dict()
+    weights = prepare_mtp_weights(state, submesh)
+    expected_shapes = {
+        "h_gamma": weights.h_gamma.shape,
+        "e_gamma": weights.e_gamma.shape,
+        "eh_projection": weights.eh_projection.shape,
+    }
 
-    num_layers = 4
-    first_k_dense_replace = 3  # layers 0,1,2 dense; layer 3 MoE
-    for layer_idx in range(num_layers):
-        is_moe = layer_idx >= first_k_dense_replace
-        submesh = submeshes[layer_idx]
-        bdw = BlitzDecodeWeights(submesh)
-        # State for "layer 0" (prepare_*_layer_weights take layer_idx for key lookup)
-        state = _layer_state_dict(0, is_moe=is_moe, seed=42 + layer_idx)
-        t0 = time.perf_counter()
-        if is_moe:
-            layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
-        else:
-            layer = prepare_dense_layer_weights(bdw, state, 0)
-        elapsed = time.perf_counter() - t0
-        logger.info(
-            "prepare (layer %d, %s, on submesh %d): {:.3f} s",
-            layer_idx,
-            "moe" if is_moe else "dense",
-            layer_idx,
-            elapsed,
-        )
-        save_decoder_layer(
-            layer,
-            tmp_path,
-            layer_idx,
-            hf_model_name="test-4layer-model",
-            hf_state_dict_name="test-4layer-state-dict.safetensors",
-            device_mesh_shape=(4, 2),
-        )
-        _deallocate_layer(layer)
+    save_mtp_weights(
+        weights,
+        tmp_path,
+        hf_model_name="test-mtp-model-4x2",
+        hf_state_dict_name="test-mtp.safetensors",
+        device_mesh_shape=(4, 2),
+    )
 
-    loaded = []
-    t0 = time.time()
-    for layer_idx in range(num_layers):
-        submesh = submeshes[layer_idx]
-        if layer_idx >= first_k_dense_replace:
-            layer = load_moe_decoder_layer(tmp_path, submesh, layer_idx)
-        else:
-            layer = load_dense_decoder_layer(tmp_path, submesh, layer_idx)
-        loaded.append(layer)
-    elapsed = time.time() - t0
-    logger.info("load_decoder_layer (4 layers, 4x2 submesh): %s s", elapsed)
+    mtp_dir = tmp_path / "mtp"
+    assert (mtp_dir / "manifest.json").exists()
+    assert (mtp_dir / "mtp_h_gamma.tensorbin").exists()
+    assert (mtp_dir / "mtp_e_gamma.tensorbin").exists()
+    assert (mtp_dir / "mtp_eh_projection.tensorbin").exists()
 
-    assert isinstance(loaded[0], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[1], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[2], DeepSeekV3DenseLayerWeights)
-    assert isinstance(loaded[3], DeepSeekV3MoELayerWeights)
-    for i in range(3):
-        assert hasattr(loaded[i], "shared_gate_proj") and loaded[i].shared_gate_proj is not None
-        assert hasattr(loaded[i], "routed_gate_proj") and loaded[i].routed_gate_proj is not None
-        assert loaded[i].routed_gate_proj.shape is not None
-    assert len(loaded[3].routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(loaded[3].routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(loaded[3].routed_down_proj) == NUM_ROUTED_EXPERTS
-    assert loaded[3].shared_down_proj is not None
-    for i in range(num_layers):
-        _assert_layer_on_device_with_topology(loaded[i])
+    ttnn.deallocate(weights.h_gamma, force=True)
+    ttnn.deallocate(weights.e_gamma, force=True)
+    ttnn.deallocate(weights.eh_projection, force=True)
+
+    loaded = load_mtp_weights(tmp_path, submesh)
+    assert isinstance(loaded, DeepSeekV3MTPWeights)
+    assert loaded.h_gamma.shape == expected_shapes["h_gamma"]
+    assert loaded.e_gamma.shape == expected_shapes["e_gamma"]
+    assert loaded.eh_projection.shape == expected_shapes["eh_projection"]
+    _assert_on_device(loaded.h_gamma)
+    _assert_on_device(loaded.e_gamma)
+    _assert_on_device(loaded.eh_projection)


### PR DESCRIPTION
### Summary
Add `DeepSeekV3MTPWeights` dataclass and full prepare/save/load pipeline for the MTP (Multi-Token Prediction) speculative decode layer (layer 61). Per the [DeepSeek-V3 weight docs](https://github.com/deepseek-ai/DeepSeek-V3/blob/main/README_WEIGHTS.md), the MTP module contains a full MoE decoder block (identical structure to layers 3–60) plus embedding, shared head, and norm weights. 

### What's changed
- **`prepare_weights.py`** — New `DeepSeekV3MTPWeights` dataclass with `h_gamma`, `e_gamma`, `eh_projection`. New `prepare_mtp_weights`, `save_mtp_weights`, `load_mtp_weights`. MTP weights are saved under `<cache_root>/mtp/` alongside the corresponding decoder layer files under `<cache_root>/mtp/`.
- **`weight_provider.py`** — `load_mtp()` on `CacheWeightProvider`, `SyntheticWeightProvider`, and `StateDictWeightProvider`.
- **`generate_cache.py`** — `--type mtp` for offline MTP cache generation and verification.
- **`test_prepare_weights.py`** — `test_prepare_mtp_weights_4x2` and `test_save_load_mtp_weights_4x2` (save/load round-trip with on-device checks).
- Minor log message formatting cleanup in `prepare_weights.py`.