### PR TITLE
[skip ci] Add cutoff_commit input to auto-triage workflow

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: ''
         type: string
+      cutoff_commit:
+        description: "Optional commit SHA to ignore runs newer than this commit"
+        required: false
+        default: ""
+        type: string
 
 
 jobs:
@@ -51,6 +56,7 @@ jobs:
           slack_ts: ${{ inputs.slack_ts }}
           allow-pings: true
           send-slack-message: ${{ inputs.send-slack-message }}
+          cutoff-commit: ${{ inputs.cutoff_commit }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # SLACK_WEBHOOK_URL is removed in favor of SLACK_BOT_TOKEN + channel logic in the action


### PR DESCRIPTION
## Summary
- add optional `cutoff_commit` input to `.github/workflows/auto-triage.yml` workflow_dispatch
- pass the new input through to `tenstorrent/tt-auto-triage` as `cutoff-commit`
- keep defaults unchanged so existing invocations continue to work

## Test plan
- [x] Validate workflow YAML syntax and pre-commit hooks locally
- [x] Confirm input is wired into action `with:` block
- [ ] Trigger a manual run with and without `cutoff_commit`

Made with [Cursor](https://cursor.com)