### PR TITLE
Add id field to captured_graph nodes for visualizer compatibility

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -2665,7 +2665,7 @@ class TestPerOpCapturedGraphImport:
     """Tests that per-op captured_graph from python_io is used directly."""
 
     def test_per_op_captured_graph_used_when_available(self, tmp_path):
-        """captured_graph from python_io should be stored as-is."""
+        """captured_graph from python_io should be stored with id fields injected."""
         per_op_graph = [
             {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1]},
             {
@@ -2681,6 +2681,24 @@ class TestPerOpCapturedGraphImport:
                 "connections": [3],
             },
             {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        expected_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1], "id": 0},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "InnerOp"},
+                "connections": [2],
+                "id": 1,
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "InnerOp"},
+                "connections": [3],
+                "id": 2,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": [], "id": 3},
         ]
         mock_graph = [
             {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
@@ -2716,7 +2734,7 @@ class TestPerOpCapturedGraphImport:
         rows = cursor.fetchall()
         assert len(rows) == 1
         stored = json.loads(rows[0][0])
-        assert stored == per_op_graph, "Per-op graph should be stored exactly as provided"
+        assert stored == expected_graph, "Per-op graph should have id fields injected from counter"
         conn.close()
 
     def test_fallback_extraction_when_no_per_op_graph(self, tmp_path):

--- a/ttnn/ttnn/graph_report.py
+++ b/ttnn/ttnn/graph_report.py
@@ -943,10 +943,16 @@ def import_graph(
                 for buf in active_buffers:
                     buffers_batch.append((operation_id, *buf))
 
+                node_copy = dict(node)
+                node_copy["counter"] = 1
+                node_copy["id"] = 1
+                if "connections" in node_copy:
+                    node_copy["connections"] = [2]
                 capture_start = {
                     "arguments": [],
                     "connections": [1],
                     "counter": 0,
+                    "id": 0,
                     "input_tensors": [],
                     "node_type": "capture_start",
                     "params": {},
@@ -955,16 +961,14 @@ def import_graph(
                 capture_end = {
                     "arguments": [],
                     "connections": [],
-                    "counter": 0,
+                    "counter": 2,
+                    "id": 2,
                     "input_tensors": [],
                     "node_type": "capture_end",
                     "params": {},
                     "stacking_level": 0,
                 }
-                dealloc_subgraph = [capture_start, node, capture_end]
-                for snode in dealloc_subgraph:
-                    if "counter" in snode:
-                        snode["id"] = snode["counter"]
+                dealloc_subgraph = [capture_start, node_copy, capture_end]
                 captured_graph_batch.append((operation_id, json.dumps(dealloc_subgraph)))
 
                 operation_counter += 1

--- a/ttnn/ttnn/graph_report.py
+++ b/ttnn/ttnn/graph_report.py
@@ -808,6 +808,9 @@ def import_graph(
                     if "input_tensors" in nd_copy:
                         nd_copy["input_tensors"] = [old_to_new.get(c, c) for c in nd_copy["input_tensors"]]
                     subgraph.append(nd_copy)
+            for snode in subgraph:
+                if "counter" in snode:
+                    snode["id"] = snode["counter"]
             captured_graph_batch.append((operation_id, json.dumps(subgraph)))
             current_op_nodes = []
 
@@ -958,7 +961,11 @@ def import_graph(
                     "params": {},
                     "stacking_level": 0,
                 }
-                captured_graph_batch.append((operation_id, json.dumps([capture_start, node, capture_end])))
+                dealloc_subgraph = [capture_start, node, capture_end]
+                for snode in dealloc_subgraph:
+                    if "counter" in snode:
+                        snode["id"] = snode["counter"]
+                captured_graph_batch.append((operation_id, json.dumps(dealloc_subgraph)))
 
                 operation_counter += 1
             else:
@@ -1301,6 +1308,10 @@ def import_report(
                 total_stats["devices"] += len(device_ids)
 
             if "graph" in report:
+                for node in report["graph"]:
+                    if "counter" in node:
+                        node["id"] = node["counter"]
+
                 python_io = report.get("python_io")
                 if python_io is None:
                     sidecar_path = rpath.with_suffix(".python_io.json")


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/ttnn-visualizer/issues/1353)

### Problem description
The ttnn-visualizer backend expects an integer "id" field on each node in the captured_graph JSON. 

### What's changed
The importer now injects "id" (equal to "counter") into every graph node during import, covering the main graph, per-operation captured subgraphs, and synthesized deallocate subgraphs.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomeztt/captured-graph-add-id-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomeztt/captured-graph-add-id-field)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
