### PR TITLE
Add support for enums in DEVICE_PRINT

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -176,3 +176,22 @@ TEST_F(DevicePrintFormatUpdatesFixture, PrintAllArgumentSizes) {
     TestFormatUpdate(
         "tests/tt_metal/tt_metal/test_kernels/device_print/print_all_argument_sizes.cpp", ttsl::make_span(messages));
 }
+
+// Enum arguments are serialized as their base type on device, with the format string updated to contain
+// /e_<base_type_char>_<fully_qualified_enum_type_name> as the type specifier.
+// The '#' alternate form flag encodes "print full enum type name including value name" on the host side.
+TEST_F(DevicePrintFormatUpdatesFixture, PrintEnumValue) {
+    std::vector<std::string_view> messages = {
+        "Enum1 value: {0,/e_I_test::deep::Enum1}\n"sv,
+        "Enum1 full name value: {0,/e_I_test::deep::Enum1:#}\n"sv,
+        "Enum2 value: {0,/e_I_test_shallow::Enum2}\n"sv,
+        "Enum2 full name value: {0,/e_I_test_shallow::Enum2:#}\n"sv,
+        "EnumClass value: {0,/e_B_EnumClass}\n"sv,
+        "EnumClass full name value: {0,/e_B_EnumClass:#}\n"sv,
+        "BitEnum value: {0,/E_I_flags::BitEnum}\n"sv,
+        "BitEnum full name value: {0,/E_I_flags::BitEnum:#}\n"sv,
+    };
+
+    TestFormatUpdate(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp", ttsl::make_span(messages));
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -184,6 +184,10 @@ TEST_F(DevicePrintFormatUpdatesFixture, PrintEnumValue) {
     std::vector<std::string_view> messages = {
         "Enum1 value: {0,/e_I_test::deep::Enum1}\n"sv,
         "Enum1 full name value: {0,/e_I_test::deep::Enum1:#}\n"sv,
+        "Enum1 value: {0,/e_I_test::deep::Enum1}\n"sv,
+        "Enum1 full name value: {0,/e_I_test::deep::Enum1:#}\n"sv,
+        "Enum1 unrecognized value: {0,/e_I_test::deep::Enum1}\n"sv,
+        "Enum1 full name unrecognized value: {0,/e_I_test::deep::Enum1:#}\n"sv,
         "Enum2 value: {0,/e_I_test_shallow::Enum2}\n"sv,
         "Enum2 full name value: {0,/e_I_test_shallow::Enum2:#}\n"sv,
         "EnumClass value: {0,/e_B_EnumClass}\n"sv,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -68,6 +68,7 @@ public:
 TEST_F(DevicePrintFormatUpdatesFixture, PrintSimpleString) {
     std::vector<std::string_view> messages = {
         "Hello world!\n"sv,
+        "First line.\nSecond line.\n"sv,
     };
 
     TestFormatUpdate(

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -225,6 +225,8 @@ TEST_F(DevicePrintOutputFixture, PrintEnumValue) {
         "Enum1 value: Value2",
         // Alternate form (#): full qualified type name + value name
         "Enum1 full name value: test::deep::Enum1::Value3",
+        "Enum1 unrecognized value: (test::deep::Enum1)100",
+        "Enum1 full name unrecognized value: (test::deep::Enum1)100",
         "Enum2 value: ValueB",
         "Enum2 full name value: test_shallow::Enum2::ValueC",
         "EnumClass value: ValueY",

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -214,3 +214,25 @@ TEST_F(DevicePrintOutputFixture, PrintAllArgumentSizes) {
 
     TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_all_argument_sizes.cpp", messages);
 }
+
+// When DWARF debug info is present in the ELF, enum values are printed as their symbolic names.
+// Without '#' the output is just the value name; with '#' the full qualified type::value name is printed.
+// Bit-field enums print each active flag separated by " | ".
+// Unrecognised values are printed as (EnumType)integer.
+TEST_F(DevicePrintOutputFixture, PrintEnumValue) {
+    std::vector<std::string> messages = {
+        // Plain format: only the value name
+        "Enum1 value: Value2",
+        // Alternate form (#): full qualified type name + value name
+        "Enum1 full name value: test::deep::Enum1::Value3",
+        "Enum2 value: ValueB",
+        "Enum2 full name value: test_shallow::Enum2::ValueC",
+        "EnumClass value: ValueY",
+        "EnumClass full name value: EnumClass::ValueZ",
+        // Bit-field enum: active flags joined by " | "
+        "BitEnum value: Flag1 | Flag3",
+        "BitEnum full name value: flags::BitEnum::Flag2 | flags::BitEnum::Flag3",
+    };
+
+    TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp", messages);
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -24,6 +24,8 @@ public:
 TEST_F(DevicePrintOutputFixture, PrintSimpleString) {
     std::vector<std::string> messages = {
         "Hello world!",
+        "First line.",
+        "Second line.",
     };
 
     TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp", messages);

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp
@@ -45,6 +45,8 @@ constexpr BitEnum operator|(BitEnum a, BitEnum b) {
 void kernel_main() {
     DEVICE_PRINT("Enum1 value: {}\n", test::deep::Value2);
     DEVICE_PRINT("Enum1 full name value: {:#}\n", test::deep::Value3);
+    DEVICE_PRINT("Enum1 unrecognized value: {}\n", (test::deep::Enum1)100);
+    DEVICE_PRINT("Enum1 full name unrecognized value: {:#}\n", (test::deep::Enum1)100);
     DEVICE_PRINT("Enum2 value: {}\n", test_shallow::ValueB);
     DEVICE_PRINT("Enum2 full name value: {:#}\n", test_shallow::ValueC);
     DEVICE_PRINT("EnumClass value: {}\n", EnumClass::ValueY);

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_enum_value.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+namespace test::deep {
+enum Enum1 {
+    Value1 = 0,
+    Value2 = 1,
+    Value3 = 2,
+};
+}
+
+namespace test_shallow {
+enum Enum2 {
+    ValueA = 0,
+    ValueB = 1,
+    ValueC = 2,
+};
+}
+
+enum class EnumClass : uint8_t {
+    ValueX = 0,
+    ValueY = 1,
+    ValueZ = 2,
+};
+
+namespace flags {
+enum class BitEnum : uint32_t {
+    Flag1 = 1 << 0,
+    Flag2 = 1 << 1,
+    Flag3 = 1 << 2,
+};
+
+constexpr BitEnum operator|(BitEnum a, BitEnum b) {
+    return static_cast<BitEnum>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+}  // namespace flags
+
+/*
+ * Test printing from a kernel running on BRISC.
+ */
+
+void kernel_main() {
+    DEVICE_PRINT("Enum1 value: {}\n", test::deep::Value2);
+    DEVICE_PRINT("Enum1 full name value: {:#}\n", test::deep::Value3);
+    DEVICE_PRINT("Enum2 value: {}\n", test_shallow::ValueB);
+    DEVICE_PRINT("Enum2 full name value: {:#}\n", test_shallow::ValueC);
+    DEVICE_PRINT("EnumClass value: {}\n", EnumClass::ValueY);
+    DEVICE_PRINT("EnumClass full name value: {:#}\n", EnumClass::ValueZ);
+    DEVICE_PRINT("BitEnum value: {}\n", flags::BitEnum::Flag1 | flags::BitEnum::Flag3);
+    DEVICE_PRINT("BitEnum full name value: {:#}\n", flags::BitEnum::Flag2 | flags::BitEnum::Flag3);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp
@@ -8,4 +8,9 @@
  * Test printing from a kernel running on BRISC.
  */
 
-void kernel_main() { DEVICE_PRINT("Hello world!\n"); }
+void kernel_main() {
+    DEVICE_PRINT("Hello world!\n");
+    DEVICE_PRINT(
+        "First line.\n"
+        "Second line.\n");
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -364,6 +364,23 @@ CPMAddPackage(
 )
 
 ####################################################################################################################
+# libdwarf : https://github.com/davea42/libdwarf-code
+# Portable DWARF debug info parser (no libelf dependency, built-in ELF reader)
+####################################################################################################################
+CPMAddPackage(
+    NAME libdwarf
+    GITHUB_REPOSITORY davea42/libdwarf-code
+    GIT_TAG v0.12.0
+    OPTIONS
+        "BUILD_DWARFDUMP OFF"
+        "BUILD_DWARFEXAMPLE OFF"
+        "BUILD_SHARED_LIBS OFF"
+        "PIC_ALWAYS ON"
+        "BUILD_TESTING OFF"
+        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+)
+
+####################################################################################################################
 # Cap'n Proto : https://github.com/capnproto/capnproto
 ####################################################################################################################
 CPMAddPackage(

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -906,11 +906,10 @@ constexpr std::array<uint32_t, sizeof...(Args)> get_arg_offsets() {
 // GCC format: "... [with T = test::deep::Enum1]"
 template <typename T>
 constexpr auto get_type_name_string() {
-    constexpr const char* fn =
 #if defined(__GNUC__)
-        __PRETTY_FUNCTION__;
+    constexpr const char* fn = __PRETTY_FUNCTION__;
 #else
-        static_assert(false, "get_type_name_string requires __PRETTY_FUNCTION__ (GCC/Clang)");
+    static_assert(false, "get_type_name_string requires __PRETTY_FUNCTION__ (GCC/Clang)");
 #endif
     std::size_t fn_len = 0;
     while (fn[fn_len] != '\0') {

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "hostdev/device_print_common.h"
 #include "hostdev/device_print_structures.h"

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -589,7 +589,7 @@ struct device_print_type_info {
 };
 
 // Type-to-info mapping for format strings and serialization
-template <typename T>
+template <typename T, typename = void>
 struct device_print_type {
     static constexpr device_print_type_info value = {'#', 0};  // Unknown type default
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, T argument) {
@@ -700,6 +700,28 @@ struct device_print_type<bf16_t> {
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, bf16_t argument) {
         *reinterpret_cast<device_print_buffer_ptr<uint16_t>>(device_print_buffer + offset) =
             static_cast<uint16_t>(argument.val);
+    }
+};
+
+// On some platforms (e.g. 32-bit RISC-V), 'int'/'unsigned int' are distinct types from
+// 'int32_t'/'uint32_t' (which are typedefs for 'long'/'unsigned long'). Add forwarding
+// specializations so that enum underlying types resolve correctly.
+template <typename T>
+struct device_print_type<
+    T,
+    std::enable_if_t<
+        std::is_integral_v<T> && !std::is_same_v<T, bool> && sizeof(T) == 4 && !std::is_same_v<T, std::int32_t> &&
+        !std::is_same_v<T, std::uint32_t>>> {
+    static constexpr device_print_type_info value =
+        std::is_signed_v<T> ? device_print_type<std::int32_t>::value : device_print_type<std::uint32_t>::value;
+    static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, T argument) {
+        if constexpr (std::is_signed_v<T>) {
+            device_print_type<std::int32_t>::serialize(
+                device_print_buffer, offset, static_cast<std::int32_t>(argument));
+        } else {
+            device_print_type<std::uint32_t>::serialize(
+                device_print_buffer, offset, static_cast<std::uint32_t>(argument));
+        }
     }
 };
 
@@ -814,6 +836,19 @@ struct device_print_type<TileSlice<128>> {
 };
 #endif
 
+// Enum types: serialized as their underlying type.
+template <typename T>
+struct device_print_type<T, std::enable_if_t<std::is_enum_v<T>>> {
+    using underlying_type = std::underlying_type_t<T>;
+
+    static constexpr device_print_type_info value = device_print_type<underlying_type>::value;
+
+    static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, T argument) {
+        device_print_type<underlying_type>::serialize(
+            device_print_buffer, offset, static_cast<underlying_type>(argument));
+    }
+};
+
 // Helper to get type character for a single type, removing cv-qualifiers and references
 template <typename T>
 constexpr device_print_type_info get_type_info() {
@@ -866,6 +901,108 @@ constexpr std::array<uint32_t, sizeof...(Args)> get_arg_offsets() {
     return arg_offset;
 }
 
+// Extracts the fully-qualified type name from __PRETTY_FUNCTION__ at compile time.
+// GCC format: "... [with T = test::deep::Enum1]"
+template <typename T>
+constexpr auto get_type_name_string() {
+    constexpr const char* fn =
+#if defined(__GNUC__)
+        __PRETTY_FUNCTION__;
+#else
+        static_assert(false, "get_type_name_string requires __PRETTY_FUNCTION__ (GCC/Clang)");
+#endif
+    std::size_t fn_len = 0;
+    while (fn[fn_len] != '\0') {
+        fn_len++;
+    }
+
+    // Search for "T = " in "[with T = TypeName]"
+    std::size_t name_start = 0;
+    for (std::size_t i = 0; i + 3 < fn_len; i++) {
+        if (fn[i] == 'T' && fn[i + 1] == ' ' && fn[i + 2] == '=' && fn[i + 3] == ' ') {
+            name_start = i + 4;
+            break;
+        }
+    }
+    // End is at ']' (last char before null, or ';' for multiple template params)
+    std::size_t name_end = fn_len - 1;
+
+    helpers::static_string<1024> result;
+    for (std::size_t i = name_start; i < name_end; i++) {
+        result.push_back(fn[i]);
+    }
+    return result;
+}
+
+// Returns the extra characters needed in the format string for an enum type argument.
+// Non-enum types contribute 0 extra chars.
+template <typename T>
+constexpr std::size_t enum_extra_format_chars() {
+    using base = std::remove_cv_t<std::remove_reference_t<T>>;
+    if constexpr (std::is_enum_v<base>) {
+        constexpr auto name = get_type_name_string<base>();
+        return 4 + name.size;  // '/e_' + base_type_char + '_' + name  (minus the 1 char already in baseline)
+    } else {
+        return 0;
+    }
+}
+
+// Detect at compile time whether an enum type has an operator| that returns the enum type itself
+// (i.e. is a flag/bitmask enum). Unscoped enums implicitly convert to int so T|T works for all
+// of them via integer promotion — we require the result type to be T to distinguish true flag enums.
+template <typename T, typename = void>
+struct is_flag_enum : std::false_type {};
+
+template <typename T>
+struct is_flag_enum<
+    T,
+    std::enable_if_t<std::is_enum_v<T> && std::is_same_v<T, decltype(std::declval<T>() | std::declval<T>())>>>
+    : std::true_type {};
+
+// Writes the type format info for a single type into the result string.
+// Simple types: single character (e.g. 'I' for uint32_t)
+// Regular enums: /e_<base_char>_<EnumTypeName>
+// Flag enums (with operator|): /E_<base_char>_<EnumTypeName>
+template <typename T, std::size_t MaxLen>
+constexpr void write_type(helpers::static_string<MaxLen>& result) {
+    using base = std::remove_cv_t<std::remove_reference_t<T>>;
+    if constexpr (std::is_enum_v<base>) {
+        constexpr auto enum_name = get_type_name_string<base>();
+        result.push_back('/');
+        result.push_back(is_flag_enum<base>::value ? 'E' : 'e');
+        result.push_back('_');
+        result.push_back(device_print_type<base>::value.type_char);
+        result.push_back('_');
+        for (std::size_t j = 0; j < enum_name.size; j++) {
+            result.push_back(enum_name.data[j]);
+        }
+    } else {
+        result.push_back(device_print_type<base>::value.type_char);
+    }
+}
+
+// Finds the arg_index-th type in the Args... pack and calls write_type for it.
+template <typename... Types>
+struct TypeWriter;
+
+template <>
+struct TypeWriter<> {
+    template <std::size_t MaxLen>
+    static constexpr void write(helpers::static_string<MaxLen>&, uint32_t, uint32_t = 0) {}
+};
+
+template <typename First, typename... Rest>
+struct TypeWriter<First, Rest...> {
+    template <std::size_t MaxLen>
+    static constexpr void write(helpers::static_string<MaxLen>& result, uint32_t arg_index, uint32_t current = 0) {
+        if (current == arg_index) {
+            write_type<First>(result);
+        } else {
+            TypeWriter<Rest...>::write(result, arg_index, current + 1);
+        }
+    }
+};
+
 // Main function to update format string with type information
 // Supports both {} and {N} placeholder styles (fmtlib-compatible)
 template <std::size_t N, typename... Args>
@@ -881,7 +1018,8 @@ constexpr auto update_format_string(const char (&format)[N]) {
     // Use sizeof...(Args) to pick the right bound rather than always assuming 2.
     constexpr std::size_t num_args_ = sizeof...(Args);
     constexpr std::size_t max_index_digits_ = (num_args_ <= 9) ? 1 : (num_args_ <= 99) ? 2 : (num_args_ <= 999) ? 3 : 4;
-    constexpr std::size_t result_len = format_len + (format_len / 2 + 1) * (2 + max_index_digits_);
+    constexpr std::size_t enum_extra_ = (enum_extra_format_chars<Args>() + ... + 0);
+    constexpr std::size_t result_len = format_len + (format_len / 2 + 1) * (2 + max_index_digits_) + enum_extra_;
 
     helpers::static_string<result_len> result;
 
@@ -911,9 +1049,9 @@ constexpr auto update_format_string(const char (&format)[N]) {
             // Output the index (updated with reordered index)
             result.push_back_uint32(arg_reorder[arg_index]);
 
-            // Add comma and type character
+            // Add comma and type character (enum types emit extended type info)
             result.push_back(',');
-            result.push_back(type_infos[arg_index].type_char);
+            TypeWriter<Args...>::write(result, arg_index);
 
             // If there are any format specifiers, add them
             bool has_format_spec = token.fill.has_value() || token.align.has_value() || token.sign.has_value() ||

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(
         Metalium::Metal::LLRT
         capnp
         capnp-rpc
+        libdwarf::dwarf-static
 )
 
 target_include_directories(

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -21,6 +21,9 @@
 #include "hostdevcommon/kernel_structs.h"
 #include "tt_backend_api_types.hpp"
 
+#include "dwarf.h"
+#include "libdwarf.h"
+
 using std::setw;
 using std::string;
 using std::to_string;
@@ -523,9 +526,16 @@ DevicePrintParser::ParsedStringInfo* DevicePrintParser::get_string_info(uint32_t
                     max_arg_id = std::max(max_arg_id, placeholder.arg_id);
                 }
                 parsed_info.argument_types.resize(max_arg_id + 1);
-                for (const auto& placeholder : parsed_info.placeholders) {
-                    parsed_info.argument_types[placeholder.arg_id] = placeholder.type_id;
-                    parsed_info.arguments_size += get_argument_size_from_type_id(placeholder.type_id);
+                for (auto& placeholder : parsed_info.placeholders) {
+                    // For long types (type_id == '/'), the serialization uses the base type
+                    char serialization_type = placeholder.type_id;
+                    if (placeholder.type_id == '/' && placeholder.enum_base_type_id != 0) {
+                        // '/e' enum type: serialize as the underlying integer type
+                        serialization_type = placeholder.enum_base_type_id;
+                        placeholder.enum_info = get_enum_info(placeholder.enum_type_name);
+                    }
+                    parsed_info.argument_types[placeholder.arg_id] = serialization_type;
+                    parsed_info.arguments_size += get_argument_size_from_type_id(serialization_type);
                 }
             }
         }
@@ -592,7 +602,6 @@ DevicePrintParser::parse_format_string(std::string_view format_str) {
             if (!placeholder) {
                 TT_THROW("Invalid format string: failed to parse placeholder at position {}", i);
             }
-            placeholder->fmt_format = "{0" + std::string(placeholder->format_spec) + "}";
             placeholders.push_back(*placeholder);
             plain_text_parts.push_back(std::string(current_text.data(), current_text.size()));
             current_text.clear();
@@ -617,11 +626,16 @@ std::optional<DevicePrintParser::FormatPlaceholderInfo> DevicePrintParser::parse
     pos++;  // Skip '{'
 
     // We are trying to mimic fmtlib format specifiers here, but device already changed it a bit:
-    // replacement_field ::= "{" arg_id "," type_id [":" (format_spec | chrono_format_spec)] "}"
-    // type_id           ::= "a"..."z" | "A"..."Z"
+    // replacement_field ::= "{" arg_id "," type_id [":" format_spec] "}"
     // arg_id            ::= integer
     // integer           ::= digit+
     // digit             ::= "0"..."9"
+    // type_id           ::= short_type | long_type
+    // short_type        ::= "a"..."z" | "A"..."Z"         (single character, e.g. 'I' for uint32_t)
+    // long_type         ::= "/" sub_type "_" extra_info   ('/' signals a multi-character type descriptor)
+    // sub_type          ::= "e"                           (regular enum)
+    //                     | "E"                           (flag/bitmask enum with operator|)
+    // extra_info        ::= short_type "_" enum_name      (e.g. "I_test::deep::Enum1")
     // But we don't support using identifiers to reduce kernel size, only integers for arg_id.
 
     // Regarding format_spec:
@@ -655,12 +669,78 @@ std::optional<DevicePrintParser::FormatPlaceholderInfo> DevicePrintParser::parse
     pos++;  // Skip ','
     char type_id = format_str[pos++];
 
+    // Check for long type marker: '/' followed by sub-type character.
+    // Supported: /e_<base_type>_<enum_name> (regular enum), /E_<base_type>_<enum_name> (flag enum)
+    if (type_id == '/' && pos + 3 < format_str.size() && (format_str[pos] == 'e' || format_str[pos] == 'E') &&
+        format_str[pos + 1] == '_') {
+        bool is_flag_enum = (format_str[pos] == 'E');
+        pos += 2;  // Skip 'e_' or 'E_'
+        char base_type = format_str[pos++];
+        if (pos < format_str.size() && format_str[pos] == '_') {
+            pos++;  // Skip second '_'
+        }
+        // Read enum type name until format spec separator or '}'.
+        // A single ':' not followed by ':' marks the start of a format spec.
+        // '::' is a C++ namespace separator and is part of the enum type name.
+        std::size_t name_start = pos;
+        while (pos < format_str.size() && format_str[pos] != '}') {
+            if (format_str[pos] == ':' && (pos + 1 >= format_str.size() || format_str[pos + 1] != ':')) {
+                break;  // Single ':' = format spec separator
+            }
+            if (format_str[pos] == ':' && pos + 1 < format_str.size() && format_str[pos + 1] == ':') {
+                pos += 2;  // Skip '::' as part of the name
+                continue;
+            }
+            pos++;
+        }
+        std::string_view enum_type_name = format_str.substr(name_start, pos - name_start);
+
+        // Parse optional format spec (may contain '#' for full name)
+        bool use_full_name = false;
+        std::size_t format_spec_start = pos;
+        while (pos < format_str.size() && format_str[pos] != '}') {
+            if (format_str[pos] == '#') {
+                use_full_name = true;
+            }
+            pos++;
+        }
+        auto format_spec = format_str.substr(format_spec_start, pos - format_spec_start);
+        pos++;  // Skip '}'
+
+        // Build fmt_format for the enum string, stripping '#' which is consumed as enum_use_full_name.
+        std::string fmt_format = "{0";
+        for (char c : format_spec) {
+            if (c != '#') {
+                fmt_format += c;
+            }
+        }
+        fmt_format += '}';
+
+        FormatPlaceholderInfo info;
+        info.arg_id = arg_id;
+        info.type_id = '/';  // Mark as long type (enum)
+        info.format_spec = format_spec;
+        info.fmt_format = std::move(fmt_format);
+        info.enum_type_name = enum_type_name;
+        info.enum_base_type_id = base_type;
+        info.enum_is_flag = is_flag_enum;
+        info.enum_use_full_name = use_full_name;
+        return info;
+    }
+
     uint32_t format_spec_start = pos;
     while (pos < format_str.size() && format_str[pos] != '}') {
         pos++;
     }
     pos++;  // Skip '}'
-    return {{arg_id, type_id, format_str.substr(format_spec_start, pos - format_spec_start - 1)}};
+    auto format_spec = format_str.substr(format_spec_start, pos - format_spec_start - 1);
+
+    FormatPlaceholderInfo info;
+    info.arg_id = arg_id;
+    info.type_id = type_id;
+    info.format_spec = format_spec;
+    info.fmt_format = "{0" + std::string(format_spec) + "}";
+    return info;
 }
 
 std::string_view DevicePrintParser::format_message(
@@ -895,6 +975,85 @@ std::string_view DevicePrintParser::format_message(
 
                 break;
             }
+            case '/':  // Long type: '/' followed by sub-type character
+            {
+                TT_ASSERT(placeholder.enum_base_type_id != 0, "Unsupported long type in format placeholder");
+                // Currently only '/e' (enum) and /E (flag enum) are supported
+                // Get the integer value from the argument (using the base type)
+                int64_t int_val = 0;
+                auto& arg = buffer.argument_values[placeholder.arg_id];
+                std::visit(
+                    [&int_val](auto&& v) {
+                        using V = std::decay_t<decltype(v)>;
+                        if constexpr (std::is_integral_v<V>) {
+                            int_val = static_cast<int64_t>(v);
+                        }
+                    },
+                    arg);
+
+                // Build the enum string representation, then format it with the user's format spec.
+                fmt::memory_buffer enum_str;
+                auto* ei = placeholder.enum_info;
+
+                // Append "TypeName::" prefix when full name is requested
+                auto append_type_prefix = [&]() {
+                    if (placeholder.enum_use_full_name) {
+                        enum_str.append(placeholder.enum_type_name);
+                        enum_str.append("::"sv);
+                    }
+                };
+
+                // Format an unrecognized value as (TypeName)integer
+                auto append_raw_value = [&](int64_t val) {
+                    fmt::format_to(std::back_inserter(enum_str), "({}){}", placeholder.enum_type_name, val);
+                };
+
+                if (!ei || ei->enumerators.empty()) {
+                    // No DWARF info available
+                    append_raw_value(int_val);
+                } else if (placeholder.enum_is_flag && int_val != 0) {
+                    // Print bitfield: Flag1 | Flag3 or BitEnum::Flag1 | BitEnum::Flag3
+                    bool first = true;
+                    int64_t remaining = int_val;
+                    for (auto& [eval, ename] : ei->enumerators) {
+                        if (eval != 0 && (remaining & eval) == eval) {
+                            if (!first) {
+                                enum_str.append(" | "sv);
+                            }
+                            append_type_prefix();
+                            enum_str.append(std::string_view(ename));
+                            remaining &= ~eval;
+                            first = false;
+                        }
+                    }
+                    if (remaining != 0) {
+                        if (!first) {
+                            enum_str.append(" | "sv);
+                        }
+                        append_raw_value(remaining);
+                    }
+                } else {
+                    // Non-bitfield: find exact match
+                    const std::string* found_name = nullptr;
+                    for (auto& [eval, ename] : ei->enumerators) {
+                        if (eval == int_val) {
+                            found_name = &ename;
+                            break;  // Use first match
+                        }
+                    }
+                    if (found_name) {
+                        append_type_prefix();
+                        enum_str.append(std::string_view(*found_name));
+                    } else {
+                        append_raw_value(int_val);
+                    }
+                }
+
+                // Apply user's format spec (alignment, width, fill, etc.)
+                auto enum_sv = std::string_view(enum_str.data(), enum_str.size());
+                fmt::format_to(std::back_inserter(buffer.buffer), fmt::runtime(placeholder.fmt_format), enum_sv);
+                break;
+            }
             default: TT_THROW("Unsupported type_id in format placeholder (format_message): {}", placeholder.type_id);
         }
     }
@@ -962,6 +1121,174 @@ DevicePrintParser::ArgumentValue DevicePrintParser::read_argument_from_payload(
         }
         default: TT_THROW("Unsupported type_id in format placeholder (read_argument_from_payload): {}", type_id);
     }
+}
+
+const DevicePrintParser::EnumInfo* DevicePrintParser::get_enum_info(std::string_view type_name) {
+    if (!enum_info_loaded_) {
+        load_enum_info_from_dwarf();
+        enum_info_loaded_ = true;
+    }
+    auto it = enum_info_cache_.find(type_name);
+    if (it != enum_info_cache_.end()) {
+        return &it->second;
+    }
+    return nullptr;
+}
+
+void DevicePrintParser::load_enum_info_from_dwarf() {
+    Dwarf_Debug dbg = nullptr;
+    Dwarf_Error err = nullptr;
+
+    // libdwarf can open ELF files directly by path
+    int res = dwarf_init_path(
+        elf_path.c_str(),
+        nullptr,  // true_pathbuf
+        0,        // true_pathlen
+        DW_GROUPNUMBER_ANY,
+        nullptr,  // errhand
+        nullptr,  // errarg
+        &dbg,
+        &err);
+
+    if (res != DW_DLV_OK) {
+        // No DWARF info available
+        return;
+    }
+
+    // Traverse all compilation units
+    Dwarf_Unsigned cu_header_length = 0;
+    Dwarf_Half version_stamp = 0;
+    Dwarf_Off abbrev_offset = 0;
+    Dwarf_Half address_size = 0;
+    Dwarf_Half offset_size = 0;
+    Dwarf_Half extension_size = 0;
+    Dwarf_Sig8 type_signature;
+    Dwarf_Unsigned typeoffset = 0;
+    Dwarf_Unsigned next_cu_header = 0;
+    Dwarf_Half header_cu_type = 0;
+    Dwarf_Bool is_info = true;
+
+    while (dwarf_next_cu_header_d(
+               dbg,
+               is_info,
+               &cu_header_length,
+               &version_stamp,
+               &abbrev_offset,
+               &address_size,
+               &offset_size,
+               &extension_size,
+               &type_signature,
+               &typeoffset,
+               &next_cu_header,
+               &header_cu_type,
+               &err) == DW_DLV_OK) {
+        Dwarf_Die cu_die = nullptr;
+        if (dwarf_siblingof_b(dbg, nullptr, is_info, &cu_die, &err) != DW_DLV_OK) {
+            continue;
+        }
+
+        // Recursive lambda to walk the DIE tree and collect enum types with qualified names
+        std::function<void(Dwarf_Die, const std::string&)> walk_die;
+        walk_die = [&](Dwarf_Die die, const std::string& parent_scope) {
+            Dwarf_Half tag = 0;
+            if (dwarf_tag(die, &tag, &err) != DW_DLV_OK) {
+                return;
+            }
+
+            // Build the current scope name
+            std::string current_scope = parent_scope;
+            char* die_name = nullptr;
+            bool has_name = (dwarf_diename(die, &die_name, &err) == DW_DLV_OK && die_name);
+
+            if (tag == DW_TAG_namespace || tag == DW_TAG_class_type || tag == DW_TAG_structure_type) {
+                if (has_name) {
+                    if (!current_scope.empty()) {
+                        current_scope += "::";
+                    }
+                    current_scope += die_name;
+                }
+            }
+
+            if (tag == DW_TAG_enumeration_type && has_name) {
+                std::string enum_qualified_name = current_scope;
+                if (!enum_qualified_name.empty()) {
+                    enum_qualified_name += "::";
+                }
+                enum_qualified_name += die_name;
+
+                // Extract enumerator children
+                EnumInfo info;
+                info.type_name = enum_qualified_name;
+
+                Dwarf_Die child = nullptr;
+                if (dwarf_child(die, &child, &err) == DW_DLV_OK) {
+                    while (child) {
+                        Dwarf_Half child_tag = 0;
+                        if (dwarf_tag(child, &child_tag, &err) == DW_DLV_OK && child_tag == DW_TAG_enumerator) {
+                            char* enumerator_name = nullptr;
+                            Dwarf_Signed sval = 0;
+                            Dwarf_Unsigned uval = 0;
+                            bool got_value = false;
+                            int64_t enum_val = 0;
+
+                            if (dwarf_diename(child, &enumerator_name, &err) == DW_DLV_OK && enumerator_name) {
+                                // Try to get const_value as signed first, then unsigned
+                                Dwarf_Attribute attr = nullptr;
+                                if (dwarf_attr(child, DW_AT_const_value, &attr, &err) == DW_DLV_OK) {
+                                    Dwarf_Half form = 0;
+                                    dwarf_whatform(attr, &form, &err);
+                                    if (dwarf_formsdata(attr, &sval, &err) == DW_DLV_OK) {
+                                        enum_val = sval;
+                                        got_value = true;
+                                    } else if (dwarf_formudata(attr, &uval, &err) == DW_DLV_OK) {
+                                        enum_val = static_cast<int64_t>(uval);
+                                        got_value = true;
+                                    }
+                                    dwarf_dealloc_attribute(attr);
+                                }
+
+                                if (got_value) {
+                                    info.enumerators.emplace_back(enum_val, std::string(enumerator_name));
+                                }
+                            }
+                        }
+
+                        Dwarf_Die sibling = nullptr;
+                        if (dwarf_siblingof_b(dbg, child, is_info, &sibling, &err) != DW_DLV_OK) {
+                            dwarf_dealloc_die(child);
+                            break;
+                        }
+                        dwarf_dealloc_die(child);
+                        child = sibling;
+                    }
+                }
+
+                if (!info.enumerators.empty()) {
+                    enum_info_cache_[enum_qualified_name] = std::move(info);
+                }
+            }
+
+            // Recurse into children
+            Dwarf_Die child = nullptr;
+            if (dwarf_child(die, &child, &err) == DW_DLV_OK) {
+                while (child) {
+                    walk_die(child, (tag == DW_TAG_enumeration_type) ? parent_scope : current_scope);
+                    Dwarf_Die sibling = nullptr;
+                    if (dwarf_siblingof_b(dbg, child, is_info, &sibling, &err) != DW_DLV_OK) {
+                        dwarf_dealloc_die(child);
+                        break;
+                    }
+                    dwarf_dealloc_die(child);
+                    child = sibling;
+                }
+            }
+        };
+
+        walk_die(cu_die, "");
+        dwarf_dealloc_die(cu_die);
+    }
+
+    dwarf_finish(dbg);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -993,7 +993,7 @@ std::string_view DevicePrintParser::format_message(
 
                 // Build the enum string representation, then format it with the user's format spec.
                 fmt::memory_buffer enum_str;
-                auto* ei = placeholder.enum_info;
+                const auto* ei = placeholder.enum_info;
 
                 // Append "TypeName::" prefix when full name is requested
                 auto append_type_prefix = [&]() {
@@ -1015,7 +1015,7 @@ std::string_view DevicePrintParser::format_message(
                     // Print bitfield: Flag1 | Flag3 or BitEnum::Flag1 | BitEnum::Flag3
                     bool first = true;
                     int64_t remaining = int_val;
-                    for (auto& [eval, ename] : ei->enumerators) {
+                    for (const auto& [eval, ename] : ei->enumerators) {
                         if (eval != 0 && (remaining & eval) == eval) {
                             if (!first) {
                                 enum_str.append(" | "sv);
@@ -1035,7 +1035,7 @@ std::string_view DevicePrintParser::format_message(
                 } else {
                     // Non-bitfield: find exact match
                     const std::string* found_name = nullptr;
-                    for (auto& [eval, ename] : ei->enumerators) {
+                    for (const auto& [eval, ename] : ei->enumerators) {
                         if (eval == int_val) {
                             found_name = &ename;
                             break;  // Use first match
@@ -1250,6 +1250,8 @@ void DevicePrintParser::load_enum_info_from_dwarf() {
                                 if (got_value) {
                                     info.enumerators.emplace_back(enum_val, std::string(enumerator_name));
                                 }
+
+                                dwarf_dealloc(dbg, enumerator_name, DW_DLA_STRING);
                             }
                         }
 

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -1270,6 +1270,7 @@ void DevicePrintParser::load_enum_info_from_dwarf() {
                     enum_info_cache_[enum_qualified_name] = std::move(info);
                 }
             }
+            dwarf_dealloc(dbg, die_name, DW_DLA_STRING);
 
             // Recurse into children
             Dwarf_Die child = nullptr;

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <functional>
 #include <iomanip>
 #include <string>
 #include <string_view>

--- a/tt_metal/impl/debug/dprint_parser.cpp
+++ b/tt_metal/impl/debug/dprint_parser.cpp
@@ -981,78 +981,78 @@ std::string_view DevicePrintParser::format_message(
                 TT_ASSERT(placeholder.enum_base_type_id != 0, "Unsupported long type in format placeholder");
                 // Currently only '/e' (enum) and /E (flag enum) are supported
                 // Get the integer value from the argument (using the base type)
-                int64_t int_val = 0;
                 auto& arg = buffer.argument_values[placeholder.arg_id];
                 std::visit(
-                    [&int_val](auto&& v) {
-                        using V = std::decay_t<decltype(v)>;
-                        if constexpr (std::is_integral_v<V>) {
-                            int_val = static_cast<int64_t>(v);
+                    [&placeholder, &buffer](auto&& v) {
+                        using int_type = std::decay_t<decltype(v)>;
+                        if constexpr (std::is_integral_v<int_type>) {
+                            int_type int_val = static_cast<int_type>(v);
+
+                            // Build the enum string representation, then format it with the user's format spec.
+                            fmt::memory_buffer enum_str;
+                            const auto* ei = placeholder.enum_info;
+
+                            // Append "TypeName::" prefix when full name is requested
+                            auto append_type_prefix = [&]() {
+                                if (placeholder.enum_use_full_name) {
+                                    enum_str.append(placeholder.enum_type_name);
+                                    enum_str.append("::"sv);
+                                }
+                            };
+
+                            // Format an unrecognized value as (TypeName)integer
+                            auto append_raw_value = [&](int_type val) {
+                                fmt::format_to(std::back_inserter(enum_str), "({}){}", placeholder.enum_type_name, val);
+                            };
+
+                            if (!ei || ei->enumerators.empty()) {
+                                // No DWARF info available
+                                append_raw_value(int_val);
+                            } else if (placeholder.enum_is_flag && int_val != 0) {
+                                // Print bitfield: Flag1 | Flag3 or BitEnum::Flag1 | BitEnum::Flag3
+                                bool first = true;
+                                int_type remaining = int_val;
+                                for (const auto& [eval, ename] : ei->enumerators) {
+                                    if (eval != 0 && (remaining & eval) == eval) {
+                                        if (!first) {
+                                            enum_str.append(" | "sv);
+                                        }
+                                        append_type_prefix();
+                                        enum_str.append(std::string_view(ename));
+                                        remaining &= ~eval;
+                                        first = false;
+                                    }
+                                }
+                                if (remaining != 0) {
+                                    if (!first) {
+                                        enum_str.append(" | "sv);
+                                    }
+                                    append_raw_value(remaining);
+                                }
+                            } else {
+                                // Non-bitfield: find exact match
+                                const std::string* found_name = nullptr;
+                                for (const auto& [eval, ename] : ei->enumerators) {
+                                    if (eval == int_val) {
+                                        found_name = &ename;
+                                        break;  // Use first match
+                                    }
+                                }
+                                if (found_name) {
+                                    append_type_prefix();
+                                    enum_str.append(std::string_view(*found_name));
+                                } else {
+                                    append_raw_value(int_val);
+                                }
+                            }
+
+                            // Apply user's format spec (alignment, width, fill, etc.)
+                            auto enum_sv = std::string_view(enum_str.data(), enum_str.size());
+                            fmt::format_to(
+                                std::back_inserter(buffer.buffer), fmt::runtime(placeholder.fmt_format), enum_sv);
                         }
                     },
                     arg);
-
-                // Build the enum string representation, then format it with the user's format spec.
-                fmt::memory_buffer enum_str;
-                const auto* ei = placeholder.enum_info;
-
-                // Append "TypeName::" prefix when full name is requested
-                auto append_type_prefix = [&]() {
-                    if (placeholder.enum_use_full_name) {
-                        enum_str.append(placeholder.enum_type_name);
-                        enum_str.append("::"sv);
-                    }
-                };
-
-                // Format an unrecognized value as (TypeName)integer
-                auto append_raw_value = [&](int64_t val) {
-                    fmt::format_to(std::back_inserter(enum_str), "({}){}", placeholder.enum_type_name, val);
-                };
-
-                if (!ei || ei->enumerators.empty()) {
-                    // No DWARF info available
-                    append_raw_value(int_val);
-                } else if (placeholder.enum_is_flag && int_val != 0) {
-                    // Print bitfield: Flag1 | Flag3 or BitEnum::Flag1 | BitEnum::Flag3
-                    bool first = true;
-                    int64_t remaining = int_val;
-                    for (const auto& [eval, ename] : ei->enumerators) {
-                        if (eval != 0 && (remaining & eval) == eval) {
-                            if (!first) {
-                                enum_str.append(" | "sv);
-                            }
-                            append_type_prefix();
-                            enum_str.append(std::string_view(ename));
-                            remaining &= ~eval;
-                            first = false;
-                        }
-                    }
-                    if (remaining != 0) {
-                        if (!first) {
-                            enum_str.append(" | "sv);
-                        }
-                        append_raw_value(remaining);
-                    }
-                } else {
-                    // Non-bitfield: find exact match
-                    const std::string* found_name = nullptr;
-                    for (const auto& [eval, ename] : ei->enumerators) {
-                        if (eval == int_val) {
-                            found_name = &ename;
-                            break;  // Use first match
-                        }
-                    }
-                    if (found_name) {
-                        append_type_prefix();
-                        enum_str.append(std::string_view(*found_name));
-                    } else {
-                        append_raw_value(int_val);
-                    }
-                }
-
-                // Apply user's format spec (alignment, width, fill, etc.)
-                auto enum_sv = std::string_view(enum_str.data(), enum_str.size());
-                fmt::format_to(std::back_inserter(buffer.buffer), fmt::runtime(placeholder.fmt_format), enum_sv);
                 break;
             }
             default: TT_THROW("Unsupported type_id in format placeholder (format_message): {}", placeholder.type_id);

--- a/tt_metal/impl/debug/dprint_parser.hpp
+++ b/tt_metal/impl/debug/dprint_parser.hpp
@@ -10,8 +10,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
+#include <span>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "device/device_impl.hpp"
@@ -19,8 +23,6 @@
 #include "hostdevcommon/dprint_common.h"
 #include "hostdev/device_print_common.h"
 #include "hostdev/device_print_structures.h"
-
-#include <unordered_map>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/debug/dprint_parser.hpp
+++ b/tt_metal/impl/debug/dprint_parser.hpp
@@ -20,6 +20,8 @@
 #include "hostdev/device_print_common.h"
 #include "hostdev/device_print_structures.h"
 
+#include <unordered_map>
+
 namespace tt::tt_metal {
 
 class DPrintParser {
@@ -93,11 +95,24 @@ public:
 private:
     DevicePrintParser(const std::string& elf_path);
 
+    // Enum debug info extracted from DWARF: maps enumerator integer values to their names.
+    struct EnumInfo {
+        std::string type_name;                                     // Fully-qualified enum type name from format string
+        std::vector<std::pair<int64_t, std::string>> enumerators;  // (value, name) pairs from DWARF
+    };
+
     struct FormatPlaceholderInfo {
         uint32_t arg_id;
         char type_id;
         std::string_view format_spec;  // The part after ':' in the format string, if it exists, including ':' itself.
         std::string fmt_format;        // The full format to be used in fmt::format, e.g. "{0:08x}"
+
+        // Enum-specific fields (populated when type_id marker is '/e' or '/E')
+        std::string_view enum_type_name;      // e.g. "test::deep::Enum1" (view into format string)
+        char enum_base_type_id = 0;           // e.g. 'I' for uint32_t
+        bool enum_is_flag = false;            // true for '/E' (flag/bitmask enum), false for '/e'
+        bool enum_use_full_name = false;      // true when '#' alternate form was specified
+        const EnumInfo* enum_info = nullptr;  // Points into DevicePrintParser::enum_info_cache_; null if no DWARF info
     };
 
     struct ParsedStringInfo {
@@ -126,6 +141,11 @@ private:
     static std::string_view format_message(
         ParsedStringInfo& string_info, std::span<const std::byte> payload_bytes, FormatMessageBuffer& buffer);
 
+    // Loads all enum type definitions from DWARF debug info in the ELF file.
+    void load_enum_info_from_dwarf();
+    // Look up (or lazily load) enum info by fully-qualified type name.
+    const EnumInfo* get_enum_info(std::string_view type_name);
+
     std::string elf_path;
     ll_api::ElfFile elf_file;
     std::span<std::byte> format_strings_info_bytes;
@@ -135,6 +155,14 @@ private:
     DevicePrintStringInfo* string_info_ptr = nullptr;
     size_t string_info_size = 0;
     std::vector<ParsedStringInfo> parsed_string_info;
+    // Enum DWARF info: maps fully-qualified type name -> EnumInfo
+    // Transparent hash/eq to allow lookup by string_view without allocating a std::string.
+    struct StringHash {
+        using is_transparent = void;
+        size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
+    };
+    std::unordered_map<std::string, EnumInfo, StringHash, std::equal_to<>> enum_info_cache_;
+    bool enum_info_loaded_ = false;
     static std::map<std::string, std::weak_ptr<DevicePrintParser>> parser_cache;
     friend struct DevicePrintParserDeleter;
 };


### PR DESCRIPTION
Printing enums with `DPRINT` was very unpleasant, one would always cast `enum` to `uint32_t` and read `int` value from the output. A bit smarter way was to compare `enum` variable with some `enum` value and then stringify it in `DPRINT` statement in kernel. With `DEVICE_PRINT` users can just serialize `enum` variable and it will automagically be converted to string based on DWARF info that is already available in elf (as it is enabled by default). If user disables debug info in elfs, `DEVICE_PRINT` will output `(enum_type)value`.

Users can take alternative serialization by specifying `{:#}` in format which will print fully qualified `enum` type name before the value.

If `enum` supports `operator |`, `DEVICE_PRINT` will consider that `enum` as flags and will generate output similar to C++ output (`Flag1 | Flag2`).

You can take a look at tests to understand how it looks like and how output is generated.