### PR TITLE
#0: Optimize kv cache update path for nope

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -269,17 +269,37 @@ void kernel_main() {
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
         .local_cur_pos = 0,
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_intermed_sync_cb = get_named_compile_time_arg_val("kv_cache_intermed_sync_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
         .kv_cache_cur_pos_ready_semaphore_addr =
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+        .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+        .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+        .mla_sender_noc_x =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_x_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_7"),
+            },
+        .mla_sender_noc_y =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_y_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_7"),
+            },
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -839,7 +859,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
         get_common_arg_val<uint32_t>(0),   // epsilon
         get_common_arg_val<float>(1),      // scalar (1/sqrt(7168))
-        get_common_arg_val<uint32_t>(15),  // rmsnorm_gamma_addr
+        get_common_arg_val<uint32_t>(16),  // rmsnorm_gamma_addr
     };
 
     // Mcast compute args (no-op for TRISC)
@@ -866,7 +886,7 @@ void kernel_main() {
         k_offset,
         get_named_compile_time_arg_val("matmul_k_per_core"),
         get_named_compile_time_arg_val("matmul_act_total_tiles"),
-        get_common_arg_val<uint32_t>(8),  // matmul_weights_addr
+        get_common_arg_val<uint32_t>(9),  // matmul_weights_addr
     };
 
     // Gather reduce compute args
@@ -880,7 +900,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
         get_common_arg_val<uint32_t>(0),   // epsilon (same as rmsnorm1)
         get_common_arg_val<float>(2),      // scalar (1/sqrt(1536))
-        get_common_arg_val<uint32_t>(16),  // rmsnorm2_gamma_addr
+        get_common_arg_val<uint32_t>(17),  // rmsnorm2_gamma_addr
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)
@@ -893,7 +913,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul2_in1"),
         get_named_compile_time_arg_val("matmul2_out"),
         get_named_compile_time_arg_val("matmul2_k_num_tiles"),
-        get_common_arg_val<uint32_t>(9),  // matmul2_weights_addr
+        get_common_arg_val<uint32_t>(10),  // matmul2_weights_addr
     };
 
     // Mcast2 compute args (no-op for TRISC)
@@ -909,7 +929,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul3_in1"),
         get_named_compile_time_arg_val("matmul3_out"),
         get_named_compile_time_arg_val("matmul3_k_num_tiles"),
-        get_common_arg_val<uint32_t>(11),  // matmul3_weights_addr
+        get_common_arg_val<uint32_t>(12),  // matmul3_weights_addr
     };
 
     // Qrope CTArgs type alias
@@ -924,7 +944,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
         get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
-        get_common_arg_val<uint32_t>(14),  // qrope_trans_mat_addr
+        get_common_arg_val<uint32_t>(15),  // qrope_trans_mat_addr
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
@@ -946,7 +966,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("dkv_matmul_in1"),
         get_named_compile_time_arg_val("dkv_matmul_out"),
         get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
-        get_common_arg_val<uint32_t>(10),  // dkv_matmul_weights_addr
+        get_common_arg_val<uint32_t>(11),  // dkv_matmul_weights_addr
     };
 
     // Gather compute args (no-op for TRISC)
@@ -965,7 +985,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
         get_common_arg_val<uint32_t>(0),   // epsilon
         get_common_arg_val<float>(3),      // kv_scalar (1/sqrt(512))
-        get_common_arg_val<uint32_t>(17),  // kv_rmsnorm_gamma_addr
+        get_common_arg_val<uint32_t>(18),  // kv_rmsnorm_gamma_addr
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::
@@ -987,13 +1007,14 @@ void kernel_main() {
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
         .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
-        .trans_mat_address_override = get_common_arg_val<uint32_t>(14),
+        .trans_mat_address_override = get_common_arg_val<uint32_t>(15),
     };
 
     deepseek_b1_ops::KVCacheUpdate::ComputeArgs kv_cache_update_args{
         .kv_cache_input_cb = get_common_arg_val<uint32_t>(4),
         .kv_cache_output_cb = get_common_arg_val<uint32_t>(5),
         .kv_cache_intermed_cb = get_common_arg_val<uint32_t>(6),
+        .kv_cache_intermed_sync_cb = get_common_arg_val<uint32_t>(7),
     };
     deepseek_b1_ops::FlashMLADecode::ComputeArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -1040,7 +1061,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul4_in1"),
         get_named_compile_time_arg_val("matmul4_out"),
         get_named_compile_time_arg_val("matmul4_k_num_tiles"),
-        get_common_arg_val<uint32_t>(12),  // matmul4_weights_addr
+        get_common_arg_val<uint32_t>(13),  // matmul4_weights_addr
     };
 
     // Gather2 compute args (no-op)
@@ -1057,7 +1078,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
         get_named_compile_time_arg_val("matmul5_k_num_tiles"),
-        get_common_arg_val<uint32_t>(13),  // matmul5_weights_addr
+        get_common_arg_val<uint32_t>(14),  // matmul5_weights_addr
     };
 
     // Gather3 compute args (no-op)
@@ -1117,7 +1138,7 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_NCRISC)
     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 1);
 #elif defined(COMPILE_FOR_TRISC)
-    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(7);
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(8);
 #endif
 
     // ====================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -906,6 +906,7 @@ class AttentionBlock:
 
         kv_cache_output_cb = cb_id_context.get_cb_id(k_df, TD_32x32)  # Output CB for KV Cache Branch
         kv_cache_intermed_cb = cb_id_context.get_cb_id(untilize_df, TD_32x32)  # Intermed CB for KV Cache Branch
+        kv_cache_intermed_sync_cb = cb_id_context.get_cb_id(untilize_df, TD_32x32)  # Sync CB overlapping intermed CB
         kv_cache_input_cb = cb_id_context.get_cb_id(k_df, TD_32x32)  # Input CB for KV Cache Branch
 
         # MLA parameters
@@ -1455,17 +1456,15 @@ class AttentionBlock:
         ]
 
         # KVCacheUpdate compile-time args split across NCRISC (patch + writeback) and BRISC (DRAM read)
+        # k_chunk_size and num_cores_per_head are shared with MLA args (set in mla_ncrisc section)
+        # mla_sender_noc_x/y args are appended after MLA core group is built (depends on num_s_blocks)
         kv_cache_ncrisc_named_compile_time_args = [
             ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
             ("krope_output_cb", krope_output_cb),
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_intermed_sync_cb", kv_cache_intermed_sync_cb),
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
-            ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
-            ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
-            ("full_grid_mcast_end_x", mcast_dest_noc_end_core.x),
-            ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
-            ("full_grid_mcast_num_dests", mcast_num_cores - 1),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
         ]
         kv_cache_brisc_named_compile_time_args = [
@@ -1477,6 +1476,7 @@ class AttentionBlock:
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_input_cb", kv_cache_input_cb),
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_intermed_sync_cb", kv_cache_intermed_sync_cb),
         ]
 
         # Flash MLA named compile-time args
@@ -1591,6 +1591,20 @@ class AttentionBlock:
 
         # Create core group with the same layout
         mla_core_group = [ttnn.CoreCoord(x, y) for x, y in mla_all_cores]
+
+        # Physical NOC coordinates of mcast sender cores (first batch, one per S block).
+        # Used by kv_cache_update to unicast the cache-ready signal to the specific
+        # MLA reader core that handles the last KV chunk.
+        mla_sender_noc_xs = []
+        mla_sender_noc_ys = []
+        for s_idx in range(num_s_blocks):
+            phys = device.worker_core_from_logical_core(mla_core_group[s_idx])
+            mla_sender_noc_xs.append(phys.x)
+            mla_sender_noc_ys.append(phys.y)
+
+        kv_cache_ncrisc_named_compile_time_args += [
+            (f"mla_sender_noc_x_{i}", mla_sender_noc_xs[i]) for i in range(num_s_blocks)
+        ] + [(f"mla_sender_noc_y_{i}", mla_sender_noc_ys[i]) for i in range(num_s_blocks)]
 
         # Multicast: each S block's first core (Q1) reads KV and multicasts to others in that S block
         # Since all S blocks have 8 cores, num_mcast_dests is the same for all (7 = 8-1)
@@ -2471,15 +2485,23 @@ class AttentionBlock:
             page_size=TILE_32x32.get_tile_size(untilize_df),
             tile=ttnn.TileDescriptor(TILE_32x32),
         )
-        # One extra tile for syncing, can optimize to remove
+        kv_cache_intermed_sync_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=kv_cache_intermed_sync_cb,
+            data_format=untilize_df,
+            page_size=TILE_32x32.get_tile_size(untilize_df),
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
         kv_cache_intermed_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_cache_intermed_cb,
             ref_sdpa_forwarder_scratch,
             address_offset=sdpa_forwarder_scratch_running_offset,
-            total_size=(kv_cache_num_tiles + 1) * TILE_32x32.get_tile_size(untilize_df),
+            total_size=kv_cache_num_tiles * TILE_32x32.get_tile_size(untilize_df),
             core_ranges=full_device_grid,
         )
-        kv_cache_intermed_cb_descriptor.format_descriptors = [kv_cache_intermed_cb_format]
+        kv_cache_intermed_cb_descriptor.format_descriptors = [
+            kv_cache_intermed_cb_format,
+            kv_cache_intermed_sync_cb_format,
+        ]
         sdpa_forwarder_scratch_running_offset += kv_cache_intermed_cb_descriptor.total_size
         # Flash MLA cb descriptors
         mla_cb_descriptors = []
@@ -3424,17 +3446,18 @@ class AttentionBlock:
                     kv_cache_input_cb,  # idx 4
                     kv_cache_output_cb,  # idx 5
                     kv_cache_intermed_cb,  # idx 6
-                    position_ids_tensor_addr,  # idx 7
-                    matmul_weights_addr,  # idx 8
-                    matmul2_weights_addr,  # idx 9
-                    dkv_matmul_weights_addr,  # idx 10
-                    matmul3_weights_addr,  # idx 11
-                    matmul4_weights_addr,  # idx 12
-                    matmul5_weights_addr,  # idx 13
-                    qrope_trans_mat_addr,  # idx 14
-                    gamma_addr,  # idx 15
-                    rmsnorm2_gamma_addr,  # idx 16
-                    kv_rmsnorm_gamma_addr,  # idx 17
+                    kv_cache_intermed_sync_cb,  # idx 7
+                    position_ids_tensor_addr,  # idx 8
+                    matmul_weights_addr,  # idx 9
+                    matmul2_weights_addr,  # idx 10
+                    dkv_matmul_weights_addr,  # idx 11
+                    matmul3_weights_addr,  # idx 12
+                    matmul4_weights_addr,  # idx 13
+                    matmul5_weights_addr,  # idx 14
+                    qrope_trans_mat_addr,  # idx 15
+                    gamma_addr,  # idx 16
+                    rmsnorm2_gamma_addr,  # idx 17
+                    kv_rmsnorm_gamma_addr,  # idx 18
                 ]
 
                 qrope_ncrisc_addr_args = [

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -308,17 +308,37 @@ void kernel_main() {
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 0),
         .local_cur_pos = 0,
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_intermed_sync_cb = get_named_compile_time_arg_val("kv_cache_intermed_sync_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
         .kv_cache_cur_pos_ready_semaphore_addr =
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+        .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+        .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+        .mla_sender_noc_x =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_x_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_7"),
+            },
+        .mla_sender_noc_y =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_y_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_7"),
+            },
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -878,7 +898,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
         get_common_arg_val<uint32_t>(0),   // epsilon
         get_common_arg_val<float>(1),      // scalar (1/sqrt(7168))
-        get_common_arg_val<uint32_t>(15),  // rmsnorm_gamma_addr
+        get_common_arg_val<uint32_t>(16),  // rmsnorm_gamma_addr
     };
 
     // Mcast compute args (no-op for TRISC)
@@ -905,7 +925,7 @@ void kernel_main() {
         k_offset,
         get_named_compile_time_arg_val("matmul_k_per_core"),
         get_named_compile_time_arg_val("matmul_act_total_tiles"),
-        get_common_arg_val<uint32_t>(8),  // matmul_weights_addr
+        get_common_arg_val<uint32_t>(9),  // matmul_weights_addr
     };
 
     // Gather reduce compute args
@@ -919,7 +939,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
         get_common_arg_val<uint32_t>(0),   // epsilon (same as rmsnorm1)
         get_common_arg_val<float>(2),      // scalar (1/sqrt(1536))
-        get_common_arg_val<uint32_t>(16),  // rmsnorm2_gamma_addr
+        get_common_arg_val<uint32_t>(17),  // rmsnorm2_gamma_addr
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)
@@ -932,7 +952,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul2_in1"),
         get_named_compile_time_arg_val("matmul2_out"),
         get_named_compile_time_arg_val("matmul2_k_num_tiles"),
-        get_common_arg_val<uint32_t>(9),  // matmul2_weights_addr
+        get_common_arg_val<uint32_t>(10),  // matmul2_weights_addr
     };
 
     // Mcast2 compute args (no-op for TRISC)
@@ -948,7 +968,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul3_in1"),
         get_named_compile_time_arg_val("matmul3_out"),
         get_named_compile_time_arg_val("matmul3_k_num_tiles"),
-        get_common_arg_val<uint32_t>(11),  // matmul3_weights_addr
+        get_common_arg_val<uint32_t>(12),  // matmul3_weights_addr
     };
 
     // Qrope CTArgs type alias
@@ -963,7 +983,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("qrope_rotated_in_interm_cb"),
         get_named_compile_time_arg_val("qrope_cos_sin_interm_cb"),
         get_named_compile_time_arg_val("qrope_output_cb"),
-        get_common_arg_val<uint32_t>(14),  // qrope_trans_mat_addr
+        get_common_arg_val<uint32_t>(15),  // qrope_trans_mat_addr
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
@@ -985,7 +1005,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("dkv_matmul_in1"),
         get_named_compile_time_arg_val("dkv_matmul_out"),
         get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
-        get_common_arg_val<uint32_t>(10),  // dkv_matmul_weights_addr
+        get_common_arg_val<uint32_t>(11),  // dkv_matmul_weights_addr
     };
 
     // Gather compute args (no-op for TRISC)
@@ -1004,7 +1024,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
         get_common_arg_val<uint32_t>(0),   // epsilon
         get_common_arg_val<float>(3),      // kv_scalar (1/sqrt(512))
-        get_common_arg_val<uint32_t>(17),  // kv_rmsnorm_gamma_addr
+        get_common_arg_val<uint32_t>(18),  // kv_rmsnorm_gamma_addr
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::
@@ -1026,13 +1046,14 @@ void kernel_main() {
         .rotated_in_interm_cb = krope_rotated_in_interm_cb,
         .cos_sin_interm_cb = krope_cos_sin_interm_cb,
         .out_cb = krope_output_cb,
-        .trans_mat_address_override = get_common_arg_val<uint32_t>(14),
+        .trans_mat_address_override = get_common_arg_val<uint32_t>(15),
     };
 
     deepseek_b1_ops::KVCacheUpdate::ComputeArgs kv_cache_update_args{
         .kv_cache_input_cb = get_common_arg_val<uint32_t>(4),
         .kv_cache_output_cb = get_common_arg_val<uint32_t>(5),
         .kv_cache_intermed_cb = get_common_arg_val<uint32_t>(6),
+        .kv_cache_intermed_sync_cb = get_common_arg_val<uint32_t>(7),
     };
     deepseek_b1_ops::FlashMLADecode::ComputeArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -1079,7 +1100,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul4_in1"),
         get_named_compile_time_arg_val("matmul4_out"),
         get_named_compile_time_arg_val("matmul4_k_num_tiles"),
-        get_common_arg_val<uint32_t>(12),  // matmul4_weights_addr
+        get_common_arg_val<uint32_t>(13),  // matmul4_weights_addr
     };
 
     // Gather2 compute args (no-op)
@@ -1096,7 +1117,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul5_in1"),
         get_named_compile_time_arg_val("matmul5_out"),
         get_named_compile_time_arg_val("matmul5_k_num_tiles"),
-        get_common_arg_val<uint32_t>(13),  // matmul5_weights_addr
+        get_common_arg_val<uint32_t>(14),  // matmul5_weights_addr
     };
 
     // Gather3 compute args (no-op)
@@ -1937,7 +1958,7 @@ void kernel_main() {
 #elif defined(COMPILE_FOR_NCRISC)
     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 1);
 #elif defined(COMPILE_FOR_TRISC)
-    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(7);
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(8);
 #endif
     volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cur_pos_addr);
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -273,17 +273,37 @@ if constexpr (!Core::skip_ccl) {
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(5),
         .local_cur_pos = 0,  // set via kv_cache_update.set_local_cur_pos() below
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_intermed_sync_cb = get_named_compile_time_arg_val("kv_cache_intermed_sync_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
         .kv_cache_cur_pos_ready_semaphore_addr =
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
+        .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
+        .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
+        .mla_sender_noc_x =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_x_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_x_7"),
+            },
+        .mla_sender_noc_y =
+            {
+                get_named_compile_time_arg_val("mla_sender_noc_y_0"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_1"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_2"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_3"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_4"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_5"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_6"),
+                get_named_compile_time_arg_val("mla_sender_noc_y_7"),
+            },
     };
 
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
@@ -685,6 +705,7 @@ if constexpr (!Core::skip_ccl) {
         .kv_cache_input_cb = get_common_arg_val<uint32_t>(4),
         .kv_cache_output_cb = get_common_arg_val<uint32_t>(5),
         .kv_cache_intermed_cb = get_common_arg_val<uint32_t>(6),
+        .kv_cache_intermed_sync_cb = get_common_arg_val<uint32_t>(7),
     };
     deepseek_b1_ops::FlashMLADecode::ComputeArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
@@ -798,7 +819,7 @@ if constexpr (!Core::skip_ccl) {
 #elif defined(COMPILE_FOR_NCRISC)
     uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(6);
 #elif defined(COMPILE_FOR_TRISC)
-    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(7);
+    uint32_t cur_pos_addr = get_common_arg_val<uint32_t>(8);
 #endif
 
     // ========================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -566,6 +566,7 @@ class PreSDPA:
         kv_cache_output_cb = 32  # Output CB for KV Cache Branch
         kv_cache_intermed_cb = 33  # Intermed CB for KV Cache Branch
         kv_cache_input_cb = 34  # Input CB for KV Cache Branch
+        kv_cache_intermed_sync_cb = 30  # Sync CB overlapping intermed CB for NCRISC->TRISC signaling
 
         # MLA parameters
         mla_q_in_cb = create_q_heads_out_cb  # In for MLA q heads
@@ -1076,15 +1077,13 @@ class PreSDPA:
         # KVCacheUpdate compile-time args split across NCRISC (patch + writeback) and BRISC (DRAM read)
         flash_mla_program_config = FlashMLADecode.ProgramConfig()
         device_chunk_size = flash_mla_program_config.device_chunk_size
+        # k_chunk_size and num_cores_per_head are shared with MLA args (set in mla_ncrisc section)
+        # mla_sender_noc_x/y args are appended after MLA core group is built (depends on num_s_blocks)
         kv_cache_ncrisc_named_compile_time_args = [
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_intermed_sync_cb", kv_cache_intermed_sync_cb),
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_grid_start_y", list(krope_grid.ranges())[0].start.y),
-            ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
-            ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
-            ("full_grid_mcast_end_x", mcast_dest_noc_end_core.x),
-            ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
-            ("full_grid_mcast_num_dests", mcast_num_cores - 1),
             ("kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
         ]
         kv_cache_brisc_named_compile_time_args = [
@@ -1096,6 +1095,7 @@ class PreSDPA:
             ("kv_cache_output_cb", kv_cache_output_cb),
             ("kv_cache_input_cb", kv_cache_input_cb),
             ("kv_cache_intermed_cb", kv_cache_intermed_cb),
+            ("kv_cache_intermed_sync_cb", kv_cache_intermed_sync_cb),
         ]
 
         # Flash MLA named compile-time args
@@ -1200,6 +1200,20 @@ class PreSDPA:
 
         # Create core group with the same layout
         mla_core_group = [ttnn.CoreCoord(x, y) for x, y in mla_all_cores]
+
+        # Physical NOC coordinates of mcast sender cores (first batch, one per S block).
+        # Used by kv_cache_update to unicast the cache-ready signal to the specific
+        # MLA reader core that handles the last KV chunk.
+        mla_sender_noc_xs = []
+        mla_sender_noc_ys = []
+        for s_idx in range(num_s_blocks):
+            phys = device.worker_core_from_logical_core(mla_core_group[s_idx])
+            mla_sender_noc_xs.append(phys.x)
+            mla_sender_noc_ys.append(phys.y)
+
+        kv_cache_ncrisc_named_compile_time_args += [
+            (f"mla_sender_noc_x_{i}", mla_sender_noc_xs[i]) for i in range(num_s_blocks)
+        ] + [(f"mla_sender_noc_y_{i}", mla_sender_noc_ys[i]) for i in range(num_s_blocks)]
 
         # Multicast: each S block's first core (Q1) reads KV and multicasts to others in that S block
         # Since all S blocks have 8 cores, num_mcast_dests is the same for all (7 = 8-1)
@@ -1785,11 +1799,16 @@ class PreSDPA:
                     page_size=TILE_32x32.get_tile_size(ttnn.bfloat16),
                     tile=ttnn.TileDescriptor(TILE_32x32),
                 )
-                # One extra tile for syncing, can optimize to remove
+                kv_cache_intermed_sync_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=kv_cache_intermed_sync_cb,
+                    data_format=ttnn.bfloat16,
+                    page_size=TILE_32x32.get_tile_size(ttnn.bfloat16),
+                    tile=ttnn.TileDescriptor(TILE_32x32),
+                )
                 kv_cache_intermed_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=(kv_cache_num_tiles + 1) * TILE_32x32.get_tile_size(ttnn.bfloat16),
+                    total_size=kv_cache_num_tiles * TILE_32x32.get_tile_size(ttnn.bfloat16),
                     core_ranges=kv_cache_update_grid,
-                    format_descriptors=[kv_cache_intermed_cb_format],
+                    format_descriptors=[kv_cache_intermed_cb_format, kv_cache_intermed_sync_cb_format],
                 )
 
                 # Flash MLA cb descriptors
@@ -2047,7 +2066,8 @@ class PreSDPA:
                     kv_cache_input_cb,  # idx 4
                     kv_cache_output_cb,  # idx 5
                     kv_cache_intermed_cb,  # idx 6
-                    position_ids_tensor_addr,  # idx 7
+                    kv_cache_intermed_sync_cb,  # idx 7
+                    position_ids_tensor_addr,  # idx 8
                 ]
 
                 qrope_ncrisc_addr_args = [

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -30,17 +30,17 @@ void kernel_main() {
         .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
         .local_cur_pos = 0,
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_intermed_sync_cb = get_named_compile_time_arg_val("kv_cache_intermed_sync_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
         .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
         .kv_cache_cur_pos_ready_semaphore_addr =
             get_semaphore(get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_id")),
+        .k_chunk_size = 0,
+        .num_cores_per_head = 0,
+        .mla_sender_noc_x = {},
+        .mla_sender_noc_y = {},
     };
 #elif defined(COMPILE_FOR_BRISC)
     deepseek_b1_ops::KVCacheUpdate::ReaderArgs args{
@@ -54,6 +54,7 @@ void kernel_main() {
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_intermed_sync_cb = get_named_compile_time_arg_val("kv_cache_intermed_sync_cb"),
     };
 
     deepseek_compute_kernel_init();

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
@@ -18,6 +18,7 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
 KV_CACHE_INPUT_CB = 31
 KV_CACHE_OUTPUT_CB = 30
 KV_CACHE_INTERMED_CB = 29
+KV_CACHE_INTERMED_SYNC_CB = 28
 KV_RMSNORM_OUTPUT_CB = 26
 KROPE_OUTPUT_CB = 27
 KV_CACHE_NUM_TILES = 16
@@ -63,27 +64,14 @@ class KVCacheUpdate:
         ncrisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
         brisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
 
-        device = full_kv_cache_tensor.device()
-        device_grid_size = device.compute_with_storage_grid_size()
-        full_device_grid = ttnn.CoreRange(
-            ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1)
-        )
-        full_grid_mcast_start_core = device.worker_core_from_logical_core(full_device_grid.start)
-        full_grid_mcast_end_core = device.worker_core_from_logical_core(full_device_grid.end)
-        full_grid_mcast_num_dests = full_device_grid.grid_size().x * full_device_grid.grid_size().y
-
         # CB indices passed as named compile-time args; kernel uses get_named_compile_time_arg_val
         ncrisc_named = [
             ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
             ("krope_output_cb", KROPE_OUTPUT_CB),
             ("kv_cache_intermed_cb", KV_CACHE_INTERMED_CB),
+            ("kv_cache_intermed_sync_cb", KV_CACHE_INTERMED_SYNC_CB),
             ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
             ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
-            ("full_grid_mcast_start_x", full_grid_mcast_start_core.x),
-            ("full_grid_mcast_start_y", full_grid_mcast_start_core.y),
-            ("full_grid_mcast_end_x", full_grid_mcast_end_core.x),
-            ("full_grid_mcast_end_y", full_grid_mcast_end_core.y),
-            ("full_grid_mcast_num_dests", full_grid_mcast_num_dests - 1),
             ("kv_cache_cur_pos_ready_semaphore_id", 0),
         ]
         brisc_named = [
@@ -94,6 +82,7 @@ class KVCacheUpdate:
             ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
             ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
             ("kv_cache_intermed_cb", KV_CACHE_INTERMED_CB),
+            ("kv_cache_intermed_sync_cb", KV_CACHE_INTERMED_SYNC_CB),
             ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
             ("krope_output_cb", KROPE_OUTPUT_CB),
         ]
@@ -119,6 +108,12 @@ class KVCacheUpdate:
             page_size=intermed_page_size,
             tile=ttnn.TileDescriptor(TILE_32x32),
         )
+        kv_cache_intermed_sync_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=KV_CACHE_INTERMED_SYNC_CB,
+            data_format=ttnn.bfloat16,
+            page_size=intermed_page_size,
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
 
         kv_rmsnorm_output_cb_format = ttnn.cb_descriptor_from_sharded_tensor(KV_RMSNORM_OUTPUT_CB, nope_cache_tensor)
 
@@ -138,9 +133,9 @@ class KVCacheUpdate:
                 format_descriptors=[kv_cache_output_cb_format],
             ),
             ttnn.CBDescriptor(
-                total_size=(KV_CACHE_NUM_TILES + 1) * intermed_page_size,
+                total_size=KV_CACHE_NUM_TILES * intermed_page_size,
                 core_ranges=kv_cache_core_grid,
-                format_descriptors=[kv_cache_intermed_cb_format],
+                format_descriptors=[kv_cache_intermed_cb_format, kv_cache_intermed_sync_cb_format],
             ),
         ]
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -255,14 +255,11 @@ struct FlashMLADecode {
 
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
-            (void)k_num_chunks;
 
             volatile tt_l1_ptr uint32_t* kv_cache_cur_pos_ready_semaphore_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.kv_cache_cur_pos_ready_semaphore_addr);
 
             if (k_chunk_start == k_chunk_end) {
-                noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
-                noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
                 return;
             }
 
@@ -327,6 +324,7 @@ struct FlashMLADecode {
                         uint32_t pages_completed = 0;
                         if (wait_for_kv_cache_ready && (k_chunk + args.num_cores_per_head) >= k_chunk_end) {
                             noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
+                            noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
                         }
 
                         noc_semaphore_wait(ncrisc_brisc_sync_curr_ptr, 0);
@@ -372,9 +370,6 @@ struct FlashMLADecode {
                     cb_push_back(args.cb_k_in, k_chunk_tiles);
                 }
             }
-            noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value);
-            noc_semaphore_set(kv_cache_cur_pos_ready_semaphore_ptr, 0);
-
 // ====================================================================
 // NCRISC (Writer)
 // ====================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -50,19 +50,20 @@ struct KVCacheUpdate {
     // CB indices etc. filled in kernel via get_named_compile_time_arg_val
     // ========================================================================
     struct WriterArgs {
+        static constexpr uint32_t MAX_MLA_CORES_PER_HEAD = 8;
         uint32_t kv_cache_buffer_base_addr;
         uint32_t local_cur_pos;
         uint32_t kv_cache_intermed_cb;
+        uint32_t kv_cache_intermed_sync_cb;
         uint32_t kv_cache_output_cb;
         uint32_t kv_rmsnorm_output_cb;
         uint32_t krope_output_cb;
         uint32_t grid_start_y;
-        uint32_t full_grid_mcast_start_x;
-        uint32_t full_grid_mcast_start_y;
-        uint32_t full_grid_mcast_end_x;
-        uint32_t full_grid_mcast_end_y;
-        uint32_t full_grid_mcast_num_dests;
         uint32_t kv_cache_cur_pos_ready_semaphore_addr;
+        uint32_t k_chunk_size;
+        uint32_t num_cores_per_head;
+        uint32_t mla_sender_noc_x[MAX_MLA_CORES_PER_HEAD];
+        uint32_t mla_sender_noc_y[MAX_MLA_CORES_PER_HEAD];
     };
     struct ReaderArgs {
         uint32_t kv_cache_buffer_base_addr;
@@ -74,6 +75,7 @@ struct KVCacheUpdate {
         uint32_t kv_cache_input_cb;
         uint32_t kv_cache_output_cb;
         uint32_t kv_cache_intermed_cb;
+        uint32_t kv_cache_intermed_sync_cb;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<WriterArgs, ReaderArgs, ComputeArgs>;
@@ -96,18 +98,15 @@ struct KVCacheUpdate {
 #if defined(COMPILE_FOR_NCRISC)
             if constexpr (IsRopeCore || IsNopeCore) {
                 static_assert(noc_mode == DM_DYNAMIC_NOC, "KV Cache Update only supports DM_DYNAMIC_NOC");
-                constexpr uint8_t MCAST_NOC = 0;
-                uint64_t sem_noc_addr = get_noc_multicast_addr<MCAST_NOC>(
-                    args.full_grid_mcast_start_x,
-                    args.full_grid_mcast_start_y,
-                    args.full_grid_mcast_end_x,
-                    args.full_grid_mcast_end_y,
-                    args.kv_cache_cur_pos_ready_semaphore_addr);
-                noc_semaphore_inc_multicast(sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC);
-                volatile tt_l1_ptr uint32_t* sem_addr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.kv_cache_cur_pos_ready_semaphore_addr);
-                __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
-                noc_async_atomic_barrier(MCAST_NOC);
+                constexpr uint8_t WRITE_NOC = 0;
+                uint32_t target_core_idx = (args.local_cur_pos / args.k_chunk_size) % args.num_cores_per_head;
+                uint64_t sem_noc_addr = get_noc_addr(
+                    args.mla_sender_noc_x[target_core_idx],
+                    args.mla_sender_noc_y[target_core_idx],
+                    args.kv_cache_cur_pos_ready_semaphore_addr,
+                    WRITE_NOC);
+                noc_semaphore_inc(sem_noc_addr, 1, WRITE_NOC);
+                noc_async_atomic_barrier(WRITE_NOC);
             }
 #endif
         }
@@ -120,7 +119,8 @@ struct KVCacheUpdate {
                 constexpr uint32_t PAGES_PER_BLOCK = 18;
                 constexpr uint32_t CACHES_PER_BLOCK = 32;
                 constexpr uint32_t nope_num_pages = 16;
-                constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
+                constexpr uint32_t CHUNK_SIZE = IsRopeCore ? 1 : 8;
+                constexpr uint32_t NUM_CHUNKS = IsRopeCore ? 1 : 2;
 
                 uint32_t cur_pos = args.local_cur_pos;
 
@@ -135,94 +135,111 @@ struct KVCacheUpdate {
                 }
 
 #if defined(COMPILE_FOR_BRISC)
-                // BRISC: stream existing KV cache pages from DRAM into kv_cache_input_cb
                 uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
 
-                cb_reserve_back(kv_cache_input_cb, kv_cache_num_tiles);
-                uint32_t cb_addr = get_write_ptr(kv_cache_input_cb);
-                for (uint32_t i = 0; i < kv_cache_num_tiles; i++) {
-                    noc_async_read_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
-                    cb_addr += kv_tensor_accessor.get_aligned_page_size();
+                for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    DeviceZoneScopedN("READ_FROM_DRAM");
+                    uint32_t tile_offset = chunk * CHUNK_SIZE;
+                    cb_reserve_back(kv_cache_input_cb, CHUNK_SIZE);
+                    uint32_t cb_addr = get_write_ptr(kv_cache_input_cb);
+                    for (uint32_t i = 0; i < CHUNK_SIZE; i++) {
+                        noc_async_read_page(kv_cache_page_id_start + tile_offset + i, kv_tensor_accessor, cb_addr);
+                        cb_addr += kv_tensor_accessor.get_aligned_page_size();
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(kv_cache_input_cb, CHUNK_SIZE);
                 }
-                noc_async_read_barrier();
-
-                cb_push_back(kv_cache_input_cb, kv_cache_num_tiles);
 #elif defined(COMPILE_FOR_NCRISC)
-                // NCRISC: wait on compute, patch new data, wait on compute, write back to DRAM
                 uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
+                uint32_t kv_cache_intermed_sync_cb = args.kv_cache_intermed_sync_cb;
                 uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
                 uint32_t new_cache_cb = IsRopeCore ? args.krope_output_cb : args.kv_rmsnorm_output_cb;
                 uint32_t offset_in_page = cur_pos % CACHES_PER_BLOCK;
-                uint32_t num_bytes_per_core = IsRopeCore ? 64 : 1024;
 
-                // 1. Wait for TRISC to finish untilize into kv_cache_intermed_cb
-                cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles);
+                constexpr uint32_t num_bytes_per_chunk = IsRopeCore ? 64 : (CHUNK_SIZE * 32 * 2);
 
-                // 2. Wait for new cache data and update into kv_cache_intermed_cb
                 cb_wait_front(new_cache_cb, 1);
+                uint32_t src_addr = get_read_ptr(new_cache_cb);
+                uint32_t write_addr_offset = offset_in_page * num_bytes_per_chunk;
 
-                uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + offset_in_page * num_bytes_per_core;
-                uint32_t new_cache_addr = get_read_ptr(new_cache_cb);
-                {
-                    uint32_t words_per_face = (num_bytes_per_core >> 2);
-                    volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(new_cache_addr);
-                    volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
-                    for (uint32_t i = 0; i < words_per_face; ++i) {
-                        dst[i] = src[i];
+                for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    {
+                        DeviceZoneScopedN("WAIT_UNTILIZE");
+                        cb_reserve_back(kv_cache_intermed_sync_cb, CHUNK_SIZE);
+                        cb_wait_front(kv_cache_intermed_cb, CHUNK_SIZE);
+                    }
+
+                    {
+                        DeviceZoneScopedN("UPDATE_NEW_CACHE");
+                        uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + write_addr_offset;
+                        noc_async_write(src_addr, get_noc_addr(write_addr), num_bytes_per_chunk);
+                        noc_async_write_barrier();
+                    }
+
+                    cb_push_back(kv_cache_intermed_sync_cb, CHUNK_SIZE);
+                    cb_pop_front(kv_cache_intermed_cb, CHUNK_SIZE);
+
+                    src_addr += num_bytes_per_chunk;
+                }
+
+                cb_pop_front(new_cache_cb, 1);
+
+                // Phase 2: Wait for tilize to complete, write to DRAM
+                for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    {
+                        DeviceZoneScopedN("WAIT_TILIZE");
+                        cb_wait_front(kv_cache_output_cb, CHUNK_SIZE);
+                    }
+
+                    {
+                        DeviceZoneScopedN("WRITE_TO_DRAM");
+                        uint32_t tile_offset = chunk * CHUNK_SIZE;
+                        uint32_t cb_addr = get_read_ptr(kv_cache_output_cb);
+                        for (uint32_t i = 0; i < CHUNK_SIZE; i++) {
+                            noc_async_write_page(kv_cache_page_id_start + tile_offset + i, kv_tensor_accessor, cb_addr);
+                            cb_addr += kv_tensor_accessor.get_aligned_page_size();
+                        }
+                        noc_async_write_barrier();
+                        cb_pop_front(kv_cache_output_cb, CHUNK_SIZE);
                     }
                 }
-                cb_pop_front(new_cache_cb, 1);
-                cb_push_back(kv_cache_intermed_cb, 1);
-
-                // 3. Wait for TRISC to finish tilize into kv_cache_output_cb and write out to DRAM
-                cb_wait_front(kv_cache_output_cb, kv_cache_num_tiles);
-
-                uint32_t cb_addr = get_read_ptr(kv_cache_output_cb);
-                for (uint32_t i = 0; i < kv_cache_num_tiles; i++) {
-                    noc_async_write_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
-                    cb_addr += kv_tensor_accessor.get_aligned_page_size();
-                }
-                noc_async_write_barrier();
-                cb_pop_front(kv_cache_output_cb, kv_cache_num_tiles);
 #endif
             }
 #elif defined(COMPILE_FOR_TRISC)
             if constexpr (IsNopeCore || IsRopeCore) {
                 uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
+                uint32_t kv_cache_intermed_sync_cb = args.kv_cache_intermed_sync_cb;
                 uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
                 uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
-                // half dest calculations
                 constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
-                constexpr uint32_t full_ct_dim = IsRopeCore ? 1 : 16;
-                constexpr uint32_t block_ct_dim = IsRopeCore ? 1 : 8;
+                constexpr uint32_t CHUNK_SIZE = IsRopeCore ? 1 : 8;
+                constexpr uint32_t NUM_CHUNKS = kv_cache_num_tiles / CHUNK_SIZE;
 
+                // Phase 1: Untilize into intermed_cb, pushing each chunk of CHUNK_SIZE
                 reconfig_data_format_srca<false, true>(kv_cache_input_cb);
                 pack_reconfig_data_format<true>(kv_cache_intermed_cb);
-                cb_wait_front(kv_cache_input_cb, kv_cache_num_tiles);
-                cb_reserve_back(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
-                pack_untilize_init<block_ct_dim, full_ct_dim>(kv_cache_input_cb, kv_cache_intermed_cb);
-                pack_untilize_block<block_ct_dim, full_ct_dim>(kv_cache_input_cb, 1, kv_cache_intermed_cb, 0);
-                cb_pop_front(kv_cache_input_cb, block_ct_dim);  // consume first 8 so second block reads tiles 8-15
-                if (IsNopeCore) {
-                    pack_untilize_block<block_ct_dim, full_ct_dim>(kv_cache_input_cb, 1, kv_cache_intermed_cb, 1);
-                    cb_pop_front(kv_cache_input_cb, kv_cache_num_tiles - block_ct_dim);  // pop remaining 8
+                pack_untilize_init<CHUNK_SIZE, CHUNK_SIZE>(kv_cache_input_cb, kv_cache_intermed_cb);
+                for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    cb_reserve_back(kv_cache_intermed_cb, CHUNK_SIZE);
+                    cb_wait_front(kv_cache_input_cb, CHUNK_SIZE);
+                    pack_untilize_block<CHUNK_SIZE, CHUNK_SIZE>(kv_cache_input_cb, 1, kv_cache_intermed_cb, 0);
+                    cb_push_back(kv_cache_intermed_cb, CHUNK_SIZE);
+                    cb_pop_front(kv_cache_input_cb, CHUNK_SIZE);
                 }
                 pack_untilize_uninit(kv_cache_intermed_cb);
 
-                // Push back to unblock ncrisc to update kv cache with new data
-                cb_push_back(kv_cache_intermed_cb, kv_cache_num_tiles);
-
-                // Waits for ncrisc to push one more "tile"
-                cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
-                cb_reserve_back(kv_cache_output_cb, kv_cache_num_tiles);
-
-                reconfig_data_format_srca<false, true>(kv_cache_intermed_cb);
+                // Phase 2: Tilize each chunk after NCRISC signals via sync CB
+                reconfig_data_format_srca<false, true>(kv_cache_intermed_sync_cb);
                 pack_reconfig_data_format<true>(kv_cache_output_cb);
-                tilize_init(kv_cache_intermed_cb, kv_cache_num_tiles, kv_cache_output_cb);
-                tilize_block(kv_cache_intermed_cb, kv_cache_num_tiles, kv_cache_output_cb);
-                tilize_uninit(kv_cache_intermed_cb, kv_cache_output_cb);
-                cb_push_back(kv_cache_output_cb, kv_cache_num_tiles);
-                cb_pop_front(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
+                tilize_init(kv_cache_intermed_sync_cb, CHUNK_SIZE, kv_cache_output_cb);
+                for (uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                    cb_reserve_back(kv_cache_output_cb, CHUNK_SIZE);
+                    cb_wait_front(kv_cache_intermed_sync_cb, CHUNK_SIZE);
+                    tilize_block(kv_cache_intermed_sync_cb, CHUNK_SIZE, kv_cache_output_cb);
+                    cb_push_back(kv_cache_output_cb, CHUNK_SIZE);
+                    cb_pop_front(kv_cache_intermed_sync_cb, CHUNK_SIZE);
+                }
+                tilize_uninit(kv_cache_intermed_sync_cb, kv_cache_output_cb);
             }
 #endif
         }


### PR DESCRIPTION
### Ticket
None

### Problem description
KV cache update for NOPE is on the critical path for the FlashMLA core that needs to stream kv cache after update (eg. for cur position 8191, the S8 group is on the critical path). This PR optimizes this path to unblock kv cache read as early as possible. With these changes, all kv cache reads in FlashMLA are prefetched.

### What's changed
- Block work in chunks of 8 tiles (2 blocks total)
  * Add new cb aliased to kv_cache_intermed to use as sync
  * Reduce cb size by one tile
  * Add pipelined and overlapped execution for:
    ** DRAM read -> untilize -> L1 update -> tilize -> DRAM write
    ** DRAM read is entirely prefetched ahead-of-time
  * Use noc for L1 update
    ** ~0.1us comapred to ~1us before
  * Add profiler zones for NCRISC/BRISC
- Switch to unicasts for kv cache signal ready
  * Mcast may be overlapped and be very slow
  * Unicast is ~0.3us compared to ~1us before

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/main)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/main): https://github.com/tenstorrent/tt-metal/actions/runs/23931554291
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/main)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
