### PR TITLE
SDXL: Update perf 

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -117,11 +117,11 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "refiner_unet_1024x1024": {
         "wormhole": 244_107_203 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
-        "blackhole": None,  # Refiner not supported yet on Blackhole
+        "blackhole": 114_154_100 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
     },
     "refiner_unet_512x512": {
         "wormhole": 79_843_092 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
-        "blackhole": None,  # Refiner not supported yet on Blackhole
+        "blackhole": None,  # Only 1024x1024 tested on Blackhole
     },
     "vae_decode_1024x1024": {
         "wormhole": 663_083_865,

--- a/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -109,7 +109,7 @@ def test_refiner_unet(
 DEVICE_PERF_EXPECTATIONS = {
     "unet_1024x1024": {
         "wormhole": 191_201_442 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
-        "blackhole": 81_886_264 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+        "blackhole": 78_106_452 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
     },
     "unet_512x512": {
         "wormhole": 82_300_000 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -125,7 +125,7 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "vae_decode_1024x1024": {
         "wormhole": 663_083_865,
-        "blackhole": 271_459_000,
+        "blackhole": 267_498_780,
     },
     "vae_decode_512x512": {
         "wormhole": 171_560_642,
@@ -141,11 +141,11 @@ DEVICE_PERF_EXPECTATIONS = {
     },
     "clip_encoder_1": {
         "wormhole": 13_112_562,
-        "blackhole": 7_101_101,
+        "blackhole": 7_089_747,
     },
     "clip_encoder_2": {
         "wormhole": 63_591_763,  # Note: this is an average value of 30 test runs due to high variability
-        "blackhole": 29_235_442,
+        "blackhole": 29_182_499,
     },
 }
 


### PR DESCRIPTION
### Problem description
Perf has slightly improved with the new device 2.0 api usage. [CI](https://github.com/tenstorrent/tt-metal/actions/runs/23721401754/job/69103610624#step:7:1083)

### What's changed
Updated perf times and added perf for refiner since it is working after the https://github.com/tenstorrent/tt-metal/pull/39940

### Checklist

- [ ] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=nmilicevic/sdxl-update-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:nmilicevic/sdxl-update-perf)

### Refiner perf 
<img width="1800" height="2400" alt="image" src="https://github.com/user-attachments/assets/637401f3-476d-4d0c-9fe8-082a5e4cf6d9" />
