### PR TITLE
Re-add p150b prio into triage tests

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -393,7 +393,7 @@ jobs:
       matrix:
         platform: [
           "N150-viommu",
-          #"P150b-viommu-prio",   # p150b triage has been failing since latest p150b runner update; disable for now until we can investigate and stabilize
+          "P150b-viommu-prio",
         ]
     uses: ./.github/workflows/triage.yaml
     with:


### PR DESCRIPTION
Triage tests were failing after the latest blackhole runner upgrades, the problems were resolved and we can re-add blackhole to triage