### PR TITLE
Change reduce test ULP threshold for ttsim

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
@@ -13,6 +13,10 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 
+def is_simulator():
+    return os.environ.get("TT_METAL_SIMULATOR") != None
+
+
 @pytest.mark.parametrize(
     "shape,shard_shape",
     [
@@ -63,6 +67,10 @@ def test_reduce_on_batch(shape, shard_shape, dim, interleaved, device):
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=True, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
+    # ttsim issue: #309
+    check_ulp = not is_simulator()
+    frobenius_threshold = 0.003 if is_simulator() else 0.002
+
     # test for equivalance
     assert_numeric_metrics(
         torch_output_tensor,
@@ -70,6 +78,6 @@ def test_reduce_on_batch(shape, shard_shape, dim, interleaved, device):
         pcc_threshold=0.999,
         rtol=0.008,
         atol=8.1,
-        frobenius_threshold=0.002,
-        check_ulp=True,
+        frobenius_threshold=frobenius_threshold,
+        check_ulp=check_ulp,
     )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 pytestmark = pytest.mark.use_module_device
@@ -14,7 +16,7 @@ from models.common.utility_functions import torch_random
 
 
 def is_simulator():
-    return os.environ.get("TT_METAL_SIMULATOR") != None
+    return os.environ.get("TT_METAL_SIMULATOR") is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem description
Additional accuracy validation was recently added to tests/ttnn/unit_tests/operations/reduce tests, where the output returned by ttnn is compared against reference output from torch using metrics like ULP.

With these additional checks test_reduce_on_batch started to fail on ttsim, which caused the sanity tests to fail on main.
This change disables the ULP check and relaxes a threshold used for check based on the Frobenius norm when test_reduce_on_batch is ran on the simulator.

### What's changed
- In `test_reduce_on_batch`, disable ULP checking and relax Frobenius threshold when running under ttsim.
- Added `import os` to `test_reduction_on_batch.py` and updated the `is_simulator()` helper to use `is not None` for the environment variable check.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs