### PR TITLE
Fix fabric router re-init after interruption

### DIFF
--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2908,12 +2908,18 @@ __attribute__((optimize("Os"))) void teardown(
                 *termination_signal_ptr);
         }
     }
-
     // write barrier should be coordinated for dynamic noc mode. Safest is probably to do a `wait_for_other_local_erisc`
     // followed by master core doing barrier
     static_assert(noc_mode != DM_DYNAMIC_NOC, "Update here when enabling dynamic noc mode");
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    {
+        router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
+        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
+        tt_l1_ptr launch_msg_t* const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
+        if (!launch_msg->kernel_config.exit_erisc_kernel) {
+            noc_async_write_barrier();
+            noc_async_atomic_barrier();
+        }
+    }
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2908,18 +2908,12 @@ __attribute__((optimize("Os"))) void teardown(
                 *termination_signal_ptr);
         }
     }
+
     // write barrier should be coordinated for dynamic noc mode. Safest is probably to do a `wait_for_other_local_erisc`
     // followed by master core doing barrier
     static_assert(noc_mode != DM_DYNAMIC_NOC, "Update here when enabling dynamic noc mode");
-    {
-        router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
-        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
-        tt_l1_ptr launch_msg_t* const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
-        if (!launch_msg->kernel_config.exit_erisc_kernel) {
-            noc_async_write_barrier();
-            noc_async_atomic_barrier();
-        }
-    }
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {
         wait_for_other_local_erisc();

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -385,17 +385,6 @@ void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
         }
         cluster_.l1_barrier(chip_id);
     }
-
-    // Now send the termination signal. All cores already have exit_erisc_kernel set.
-    for (tt::ChipId chip_id : cluster_.all_chip_ids()) {
-        for (const auto& logical_core : this->get_control_plane_().get_active_ethernet_cores(chip_id)) {
-            CoreCoord virtual_core =
-                cluster_.get_virtual_coordinate_from_logical_coordinates(chip_id, logical_core, CoreType::ETH);
-            cluster_.write_core(
-                term_val.data(), term_val.size() * sizeof(uint32_t), tt_cxy_pair(chip_id, virtual_core), term_addr);
-        }
-        cluster_.l1_barrier(chip_id);
-    }
 }
 
 void RiscFirmwareInitializer::reset_cores(tt::ChipId device_id) {

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -350,11 +350,6 @@ void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
         hal_.get_eth_fw_is_cooperative()) {
         return;
     }
-    auto [term_addr, term_signal] = this->get_control_plane_()
-                                        .get_fabric_context()
-                                        .get_builder_context()
-                                        .get_fabric_router_termination_address_and_signal();
-    std::vector<uint32_t> term_val = {term_signal};
 
     constexpr auto k_ActiveEthCoreType = HalProgrammableCoreType::ACTIVE_ETH;
     auto dev_msgs_factory = hal_.get_dev_msgs_factory(k_ActiveEthCoreType);

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -350,7 +350,6 @@ void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
         hal_.get_eth_fw_is_cooperative()) {
         return;
     }
-
     auto [term_addr, term_signal] = this->get_control_plane_()
                                         .get_fabric_context()
                                         .get_builder_context()
@@ -364,11 +363,6 @@ void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
     auto launch_msg_size = dev_msgs_factory.size_of<dev_msgs::launch_msg_t>();
     auto launch_msg_buf = dev_msgs_factory.create<dev_msgs::launch_msg_t>();
 
-    // Set exit_erisc_kernel on ALL cores before writing any termination signals.
-    // The kernel checks exit_erisc_kernel in teardown to skip NOC barriers that
-    // would hang if remote peers are already torn down. If we write the termination
-    // signal first, the kernel can race through to the barrier check before
-    // exit_erisc_kernel is visible.
     for (tt::ChipId chip_id : cluster_.all_chip_ids()) {
         for (const auto& logical_core : this->get_control_plane_().get_active_ethernet_cores(chip_id)) {
             CoreCoord virtual_core =
@@ -376,7 +370,7 @@ void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
             uint32_t rd_ptr = 0;
             cluster_.read_core(&rd_ptr, sizeof(rd_ptr), tt_cxy_pair(chip_id, virtual_core), rd_ptr_addr);
             rd_ptr &= (dev_msgs::launch_msg_buffer_num_entries - 1);
-            DeviceAddr launch_slot_addr = launch_base_addr + rd_ptr * launch_msg_size;
+            DeviceAddr launch_slot_addr = launch_base_addr + (rd_ptr * launch_msg_size);
             cluster_.read_core(
                 launch_msg_buf.data(), launch_msg_buf.size(), tt_cxy_pair(chip_id, virtual_core), launch_slot_addr);
             launch_msg_buf.view().kernel_config().exit_erisc_kernel() = 1;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -29,6 +29,8 @@
 #include "common/executor.hpp"
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/fabric/fabric_types.hpp>
+#include "fabric/fabric_builder_context.hpp"
+#include "fabric/fabric_context.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "tt_align.hpp"
 #include <umd/device/types/xy_pair.hpp>
@@ -157,6 +159,8 @@ void RiscFirmwareInitializer::run_launch_phase(const std::set<tt::ChipId>& devic
     // See https://github.com/tenstorrent/tt-metal/issues/35701
     ZoneScopedN("Resets and FW Launch");
     if (cluster_.get_target_device_type() != tt::TargetDevice::Mock) {
+        terminate_active_ethernet_cores_on_all_chips();
+
         for (tt::ChipId device_id : device_ids) {
             ClearNocData(descriptor_->env_impl(), device_id);
             reset_cores(device_id);
@@ -337,6 +341,60 @@ void RiscFirmwareInitializer::assert_dram_cores(tt::ChipId device_id) {
             CoreCoord virtual_core{dram_core.x, dram_core.y};
             cluster_.assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), tt::umd::RiscType::BRISC);
         }
+    }
+}
+
+void RiscFirmwareInitializer::terminate_active_ethernet_cores_on_all_chips() {
+    if (cluster_.arch() != ARCH::BLACKHOLE ||
+        !has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) ||
+        hal_.get_eth_fw_is_cooperative()) {
+        return;
+    }
+
+    auto [term_addr, term_signal] = this->get_control_plane_()
+                                        .get_fabric_context()
+                                        .get_builder_context()
+                                        .get_fabric_router_termination_address_and_signal();
+    std::vector<uint32_t> term_val = {term_signal};
+
+    constexpr auto k_ActiveEthCoreType = HalProgrammableCoreType::ACTIVE_ETH;
+    auto dev_msgs_factory = hal_.get_dev_msgs_factory(k_ActiveEthCoreType);
+    DeviceAddr launch_base_addr = hal_.get_dev_addr(k_ActiveEthCoreType, HalL1MemAddrType::LAUNCH);
+    DeviceAddr rd_ptr_addr = hal_.get_dev_addr(k_ActiveEthCoreType, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
+    auto launch_msg_size = dev_msgs_factory.size_of<dev_msgs::launch_msg_t>();
+    auto launch_msg_buf = dev_msgs_factory.create<dev_msgs::launch_msg_t>();
+
+    // Set exit_erisc_kernel on ALL cores before writing any termination signals.
+    // The kernel checks exit_erisc_kernel in teardown to skip NOC barriers that
+    // would hang if remote peers are already torn down. If we write the termination
+    // signal first, the kernel can race through to the barrier check before
+    // exit_erisc_kernel is visible.
+    for (tt::ChipId chip_id : cluster_.all_chip_ids()) {
+        for (const auto& logical_core : this->get_control_plane_().get_active_ethernet_cores(chip_id)) {
+            CoreCoord virtual_core =
+                cluster_.get_virtual_coordinate_from_logical_coordinates(chip_id, logical_core, CoreType::ETH);
+            uint32_t rd_ptr = 0;
+            cluster_.read_core(&rd_ptr, sizeof(rd_ptr), tt_cxy_pair(chip_id, virtual_core), rd_ptr_addr);
+            rd_ptr &= (dev_msgs::launch_msg_buffer_num_entries - 1);
+            DeviceAddr launch_slot_addr = launch_base_addr + rd_ptr * launch_msg_size;
+            cluster_.read_core(
+                launch_msg_buf.data(), launch_msg_buf.size(), tt_cxy_pair(chip_id, virtual_core), launch_slot_addr);
+            launch_msg_buf.view().kernel_config().exit_erisc_kernel() = 1;
+            cluster_.write_core(
+                launch_msg_buf.data(), launch_msg_buf.size(), tt_cxy_pair(chip_id, virtual_core), launch_slot_addr);
+        }
+        cluster_.l1_barrier(chip_id);
+    }
+
+    // Now send the termination signal. All cores already have exit_erisc_kernel set.
+    for (tt::ChipId chip_id : cluster_.all_chip_ids()) {
+        for (const auto& logical_core : this->get_control_plane_().get_active_ethernet_cores(chip_id)) {
+            CoreCoord virtual_core =
+                cluster_.get_virtual_coordinate_from_logical_coordinates(chip_id, logical_core, CoreType::ETH);
+            cluster_.write_core(
+                term_val.data(), term_val.size() * sizeof(uint32_t), tt_cxy_pair(chip_id, virtual_core), term_addr);
+        }
+        cluster_.l1_barrier(chip_id);
     }
 }
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.hpp
@@ -50,6 +50,7 @@ private:
     // Take the cores out of reset state. This should be called after setting the correct program counter for execution.
     void reset_cores(tt::ChipId device_id);
 
+    void terminate_active_ethernet_cores_on_all_chips();
     void assert_active_ethernet_cores_to_reset(tt::ChipId device_id);
     void assert_tensix_workers_impl(tt::ChipId device_id);
     void assert_inactive_ethernet_cores(tt::ChipId device_id);


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/40352
### Problem description
On blackhole machines, if fabric workloads are running and we press ctrl+c and then try to re-run them, we timeout during fabric init because the older fabric routers are never reset

### What's changed
Added termination signals to init so any previous running fabric routers on BH machines are reset before init
Modified teardown to avoid hanging from reliances on non-existent workloads from interrupted runs

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/fabric-erisc-terminate-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/fabric-erisc-terminate-init)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
