### PR TITLE
Add content-addressed TensorCache for standalone DeepSeekV3 B1 weight tensors

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/stage.py
+++ b/models/demos/deepseek_v3_b1/demo/stage.py
@@ -16,9 +16,9 @@ from typing import Any
 import torch
 
 import ttnn
-from models.demos.deepseek_v3_b1.demo.weight_provider import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.prepare_weights import DeepSeekV3EmbeddingLayerWeights, DeepSeekV3LMHeadWeights
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import build_broadcast_test_inputs
 

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -17,6 +17,7 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.prepare_weights import (
     _MTP_LAYER_IDX,
     NUM_ROUTED_EXPERTS,
@@ -56,22 +57,6 @@ class WeightProvider(Protocol):
 
     def load_mtp(self, device: ttnn.MeshDevice) -> DeepSeekV3MTPWeights:
         ...
-
-
-class LogicalModelDimensions:
-    """HF / logical tensor dimensions for DeepSeek V3 B1. Must match prepare_weights and stage expectations."""
-
-    HIDDEN_SIZE = 7168
-    VOCAB_SIZE = 129280
-    Q_A_DIM = 1536
-    Q_B_OUT = 24576
-    KV_A_DIM = 576
-    KV_B_LORA_RANK = 512
-    KV_B_PROJ_OUT = 32768
-    O_PROJ_OUT = 16384
-    MOE_INTERMEDIATE_SIZE = 2048
-    INTERMEDIATE_SIZE = 18432
-    GATE_NUM_INDICES = 256
 
 
 def _layer_key(layer_id: int, suffix: str) -> str:

--- a/models/demos/deepseek_v3_b1/model_dimensions.py
+++ b/models/demos/deepseek_v3_b1/model_dimensions.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek V3 B1 logical model dimensions (HF / full-model shapes).
+
+Single source of truth for dimension constants used by prepare_weights,
+weight_provider, stage, and tests.
+"""
+
+
+class LogicalModelDimensions:
+    """HF / logical tensor dimensions for DeepSeek V3 B1."""
+
+    HIDDEN_SIZE = 7168
+    VOCAB_SIZE = 129280
+    Q_A_DIM = 1536
+    Q_B_OUT = 24576
+    KV_A_DIM = 576
+    KV_B_LORA_RANK = 512
+    KV_B_PROJ_OUT = 32768
+    O_PROJ_OUT = 16384
+    MOE_INTERMEDIATE_SIZE = 2048
+    INTERMEDIATE_SIZE = 18432
+    GATE_NUM_INDICES = 256

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -27,6 +27,12 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
+from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, ShardMeshMapper, SourceTensorSelection, TensorTarget
+
+# Bump when any standalone tensor preprocessing logic changes to invalidate caches.
+CURRENT_TRANSFORM_VERSION = 1
+
 
 # Serialization: manifest version and dtype name mapping
 _MANIFEST_VERSION = 1
@@ -263,11 +269,11 @@ class DeepSeekV3MTPWeights:
 _NUM_HEADS = 64
 
 # MoE routed experts (DeepSeek V3 config: n_routed_experts=256).
-NUM_ROUTED_EXPERTS = 256
+NUM_ROUTED_EXPERTS = D.GATE_NUM_INDICES
 _QK_NOPE_HEAD_DIM = 128
 _QK_ROPE_HEAD_DIM = 64
 _V_HEAD_DIM = 128
-_KV_LORA_RANK = 512
+_KV_LORA_RANK = D.KV_B_LORA_RANK
 _KV_B_PROJ_HEAD_DIM = _QK_NOPE_HEAD_DIM + _V_HEAD_DIM  # 256
 _Q_HEAD_DIM = _QK_NOPE_HEAD_DIM + _QK_ROPE_HEAD_DIM  # 192
 
@@ -275,6 +281,99 @@ _Q_HEAD_DIM = _QK_NOPE_HEAD_DIM + _QK_ROPE_HEAD_DIM  # 192
 _MTP_LAYER_IDX = 61
 _MTP_NUM_DRAM_BANKS = 8
 _MTP_B_TILE = ttnn.Tile([32, 32])
+
+_GATE_BIAS_SENDER_CORE = ttnn.CoreCoord(MOE_SENDER_GRID_SIZE[0] - 1, MOE_SENDER_GRID_SIZE[1] - 1)
+_GATE_BIAS_SENDER_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_GATE_BIAS_SENDER_CORE, _GATE_BIAS_SENDER_CORE)])
+
+_LM_HEAD_K = D.HIDDEN_SIZE
+_LM_HEAD_VOCAB_SIZE = D.VOCAB_SIZE
+_LM_HEAD_NUM_MATMUL_CORES = 101
+_LM_HEAD_MATMUL_CORE_GRID = ttnn.CoreRangeSet(
+    [
+        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(10, 0)),
+    ]
+)
+_LM_HEAD_B_TILE = ttnn.Tile([32, 32])
+_LM_HEAD_A_TILE = ttnn.Tile([1, 32])
+_LM_HEAD_N_PER_CORE = 160
+_LM_HEAD_MCAST_CORE = ttnn.CoreCoord(10, 9)
+_LM_HEAD_MCAST_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_LM_HEAD_MCAST_CORE, _LM_HEAD_MCAST_CORE)])
+
+_NORM_MEM_CONFIG = ttnn.MemoryConfig(
+    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    ttnn.BufferType.L1,
+    ttnn.ShardSpec(_LM_HEAD_MCAST_CORE_GRID, (1, _LM_HEAD_K), ttnn.ShardOrientation.ROW_MAJOR),
+)
+
+
+def _gate_bias_target(layer_idx: int) -> TensorTarget:
+    return TensorTarget(
+        name=f"gate_bias_layer{layer_idx}",
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(_GATE_BIAS_SENDER_CORE_GRID, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+        tile_shape=(16, 16),
+    )
+
+
+_EMBEDDING_TARGET = TensorTarget(
+    name="embedding",
+    dtype=ttnn.bfloat16,
+    layout=ttnn.ROW_MAJOR_LAYOUT,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+)
+
+_LM_HEAD_TARGET = TensorTarget(
+    name="lm_head",
+    dtype=ttnn.bfloat8_b,
+    layout=ttnn.TILE_LAYOUT,
+    memory_config=ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(_LM_HEAD_MATMUL_CORE_GRID, (_LM_HEAD_K, _LM_HEAD_N_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR),
+    ),
+    mesh_mapper_config=ShardMeshMapper(dim=1),
+)
+
+_FINAL_NORM_TARGET = TensorTarget(
+    name="final_norm",
+    dtype=ttnn.bfloat16,
+    layout=ttnn.TILE_LAYOUT,
+    memory_config=_NORM_MEM_CONFIG,
+    tile_shape=(1, 32),
+)
+
+
+def _mtp_norm_target(name: str) -> TensorTarget:
+    return TensorTarget(
+        name=name,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=_NORM_MEM_CONFIG,
+        tile_shape=(1, 32),
+    )
+
+
+def _mtp_eh_proj_target(K: int, N: int) -> TensorTarget:
+    n_per_bank = N // _MTP_NUM_DRAM_BANKS
+    eh_shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(_MTP_NUM_DRAM_BANKS - 1, 0))}
+    )
+    return TensorTarget(
+        name="mtp_eh_projection",
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.ShardSpec(eh_shard_grid, (K, n_per_bank), ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+    )
 
 
 def deinterleave_q_b_proj(q_b_proj: torch.Tensor, num_heads: int | None = None) -> torch.Tensor:
@@ -318,13 +417,11 @@ def create_gate_bias_tensor(raw_tensor: torch.Tensor, device, *, move_to_device:
     When move_to_device is False (default), tensor is not placed (device=None) for cache generation.
     When move_to_device is True, tensor is placed on device so is_sharded() is true for runtime use.
     """
-    sender_core = ttnn.CoreCoord(MOE_SENDER_GRID_SIZE[0] - 1, MOE_SENDER_GRID_SIZE[1] - 1)
-    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
     gate_bias_reshaped = raw_tensor.reshape(16, 16).T.contiguous().to(torch.bfloat16)
     gate_bias_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.BufferType.L1,
-        ttnn.ShardSpec(sender_core_grid, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
+        ttnn.ShardSpec(_GATE_BIAS_SENDER_CORE_GRID, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
     )
     return ttnn.from_torch(
         gate_bias_reshaped,
@@ -469,7 +566,7 @@ def get_layer_raw_tensors(
 
 # Gate routing constants (bias/indices layout on sender core)
 _GATE_BIAS_INDICES_SHAPE = (16, 16)
-_GATE_NUM_INDICES = 256
+_GATE_NUM_INDICES = D.GATE_NUM_INDICES
 
 
 def create_gate_indices_tensor(
@@ -511,6 +608,7 @@ def prepare_attention_weights(
     *,
     is_moe: bool,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> AttentionWeights:
     """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)."""
     logger.debug("Loading raw tensors from state dict for layer {}", layer_idx)
@@ -518,7 +616,6 @@ def prepare_attention_weights(
     q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = get_layer_raw_tensors(
         state_dict, layer_idx
     )
-    # Single-device (mla_tp=1) expects per-TP shapes; slice if state dict has full logical (2-TP) size
     q_b, o_proj, kv_b1, kv_b2 = _slice_attention_weights_for_mla_tp(q_b, o_proj, kv_b1, kv_b2, bdw.mla_tp)
     logger.debug("Loaded raw tensors in {:.3f}s", time.perf_counter() - t0)
     logger.debug("Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)", layer_idx)
@@ -535,11 +632,27 @@ def prepare_attention_weights(
             o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
         o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-        gate_bias_tt = create_gate_bias_tensor(
-            state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")],
-            bdw._device,
-            move_to_device=move_to_device,
-        )
+
+        _bias_key = _key(layer_idx, "mlp.gate.e_score_correction_bias")
+        if cache_config is not None:
+            target = _gate_bias_target(layer_idx)
+            fingerprint = cache_config.context.fingerprint(
+                source=SourceTensorSelection(names=(_bias_key,)),
+                target=target,
+            )
+            gate_bias_tt = cache_config.cache.get_or_create(
+                fingerprint,
+                bdw._device,
+                preprocess=lambda t: {target.name: t[_bias_key].reshape(16, 16).T.contiguous().to(torch.bfloat16)},
+                raw_tensors=lambda: {_bias_key: state_dict[_bias_key]},
+            )
+        else:
+            gate_bias_tt = create_gate_bias_tensor(
+                state_dict[_bias_key],
+                bdw._device,
+                move_to_device=move_to_device,
+            )
+
         logger.debug("Converted o_proj_gate_mm_norms (MoE) in {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
@@ -556,7 +669,9 @@ def prepare_attention_weights(
             gate_bias=gate_bias_tt,
         )
     else:
-        gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
+        gate_mm_dummy = torch.zeros(
+            D.HIDDEN_SIZE, D.GATE_NUM_INDICES, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device
+        )
         o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
             o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=move_to_device
         )
@@ -680,11 +795,19 @@ def prepare_dense_layer_weights(
     layer_idx: int,
     *,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> DeepSeekV3DenseLayerWeights:
     """Prepare fused weights for a single dense decoder layer."""
     logger.info("Preparing dense layer {}...", layer_idx)
     t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
+    attn = prepare_attention_weights(
+        bdw,
+        state_dict,
+        layer_idx,
+        is_moe=False,
+        move_to_device=move_to_device,
+        cache_config=cache_config,
+    )
     shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False, move_to_device=move_to_device)
     assert isinstance(routed, DenseRoutedExpertWeights)
@@ -717,11 +840,19 @@ def prepare_moe_layer_weights(
     *,
     num_routed_experts: int = NUM_ROUTED_EXPERTS,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> DeepSeekV3MoELayerWeights:
     """Prepare fused weights for a single MoE decoder layer."""
     logger.info("Preparing MoE layer {}...", layer_idx)
     t0 = time.perf_counter()
-    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=True, move_to_device=move_to_device)
+    attn = prepare_attention_weights(
+        bdw,
+        state_dict,
+        layer_idx,
+        is_moe=True,
+        move_to_device=move_to_device,
+        cache_config=cache_config,
+    )
     shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True, move_to_device=move_to_device)
     routed = prepare_routed_expert_weights(
         bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts, move_to_device=move_to_device
@@ -770,12 +901,38 @@ def prepare_embedding_weights(
     device,
     *,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> DeepSeekV3EmbeddingLayerWeights:
     """Prepare embedding weights from state dict (model.embed_tokens.weight)."""
     logger.info("Preparing embedding weights...")
-    w = state_dict["model.embed_tokens.weight"]
-    assert w.shape == (129280, 7168), f"Expected embedding shape (129280, 7168), got {w.shape}"
-    embedding_tt = _to_tt_embedding(w, device, move_to_device=move_to_device)
+    if cache_config is not None:
+        _src_key = "model.embed_tokens.weight"
+
+        def _preprocess_embedding(t):
+            w = t[_src_key]
+            assert w.shape == (
+                D.VOCAB_SIZE,
+                D.HIDDEN_SIZE,
+            ), f"Expected embedding shape ({D.VOCAB_SIZE}, {D.HIDDEN_SIZE}), got {w.shape}"
+            return {"embedding": w.contiguous()}
+
+        fingerprint = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=(_src_key,)),
+            target=_EMBEDDING_TARGET,
+        )
+        embedding_tt = cache_config.cache.get_or_create(
+            fingerprint,
+            device,
+            preprocess=_preprocess_embedding,
+            raw_tensors=lambda: {_src_key: state_dict[_src_key]},
+        )
+    else:
+        w = state_dict["model.embed_tokens.weight"]
+        assert w.shape == (
+            D.VOCAB_SIZE,
+            D.HIDDEN_SIZE,
+        ), f"Expected embedding shape ({D.VOCAB_SIZE}, {D.HIDDEN_SIZE}), got {w.shape}"
+        embedding_tt = _to_tt_embedding(w, device, move_to_device=move_to_device)
     return DeepSeekV3EmbeddingLayerWeights(embedding=embedding_tt)
 
 
@@ -812,25 +969,6 @@ def load_embedding_weights(path: str | Path, device) -> DeepSeekV3EmbeddingLayer
         raise FileNotFoundError(f"Embedding dir not found: {emb_dir}")
     embedding = ttnn.load_tensor(emb_dir / "embedding.tensorbin", device=device)
     return DeepSeekV3EmbeddingLayerWeights(embedding=embedding)
-
-
-# LM head: HF keeps full vocab (129280, 7168). Prepare shards vocab (N) across the mesh (TP=mesh size)
-# and uses the same per-device L1 WIDTH_SHARDED layout as test_lm_head_sampling (101 matmul cores).
-
-_LM_HEAD_K = 7168
-_LM_HEAD_VOCAB_SIZE = 129280
-_LM_HEAD_NUM_MATMUL_CORES = 101
-_LM_HEAD_MATMUL_CORE_GRID = ttnn.CoreRangeSet(
-    [
-        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 9)),
-        ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(10, 0)),
-    ]
-)
-_LM_HEAD_B_TILE = ttnn.Tile([32, 32])
-_LM_HEAD_A_TILE = ttnn.Tile([1, 32])
-_LM_HEAD_N_PER_CORE = 160
-_LM_HEAD_MCAST_CORE = ttnn.CoreCoord(10, 9)
-_LM_HEAD_MCAST_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_LM_HEAD_MCAST_CORE, _LM_HEAD_MCAST_CORE)])
 
 
 def _to_tt_lm_head_matrix(
@@ -882,6 +1020,7 @@ def prepare_lm_head_weights(
     device,
     *,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> DeepSeekV3LMHeadWeights:
     """Prepare LM head and final norm weights from state dict.
 
@@ -890,23 +1029,60 @@ def prepare_lm_head_weights(
     sampling op: WIDTH_SHARDED in L1 across 101 matmul cores with shard shape (7168, N_per_core).
     """
     logger.info("Preparing LM head weights...")
-    # lm_head.weight: HF (vocab_size, hidden_size) = (129280, 7168) -> (7168, 129280) for matmul
-    lm_w = state_dict["lm_head.weight"]
-    assert lm_w.shape == (
-        _LM_HEAD_VOCAB_SIZE,
-        _LM_HEAD_K,
-    ), f"Expected lm_head shape ({_LM_HEAD_VOCAB_SIZE}, {_LM_HEAD_K}), got {lm_w.shape}"
+    if cache_config is not None:
+        _lm_key = "lm_head.weight"
 
-    lm_head_tt = _to_tt_lm_head_matrix(
-        lm_w.T, device, mesh_mapper=ttnn.ShardTensorToMesh(device, dim=1), move_to_device=move_to_device
-    )
+        def _preprocess_lm_head(t):
+            lm_w = t[_lm_key]
+            assert lm_w.shape == (
+                _LM_HEAD_VOCAB_SIZE,
+                _LM_HEAD_K,
+            ), f"Expected lm_head shape ({_LM_HEAD_VOCAB_SIZE}, {_LM_HEAD_K}), got {lm_w.shape}"
+            return {"lm_head": lm_w.T.contiguous()}
 
-    # model.norm.weight: (7168,) -> (1, 7168), HEIGHT_SHARDED on the mcast core
-    logger.info("Preparing LM head norm...")
-    norm_w = state_dict["model.norm.weight"]
-    assert norm_w.shape == (7168,), f"Expected final norm shape (7168,), got {norm_w.shape}"
+        lm_fingerprint = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=(_lm_key,)),
+            target=_LM_HEAD_TARGET,
+        )
+        lm_head_tt = cache_config.cache.get_or_create(
+            lm_fingerprint,
+            device,
+            preprocess=_preprocess_lm_head,
+            raw_tensors=lambda: {_lm_key: state_dict[_lm_key]},
+        )
 
-    final_norm_tt = _to_tt_lm_head_final_norm(norm_w.unsqueeze(0), device, move_to_device=move_to_device)
+        _norm_key = "model.norm.weight"
+
+        def _preprocess_final_norm(t):
+            norm_w = t[_norm_key]
+            assert norm_w.shape == (D.HIDDEN_SIZE,), f"Expected final norm shape ({D.HIDDEN_SIZE},), got {norm_w.shape}"
+            return {"final_norm": norm_w.unsqueeze(0).contiguous()}
+
+        norm_fingerprint = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=(_norm_key,)),
+            target=_FINAL_NORM_TARGET,
+        )
+        final_norm_tt = cache_config.cache.get_or_create(
+            norm_fingerprint,
+            device,
+            preprocess=_preprocess_final_norm,
+            raw_tensors=lambda: {_norm_key: state_dict[_norm_key]},
+        )
+    else:
+        lm_w = state_dict["lm_head.weight"]
+        assert lm_w.shape == (
+            _LM_HEAD_VOCAB_SIZE,
+            _LM_HEAD_K,
+        ), f"Expected lm_head shape ({_LM_HEAD_VOCAB_SIZE}, {_LM_HEAD_K}), got {lm_w.shape}"
+        lm_head_tt = _to_tt_lm_head_matrix(
+            lm_w.T, device, mesh_mapper=ttnn.ShardTensorToMesh(device, dim=1), move_to_device=move_to_device
+        )
+
+        logger.info("Preparing LM head norm...")
+        norm_w = state_dict["model.norm.weight"]
+        assert norm_w.shape == (D.HIDDEN_SIZE,), f"Expected final norm shape ({D.HIDDEN_SIZE},), got {norm_w.shape}"
+        final_norm_tt = _to_tt_lm_head_final_norm(norm_w.unsqueeze(0), device, move_to_device=move_to_device)
+
     return DeepSeekV3LMHeadWeights(lm_head=lm_head_tt, final_norm=final_norm_tt)
 
 
@@ -949,6 +1125,17 @@ def load_lm_head_weights(path: str | Path, device) -> DeepSeekV3LMHeadWeights:
     return DeepSeekV3LMHeadWeights(lm_head=lm_head, final_norm=final_norm)
 
 
+def _transform_eh_proj(eh_proj_weight_T: torch.Tensor) -> torch.Tensor:
+    """Pad to DRAM bank alignment and tile-shuffle. Input: already transposed (K, N)."""
+    K, N = eh_proj_weight_T.shape
+    assert N % _MTP_NUM_DRAM_BANKS == 0, f"eh_proj N={N} must be divisible by {_MTP_NUM_DRAM_BANKS} DRAM banks"
+    n_per_bank = N // _MTP_NUM_DRAM_BANKS
+    padded_N = _MTP_NUM_DRAM_BANKS * n_per_bank
+    eh_padded = torch.zeros((K, padded_N), dtype=eh_proj_weight_T.dtype)
+    eh_padded[:, :N] = eh_proj_weight_T
+    return BlitzDecodeWeights._shuffle_dram_tiles(eh_padded, 32, _MTP_NUM_DRAM_BANKS).contiguous()
+
+
 def _to_tt_mtp_eh_proj(eh_proj_torch: torch.Tensor, device, *, move_to_device: bool = False) -> ttnn.Tensor:
     """Convert transposed eh_proj (K+embedding_dim, hidden) to TT WIDTH_SHARDED DRAM with tile shuffle.
 
@@ -957,14 +1144,8 @@ def _to_tt_mtp_eh_proj(eh_proj_torch: torch.Tensor, device, *, move_to_device: b
     and creates a WIDTH_SHARDED DRAM tensor.
     """
     K, N = eh_proj_torch.shape
-    assert N % _MTP_NUM_DRAM_BANKS == 0, f"eh_proj N={N} must be divisible by {_MTP_NUM_DRAM_BANKS} DRAM banks"
     n_per_bank = N // _MTP_NUM_DRAM_BANKS
-    padded_N = _MTP_NUM_DRAM_BANKS * n_per_bank
-
-    eh_padded = torch.zeros((K, padded_N), dtype=eh_proj_torch.dtype)
-    eh_padded[:, :N] = eh_proj_torch
-
-    eh_shuffled = BlitzDecodeWeights._shuffle_dram_tiles(eh_padded, 32, _MTP_NUM_DRAM_BANKS)
+    eh_shuffled = _transform_eh_proj(eh_proj_torch)
 
     eh_shard_grid = ttnn.CoreRangeSet(
         {
@@ -980,7 +1161,7 @@ def _to_tt_mtp_eh_proj(eh_proj_torch: torch.Tensor, device, *, move_to_device: b
         ttnn.ShardSpec(eh_shard_grid, (K, n_per_bank), ttnn.ShardOrientation.ROW_MAJOR),
     )
     return ttnn.from_torch(
-        eh_shuffled.contiguous(),
+        eh_shuffled,
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
         device=device if move_to_device else None,
@@ -990,12 +1171,18 @@ def _to_tt_mtp_eh_proj(eh_proj_torch: torch.Tensor, device, *, move_to_device: b
     )
 
 
+def _mtp_eh_proj_preprocess(raw: dict[str, torch.Tensor], src_key: str, target_name: str) -> dict[str, torch.Tensor]:
+    """Preprocess eh_proj for cache: transpose, pad to DRAM bank alignment, tile-shuffle."""
+    return {target_name: _transform_eh_proj(raw[src_key].T.contiguous())}
+
+
 def prepare_mtp_weights(
     state_dict: dict[str, torch.Tensor],
     device,
     *,
     mtp_layer_idx: int = _MTP_LAYER_IDX,
     move_to_device: bool = False,
+    cache_config: CacheConfig | None = None,
 ) -> DeepSeekV3MTPWeights:
     """Prepare lightweight MTP projection/norm weights from state dict.
 
@@ -1006,14 +1193,47 @@ def prepare_mtp_weights(
     logger.info("Preparing MTP weights (layer {})...", mtp_layer_idx)
     t0 = time.perf_counter()
 
-    h_gamma_w = state_dict[_key(mtp_layer_idx, "hnorm.weight")].unsqueeze(0)
-    h_gamma_tt = _to_tt_lm_head_final_norm(h_gamma_w, device, move_to_device=move_to_device)
+    if cache_config is not None:
+        _h_key = _key(mtp_layer_idx, "hnorm.weight")
+        h_target = _mtp_norm_target("mtp_h_gamma")
+        h_fingerprint = cache_config.context.fingerprint(source=SourceTensorSelection(names=(_h_key,)), target=h_target)
+        h_gamma_tt = cache_config.cache.get_or_create(
+            h_fingerprint,
+            device,
+            preprocess=lambda t: {h_target.name: t[_h_key].unsqueeze(0).contiguous()},
+            raw_tensors=lambda: {_h_key: state_dict[_h_key]},
+        )
 
-    e_gamma_w = state_dict[_key(mtp_layer_idx, "enorm.weight")].unsqueeze(0)
-    e_gamma_tt = _to_tt_lm_head_final_norm(e_gamma_w, device, move_to_device=move_to_device)
+        _e_key = _key(mtp_layer_idx, "enorm.weight")
+        e_target = _mtp_norm_target("mtp_e_gamma")
+        e_fingerprint = cache_config.context.fingerprint(source=SourceTensorSelection(names=(_e_key,)), target=e_target)
+        e_gamma_tt = cache_config.cache.get_or_create(
+            e_fingerprint,
+            device,
+            preprocess=lambda t: {e_target.name: t[_e_key].unsqueeze(0).contiguous()},
+            raw_tensors=lambda: {_e_key: state_dict[_e_key]},
+        )
 
-    eh_proj_w = state_dict[_key(mtp_layer_idx, "eh_proj.weight")].T.contiguous()
-    eh_proj_tt = _to_tt_mtp_eh_proj(eh_proj_w, device, move_to_device=move_to_device)
+        _eh_key = _key(mtp_layer_idx, "eh_proj.weight")
+        eh_target = _mtp_eh_proj_target(K=2 * _LM_HEAD_K, N=_LM_HEAD_K)
+        eh_fingerprint = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=(_eh_key,)), target=eh_target
+        )
+        eh_proj_tt = cache_config.cache.get_or_create(
+            eh_fingerprint,
+            device,
+            preprocess=lambda t: _mtp_eh_proj_preprocess(t, _eh_key, eh_target.name),
+            raw_tensors=lambda: {_eh_key: state_dict[_eh_key]},
+        )
+    else:
+        h_gamma_w = state_dict[_key(mtp_layer_idx, "hnorm.weight")].unsqueeze(0)
+        h_gamma_tt = _to_tt_lm_head_final_norm(h_gamma_w, device, move_to_device=move_to_device)
+
+        e_gamma_w = state_dict[_key(mtp_layer_idx, "enorm.weight")].unsqueeze(0)
+        e_gamma_tt = _to_tt_lm_head_final_norm(e_gamma_w, device, move_to_device=move_to_device)
+
+        eh_proj_w = state_dict[_key(mtp_layer_idx, "eh_proj.weight")].T.contiguous()
+        eh_proj_tt = _to_tt_mtp_eh_proj(eh_proj_w, device, move_to_device=move_to_device)
 
     logger.info("MTP weights prepared in {:.3f}s", time.perf_counter() - t0)
     return DeepSeekV3MTPWeights(

--- a/models/demos/deepseek_v3_b1/tensor_cache/__init__.py
+++ b/models/demos/deepseek_v3_b1/tensor_cache/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Content-addressed tensor cache for preprocessed weight artifacts."""
+
+from dataclasses import dataclass
+
+from models.demos.deepseek_v3_b1.tensor_cache.cache import TensorCache
+from models.demos.deepseek_v3_b1.tensor_cache.types import (
+    ArtifactTarget,
+    CacheContext,
+    Fingerprint,
+    MeshMapperConfig,
+    ReplicateMeshMapper,
+    Shard2dMeshMapper,
+    ShardMeshMapper,
+    SourceTensorSelection,
+    TensorTarget,
+)
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Bundles a TensorCache and its CacheContext for passing to prepare functions."""
+
+    cache: TensorCache
+    context: CacheContext
+
+
+__all__ = [
+    "ArtifactTarget",
+    "CacheConfig",
+    "CacheContext",
+    "Fingerprint",
+    "MeshMapperConfig",
+    "ReplicateMeshMapper",
+    "Shard2dMeshMapper",
+    "ShardMeshMapper",
+    "SourceTensorSelection",
+    "TensorCache",
+    "TensorTarget",
+]

--- a/models/demos/deepseek_v3_b1/tensor_cache/cache.py
+++ b/models/demos/deepseek_v3_b1/tensor_cache/cache.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Content-addressed TensorCache for standalone (non-fused) tensors.
+
+Manages the full lifecycle: fingerprint -> CAS lookup -> on miss: preprocess,
+serialize to NVMe, load to device -> on hit: load from NVMe to device.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Union
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.tensor_cache.fingerprint import canonical, compute_artifact_id
+from models.demos.deepseek_v3_b1.tensor_cache.types import (
+    Fingerprint,
+    ReplicateMeshMapper,
+    Shard2dMeshMapper,
+    ShardMeshMapper,
+    TensorTarget,
+)
+
+
+@dataclass(frozen=True)
+class ContentAddressedStoragePaths:
+    """Filesystem paths for one content-addressed storage object."""
+
+    object_dir: Path
+    data_path: Path
+
+
+@dataclass(frozen=True)
+class AbsentCacheEntry:
+    """CAS lookup result: no object directory exists for this artifact."""
+
+    artifact_id: str
+
+
+@dataclass(frozen=True)
+class PresentCacheEntry:
+    """CAS lookup result: object directory and data file both exist."""
+
+    artifact_id: str
+    paths: ContentAddressedStoragePaths
+
+
+@dataclass(frozen=True)
+class CorruptCacheEntry:
+    """CAS lookup result: object directory exists but data file is missing."""
+
+    artifact_id: str
+    paths: ContentAddressedStoragePaths
+
+
+CacheEntry = Union[AbsentCacheEntry, PresentCacheEntry, CorruptCacheEntry]
+
+
+def _sha256_file(path: Path, chunk_size: int = 1 << 20) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class TensorCache:
+    """Content-addressed cache backed by a local filesystem (NVMe).
+
+    Storage layout::
+
+        {local_root}/
+          objects/{id[:2]}/{id}/
+            manifest.json
+            metadata.json
+            data.tensorbin
+          tmp/
+            {id}_{pid}/
+    """
+
+    def __init__(self, local_root: Path):
+        self.local_root = Path(local_root)
+        self._objects_dir = self.local_root / "objects"
+        self._tmp_dir = self.local_root / "tmp"
+
+    def _content_addressed_paths(self, artifact_id: str) -> ContentAddressedStoragePaths:
+        object_dir = self._objects_dir / artifact_id[:2] / artifact_id
+        return ContentAddressedStoragePaths(object_dir=object_dir, data_path=object_dir / "data.tensorbin")
+
+    def _lookup(self, artifact_id: str) -> CacheEntry:
+        paths = self._content_addressed_paths(artifact_id)
+        if not paths.object_dir.exists():
+            return AbsentCacheEntry(artifact_id=artifact_id)
+        if paths.data_path.is_file():
+            return PresentCacheEntry(artifact_id=artifact_id, paths=paths)
+        return CorruptCacheEntry(artifact_id=artifact_id, paths=paths)
+
+    def _store(
+        self,
+        artifact_id: str,
+        fingerprint: Fingerprint,
+        tensor_host: ttnn.Tensor,
+    ) -> ContentAddressedStoragePaths:
+        tmp = self._tmp_dir / f"{artifact_id}_{os.getpid()}"
+        tmp.mkdir(parents=True, exist_ok=True)
+        try:
+            data_path = tmp / "data.tensorbin"
+            ttnn.dump_tensor(data_path, tensor_host)
+
+            content_hash = _sha256_file(data_path)
+            size_bytes = data_path.stat().st_size
+
+            manifest_dict = {
+                "fingerprint": canonical(fingerprint),
+                "logical_name": fingerprint.target.name if isinstance(fingerprint.target, TensorTarget) else None,
+            }
+            with open(tmp / "manifest.json", "w") as f:
+                json.dump(manifest_dict, f, indent=2, sort_keys=True)
+
+            metadata_dict = {
+                "artifact_id": artifact_id,
+                "content_hash": content_hash,
+                "size_bytes": size_bytes,
+                "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+            with open(tmp / "metadata.json", "w") as f:
+                json.dump(metadata_dict, f, indent=2, sort_keys=True)
+
+            dest = self._content_addressed_paths(artifact_id)
+            dest.object_dir.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.rename(str(tmp), str(dest.object_dir))
+            except OSError:
+                # Another process wrote the same artifact concurrently -- that's fine,
+                # same fingerprint guarantees same content.
+                shutil.rmtree(tmp, ignore_errors=True)
+            return dest
+        except BaseException:
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise
+
+    def _load(self, paths: ContentAddressedStoragePaths, device) -> ttnn.Tensor:
+        return ttnn.load_tensor(paths.data_path, device=device)
+
+    @staticmethod
+    def _build_mesh_mapper(target: TensorTarget, device):
+        """Reconstruct the runtime mesh_mapper from the declarative config + device."""
+        mapper_config = target.mesh_mapper_config
+        if isinstance(mapper_config, ReplicateMeshMapper):
+            return ttnn.ReplicateTensorToMesh(device)
+        if isinstance(mapper_config, ShardMeshMapper):
+            return ttnn.ShardTensorToMesh(device, dim=mapper_config.dim)
+        if isinstance(mapper_config, Shard2dMeshMapper):
+            mesh_shape = (device.shape[0], device.shape[1])
+            return ttnn.ShardTensor2dMesh(device, mesh_shape=mesh_shape, dims=mapper_config.dims)
+        raise TypeError(f"Unknown mesh mapper config type: {type(mapper_config)}")
+
+    def get_or_create(
+        self,
+        fingerprint: Fingerprint,
+        device,
+        *,
+        preprocess: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
+        raw_tensors: Callable[[], dict[str, torch.Tensor]] | dict[str, torch.Tensor],
+    ) -> ttnn.Tensor:
+        """Return a device tensor, loading from cache on hit or building on miss.
+
+        On hit:  load from local NVMe directly to device.
+        On miss: raw_tensors() -> preprocess() -> from_torch(host) -> store -> load to device.
+
+        raw_tensors can be a callable (lazy) so HF safetensors are never read when
+        the cache is warm.
+        """
+        target = fingerprint.target
+        if not isinstance(target, TensorTarget):
+            raise TypeError(f"TensorCache only supports TensorTarget, got {type(target)}")
+
+        artifact_id = compute_artifact_id(fingerprint)
+        entry = self._lookup(artifact_id)
+
+        if isinstance(entry, PresentCacheEntry):
+            logger.debug("Cache hit for {} ({})", target.name, artifact_id[:12])
+            return self._load(entry.paths, device)
+
+        if isinstance(entry, CorruptCacheEntry):
+            logger.warning("Corrupt cache entry for {} ({}), rebuilding", target.name, artifact_id[:12])
+            shutil.rmtree(entry.paths.object_dir, ignore_errors=True)
+
+        logger.info("Cache miss for {} ({}), preprocessing...", target.name, artifact_id[:12])
+        t0 = time.perf_counter()
+
+        tensors = raw_tensors() if callable(raw_tensors) else raw_tensors
+        preprocessed = preprocess(tensors)
+
+        torch_tensor = preprocessed[target.name]
+
+        from_torch_kwargs: dict = {
+            "dtype": target.dtype,
+            "layout": target.layout,
+            "device": None,
+            "memory_config": target.memory_config,
+            "mesh_mapper": self._build_mesh_mapper(target, device),
+        }
+        if target.layout == ttnn.TILE_LAYOUT:
+            from_torch_kwargs["tile"] = ttnn.Tile(target.tile_shape)
+        tensor_host = ttnn.from_torch(torch_tensor, **from_torch_kwargs)
+
+        paths = self._store(artifact_id, fingerprint, tensor_host)
+        elapsed = time.perf_counter() - t0
+        logger.info("Cache miss for {} resolved in {:.3f}s, stored as {}", target.name, elapsed, artifact_id[:12])
+
+        return self._load(paths, device)

--- a/models/demos/deepseek_v3_b1/tensor_cache/fingerprint.py
+++ b/models/demos/deepseek_v3_b1/tensor_cache/fingerprint.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fingerprint canonicalization and artifact ID computation.
+
+Deterministic JSON serialization of a Fingerprint, then SHA-256 hash to produce
+the content-addressed artifact ID.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from models.demos.deepseek_v3_b1.tensor_cache.types import Fingerprint, Shard2dMeshMapper, ShardMeshMapper, TensorTarget
+
+
+def _canonical_mesh_mapper(mapper_config) -> dict:
+    """Serialize a MeshMapperConfig variant to a dict compatible with existing fingerprint hashes."""
+    if isinstance(mapper_config, ShardMeshMapper):
+        return {"strategy": "shard", "dim": mapper_config.dim, "dims": None}
+    if isinstance(mapper_config, Shard2dMeshMapper):
+        return {"strategy": "shard_2d", "dim": None, "dims": list(mapper_config.dims)}
+    return {"strategy": "replicate", "dim": None, "dims": None}
+
+
+def canonical(fingerprint: Fingerprint) -> dict:
+    """Produce a deterministic, JSON-serializable dict from a Fingerprint.
+
+    Only ArtifactTarget variants with kind='tensor' are supported; FusionGroupSpec will be added later.
+    """
+    target = fingerprint.target
+    if not isinstance(target, TensorTarget):
+        raise TypeError(f"Unsupported target type: {type(target)}")
+    target_dict = {
+        "kind": "tensor",
+        "name": target.name,
+        "dtype": target.dtype.name,
+        "layout": target.layout.name,
+        "memory_config": json.loads(target.memory_config.to_json()),
+        "tile_shape": list(target.tile_shape),
+        "mesh_mapper_config": _canonical_mesh_mapper(target.mesh_mapper_config),
+    }
+    return {
+        "schema_version": fingerprint.schema_version,
+        "source": sorted(fingerprint.source.names),
+        "hf_model_id": fingerprint.hf_model_id,
+        "hf_revision": fingerprint.hf_revision,
+        "transform_version": fingerprint.transform_version,
+        "mesh_shape": list(fingerprint.mesh_shape),
+        "target": target_dict,
+    }
+
+
+def compute_artifact_id(fingerprint: Fingerprint) -> str:
+    """SHA-256 hex digest of the canonical JSON representation."""
+    blob = json.dumps(canonical(fingerprint), sort_keys=True).encode()
+    return hashlib.sha256(blob).hexdigest()

--- a/models/demos/deepseek_v3_b1/tensor_cache/types.py
+++ b/models/demos/deepseek_v3_b1/tensor_cache/types.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Content-addressed tensor cache data model.
+
+Frozen dataclasses for fingerprinting and tensor target specifications.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Union
+
+import ttnn
+
+
+@dataclass(frozen=True)
+class SourceTensorSelection:
+    """Which HF state dict tensors feed into this artifact."""
+
+    names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReplicateMeshMapper:
+    """Replicate the tensor on every device in the mesh."""
+
+    strategy: Literal["replicate"] = "replicate"
+
+
+@dataclass(frozen=True)
+class ShardMeshMapper:
+    """Shard the tensor along a single dimension across the mesh."""
+
+    dim: int
+    strategy: Literal["shard"] = "shard"
+
+
+@dataclass(frozen=True)
+class Shard2dMeshMapper:
+    """Shard the tensor along two dimensions across a 2D mesh."""
+
+    dims: tuple[int | None, int | None]
+    strategy: Literal["shard_2d"] = "shard_2d"
+
+
+MeshMapperConfig = Union[ReplicateMeshMapper, ShardMeshMapper, Shard2dMeshMapper]
+
+
+@dataclass(frozen=True)
+class TensorTarget:
+    """Complete specification for a single (non-fused) cached tensor artifact.
+
+    Contains every parameter needed for ttnn.from_torch on the miss path.
+    All fields participate in the fingerprint hash.
+    """
+
+    kind: Literal["tensor"] = "tensor"
+    name: str = ""
+    dtype: ttnn.DataType = ttnn.bfloat16
+    layout: ttnn.Layout = ttnn.TILE_LAYOUT
+    memory_config: ttnn.MemoryConfig = field(default_factory=lambda: ttnn.DRAM_MEMORY_CONFIG)
+    tile_shape: tuple[int, int] = (32, 32)
+    mesh_mapper_config: MeshMapperConfig = field(default_factory=ReplicateMeshMapper)
+
+
+ArtifactTarget = TensorTarget  # Will become TensorTarget | FusionGroupSpec in Phase 2
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    """Cache key. All fields are known before any computation runs."""
+
+    schema_version: int
+    source: SourceTensorSelection
+    hf_model_id: str
+    hf_revision: str
+    transform_version: int
+    mesh_shape: tuple[int, int]
+    target: ArtifactTarget
+
+
+@dataclass(frozen=True)
+class CacheContext:
+    """Bundles the common cache key fields shared across all tensors in a model.
+
+    Prepare functions accept this to avoid repeating hf_model_id, hf_revision, etc.
+    for every standalone tensor they cache.
+    """
+
+    schema_version: int
+    hf_model_id: str
+    hf_revision: str
+    transform_version: int
+    mesh_shape: tuple[int, int]
+
+    def fingerprint(self, *, source: SourceTensorSelection, target: ArtifactTarget) -> Fingerprint:
+        return Fingerprint(
+            schema_version=self.schema_version,
+            source=source,
+            hf_model_id=self.hf_model_id,
+            hf_revision=self.hf_revision,
+            transform_version=self.transform_version,
+            mesh_shape=self.mesh_shape,
+            target=target,
+        )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -23,9 +23,10 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
-from models.demos.deepseek_v3_b1.demo.weight_provider import LogicalModelDimensions
+from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.prepare_weights import (
     _MTP_LAYER_IDX,
+    CURRENT_TRANSFORM_VERSION,
     AttentionWeights,
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3EmbeddingLayerWeights,
@@ -56,6 +57,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     save_routed_expert_weights,
     save_shared_expert_weights,
 )
+from models.demos.deepseek_v3_b1.tensor_cache import CacheConfig, CacheContext, TensorCache
 
 
 def _deallocate_layer(layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights) -> None:
@@ -140,6 +142,16 @@ def _skip_unless_4x2_mesh(bh_2d_mesh_device):
         pytest.skip("Test requires 8 devices (4x2 mesh)")
 
 
+def _test_cache_context(mesh_shape: tuple[int, int] = (4, 2)) -> CacheContext:
+    return CacheContext(
+        schema_version=1,
+        hf_model_id="test-model",
+        hf_revision="test-rev",
+        transform_version=CURRENT_TRANSFORM_VERSION,
+        mesh_shape=mesh_shape,
+    )
+
+
 # Expected placements for 4x2 mesh (mla_tp=2, moe_tp=8)
 _PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]
 _PLACEMENTS_SHARD_NONE_0 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(0)]
@@ -212,10 +224,10 @@ def _assert_layer_on_device_with_topology(
 
 
 # HF state dict shapes (out_features, in_features) for linears; full logical for 4x2 mesh. See DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md §5.
-HF_Q_B_FULL_LOGICAL = (24576, 1536)
-HF_O_PROJ_FULL_LOGICAL = (7168, 16384)
-HF_KV_B_FULL_LOGICAL = (32768, 512)
-HF_SHARED_GATE_UP_FULL_LOGICAL = (2048, 7168)
+HF_Q_B_FULL_LOGICAL = (LogicalModelDimensions.Q_B_OUT, LogicalModelDimensions.Q_A_DIM)
+HF_O_PROJ_FULL_LOGICAL = (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.O_PROJ_OUT)
+HF_KV_B_FULL_LOGICAL = (LogicalModelDimensions.KV_B_PROJ_OUT, LogicalModelDimensions.KV_B_LORA_RANK)
+HF_SHARED_GATE_UP_FULL_LOGICAL = (LogicalModelDimensions.MOE_INTERMEDIATE_SIZE, LogicalModelDimensions.HIDDEN_SIZE)
 
 # Don't use all the experts in tests to avoid taking too long
 NUM_ROUTED_EXPERTS_FOR_TESTS = 4
@@ -239,31 +251,38 @@ def _layer_state_dict(
 
     state = {
         f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(
-            1536, 7168, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.Q_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
         ),
         f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(*q_b_hf, generator=g, dtype=torch.bfloat16),
         f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(
-            576, 7168, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.KV_A_DIM, LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
         ),
         f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(
             *kv_b_hf, generator=g, dtype=torch.bfloat16
         ),
         f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(*o_proj_hf, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(
+            LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
+        ),
         f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(
-            1536, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.Q_A_DIM, generator=g, dtype=torch.bfloat16
         ),
         f"model.layers.{layer_idx}.self_attn.kv_a_layernorm.weight": torch.randn(
-            512, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.KV_B_LORA_RANK, generator=g, dtype=torch.bfloat16
         ),
         f"model.layers.{layer_idx}.post_attention_layernorm.weight": torch.randn(
-            7168, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
         ),
     }
     if is_moe:
-        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(
+            LogicalModelDimensions.GATE_NUM_INDICES,
+            LogicalModelDimensions.HIDDEN_SIZE,
+            generator=g,
+            dtype=torch.bfloat16,
+        )
         state[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = torch.randn(
-            256, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.GATE_NUM_INDICES, generator=g, dtype=torch.bfloat16
         )
         state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(
             *shared_hf, generator=g, dtype=torch.bfloat16
@@ -271,32 +290,50 @@ def _layer_state_dict(
         state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(
             *shared_hf, generator=g, dtype=torch.bfloat16
         )
-        # shared down: HF (7168, 2048*tp) full logical
-        shared_down_rows = 7168
+        # shared down: HF (HIDDEN_SIZE, MOE_INTERMEDIATE_SIZE*tp) full logical
+        shared_down_rows = LogicalModelDimensions.HIDDEN_SIZE
         shared_down_cols = shared_hf[0]  # 2048 for 4x2
         state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = torch.randn(
             shared_down_rows, shared_down_cols, generator=g, dtype=torch.bfloat16
         )
         for e in range(NUM_ROUTED_EXPERTS_FOR_TESTS):
             state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
-                2048, 7168, generator=g, dtype=torch.bfloat16
+                LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+                LogicalModelDimensions.HIDDEN_SIZE,
+                generator=g,
+                dtype=torch.bfloat16,
             )
             state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = torch.randn(
-                2048, 7168, generator=g, dtype=torch.bfloat16
+                LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+                LogicalModelDimensions.HIDDEN_SIZE,
+                generator=g,
+                dtype=torch.bfloat16,
             )
             state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = torch.randn(
-                7168, 2048, generator=g, dtype=torch.bfloat16
+                LogicalModelDimensions.HIDDEN_SIZE,
+                LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+                generator=g,
+                dtype=torch.bfloat16,
             )
     else:
-        # Dense MLP: HF (out, in) gate/up (18432, 7168), down (7168, 18432)
+        # Dense MLP: HF (out, in) gate/up (INTERMEDIATE_SIZE, HIDDEN_SIZE), down (HIDDEN_SIZE, INTERMEDIATE_SIZE)
         state[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = torch.randn(
-            18432, 7168, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.INTERMEDIATE_SIZE,
+            LogicalModelDimensions.HIDDEN_SIZE,
+            generator=g,
+            dtype=torch.bfloat16,
         )
         state[f"model.layers.{layer_idx}.mlp.up_proj.weight"] = torch.randn(
-            18432, 7168, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.INTERMEDIATE_SIZE,
+            LogicalModelDimensions.HIDDEN_SIZE,
+            generator=g,
+            dtype=torch.bfloat16,
         )
         state[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = torch.randn(
-            7168, 18432, generator=g, dtype=torch.bfloat16
+            LogicalModelDimensions.HIDDEN_SIZE,
+            LogicalModelDimensions.INTERMEDIATE_SIZE,
+            generator=g,
+            dtype=torch.bfloat16,
         )
     return state
 
@@ -304,9 +341,13 @@ def _layer_state_dict(
 def _add_global_weights(state: dict[str, torch.Tensor], seed: int = 42) -> None:
     """Add embedding, final norm, and lm_head to state (in place)."""
     g = torch.Generator().manual_seed(seed)
-    state["model.embed_tokens.weight"] = torch.randn(129280, 7168, generator=g, dtype=torch.bfloat16)
-    state["model.norm.weight"] = torch.randn(7168, generator=g, dtype=torch.bfloat16)
-    state["lm_head.weight"] = torch.randn(129280, 7168, generator=g, dtype=torch.bfloat16)
+    state["model.embed_tokens.weight"] = torch.randn(
+        LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
+    )
+    state["model.norm.weight"] = torch.randn(LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16)
+    state["lm_head.weight"] = torch.randn(
+        LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE, generator=g, dtype=torch.bfloat16
+    )
 
 
 @pytest.mark.parametrize(
@@ -323,12 +364,12 @@ def test_prepare_attention_weights_dense_4x2(bh_2d_mesh_device):
     attn = prepare_attention_weights(bdw, state, 0, is_moe=False)
     assert attn.gate_mm is None
     assert attn.q_a_proj.tensor_shape == (3584, 3072)
-    assert attn.q_b_proj.tensor_shape == (1536, 12288)
-    assert attn.kv_a_proj.tensor_shape == (7168, 576)
-    assert attn.o_proj.tensor_shape == (8192, 7168)
-    assert attn.attn_norm.tensor_shape == (1, 7168)
-    assert attn.kv_b1_proj.tensor_shape == (8192, 512)
-    assert attn.kv_b2_proj.tensor_shape == (512, 8192)
+    assert attn.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert attn.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert attn.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert attn.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert attn.kv_b1_proj.tensor_shape == (8192, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert attn.kv_b2_proj.tensor_shape == (LogicalModelDimensions.KV_B_LORA_RANK, 8192)
 
 
 @pytest.mark.parametrize(
@@ -344,11 +385,11 @@ def test_prepare_attention_weights_moe_4x2(bh_2d_mesh_device):
     bdw = BlitzDecodeWeights(submesh)
     attn = prepare_attention_weights(bdw, state, 0, is_moe=True)
     assert attn.gate_mm is not None
-    assert attn.gate_mm.tensor_shape == (7168, 256)
+    assert attn.gate_mm.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.GATE_NUM_INDICES)
     assert attn.gate_bias is not None
     assert attn.gate_bias.shape == (16, 16)
     assert attn.q_a_proj.tensor_shape == (3584, 3072)
-    assert attn.o_proj.tensor_shape == (8192, 7168)
+    assert attn.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
 
 
 @pytest.mark.parametrize(
@@ -380,8 +421,14 @@ def test_prepare_shared_expert_weights_moe_4x2(bh_2d_mesh_device):
     state = _layer_state_dict(0, is_moe=True, seed=43)
     bdw = BlitzDecodeWeights(submesh)
     shared = prepare_shared_expert_weights(bdw, state, 0, is_moe=True)
-    assert shared.shared_gate_proj.tensor_shape == (7168, 256)
-    assert shared.shared_up_proj.tensor_shape == (7168, 256)
+    assert shared.shared_gate_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
+    assert shared.shared_up_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
     assert shared.shared_down_proj.shape is not None
 
 
@@ -548,10 +595,28 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
 def _moe_routed_expert_stacked_tensors(seed: int = 43):
     """Build (num_experts, K, N) stacked gate/up and (num_experts, K_down, N_down) down for get_tt_moe_routed_expert_weights."""
     g = torch.Generator().manual_seed(seed)
-    # MoE expert shapes: gate/up (K=7168, N=2048), down (2048, 7168)
-    gate_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
-    up_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
-    down_stacked = torch.randn(NUM_ROUTED_EXPERTS_FOR_TESTS, 2048, 7168, generator=g, dtype=torch.bfloat16)
+    # MoE expert shapes: gate/up (K=HIDDEN_SIZE, N=MOE_INTERMEDIATE_SIZE), down (MOE_INTERMEDIATE_SIZE, HIDDEN_SIZE)
+    gate_stacked = torch.randn(
+        NUM_ROUTED_EXPERTS_FOR_TESTS,
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+        generator=g,
+        dtype=torch.bfloat16,
+    )
+    up_stacked = torch.randn(
+        NUM_ROUTED_EXPERTS_FOR_TESTS,
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+        generator=g,
+        dtype=torch.bfloat16,
+    )
+    down_stacked = torch.randn(
+        NUM_ROUTED_EXPERTS_FOR_TESTS,
+        LogicalModelDimensions.MOE_INTERMEDIATE_SIZE,
+        LogicalModelDimensions.HIDDEN_SIZE,
+        generator=g,
+        dtype=torch.bfloat16,
+    )
     return gate_stacked, up_stacked, down_stacked
 
 
@@ -651,15 +716,15 @@ def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
     logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.q_norm.tensor_shape == (1, 1536)
-    assert layer.kv_norm.tensor_shape == (1, 512)
-    assert layer.ffn_norm.tensor_shape == (1, 7168)
-    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
-    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert layer.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert layer.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.q_norm.tensor_shape == (1, LogicalModelDimensions.Q_A_DIM)
+    assert layer.kv_norm.tensor_shape == (1, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert layer.ffn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.kv_b1_proj.tensor_shape == (8192, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert layer.kv_b2_proj.tensor_shape == (LogicalModelDimensions.KV_B_LORA_RANK, 8192)
     assert hasattr(layer, "shared_gate_proj") and layer.shared_gate_proj is not None
     assert hasattr(layer, "shared_up_proj") and layer.shared_up_proj is not None
     assert hasattr(layer, "routed_gate_proj") and layer.routed_gate_proj is not None
@@ -687,15 +752,15 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3DenseLayerWeights)
     assert orig.q_a_proj.tensor_shape == (3584, 3072)
-    assert orig.q_b_proj.tensor_shape == (1536, 12288)
-    assert orig.kv_a_proj.tensor_shape == (7168, 576)
-    assert orig.o_proj.tensor_shape == (8192, 7168)
-    assert orig.attn_norm.tensor_shape == (1, 7168)
-    assert orig.q_norm.tensor_shape == (1, 1536)
-    assert orig.kv_norm.tensor_shape == (1, 512)
-    assert orig.ffn_norm.tensor_shape == (1, 7168)
-    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
-    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
+    assert orig.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert orig.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert orig.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.q_norm.tensor_shape == (1, LogicalModelDimensions.Q_A_DIM)
+    assert orig.kv_norm.tensor_shape == (1, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert orig.ffn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.kv_b1_proj.tensor_shape == (8192, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert orig.kv_b2_proj.tensor_shape == (LogicalModelDimensions.KV_B_LORA_RANK, 8192)
     assert hasattr(orig, "shared_gate_proj") and orig.shared_gate_proj is not None
     assert hasattr(orig, "shared_up_proj") and orig.shared_up_proj is not None
     assert hasattr(orig, "routed_gate_proj") and orig.routed_gate_proj is not None
@@ -776,19 +841,25 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert layer.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert layer.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.gate_mm.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.GATE_NUM_INDICES)
     assert layer.gate_bias.shape == (16, 16)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.q_norm.tensor_shape == (1, 1536)
-    assert layer.kv_norm.tensor_shape == (1, 512)
-    assert layer.ffn_norm.tensor_shape == (1, 7168)
-    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
-    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
-    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
-    assert layer.shared_up_proj.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.q_norm.tensor_shape == (1, LogicalModelDimensions.Q_A_DIM)
+    assert layer.kv_norm.tensor_shape == (1, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert layer.ffn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.kv_b1_proj.tensor_shape == (8192, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert layer.kv_b2_proj.tensor_shape == (LogicalModelDimensions.KV_B_LORA_RANK, 8192)
+    assert layer.shared_gate_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
+    assert layer.shared_up_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
     assert hasattr(layer, "shared_down_proj")
     assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
@@ -815,19 +886,25 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
     assert orig.q_a_proj.tensor_shape == (3584, 3072)
-    assert orig.q_b_proj.tensor_shape == (1536, 12288)
-    assert orig.kv_a_proj.tensor_shape == (7168, 576)
-    assert orig.o_proj.tensor_shape == (8192, 7168)
-    assert orig.gate_mm.tensor_shape == (7168, 256)
+    assert orig.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert orig.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert orig.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.gate_mm.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.GATE_NUM_INDICES)
     assert orig.gate_bias.shape == (16, 16)
-    assert orig.attn_norm.tensor_shape == (1, 7168)
-    assert orig.q_norm.tensor_shape == (1, 1536)
-    assert orig.kv_norm.tensor_shape == (1, 512)
-    assert orig.ffn_norm.tensor_shape == (1, 7168)
-    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
-    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
-    assert orig.shared_gate_proj.tensor_shape == (7168, 256)
-    assert orig.shared_up_proj.tensor_shape == (7168, 256)
+    assert orig.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.q_norm.tensor_shape == (1, LogicalModelDimensions.Q_A_DIM)
+    assert orig.kv_norm.tensor_shape == (1, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert orig.ffn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert orig.kv_b1_proj.tensor_shape == (8192, LogicalModelDimensions.KV_B_LORA_RANK)
+    assert orig.kv_b2_proj.tensor_shape == (LogicalModelDimensions.KV_B_LORA_RANK, 8192)
+    assert orig.shared_gate_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
+    assert orig.shared_up_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
     assert hasattr(orig, "shared_down_proj")
     assert len(orig.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     assert len(orig.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
@@ -921,14 +998,20 @@ def test_load_moe_decoder_layer_4x2(bh_2d_mesh_device, tmp_path):
     layer = load_moe_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer.q_b_proj.tensor_shape == (1536, 12288)
-    assert layer.kv_a_proj.tensor_shape == (7168, 576)
-    assert layer.o_proj.tensor_shape == (8192, 7168)
-    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.q_b_proj.tensor_shape == (LogicalModelDimensions.Q_A_DIM, 12288)
+    assert layer.kv_a_proj.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.KV_A_DIM)
+    assert layer.o_proj.tensor_shape == (8192, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.gate_mm.tensor_shape == (LogicalModelDimensions.HIDDEN_SIZE, LogicalModelDimensions.GATE_NUM_INDICES)
     assert layer.gate_bias.shape == (16, 16)
-    assert layer.attn_norm.tensor_shape == (1, 7168)
-    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
-    assert layer.shared_up_proj.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert layer.shared_gate_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
+    assert layer.shared_up_proj.tensor_shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        LogicalModelDimensions.GATE_NUM_INDICES,
+    )
     assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
     assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS_FOR_TESTS
@@ -954,9 +1037,9 @@ def test_prepare_embedding_weights_4x2(bh_2d_mesh_device):
     assert isinstance(weights, DeepSeekV3EmbeddingLayerWeights)
     assert weights.embedding.shape is not None
     assert weights.embedding.shape == (
-        129280,
-        7168,
-    ), f"Expected embedding shape (129280, 7168), got {weights.embedding.shape}"
+        LogicalModelDimensions.VOCAB_SIZE,
+        LogicalModelDimensions.HIDDEN_SIZE,
+    ), f"Expected embedding shape ({LogicalModelDimensions.VOCAB_SIZE}, {LogicalModelDimensions.HIDDEN_SIZE}), got {weights.embedding.shape}"
 
 
 @pytest.mark.parametrize(
@@ -973,9 +1056,15 @@ def test_prepare_lm_head_weights_4x2(bh_2d_mesh_device):
     weights = prepare_lm_head_weights(state, submesh)
     assert isinstance(weights, DeepSeekV3LMHeadWeights)
     assert weights.lm_head.shape is not None
-    assert weights.lm_head.shape == (7168, 16160), f"Expected lm_head shape (7168, 16160), got {weights.lm_head.shape}"
+    assert weights.lm_head.shape == (
+        LogicalModelDimensions.HIDDEN_SIZE,
+        16160,
+    ), f"Expected lm_head shape ({LogicalModelDimensions.HIDDEN_SIZE}, 16160), got {weights.lm_head.shape}"
     assert weights.final_norm.shape is not None
-    assert weights.final_norm.shape == (1, 7168), f"Expected final_norm shape (1, 7168), got {weights.final_norm.shape}"
+    assert weights.final_norm.shape == (
+        1,
+        LogicalModelDimensions.HIDDEN_SIZE,
+    ), f"Expected final_norm shape (1, {LogicalModelDimensions.HIDDEN_SIZE}), got {weights.final_norm.shape}"
 
 
 @pytest.mark.parametrize(
@@ -1104,3 +1193,154 @@ def test_save_load_mtp_weights_4x2(bh_2d_mesh_device, tmp_path):
     _assert_on_device(loaded.h_gamma)
     _assert_on_device(loaded.e_gamma)
     _assert_on_device(loaded.eh_projection)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_embedding_weights_with_cache_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare embedding weights via TensorCache on 4x2 mesh: cold miss then warm hit."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    cache_config = CacheConfig(cache=TensorCache(tmp_path), context=_test_cache_context())
+
+    state = {}
+    _add_global_weights(state)
+
+    weights = prepare_embedding_weights(state, submesh, cache_config=cache_config)
+    assert isinstance(weights, DeepSeekV3EmbeddingLayerWeights)
+    expected_shape = (LogicalModelDimensions.VOCAB_SIZE, LogicalModelDimensions.HIDDEN_SIZE)
+    assert weights.embedding.shape == expected_shape, f"Expected {expected_shape}, got {weights.embedding.shape}"
+
+    ttnn.deallocate(weights.embedding, force=True)
+
+    weights_hit = prepare_embedding_weights(state, submesh, cache_config=cache_config)
+    assert weights_hit.embedding.shape == expected_shape
+
+    objects_dir = cache_config.cache.local_root / "objects"
+    assert objects_dir.exists()
+    artifact_dirs = list(objects_dir.rglob("data.tensorbin"))
+    assert len(artifact_dirs) >= 1, f"Expected at least 1 cached artifact, found {len(artifact_dirs)}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_lm_head_weights_with_cache_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare LM head + final norm via TensorCache on 4x2 mesh: cold miss then warm hit."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    cache_config = CacheConfig(cache=TensorCache(tmp_path), context=_test_cache_context())
+
+    state = {}
+    _add_global_weights(state)
+
+    weights = prepare_lm_head_weights(state, submesh, cache_config=cache_config)
+    assert isinstance(weights, DeepSeekV3LMHeadWeights)
+    expected_lm = (LogicalModelDimensions.HIDDEN_SIZE, 16160)
+    expected_norm = (1, LogicalModelDimensions.HIDDEN_SIZE)
+    assert weights.lm_head.shape == expected_lm, f"Expected lm_head {expected_lm}, got {weights.lm_head.shape}"
+    assert (
+        weights.final_norm.shape == expected_norm
+    ), f"Expected final_norm {expected_norm}, got {weights.final_norm.shape}"
+
+    ttnn.deallocate(weights.lm_head, force=True)
+    ttnn.deallocate(weights.final_norm, force=True)
+
+    weights_hit = prepare_lm_head_weights(state, submesh, cache_config=cache_config)
+    assert weights_hit.lm_head.shape == expected_lm
+    assert weights_hit.final_norm.shape == expected_norm
+
+    objects_dir = cache_config.cache.local_root / "objects"
+    artifact_dirs = list(objects_dir.rglob("data.tensorbin"))
+    assert len(artifact_dirs) >= 2, f"Expected at least 2 cached artifacts (lm_head + norm), found {len(artifact_dirs)}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_moe_layer_weights_with_cache_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare MoE layer via TensorCache on 4x2 mesh: verifies gate_bias caching (cold miss then warm hit)."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    cache_config = CacheConfig(cache=TensorCache(tmp_path), context=_test_cache_context())
+
+    layer_idx = 3
+    state = _layer_state_dict(layer_idx, is_moe=True)
+    bdw = BlitzDecodeWeights(submesh)
+
+    weights = prepare_moe_layer_weights(
+        bdw,
+        state,
+        layer_idx,
+        num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS,
+        cache_config=cache_config,
+    )
+    assert isinstance(weights, DeepSeekV3MoELayerWeights)
+    expected_gate_bias = (16, 16)
+    assert (
+        weights.gate_bias.shape == expected_gate_bias
+    ), f"Expected gate_bias {expected_gate_bias}, got {weights.gate_bias.shape}"
+
+    _deallocate_layer(weights)
+
+    weights_hit = prepare_moe_layer_weights(
+        bdw,
+        state,
+        layer_idx,
+        num_routed_experts=NUM_ROUTED_EXPERTS_FOR_TESTS,
+        cache_config=cache_config,
+    )
+    assert weights_hit.gate_bias.shape == expected_gate_bias
+
+    objects_dir = cache_config.cache.local_root / "objects"
+    artifact_dirs = list(objects_dir.rglob("data.tensorbin"))
+    assert len(artifact_dirs) >= 1, f"Expected at least 1 cached artifact (gate_bias), found {len(artifact_dirs)}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_mtp_weights_with_cache_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare MTP weights via TensorCache on 4x2 mesh: cold miss then warm hit for h/e gamma, eh_proj."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    cache_config = CacheConfig(cache=TensorCache(tmp_path), context=_test_cache_context())
+
+    state = _mtp_state_dict()
+    H = LogicalModelDimensions.HIDDEN_SIZE
+
+    weights = prepare_mtp_weights(state, submesh, cache_config=cache_config)
+    assert isinstance(weights, DeepSeekV3MTPWeights)
+    assert weights.h_gamma.shape == (1, H)
+    assert weights.e_gamma.shape == (1, H)
+    assert weights.eh_projection.shape == (2 * H, H)
+
+    expected_shapes = {
+        "h_gamma": weights.h_gamma.shape,
+        "e_gamma": weights.e_gamma.shape,
+        "eh_projection": weights.eh_projection.shape,
+    }
+
+    ttnn.deallocate(weights.h_gamma, force=True)
+    ttnn.deallocate(weights.e_gamma, force=True)
+    ttnn.deallocate(weights.eh_projection, force=True)
+
+    weights_hit = prepare_mtp_weights(state, submesh, cache_config=cache_config)
+    assert weights_hit.h_gamma.shape == expected_shapes["h_gamma"]
+    assert weights_hit.e_gamma.shape == expected_shapes["e_gamma"]
+    assert weights_hit.eh_projection.shape == expected_shapes["eh_projection"]
+
+    objects_dir = cache_config.cache.local_root / "objects"
+    artifact_dirs = list(objects_dir.rglob("data.tensorbin"))
+    assert (
+        len(artifact_dirs) >= 3
+    ), f"Expected at least 3 cached artifacts (h/e gamma, eh_proj), found {len(artifact_dirs)}"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_tensor_cache.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_tensor_cache.py
@@ -1,0 +1,547 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the content-addressed TensorCache (standalone tensors).
+
+- Fingerprint determinism and sensitivity (no device needed).
+- CAS directory layout after store.
+- Cache round-trip: miss -> store -> hit -> load.
+- Content hash verification.
+- Corrupt entry recovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.tensor_cache.cache import (
+    AbsentCacheEntry,
+    CorruptCacheEntry,
+    PresentCacheEntry,
+    TensorCache,
+)
+from models.demos.deepseek_v3_b1.tensor_cache.fingerprint import canonical, compute_artifact_id
+from models.demos.deepseek_v3_b1.tensor_cache.types import (
+    CacheContext,
+    Fingerprint,
+    ReplicateMeshMapper,
+    Shard2dMeshMapper,
+    ShardMeshMapper,
+    SourceTensorSelection,
+    TensorTarget,
+)
+
+
+def _make_fingerprint(**overrides) -> Fingerprint:
+    """Build a Fingerprint with sensible defaults; override any field via kwargs."""
+    defaults = dict(
+        schema_version=1,
+        source=SourceTensorSelection(names=("weight_a", "weight_b")),
+        hf_model_id="deepseek-ai/DeepSeek-V3",
+        hf_revision="d1a891dd58e6bb0a671bfc6f3046e29e3478e924",
+        transform_version=4,
+        mesh_shape=(4, 2),
+        target=TensorTarget(
+            name="test_tensor",
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile_shape=(32, 32),
+        ),
+    )
+    defaults.update(overrides)
+    return Fingerprint(**defaults)
+
+
+class TestFingerprint:
+    def test_determinism(self):
+        """Same inputs produce the same artifact_id across calls."""
+        fingerprint1 = _make_fingerprint()
+        fingerprint2 = _make_fingerprint()
+        assert compute_artifact_id(fingerprint1) == compute_artifact_id(fingerprint2)
+
+    def test_canonical_is_dict(self):
+        fingerprint = _make_fingerprint()
+        c = canonical(fingerprint)
+        assert isinstance(c, dict)
+        assert c["schema_version"] == 1
+        assert c["source"] == ["weight_a", "weight_b"]
+        assert c["target"]["kind"] == "tensor"
+        assert c["target"]["tile_shape"] == [32, 32]
+        assert c["target"]["mesh_mapper_config"] == {"strategy": "replicate", "dim": None, "dims": None}
+
+    def test_canonical_source_sorted(self):
+        """Source names are sorted in canonical form regardless of input order."""
+        fingerprint = _make_fingerprint(source=SourceTensorSelection(names=("z_weight", "a_weight")))
+        c = canonical(fingerprint)
+        assert c["source"] == ["a_weight", "z_weight"]
+
+    def test_sensitivity_source(self):
+        fingerprint1 = _make_fingerprint(source=SourceTensorSelection(names=("a",)))
+        fingerprint2 = _make_fingerprint(source=SourceTensorSelection(names=("b",)))
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_transform_version(self):
+        fingerprint1 = _make_fingerprint(transform_version=1)
+        fingerprint2 = _make_fingerprint(transform_version=2)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_mesh_shape(self):
+        fingerprint1 = _make_fingerprint(mesh_shape=(4, 2))
+        fingerprint2 = _make_fingerprint(mesh_shape=(8, 4))
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_dtype(self):
+        t1 = TensorTarget(name="t", dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        t2 = TensorTarget(name="t", dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
+        fingerprint1 = _make_fingerprint(target=t1)
+        fingerprint2 = _make_fingerprint(target=t2)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_tile_shape(self):
+        t1 = TensorTarget(name="t", tile_shape=(32, 32))
+        t2 = TensorTarget(name="t", tile_shape=(16, 16))
+        fingerprint1 = _make_fingerprint(target=t1)
+        fingerprint2 = _make_fingerprint(target=t2)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_hf_revision(self):
+        fingerprint1 = _make_fingerprint(hf_revision="aaa")
+        fingerprint2 = _make_fingerprint(hf_revision="bbb")
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_schema_version(self):
+        fingerprint1 = _make_fingerprint(schema_version=1)
+        fingerprint2 = _make_fingerprint(schema_version=2)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_name(self):
+        t1 = TensorTarget(name="gate_bias")
+        t2 = TensorTarget(name="shared_down_proj")
+        fingerprint1 = _make_fingerprint(target=t1)
+        fingerprint2 = _make_fingerprint(target=t2)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_sensitivity_mesh_mapper_config(self):
+        t1 = TensorTarget(name="t", mesh_mapper_config=ReplicateMeshMapper())
+        t2 = TensorTarget(name="t", mesh_mapper_config=ShardMeshMapper(dim=1))
+        t3 = TensorTarget(name="t", mesh_mapper_config=Shard2dMeshMapper(dims=(0, 1)))
+        t4 = TensorTarget(name="t", mesh_mapper_config=Shard2dMeshMapper(dims=(None, 1)))
+        fingerprint1 = _make_fingerprint(target=t1)
+        fingerprint2 = _make_fingerprint(target=t2)
+        fingerprint3 = _make_fingerprint(target=t3)
+        fingerprint4 = _make_fingerprint(target=t4)
+        ids = {
+            compute_artifact_id(fingerprint1),
+            compute_artifact_id(fingerprint2),
+            compute_artifact_id(fingerprint3),
+            compute_artifact_id(fingerprint4),
+        }
+        assert len(ids) == 4
+
+    def test_canonical_includes_mesh_mapper_config(self):
+        t = TensorTarget(name="t", mesh_mapper_config=ShardMeshMapper(dim=1))
+        fingerprint = _make_fingerprint(target=t)
+        c = canonical(fingerprint)
+        assert c["target"]["mesh_mapper_config"] == {"strategy": "shard", "dim": 1, "dims": None}
+
+    def test_canonical_mesh_mapper_config_shard_2d(self):
+        t = TensorTarget(name="t", mesh_mapper_config=Shard2dMeshMapper(dims=(0, 1)))
+        fingerprint = _make_fingerprint(target=t)
+        c = canonical(fingerprint)
+        assert c["target"]["mesh_mapper_config"] == {"strategy": "shard_2d", "dim": None, "dims": [0, 1]}
+
+    def test_canonical_mesh_mapper_config_shard_2d_with_none_dim(self):
+        t = TensorTarget(name="t", mesh_mapper_config=Shard2dMeshMapper(dims=(None, 1)))
+        fingerprint = _make_fingerprint(target=t)
+        c = canonical(fingerprint)
+        assert c["target"]["mesh_mapper_config"] == {"strategy": "shard_2d", "dim": None, "dims": [None, 1]}
+
+    def test_artifact_id_is_hex_sha256(self):
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+        assert len(artifact_id) == 64
+        int(artifact_id, 16)  # valid hex
+
+
+class TestCasLayout:
+    def test_store_creates_expected_files(self, tmp_path):
+        """After _store, the object dir contains data.tensorbin, manifest.json, metadata.json."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        paths = cache._store(artifact_id, fingerprint, tensor_host)
+
+        assert paths.object_dir.is_dir()
+        assert paths.data_path.is_file()
+        assert (paths.object_dir / "manifest.json").is_file()
+        assert (paths.object_dir / "metadata.json").is_file()
+
+    def test_store_directory_structure(self, tmp_path):
+        """Object is stored under objects/{id[:2]}/{id}/."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        cache._store(artifact_id, fingerprint, tensor_host)
+
+        expected_dir = tmp_path / "objects" / artifact_id[:2] / artifact_id
+        assert expected_dir.is_dir()
+
+    def test_tmp_empty_after_store(self, tmp_path):
+        """The tmp/ directory should be empty after a successful store."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        cache._store(artifact_id, fingerprint, tensor_host)
+
+        tmp_dir = tmp_path / "tmp"
+        if tmp_dir.exists():
+            assert list(tmp_dir.iterdir()) == []
+
+    def test_content_hash_matches(self, tmp_path):
+        """metadata.json content_hash matches SHA-256 of data.tensorbin."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        paths = cache._store(artifact_id, fingerprint, tensor_host)
+
+        with open(paths.object_dir / "metadata.json") as f:
+            meta = json.load(f)
+        stored_hash = meta["content_hash"]
+
+        h = hashlib.sha256()
+        with open(paths.data_path, "rb") as f:
+            while True:
+                chunk = f.read(1 << 20)
+                if not chunk:
+                    break
+                h.update(chunk)
+        assert stored_hash == h.hexdigest()
+
+    def test_manifest_contains_fingerprint(self, tmp_path):
+        """manifest.json contains the canonical fingerprint."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        paths = cache._store(artifact_id, fingerprint, tensor_host)
+
+        with open(paths.object_dir / "manifest.json") as f:
+            manifest = json.load(f)
+        assert manifest["fingerprint"] == canonical(fingerprint)
+        assert manifest["logical_name"] == "test_tensor"
+
+
+class TestLookup:
+    def test_absent(self, tmp_path):
+        cache = TensorCache(tmp_path)
+        entry = cache._lookup("deadbeef" * 8)
+        assert isinstance(entry, AbsentCacheEntry)
+
+    def test_present_after_store(self, tmp_path):
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        cache._store(artifact_id, fingerprint, tensor_host)
+        entry = cache._lookup(artifact_id)
+        assert isinstance(entry, PresentCacheEntry)
+
+    def test_corrupt_when_data_missing(self, tmp_path):
+        """If the object dir exists but data.tensorbin is missing, entry is corrupt."""
+        cache = TensorCache(tmp_path)
+        fingerprint = _make_fingerprint()
+        artifact_id = compute_artifact_id(fingerprint)
+
+        tensor_host = ttnn.from_torch(
+            torch.randn(4, 4, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            tile=ttnn.Tile((32, 32)),
+        )
+        paths = cache._store(artifact_id, fingerprint, tensor_host)
+        paths.data_path.unlink()
+
+        entry = cache._lookup(artifact_id)
+        assert isinstance(entry, CorruptCacheEntry)
+
+
+class TestGetOrCreate:
+    @pytest.fixture()
+    def cache_dir(self, tmp_path):
+        return tmp_path / "tensor_cache"
+
+    def test_miss_then_hit(self, cache_dir, device):
+        """First call is a miss (preprocess called), second is a hit (preprocess not called)."""
+        cache = TensorCache(cache_dir)
+
+        raw_data = torch.randn(16, 16, dtype=torch.bfloat16)
+        preprocess_call_count = [0]
+
+        def preprocess(tensors):
+            preprocess_call_count[0] += 1
+            return {"gate_bias": tensors["raw"].reshape(16, 16).T.contiguous()}
+
+        fingerprint = _make_fingerprint(
+            source=SourceTensorSelection(names=("mlp.gate.e_score_correction_bias",)),
+            target=TensorTarget(
+                name="gate_bias",
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                tile_shape=(32, 32),
+            ),
+        )
+
+        result1 = cache.get_or_create(
+            fingerprint,
+            device,
+            preprocess=preprocess,
+            raw_tensors=lambda: {"raw": raw_data},
+        )
+        assert preprocess_call_count[0] == 1
+        assert isinstance(result1, ttnn.Tensor)
+
+        result2 = cache.get_or_create(
+            fingerprint,
+            device,
+            preprocess=preprocess,
+            raw_tensors=lambda: {"raw": raw_data},
+        )
+        assert preprocess_call_count[0] == 1  # preprocess NOT called again
+
+        ttnn.deallocate(result1, force=True)
+        ttnn.deallocate(result2, force=True)
+
+    def test_raw_tensors_not_called_on_hit(self, cache_dir, device):
+        """raw_tensors callable should not be invoked on a cache hit."""
+        cache = TensorCache(cache_dir)
+        raw_data = torch.randn(16, 16, dtype=torch.bfloat16)
+
+        fingerprint = _make_fingerprint(
+            source=SourceTensorSelection(names=("w",)),
+            target=TensorTarget(name="t", dtype=ttnn.bfloat16, tile_shape=(32, 32)),
+        )
+
+        result1 = cache.get_or_create(
+            fingerprint, device, preprocess=lambda d: {"t": d["w"]}, raw_tensors=lambda: {"w": raw_data}
+        )
+
+        raw_called = [False]
+
+        def raw_tensors_spy():
+            raw_called[0] = True
+            return {"w": raw_data}
+
+        result2 = cache.get_or_create(
+            fingerprint, device, preprocess=lambda d: {"t": d["w"]}, raw_tensors=raw_tensors_spy
+        )
+        assert not raw_called[0]
+
+        ttnn.deallocate(result1, force=True)
+        ttnn.deallocate(result2, force=True)
+
+    def test_corrupt_recovery(self, cache_dir, device):
+        """Deleting data.tensorbin should cause a transparent rebuild on next access."""
+        cache = TensorCache(cache_dir)
+        raw_data = torch.randn(16, 16, dtype=torch.bfloat16)
+
+        fingerprint = _make_fingerprint(
+            source=SourceTensorSelection(names=("w",)),
+            target=TensorTarget(name="t", dtype=ttnn.bfloat16, tile_shape=(32, 32)),
+        )
+
+        result1 = cache.get_or_create(
+            fingerprint, device, preprocess=lambda d: {"t": d["w"]}, raw_tensors=lambda: {"w": raw_data}
+        )
+        ttnn.deallocate(result1, force=True)
+
+        artifact_id = compute_artifact_id(fingerprint)
+        data_path = cache._content_addressed_paths(artifact_id).data_path
+        assert data_path.is_file()
+        data_path.unlink()
+
+        preprocess_calls = [0]
+
+        def counting_preprocess(d):
+            preprocess_calls[0] += 1
+            return {"t": d["w"]}
+
+        result2 = cache.get_or_create(
+            fingerprint, device, preprocess=counting_preprocess, raw_tensors=lambda: {"w": raw_data}
+        )
+        assert preprocess_calls[0] == 1
+        assert isinstance(result2, ttnn.Tensor)
+        ttnn.deallocate(result2, force=True)
+
+    def test_different_fingerprints_different_artifacts(self, cache_dir, device):
+        """Two different fingerprints produce two separate cache entries."""
+        cache = TensorCache(cache_dir)
+
+        fingerprint1 = _make_fingerprint(
+            source=SourceTensorSelection(names=("a",)),
+            target=TensorTarget(name="t", dtype=ttnn.bfloat16, tile_shape=(32, 32)),
+        )
+        fingerprint2 = _make_fingerprint(
+            source=SourceTensorSelection(names=("b",)),
+            target=TensorTarget(name="t", dtype=ttnn.bfloat16, tile_shape=(32, 32)),
+        )
+
+        data = torch.randn(16, 16, dtype=torch.bfloat16)
+        identity = lambda d: {"t": d["w"]}
+        raw = lambda: {"w": data}
+
+        r1 = cache.get_or_create(fingerprint1, device, preprocess=identity, raw_tensors=raw)
+        r2 = cache.get_or_create(fingerprint2, device, preprocess=identity, raw_tensors=raw)
+
+        artifact_id_1 = compute_artifact_id(fingerprint1)
+        artifact_id_2 = compute_artifact_id(fingerprint2)
+        assert artifact_id_1 != artifact_id_2
+        assert isinstance(cache._lookup(artifact_id_1), PresentCacheEntry)
+        assert isinstance(cache._lookup(artifact_id_2), PresentCacheEntry)
+
+        ttnn.deallocate(r1, force=True)
+        ttnn.deallocate(r2, force=True)
+
+    def test_dict_raw_tensors(self, cache_dir, device):
+        """raw_tensors can be a plain dict instead of a callable."""
+        cache = TensorCache(cache_dir)
+
+        fingerprint = _make_fingerprint(
+            source=SourceTensorSelection(names=("w",)),
+            target=TensorTarget(name="t", dtype=ttnn.bfloat16, tile_shape=(32, 32)),
+        )
+        data = torch.randn(16, 16, dtype=torch.bfloat16)
+
+        result = cache.get_or_create(fingerprint, device, preprocess=lambda d: {"t": d["w"]}, raw_tensors={"w": data})
+        assert isinstance(result, ttnn.Tensor)
+        ttnn.deallocate(result, force=True)
+
+    def test_row_major_round_trip(self, cache_dir, device):
+        """ROW_MAJOR_LAYOUT tensors round-trip through cache without tile kwarg."""
+        cache = TensorCache(cache_dir)
+
+        target = TensorTarget(
+            name="emb",
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        fingerprint = _make_fingerprint(
+            source=SourceTensorSelection(names=("model.embed_tokens.weight",)),
+            target=target,
+        )
+        data = torch.randn(64, 32, dtype=torch.bfloat16)
+
+        result = cache.get_or_create(
+            fingerprint, device, preprocess=lambda d: {"emb": d["w"].contiguous()}, raw_tensors={"w": data}
+        )
+        assert isinstance(result, ttnn.Tensor)
+
+        result2 = cache.get_or_create(
+            fingerprint, device, preprocess=lambda d: {"emb": d["w"].contiguous()}, raw_tensors={"w": data}
+        )
+        assert isinstance(result2, ttnn.Tensor)
+
+        ttnn.deallocate(result, force=True)
+        ttnn.deallocate(result2, force=True)
+
+
+class TestCacheContext:
+    def test_factory_produces_valid_fingerprint(self):
+        ctx = CacheContext(
+            schema_version=1,
+            hf_model_id="deepseek-ai/DeepSeek-V3",
+            hf_revision="abc123",
+            transform_version=1,
+            mesh_shape=(4, 2),
+        )
+        target = TensorTarget(name="embedding", dtype=ttnn.bfloat16)
+        source = SourceTensorSelection(names=("model.embed_tokens.weight",))
+        fingerprint = ctx.fingerprint(source=source, target=target)
+
+        assert isinstance(fingerprint, Fingerprint)
+        assert fingerprint.schema_version == 1
+        assert fingerprint.hf_model_id == "deepseek-ai/DeepSeek-V3"
+        assert fingerprint.hf_revision == "abc123"
+        assert fingerprint.transform_version == 1
+        assert fingerprint.mesh_shape == (4, 2)
+        assert fingerprint.target is target
+        assert fingerprint.source is source
+
+    def test_different_contexts_different_ids(self):
+        ctx1 = CacheContext(schema_version=1, hf_model_id="m", hf_revision="a", transform_version=1, mesh_shape=(4, 2))
+        ctx2 = CacheContext(schema_version=1, hf_model_id="m", hf_revision="b", transform_version=1, mesh_shape=(4, 2))
+        target = TensorTarget(name="t")
+        source = SourceTensorSelection(names=("w",))
+        fingerprint1 = ctx1.fingerprint(source=source, target=target)
+        fingerprint2 = ctx2.fingerprint(source=source, target=target)
+        assert compute_artifact_id(fingerprint1) != compute_artifact_id(fingerprint2)
+
+    def test_same_context_same_ids(self):
+        ctx = CacheContext(schema_version=1, hf_model_id="m", hf_revision="a", transform_version=1, mesh_shape=(4, 2))
+        target = TensorTarget(name="t")
+        source = SourceTensorSelection(names=("w",))
+        fingerprint1 = ctx.fingerprint(source=source, target=target)
+        fingerprint2 = ctx.fingerprint(source=source, target=target)
+        assert compute_artifact_id(fingerprint1) == compute_artifact_id(fingerprint2)


### PR DESCRIPTION
### Summary

Introduce a content-addressed TensorCache for DeepSeek V3 B1 standalone (non-fused) weight tensors. 

On cache hit, preprocessed tensors load directly from local NVMe; on miss, the cache transparently preprocesses from HF source weights and stores the result for future runs. No manual cache management or version bumping required -- artifact identity is derived from a SHA-256 fingerprint of the source tensors, model revision, preprocessing version, mesh shape, and full target layout.

- Add the tensor_cache/ package (types.py, fingerprint.py, cache.py) implementing the CAS (content-addressed storage) core: Fingerprint, TensorTarget, MeshMapperConfig, FingerprintContext, CacheEntryState, and the TensorCache.get_or_create() interface with atomic writes and corrupt-entry recovery.

- Wire 7 standalone tensors in prepare_weights.py through the cache via optional cache/fp_ctx parameters on the prepare_* functions: embedding (ROW_MAJOR), lm_head (bfp8, WIDTH_SHARDED, vocab-sharded across mesh), final_norm, gate_bias (per MoE layer), mtp_h_gamma, mtp_e_gamma, and mtp_eh_projection. The existing non-cache code path is preserved when cache=None.

- Add comprehensive unit tests in test_tensor_cache.py (fingerprint determinism/sensitivity, CAS directory layout, round-trip miss/hit, corrupt recovery, MeshMapperConfig strategies, FingerprintContext factory, ROW_MAJOR_LAYOUT round-trip) and 4x2 mesh integration tests in test_prepare_weights.py (cold-miss then warm-hit for each prepare function).

Follow-on work will add support for overlapped tensors and integrate the cache into the end-to-end demo.