### PR TITLE
Adjust vovnet perf target

### DIFF
--- a/models/experimental/vovnet/tests/perf/test_e2e_performant.py
+++ b/models/experimental/vovnet/tests/perf/test_e2e_performant.py
@@ -16,8 +16,8 @@ from models.experimental.vovnet.common import VOVNET_L1_SMALL_SIZE
 
 
 def get_expected_times(name):
-    # issue #35265 - treshold needs to be confirmed
-    base = {"vovnet": (172, 0.0085)}
+    # See issue #41006. Recent single-card perf runs observed vovnet up to 0.0096s.
+    base = {"vovnet": (172, 0.0098)}
     return base[name]
 
 


### PR DESCRIPTION
## Summary
- raise the vovnet expected inference-time target from `0.0085` to `0.0098`
- add an inline reference to issue #41006 above the target

## Context
- issue: #41006
- recent single-card perf artifacts observed vovnet up to `0.0096s`
- this change adds a small buffer above the recent observed max to reduce noise-driven failures

## CI
- Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/23747963837 ✅ 