### PR TITLE
Sliding Window 32 Bit Indexing Support

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -394,6 +394,13 @@ void kernel_main() {
     constexpr uint32_t intra_kernel_down_left_wrap_inc_cb_id = get_compile_time_arg_val(53);
     constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(54);
     constexpr uint32_t reader_tensor_args_index = 55;
+    // reader_indices_is_32bit placed after all TensorAccessorArgs
+    constexpr uint32_t reader_indices_is_32bit_index =
+        one_scalar_per_core
+            ? TensorAccessorArgs<reader_tensor_args_index>().next_compile_time_args_offset()
+            : TensorAccessorArgs<TensorAccessorArgs<reader_tensor_args_index>().next_compile_time_args_offset()>()
+                  .next_compile_time_args_offset();
+    constexpr uint32_t reader_indices_is_32bit = get_compile_time_arg_val(reader_indices_is_32bit_index);
 
     constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
 
@@ -467,18 +474,30 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 
-    uint32_t segments_counter = 1;
+    uint32_t segments_counter = reader_indices_is_32bit ? 2 : 1;
     constexpr uint32_t total_elems_to_reduce = kernel_h * kernel_w;
 
-    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+    uint32_t num_segments;
+    if constexpr (reader_indices_is_32bit) {
+        num_segments = reader_indices_ptr[0];
+    } else {
+        num_segments = reader_indices_ptr[0] & 0xffff;
+    }
 
     while (num_segments--) {
-        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
-        uint16_t start = start_end_segment & 0xffff;
-        uint16_t end = start_end_segment >> 16;
+        uint32_t start;
+        uint32_t end;
+        if constexpr (reader_indices_is_32bit) {
+            start = reader_indices_ptr[segments_counter++];
+            end = reader_indices_ptr[segments_counter++];
+        } else {
+            uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+            start = start_end_segment & 0xffff;
+            end = start_end_segment >> 16;
+        }
 
         constexpr uint32_t stride_multiple = 1;
-        for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
+        for (uint32_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
             read_kernel_with_top_left_index<
                 in_nblocks_c,
                 in_cb_id,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -181,6 +181,13 @@ void kernel_main() {
     constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(35);
     constexpr uint32_t reader_page_size = get_compile_time_arg_val(36);
     constexpr uint32_t reader_tensor_args_index = 55;
+    // reader_indices_is_32bit placed after all TensorAccessorArgs
+    constexpr uint32_t reader_indices_is_32bit_index =
+        one_scalar_per_core
+            ? TensorAccessorArgs<reader_tensor_args_index>().next_compile_time_args_offset()
+            : TensorAccessorArgs<TensorAccessorArgs<reader_tensor_args_index>().next_compile_time_args_offset()>()
+                  .next_compile_time_args_offset();
+    constexpr uint32_t reader_indices_is_32bit = get_compile_time_arg_val(reader_indices_is_32bit_index);
 
     constexpr bool use_split_reader = split_reader;
     constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;
@@ -247,7 +254,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reader_indices_l1_addr);
 
-    uint32_t segments_counter = 1;
+    uint32_t segments_counter = reader_indices_is_32bit ? 2 : 1;
     constexpr uint32_t total_elems_to_reduce = kernel_h * kernel_w;
 
     volatile tt_l1_ptr uint16_t* config_ptr;
@@ -277,13 +284,25 @@ void kernel_main() {
         scalar_end = config_ptr[2];
     }
 
-    uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
+    uint32_t num_segments;
+    if constexpr (reader_indices_is_32bit) {
+        num_segments = reader_indices_ptr[0];
+    } else {
+        num_segments = reader_indices_ptr[0] & 0xffff;
+    }
     bool first_row_value = reader_id == 0 || !use_split_reader;
 
     while (num_segments--) {
-        uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
-        uint16_t start = start_end_segment & 0xffff;
-        uint16_t end = start_end_segment >> 16;
+        uint32_t start;
+        uint32_t end;
+        if constexpr (reader_indices_is_32bit) {
+            start = reader_indices_ptr[segments_counter++];
+            end = reader_indices_ptr[segments_counter++];
+        } else {
+            uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
+            start = start_end_segment & 0xffff;
+            end = start_end_segment >> 16;
+        }
 
         if (!first_row_value) {
             start += stride_w;
@@ -291,7 +310,7 @@ void kernel_main() {
         }
 
         constexpr uint32_t stride_multiple = use_split_reader ? 2 : 1;
-        for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
+        for (uint32_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
             if constexpr (!one_scalar_per_core) {
                 fill_scalar<
                     one_scalar_per_core,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -301,12 +301,6 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
     const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
     const uint32_t max_out_nhw_per_core = outputs[0].shard_spec()->shape[0];
-    const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
-    TT_FATAL(
-        max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
-        "Input nhw per core {} exceeds uint16_t limit, this will cause overflow because the reader indices are stored "
-        "as uint16_t",
-        max_in_nhw_per_core);
 
     const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
     const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
@@ -391,21 +385,25 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         tt::round_up(reader_indices_size, 4);  // pagesize needs to be multiple of 4
     constexpr uint32_t in_reader_indices_cb_npages = 1;
 
+    const bool reader_indices_is_32bit = reader_indices.dtype() == DataType::UINT32;
+    const uint32_t reader_index_elem_size = reader_indices_is_32bit ? sizeof(uint32_t) : sizeof(uint16_t);
     const uint32_t max_reader_indices_size =
-        (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
+        (max_out_nhw_per_core * 3 * reader_index_elem_size) +
+        reader_index_elem_size;  // worst case of 3 indices per output element + header
     TT_FATAL(
         reader_indices_storage.get_buffer()->page_size() <= max_reader_indices_size,
         "Reader indices buffer page size {} exceeds max expected size {}",
         reader_indices_storage.get_buffer()->page_size(),
         max_reader_indices_size);
 
+    const tt::DataFormat reader_indices_df = reader_indices_is_32bit ? tt::DataFormat::UInt32 : tt::DataFormat::UInt16;
     tt::tt_metal::create_cb(
         in_reader_indices_cb_id,
         program,
         all_cores,
         config_tensor_in_dram ? max_reader_indices_size : in_reader_indices_cb_pagesize,
         in_reader_indices_cb_npages,
-        tt::DataFormat::UInt16,
+        reader_indices_df,
         config_tensor_in_dram ? nullptr : reader_indices_storage.get_buffer());
 
     log_debug(
@@ -746,6 +744,9 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     if (!one_scalar_per_core) {
         tt::tt_metal::TensorAccessorArgs(config_tensor.device_storage().get_buffer()).append_to(reader0_ct_args);
     }
+    // Place reader_indices_is_32bit after all TensorAccessorArgs so we don't shift their indices
+    reader0_ct_args.push_back((uint32_t)reader_indices_is_32bit);
+
     std::vector<uint32_t> reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
 
@@ -1041,8 +1042,30 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
     std::vector<sliding_window::ShardBoundary> shard_boundaries =
         ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
-    std::vector<std::vector<uint16_t>> top_left_indices =
-        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, stride_w);
+
+    const bool config_is_32bit =
+        sliding_window::needs_uint32_sliding_window_config(shard_boundaries, op_trace_metadata);
+
+    Tensor reader_indices_on_device;
+    uint32_t reader_indices_element_count;
+    if (config_is_32bit) {
+        auto top_left_indices =
+            sliding_window::generate_sliding_window_op_config<uint32_t>(op_trace_metadata, shard_boundaries, stride_w);
+        reader_indices_element_count = top_left_indices[0].size();
+        Tensor reader_indices = sliding_window::construct_on_host_config_tensor<uint32_t>(
+            top_left_indices, parallel_config, op_attr.config_tensor_in_dram);
+        reader_indices_on_device = sliding_window::move_config_tensor_to_device(
+            reader_indices, parallel_config, is_block_sharded, input.device(), op_attr.config_tensor_in_dram);
+    } else {
+        auto top_left_indices =
+            sliding_window::generate_sliding_window_op_config<uint16_t>(op_trace_metadata, shard_boundaries, stride_w);
+        reader_indices_element_count = top_left_indices[0].size();
+        Tensor reader_indices = sliding_window::construct_on_host_config_tensor<uint16_t>(
+            top_left_indices, parallel_config, op_attr.config_tensor_in_dram);
+        reader_indices_on_device = sliding_window::move_config_tensor_to_device(
+            reader_indices, parallel_config, is_block_sharded, input.device(), op_attr.config_tensor_in_dram);
+    }
+
     std::vector<uint32_t> core_starting_indices;
     if (return_indices) {
         const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
@@ -1052,16 +1075,11 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
             generate_core_starting_indices(op_trace_metadata, shard_boundaries, shard_scheme, num_cores_x, ncores);
     }
 
-    Tensor reader_indices = sliding_window::construct_on_host_config_tensor(
-        top_left_indices, parallel_config, op_attr.config_tensor_in_dram);
-    Tensor reader_indices_on_device = sliding_window::move_config_tensor_to_device(
-        reader_indices, parallel_config, is_block_sharded, input.device(), op_attr.config_tensor_in_dram);
-
     return pool2d_multi_core_sharded_with_halo_v2_impl_new(
         program,
         tensor_args.input_tensor_,
         reader_indices_on_device,
-        top_left_indices[0].size(),
+        reader_indices_element_count,
         output_tensors,
         pool_type,
         in_n,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -16,6 +16,16 @@
 
 constexpr uint16_t TILE_SIZE = 32;
 
+// Type selector: when ConfigIs32Bit is true, config entries are uint32_t; otherwise uint16_t.
+template <bool ConfigIs32Bit>
+struct ConfigType {
+    using type = uint16_t;
+};
+template <>
+struct ConfigType<true> {
+    using type = uint32_t;
+};
+
 template <uint32_t N, uint16_t PaddingValue>
 FORCE_INLINE void fill_with_val(uint32_t begin_addr) {
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(begin_addr);
@@ -88,17 +98,19 @@ FORCE_INLINE void copy_padding_large_sticks(uint64_t padding_l1_addr, uint64_t d
     }
 }
 
-template <uint32_t PaddingConfigCBId, uint32_t OutCBId, uint32_t StickNBytes, uint32_t MaxChunkSize>
+template <uint32_t PaddingConfigCBId, uint32_t OutCBId, uint32_t StickNBytes, uint32_t MaxChunkSize, bool ConfigIs32Bit>
 FORCE_INLINE void copy_padding(uint64_t padding_l1_addr) {
+    using config_t = typename ConfigType<ConfigIs32Bit>::type;
+
     const uint32_t padding_config_l1_addr = get_read_ptr(PaddingConfigCBId);
-    volatile tt_l1_ptr uint16_t* config_data = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
+    volatile tt_l1_ptr config_t* config_data = reinterpret_cast<volatile tt_l1_ptr config_t*>(padding_config_l1_addr);
 
     const uint64_t dst_base_addr = get_write_ptr(OutCBId);
 
-    uint16_t nsticks = 1;
+    uint32_t nsticks = 1;
     constexpr uint32_t stick_stride = StickNBytes;
-    for (uint16_t j = 0; nsticks != 0; j += 2) {
-        uint16_t dst_local_idx = config_data[j + 0];
+    for (uint32_t j = 0; nsticks != 0; j += 2) {
+        uint32_t dst_local_idx = config_data[j + 0];
         nsticks = config_data[j + 1];
 
         const uint64_t dst_addr = dst_base_addr + (static_cast<uint64_t>(dst_local_idx) * stick_stride);
@@ -137,9 +149,9 @@ template <uint32_t StickSizeBytes, bool EnableBlocking, uint32_t BlockHeightStic
 static inline void write_stick_async(
     uint32_t in_base_l1_addr,
     uint64_t out_base_l1_addr,
-    uint16_t src_offset_id,
-    uint16_t dst_offset_id,
-    uint16_t transfer_size) {
+    uint32_t src_offset_id,
+    uint32_t dst_offset_id,
+    uint32_t transfer_size) {
     if constexpr (EnableBlocking) {
         const uint32_t src_offset = (src_offset_id % BlockHeightSticks) *
                                     StickSizeBytes;  // Convert from global stick offset to local block stick offset
@@ -169,15 +181,19 @@ template <
     bool EnableBlocking,
     bool IsBlockSharded,
     bool IsWidthSharded,
-    bool IsColumnMajor>
-static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my_noc_x, uint32_t my_noc_y) {
+    bool IsColumnMajor,
+    bool ConfigIs32Bit>
+static inline void run_halo_gather(const void* config_raw, uint32_t my_noc_x, uint32_t my_noc_y) {
+    using config_t = typename ConfigType<ConfigIs32Bit>::type;
+    const tt_l1_ptr config_t* config = reinterpret_cast<const tt_l1_ptr config_t*>(config_raw);
+
     static_assert(BlockStride >= 1, "Blocks stride must be at least 1");
 
     constexpr uint32_t block_size_height_tiles = BlockSizeHeight / TILE_SIZE;
     constexpr uint32_t total_tiles_in_single_block = block_size_height_tiles * BlockSizeWidthTiles;
 
-    uint16_t current_config_index = 0;
-    uint16_t number_of_segments_remaining = config[current_config_index++];
+    uint32_t current_config_index = 0;
+    uint32_t number_of_segments_remaining = config[current_config_index++];
 
     if (number_of_segments_remaining == 0) {
         return;
@@ -192,22 +208,22 @@ static inline void run_halo_gather(const tt_l1_ptr uint16_t* config, uint32_t my
     }
 
     uint64_t out_l1_addr = 0;
-    uint16_t block_id = BlockStartOffset;
-    uint16_t block_boundary_offset = BlockSizeHeight + (BlockSizeHeight * BlockStartOffset);
+    uint32_t block_id = BlockStartOffset;
+    uint32_t block_boundary_offset = BlockSizeHeight + (BlockSizeHeight * BlockStartOffset);
     while (number_of_segments_remaining) {
         //  Read header for to get destination for this route
-        const uint16_t destination_noc_x = config[current_config_index++];
-        const uint16_t destination_noc_y = config[current_config_index++];
-        uint16_t transfers_remaining = config[current_config_index++];
+        const uint32_t destination_noc_x = config[current_config_index++];
+        const uint32_t destination_noc_y = config[current_config_index++];
+        uint32_t transfers_remaining = config[current_config_index++];
 
         out_l1_addr = get_remote_core_l1_noc_addr<IsBlockSharded, IsWidthSharded, IsColumnMajor>(
             destination_noc_x, destination_noc_y, my_noc_x, my_noc_y, out_base_l1_addr);
 
         // Perform all transfers in this route
         while (transfers_remaining > 0) {
-            const uint16_t src_offset = config[current_config_index++];
-            const uint16_t dst_offset = config[current_config_index++];
-            const uint16_t transfer_size = config[current_config_index++];
+            const uint32_t src_offset = config[current_config_index++];
+            const uint32_t dst_offset = config[current_config_index++];
+            const uint32_t transfer_size = config[current_config_index++];
             if constexpr (EnableBlocking) {
                 // Pop blocks until we have the right one - this works because transfers are globally ordered by
                 // ascending block IDs
@@ -269,6 +285,9 @@ void kernel_main() {
     constexpr auto padding_config_tensor_args = TensorAccessorArgs<22>();
     constexpr auto gather_config_tensor_args =
         TensorAccessorArgs<padding_config_tensor_args.next_compile_time_args_offset()>();
+    // config_is_32bit always appended in DRAM mode
+    constexpr bool config_is_32bit =
+        get_compile_time_arg_val(gather_config_tensor_args.next_compile_time_args_offset()) == 1;
 
     const auto padding_config_accessor =
         TensorAccessor(padding_config_tensor_args, padding_config_dram_addr, padding_config_page_size);
@@ -283,6 +302,15 @@ void kernel_main() {
     noc_async_read(padding_src_noc_addr, get_write_ptr(padding_config_cb_id), padding_config_page_size);
     noc_async_read(gather_src_noc_addr, get_write_ptr(gather_config_cb_id), gather_config_page_size);
     noc_async_read_barrier();
+#else
+    // Non-DRAM: config_is_32bit is only appended when true; detect via arg count
+    constexpr bool config_is_32bit = []() constexpr {
+        if constexpr (kernel_compile_time_args.size() > 18) {
+            return get_ct_arg<18>() == 1;
+        } else {
+            return false;
+        }
+    }();
 #endif
 
     const uint16_t my_noc_x = NOC_X(my_x[noc_index]);
@@ -299,7 +327,8 @@ void kernel_main() {
             // Use MEM_ZEROS_BASE if we are zero padded
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, MEM_ZEROS_BASE);
             constexpr uint32_t padding_region_size = MEM_ZEROS_SIZE;
-            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size, config_is_32bit>(
+                padding_l1_addr);
         } else {
             constexpr uint16_t pad_val = static_cast<uint16_t>(pad_val_u32);
             constexpr uint32_t num_elements_to_fill = aligned_stick_nbytes / elem_nbytes;
@@ -308,7 +337,8 @@ void kernel_main() {
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
             // MaxChunkSize must be in bytes and >= StickNBytes to avoid misaligned NOC transactions
             constexpr uint32_t padding_region_size = aligned_stick_nbytes;
-            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
+            copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size, config_is_32bit>(
+                padding_l1_addr);
         }
     }
 
@@ -317,7 +347,7 @@ void kernel_main() {
     }
 
     const uint32_t config_data_l1_addr = get_read_ptr(gather_config_cb_id);
-    const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+    const void* config_data = reinterpret_cast<const void*>(config_data_l1_addr);
     run_halo_gather<
         in_cb_id,
         out_cb_id,
@@ -329,7 +359,8 @@ void kernel_main() {
         enable_blocking,
         is_block_sharded,
         is_width_sharded,
-        is_col_major>(config_data, my_noc_x, my_noc_y);
+        is_col_major,
+        config_is_32bit>(config_data, my_noc_x, my_noc_y);
 
     noc_async_read_barrier();
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -87,58 +87,126 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
 
     uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
 
-    auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
-        tensor_metadata,
-        shard_boundaries,
-        is_block_sharded,
-        transpose_mcast,
-        remote_read,
-        device,
-        num_cores_x,
-        is_in_tiled,
-        UNTILIZE_BLOCK_SIZE);
+    const bool halo_config_is_32bit = sliding_window::needs_uint32_halo_config(shard_boundaries);
 
-    const auto& pad_config0 = kernel_config.pad_config0;
-    const auto& pad_config1 = kernel_config.pad_config1;
-    const auto& gather_config0 = kernel_config.gather_config0;
-    const auto& gather_config1 = kernel_config.gather_config1;
+    Tensor pad_config_device_tensor0, pad_config_device_tensor1;
+    Tensor gather_config_device_tensor0, gather_config_device_tensor1;
+    std::vector<uint16_t> number_of_blocks_per_core_raw;
 
-    const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        pad_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        pad_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        gather_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        gather_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    if (halo_config_is_32bit) {
+        auto kernel_config = sliding_window::generate_halo_kernel_config_tensors<uint32_t>(
+            tensor_metadata,
+            shard_boundaries,
+            is_block_sharded,
+            transpose_mcast,
+            remote_read,
+            device,
+            num_cores_x,
+            is_in_tiled,
+            UNTILIZE_BLOCK_SIZE);
 
-    auto pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    auto gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
+        const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor<uint32_t>(
+            kernel_config.pad_config0,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor<uint32_t>(
+            kernel_config.pad_config1,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor<uint32_t>(
+            kernel_config.gather_config0,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor<uint32_t>(
+            kernel_config.gather_config1,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+
+        pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor0,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor1,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+            gather_config_tensor0,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+            gather_config_tensor1,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+
+        number_of_blocks_per_core_raw = kernel_config.number_of_blocks_per_core;
+    } else {
+        auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
+            tensor_metadata,
+            shard_boundaries,
+            is_block_sharded,
+            transpose_mcast,
+            remote_read,
+            device,
+            num_cores_x,
+            is_in_tiled,
+            UNTILIZE_BLOCK_SIZE);
+
+        const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+            kernel_config.pad_config0,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            kernel_config.pad_config1,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
+            kernel_config.gather_config0,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+        const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
+            kernel_config.gather_config1,
+            operation_attributes.parallel_config,
+            operation_attributes.config_tensors_in_dram);
+
+        pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor0,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+            pad_config_tensor1,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
+            gather_config_tensor0,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+        gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
+            gather_config_tensor1,
+            operation_attributes.parallel_config,
+            is_block_sharded,
+            device,
+            operation_attributes.config_tensors_in_dram);
+
+        number_of_blocks_per_core_raw = kernel_config.number_of_blocks_per_core;
+    }
 
     const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
-        kernel_config.number_of_blocks_per_core, operation_attributes.parallel_config);
+        number_of_blocks_per_core_raw, operation_attributes.parallel_config);
 
     Program program = CreateProgram();
 
@@ -216,7 +284,7 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
     cb_indices.pad_cb_id1 = cb_indices.get_next_cb_id();
     create_circular_buffer(program, all_cores, cb_indices.pad_cb_id1, out_df, pad_cb_npages, pad_cb_pagesize);
 
-    tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
+    tt::DataFormat kernel_config_df = halo_config_is_32bit ? tt::DataFormat::RawUInt32 : tt::DataFormat::RawUInt16;
 
     uint32_t input_to_writer_cb_id0 = cb_indices.src_cb_id;
     uint32_t input_to_writer_cb_id1 = cb_indices.src_cb_id;
@@ -253,10 +321,11 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         }
     }
 
-    TT_ASSERT(pad_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(pad_config_device_tensor1.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor1.dtype() == DataType::UINT16);
+    const DataType expected_config_dtype = halo_config_is_32bit ? DataType::UINT32 : DataType::UINT16;
+    TT_ASSERT(pad_config_device_tensor0.dtype() == expected_config_dtype);
+    TT_ASSERT(pad_config_device_tensor1.dtype() == expected_config_dtype);
+    TT_ASSERT(gather_config_device_tensor0.dtype() == expected_config_dtype);
+    TT_ASSERT(gather_config_device_tensor1.dtype() == expected_config_dtype);
 
     const auto& padding_config_storage0 = pad_config_device_tensor0.device_storage();
     auto* padding_config_buffer0 = padding_config_storage0.get_buffer();
@@ -356,6 +425,18 @@ UntilizeWithHaloProgramFactory::cached_program_t UntilizeWithHaloProgramFactory:
         tt::tt_metal::TensorAccessorArgs(padding_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
         tt::tt_metal::TensorAccessorArgs(gather_config_storage1.get_buffer()).append_to(core_1_reader_ct_args);
     }
+    // In DRAM mode the kernel hash already differs (CONFIG_TENSOR_IN_DRAM define), so always append.
+    // In non-DRAM mode, only append when true to preserve the default kernel hash for conv/pool perf.
+    if (config_tensors_in_dram || halo_config_is_32bit) {
+        core_0_reader_ct_args.push_back((uint32_t)halo_config_is_32bit);
+        core_1_reader_ct_args.push_back((uint32_t)halo_config_is_32bit);
+    }
+    log_debug(
+        tt::LogOp,
+        "halo_gather: core_0 ct_args size={}, core_1 ct_args size={}, config_tensors_in_dram={}",
+        core_0_reader_ct_args.size(),
+        core_1_reader_ct_args.size(),
+        config_tensors_in_dram);
     const uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
     const bool enable_padding = config_tensors_in_dram ||
                                 padding_config_buffer0->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -461,11 +461,50 @@ std::vector<PixelMetadata> generate_tensor_metadata(
     return tensor_metadata;
 }
 
-const uint16_t PAD_LOCAL_SENTINAL = 0xFFFF;
+const uint32_t PAD_LOCAL_SENTINAL = 0xFFFF;
 
 using uint32_triplet_t = std::tuple<uint32_t, uint32_t, uint32_t>;
 using GatherStep = uint32_triplet_t;
 using PerCoreGatherData = std::map<std::pair<uint32_t, uint32_t>, std::vector<GatherStep>>;
+
+bool needs_uint32_sliding_window_config(
+    const std::vector<ShardBoundary>& shard_boundaries, const std::vector<uint32_t>& op_trace_metadata) {
+    uint32_t global_max_relative_index = 0;
+    for (const auto& item : shard_boundaries) {
+        const auto& [output_shard_start, output_shard_end] = item.output_range;
+        if (output_shard_start >= op_trace_metadata.size()) {
+            continue;
+        }
+        uint32_t max_relative_index =
+            op_trace_metadata[std::min(output_shard_end, static_cast<uint32_t>(op_trace_metadata.size()) - 1)] -
+            op_trace_metadata[output_shard_start];
+        global_max_relative_index = std::max(global_max_relative_index, max_relative_index);
+    }
+    bool result = global_max_relative_index > std::numeric_limits<uint16_t>::max();
+    log_debug(
+        tt::LogOp,
+        "needs_uint32_sliding_window_config: max_relative_index={}, uint16_max={}, needs_uint32={}",
+        global_max_relative_index,
+        std::numeric_limits<uint16_t>::max(),
+        result);
+    return result;
+}
+
+bool needs_uint32_halo_config(const std::vector<ShardBoundary>& shard_boundaries) {
+    uint32_t global_max_halo_size = 0;
+    for (const auto& [output_range, input_range] : shard_boundaries) {
+        uint32_t halo_size = input_range.end - input_range.start;
+        global_max_halo_size = std::max(global_max_halo_size, halo_size);
+    }
+    bool result = global_max_halo_size > std::numeric_limits<uint16_t>::max();
+    log_debug(
+        tt::LogOp,
+        "needs_uint32_halo_config: max_halo_size={}, uint16_max={}, needs_uint32={}",
+        global_max_halo_size,
+        std::numeric_limits<uint16_t>::max(),
+        result);
+    return result;
+}
 
 uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& shard_boundaries) {
     uint32_t max_out_nsticks_per_core = 0;
@@ -488,15 +527,15 @@ uint32_t calculate_precise_halo_output_elems(
 }
 
 struct GatherHeader {
-    uint16_t noc_x;
-    uint16_t noc_y;
-    uint16_t num_transfers;
+    uint32_t noc_x;
+    uint32_t noc_y;
+    uint32_t num_transfers;
 };
 
 struct GatherTransfer {
-    uint16_t src_id;
-    uint16_t dst_id;
-    uint16_t size;
+    uint32_t src_id;
+    uint32_t dst_id;
+    uint32_t size;
 };
 
 struct GatherRoute {
@@ -509,21 +548,24 @@ struct GatherConfig {
 };
 
 // transfer = noc_x noc_y num_transfers
-static void serialize_gather_header(const GatherHeader& header, std::vector<uint16_t>& output) {
-    output.push_back(header.noc_x);
-    output.push_back(header.noc_y);
-    output.push_back(header.num_transfers);
+template <typename T>
+static void serialize_gather_header(const GatherHeader& header, std::vector<T>& output) {
+    output.push_back(static_cast<T>(header.noc_x));
+    output.push_back(static_cast<T>(header.noc_y));
+    output.push_back(static_cast<T>(header.num_transfers));
 }
 
 // transfer = src_id dst_id size
-static void serialize_gather_transfer(const GatherTransfer& transfer, std::vector<uint16_t>& output) {
-    output.push_back(transfer.src_id);
-    output.push_back(transfer.dst_id);
-    output.push_back(transfer.size);
+template <typename T>
+static void serialize_gather_transfer(const GatherTransfer& transfer, std::vector<T>& output) {
+    output.push_back(static_cast<T>(transfer.src_id));
+    output.push_back(static_cast<T>(transfer.dst_id));
+    output.push_back(static_cast<T>(transfer.size));
 }
 
 // route = header [tranfer0 transfer1 ... ]
-static void serialize_gather_route(const GatherRoute& route, std::vector<uint16_t>& output) {
+template <typename T>
+static void serialize_gather_route(const GatherRoute& route, std::vector<T>& output) {
     serialize_gather_header(route.header, output);
     TT_FATAL(route.header.num_transfers == route.transfers.size(), "Number of transfers in route must match header");
     for (const auto& transfer : route.transfers) {
@@ -532,9 +574,10 @@ static void serialize_gather_route(const GatherRoute& route, std::vector<uint16_
 }
 
 // config = len [route0 route1 ...]
-static std::vector<uint16_t> serialize_gather_config(const GatherConfig& config) {
-    std::vector<uint16_t> output;
-    output.push_back(config.routes.size());
+template <typename T>
+static std::vector<T> serialize_gather_config(const GatherConfig& config) {
+    std::vector<T> output;
+    output.push_back(static_cast<T>(config.routes.size()));
     for (const auto& route : config.routes) {
         TT_FATAL(!route.transfers.empty(), "Expected all routes to have at least one transfer");
         serialize_gather_route(route, output);
@@ -543,18 +586,19 @@ static std::vector<uint16_t> serialize_gather_config(const GatherConfig& config)
 }
 
 // Flatten a list of configs and ensure they are uniform lengths by padding
-static std::vector<std::vector<uint16_t>> serialize_gather_configs(const std::vector<GatherConfig>& configs) {
-    std::vector<std::vector<uint16_t>> serialized_configs;
+template <typename T>
+static std::vector<std::vector<T>> serialize_gather_configs(const std::vector<GatherConfig>& configs) {
+    std::vector<std::vector<T>> serialized_configs;
     serialized_configs.reserve(configs.size());
     for (const auto& config : configs) {
-        serialized_configs.push_back(serialize_gather_config(config));
+        serialized_configs.push_back(serialize_gather_config<T>(config));
     }
     // Pad each core's config to the same length so we can shard it
     size_t max_size = 0;
     for (const auto& config : serialized_configs) {
         max_size = std::max(max_size, config.size());
     }
-    for (std::vector<uint16_t>& config : serialized_configs) {
+    for (std::vector<T>& config : serialized_configs) {
         TT_ASSERT(config.size() <= max_size);
         config.resize(max_size, 0);
     }
@@ -562,11 +606,11 @@ static std::vector<std::vector<uint16_t>> serialize_gather_configs(const std::ve
 }
 
 struct DestinationTransferPair {
-    uint16_t noc_x;
-    uint16_t noc_y;
-    uint16_t src_id;
-    uint16_t dst_id;
-    uint16_t size;
+    uint32_t noc_x;
+    uint32_t noc_y;
+    uint32_t src_id;
+    uint32_t dst_id;
+    uint32_t size;
 };
 
 static std::vector<DestinationTransferPair> flatten_gather_config(const GatherConfig& input) {
@@ -593,7 +637,7 @@ static GatherConfig reduce_flattened_transfers(const std::vector<DestinationTran
     for (const auto& xfer : transfers) {
         bool same_core = (xfer.noc_x == current_route.header.noc_x) && (xfer.noc_y == current_route.header.noc_y);
         if (!same_core) {
-            current_route.header.num_transfers = static_cast<uint16_t>(current_route.transfers.size());
+            current_route.header.num_transfers = static_cast<uint32_t>(current_route.transfers.size());
             TT_FATAL(current_route.header.num_transfers > 0, "Route cannot have zero transfers");
             output.routes.push_back(current_route);
 
@@ -608,7 +652,7 @@ static GatherConfig reduce_flattened_transfers(const std::vector<DestinationTran
         transfer.size = xfer.size;
         current_route.transfers.push_back(transfer);
     }
-    current_route.header.num_transfers = static_cast<uint16_t>(current_route.transfers.size());
+    current_route.header.num_transfers = static_cast<uint32_t>(current_route.transfers.size());
     TT_FATAL(current_route.header.num_transfers > 0, "Route cannot have zero transfers");
     output.routes.push_back(current_route);
 
@@ -691,7 +735,8 @@ static std::pair<GatherConfig, GatherConfig> divide_transfers_between_cores(cons
     return std::make_pair(reduce_flattened_transfers(first), reduce_flattened_transfers(second));
 }
 
-HaloGatherKernelConfig generate_halo_kernel_config_tensors(
+template <typename T>
+HaloGatherKernelConfig<T> generate_halo_kernel_config_tensors(
     const std::vector<PixelMetadata>& tensor_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
@@ -778,12 +823,12 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         const auto& [src_core_id, dst_core_id, num_copies] = config.first;
         std::vector<GatherTransfer> transfers;
         for (const auto& transfer : config.second) {
-            const uint16_t src_offset_id = std::get<0>(transfer);
-            const uint16_t dst_offset_id = std::get<1>(transfer);
-            const uint16_t size = std::get<2>(transfer);
+            const uint32_t src_offset_id = std::get<0>(transfer);
+            const uint32_t dst_offset_id = std::get<1>(transfer);
+            const uint32_t size = std::get<2>(transfer);
             transfers.emplace_back(src_offset_id, dst_offset_id, size);
         }
-        GatherHeader header{src_core_id, dst_core_id, transfers.size()};
+        GatherHeader header{src_core_id, dst_core_id, static_cast<uint32_t>(transfers.size())};
         gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
     }
 
@@ -792,12 +837,12 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
             const auto& [src_core_id, dst_core_id, num_copies] = destination.first;
             std::vector<GatherTransfer> transfers;
             for (const auto& transfer : destination.second) {
-                const uint16_t src_offset_id = std::get<0>(transfer);
-                const uint16_t dst_offset_id = std::get<1>(transfer);
-                const uint16_t size = std::get<2>(transfer);
+                const uint32_t src_offset_id = std::get<0>(transfer);
+                const uint32_t dst_offset_id = std::get<1>(transfer);
+                const uint32_t size = std::get<2>(transfer);
                 transfers.emplace_back(src_offset_id, dst_offset_id, size);
             }
-            GatherHeader header{src_core_id, dst_core_id, transfers.size()};
+            GatherHeader header{src_core_id, dst_core_id, static_cast<uint32_t>(transfers.size())};
             gather_configs[core_id].routes.push_back(GatherRoute{header, transfers});
         }
     }
@@ -821,24 +866,24 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         }
     }
 
-    const auto serialized_gather_configs0 = serialize_gather_configs(ordered_gather_configs0);
-    const auto serialized_gather_configs1 = serialize_gather_configs(ordered_gather_configs1);
+    const auto serialized_gather_configs0 = serialize_gather_configs<T>(ordered_gather_configs0);
+    const auto serialized_gather_configs1 = serialize_gather_configs<T>(ordered_gather_configs1);
 
     // Flatten and uniformize the lengths of each config list
-    auto flatten_pad_config = [](auto& config) -> std::vector<std::vector<uint16_t>> {
+    auto flatten_pad_config = [](auto& config) -> std::vector<std::vector<T>> {
         // find max length
         size_t max_len = 0;
         for (auto& data : config) {
             max_len = std::max(max_len, 2 * data.size());  // each data is 2 * data.size()
         }
-        std::vector<std::vector<uint16_t>> flattened_config;
+        std::vector<std::vector<T>> flattened_config;
         for (auto& data : config) {
-            std::vector<uint16_t> flat_data(max_len, 0);
+            std::vector<T> flat_data(max_len, 0);
             uint32_t idx = 0;
             for (auto data_elem : data) {
                 auto [dst_start, length] = data_elem;
-                flat_data[idx++] = dst_start;
-                flat_data[idx++] = length;
+                flat_data[idx++] = static_cast<T>(dst_start);
+                flat_data[idx++] = static_cast<T>(length);
             }
             // null plug
             flat_data.emplace_back(0);
@@ -860,7 +905,7 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     auto flattened_pad_config0 = flatten_pad_config(pad_config0);
     auto flattened_pad_config1 = flatten_pad_config(pad_config1);
 
-    auto align_config = [](auto& config, size_t align_granularity = 1, uint16_t align_value = 0) {
+    auto align_config = [](auto& config, size_t align_granularity = 1, T align_value = 0) {
         size_t max_len = 0;
         for (auto& core_config : config) {
             max_len = std::max(max_len, core_config.size());
@@ -872,16 +917,18 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         for (auto& core_config : config) {
             size_t extend_amount = max_len - core_config.size();
             if (extend_amount > 0) {
-                std::vector<uint16_t> extend_v(extend_amount, align_value);
+                std::vector<T> extend_v(extend_amount, align_value);
                 core_config.insert(core_config.end(), extend_v.begin(), extend_v.end());
             }
         }
     };
 
-    align_config(flattened_pad_config0, 2);
-    align_config(flattened_pad_config1, 2);
+    // For uint16, align to 2 elements (4 bytes). For uint32, each element is already 4 bytes.
+    constexpr size_t pad_align = std::is_same_v<T, uint16_t> ? 2 : 1;
+    align_config(flattened_pad_config0, pad_align);
+    align_config(flattened_pad_config1, pad_align);
 
-    return HaloGatherKernelConfig{
+    return HaloGatherKernelConfig<T>{
         flattened_pad_config0,
         flattened_pad_config1,
         serialized_gather_configs0,
@@ -889,7 +936,29 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
         number_of_blocks_per_core};
 }
 
-void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>& config) {
+template HaloGatherKernelConfig<uint16_t> generate_halo_kernel_config_tensors<uint16_t>(
+    const std::vector<PixelMetadata>&,
+    const std::vector<ShardBoundary>&,
+    bool,
+    bool,
+    bool,
+    IDevice*,
+    uint32_t,
+    bool,
+    int);
+template HaloGatherKernelConfig<uint32_t> generate_halo_kernel_config_tensors<uint32_t>(
+    const std::vector<PixelMetadata>&,
+    const std::vector<ShardBoundary>&,
+    bool,
+    bool,
+    bool,
+    IDevice*,
+    uint32_t,
+    bool,
+    int);
+
+template <typename T>
+void visualize_sliding_window_op_config(const std::vector<std::vector<T>>& config) {
     log_info(tt::LogOp, "========================================");
     log_info(tt::LogOp, "  Sliding Window Op Config Visualization");
     log_info(tt::LogOp, "========================================");
@@ -948,7 +1017,7 @@ void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>
             while (segment_count < num_segments && idx + 1 < core_config.size()) {
                 uint16_t start_idx = core_config[idx];
                 uint16_t end_idx = core_config[idx + 1];
-                uint16_t range_size = (end_idx >= start_idx) ? (end_idx - start_idx + 1) : 0;
+                T range_size = (end_idx >= start_idx) ? (end_idx - start_idx + 1) : 0;
 
                 log_info(
                     tt::LogOp,
@@ -982,7 +1051,11 @@ void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>
     log_info(tt::LogOp, "========================================");
 }
 
-std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
+template void visualize_sliding_window_op_config<uint16_t>(const std::vector<std::vector<uint16_t>>&);
+template void visualize_sliding_window_op_config<uint32_t>(const std::vector<std::vector<uint32_t>>&);
+
+template <typename T>
+std::vector<std::vector<T>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     uint32_t stride_w,
@@ -990,11 +1063,11 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     uint32_t reader0_datums,
     uint32_t reader1_datums,
     bool pad_cores) {
-    std::vector<std::vector<uint16_t>> sharded_input_top_left_indices;
+    std::vector<std::vector<T>> sharded_input_top_left_indices;
     for (const auto& item : shard_boundaries) {
         const auto& [output_shard_start, output_shard_end] = item.output_range;
         const auto& [input_shard_start, input_shard_end] = item.input_range;
-        std::vector<uint16_t> local_top_left_indices;
+        std::vector<T> local_top_left_indices;
         // sanity check
         if (output_shard_start >= op_trace_metadata.size()) {
             // this core has no output
@@ -1056,7 +1129,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
         for (uint32_t core_idx = 0; core_idx < shard_boundaries.size(); core_idx++) {
             // Pad indices for this core if not equal to other cores
             if (sharded_input_top_left_indices.size() == core_idx) {
-                sharded_input_top_left_indices.push_back(std::vector<uint16_t>());
+                sharded_input_top_left_indices.push_back(std::vector<T>());
             }
             TT_FATAL(
                 core_idx < sharded_input_top_left_indices.size(),
@@ -1064,7 +1137,7 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
                 core_idx);
             uint32_t indices_length_this_core = sharded_input_top_left_indices[core_idx].size();
             if (indices_length_per_core - indices_length_this_core > 0) {
-                std::vector<uint16_t> extend_v(indices_length_per_core - indices_length_this_core, 0);
+                std::vector<T> extend_v(indices_length_per_core - indices_length_this_core, 0);
                 sharded_input_top_left_indices[core_idx].insert(
                     sharded_input_top_left_indices[core_idx].end(), extend_v.begin(), extend_v.end());
             }
@@ -1073,18 +1146,27 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     return sharded_input_top_left_indices;
 }
 
-std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes) {
-    std::vector<uint16_t> flattened_vector;
+template std::vector<std::vector<uint16_t>> generate_sliding_window_op_config<uint16_t>(
+    const std::vector<uint32_t>&, const std::vector<ShardBoundary>&, uint32_t, bool, uint32_t, uint32_t, bool);
+template std::vector<std::vector<uint32_t>> generate_sliding_window_op_config<uint32_t>(
+    const std::vector<uint32_t>&, const std::vector<ShardBoundary>&, uint32_t, bool, uint32_t, uint32_t, bool);
+
+template <typename T>
+std::vector<T> flatten(const std::vector<std::vector<T>>& input, uint32_t extend_with_zeroes) {
+    std::vector<T> flattened_vector;
     for (auto sub_vec : input) {
         flattened_vector.insert(flattened_vector.end(), sub_vec.begin(), sub_vec.end());
         if (extend_with_zeroes > 0) {
-            std::vector<uint16_t> extend_v(extend_with_zeroes, 0);
+            std::vector<T> extend_v(extend_with_zeroes, 0);
             flattened_vector.insert(flattened_vector.end(), extend_v.begin(), extend_v.end());
         }
     }
     log_debug(tt::LogOp, "flattened_vector size: {}", flattened_vector.size());
     return flattened_vector;
 }
+
+template std::vector<uint16_t> flatten<uint16_t>(const std::vector<std::vector<uint16_t>>&, uint32_t);
+template std::vector<uint32_t> flatten<uint32_t>(const std::vector<std::vector<uint32_t>>&, uint32_t);
 
 uint32_t get_repeat_factor_for_replicating_nhw_config_across_grid(const ParallelConfig& p_config) {
     switch (p_config.shard_scheme) {
@@ -1106,13 +1188,17 @@ uint32_t get_repeat_factor_for_replicating_nhw_config_across_grid(const Parallel
     }
 }
 
-std::vector<uint16_t> replicate_config(const std::vector<uint16_t>& config_vector, int factor) {
-    std::vector<uint16_t> repeat_config;
+template <typename T>
+std::vector<T> replicate_config(const std::vector<T>& config_vector, int factor) {
+    std::vector<T> repeat_config;
     for (uint32_t i = 0; i < factor; ++i) {
         repeat_config.insert(repeat_config.end(), config_vector.begin(), config_vector.end());
     }
     return repeat_config;
 }
+
+template std::vector<uint16_t> replicate_config<uint16_t>(const std::vector<uint16_t>&, int);
+template std::vector<uint32_t> replicate_config<uint32_t>(const std::vector<uint32_t>&, int);
 
 std::vector<uint16_t> remap_nhw_scalar_argument_across_full_grid(
     const std::vector<uint16_t>& config, const ParallelConfig& parallel_config) {
@@ -1131,26 +1217,36 @@ std::vector<uint16_t> remap_nhw_scalar_argument_across_full_grid(
         };
         return broadcast_config_per_row(config, factor);
     }
-    return sliding_window::replicate_config(config, factor);
+    return sliding_window::replicate_config<uint16_t>(config, factor);
 }
 
+template <typename T>
 Tensor construct_on_host_config_tensor(
-    const std::vector<std::vector<uint16_t>>& config, const ParallelConfig& p_config, bool store_in_dram) {
-    // We need the last dim of tensors to be multiple of 2, pad if needed
-    uint32_t extend_with_zeroes = config[0].size() % 2;
-    extend_with_zeroes = extend_with_zeroes > 0 ? 2 - extend_with_zeroes : 0;
+    const std::vector<std::vector<T>>& config, const ParallelConfig& p_config, bool store_in_dram) {
+    // For uint16: last dim must be multiple of 2 (4-byte alignment). For uint32: already 4-byte aligned.
+    uint32_t extend_with_zeroes = 0;
+    if constexpr (std::is_same_v<T, uint16_t>) {
+        extend_with_zeroes = config[0].size() % 2;
+        extend_with_zeroes = extend_with_zeroes > 0 ? 2 - extend_with_zeroes : 0;
+    }
 
     ttnn::Shape config_shape(
         {static_cast<uint32_t>(config.size()), static_cast<uint32_t>(config[0].size()) + extend_with_zeroes});
-    std::vector<uint16_t> config_vector = flatten(config, extend_with_zeroes);
+    std::vector<T> config_vector = flatten<T>(config, extend_with_zeroes);
 
     const uint32_t factor = store_in_dram ? 1 : get_repeat_factor_for_replicating_nhw_config_across_grid(p_config);
-    auto repeat_config = replicate_config(config_vector, factor);
+    auto repeat_config = replicate_config<T>(config_vector, factor);
 
     auto config_buffer = tt::tt_metal::HostBuffer(std::move(repeat_config));
     config_shape = ttnn::Shape({config_shape[0] * factor, config_shape[1]});
-    return Tensor(std::move(config_buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
+    constexpr DataType dtype = std::is_same_v<T, uint16_t> ? DataType::UINT16 : DataType::UINT32;
+    return Tensor(std::move(config_buffer), config_shape, dtype, Layout::ROW_MAJOR);
 }
+
+template Tensor construct_on_host_config_tensor<uint16_t>(
+    const std::vector<std::vector<uint16_t>>&, const ParallelConfig&, bool);
+template Tensor construct_on_host_config_tensor<uint32_t>(
+    const std::vector<std::vector<uint32_t>>&, const ParallelConfig&, bool);
 
 Tensor move_config_tensor_to_device(
     const Tensor& config_tensor,

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -134,15 +134,22 @@ uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& sha
 uint32_t calculate_precise_halo_output_elems(
     const SlidingWindowConfig& config, const std::array<uint32_t, 2>& shard_shape);
 
+template <typename T = uint16_t>
 struct HaloGatherKernelConfig {
-    std::vector<std::vector<uint16_t>> pad_config0;
-    std::vector<std::vector<uint16_t>> pad_config1;
-    std::vector<std::vector<uint16_t>> gather_config0;
-    std::vector<std::vector<uint16_t>> gather_config1;
-    std::vector<uint16_t> number_of_blocks_per_core;
+    std::vector<std::vector<T>> pad_config0;
+    std::vector<std::vector<T>> pad_config1;
+    std::vector<std::vector<T>> gather_config0;
+    std::vector<std::vector<T>> gather_config1;
+    std::vector<uint16_t> number_of_blocks_per_core;  // always uint16 - these are small block counts
 };
 
-HaloGatherKernelConfig generate_halo_kernel_config_tensors(
+// Runtime checks: determine if uint32 config is needed based on index ranges
+bool needs_uint32_sliding_window_config(
+    const std::vector<ShardBoundary>& shard_boundaries, const std::vector<uint32_t>& op_trace_metadata);
+bool needs_uint32_halo_config(const std::vector<ShardBoundary>& shard_boundaries);
+
+template <typename T = uint16_t>
+HaloGatherKernelConfig<T> generate_halo_kernel_config_tensors(
     const std::vector<PixelMetadata>& tensor_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
@@ -153,9 +160,11 @@ HaloGatherKernelConfig generate_halo_kernel_config_tensors(
     bool is_in_tiled,
     int block_size);
 
-void visualize_sliding_window_op_config(const std::vector<std::vector<uint16_t>>& config);
+template <typename T = uint16_t>
+void visualize_sliding_window_op_config(const std::vector<std::vector<T>>& config);
 
-std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
+template <typename T = uint16_t>
+std::vector<std::vector<T>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     uint32_t stride_w,
@@ -165,17 +174,20 @@ std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     uint32_t reader1_datums = 0,
     bool pad_cores = true);
 
-std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes = 0);
+template <typename T = uint16_t>
+std::vector<T> flatten(const std::vector<std::vector<T>>& input, uint32_t extend_with_zeroes = 0);
 
 uint32_t get_repeat_factor_for_replicating_nhw_config_across_grid(const ParallelConfig& p_config);
 
-std::vector<uint16_t> replicate_config(const std::vector<uint16_t>& config_vector, int factor);
+template <typename T = uint16_t>
+std::vector<T> replicate_config(const std::vector<T>& config_vector, int factor);
 
 std::vector<uint16_t> remap_nhw_scalar_argument_across_full_grid(
     const std::vector<uint16_t>& config, const ParallelConfig& parallel_config);
 
+template <typename T = uint16_t>
 Tensor construct_on_host_config_tensor(
-    const std::vector<std::vector<uint16_t>>& config, const ParallelConfig& p_config, bool store_in_dram = false);
+    const std::vector<std::vector<T>>& config, const ParallelConfig& p_config, bool store_in_dram = false);
 
 Tensor move_config_tensor_to_device(
     const Tensor& config_tensor,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37074

### Problem description
Max pool operations (max_pool2d, max_pool2d_with_indices) store sliding window configuration indices as uint16_t, which overflows when a single     
  core's input shard (including halo region) spans more than 65,535 sticks. This manifested as a TT_FATAL in pool_multi_core_program_factory.cpp that
  blocked any input configuration where max_in_nhw_per_core > uint16_t limit. The same limitation existed in the halo gather kernel configuration.

Note these changes should theoretically work for 32 bit indexes, but this could not be verified since L1 memory constraints are hit first as explained by Claude: "Great and how did you verify that the new regression tests you added actually utilize this new 32 bit sliding window path?                          
                                                                                                                                                      
They don't. I removed the test file (test_sliding_window_32bit.py) because the analysis showed the test parameters wouldn't actually trigger the    
  uint32 path:                                 
                                                                                                                                                      
  - For 384x384 with ~64 cores, max_relative_index is only ~2,322 — far below the 65,535 uint16 limit                                                 
  - To truly exceed it you'd need ~2048x2048 inputs, which exceeds device L1 memory constraints                                                       
  - The needs_uint32_sliding_window_config() and needs_uint32_halo_config() functions would return false for all practically runnable device test     
  cases                                                                                                                                               
                                                                                                                                                      
  The existing test_mpwi_32_bit_index tests (384x384, 350x350, 300x300) served as regression tests to verify the full pipeline still works correctly  
  after the refactor — they exercise the uint16 default path end-to-end through all the newly templated code.
                                                                                                                                                      
  The uint32 code path correctness relies on the fact that the template produces identical logic for both types — the only difference is the width of 
  the index type. The runtime detection functions (needs_uint32_sliding_window_config, needs_uint32_halo_config) are straightforward max-value
  comparisons against std::numeric_limits<uint16_t>::max().   "

### What's changed
Core infrastructure (sliding_window.hpp, sliding_window.cpp):                                                                                       
  - Templated key config generation functions (generate_sliding_window_op_config, generate_halo_kernel_config_tensors, HaloGatherKernelConfig,
  construct_on_host_config_tensor, flatten, replicate_config, visualize_sliding_window_op_config) on typename T defaulting to uint16_t for full       
  backward compatibility                                                                                                                       
  - Added runtime detection functions needs_uint32_sliding_window_config() and needs_uint32_halo_config() that check if any core's shard indices or   
  halo sizes exceed the uint16 limit                                                                                                               
  - Internal structs (GatherHeader, GatherTransfer, DestinationTransferPair) widened to uint32_t; serialization templated to produce the correct      
  output type                                                                                                                                   
  - Explicit template instantiations for both uint16_t and uint32_t                                                                                   
                                                                   
  Pool program factory (pool_multi_core_program_factory.cpp):                                                                                         
  - Removed the blocking TT_FATAL that rejected inputs exceeding uint16                                                                               
  - Runtime type selection via needs_uint32_sliding_window_config() — generates config tensors with <uint32_t> or <uint16_t> accordingly              
  - CB data format dynamically selects UInt16 vs UInt32 based on config tensor dtype                                                                  
  - Passes reader_indices_is_32bit as a JIT compile-time arg (placed after TensorAccessorArgs) to reader kernels                                      
                                                                                                                                                      
  Reader kernels (reader_pool_2d.cpp, reader_mpwi.cpp):                                                                                               
  - Support both 16-bit packed (two indices per uint32 word) and 32-bit unpacked (one index per word) config reading, controlled by                   
  reader_indices_is_32bit compile-time arg                                                                                                            
  - Index located dynamically after TensorAccessorArgs via next_compile_time_args_offset()                                                            
  - Loop variables widened from uint16_t to uint32_t                                                                                                  
                                                                                                                                                      
  Halo gather kernel (halo_gather.cpp):                                                                                                               
  - Templated copy_padding and run_halo_gather on ConfigIs32Bit to select uint16_t or uint32_t config pointer type                                    
  - ConfigType helper struct for compile-time type selection (avoids <type_traits> dependency on device)                                              
  - config_is_32bit passed as JIT compile-time arg — placed after TensorAccessorArgs in DRAM mode (via next_compile_time_args_offset()), at index 18  
  in non-DRAM mode                                                                                                                                    
                                                                                                                                                      
  Halo program factory (untilize_with_halo_program_factory.cpp):                                                                                      
  - Runtime type selection via needs_uint32_halo_config()                                                                                             
  - Dynamic kernel_config_df (RawUInt16 vs RawUInt32) and dtype assertions                                                                            
  - config_is_32bit appended to compile-time args after TensorAccessorArgs                                                                            
                                                                                                                                                      
  Conv callers: No changes needed — template defaults to uint16_t.

### Checklist
In progress