### PR TITLE
[Bug fix]: Update dfb.finish to handle when there are outstanding transactions that don't meet txn id threshold

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -93,7 +94,8 @@ void run_single_dfb_program(
     experimental::dfb::DataflowBufferConfig& dfb_config,
     DFBPorCType producer_type,
     DFBPorCType consumer_type,
-    const CoreRangeSet& core_range_set = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)))) {
+    const CoreRangeSet& core_range_set = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))),
+    std::optional<uint32_t> num_entries_in_buffer = std::nullopt) {
 
     TT_FATAL(
         !(producer_type == DFBPorCType::TENSIX && consumer_type == DFBPorCType::TENSIX),
@@ -107,11 +109,9 @@ void run_single_dfb_program(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
 
     const uint32_t num_cores = core_range_set.num_cores();
-    const uint32_t entries_per_core = dfb_config.num_entries;
+    const uint32_t entries_per_core = num_entries_in_buffer.has_value() ? num_entries_in_buffer.value() : dfb_config.num_entries;
     const uint32_t entry_size = dfb_config.entry_size;
-    // page_size = entry_size makes every entry independently addressable by
-    // page_id.  For single-core this is equivalent to page_size = buffer_size
-    // because chunk_offset = 0 and page_ids 0..num_entries-1 stay in range.
+    // page_size = entry_size makes every entry independently addressable by page_id.
     const uint32_t total_buffer_size = num_cores * entries_per_core * entry_size;
     distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = entry_size, .buffer_type = BufferType::DRAM};
     distributed::ReplicatedBufferConfig buffer_config{.size = total_buffer_size};
@@ -146,7 +146,6 @@ void run_single_dfb_program(
             experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
     }
 
-    // is_blocked is already defined above
     uint32_t num_entries_per_consumer = is_blocked ? entries_per_core : entries_per_core / dfb_config.num_consumers;
     std::vector<uint32_t> consumer_cta = {
         (uint32_t)out_buffer->address(),
@@ -284,7 +283,12 @@ void run_in_dfb_out_dfb_program(
     CoreCoord logical_core = CoreCoord(0, 0);
 
     uint32_t num_entries_per_producer = dm2tensix_config.num_entries / dm2tensix_config.num_producers;
-    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address(), num_entries_per_producer};
+    const bool in_is_blocked = (dm2tensix_config.cap == dfb::AccessPattern::BLOCKED);
+    std::vector<uint32_t> producer_cta = {
+        (uint32_t)in_buffer->address(),
+        num_entries_per_producer,
+        0 /*implicit_sync=false*/,
+        (uint32_t)in_is_blocked};
     tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
 
     auto producer_kernel = experimental::quasar::CreateKernel(
@@ -305,8 +309,13 @@ void run_in_dfb_out_dfb_program(
         logical_core,
         experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1, .compile_args = compute_cta});
 
-    uint32_t num_entries_per_consumer = tensix2dm_config.num_entries / tensix2dm_config.num_consumers;
-    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address(), num_entries_per_consumer, (uint32_t)tensix2dm_config.cap == dfb::AccessPattern::BLOCKED};
+    const bool out_is_blocked = (tensix2dm_config.cap == dfb::AccessPattern::BLOCKED);
+    uint32_t num_entries_per_consumer = out_is_blocked ? tensix2dm_config.num_entries : tensix2dm_config.num_entries / tensix2dm_config.num_consumers;
+    std::vector<uint32_t> consumer_cta = {
+        (uint32_t)out_buffer->address(),
+        num_entries_per_consumer,
+        (uint32_t)out_is_blocked,
+        0 /*implicit_sync=false*/};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
     auto consumer_kernel = experimental::quasar::CreateKernel(
         program,
@@ -349,7 +358,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
+    uint32_t num_entries_in_buffer = 18;
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
@@ -564,7 +574,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB4Sx4S) {
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
+    uint32_t num_entries_in_buffer = 29;
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB4Sx4S) {
@@ -611,7 +622,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB2Sx4S) {
         .cap = dfb::AccessPattern::STRIDED,
         .enable_implicit_sync = GetParam()};
 
-    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM);
+    uint32_t num_entries_in_buffer = 21;
+    run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, {}, num_entries_in_buffer);
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB2Sx4S) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
@@ -7,30 +7,30 @@
 #include "api/debug/dprint.h"
 
 void kernel_main() {
-    const uint32_t dst_addr_base = get_compile_time_arg_val(0);
+    // CTA layout mirrors dfb_consumer.cpp: [dst_addr, num_entries_per_consumer, blocked_consumer, implicit_sync, ...]
+    // dst_addr (CTA[0]) and TensorAccessorArgs are unused by the Tensix consumer.
     const uint32_t num_entries_per_consumer = get_compile_time_arg_val(1);
-    const uint32_t blocked_consumer = get_compile_time_arg_val(2);
+    constexpr uint32_t blocked_consumer = get_compile_time_arg_val(2);
 
-    uint32_t consumer_mask = get_arg_val<uint32_t>(0);
-    const uint32_t num_consumers = static_cast<uint32_t>(__builtin_popcount(consumer_mask));
+    // RTA layout mirrors dfb_consumer.cpp: [consumer_mask, logical_dfb_id, chunk_offset]
+    // chunk_offset (RTA[2]) is unused since Tensix pops from DFB without writing to DRAM.
+    uint32_t logical_dfb_id = get_arg_val<uint32_t>(1);
 
-    experimental::DataflowBuffer dfb(0);
+    experimental::DataflowBuffer dfb(logical_dfb_id);
 
-    // DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer <<
-    // ENDL();
+    // DPRINT << "t6 consumer trisc_id: " << trisc_id << " consumer_idx: " << consumer_idx
+    //        << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
 
-    // uint32_t dst_addr_base = get_arg_val<uint32_t>(0);
-
+    // Each consumer pops exactly num_entries_per_consumer entries from its own TC(s).
+    // No modulo-skip is needed: the DFB hardware delivers only this consumer's entries
+    // to its TC, so every wait_front/pop_front here is for a tile this consumer owns.
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
-        // DPRINT << "wfw" << ENDL();
         dfb.wait_front(1);
-        // in blocked case maybe each consumer can modify the data so host knows that each have consumed it
-        // DPRINT << "wfd" << ENDL();
-        // DPRINT << "pfw" << ENDL();
-        DPRINT << "consumer tile id " << tile_id << ENDL();
+        UNPACK(DPRINT << "unpack consumer tile id " << tile_id << ENDL());
         dfb.pop_front(1);
-        // DPRINT << "pfd" << ENDL();
+        PACK(DPRINT << "pack consumer tile id " << tile_id << ENDL());
     }
-    // dfb.finish();
+    DPRINT << "CBWW" << ENDL();
+    dfb.finish();
     DPRINT << "CBWD" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp
@@ -7,28 +7,29 @@
 #include "api/debug/dprint.h"
 
 void kernel_main() {
+    // CTA layout mirrors dfb_producer.cpp: [src_addr, num_entries_per_producer, implicit_sync, blocked_consumer, ...]
+    // src_addr (CTA[0]), implicit_sync (CTA[2]), blocked_consumer (CTA[3]), and TensorAccessorArgs are
+    // unused: the Tensix producer doesn't do NOC reads. The host pre-fills DFB L1 and the kernel
+    // only posts credits so the DM consumer knows data is available.
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
+
+    // RTA layout mirrors dfb_producer.cpp: [producer_mask, chunk_offset]
+    // chunk_offset (RTA[1]) is unused since Tensix doesn't read from DRAM.
+    uint32_t producer_mask = get_arg_val<uint32_t>(0);
+
+    // Compute which logical producer slot this TRISC occupies within the mask.
+    uint32_t trisc_id     = static_cast<uint32_t>(ckernel::csr_read<ckernel::CSR::TRISC_ID>());
+    uint32_t producer_idx = static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << trisc_id) - 1u)));
 
     experimental::DataflowBuffer dfb(0);
 
-    DPRINT << "num_entries_per_producer: " << num_entries_per_producer << ENDL();
-
-    // for (uint32_t tensix_id = 0; tensix_id < 4; tensix_id++) {
-    //     for (uint32_t tc_id = 0; tc_id < 16; tc_id++) {
-    //         DPRINT << "tensix_id: " << tensix_id << " tc_id: " << tc_id
-    //                << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id)) << ENDL();
-    //     }
-    // }
+    // DPRINT << "t6 producer trisc_id: " << trisc_id << " producer_idx: " << producer_idx
+    //        << " num_entries_per_producer: " << num_entries_per_producer << ENDL();
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        // DPRINT << "rbw" << ENDL();
-        dfb.reserve_back(1);
-        // DPRINT << "rbd" << ENDL();
-        // DPRINT << "rdi" << ENDL();
-        // generate
         DPRINT << "producer tile id " << tile_id << ENDL();
+        dfb.reserve_back(1);
         dfb.push_back(1);
-        // DPRINT << "pbd" << ENDL();
     }
     DPRINT << "PFW" << ENDL();
     dfb.finish();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -29,8 +29,7 @@ void kernel_main() {
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     uint32_t consumer_idx = static_cast<uint32_t>(__builtin_popcount(consumer_mask & ((1u << hartid) - 1u)));
 
-    // DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer <<
-    // ENDL();
+    DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
 
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -33,17 +33,18 @@ void kernel_main() {
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     uint32_t producer_idx = static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << hartid) - 1u)));
 
-    // DPRINT << "producer_idx: " << producer_idx << " num_entries_per_producer: " << num_entries_per_producer <<
-    // ENDL();
+    // DPRINT << "producer_idx: " << producer_idx << " num_entries_per_producer: " << num_entries_per_producer << ENDL();
 
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
+
+    DPRINT << "HERE" << ENDL();
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
         const uint32_t page_id = blocked_consumer
                                      ? chunk_offset + producer_idx * num_entries_per_producer + tile_id
                                      : chunk_offset + tile_id * num_producers + producer_idx;
-        // DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
+        DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         if constexpr (implicit_sync) {
             dfb.read_in(noc, tensor_accessor, {.page_id = page_id});
         } else {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -35,6 +35,8 @@ void kernel_main() {
         tlocal_dst_addr += dfb.get_stride_size();
     }
 
+    dfb.finish();
+
     // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
     LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
     for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -7,6 +7,7 @@
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"  // For g_dfb_interface extern declaration
 #include "api/debug/assert.h"
+#include "api/debug/waypoint.h"
 
 // TODO: make this the top level api header but then separate out 1xx and 2xx implementations
 
@@ -83,7 +84,7 @@ public:
             // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
             for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
                 dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                ASSERT(llk_intf_get_capacity(get_tensix_id(ptc), get_counter_id(ptc)) >= num_entries);
+                ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
                 // DPRINT << "push_back: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(get_tensix_id(ptc), get_counter_id(ptc))) << ENDL();
                 llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
             }
@@ -96,9 +97,9 @@ public:
             uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
             ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
             llk_intf_inc_posted(tensix_id, tc_id, num_entries);
-            // DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
-            //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
-            //         << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
+            DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
+                    << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
+                    << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
 
             local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
             if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
@@ -118,6 +119,7 @@ public:
         if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
             return;
         }
+        DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id) << " num_entries: " << static_cast<uint32_t>(num_entries) << ENDL();
         llk_wait_tiles(logical_dfb_id_, num_entries);
 #elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
@@ -164,10 +166,13 @@ public:
 
         // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW doesn't track pending posts
         // When this condition is met, we know previous reads were committed
+        DPRINT << "read_in: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
         while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
 
         // Make sure there is space for the new tile
         while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
+
+        // DPRINT << "issuing the read on " << static_cast<uint32_t>(local_dfb_interface_.txn_ids[ptxn_id_index_]) << ENDL();
 
         noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
 
@@ -200,6 +205,8 @@ public:
 
         while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
 
+        // DPRINT << "issuing the write on " << static_cast<uint32_t>(local_dfb_interface_.txn_ids[ctxn_id_index_]) << ENDL();
+
         noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
 
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
@@ -220,11 +227,20 @@ public:
     // Implicit sync APIs end
 #endif
 
-    // from pov of producer need to make sure all the entries get posted (check the raw posted per TC == raw acked per
-    // TC)
-    // also that there are no interrupts remaining...
     void finish() {
+#ifndef COMPILE_FOR_TRISC
+        // Handle case where outstanding transactions do not meet ISR threshold
+        // Each DM updates tile counters for the tiles it read/wrote by using its local counter
+        // DPRINT << "ptiles_read: " << static_cast<uint32_t>(ptiles_read_) << " ctiles_written: " << static_cast<uint32_t>(ctiles_written_) << ENDL();
+        if (ptiles_read_ > 0) {
+            handle_final_credits<true>(ptiles_read_, ptxn_id_index_);
+        }
+        if (ctiles_written_ > 0) {
+            handle_final_credits<false>(ctiles_written_, ctxn_id_index_);
+        }
+#endif
         bool all_acked = false;
+        WAYPOINT("AAW");
         while (!all_acked) {
             all_acked = true;
             for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
@@ -237,12 +253,13 @@ public:
                 all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
 #elif !defined(COMPILE_FOR_TRISC)
                 uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-                // DPRINT << "read acked: " << static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id)) << " read posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
+                DPRINT << "read acked: " << static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id)) << " read posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
                 all_acked &=
                     (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
 #endif
             }
         }
+        WAYPOINT("AAD");
     }
 
     uint32_t get_write_ptr() const {
@@ -261,6 +278,104 @@ public:
     }
 
 private:
+    // Handle case when final transactions issued by DMs do not meet ISR threshold by manually posting/acking credits.
+    // Each DM independently enters finish() so this needs to ensure all DMs have completed their final transactions
+    // to avoid manually posting/acking credits that would be handled by the ISR.
+    template <bool is_producer>
+    void handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index) {
+#ifndef COMPILE_FOR_TRISC
+        // Determine the txn_id for the last batch. If transactions_issued lands exactly on
+        // a boundary, txn_id_index has already wrapped past it, so step back one slot.
+        uint8_t tail_txn_idx = (transactions_issued % local_dfb_interface_.num_entries_per_txn_id == 0)
+                                    ? static_cast<uint8_t>((txn_id_index + local_dfb_interface_.num_txn_ids - 1) % local_dfb_interface_.num_txn_ids)
+                                    : txn_id_index;
+        uint8_t tail_txn_id = local_dfb_interface_.txn_ids[tail_txn_idx];
+
+        uint8_t N = local_dfb_interface_.num_tcs_to_rr;
+        dfb::PackedTileCounter ptc0 = local_dfb_interface_.tc_slots[0].packed_tile_counter;
+        uint16_t expected_slot0 = transactions_issued / N + (0u < (transactions_issued % N) ? 1u : 0u);
+
+        auto read_actual_slot0 = [&]() -> uint16_t {
+            if constexpr (is_producer) {
+                return static_cast<uint16_t>(
+                    fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+            } else {
+                return static_cast<uint16_t>(
+                    fast_llk_intf_read_acked(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+            }
+        };
+
+        uint64_t threshold;
+        if constexpr (is_producer) {
+            threshold = GET_TILES_TO_PROCESS_THRES_TR_ACK(tail_txn_id);
+        } else {
+            threshold = GET_TILES_TO_PROCESS_THRES_WR_SENT(tail_txn_id);
+        }
+
+        // Wait until this DM's tail reads have completed.
+        // A transaction passes through three observable states:
+        //   not dispatched → tack == 0, tiles == 0
+        //   in-flight      → tack >  0
+        //   completed      → tack == 0, tiles >  0   ← break here
+        // Also exits early if the ISR fires (collective batch done).
+        WAYPOINT("WTP1");
+        while (read_actual_slot0() < expected_slot0) {
+            uint64_t tack, tiles;
+            if constexpr (is_producer) {
+                tack  = CMDBUF_TR_ACK_TRID(OVERLAY_RD_CMD_BUF, tail_txn_id);
+                tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+            } else {
+                tack  = CMDBUF_WR_SENT_TRID(OVERLAY_WR_CMD_BUF, tail_txn_id);
+                tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
+            }
+            if (tack == 0 && tiles > 0) break;
+        }
+
+        // Transactions are completed. Spin giving the ISR a chance to fire
+        // Break when tiles < threshold which is a genuine partial tail the ISR can never handle.
+        WAYPOINT("WTP2");
+        while (read_actual_slot0() < expected_slot0) {
+            uint64_t tiles;
+            if constexpr (is_producer) {
+                tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+            } else {
+                tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
+            }
+            if (tiles > 0 && tiles < threshold) break;
+        }
+
+        // Manually post missing credits if ISR did not fire.
+        uint16_t actual_slot0 = read_actual_slot0();
+        // DPRINT << "actual_slot0: " << static_cast<uint32_t>(actual_slot0)
+        //        << " expected_slot0: " << static_cast<uint32_t>(expected_slot0) << ENDL();
+
+        if (actual_slot0 < expected_slot0) {
+            for (uint8_t i = 0; i < N; i++) {
+                dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                uint8_t tensix_id = dfb::get_tensix_id(ptc);
+                uint8_t tc_id     = dfb::get_counter_id(ptc);
+                uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
+                if constexpr (is_producer) {
+                    uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_posted(tensix_id, tc_id));
+                    if (actual < expected) {
+                        // DPRINT << "inc_posted tc(" << static_cast<uint32_t>(tensix_id) << "," << static_cast<uint32_t>(tc_id)
+                        //        << ") delta: " << static_cast<uint32_t>(expected - actual) << ENDL();
+                        fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
+                    }
+                } else {
+                    uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_acked(tensix_id, tc_id));
+                    if (actual < expected) {
+                        // DPRINT << "inc_acked tc(" << static_cast<uint32_t>(tensix_id) << "," << static_cast<uint32_t>(tc_id)
+                        //        << ") delta: " << static_cast<uint32_t>(expected - actual) << ENDL();
+                        fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
+                    }
+                }
+            }
+        }
+#endif
+    }
+
+
     void release_scoped_lock() {
         // TODO: Unregister with the debugger
     }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -190,6 +190,11 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                     dst.tile_counters[j] = producer_tcs[j];
                 }
                 dst.tiles_to_post = init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
+                // To avoid DM synchronization, the final credit sync that manually posts credits in DataflowBuffer::finish doesn't clear tiles to process
+                // do that here to avoid raising spurious interrupts
+                CMDBUF_CLEAR_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, txn_id);
+                asm volatile("nop");
+
                 SET_TILES_TO_PROCESS_THRES_TR_ACK(
                     txn_id, init_ptr->producer_txn_descriptor.num_entries_to_process_threshold);
             }
@@ -201,6 +206,11 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 for (uint8_t j = 0; j < dst.num_counters; j++) {
                     dst.tile_counters[j] = consumer_tcs[j];
                 }
+                // To avoid DM synchronization, the final credit sync that manually posts credits in DataflowBuffer::finish doesn't clear tiles to process
+                // do that here to avoid raising spurious interrupts
+                CMDBUF_CLEAR_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, txn_id);
+                asm volatile("nop");
+
                 dst.tiles_to_ack = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
                 SET_TILES_TO_PROCESS_THRES_WR_SENT(
                     txn_id, init_ptr->consumer_txn_descriptor.num_entries_to_process_threshold);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
With DFB implicit sync enabled an ISR is fired to post/ack tile counters when a threshold num of transactions have completed (reads have landed / writes were sent out). There are cases where the total number of transactions expected for a DFB isn't a multiple of these threshold values. The final flush wasn't implemented so transactions would complete but the relevant tile counters were never updated 

### What's changed
Update `dfb.finish()` to take the number of credits posted/acked for a given tile counter and then compare it to expected. If this doesn't match then we need to wait for all outstanding transactions to complete by reading the relevant transactions to process reg counter and then post/ack the remaining credits. 

Now require both producer and consumer to call `dfb.finish()`

Note: the transactions to process reg is cleared when we set up the thresholds for the txn ids during initialization. Only one DM should be doing this (did it during init to avoid need of DM synchronization)

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-finish)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-finish)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
