### PR TITLE
UMD Cluster Discovery Performance Optimization

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -383,13 +383,18 @@ const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_pr
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
     if (this->target_type_ == TargetDevice::Silicon) {
-        // One topology discovery; pass descriptor into Cluster so UMD does not discover again. Omit sdesc_path so UMD
-        // uses its arch-default SocDescriptor; Metal loads dram_views YAML once in get_metal_desc_from_tt_desc().
-        auto discovered_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+        // This is the target/desired number of mem channels per arch/device.
+        // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
+        // and assert if workload uses more than available.
+        auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+        auto grouped_chips = temp_cluster_desc->get_chips_grouped_by_closest_mmio();
+        uint32_t max_chips_per_mmio = 0;
+        for (const auto& [mmio_device_id, chips] : grouped_chips) {
+            max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
+        }
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-            // Metal uses one host mem channel per MMIO device; see https://github.com/tenstorrent/tt-metal/issues/4087
-            .num_host_mem_ch_per_mmio_device = 1,
-            .cluster_descriptor = discovered_cluster_desc.get(),
+            .num_host_mem_ch_per_mmio_device = std::min(HOST_MEM_CHANNELS, max_chips_per_mmio),
+            .cluster_descriptor = temp_cluster_desc.get(),
         });
     } else if (this->target_type_ == TargetDevice::Simulator) {
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -373,21 +373,17 @@ const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_pr
 
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
-    std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
     if (this->target_type_ == TargetDevice::Silicon) {
-        // This is the target/desired number of mem channels per arch/device.
-        // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
-        // and assert if workload uses more than available.
-        // auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
-        // auto grouped_chips = temp_cluster_desc->get_chips_grouped_by_closest_mmio();
-        // uint32_t max_chips_per_mmio = 0;
-        // for (const auto& [mmio_device_id, chips] : grouped_chips) {
-        //     max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
-        // }
+        // One topology discovery; pass descriptor into Cluster so UMD does not discover again. Omit sdesc_path so UMD
+        // builds SocDescriptors from arch/chip_info (no redundant metal YAML parse).
+        auto discovered_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
+            // Metal uses one host mem channel per MMIO device; see https://github.com/tenstorrent/tt-metal/issues/4087
             .num_host_mem_ch_per_mmio_device = 1,
+            .cluster_descriptor = discovered_cluster_desc.get(),
         });
     } else if (this->target_type_ == TargetDevice::Simulator) {
+        const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
         std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc;
         if (rtoptions_.get_mock_enabled()) {
             mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
@@ -405,6 +401,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
             });
         }
     } else if (this->target_type_ == TargetDevice::Mock) {
+        const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
         // If a cluster descriptor was not provided via constructor, and mock is enabled via rtoptions,
         // load it from the YAML path and pass it into UMD for mock initialization.
         auto mock_cluster_desc = get_mock_cluster_desc(rtoptions_);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -361,9 +361,18 @@ void Cluster::assign_mem_channels_to_devices(
 }
 
 void Cluster::get_metal_desc_from_tt_desc() {
+    std::string silicon_dram_metadata_yaml;
+    if (this->target_type_ == TargetDevice::Silicon) {
+        // UMD uses arch-default soc descriptors without sdesc_path; device_descriptor_file_path is empty until we set
+        // it on a copy (public field on tt::umd::SocDescriptor) for metal_SocDescriptor's dram_views YAML load.
+        silicon_dram_metadata_yaml = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
+    }
     for (const auto& id : this->driver_->get_target_device_ids()) {
-        this->sdesc_per_chip_.emplace(
-            id, metal_SocDescriptor(this->driver_->get_soc_descriptor(id), this->cluster_desc_->get_board_type(id)));
+        tt::umd::SocDescriptor umd_soc = this->driver_->get_soc_descriptor(id);
+        if (this->target_type_ == TargetDevice::Silicon) {
+            umd_soc.device_descriptor_file_path = silicon_dram_metadata_yaml;
+        }
+        this->sdesc_per_chip_.emplace(id, metal_SocDescriptor(umd_soc, this->cluster_desc_->get_board_type(id)));
     }
 }
 
@@ -375,7 +384,7 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
     if (this->target_type_ == TargetDevice::Silicon) {
         // One topology discovery; pass descriptor into Cluster so UMD does not discover again. Omit sdesc_path so UMD
-        // builds SocDescriptors from arch/chip_info (no redundant metal YAML parse).
+        // uses its arch-default SocDescriptor; Metal loads dram_views YAML once in get_metal_desc_from_tt_desc().
         auto discovered_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
             // Metal uses one host mem channel per MMIO device; see https://github.com/tenstorrent/tt-metal/issues/4087

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -378,15 +378,14 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
         // This is the target/desired number of mem channels per arch/device.
         // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
         // and assert if workload uses more than available.
-        auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
-        auto grouped_chips = temp_cluster_desc->get_chips_grouped_by_closest_mmio();
-        uint32_t max_chips_per_mmio = 0;
-        for (const auto& [mmio_device_id, chips] : grouped_chips) {
-            max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
-        }
+        // auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+        // auto grouped_chips = temp_cluster_desc->get_chips_grouped_by_closest_mmio();
+        // uint32_t max_chips_per_mmio = 0;
+        // for (const auto& [mmio_device_id, chips] : grouped_chips) {
+        //     max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
+        // }
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-            .num_host_mem_ch_per_mmio_device = std::min(HOST_MEM_CHANNELS, max_chips_per_mmio),
-            .sdesc_path = sdesc_path,
+            .num_host_mem_ch_per_mmio_device = 1,
         });
     } else if (this->target_type_ == TargetDevice::Simulator) {
         std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -386,15 +386,17 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
         // This is the target/desired number of mem channels per arch/device.
         // Silicon driver will attempt to open this many hugepages as channels per mmio chip,
         // and assert if workload uses more than available.
-        auto temp_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
-        auto grouped_chips = temp_cluster_desc->get_chips_grouped_by_closest_mmio();
+        auto discovered_cluster_desc = tt::umd::Cluster::create_cluster_descriptor();
+        auto grouped_chips = discovered_cluster_desc->get_chips_grouped_by_closest_mmio();
         uint32_t max_chips_per_mmio = 0;
         for (const auto& [mmio_device_id, chips] : grouped_chips) {
             max_chips_per_mmio = std::max(max_chips_per_mmio, static_cast<uint32_t>(chips.size()));
         }
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
             .num_host_mem_ch_per_mmio_device = std::min(HOST_MEM_CHANNELS, max_chips_per_mmio),
-            .cluster_descriptor = temp_cluster_desc.get(),
+            .sdesc_path = {},
+            .target_devices = discovered_cluster_desc->get_all_chips(),
+            .cluster_descriptor = discovered_cluster_desc.get(),
         });
     } else if (this->target_type_ == TargetDevice::Simulator) {
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);


### PR DESCRIPTION
## Description

Silicon bring-up previously let UMD run full topology discovery in `Cluster`’s constructor while we also had paths that implied duplicate work and an unused metal SoC descriptor path. This change loads the cluster descriptor once via `Cluster::create_cluster_descriptor()`, passes it into `ClusterOptions::cluster_descriptor`, and builds the UMD `Cluster` with **`num_host_mem_ch_per_mmio_device = 1`** unchanged (same as today; see [#4087](https://github.com/tenstorrent/tt-metal/issues/4087)).

### What changes

- **One discovery for silicon** — Pre-created descriptor is passed into UMD so the constructor does not run discovery again for the default path.
- **No custom SoC YAML on silicon** — We do not pass `sdesc_path`; UMD constructs `SocDescriptor` from arch and chip info, avoiding a redundant parse of `tt_metal/soc_descriptors/*.yaml`.
- **Lazy SoC path** — `get_soc_description_file` is only used for simulator and mock, not silicon.

### Risk / validation

- Silicon init and any tests that exercise `Cluster::initialize_device_drivers` / device open should behave the same aside from less redundant I/O and parsing. Run your usual metal/UMD smoke or post-commit targets that touch real silicon if available.

### Tests
- [x] [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/23814369093)
- [x] [Galaxy Unit](https://github.com/tenstorrent/tt-metal/actions/runs/24039325380)
- [x] [T3k Unit](https://github.com/tenstorrent/tt-metal/actions/runs/24039333775)
- [x] [Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/23869945810)
- [x] [Blackhole post commit](https://github.com/tenstorrent/tt-metal/actions/runs/24039313430)
