### PR TITLE
Pool CB Cleanup

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -875,8 +875,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         SetRuntimeArgs(program, compute_kernel, core, args);
     }
 
-    // Validate local and global CB sizes separately to prevent two errors from cancelling out (#23133).
-    // Local CBs are non-globally-allocated (computed by the program); global CBs are tensor-backed.
+    // Validate local and global CB sizes separately to prevent two errors from cancelling out
+    // Note local CBs are non-globally-allocated (computed by the program); global CBs are tensor-backed.
     auto actual_local_cb_size = calculate_total_cb_size(program);
 
     uint32_t post_allocate_size =

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -875,25 +875,27 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         SetRuntimeArgs(program, compute_kernel, core, args);
     }
 
-    // Validate that the CB sizes computed by calculate_pool_cb_sizes match the actual program allocation.
-    // The factory has additional CBs (raw_in_cb, reader_indices, scalar config) that are outside the
-    // pool CB sizing, so we validate the combined total against (local CBs + global allocations).
-    auto temporary_size = calculate_total_cb_size(program);
+    // Validate local and global CB sizes separately to prevent two errors from cancelling out (#23133).
+    // Local CBs are non-globally-allocated (computed by the program); global CBs are tensor-backed.
+    auto actual_local_cb_size = calculate_total_cb_size(program);
 
     uint32_t post_allocate_size =
         input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    uint32_t output_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
+    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
 
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
     // in graph capture NO_DISPATCH mode.
     bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
     TT_FATAL(
-        temporary_size + output_cb_size == cb_sizes.total() || is_graph_capture_no_dispatch_mode,
-        "Calculated CB size {} + {} = {} does not match with the expected CB size {}",
-        temporary_size,
-        output_cb_size,
-        temporary_size + output_cb_size,
-        cb_sizes.total());
+        actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Local CB size mismatch: actual {} != expected {}",
+        actual_local_cb_size,
+        cb_sizes.local_cb_total());
+    TT_FATAL(
+        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Global CB size mismatch: actual {} != expected {}",
+        actual_global_cb_size,
+        cb_sizes.global_cb_total());
 
     {  // debug
         log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -875,27 +875,25 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         SetRuntimeArgs(program, compute_kernel, core, args);
     }
 
-    // Validate local and global CB sizes separately to prevent two errors from cancelling out (#23133).
-    // Local CBs are non-globally-allocated (computed by the program); global CBs are tensor-backed.
-    auto actual_local_cb_size = calculate_total_cb_size(program);
+    // Validate that the CB sizes computed by calculate_pool_cb_sizes match the actual program allocation.
+    // The factory has additional CBs (raw_in_cb, reader_indices, scalar config) that are outside the
+    // pool CB sizing, so we validate the combined total against (local CBs + global allocations).
+    auto temporary_size = calculate_total_cb_size(program);
 
     uint32_t post_allocate_size =
         input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
+    uint32_t output_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
 
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
     // in graph capture NO_DISPATCH mode.
     bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
     TT_FATAL(
-        actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
-        "Local CB size mismatch: actual {} != expected {}",
-        actual_local_cb_size,
-        cb_sizes.local_cb_total());
-    TT_FATAL(
-        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
-        "Global CB size mismatch: actual {} != expected {}",
-        actual_global_cb_size,
-        cb_sizes.global_cb_total());
+        temporary_size + output_cb_size == cb_sizes.total() || is_graph_capture_no_dispatch_mode,
+        "Calculated CB size {} + {} = {} does not match with the expected CB size {}",
+        temporary_size,
+        output_cb_size,
+        temporary_size + output_cb_size,
+        cb_sizes.total());
 
     {  // debug
         log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -331,6 +331,17 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
+    // Compute CB sizes centrally - used for both CB creation and L1 validation
+    auto output_shard_shape = outputs[0].shard_spec().value().shape;
+    PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
+        params,
+        one_scalar_per_core,
+        return_indices,
+        output_layout,
+        outputs[0].dtype(),
+        {output_shard_shape[0], output_shard_shape[1]},
+        config_tensor_in_dram);
+
     const auto& input_shape = input.padded_shape();
     const uint32_t shard_width = input.shard_spec()->shape[1];
     const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
@@ -355,14 +366,14 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     uint32_t next_cb_index = tt::CBIndex::c_0;
     const uint32_t in_scalar_cb_id_0 = next_cb_index++;
-    const uint32_t in_scalar_cb_pagesize = tile_size(params.data_format);
-    const uint32_t in_scalar_cb_npages = params.multi_buffering_factor;
+    const uint32_t in_scalar_cb_pagesize = cb_sizes.scalar_cb_pagesize;
+    const uint32_t in_scalar_cb_npages = cb_sizes.scalar_cb_npages;
     tt::tt_metal::create_cb(
         in_scalar_cb_id_0, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format);
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id_0, in_scalar_cb_pagesize, in_scalar_cb_npages);
 
     uint32_t in_scalar_cb_id_1 = INVALID_CB_ID;
-    if (params.is_avg_pool && params.split_reader && !one_scalar_per_core) {
+    if (cb_sizes.has_second_scalar_cb) {
         in_scalar_cb_id_1 = next_cb_index++;
         tt::tt_metal::create_cb(
             in_scalar_cb_id_1, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format);
@@ -372,9 +383,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
     uint32_t clear_value_cb_id = next_cb_index++;
-    tt::tt_metal::create_cb(
-        clear_value_cb_id, program, all_cores, tile_size(params.data_format), 1, params.data_format);
-    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", clear_value_cb_id, tile_size(params.data_format), 1);
+    tt::tt_metal::create_cb(clear_value_cb_id, program, all_cores, cb_sizes.clear_value_cb_size, 1, params.data_format);
+    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", clear_value_cb_id, cb_sizes.clear_value_cb_size, 1);
 
     // incoming data is the input cb instead of raw l1/dram addr
     // this input shard has halo and padding inserted.
@@ -414,30 +424,22 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_reader_indices_cb_id,
         in_reader_indices_cb_pagesize,
         in_reader_indices_cb_npages);
-    uint32_t in_cb_sz = 0;
+    // in_nblocks_c is factory-specific (used for kernel args), derived from the shared in_cb_raw_size
     uint32_t in_nblocks_c = 1;
     if (return_indices || params.is_wide_reduction) {
-        // for return indices we use 1 whole tile per reduction to simplify logic
-        uint32_t height_multiplier = return_indices ? tt::constants::TILE_HEIGHT : params.num_tilized_rows;
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * height_multiplier;
         in_nblocks_c = std::ceil((float)params.in_ntiles_c / params.MAX_TILES_PER_REDUCTION);
-    } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
     }
 
     // reader output == input to tilize
     const uint32_t in_cb_id_0 = next_cb_index++;  // input rows for "multiple (out_nelems)" output pixels
     uint32_t in_cb_id_1 = INVALID_CB_ID;          // input rows for "multiple (out_nelems)" output pixels
-    const uint32_t in_cb_page_padded = tt::round_up(
-        in_cb_sz,
-        tt::constants::TILE_HW);  // NOTE: ceil to tile size since triscs work with tilesize instead of pagesize
-    const uint32_t in_cb_pagesize = params.nbytes * in_cb_page_padded;
-    const uint32_t in_cb_npages = params.multi_buffering_factor;
+    const uint32_t in_cb_pagesize = cb_sizes.in_cb_pagesize;
+    const uint32_t in_cb_npages = cb_sizes.in_cb_npages;
 
     tt::tt_metal::create_cb(in_cb_id_0, program, all_cores, in_cb_pagesize, in_cb_npages, params.data_format);
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_0, in_cb_pagesize, in_cb_npages);
 
-    if (params.split_reader) {
+    if (cb_sizes.has_split_reader) {
         in_cb_id_1 = next_cb_index++;
         tt::tt_metal::create_cb(in_cb_id_1, program, all_cores, in_cb_pagesize, in_cb_npages, params.data_format);
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
@@ -556,30 +558,25 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     // Conditionally allocate temporary CB - only needed for TILED output
     uint32_t pre_tilize_cb_id = INVALID_CB_ID;
 
-    if (is_output_tiled) {
+    if (cb_sizes.has_pre_tilize) {
         pre_tilize_cb_id = next_cb_index++;
-        const uint32_t pre_tilize_cb_pagesize = tt::constants::TILE_WIDTH * params.nbytes;
-        const uint32_t pre_tilize_cb_npages = tt::constants::TILE_HEIGHT * params.in_ntiles_c;
         tt::tt_metal::create_cb(
-            pre_tilize_cb_id, program, all_cores, pre_tilize_cb_pagesize, pre_tilize_cb_npages, params.data_format);
+            pre_tilize_cb_id,
+            program,
+            all_cores,
+            cb_sizes.pre_tilize_cb_pagesize,
+            cb_sizes.pre_tilize_cb_npages,
+            params.data_format);
         log_debug(
-            tt::LogOp, "CB {} :: PS = {}, NP = {}", pre_tilize_cb_id, pre_tilize_cb_pagesize, pre_tilize_cb_npages);
+            tt::LogOp,
+            "CB {} :: PS = {}, NP = {}",
+            pre_tilize_cb_id,
+            cb_sizes.pre_tilize_cb_pagesize,
+            cb_sizes.pre_tilize_cb_npages);
     }
 
-    uint32_t out_cb_pagesize;
-    uint32_t out_cb_npages;
-
-    if (is_output_tiled) {
-        out_cb_pagesize = tt::tile_size(params.output_data_format);
-        out_cb_npages =
-            outputs[0].shard_spec().value().shape[0] * outputs[0].shard_spec().value().shape[1] / tt::constants::TILE_HW;
-    } else {
-        out_cb_pagesize =
-            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
-            params.nbytes;  // there is just one row of channels after each reduction (or 1
-                            // block of c if its greater than 8 tiles)
-        out_cb_npages = outputs[0].shard_spec().value().shape[0] * params.out_ntiles_c;
-    }
+    const uint32_t out_cb_pagesize = cb_sizes.out_cb_pagesize;
+    const uint32_t out_cb_npages = cb_sizes.out_cb_npages;
 
     const auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
         next_cb_index++,
@@ -592,21 +589,17 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     uint32_t out_idx_cb_id = INVALID_CB_ID;
     tt::tt_metal::CBHandle out_idx_cb = 0;
-    if (return_indices) {
+    if (cb_sizes.has_out_idx) {
         TT_FATAL(
             outputs.size() == 2,
             "When return_indices is true, there should be two outputs, but got {}",
             outputs.size());
-        uint32_t out_idx_cb_npages = out_cb_npages;
-        uint32_t out_idx_cb_pagesize =
-            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), outputs[0].shard_spec().value().shape[1]) *
-            params.index_nbytes;
         std::tie(out_idx_cb_id, out_idx_cb) = tt::tt_metal::create_cb(
             next_cb_index++,
             program,
             all_cores,
-            out_idx_cb_pagesize,
-            out_idx_cb_npages,
+            cb_sizes.out_idx_cb_pagesize,
+            cb_sizes.out_idx_cb_npages,
             params.index_format,
             outputs[1].buffer());
     }
@@ -696,7 +689,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         bf16_scalar,                                                                         // 9
         bf16_init_value,                                                                     // 10
         in_nblocks_c,                                                                        // 11
-        in_cb_sz,                                                                            // 12
+        cb_sizes.in_cb_raw_size,                                                             // 12
         params.max_rows_for_reduction,                                                       // 13
         ceil_pad_w,                                                                          // 14
         in_cb_id_0,                                                                          // 15
@@ -882,44 +875,27 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         SetRuntimeArgs(program, compute_kernel, core, args);
     }
 
-    auto temporary_size = calculate_total_cb_size(program);
+    // Validate local and global CB sizes separately to prevent two errors from cancelling out (#23133).
+    // Local CBs are non-globally-allocated (computed by the program); global CBs are tensor-backed.
+    auto actual_local_cb_size = calculate_total_cb_size(program);
 
     uint32_t post_allocate_size =
         input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    uint32_t l1_usage = calculate_L1_usage(
-        input.dtype(),
-        in_h,
-        in_w,
-        in_c,
-        pad_h,
-        pad_w,
-        ceil_pad_h,
-        ceil_pad_w,
-        ceil_mode,
-        return_indices,
-        kernel_h,
-        kernel_w,
-        input.memory_config(),
-        outputs[0].memory_config(),
-        pool_type,
-        count_include_pad,
-        divisor_override,
-        output_layout,
-        outputs[0].dtype(),
-        config_tensor_in_dram);
-
-    uint32_t output_cb_size = post_allocate_size - memory_used;
+    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
 
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
     // in graph capture NO_DISPATCH mode.
     bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
     TT_FATAL(
-        temporary_size + output_cb_size == l1_usage || is_graph_capture_no_dispatch_mode,
-        "Calculated CB size {} + {} = {} does not match with the actual CB size {}  ",
-        temporary_size,
-        output_cb_size,
-        temporary_size + output_cb_size,
-        l1_usage);
+        actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Local CB size mismatch: actual {} != expected {}",
+        actual_local_cb_size,
+        cb_sizes.local_cb_total());
+    TT_FATAL(
+        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
+        "Global CB size mismatch: actual {} != expected {}",
+        actual_global_cb_size,
+        cb_sizes.global_cb_total());
 
     {  // debug
         log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -189,7 +189,128 @@ FactoryParameters get_factory_parameters(
     };
 }
 
-uint32_t calculate_L1_usage(
+uint32_t PoolCBSizes::local_cb_total() const {
+    uint32_t total = scalar_cb_pagesize * scalar_cb_npages;
+    if (has_second_scalar_cb) {
+        total += scalar_cb_pagesize * scalar_cb_npages;
+    }
+    total += clear_value_cb_size;
+    total += in_cb_pagesize * in_cb_npages;
+    if (has_split_reader) {
+        total += in_cb_pagesize * in_cb_npages;
+    }
+    total += mpwi_total_size;
+    if (has_pre_tilize) {
+        total += pre_tilize_cb_pagesize * pre_tilize_cb_npages;
+    }
+    total += config_tensor_l1_size;
+    return total;
+}
+
+uint32_t PoolCBSizes::global_cb_total() const {
+    uint32_t total = sliding_window::align_buffer(out_cb_pagesize * out_cb_npages);
+    if (has_out_idx) {
+        total += sliding_window::align_buffer(out_idx_cb_pagesize * out_idx_cb_npages);
+    }
+    return total;
+}
+
+uint32_t PoolCBSizes::total() const { return local_cb_total() + global_cb_total(); }
+
+PoolCBSizes calculate_pool_cb_sizes(
+    const FactoryParameters& params,
+    bool one_scalar_per_core,
+    bool return_indices,
+    const Layout& output_layout,
+    const DataType& output_dtype,
+    const std::array<uint32_t, 2>& output_shard_shape,
+    bool config_tensor_in_dram) {
+    PoolCBSizes sizes;
+    const bool is_output_tiled = output_layout == Layout::TILE;
+
+    // Scalar CB (coefficient of reduce)
+    sizes.scalar_cb_pagesize = tt::tile_size(params.data_format);
+    sizes.scalar_cb_npages = params.multi_buffering_factor;
+    sizes.has_second_scalar_cb = params.is_avg_pool && params.split_reader && !one_scalar_per_core;
+
+    // Clear value CB (-inf for maxpool, 0 for avgpool)
+    sizes.clear_value_cb_size = tt::tile_size(params.data_format);
+
+    // Input CB
+    uint32_t in_cb_sz = 0;
+    if (return_indices || params.is_wide_reduction) {
+        uint32_t height_multiplier = return_indices ? tt::constants::TILE_HEIGHT : params.num_tilized_rows;
+        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * height_multiplier;
+    } else {
+        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
+    }
+    sizes.in_cb_raw_size = in_cb_sz;
+    uint32_t in_cb_page_padded = tt::round_up(in_cb_sz, tt::constants::TILE_HW);
+    sizes.in_cb_pagesize = params.nbytes * in_cb_page_padded;
+    sizes.in_cb_npages = params.multi_buffering_factor;
+    sizes.has_split_reader = params.split_reader;
+
+    // MPWI CBs (return_indices temporaries)
+    sizes.mpwi_total_size = 0;
+    if (return_indices) {
+        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+        uint32_t idx_tile_size = params.index_nbytes * tile_elems;
+        uint32_t data_tile_size = params.nbytes * tile_elems;
+        // 1 data tile (pack_tmp_cb) + 6 index tiles (in_idx, pack_idx_tmp, right_inc,
+        // down_left_wrap_inc, up_left_wrap_inc, compute_idx_tmp)
+        sizes.mpwi_total_size = (6 * idx_tile_size) + data_tile_size;
+        if (params.is_large_kernel) {
+            // additional index tiles (intra_kernel_right_inc, intra_kernel_down_left_wrap_inc)
+            sizes.mpwi_total_size += 2 * idx_tile_size;
+        }
+    }
+
+    // Pre-tilize CB (only for tiled output)
+    sizes.has_pre_tilize = is_output_tiled;
+    if (is_output_tiled) {
+        sizes.pre_tilize_cb_pagesize = tt::constants::TILE_WIDTH * params.nbytes;
+        sizes.pre_tilize_cb_npages = tt::constants::TILE_HEIGHT * params.in_ntiles_c;
+    } else {
+        sizes.pre_tilize_cb_pagesize = 0;
+        sizes.pre_tilize_cb_npages = 0;
+    }
+
+    // Output CB (globally allocated, backed by output tensor buffer)
+    if (is_output_tiled) {
+        sizes.out_cb_pagesize = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype));
+        sizes.out_cb_npages = output_shard_shape[0] * output_shard_shape[1] / tt::constants::TILE_HW;
+    } else {
+        sizes.out_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_shard_shape[1]) * params.nbytes;
+        sizes.out_cb_npages = output_shard_shape[0] * params.out_ntiles_c;
+    }
+
+    // Output index CB (globally allocated, backed by output index tensor buffer)
+    sizes.has_out_idx = return_indices;
+    if (return_indices) {
+        sizes.out_idx_cb_pagesize =
+            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_shard_shape[1]) * params.index_nbytes;
+        sizes.out_idx_cb_npages = sizes.out_cb_npages;
+    } else {
+        sizes.out_idx_cb_pagesize = 0;
+        sizes.out_idx_cb_npages = 0;
+    }
+
+    // Config tensor L1 CB (for DRAM-based config tensors)
+    sizes.config_tensor_l1_size = 0;
+    if (config_tensor_in_dram) {
+        sizes.config_tensor_l1_size =
+            (output_shard_shape[0] * 6) + 2;  // Worst case of 6 Bytes per output elem for reader indices
+        if (!one_scalar_per_core) {
+            sizes.config_tensor_l1_size +=
+                output_shard_shape[0] * 6;  // Additional 6 Bytes per output elem for avg pool scalar config tensor
+        }
+    }
+
+    return sizes;
+}
+
+pool_op_l1_usage calculate_L1_usage(
     DataType input_dtype,
     uint32_t in_h,
     uint32_t in_w,
@@ -238,112 +359,24 @@ uint32_t calculate_L1_usage(
     bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
         pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
 
-    // scalar CB as coefficient of reduce
-    uint32_t in_scalar_cb_pagesize = tt::constants::TILE_HW * params.nbytes;
-    uint32_t in_scalar_cb_npages = params.multi_buffering_factor;
-    uint32_t in_scalar_cb_size_0 = in_scalar_cb_npages * in_scalar_cb_pagesize;
-    uint32_t in_scalar_cb_size_1 = 0;
+    auto output_shard_shape = output_memory.shard_spec().value().shape;
+    PoolCBSizes sizes = calculate_pool_cb_sizes(
+        params,
+        one_scalar_per_core,
+        return_indices,
+        output_layout,
+        output_dtype,
+        {output_shard_shape[0], output_shard_shape[1]},
+        config_tensor_in_dram);
 
-    if (pool_type == Pool2DType::AVG_POOL2D && params.split_reader && !one_scalar_per_core) {
-        in_scalar_cb_size_1 = in_scalar_cb_npages * in_scalar_cb_pagesize;
-    }
-
-    uint32_t clear_value_cb_size = tt::constants::TILE_HW * params.nbytes;
-
-    uint32_t in_cb_sz = 0;
-    if (return_indices || params.is_wide_reduction) {
-        uint32_t height_multiplier = return_indices ? tt::constants::TILE_HEIGHT : params.num_tilized_rows;
-        in_cb_sz = params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * height_multiplier;
-    } else {
-        in_cb_sz = params.in_ntiles_c * tt::constants::TILE_WIDTH * params.num_tilized_rows;
-    }
-
-    uint32_t in_cb_page_padded = tt::round_up(in_cb_sz, tt::constants::TILE_HW);
-    uint32_t in_cb_pagesize = params.nbytes * in_cb_page_padded;
-    uint32_t in_cb_npages = params.multi_buffering_factor;
-    uint32_t in_cb_config_0_size = in_cb_npages * in_cb_pagesize;
-    uint32_t in_cb_config_1_size = 0;
-
-    if (params.split_reader) {
-        in_cb_config_1_size = in_cb_npages * in_cb_pagesize;
-    }
-
-    uint32_t total_mpwi_cb_size = 0;
-    if (return_indices) {
-        // Add tile temporary CBs for return_indices
-        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        uint32_t idx_tile_size = params.index_nbytes * tile_elems * 1;  // 1 page
-        uint32_t data_tile_size = params.nbytes * tile_elems * 1;       // 1 page
-        // 1 data sized tile (pack_tmp_cb) and 6 index sized tiles (in_idx, pack_idx_tmp, right_inc, down_left_wrap_inc,
-        // up_left_wrap_inc, compute_idx_tmp)
-        total_mpwi_cb_size = (6 * idx_tile_size) + data_tile_size;
-        if (params.is_large_kernel) {
-            // additional temp data tile for large kernel (intra_kernel_right_inc, intra_kernel_down_left_wrap_inc)
-            total_mpwi_cb_size += 2 * idx_tile_size;
-        }
-    }
-
-    uint32_t out_cb_pagesize;
-    uint32_t out_cb_npages;
-    const bool is_output_tiled = output_layout == Layout::TILE;
-
-    if (is_output_tiled) {
-        out_cb_pagesize = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype));
-        out_cb_npages = output_memory.shard_spec().value().shape[0] * output_memory.shard_spec().value().shape[1] /
-                        tt::constants::TILE_HW;
-    } else {
-        out_cb_pagesize =
-            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
-            params.nbytes;
-        out_cb_npages = output_memory.shard_spec().value().shape[0] * params.out_ntiles_c;
-    }
-    uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
-
-    uint32_t pre_tilize_cb_size = 0;
-
-    if (is_output_tiled) {
-        const uint32_t pre_tilize_cb_pagesize = params.in_ntiles_c * tt::constants::TILE_HW * params.nbytes;
-        const uint32_t pre_tilize_cb_npages = 1;
-        pre_tilize_cb_size = pre_tilize_cb_pagesize * pre_tilize_cb_npages;
-    }
-
-    uint32_t out_idx_cb_config_size = 0;
-    if (return_indices) {
-        uint32_t out_idx_cb_pagesize =
-            std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
-            params.index_nbytes;
-        out_idx_cb_config_size = out_cb_npages * out_idx_cb_pagesize;
-    }
-    uint32_t config_tensor_l1_CB_size = 0;
-    if (config_tensor_in_dram) {
-        auto output_shard_shape = output_memory.shard_spec().value().shape;
-        config_tensor_l1_CB_size =
-            (output_shard_shape[0] * 6) + 2;  // Worst case of 6 Bytes per output elem for reader indices
-        if (!one_scalar_per_core) {
-            config_tensor_l1_CB_size +=
-                output_shard_shape[0] * 6;  // Additional 6 Bytes per output elem for avg pool scalar config tensor
-        }
-    }
     log_trace(
         tt::LogOp,
-        "L1 Usage Breakdown: in_scalar_cb_size_0 = {}, in_scalar_cb_size_1 = {}, clear_value_cb_size = {}, "
-        "in_cb_config_0_size = {}, in_cb_config_1_size = {}, total_mpwi_cb_size = {}, pre_tilize_cb_size = {}, "
-        "config_tensor_l1_CB_size = {} "
-        "out_cb_config_size = {}, out_idx_cb_config_size = {}",
-        in_scalar_cb_size_0,
-        in_scalar_cb_size_1,
-        clear_value_cb_size,
-        in_cb_config_0_size,
-        in_cb_config_1_size,
-        total_mpwi_cb_size,
-        pre_tilize_cb_size,
-        config_tensor_l1_CB_size,
-        sliding_window::align_buffer(out_cb_config_size),
-        sliding_window::align_buffer(out_idx_cb_config_size));
+        "L1 Usage Breakdown: local_cb_size = {}, global_cb_size = {}, total = {}",
+        sizes.local_cb_total(),
+        sizes.global_cb_total(),
+        sizes.total());
 
-    return in_scalar_cb_size_0 + in_scalar_cb_size_1 + clear_value_cb_size + in_cb_config_0_size + in_cb_config_1_size +
-           total_mpwi_cb_size + pre_tilize_cb_size + config_tensor_l1_CB_size +
-           sliding_window::align_buffer(out_cb_config_size) + sliding_window::align_buffer(out_idx_cb_config_size);
+    return pool_op_l1_usage{.local_cb_size = sizes.local_cb_total(), .global_cb_size = sizes.global_cb_total()};
 }
 
 std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
@@ -363,7 +396,7 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     auto output_shape = sliding_window_config.get_output_shape();
 
     struct l1_usage_config {
-        uint32_t l1_usage{};
+        pool_op_l1_usage l1_usage{};
         std::optional<ParallelConfig> config;
     };
 
@@ -393,9 +426,13 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
             0);
 
         if (!input_parallel_config.has_value()) {
-            return {std::numeric_limits<uint32_t>::max(), input_parallel_config};
+            return {
+                pool_op_l1_usage{
+                    .local_cb_size = std::numeric_limits<uint32_t>::max(),
+                    .global_cb_size = std::numeric_limits<uint32_t>::max()},
+                input_parallel_config};
         }
-        uint32_t l1_usage = calculate_L1_usage(
+        pool_op_l1_usage l1_usage = calculate_L1_usage(
             input_dtype,
             sliding_window_config.input_hw.first,
             sliding_window_config.input_hw.second,
@@ -424,9 +461,9 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     auto l1_config_width = calc_l1_usage_inner(TensorMemoryLayout::WIDTH_SHARDED, ShardOrientation::ROW_MAJOR);
     auto l1_config_block = calc_l1_usage_inner(TensorMemoryLayout::BLOCK_SHARDED, ShardOrientation::ROW_MAJOR);
 
-    uint32_t l1_usage_height = l1_config_height.l1_usage;
-    uint32_t l1_usage_width = l1_config_width.l1_usage;
-    uint32_t l1_usage_block = l1_config_block.l1_usage;
+    uint32_t l1_usage_height = l1_config_height.l1_usage.total();
+    uint32_t l1_usage_width = l1_config_width.l1_usage.total();
+    uint32_t l1_usage_block = l1_config_block.l1_usage.total();
 
     if (l1_usage_height > l1_usage_width) {
         if (l1_usage_width > l1_usage_block) {
@@ -676,7 +713,7 @@ pool2d_slice_l1_usage calculate_L1_usage_for_pool2d_slice(
     auto output_memory_config = tt::tt_metal::MemoryConfig(
         input_memory_config.memory_layout(), input_memory_config.buffer_type(), output_shard_spec);
 
-    uint32_t pool_cb_usage = calculate_L1_usage(
+    pool_op_l1_usage pool_l1 = calculate_L1_usage(
         dtype,
         sliding_window_config.input_hw.first,
         sliding_window_config.input_hw.second,
@@ -697,6 +734,7 @@ pool2d_slice_l1_usage calculate_L1_usage_for_pool2d_slice(
         output_layout,
         dtype,
         config_tensor_in_dram);
+    uint32_t pool_cb_usage = pool_l1.total();
 
     // Calculate actual pool output tensor size for memory tracking
     // Pool output has same dtype as pool input (halo output), which is BFLOAT16/FLOAT32

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -200,9 +200,7 @@ uint32_t PoolCBSizes::local_cb_total() const {
         total += in_cb_pagesize * in_cb_npages;
     }
     total += mpwi_total_size;
-    if (has_pre_tilize) {
-        total += pre_tilize_cb_pagesize * pre_tilize_cb_npages;
-    }
+    total += pre_tilize_cb_pagesize * pre_tilize_cb_npages;
     total += config_tensor_l1_size;
     return total;
 }

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -114,7 +114,7 @@ PoolCBSizes calculate_pool_cb_sizes(
     bool config_tensor_in_dram);
 
 // Separate L1 usage for local CBs vs globally-allocated tensor buffers.
-// Tracking these separately prevents two errors from cancelling out in validation (see #23133).
+// Tracking these separately prevents two errors from cancelling out in validation
 struct pool_op_l1_usage {
     uint32_t local_cb_size{};
     uint32_t global_cb_size{};

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -4,6 +4,7 @@
 #pragma once
 #include <cstdint>
 #include <string>
+#include <array>
 #include <map>
 #include <optional>
 
@@ -56,6 +57,68 @@ struct FactoryParameters {
     uint32_t MAX_TILES_PER_REDUCTION{};
     bool is_wide_reduction{};
     uint32_t num_tilized_rows{};
+};
+
+// Centralized CB size computation used by both calculate_L1_usage and the pool factory.
+// This eliminates duplicated CB sizing logic between the two (see #23218).
+struct PoolCBSizes {
+    // Scalar CB
+    uint32_t scalar_cb_pagesize{};
+    uint32_t scalar_cb_npages{};
+    bool has_second_scalar_cb{};
+
+    // Clear value CB
+    uint32_t clear_value_cb_size{};
+
+    // Input CB
+    uint32_t in_cb_pagesize{};
+    uint32_t in_cb_npages{};
+    uint32_t in_cb_raw_size{};  // raw element count before padding (used by factory for in_nblocks_c)
+    bool has_split_reader{};
+
+    // MPWI CBs (return_indices only)
+    uint32_t mpwi_total_size{};
+
+    // Pre-tilize CB
+    uint32_t pre_tilize_cb_pagesize{};
+    uint32_t pre_tilize_cb_npages{};
+    bool has_pre_tilize{};
+
+    // Output CB (globally allocated - backed by output tensor buffer)
+    uint32_t out_cb_pagesize{};
+    uint32_t out_cb_npages{};
+
+    // Output index CB (globally allocated - backed by output index tensor buffer)
+    uint32_t out_idx_cb_pagesize{};
+    uint32_t out_idx_cb_npages{};
+    bool has_out_idx{};
+
+    // Config tensor L1 CB size (for DRAM config tensors)
+    uint32_t config_tensor_l1_size{};
+
+    // Sum of all locally-allocated (non-tensor-backed) CB sizes
+    uint32_t local_cb_total() const;
+    // Sum of all globally-allocated (tensor-backed) CB sizes, with alignment
+    uint32_t global_cb_total() const;
+    // Total L1 usage from all CBs
+    uint32_t total() const;
+};
+
+PoolCBSizes calculate_pool_cb_sizes(
+    const FactoryParameters& params,
+    bool one_scalar_per_core,
+    bool return_indices,
+    const Layout& output_layout,
+    const DataType& output_dtype,
+    const std::array<uint32_t, 2>& output_shard_shape,
+    bool config_tensor_in_dram);
+
+// Separate L1 usage for local CBs vs globally-allocated tensor buffers.
+// Tracking these separately prevents two errors from cancelling out in validation (see #23133).
+struct pool_op_l1_usage {
+    uint32_t local_cb_size{};
+    uint32_t global_cb_size{};
+    uint32_t total() const { return local_cb_size + global_cb_size; }
 };
 
 uint32_t get_bf16_pool_scalar(
@@ -114,7 +177,7 @@ FactoryParameters get_factory_parameters(
     uint32_t in_w,
     const Layout& output_layout);
 
-uint32_t calculate_L1_usage(
+pool_op_l1_usage calculate_L1_usage(
     DataType input_dtype,
     uint32_t in_h,
     uint32_t in_w,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/23218
https://github.com/tenstorrent/tt-metal/issues/23133

### Problem description
The Pool2D operation had two related code quality issues:       
                                                                                                                                                                                              
  1. L1 usage validation combined local and global CB sizes into a single check (#23133). Unlike Conv2D (which checks local CB usage and globally-allocated tensor buffers separately), Pool2D
   summed everything into one uint32_t. This meant two estimation errors could cancel each other out and produce a passing validation — e.g., overestimating local CBs by N bytes while       
  underestimating global CBs by N bytes would still pass the total check.                                                                                                                     
  2. CB size logic was duplicated between calculate_L1_usage and the pool factory (#23218). Both independently computed the same CB sizes (scalar, input, output, pre-tilize, MPWI, etc.) with
   slightly different formulations (e.g., TILE_HW * nbytes vs tile_size(data_format)). This duplication was a maintenance burden and a source of potential divergence bugs.

### What's changed
Introduced calculate_pool_cb_sizes() as the single source of truth for all pool CB size computation, and pool_op_l1_usage to track local vs global L1 usage separately (mirroring Conv2D's  
  conv_op_l1_usage pattern).
                                                                                                                                                                                              
  - pool_utils.hpp: Added PoolCBSizes struct (per-CB pagesize/npages and convenience methods for local/global/total sums), pool_op_l1_usage struct (separate local_cb_size and                
  global_cb_size), and calculate_pool_cb_sizes() declaration.
  - pool_utils.cpp: Implemented calculate_pool_cb_sizes() with all CB sizing logic consolidated in one place. Simplified calculate_L1_usage() to delegate to it and return the structured     
  pool_op_l1_usage type. Updated determine_pool_config_for_auto_shard and calculate_L1_usage_for_pool2d_slice for the new return type.                                                        
  - pool_multi_core_program_factory.cpp: Factory now calls calculate_pool_cb_sizes() once and uses the returned values for all create_cb calls, eliminating inline size recomputation.
  Validation now checks local and global CB sizes independently instead of summing them, preventing cancellation errors.

### Checklist
Sanity APC:
https://github.com/tenstorrent/tt-metal/actions/runs/23814814968

Blackhole APC:
https://github.com/tenstorrent/tt-metal/actions/runs/23814830639
same failures as main

Nightly L2:
https://github.com/tenstorrent/tt-metal/actions/runs/23814823732

Frequent Model:
https://github.com/tenstorrent/tt-metal/actions/runs/23814837127