### PR TITLE
Log test device workers and their Tray/Asic location

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -83,6 +83,8 @@ int main(int argc, char** argv) {
     TestContext test_context;
     test_context.init(fixture, allocation_policies, use_dynamic_policies);
 
+    test_context.set_show_workers(cmdline_parser.show_workers());
+
     // Configure progress monitoring from cmdline flags
     if (cmdline_parser.show_progress()) {
         ProgressMonitorConfig progress_config;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
@@ -13,17 +13,12 @@
 namespace tt::tt_fabric::fabric_tests {
 
 std::string format_device_label(const FabricNodeId& node_id) {
-    try {
-        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        auto asic_id = control_plane.get_asic_id_from_fabric_node_id(node_id);
-        const auto& psd = control_plane.get_physical_system_descriptor();
-        auto tray_id = psd.get_tray_id(asic_id);
-        auto asic_location = psd.get_asic_location(asic_id);
-        return fmt::format("{} [T{}/N{}]", node_id, *tray_id, *asic_location);
-    } catch (const std::exception&) {
-        // For expected non-fatal lookup failures, fall back to a simple label.
-        return fmt::format("{}", node_id);
-    }
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto asic_id = control_plane.get_asic_id_from_fabric_node_id(node_id);
+    const auto& psd = control_plane.get_physical_system_descriptor();
+    auto tray_id = psd.get_tray_id(asic_id);
+    auto asic_location = psd.get_asic_location(asic_id);
+    return fmt::format("{} [T{}/N{}]", node_id, *tray_id, *asic_location);
 }
 
 // Helper functions for fetching pattern parameters

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
@@ -16,7 +16,7 @@ std::string format_device_label(const FabricNodeId& node_id) {
     try {
         auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
         auto asic_id = control_plane.get_asic_id_from_fabric_node_id(node_id);
-        auto& psd = control_plane.get_physical_system_descriptor();
+        const auto& psd = control_plane.get_physical_system_descriptor();
         auto tray_id = psd.get_tray_id(asic_id);
         auto asic_location = psd.get_asic_location(asic_id);
         return fmt::format("{} [T{}/N{}]", node_id, *tray_id, *asic_location);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
@@ -20,7 +20,8 @@ std::string format_device_label(const FabricNodeId& node_id) {
         auto tray_id = psd.get_tray_id(asic_id);
         auto asic_location = psd.get_asic_location(asic_id);
         return fmt::format("{} [T{}/N{}]", node_id, *tray_id, *asic_location);
-    } catch (...) {
+    } catch (const std::exception&) {
+        // For expected non-fatal lookup failures, fall back to a simple label.
         return fmt::format("{}", node_id);
     }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
@@ -6,7 +6,24 @@
 #include <enchantum/enchantum.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp"
 
+#include "impl/context/metal_context.hpp"
+#include <experimental/fabric/control_plane.hpp>
+#include <experimental/fabric/physical_system_descriptor.hpp>
+
 namespace tt::tt_fabric::fabric_tests {
+
+std::string format_device_label(const FabricNodeId& node_id) {
+    try {
+        auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+        auto asic_id = control_plane.get_asic_id_from_fabric_node_id(node_id);
+        auto& psd = control_plane.get_physical_system_descriptor();
+        auto tray_id = psd.get_tray_id(asic_id);
+        auto asic_location = psd.get_asic_location(asic_id);
+        return fmt::format("{} [T{}/N{}]", node_id, *tray_id, *asic_location);
+    } catch (...) {
+        return fmt::format("{}", node_id);
+    }
+}
 
 // Helper functions for fetching pattern parameters
 TrafficPatternConfig fetch_first_traffic_pattern(const TestConfig& config) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -319,6 +319,9 @@ struct PhysicalMeshConfig {
     }
 };
 
+// Format a fabric node id with Tray/Node info, e.g. "(0,5) [T0/N5]"
+std::string format_device_label(const FabricNodeId& node_id);
+
 // Helper functions for fetching pattern parameters
 TrafficPatternConfig fetch_first_traffic_pattern(const TestConfig& config);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -881,11 +881,19 @@ void CmdlineParser::print_help() {
         "built_tests.yaml.");
     log_info(LogTest, "  --filter <testname>           Specify a filter for the test suite");
     log_info(LogTest, "");
+    log_info(LogTest, "Display Options:");
+    log_info(
+        LogTest,
+        "  --show-workers                               Log active senders/receivers per device before each test.");
+    log_info(LogTest, "");
     log_info(LogTest, "Progress Monitoring Options:");
     log_info(LogTest, "  --show-progress                              Enable real-time progress monitoring.");
     log_info(LogTest, "  --progress-interval <seconds>                Poll interval (default: 2).");
     log_info(LogTest, "  --hung-threshold <seconds>                   Hung detection threshold (default: 30).");
 }
+
+// Display methods
+bool CmdlineParser::show_workers() { return test_args::has_command_option(input_args_, "--show-workers"); }
 
 // Progress monitoring methods
 bool CmdlineParser::show_progress() { return test_args::has_command_option(input_args_, "--show-progress"); }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -332,6 +332,9 @@ public:
     bool has_help_option();
     void print_help();
 
+    // Display options
+    bool show_workers();
+
     // Progress monitoring options
     bool show_progress();
     uint32_t get_progress_interval();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -85,6 +85,7 @@ void TestContext::wait_for_programs_with_progress() {
     }
 
     // Create progress monitor (but don't start polling thread yet)
+    progress_config_.show_workers = show_workers_;
     TestProgressMonitor monitor(this, progress_config_);
 
     // Poll and check for completion in this thread
@@ -324,6 +325,22 @@ void TestContext::compile_programs() {
         } else {
             // Normal mode: create standard kernels for all devices
             test_device.create_kernels();
+        }
+    }
+
+    if (show_workers_) {
+        for (const auto& [coord, test_device] : test_devices_) {
+            const auto& node_id = test_device.get_node_id();
+            const auto& senders = test_device.get_senders();
+            const auto& receivers = test_device.get_receivers();
+            if (!senders.empty() || !receivers.empty()) {
+                log_info(
+                    tt::LogTest,
+                    "Device {}: {} sender(s), {} receiver(s)",
+                    tt::tt_fabric::fabric_tests::format_device_label(node_id),
+                    senders.size(),
+                    receivers.size());
+            }
         }
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -133,6 +133,8 @@ public:
 
     void wait_for_programs() { fixture_->wait_for_programs(); }
 
+    void set_show_workers(bool show_workers) { show_workers_ = show_workers; }
+
     void enable_progress_monitoring(const ProgressMonitorConfig& config);
 
     void wait_for_programs_with_progress();
@@ -263,6 +265,8 @@ private:
     std::unique_ptr<LatencyResultsManager> latency_test_manager_;
     std::vector<TelemetryEntry> telemetry_entries_;  // Per-test raw data
     bool code_profiling_enabled_ = false;
+
+    bool show_workers_ = false;
 
     // Progress monitoring
     ProgressMonitorConfig progress_config_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -18,7 +18,13 @@
 namespace tt::tt_fabric::fabric_tests {
 
 TestProgressMonitor::TestProgressMonitor(::TestContext* ctx, const ProgressMonitorConfig& config) :
-    ctx_(ctx), config_(config), hung_threshold_(config.hung_threshold_seconds) {}
+    ctx_(ctx), config_(config), hung_threshold_(config.hung_threshold_seconds) {
+    for (const auto& [coord, test_device] : ctx_->get_test_devices()) {
+        if (!test_device.get_senders().empty()) {
+            total_active_devices_++;
+        }
+    }
+}
 
 TestProgressMonitor::~TestProgressMonitor() = default;
 
@@ -33,14 +39,6 @@ void TestProgressMonitor::poll_until_complete() {
         auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(now - last_poll_time_);
 
         auto progress = poll_devices();
-
-        if (total_active_devices_ == 0) {
-            for (const auto& [_, prog] : progress) {
-                if (prog.num_senders > 0) {
-                    total_active_devices_++;
-                }
-            }
-        }
 
         check_for_hung_devices(progress);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -35,13 +35,20 @@ void TestProgressMonitor::poll_until_complete() {
         auto progress = poll_devices();
 
         if (total_active_devices_ == 0) {
-            total_active_devices_ = static_cast<uint32_t>(progress.size());
+            for (const auto& [_, prog] : progress) {
+                if (prog.num_senders > 0) {
+                    total_active_devices_++;
+                }
+            }
         }
 
         check_for_hung_devices(progress);
 
         programs_complete = true;
         for (const auto& [device_id, prog] : progress) {
+            if (prog.num_senders == 0) {
+                continue;
+            }
             if (prog.current_packets >= prog.total_packets && prog.total_packets > 0) {
                 if (!completed_devices_.contains(device_id)) {
                     completed_devices_.insert(device_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -33,17 +33,35 @@ void TestProgressMonitor::poll_until_complete() {
         auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(now - last_poll_time_);
 
         auto progress = poll_devices();
+
+        if (total_active_devices_ == 0) {
+            total_active_devices_ = static_cast<uint32_t>(progress.size());
+        }
+
         check_for_hung_devices(progress);
-        display_progress(progress, elapsed);
 
         programs_complete = true;
         for (const auto& [device_id, prog] : progress) {
-            if (prog.current_packets < prog.total_packets) {
+            if (prog.current_packets >= prog.total_packets && prog.total_packets > 0) {
+                if (!completed_devices_.contains(device_id)) {
+                    completed_devices_.insert(device_id);
+                    if (config_.show_workers) {
+                        std::cout << std::endl;
+                        log_info(
+                            tt::LogTest,
+                            "Device {} completed ({} packets) [{}/{} done]",
+                            format_device_label(device_id),
+                            format_count(prog.total_packets),
+                            completed_devices_.size(),
+                            total_active_devices_);
+                    }
+                }
+            } else {
                 programs_complete = false;
-                break;
             }
         }
 
+        display_progress(progress, elapsed);
         last_poll_time_ = now;
 
         if (!programs_complete) {
@@ -149,7 +167,7 @@ void TestProgressMonitor::check_for_hung_devices(
                 log_warning(
                     tt::LogTest,
                     "⚠️  Device {} may be HUNG: no progress for {} seconds (packets: {}/{})",
-                    device_id,
+                    format_device_label(device_id),
                     elapsed.count(),
                     prog.current_packets,
                     prog.total_packets);
@@ -190,6 +208,10 @@ void TestProgressMonitor::display_progress(
     // Always update last_total_packets for next iteration
     if (total_current > 0) {
         last_total_packets_ = total_current;
+    }
+
+    if (total_active_devices_ > 0) {
+        ss << " | Devices: " << completed_devices_.size() << "/" << total_active_devices_ << " done";
     }
 
     // Pad with spaces to clear any leftover text from previous longer updates

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "tt_fabric_test_interfaces.hpp"
 #include "tt_fabric_test_common.hpp"                // For MeshCoordinate
@@ -26,6 +27,7 @@ struct TestDevice;
 // Progress monitoring configuration
 struct ProgressMonitorConfig {
     bool enabled = false;
+    bool show_workers = false;
     uint32_t poll_interval_seconds = 2;    // How often to poll progress
     uint32_t hung_threshold_seconds = 30;  // When to warn about hung devices
 };
@@ -101,6 +103,10 @@ private:
     // Hung detection state
     std::unordered_map<tt::tt_fabric::FabricNodeId, DeviceState> device_states_;
     std::chrono::seconds hung_threshold_;
+
+    // Per-device completion tracking
+    std::unordered_set<tt::tt_fabric::FabricNodeId> completed_devices_;
+    uint32_t total_active_devices_ = 0;
 };
 
 }  // namespace tt::tt_fabric::fabric_tests


### PR DESCRIPTION
Add logging of device workers. Enabled with --show-workers flag. When enabled, test prints the sender/receiver workers on test devices. For devices we log Fabric Node Id and Physical Tray/Asic location

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/tt-fabric-test-worker-status)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/tt-fabric-test-worker-status)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
