### PR TITLE
#37322: extend ttnnsort to support fp32 input

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -33,13 +33,19 @@ TILE_WIDTH = 32
         ([237], 0, False),
     ],
 )
-def test_sort_standard(shape, dim, descending, device):
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_sort_standard(shape, dim, descending, device, torch_dtype, ttnn_dtype):
     torch.manual_seed(0)
 
-    torch_dtype = torch.bfloat16
     input = torch.randn(shape, dtype=torch_dtype)
 
-    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_input = ttnn.from_torch(input, ttnn_dtype, layout=ttnn.Layout.TILE, device=device)
     torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
     ttnn_sort_values, ttnn_sort_indices = ttnn.sort(ttnn_input, dim=dim, descending=descending)
 
@@ -54,7 +60,10 @@ def test_sort_standard(shape, dim, descending, device):
         assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices)
     else:
         # Validate sorted values
-        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        if torch_dtype == torch.float32:
+            assert_allclose(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype), atol=1e-3, rtol=1e-3)
+        else:
+            assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype))
         # Validate that the indices correctly index into the original tensor
         ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn.to_torch(ttnn_sort_indices).to(torch.int64))
         assert_equal(torch_sort_values, ttnn_torch_gather_from_indices)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -60,10 +60,8 @@ def test_sort_standard(shape, dim, descending, device, torch_dtype, ttnn_dtype):
         assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices)
     else:
         # Validate sorted values
-        if torch_dtype == torch.float32:
-            assert_allclose(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype), atol=1e-3, rtol=1e-3)
-        else:
-            assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype))
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype))
+
         # Validate that the indices correctly index into the original tensor
         ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn.to_torch(ttnn_sort_indices).to(torch.int64))
         assert_equal(torch_sort_values, ttnn_torch_gather_from_indices)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -57,7 +57,7 @@ def test_sort_standard(shape, dim, descending, device, torch_dtype, ttnn_dtype):
 
     if len(shape) == 0 or (len(shape) == 1 and shape[0] == 1):
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
-        assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices)
+        assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices).to(torch.int64)
     else:
         # Validate sorted values
         assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_dtype))

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -35,16 +35,21 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
+    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
 
 #ifndef ARCH_QUASAR
     if (is_int32) {
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
+    } else {
+        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
+    }
+
+    if (is_int32 || is_fp32) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }
@@ -80,9 +85,10 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
+    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
 
 #ifndef ARCH_QUASAR
-    if (is_int32) {
+    if (is_int32 || is_fp32) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
@@ -122,9 +128,10 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     const std::uint32_t src_format = get_operand_src_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
+    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
 
 #ifndef ARCH_QUASAR
-    if (is_int32) {
+    if (is_int32 || is_fp32) {
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -34,8 +34,11 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     const std::uint32_t src_format = get_operand_src_format(icb);
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
-    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
 
 #ifndef ARCH_QUASAR
     if (is_int32) {
@@ -44,7 +47,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
     }
 
-    if (is_int32 || is_fp32) {
+    if (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
@@ -83,12 +86,13 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb, call_line);
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
-    const std::uint32_t src_format = get_operand_src_format(icb);
-    const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
-    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
 
 #ifndef ARCH_QUASAR
-    if (is_int32 || is_fp32) {
+    if (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
@@ -126,12 +130,13 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
 // clang-format on
 ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
-    const std::uint32_t src_format = get_operand_src_format(icb);
-    const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
-    const bool is_fp32 = src_format == (std::uint32_t)DataFormat::Float32;
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
 
 #ifndef ARCH_QUASAR
-    if (is_int32 || is_fp32) {
+    if (enable_unpack_to_dest) {
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -161,12 +161,17 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
         std::vector<uint32_t> compute_kernel_args = {};
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
+        std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+        if (cb_data_format == tt::DataFormat::Float32) {
+            unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        }
         compute_kernel_id = tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
             all_cores,
             tt::tt_metal::ComputeConfig{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
                 .compile_args = compute_kernel_args,
             });
     }
@@ -415,12 +420,17 @@ PermuteDeviceOperation::MultiCoreTileRowInvariant::create(
         std::vector<uint32_t> compute_kernel_args = {};
         bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                                 cb_data_format == tt::DataFormat::UInt32;
+        std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+        if (cb_data_format == tt::DataFormat::Float32) {
+            unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        }
         compute_kernel_id = tt::tt_metal::CreateKernel(
             program,
             "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
             all_cores,
             tt::tt_metal::ComputeConfig{
                 .fp32_dest_acc_en = fp32_dest_acc_en,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
                 .compile_args = compute_kernel_args,
             });
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
@@ -109,7 +109,7 @@ void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, ui
     // Transpose from sorting by column to right structure
     reconfig_data_format_srca(transposed_cb_index);
     transpose_wh_init_short(transposed_cb_index);
-    pack_reconfig_data_format(transposed_cb_index);
+    pack_reconfig_data_format(dest_cb_index);
 
     cb_wait_front(transposed_cb_index, Wt);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
@@ -78,8 +78,10 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(tensor_args.input_tensor.layout() == Layout::TILE, "The input must be in tiled format");
 
     TT_FATAL(
-        tensor_args.input_tensor.dtype() == DataType::BFLOAT16 || tensor_args.input_tensor.dtype() == DataType::UINT16,
-        "Input tensor data type must be BFLOAT16 or UINT16, got {}",
+        tensor_args.input_tensor.dtype() == DataType::BFLOAT16 ||
+            tensor_args.input_tensor.dtype() == DataType::UINT16 ||
+            tensor_args.input_tensor.dtype() == DataType::FLOAT32,
+        "Input tensor data type must be BFLOAT16, UINT16, or FLOAT32, got {}",
         tensor_args.input_tensor.dtype());
 
     if (tensor_args.output_tensors.size() == 2) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -54,7 +54,6 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     // uint32 index tensor support
     const bool is_32_bit_data =
         index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
-    std::cout << "is_32_bit_data: " << (is_32_bit_data ? "true" : "false") << std::endl;
     // Calculate core range
     /**
      * Calculates the core range based on the input tensor shape (Ht) and the total number of cores available
@@ -205,11 +204,20 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         synchronization_cb_index};
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp";
+    std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = is_32_bit_data,
+            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
+            .compile_args = compute_compile_time_args});
     SetRuntimeArgs(
         program,
         compute_kernel_id,
@@ -598,11 +606,22 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
     };
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp";
+    std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = is_32_bit_data,
+            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
+            .compile_args = compute_compile_time_args});
 
     return {std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id, core_range}};
 }
@@ -945,11 +964,20 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         log2Wt};
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp";
+    std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_output_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
         core_range,
-        tt::tt_metal::ComputeConfig{.fp32_dest_acc_en = is_32_bit_data, .compile_args = compute_compile_time_args});
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = is_32_bit_data,
+            .unpack_to_dest_mode = unpack_to_dest_mode_vector,
+            .compile_args = compute_compile_time_args});
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -52,8 +52,9 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
 
     // uint32 index tensor support
-    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
-
+    const bool is_32_bit_data =
+        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
+    std::cout << "is_32_bit_data: " << (is_32_bit_data ? "true" : "false") << std::endl;
     // Calculate core range
     /**
      * Calculates the core range based on the input tensor shape (Ht) and the total number of cores available
@@ -341,7 +342,8 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         total_number_of_cores_virtual);
 
     // uint32 index tensor support
-    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data =
+        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
 
     /**
      * Calculates the core range based on the number of work units (all_core_utilization_count) and the total number of
@@ -724,7 +726,8 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const uint32_t all_core_utilization_loop_count = total_work_units / number_of_available_cores;
 
     // uint32 index tensor support
-    const bool is_32_bit_data = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data =
+        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
 
     // Log 2 of Wt for compute kernel
     const uint32_t log2Wt = std::log2(Wt);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -132,7 +132,7 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const tt::tt_metal::CircularBufferConfig value_tensor_cb_config =
         tt::tt_metal::CircularBufferConfig(
             num_cb_unit * value_tensor_tile_size, {{value_tensor_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_cb_index, index_tensor_tile_size);
+            .set_page_size(value_tensor_cb_index, value_tensor_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_cb_config);
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_5;
@@ -464,7 +464,7 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
     const tt::tt_metal::CircularBufferConfig value_tensor_cb_config =
         tt::tt_metal::CircularBufferConfig(
             cb_scale_factor * value_tensor_tile_size, {{value_tensor_cb_index, value_tensor_cb_data_format}})
-            .set_page_size(value_tensor_cb_index, index_tensor_tile_size);
+            .set_page_size(value_tensor_cb_index, value_tensor_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_cb_config);
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_5;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -52,8 +52,8 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
 
     // uint32 index tensor support
-    const bool is_32_bit_data =
-        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
+    const bool is_32_bit_index = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data = is_32_bit_index || input_tensor_cb_data_format == tt::DataFormat::Float32;
     // Calculate core range
     /**
      * Calculates the core range based on the input tensor shape (Ht) and the total number of cores available
@@ -179,7 +179,7 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
         total_number_of_cores,
         compute_with_storage_grid_size.x,
         compute_with_storage_grid_size.y,
-        static_cast<uint32_t>(is_32_bit_data)};
+        static_cast<uint32_t>(is_32_bit_index)};
     TensorAccessorArgs(*value_buffer).append_to(writer_compile_time_args);
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp";
@@ -205,11 +205,11 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    }
+    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    // }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
@@ -350,8 +350,8 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         total_number_of_cores_virtual);
 
     // uint32 index tensor support
-    const bool is_32_bit_data =
-        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
+    const bool is_32_bit_index = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data = is_32_bit_index || input_tensor_cb_data_format == tt::DataFormat::Float32;
 
     /**
      * Calculates the core range based on the number of work units (all_core_utilization_count) and the total number of
@@ -576,7 +576,7 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
         number_of_tiles_per_core,
         total_number_of_cores_virtual,
         semaphore_exchange_readers,
-        static_cast<uint32_t>(is_32_bit_data)};
+        static_cast<uint32_t>(is_32_bit_index)};
     TensorAccessorArgs(*value_buffer).append_to(writer_compile_time_args);
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp";
@@ -607,13 +607,13 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    }
+    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    // }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
@@ -745,8 +745,8 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const uint32_t all_core_utilization_loop_count = total_work_units / number_of_available_cores;
 
     // uint32 index tensor support
-    const bool is_32_bit_data =
-        index_tensor_cb_data_format == tt::DataFormat::UInt32 || input_tensor_cb_data_format == tt::DataFormat::Float32;
+    const bool is_32_bit_index = index_tensor_cb_data_format == tt::DataFormat::UInt32;
+    const bool is_32_bit_data = is_32_bit_index || input_tensor_cb_data_format == tt::DataFormat::Float32;
 
     // Log 2 of Wt for compute kernel
     const uint32_t log2Wt = std::log2(Wt);
@@ -869,7 +869,7 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
         number_of_available_cores,
         input_tensor_cb_index,
         index_tensor_cb_index,
-        static_cast<uint32_t>(is_32_bit_data)};
+        static_cast<uint32_t>(is_32_bit_index)};
     TensorAccessorArgs(*input_buffer).append_to(coordinator_compile_time_args);
     TensorAccessorArgs(*value_buffer).append_to(coordinator_compile_time_args);
     TensorAccessorArgs(*index_buffer).append_to(coordinator_compile_time_args);
@@ -965,11 +965,11 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode_vector[input_tensor_output_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    }
+    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    //     unpack_to_dest_mode_vector[input_tensor_output_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    // }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -205,11 +205,11 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    // }
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
@@ -607,13 +607,13 @@ SortProgramFactoryCrossCoreDataExchange::cached_program_t SortProgramFactoryCros
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    // }
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_intermediate_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[value_tensor_peer_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
@@ -965,11 +965,11 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp";
     std::vector<UnpackToDestMode> unpack_to_dest_mode_vector(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    // if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
-    //     unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    //     unpack_to_dest_mode_vector[input_tensor_output_cb_index] = UnpackToDestMode::UnpackToDestFp32;
-    // }
+    if (input_tensor_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode_vector[input_tensor_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_transposed_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode_vector[input_tensor_output_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -171,22 +171,26 @@ std::vector<Tensor> sort(
 
     // Check for early exit for scalar or empty tensors tensors
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
+        auto indices = ttnn::zeros_like(input_tensor, DataType::UINT16);
         if (operations::data_movement::CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
                 optional_output_tensors, original_lshape)) {
             std::get<0>(*optional_output_tensors) = input_tensor;
+            std::get<1>(*optional_output_tensors) = indices;
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         }
-        return {input_tensor, ttnn::zeros_like(input_tensor)};
+        return {input_tensor, indices};
     }
 
     const int8_t normalized_dim = dim < 0 ? rank + dim : dim;
     if (original_lshape[normalized_dim] == 1) {
+        auto indices = ttnn::zeros_like(input_tensor, DataType::UINT16);
         if (operations::data_movement::CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
                 optional_output_tensors, original_lshape)) {
             std::get<0>(*optional_output_tensors) = input_tensor;
+            std::get<1>(*optional_output_tensors) = indices;
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         }
-        return {input_tensor, ttnn::zeros_like(input_tensor)};
+        return {input_tensor, indices};
     }
 
     const bool is_dim_last_idx = (dim == -1 || dim == rank - 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -179,6 +179,16 @@ std::vector<Tensor> sort(
         return {input_tensor, ttnn::zeros_like(input_tensor)};
     }
 
+    const int8_t normalized_dim = dim < 0 ? rank + dim : dim;
+    if (original_lshape[normalized_dim] == 1) {
+        if (operations::data_movement::CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
+                optional_output_tensors, original_lshape)) {
+            std::get<0>(*optional_output_tensors) = input_tensor;
+            return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
+        }
+        return {input_tensor, ttnn::zeros_like(input_tensor)};
+    }
+
     const bool is_dim_last_idx = (dim == -1 || dim == rank - 1);
     const bool is_rank_le_4d = rank <= 4;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort_nanobind.cpp
@@ -53,6 +53,8 @@ void bind_sort_operation(nb::module_& mod) {
                   - TILE
                 * - UINT16
                   - TILE
+                * - FLOAT32
+                  - TILE
 
             Supported dtypes and layout for index tensor values:
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -318,7 +318,7 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
     if (src0_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
         if (row_major) {
-            unpack_to_dest_mode[24] = UnpackToDestMode::UnpackToDestFp32;
+            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] = UnpackToDestMode::UnpackToDestFp32;
         }
     }
     auto compute_kernel_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -314,13 +314,23 @@ TransposeWHProgramFactory::cached_program_t TransposeWHProgramFactory::create(
     if (row_major && (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32)) {
         compute_defines["DST_ACCUM_MODE"] = "1";
     }
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        if (row_major) {
+            unpack_to_dest_mode[24] = UnpackToDestMode::UnpackToDestFp32;
+        }
+    }
     auto compute_kernel_id = CreateKernel(
         program,
         row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp"
                   : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
         total_cores,
         ComputeConfig{
-            .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args, .defines = compute_defines});
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .compile_args = compute_kernel_args,
+            .defines = compute_defines});
 
     if (row_major) {
         set_runtime_args_wh_rm(

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -77,11 +77,18 @@ TransposeWHShardedProgramFactory::cached_program_t TransposeWHShardedProgramFact
         total_cores,
         WriterDataMovementConfig(writer_compile_time_args));
 
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     auto compute_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp",
         total_cores,
-        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_compile_time_args});
+        ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .compile_args = compute_compile_time_args});
 
     auto padded_shape = input_tensor.padded_shape();
     auto shard_shape = shard_spec.shape;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -190,12 +190,17 @@ TransposeWHShardedRMProgramFactory::cached_program_t TransposeWHShardedRMProgram
     std::map<std::string, std::string> compute_defines;
     compute_defines["SHARDED"] = "1";
 
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        unpack_to_dest_mode[im_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
     CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp",
         all_cores,
         ComputeConfig{
             .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
             .compile_args = compute_compile_time_args,
             .defines = compute_defines});
 


### PR DESCRIPTION
### Ticket

#37322 

### Problem description
Currently the `ttnn.sort` only supports bfloat16 and uint16 as input values. Recent changes to LLK provided float32 support to sort LLK.

### What's changed
- Added option for Float32 support for ttnn.sort,
- Added test to cover the new dtype case,
- Updated ttnn.transpose (used in pre and post processing) to avoid truncating when working with fp32 data.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/37322-extend-ttnnsort-to-support-fp32-and-uint32-input)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
