### PR TITLE
Remove updating num_logprobs argument for all but gpt-oss models.

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -164,6 +164,7 @@ jobs:
               "runner-label": "BH-QB-GE",
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
+              "override-tt-config": "{\"trace_region_size\": 67000000}",
               "tt-llama-text-ver": "tt_transformers",
               "structured-output": true,
               "multimodal": false,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -119,7 +119,7 @@ jobs:
               "arch": "arch-wormhole_b0",
               "mesh-device": "T3K",
               "tt-llama-text-ver": "tt_transformers",
-              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"sample_on_device_mode\": \"all\"}",
+              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"sample_on_device_mode\": \"all\", \"trace_region_size\": 65000000}",
               "structured-output": true,
               "sampling-tests": true,
               "multimodal": false,

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -461,8 +461,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         if repetition_penalty[i] == 0:
             repetition_penalty[i] = defaults["repetition_penalty"]
 
-    return replace(
-        sampling_params,
+    kwargs = dict(
         temperature=temperature,
         top_p=top_p,
         top_k=top_k,
@@ -470,9 +469,16 @@ def format_sampling_params(sampling_params, max_batch_size):
         frequency_penalty=frequency_penalty,
         repetition_penalty=repetition_penalty,
         seed=seed,
-        num_logprobs=num_logprobs,
-        enable_log_probs=enable_log_probs,
     )
+    # Only include logprobs fields if the input dataclass has them
+    # (vLLM's TTSamplingParams may not have these fields)
+    input_fields = {f.name for f in fields(sampling_params)}
+    if "num_logprobs" in input_fields:
+        kwargs["num_logprobs"] = num_logprobs
+    if "enable_log_probs" in input_fields:
+        kwargs["enable_log_probs"] = enable_log_probs
+
+    return replace(sampling_params, **kwargs)
 
 
 def broadcast_sampling_params(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -592,7 +592,7 @@ class Generator(WarmupForwardMixin):
                     return scattered
 
                 updates = {}
-                for f in fields(SamplingParams):
+                for f in fields(params):
                     if f.name == "seed":
                         # Seeds stay in original order; no reordering to slot indices.
                         updates[f.name] = getattr(params, f.name)


### PR DESCRIPTION
### Problem description
vllm nightly tests are failing for num_logprobs missing in TTSamplingParams. It was part of the change where GPT-OSS gets argument for logprobs>1 and it was not properly adjusted for other models since they didn't have same argument.  

### What's changed
Updated behaviour to modify only existing arguments and not all available since they might not be configured by each module. 
### Checklist
before fix:
- [ ] [vll nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23697685344/job/69036035346#step:17:398)

after fix: 
- [ ] [vll nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23747878859)