### PR TITLE
Bump up math_fidelity for `batch_norm` call in `vovnet` model now that BN respects compute_config

### DIFF
--- a/models/experimental/vovnet/tt/common.py
+++ b/models/experimental/vovnet/tt/common.py
@@ -153,9 +153,12 @@ class Conv:
             output_tensor = ttnn.permute(output_tensor, (0, 3, 1, 2))
             output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT)
 
+            # VoVNet PCC: LoFi failed once BN honored compute_kernel_config; device sweep found HiFi2 as
+            # the lowest passing fidelity (HiFi2+True first; HiFi2+False also passed, earlier BN default
+            # was HiFi4+False).
             bn_config = ttnn.init_device_compute_kernel_config(
                 self.device.arch(),
-                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_fidelity=ttnn.MathFidelity.HiFi2,
                 math_approx_mode=True,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=False,


### PR DESCRIPTION
### Ticket
Closes #41033.

### Problem description
* #40233 stopped overriding user-provided `math_fidelity` and `math_approx_mode` to `HiFi4` and `False` in `batch_norm` API that caused failures in `vovnet` as it was passing `LoFi` and `True` to `batch_norm` at https://github.com/tenstorrent/tt-metal/blob/622361985b7114a76f33df74c09e782da31675ab/models/experimental/vovnet/tt/common.py#L158-L159
* Thankfully, `vovnet` appears to be the only model in the repo that seems to specify a `compute_kernel_config` to the `batch_norm` API, verified with:
    ```shell
    $ grep -RIn --include='*.py' -A 15 'ttnn\.batch_norm(' tests models | grep compute_kernel_config
    
    tests/ttnn/unit_tests/operations/fused/test_batch_norm.py-483-            compute_kernel_config=compute_config,
    models/experimental/vovnet/tt/common.py-173-                compute_kernel_config=bn_config,
    ```
    so no other models should need such a fix.

### What's changed
* Updated `vovnet` to the weakest compute config that lets the tests pass, which is just changing the fidelity to `HiFi2` while keeping `math_approx_mode=True`. Tests still pass with stronger compute configs. Worst-case scenario is to crank it up to the strongest one: `HiFi4` + `False`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)
- [x] Existing tests provide coverage for changes


#### Model tests
- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gchoudhary/36669-fix-vovnet-failures-from-batch_norm-changes)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
      - [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=gchoudhary%2F36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml)
      - [x] [![(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=gchoudhary%2F36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
      - [x] [![(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml/badge.svg?branch=gchoudhary%2F36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      - [x] [![(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml/badge.svg?branch=gchoudhary%2F36669-fix-vovnet-failures-from-batch_norm-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml)