### PR TITLE
Fix off-by-one in sort core_range calculation causing out-of-bounds D…

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -7,7 +7,49 @@ import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
 
+TILE_HEIGHT = 32
 TILE_WIDTH = 32
+
+
+def _residual_ht_shapes(device):
+    """
+    Build Ht values where Ht % grid_x != 0 and grid_x <= Ht < grid_x * grid_y.
+    This is the exact condition that enters the additional CoreRange branch
+    in SingleRowSingleCore / SingleRowMultiCore sort program factories.
+    """
+    grid = device.compute_with_storage_grid_size()
+    total = grid.x * grid.y
+    shapes = []
+    for r in range(1, grid.x):
+        ht = grid.x + r
+        if ht < total:
+            shapes.append(ht)
+    if grid.x * 2 + 1 < total:
+        shapes.append(grid.x * 2 + 1)
+    return shapes
+
+
+def test_sort_residual_core_range(device):
+    """
+    Regression test for an off-by-one in the additional CoreRange end
+    coordinate that allocated one extra core, causing OOB DRAM writes.
+    Shapes are derived from the device grid so the path is always hit.
+    """
+    ht_values = _residual_ht_shapes(device)
+    for ht in ht_values:
+        for descending in (False, True):
+            torch.manual_seed(0)
+            shape = [ht * TILE_HEIGHT, TILE_WIDTH]
+            input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+
+            ttnn_input = ttnn.from_torch(input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+            torch_values, _ = torch.sort(input_tensor, dim=-1, descending=descending)
+            ttnn_values, ttnn_indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
+
+            assert list(ttnn_values.shape) == shape
+            assert_equal(torch_values, ttnn.to_torch(ttnn_values))
+            ttnn_gathered = torch.gather(input_tensor, -1, ttnn.to_torch(ttnn_indices).to(torch.int64))
+            assert_equal(torch_values, ttnn_gathered)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -92,7 +92,7 @@ SortProgramFactorySingleRowSingleCore::cached_program_t SortProgramFactorySingle
             if (core_grid_calculated_columns_number != 0) {
                 const CoreRange additional_range(
                     {0, core_grid_calculated_rows_number},
-                    {core_grid_calculated_columns_number, core_grid_calculated_rows_number});
+                    {core_grid_calculated_columns_number - 1, core_grid_calculated_rows_number});
                 core_range = core_range.merge(CoreRangeSet(additional_range));
             }
         }
@@ -774,7 +774,7 @@ SortProgramFactorySingleRowMultiCore::cached_program_t SortProgramFactorySingleR
             if (core_grid_calculated_columns_number != 0) {
                 const CoreRange additional_range(
                     {0, core_grid_calculated_rows_number},
-                    {core_grid_calculated_columns_number, core_grid_calculated_rows_number});
+                    {core_grid_calculated_columns_number - 1, core_grid_calculated_rows_number});
                 core_range = core_range.merge(CoreRangeSet(additional_range));
             }
         }


### PR DESCRIPTION
…RAM writes

### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/40612)
### Problem description
`SortProgramFactorySingleRowSingleCore` and `SortProgramFactorySingleRowMultiCore` have an off-by-one error when computing the additional `CoreRange` for residual cores. The end coordinate of the additional range uses `core_grid_calculated_columns_number` directly as the x-coordinate, but `CoreRange` end coordinates are **inclusive**, so this allocates one more core than intended.
For example, with an input tensor of shape [544, 32] (bf16, TILE layout) sorted along dim=1:
- Ht = 544 / 32 = 17 tile rows
- Wt = 32 / 32 = 1 tile column → selects `SingleRowSingleCore` factory
- Grid size = 8×8 = 64 cores
- core_grid_calculated_rows_number = 17 / 8 = 2
- core_grid_calculated_columns_number = 17 % 8 = 1 The main range covers 2 full rows × 8 columns = 16 cores. The additional range is constructed as `CoreRange({0, 2}, {1, 2})` which includes **2 cores** (x=0 and x=1 at y=2), but only **1 additional core** is needed. This results in 18 cores being assigned work for only 17 tiles.

The extra core computes a tile index `h` that equals `Ht` (out of bounds). Both the reader and writer kernels use this index to perform NOC tile-addressed DRAM reads and writes:
- **Reader**: `noc_async_read_tile(h * Wt + w, ...)` reads beyond the input buffer, pulling garbage data into L1.
- **Reader**: `noc_async_write_tile(h * Wt + w, ...)` writes sorted index data one tile past the index output buffer boundary.
- **Writer**: `noc_async_write_tile(h * Wt + w, ...)` writes sorted value data one tile past the value output buffer boundary. This corrupts 2 tiles (up to 4096 bytes) of DRAM memory that may belong to other tensors. The corruption is **non-deterministic** because the DRAM allocator may place different tensors adjacent to the sort output buffers across runs.
In production, this was observed as intermittent hangs during `ttnn.reshape` operations that follow `ttnn.sort` in GPT-OSS MoE models. The sort's out-of-bounds writes were corrupting the `mapping_tensor` cached by reshape, leading to firmware-level completion queue timeouts (event_id=15).

### What's changed
Change the additional `CoreRange` end x-coordinate from `core_grid_calculated_columns_number` to
`core_grid_calculated_columns_number - 1` in both affected factories. This matches the pattern already used correctly in `SortProgramFactoryCrossCoreDataExchange`.

The bug triggers when all of the following hold:
- The sort dimension width Wt ≤ 64 (SingleRowSingleCore) or Wt > threshold with specific core counts (SingleRowMultiCore)
- Ht % compute_grid_x != 0 (residual cores needed)
- Ht >= compute_grid_x (at least one full row of cores used, so the additional range code path is entered)
- Ht < total_number_of_cores (loop_count = 0, so the residuum adjustment code that could mask the issue is skipped)

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sshon/pr-sort-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sshon/pr-sort-bug)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sshon/pr-sort-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sshon/pr-sort-bug)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sshon/pr-sort-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sshon/pr-sort-bug)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


