### PR TITLE
[skip ci] WH6u upstream test: Replace pipeline-functional with pipeline-perf

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -247,7 +247,7 @@ jobs:
       - arch-wormhole_b0
       - topology-6u
       - in-service
-      - pipeline-functional
+      - pipeline-perf
     steps:
       # TODO -likely need to put this into a script which can be parameterized
       # on the build number and whether to only pull


### PR DESCRIPTION

### What's changed
UF pipeline functional runners don't have mlperf which is required for llama model demo test

