### PR TITLE
Fix non-trace mode decode shapes

### DIFF
--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -204,6 +204,17 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 )
         else:
             assert isinstance(decode_step_output, torch.Tensor), "decode_step_output should be a torch.Tensor on host"
+            # Normalize host decode logits to [B, V], then expose [B, 1, V] for vLLM.
+            if decode_step_output.dim() == 4:
+                # Non-trace path from base generator returns [1, 1, B, V].
+                decode_step_output = decode_step_output.squeeze(0).squeeze(0)
+            elif decode_step_output.dim() == 3 and decode_step_output.shape[1] == 1:
+                # Already time-major [B, 1, V].
+                decode_step_output = decode_step_output.squeeze(1)
+            elif decode_step_output.dim() != 2:
+                raise RuntimeError(
+                    f"Unexpected decode logits rank for host sampling: {tuple(decode_step_output.shape)}"
+                )
             decode_output = decode_step_output.unsqueeze(1)
 
         # decode_output semantics:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -209,7 +209,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 # Non-trace path from base generator returns [1, 1, B, V].
                 decode_step_output = decode_step_output.squeeze(0).squeeze(0)
             elif decode_step_output.dim() == 3 and decode_step_output.shape[1] == 1:
-                # Already time-major [B, 1, V].
+                # Already [B, 1, V].
                 decode_step_output = decode_step_output.squeeze(1)
             elif decode_step_output.dim() != 2:
                 raise RuntimeError(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40979

### What's changed

Adjusts DeepSeek vLLM adapter output shaping so host-sampling (non-device sampling) receives logits in the expected layout when decode tracing is disabled, preventing downstream shape/view errors in vLLM integration.
