### PR TITLE
#36378: Disable `packer_l1_acc` solely in `LI_QKV_DECODE` `linear` call in Attention for Llama-3.2-90B-Vision-Instruct

### DIFF
--- a/models/tt_transformers/model_params/Llama-3.2-90B-Instruct/accuracy_decoder_config.json
+++ b/models/tt_transformers/model_params/Llama-3.2-90B-Instruct/accuracy_decoder_config.json
@@ -1,0 +1,1604 @@
+{
+  "decoders": {
+    "0": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "1": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "2": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "3": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "4": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "5": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "6": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "7": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "8": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "9": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "10": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "11": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "12": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "13": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "14": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "15": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "16": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "17": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "18": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "19": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "20": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "21": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "22": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "23": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "24": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "25": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "26": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "27": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "28": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "29": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "30": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "31": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "32": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "33": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "34": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "35": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "36": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "37": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "38": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "39": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "40": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "41": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "42": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "43": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "44": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "45": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "46": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "47": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "48": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "49": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "50": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "51": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "52": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "53": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "54": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "55": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "56": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "57": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "58": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "59": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "60": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "61": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "62": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "63": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "64": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "65": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "66": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "67": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "68": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "69": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "70": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "71": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "72": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "73": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "74": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "75": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "76": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "77": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "78": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "79": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    }
+  }
+}

--- a/models/tt_transformers/model_params/Llama-3.2-90B-Instruct/performance_decoder_config.json
+++ b/models/tt_transformers/model_params/Llama-3.2-90B-Instruct/performance_decoder_config.json
@@ -1,0 +1,1604 @@
+{
+  "decoders": {
+    "0": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "1": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "2": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "3": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "4": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "5": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "6": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "7": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "8": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "9": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "10": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "11": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "12": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "13": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "14": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "15": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "16": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "17": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "18": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "19": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "20": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "21": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "22": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "23": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "24": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "25": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "26": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "27": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "28": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "29": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "30": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "31": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "32": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "33": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "34": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "35": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "36": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "37": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "38": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "39": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "40": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "41": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "42": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "43": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "44": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "45": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "46": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "47": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "48": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "49": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "50": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "51": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "52": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "53": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "54": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "55": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "56": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "57": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "58": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "59": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "60": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "61": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "62": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "63": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "64": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "65": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "66": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "67": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "68": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "69": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "70": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "71": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "72": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "73": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "74": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "75": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "76": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "77": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "78": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    },
+    "79": {
+      "precision_cfg": {
+        "FF1_FF3": "BFP4",
+        "FF2": "BFP8",
+        "WQKV": "BFP8",
+        "WO": "BFP8",
+        "KV_CACHE": "BFP8"
+      },
+      "fidelity_cfg": {
+        "LI_FF1_FF3": "LOFI",
+        "LI_FF2": "HIFI2_FP16",
+        "LI_QKV_DECODE": "HIFI2_NOL1ACC",
+        "LI_O_DECODE": "HIFI2",
+        "SDPA_DECODE": "HIFI2",
+        "LI_QKV_PREFILL": "HIFI2",
+        "LI_O_PREFILL": "HIFI2",
+        "SDPA_PREFILL": "HIFI4",
+        "ACCURACY": "HIFI4_FP32"
+      }
+    }
+  }
+}

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -70,7 +70,7 @@ def test_attention_inference(
 ):
     mode = Mode.DECODE
     dtype = ttnn.bfloat8_b
-    pcc = 0.986  # pcc reduced from .99 while investigating issue #36378
+    pcc = 0.99
     llama90b_hf_rope_pcc = 0.97
     num_tensors = 2
     prefetcher = Prefetcher(mesh_device, num_tensors=num_tensors, num_layers=1) if use_prefetcher else None

--- a/models/tt_transformers/tests/test_llama90b_decoder_json.py
+++ b/models/tt_transformers/tests/test_llama90b_decoder_json.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Llama 3.2 90B decoder JSON must match ModelOptimizations baseline except LI_QKV_DECODE (issue #36378)."""
+from pathlib import Path
+
+import pytest
+
+from models.tt_transformers.tt.model_config import (
+    DecodersPrecision,
+    MathFidelitySetting,
+    ModelOptimizations,
+    OpGroup,
+    TensorGroup,
+    parse_decoder_json,
+)
+
+_MN = "Llama-3.2-90B-Instruct"
+_TT_ROOT = Path(__file__).resolve().parents[1]
+_ACC = _TT_ROOT / "model_params" / _MN / "accuracy_decoder_config.json"
+_PERF = _TT_ROOT / "model_params" / _MN / "performance_decoder_config.json"
+
+
+def _tensor_map(m: ModelOptimizations):
+    return {
+        k.name: m.tensor_dtype_settings[k].name
+        for k in TensorGroup
+        if k in m.tensor_dtype_settings and m.tensor_dtype_settings[k] is not None
+    }
+
+
+def _op_map(m: ModelOptimizations):
+    return {k.name: m.op_fidelity_settings[k].name for k in OpGroup if k in m.op_fidelity_settings}
+
+
+def _assert_json_matches_baseline_except_qkv_decode(json_path: Path, opt_fn):
+    baseline = opt_fn(_MN)
+    b_tensor = _tensor_map(baseline)
+    b_op = _op_map(baseline)
+    loaded = parse_decoder_json(json_path, default_optimization=opt_fn)
+    n = len(loaded.decoder_optimizations)
+    assert n == 80
+    for di in range(n):
+        j = loaded.decoder_optimizations[di]
+        j_tensor = _tensor_map(j)
+        j_op = _op_map(j)
+        assert j_tensor == b_tensor, f"decoder {di} tensor_dtype mismatch"
+        for ok, vb in b_op.items():
+            jv = j_op.get(ok)
+            if ok == OpGroup.LI_QKV_DECODE.name:
+                assert (
+                    vb == MathFidelitySetting.HIFI2.name and jv == MathFidelitySetting.HIFI2_NOL1ACC.name
+                ), f"decoder {di} LI_QKV_DECODE expected HIFI2->HIFI2_NOL1ACC, got {vb}->{jv}"
+            else:
+                assert jv == vb, f"decoder {di} op {ok} baseline={vb} json={jv}"
+
+
+@pytest.mark.skipif(not _ACC.is_file(), reason="accuracy_decoder_config.json not present")
+def test_llama90b_accuracy_decoder_json_matches_baseline_except_qkv_decode():
+    _assert_json_matches_baseline_except_qkv_decode(_ACC, ModelOptimizations.accuracy)
+
+
+@pytest.mark.skipif(not _PERF.is_file(), reason="performance_decoder_config.json not present")
+def test_llama90b_performance_decoder_json_matches_baseline_except_qkv_decode():
+    _assert_json_matches_baseline_except_qkv_decode(_PERF, ModelOptimizations.performance)
+
+
+def test_llama90b_decoders_precision_without_json_layers_match_accuracy_baseline():
+    """When no JSON is used, DecodersPrecision repeats optimization_level(model_name) per layer."""
+    base = ModelOptimizations.accuracy(_MN)
+    dp = DecodersPrecision(80, _MN, base)
+    for i in range(80):
+        assert dp.decoder_optimizations[i]._full_name == base._full_name

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -105,6 +105,7 @@ class MathFidelitySetting(Enum):
     HIFI2 = "hifi2"
     HIFI2_NA = "hifi2na"  # na specified `packer_l1_acc=False` and `fp32_dest_acc_en=False` in compute kernel config
     HIFI2_FP16 = "hifi2fp16"  # fp16 specified `fp32_dest_acc_en=False` in compute kernel config
+    HIFI2_NOL1ACC = "hifi2nol1acc"  # fp32_dest_acc_en=True but packer_l1_acc=False (issue #36378)
     HIFI4 = "hifi4"
     HIFI4_FP32 = "hifi4fp32"
 
@@ -753,6 +754,12 @@ class ModelArgs:
                 math_fidelity=ttnn.MathFidelity.HiFi2,
                 math_approx_mode=False,
                 fp32_dest_acc_en=False,
+                packer_l1_acc=False,
+            )
+            self.compute_kernel_config_hifi2_nol1acc = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=True,
+                fp32_dest_acc_en=True,
                 packer_l1_acc=False,
             )
             self.compute_kernel_config_sdpa = ttnn.WormholeComputeKernelConfig(
@@ -4250,6 +4257,7 @@ class DecodersPrecision:
             MathFidelitySetting.HIFI2: configuration.compute_kernel_config_hifi2,
             MathFidelitySetting.HIFI2_NA: configuration.compute_kernel_config_hifi2_na,
             MathFidelitySetting.HIFI2_FP16: configuration.compute_kernel_config_hifi2_fp16,
+            MathFidelitySetting.HIFI2_NOL1ACC: configuration.compute_kernel_config_hifi2_nol1acc,
             MathFidelitySetting.HIFI4: configuration.compute_kernel_config_hifi4,
             MathFidelitySetting.HIFI4_FP32: configuration.compute_kernel_config_hifi4_fp32,
         }


### PR DESCRIPTION
### Ticket
Closes #36378.

### Problem description
* Increasing `matmul` precision paradoxically caused PCC drops in Llama-3.2-90B-Vision-Instruct model.

### What's changed
* All investigations point to `matmul` really being more accurate, but the model PCC drops despite that.
* The best guess of the source of PCC inaccuracy creeping in is
https://github.com/tenstorrent/tt-metal/blob/57ff0816c3b53a41bff6b057c345dc59061d6efe/models/tt_transformers/tt/attention.py#L703-L713 soon after the `linear` call that downcasts results from `bfloat16` precision `linear`->`rope` to `bfloat8_b` for the SDPA call, which might be amplifying the errors. (I'm not able to try "fixes" to SDPA on my end yet.) Changing the KV cache to `bfloat16` there also fixes the precision issue, but that of course significantly increases memory requirements.
* The fix chosen is to add a JSON config to make an exception just for the Llama-3.2-90B-Vision-Instruct model to turn off the `packer_l1_acc` usage there while the rest of the models continue to benefit from the higher-accuracy in `matmul`

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)
- [x] Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gchoudhary/36378-disable-L1-acc-solely-in-tt-transformers-model_config)
  - [x] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml)
  - [x] [![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=gchoudhary%2F36378-disable-L1-acc-solely-in-tt-transformers-model_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml)