### PR TITLE
BH: Add pack_untilize test + FP8_E4M3

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -21,16 +21,14 @@ namespace unit_tests::compute {
 std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_vec, const GoldenConfig& config) {
     vector<uint32_t> dst_vec;
 
-    // Due to each element being 32 bits, for bfloat16 thats 2 elements
-
     int num_tile_rows = config.num_tiles_r_dim;
     int num_tile_cols = config.num_tiles_c_dim;
 
-    // Due to each element being 32 bits, for bfloat16 thats 2 elements
-    int num_c_dim = config.face_c_dim / 2;
-    // Untilize outputs correct number of r_dim & num_faces
-    // But assumes increments are still default 16x16 faces
-    int face_size = 16 * 16 / 2;
+    // Number of uint32 words per face row: face_c_dim elements × datum_bytes / 4 bytes per uint32
+    // BF16 (datum_bytes=2): 16*2/4 = 8  FP8 (datum_bytes=1): 16*1/4 = 4
+    int num_c_dim = config.face_c_dim * static_cast<int>(config.datum_bytes) / 4;
+    // Standard 16x16 face size in uint32 words
+    int face_size = 16 * 16 * static_cast<int>(config.datum_bytes) / 4;
     int tile_size = face_size * (config.tiny_tile ? config.num_faces : 4);
 
     std::set<int> ind;

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
@@ -21,6 +21,7 @@ struct GoldenConfig {
     int face_c_dim = 16;
     int num_faces = 4;
     bool tiny_tile = false;
+    uint32_t datum_bytes = 2;  // bytes per element: 2=BF16 (default), 1=FP8, 4=FP32
 };
 
 std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_vec, const GoldenConfig& config);

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -92,7 +92,7 @@ struct TestConfig {
     tt::DataFormat input_fmt = tt::DataFormat::Float16_b;
     tt::DataFormat output_fmt = tt::DataFormat::Float16_b;
     // Pre-generated source data; if empty, create_arange_vector_of_bfloat16 is used.
-    std::vector<uint32_t> src0_data = {};
+    std::vector<uint32_t> src0_data;
     GoldenFunc golden_function;
 };
 

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/float8.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -88,6 +89,10 @@ struct TestConfig {
     uint32_t face_r_dim = 16;
     std::optional<UntilizeType> untilize_type = std::nullopt;
     std::optional<TilizeType> tilize_type = std::nullopt;
+    tt::DataFormat input_fmt = tt::DataFormat::Float16_b;
+    tt::DataFormat output_fmt = tt::DataFormat::Float16_b;
+    // Pre-generated source data; if empty, create_arange_vector_of_bfloat16 is used.
+    std::vector<uint32_t> src0_data = {};
     GoldenFunc golden_function;
 };
 
@@ -130,7 +135,7 @@ void run_single_core_tilize_program(
     uint32_t num_input_tiles = num_tiles;
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(
-            num_input_tiles * test_config.input_single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+            num_input_tiles * test_config.input_single_tile_size, {{src0_cb_index, test_config.input_fmt}})
             .set_page_size(src0_cb_index, test_config.input_single_tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
 
@@ -155,7 +160,7 @@ void run_single_core_tilize_program(
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(
             num_output_tiles * test_config.output_single_tile_size,
-            {{ouput_cb_index, test_config.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b}})
+            {{ouput_cb_index, test_config.fp32_dest_acc_en ? tt::DataFormat::Float32 : test_config.output_fmt}})
             .set_page_size(ouput_cb_index, test_config.output_single_tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
 
@@ -225,7 +230,9 @@ void run_single_core_tilize_program(
             .compile_args = compute_kernel_args,
             .defines = defines});
 
-    std::vector<uint32_t> src0_vec = create_arange_vector_of_bfloat16(input_dram_buffer_size, false);
+    std::vector<uint32_t> src0_vec = test_config.src0_data.empty()
+                                         ? create_arange_vector_of_bfloat16(input_dram_buffer_size, false)
+                                         : test_config.src0_data;
     tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
     std::vector<uint32_t> src1_vec;
@@ -276,6 +283,7 @@ void run_single_core_tilize_program(
         .face_r_dim = test_config.face_r_dim,
         .face_c_dim = 16,
         .num_faces = test_config.num_faces_per_tile,
+        .datum_bytes = tt::datum_size(test_config.input_fmt),
     };
     bool pass = true;
 
@@ -459,6 +467,30 @@ TEST_F(MeshDeviceFixture, TensixComputePackUntilizeDst) {
                 .num_tiles_r = num_tile[0],
                 .num_tiles_c = num_tile[1],
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
+                .golden_function = ::unit_tests::compute::gold_standard_untilize};
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+        }
+    }
+}
+
+TEST_F(BlackholeSingleCardFixture, TensixComputePackUntilizeFp8e4m3) {
+    vector<vector<uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
+    for (auto num_tile : num_tiles) {
+        for (bool dst_full_sync_en : {true, false}) {
+            uint32_t num_t = num_tile[0] * num_tile[1];
+            auto src_data = create_random_vector_of_float8_e4m3(
+                tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_t, /*rand_max_float=*/20, /*seed=*/42);
+            unit_tests::compute::tilize::TestConfig test_config = {
+                .dst_full_sync_en = dst_full_sync_en,
+                .fp32_dest_acc_en = false,
+                .input_single_tile_size = tt::tile_size(tt::DataFormat::Fp8_e4m3),
+                .output_single_tile_size = tt::tile_size(tt::DataFormat::Fp8_e4m3),
+                .num_tiles_r = num_tile[0],
+                .num_tiles_c = num_tile[1],
+                .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
+                .input_fmt = tt::DataFormat::Fp8_e4m3,
+                .output_fmt = tt::DataFormat::Fp8_e4m3,
+                .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
             unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
         }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18157)

### Problem description
Add pack_untilize + fp8

### What's changed
Describe the approach used to solve the problem.
Add pack_untilize + fp8

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/fp8_tilize_untilize)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rtawfik/fp8_tilize_untilize)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/fp8_tilize_untilize)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/fp8_tilize_untilize)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/fp8_tilize_untilize)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/fp8_tilize_untilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/fp8_tilize_untilize)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
