### PR TITLE
[skip ci] Add missing workdir to avoid finding stray files

### DIFF
--- a/.github/actions/run-multi-process-tests/action.yml
+++ b/.github/actions/run-multi-process-tests/action.yml
@@ -9,6 +9,7 @@ runs:
   steps:
     - name: Run Multi-Process tests
       shell: bash
+      working-directory: /work
       env:
         LD_LIBRARY_PATH: /work/build/lib
         TT_METAL_HOME: /work


### PR DESCRIPTION
### Ticket
N/A

### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/23654457631/job/68924608344 is failing and looks as though it's picking up the wrong file.  Very Ungood.

### What's changed
Make sure that this job defines the working dir that matches the other paths its using so it doesn't accidentally find an unexpected binary by the same name.

### Checklist

- [X] Galaxy unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/23771929022 (no workdir related issue)