### PR TITLE
Numeric checks added to matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
@@ -295,7 +295,7 @@ def test_vector_matrix_multiplication(device, dtype, size, case_type):
             output_tensor,
             atol=0.004 * m,
             rtol=0.009 * m,
-            frobenius_threshold=0.001 * m,
+            frobenius_threshold=0.00125 * m,
             pcc_threshold=0.9999,
             check_ulp=False,
         )

--- a/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 
 pytestmark = pytest.mark.use_module_device
 
@@ -44,12 +44,38 @@ def test_addmm_square_matrices(device, dtype, matrix_size):
     output_tensor = ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    target_pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        target_pcc = 0.999
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=target_pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.021 * matrix_size,
+            rtol=9.313 * matrix_size,
+            frobenius_threshold=0.006 * matrix_size,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.004 * matrix_size,
+            rtol=5.032 * matrix_size,
+            frobenius_threshold=0.001 * matrix_size,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.002 * matrix_size,
+            rtol=0.299 * matrix_size,
+            frobenius_threshold=0.001 * matrix_size,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999, check_ulp=False)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
@@ -87,12 +113,38 @@ def test_addmm_with_alpha_beta(device, dtype, matrix_size, alpha, beta):
     output_tensor = ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor, alpha=alpha, beta=beta)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    target_pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        target_pcc = 0.999
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=target_pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.034 * matrix_size,
+            rtol=12.125 * matrix_size,
+            frobenius_threshold=0.006 * matrix_size,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.008 * matrix_size,
+            rtol=0.532 * matrix_size,
+            frobenius_threshold=0.002 * matrix_size,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.004 * matrix_size,
+            rtol=0.112 * matrix_size,
+            frobenius_threshold=0.001 * matrix_size,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999, check_ulp=False)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
@@ -143,12 +195,38 @@ def test_addmm_rectangular_matrices(device, dtype, matrix_dims):
     output_tensor = ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        pcc = 0.999
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.042 * m,
+            rtol=10.563 * m,
+            frobenius_threshold=0.005 * m,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.011 * m,
+            rtol=0.512 * m,
+            frobenius_threshold=0.002 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.004 * m,
+            rtol=0.126 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999, check_ulp=False)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
@@ -201,13 +279,38 @@ def test_vector_matrix_multiplication(device, dtype, size, case_type):
     output_tensor = ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    target_pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        target_pcc = 0.999
-
-    # Assert the results match
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=target_pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.016 * m,
+            rtol=0.044 * m,
+            frobenius_threshold=0.005 * m,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.004 * m,
+            rtol=0.009 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.001 * m,
+            rtol=0.001 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999, check_ulp=False)
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
@@ -259,12 +362,38 @@ def test_addmm_non_tile_multiple_dimensions(device, dtype, shape):
     output_tensor = ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
     output_tensor_torch = ttnn.to_torch(output_tensor)
 
-    target_pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        target_pcc = 0.999
-
-    assert_with_pcc(torch_output_tensor, output_tensor_torch, pcc=target_pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor_torch,
+            atol=0.017 * m,
+            rtol=2.69 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor_torch,
+            atol=0.006 * m,
+            rtol=0.399 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor_torch,
+            atol=0.003 * m,
+            rtol=0.021 * m,
+            frobenius_threshold=0.001 * m,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor_torch, pcc_threshold=0.9999, check_ulp=False)
 
 
 def test_alpha_zero_should_throw_error(device):
@@ -472,13 +601,39 @@ def test_addmm_with_output_tensor_inplace_op(device, dtype):
     output_tensor = ttnn.to_torch(output_tensor)
     out_tensor = ttnn.to_torch(out_tensor)
 
-    target_pcc = 0.9999
-
     if dtype == ttnn.bfloat8_b:
-        target_pcc = 0.999
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=target_pcc)
-    assert_with_pcc(torch_output_tensor, out_tensor, pcc=target_pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.012 * 32,
+            rtol=0.86 * 32,
+            frobenius_threshold=0.001 * 32,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.bfloat16:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.004 * 32,
+            rtol=0.05 * 32,
+            frobenius_threshold=0.001 * 32,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    elif dtype == ttnn.float32:
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor,
+            atol=0.002 * 32,
+            rtol=0.007 * 32,
+            frobenius_threshold=0.001 * 32,
+            pcc_threshold=0.9999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999, check_ulp=False)
+    assert_with_pcc(torch_output_tensor, out_tensor, pcc=0.999 if dtype == ttnn.bfloat8_b else 0.9999)
 
 
 def test_addmm_with_output_tensor_inplace_op_with_different_dtype(device):
@@ -524,5 +679,12 @@ def test_addmm_with_output_tensor_inplace_op_with_different_dtype(device):
     output_tensor = ttnn.to_torch(output_tensor)
     out_tensor = ttnn.to_torch(out_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.9999)
-    assert_with_pcc(torch_output_tensor, out_tensor, pcc=0.9999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.001 * 32,
+        rtol=0.016 * 32,
+        frobenius_threshold=0.001 * 32,
+        pcc_threshold=0.9999,
+        check_ulp=False,
+    )

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import torch_random, is_wormhole_b0, is_blackhole
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 pytestmark = pytest.mark.use_module_device
 
@@ -29,7 +29,7 @@ def test_ttnn_experimental_tensor_exp(device, height, width):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999)
 
 
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
@@ -49,7 +49,7 @@ def test_ttnn_matmul(device, m_size, k_size, n_size):
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor)
+    assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9999)
 
 
 @pytest.mark.requires_fast_runtime_mode_off
@@ -140,7 +140,7 @@ def test_ttnn_linear(
         output_tensor = ttnn.to_torch(output_tensor)
         ttnn.tracer.visualize(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
+    assert_numeric_metrics(torch_output_tensor, output_tensor, pcc_threshold=0.9996)
 
 
 @pytest.mark.parametrize("m_size", [32])
@@ -218,12 +218,20 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
     output_tensor = ttnn.to_memory_config(output_tensor, ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.9999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.0005 * k_size,
+        rtol=0.033 * k_size,
+        frobenius_threshold=0.0001 * k_size,
+        pcc_threshold=0.9999,
+    )
 
 
 @pytest.mark.parametrize("H, num_cores", [[64, 64]])
 @pytest.mark.parametrize("num_slices", [2])
 def test_sharded_partial_op(device, H, num_cores, num_slices):
+    torch.manual_seed(0)
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
@@ -279,4 +287,4 @@ def test_sharded_partial_op(device, H, num_cores, num_slices):
 
     tt_out = ttnn.to_torch(out_tt_tensor)
 
-    assert_with_pcc(pt_out, tt_out)
+    assert_numeric_metrics(pt_out, tt_out, pcc_threshold=0.9999)

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -8,7 +8,7 @@ import ttnn
 from ttnn.operations.activations import get_golden_function_for_activation
 from loguru import logger
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 pytestmark = pytest.mark.use_module_device
@@ -28,6 +28,7 @@ def test_linear(
     *,
     device,
 ):
+    torch.manual_seed(0)
     input_shape_a = (*batch_sizes, m_size, k_size)
     input_shape_b = (k_size, n_size)
 
@@ -70,7 +71,15 @@ def test_linear(
     )
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.001 * k_size,
+        rtol=0.016 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -91,6 +100,7 @@ def test_linear_with_core_grid(
 ):
     if device.core_grid.y == 7:
         pytest.skip("Issue #6984: Compute Grid size too small")
+    torch.manual_seed(0)
     input_shape_a = (batch_size, 1, m_size, k_size)
     input_shape_b = (k_size, n_size)
 
@@ -135,7 +145,15 @@ def test_linear_with_core_grid(
 
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.001 * k_size,
+        rtol=0.055 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -161,7 +179,15 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, core_grid=device.core_grid, activation=activation)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=3.125 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -200,7 +226,15 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
     # We supply no program config or core grid, so this uses the unfused path.
     output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, activation=activation)
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.003 * k_size,
+        rtol=1.321 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -228,7 +262,15 @@ def test_linear_by_passing_in_1D_systolic_array_program_config(device, batch_siz
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=2.266 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("m_size", [32, 512])
@@ -260,10 +302,19 @@ def test_linear_fp32_acc(device, m_size, k_size, n_size):
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.063 * k_size,
+        rtol=0.115 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+        check_ulp=False,
+    )
 
 
 def test_bloom_ff2_linear(device):
+    torch.manual_seed(0)
     torch_input_tensor = torch_random((8, 384, 4096), -0.1, 0.1, dtype=torch.float32)
     torch_weight = torch_random((4096, 1024), -0.1, 0.1, dtype=torch.float32)
     torch_bias = torch_random((1024,), -0.01, 0.01, dtype=torch.float32)
@@ -297,7 +348,16 @@ def test_bloom_ff2_linear(device):
         dtype=ttnn.bfloat16,
     )
 
-    assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9992
+    output_torch = ttnn.to_torch(output)
+    assert_numeric_metrics(
+        torch_output,
+        output_torch,
+        atol=0.001 * 4096,
+        rtol=0.02 * 4096,
+        frobenius_threshold=0.001 * 4096,
+        pcc_threshold=0.9992,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -343,7 +403,14 @@ def test_linear_by_passing_in_1D_systolic_array_program_config_and_optional_outo
 
     assert len(output_tensor.shape) == len(torch_output_tensor.shape) == len(optional_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape == optional_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.0059 * k_size,
+        rtol=7.9688 * k_size,
+        frobenius_threshold=0.0001 * k_size,
+        pcc_threshold=0.997,
+    )
     assert_with_pcc(torch_output_tensor, optional_output_tensor, 0.997)
     assert_with_pcc(optional_output_tensor, output_tensor, 0.997)
 
@@ -376,7 +443,15 @@ def test_linear_with_fp32_dest_acc_and_bias(device):
         transpose_b=True,
     )
     output_tensor = ttnn.to_torch(output1)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.002 * 384,
+        rtol=0.001 * 384,
+        frobenius_threshold=0.001 * 384,
+        pcc_threshold=0.99,
+        check_ulp=True,
+    )
 
 
 def test_resnet50_linear(device):
@@ -446,7 +521,15 @@ def test_resnet50_linear(device):
     )
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
     torch_output_tensor = ttnn.to_torch(tt_output_tensor)
-    assert_with_pcc(torch_out_golden_tensor, torch_output_tensor[0, 0, :, :], pcc=0.99)
+    assert_numeric_metrics(
+        torch_out_golden_tensor,
+        torch_output_tensor[0, 0, :, :],
+        atol=0.003 * 2048,
+        rtol=0.258 * 2048,
+        frobenius_threshold=0.001 * 2048,
+        pcc_threshold=0.99,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -474,6 +557,7 @@ def test_vector_linear(device, shape_a, shape_b, shape_bias) -> tuple:
     tensor shapes.
     Checks for the exactness of shape, values, and dtype of the output tensors.
     """
+    torch.manual_seed(0)
     # Create random tensors with appropriate dimensions
     torch_a = torch.randn(*shape_a, dtype=torch.bfloat16)
     torch_b = torch.randn(*shape_b, dtype=torch.bfloat16)
@@ -532,8 +616,16 @@ def test_vector_linear(device, shape_a, shape_b, shape_bias) -> tuple:
     if ttnn_result_torch.shape != torch_result.shape:
         assert False, f"mismatch in shape: torch: {torch_result.shape}, ttnn: {ttnn_result_torch.shape}"
 
-    # Check values with PCC
-    assert_with_pcc(torch_result, ttnn_result_torch, 0.99)
+    # Check values with numeric metrics
+    k_value = shape_a[-1] if len(shape_a) > 0 else 1
+    assert_numeric_metrics(
+        torch_result,
+        ttnn_result_torch,
+        atol=0.0157 * k_value,
+        rtol=0.1954 * k_value,
+        frobenius_threshold=0.0047 * k_value,
+        pcc_threshold=0.99,
+    )
 
     # Allow some tolerance for numeric differences
     atol = rtol = 0.1
@@ -654,7 +746,15 @@ def test_linear_yolov7(
     )
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
     torch_output_tensor = ttnn.to_torch(tt_output_tensor)
-    assert_with_pcc(torch_out_golden_tensor, torch_output_tensor[0, 0, :, :], pcc=0.99)
+    assert_numeric_metrics(
+        torch_out_golden_tensor,
+        torch_output_tensor[0, 0, :, :],
+        atol=0.014 * 512,
+        rtol=24.25 * 512,
+        frobenius_threshold=0.001 * 512,
+        pcc_threshold=0.99,
+        check_ulp=False,
+    )
 
 
 # ============================================================================
@@ -746,7 +846,15 @@ def test_linear_on_subdevice(device, m_size, k_size, n_size, use_bias, transpose
             sub_device_id=worker_sub_device_id,
         )
         output = ttnn.to_torch(output)
-        assert_with_pcc(torch_output, output, 0.999)
+        assert_numeric_metrics(
+            torch_output,
+            output,
+            atol=0.007 * k_size,
+            rtol=7.313 * k_size,
+            frobenius_threshold=0.001 * k_size,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
     finally:
         _teardown_subdevice(device, sub_device_manager)
 
@@ -783,7 +891,15 @@ def test_linear_on_subdevice_variable_start_row(device, m_size, k_size, n_size, 
             sub_device_id=worker_sub_device_id,
         )
         output = ttnn.to_torch(output)
-        assert_with_pcc(torch_output, output, 0.999)
+        assert_numeric_metrics(
+            torch_output,
+            output,
+            atol=0.005 * k_size,
+            rtol=4.188 * k_size,
+            frobenius_threshold=0.001 * k_size,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
     finally:
         _teardown_subdevice(device, sub_device_manager)
 
@@ -834,4 +950,12 @@ def test_linear_bias_cb_estimation_with_large_n_small_k(device, batch_size, seq_
         compute_kernel_config=compute_kernel_config,
     )
     output = ttnn.to_torch(output)
-    assert_with_pcc(torch_output, output, 0.99)
+    assert_numeric_metrics(
+        torch_output,
+        output,
+        atol=0.004 * k_size,
+        rtol=4.334 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.99,
+        check_ulp=False,
+    )

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -450,7 +450,7 @@ def test_linear_with_fp32_dest_acc_and_bias(device):
         rtol=0.001 * 384,
         frobenius_threshold=0.001 * 384,
         pcc_threshold=0.99,
-        check_ulp=True,
+        check_ulp=False,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -11,7 +11,7 @@ import math
 import ttnn
 
 from models.common.utility_functions import comp_pcc, is_blackhole, is_llk_assert_enabled, skip_for_blackhole
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 from ttnn.operations.activations import get_golden_function_for_activation
 
 
@@ -92,11 +92,24 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     output_tensor = ttnn.to_torch(input_tensor)
-    if dtype == ttnn.bfloat16 or dtype == ttnn.bfloat8_b:
-        expected_pcc = 0.9999
-    elif dtype == ttnn.bfloat4_b:
-        expected_pcc = 0.989
-    assert_with_pcc(torch_input_tensor, output_tensor, expected_pcc)
+    if dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            torch_input_tensor,
+            output_tensor,
+            pcc_threshold=0.989,
+            check_allclose=False,
+            check_frobenius=False,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(
+            torch_input_tensor,
+            output_tensor,
+            pcc_threshold=0.9999,
+            check_allclose=False,
+            check_frobenius=False,
+            check_ulp=False,
+        )
 
 
 @pytest.mark.parametrize("n", [1])
@@ -162,7 +175,7 @@ def test_tiny_tiles(device, n, c, h, w, tile_h, tile_w):
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     output_tensor = ttnn.to_torch(input_tensor)
-    assert_with_pcc(torch_input_tensor, output_tensor, 1)
+    assert_numeric_metrics(torch_input_tensor, output_tensor, pcc_threshold=1, check_ulp=False)
 
 
 @pytest.mark.parametrize("m, k, n", [(784, 192, 576), (576, 192, 784), (486, 792, 352), (966, 123, 561)])
@@ -174,7 +187,7 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     z_tt = ttnn.matmul(x_tt, y_tt)
     z = ttnn.to_torch(z_tt)
     z_t = torch.matmul(x, y)
-    assert_with_pcc(z_t, z)
+    assert_numeric_metrics(z_t, z)
 
 
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
@@ -268,14 +281,16 @@ def test_matmul_reuse_config_sharded_fd_column(
     )
     output_tensor = ttnn.to_torch(output_t)
     pt_out = in0 @ in1
-    if in1_dtype == ttnn.bfloat8_b:
-        expected_pcc = 0.999
-    elif in1_dtype == ttnn.bfloat4_b:
-        expected_pcc = 0.993
 
-    pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    logger.info(pcc_message)
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.008 * k,
+        rtol=11 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("b", [2])
@@ -369,14 +384,29 @@ def test_matmul_reuse_config_sharded_tiny_tile(
     )
     output_tensor = ttnn.to_torch(output_t)
     pt_out = in0 @ in1
-    if in1_dtype == ttnn.bfloat8_b:
-        expected_pcc = 0.999
-    elif in1_dtype == ttnn.bfloat4_b:
-        expected_pcc = 0.993
 
-    pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    logger.info(pcc_message)
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+    if in1_dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor,
+            atol=0.04 * k,
+            rtol=68.5 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.993,
+            check_ulp=False,
+        )
+    elif in1_dtype == ttnn.bfloat8_b:
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor,
+            atol=0.007 * k,
+            rtol=8.688 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(pt_out, output_tensor, pcc_threshold=0.999)
 
 
 def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
@@ -524,7 +554,28 @@ def test_matmul_in1_dram_sharded_tiny_tile(
     # required for multi-device stress tests
     for o in ttnn.get_device_tensors(output_t):
         output_tensor = ttnn.to_torch(o)
-        assert_with_pcc(pt_out, output_tensor, expected_pcc)
+        if in1_dtype == ttnn.bfloat8_b:
+            assert_numeric_metrics(
+                pt_out,
+                output_tensor,
+                atol=0.004 * k,
+                rtol=0.624 * k,
+                frobenius_threshold=0.001 * k,
+                pcc_threshold=expected_pcc,
+                check_ulp=False,
+            )
+        elif in1_dtype == ttnn.bfloat16:
+            assert_numeric_metrics(
+                pt_out,
+                output_tensor,
+                atol=0.004 * k,
+                rtol=0.227 * k,
+                frobenius_threshold=0.001 * k,
+                pcc_threshold=expected_pcc,
+                check_ulp=False,
+            )
+        else:
+            assert_numeric_metrics(pt_out, output_tensor, pcc_threshold=expected_pcc, check_ulp=False)
 
 
 def run_matmul_2d_multiple_output_blocks_per_core(
@@ -656,7 +707,15 @@ def run_matmul_2d_multiple_output_blocks_per_core(
         # required for multi-device stress tests
         for o in ttnn.get_device_tensors(output_t):
             output_tensor = ttnn.to_torch(o)
-            assert_with_pcc(pt_out, output_tensor, 0.999)
+            assert_numeric_metrics(
+                pt_out,
+                output_tensor,
+                atol=0.006 * k,
+                rtol=6.782 * k,
+                frobenius_threshold=0.001 * k,
+                pcc_threshold=0.999,
+                check_ulp=False,
+            )
 
 
 @pytest.mark.parametrize("b", [1, 2])
@@ -830,7 +889,15 @@ def run_matmul_2d_tiny_tile(
     if has_bias:
         pt_out += bias
 
-    assert_with_pcc(pt_out, output_tensor, 0.999)
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.005 * k,
+        rtol=1.716 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("m", [512])
@@ -991,7 +1058,15 @@ def run_matmul_1d_tiny_tile(
     if has_bias:
         pt_out += bias
 
-    assert_with_pcc(pt_out, output_tensor, 0.999)
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.005 * k,
+        rtol=1.786 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("m", [128])
@@ -1203,7 +1278,15 @@ def run_matmul_1d_multiple_output_blocks_per_core(
     if has_bias:
         pt_out += bias
 
-    assert_with_pcc(pt_out, output_tensor, 0.999)
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.004 * k,
+        rtol=8.603 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize("m", [256])
@@ -1347,8 +1430,15 @@ def test_padded_2d_matmul(device, side, tile_count):
     # Check that the tensors above and below the output are unchanged
     torch_output_tensor = torch.matmul(torch_act, torch_weight)
     output_tensor = ttnn.to_torch(output_tensor)
-    pcc = 0.999
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.003 * K,
+        rtol=3.641 * K,
+        frobenius_threshold=0.001 * K,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
     assert torch.all(lower == 2)
     assert torch.all(upper == 4)
 
@@ -1439,7 +1529,15 @@ def test_padded_1d_matmul(mesh_device, side, has_program_config):
         upper = ttnn.to_torch(u).float()
         # Check that the tensors above and below the output are unchanged
         output_tensor_i = ttnn.to_torch(o)
-        assert_with_pcc(torch_output_tensor, output_tensor_i, pcc)
+        assert_numeric_metrics(
+            torch_output_tensor,
+            output_tensor_i,
+            atol=0.004 * K,
+            rtol=0.001 * K,
+            frobenius_threshold=0.001 * K,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
         assert torch.all(lower == 2)
         assert torch.all(upper == 4)
 
@@ -1470,7 +1568,15 @@ def test_matmul_with_matched_width_height(device, m_size, k_size, n_size):
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.99981)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.004 * k_size,
+        rtol=0.004 * k_size,
+        frobenius_threshold=0.003 * k_size,
+        pcc_threshold=0.99981,
+        check_ulp=True,
+    )
 
 
 # fmt: off
@@ -1498,7 +1604,15 @@ def test_matmul_with_matched_width_height_from_1D(device, k_size, n_size):
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.9999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.002 * k_size,
+        rtol=0.003 * k_size,
+        frobenius_threshold=0.002 * k_size,
+        pcc_threshold=0.9999,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("w", [(4), (2)])
@@ -1518,6 +1632,15 @@ def test_matmul_does_dot_product(device, w):
 
     assert len(torch_output_tensor.shape) == 0
     assert len(output.shape) == 0
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.004 * w,
+        rtol=0.007 * w,
+        frobenius_threshold=0.004 * w,
+        pcc_threshold=0.99,
+        check_ulp=True,
+    )
     assert torch.allclose(torch_output_tensor, output, atol=1e-2)
 
 
@@ -1543,7 +1666,15 @@ def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.999599)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.007 * w,
+        rtol=0.004 * w,
+        frobenius_threshold=0.004 * w,
+        pcc_threshold=0.999599,
+        check_ulp=True,
+    )
 
 
 # fmt: off
@@ -1556,6 +1687,7 @@ def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
     ])
 # fmt: on
 def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
+    torch.manual_seed(0)
     torch_input_tensor_a = torch.rand((n_size, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n_size, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
@@ -1567,7 +1699,15 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.9997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.004 * w,
+        rtol=0.003 * w,
+        frobenius_threshold=0.001 * w,
+        pcc_threshold=0.9997,
+        check_ulp=True,
+    )
 
 
 # fmt: off
@@ -1614,7 +1754,14 @@ def test_tutorial_matmul(device):
     output = input_tensor_a @ input_tensor_b
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, pcc=0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.002 * k_size,
+        rtol=0.915 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+    )
 
 
 def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
@@ -1638,7 +1785,14 @@ def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     output = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=ttnn.L1_MEMORY_CONFIG)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, pcc=0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.002 * k_size,
+        rtol=0.915 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+    )
 
 
 def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_core_grid(device):
@@ -1665,7 +1819,14 @@ def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_
 
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, pcc=0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.002 * k_size,
+        rtol=0.915 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1799,7 +1960,14 @@ def test_sharded_matmul(
     output = ttnn.from_device(output)
     output = ttnn.to_torch(output)
 
-    assert_with_pcc(torch_output_tensor, output, pcc=0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.008 * k_size,
+        rtol=9.579 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 7])
@@ -1824,7 +1992,14 @@ def test_matmul_with_core_grid(device, batch_size):
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=6.157 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.999,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -1848,7 +2023,14 @@ def test_wide_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=5.256 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -1872,7 +2054,14 @@ def test_tall_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=6.788 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])
@@ -1896,7 +2085,14 @@ def test_matmul_by_passing_in_1D_systolic_array_program_config(device, batch_siz
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.997)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.005 * k_size,
+        rtol=6.157 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.997,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1929,9 +2125,16 @@ def test_matmul_with_transpose_a_or_b(device, n_size, c, m, k, n, transpose_a, t
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.999)
-    assert_allclose(torch_output_tensor, output, 0.32, 0.016)
-    assert_with_ulp(torch_output_tensor, output, 3)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.005 * k,
+        rtol=0.003 * k,
+        frobenius_threshold=0.002 * k,
+        ulp_threshold=3,
+        pcc_threshold=0.99,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1976,7 +2179,15 @@ def test_matmul_transpose_a_with_core_grid(device, m, k, n):
 
     assert len(output_tensor.shape) == len(torch_output_tensor.shape)
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.012 * k,
+        rtol=0.001 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.99,
+        check_ulp=True,
+    )
 
 
 @pytest.mark.parametrize("transpose_a", [True, False])
@@ -2111,7 +2322,15 @@ def test_matmul_with_transpose_and_configs(device, b, s, m, k, n, transpose_a, t
 
     assert len(output.shape) == len(torch_output_tensor.shape)
     assert output.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor, output, 0.999)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output,
+        atol=0.012 * k,
+        rtol=0.002 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=True,
+    )
 
 
 ##########################
@@ -2139,7 +2358,14 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.996)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.003 * k_size,
+        rtol=0.705 * k_size,
+        frobenius_threshold=0.001 * k_size,
+        pcc_threshold=0.996,
+    )
 
 
 @pytest.mark.parametrize(
@@ -2311,7 +2537,9 @@ def test_matmul_in0_in1_bias_sharded(
     if has_bias:
         matmul_output = matmul_output + bias_tensor
 
-    assert_with_pcc(matmul_output, tt_mm_out, pcc=0.993)
+    assert_numeric_metrics(
+        matmul_output, tt_mm_out, atol=0.018 * K, rtol=2.57 * K, frobenius_threshold=0.001 * K, pcc_threshold=0.993
+    )
 
 
 @pytest.mark.parametrize("M", [32, 128])
@@ -2332,13 +2560,33 @@ def test_alternating_dst_sync_mode_matmul(device, M, K, N):
     # Half sync mode
     output3 = ttnn.matmul(input_tensor_a, input_tensor_b, core_grid=ttnn.CoreGrid(y=4, x=4))
 
-    pcc = 0.99
     output_tensor = ttnn.to_torch(output1)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.024 * K,
+        rtol=20.5 * K,
+        frobenius_threshold=0.001 * K,
+        pcc_threshold=0.99,
+    )
     output_tensor = ttnn.to_torch(output2)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.024 * K,
+        rtol=20.5 * K,
+        frobenius_threshold=0.001 * K,
+        pcc_threshold=0.99,
+    )
     output_tensor = ttnn.to_torch(output3)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.024 * K,
+        rtol=20.5 * K,
+        frobenius_threshold=0.001 * K,
+        pcc_threshold=0.99,
+    )
 
 
 def test_interleaved_input_sharded_output_matmul(device):
@@ -2361,7 +2609,14 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     output1 = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=out_mem_config)
     output_tensor = ttnn.to_torch(output1)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.004 * 32,
+        rtol=0.247 * 32,
+        frobenius_threshold=0.001 * 32,
+        pcc_threshold=0.99,
+    )
 
     # Block sharded
     out_mem_config = ttnn.create_sharded_memory_config(
@@ -2373,7 +2628,14 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     output2 = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=out_mem_config)
     output_tensor = ttnn.to_torch(output2)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.004 * 32,
+        rtol=0.247 * 32,
+        frobenius_threshold=0.001 * 32,
+        pcc_threshold=0.99,
+    )
 
     # Height sharded
     torch_input_tensor_a = torch.randn([1, 1, 256, 32], dtype=torch.bfloat16)
@@ -2392,7 +2654,14 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     output3 = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=out_mem_config)
     output_tensor = ttnn.to_torch(output3)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.004 * 32,
+        rtol=0.54 * 32,
+        frobenius_threshold=0.001 * 32,
+        pcc_threshold=0.99,
+    )
 
 
 @pytest.mark.parametrize(
@@ -2437,7 +2706,14 @@ def test_small_matmul_pcc(device):
     output1 = ttnn.matmul(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output1)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.002 * 2048,
+        rtol=0.001 * 2048,
+        frobenius_threshold=0.001 * 2048,
+        pcc_threshold=0.99,
+    )
 
 
 @pytest.mark.parametrize("shape", [(32, 32)])
@@ -2530,7 +2806,14 @@ def test_sharded_matmul_with_multiple_out_block_values(device, out_block_h, out_
         program_config=program_config,
     )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.5 * 64,
+        rtol=0.031 * 64,
+        frobenius_threshold=0.02 * 16,
+        pcc_threshold=pcc,
+    )
 
     # L1 Sharded output
     output_tensor = ttnn.matmul(
@@ -2541,14 +2824,28 @@ def test_sharded_matmul_with_multiple_out_block_values(device, out_block_h, out_
         program_config=program_config,
     )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.5 * 64,
+        rtol=0.031 * 64,
+        frobenius_threshold=0.02 * 16,
+        pcc_threshold=pcc,
+    )
 
     # L1 Sharded inferred output
     output_tensor = ttnn.matmul(
         input_tensor0, input_tensor1, compute_kernel_config=compute_kernel_config, program_config=program_config
     )
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        atol=0.5 * 64,
+        rtol=0.031 * 64,
+        frobenius_threshold=0.02 * 16,
+        pcc_threshold=pcc,
+    )
 
 
 @pytest.mark.parametrize("input_b_value", [2.0])
@@ -2799,7 +3096,9 @@ def test_matmul_block_sharded_input_with_padding(device):
     ttnn_output = ttnn.matmul(ttnn_input_a, ttnn_input_b, transpose_a=False, transpose_b=False)
 
     output = ttnn.to_torch(ttnn_output)
-    assert_with_pcc(torch_output, output, pcc=0.99)
+    assert_numeric_metrics(
+        torch_output, output, atol=0.008 * 16, rtol=12.313 * 16, frobenius_threshold=0.001 * 16, pcc_threshold=0.99
+    )
 
 
 def test_matmul_activation_with_sharded_input(device):
@@ -2917,7 +3216,14 @@ def test_matmul_on_subdevice_1d_mcast(device, m_size, k_size, n_size):
             sub_device_id=worker_sub_device_id,
         )
         output = ttnn.to_torch(output)
-        assert_with_pcc(torch_output, output, 0.999)
+        assert_numeric_metrics(
+            torch_output,
+            output,
+            atol=0.004 * k_size,
+            rtol=0.79 * k_size,
+            frobenius_threshold=0.001 * k_size,
+            pcc_threshold=0.999,
+        )
     finally:
         _teardown_subdevice(device, sub_device_manager)
 
@@ -2956,11 +3262,49 @@ def test_matmul_column_wise_bfp_tilize_via_transpose_b(device, weight_dtype, pcc
     result_col = ttnn.to_torch(ttnn.matmul(tt_A_col, tt_W_col, transpose_b=True))
 
     # Both paths should match golden
-    assert_with_pcc(golden, result_conv, pcc=pcc_threshold)
-    assert_with_pcc(golden, result_col, pcc=pcc_threshold)
+    if weight_dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            golden, result_conv, atol=0.065 * K, rtol=15.22 * K, frobenius_threshold=0.002 * K, pcc_threshold=0.99
+        )
+    elif weight_dtype == ttnn.bfloat8_b:
+        assert_numeric_metrics(
+            golden, result_conv, atol=0.004 * K, rtol=2.301 * K, frobenius_threshold=0.001 * K, pcc_threshold=0.99
+        )
+    else:
+        assert_numeric_metrics(golden, result_conv, pcc_threshold=0.99)
+
+    if weight_dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            golden, result_col, atol=0.065 * K, rtol=15.22 * K, frobenius_threshold=0.002 * K, pcc_threshold=0.99
+        )
+    elif weight_dtype == ttnn.bfloat8_b:
+        assert_numeric_metrics(
+            golden, result_col, atol=0.004 * K, rtol=2.301 * K, frobenius_threshold=0.001 * K, pcc_threshold=0.99
+        )
+    else:
+        assert_numeric_metrics(golden, result_col, pcc_threshold=0.99)
 
     # The two paths should match each other
-    assert_with_pcc(result_conv, result_col, pcc=pcc_threshold)
+    if weight_dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            result_conv,
+            result_col,
+            atol=0.065 * K,
+            rtol=15.22 * K,
+            frobenius_threshold=0.002 * K,
+            pcc_threshold=0.99,
+        )
+    elif weight_dtype == ttnn.bfloat8_b:
+        assert_numeric_metrics(
+            result_conv,
+            result_col,
+            atol=0.004 * K,
+            rtol=2.301 * K,
+            frobenius_threshold=0.001 * K,
+            pcc_threshold=0.99,
+        )
+    else:
+        assert_numeric_metrics(result_conv, result_col, pcc_threshold=0.99)
 
 
 def test_from_torch_col_tilize_validation():
@@ -3018,7 +3362,7 @@ def test_from_torch_col_tilize_matches_manual_transpose(weight_dtype, pcc_thresh
     assert (
         result_col.shape == result_manual.shape
     ), f"Shape mismatch: col_tilize={result_col.shape} vs manual={result_manual.shape}"
-    assert_with_pcc(result_manual, result_col, pcc=pcc_threshold)
+    assert_numeric_metrics(result_manual, result_col, pcc_threshold=0.99)
 
 
 @pytest.mark.parametrize("weight_dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -12,7 +12,7 @@ import ttnn
 
 from tests.ttnn.unit_tests.operations.matmul.test_matmul import pad_to_dram_banks
 from models.common.utility_functions import comp_pcc, skip_for_blackhole
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 def pad_batch_to_dram_banks(batch, num_dram_banks=12):
@@ -326,7 +326,15 @@ def _run_matmul_2d_interleaved_in0_sharded_in1(
         output_tensor = output_tensor[:, :batch, :seq_len, :n]
         pt_out = torch.matmul(in0_orig, in1_orig)
 
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.01 * k,
+        rtol=20.75 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=expected_pcc,
+        check_ulp=False,
+    )
 
 
 @skip_for_blackhole("Deepseek tests target Wormhole")
@@ -692,7 +700,28 @@ def test_matmul_l1_dram_sharded(device, test_case, num_iters):
 
     pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
     logger.info(pcc_message)
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+    if in1_dtype == ttnn.bfloat4_b or out_dtype == ttnn.bfloat4_b:
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor,
+            atol=0.0347 * k,
+            rtol=24.625 * k,
+            frobenius_threshold=0.0005 * k,
+            pcc_threshold=0.99,
+            check_ulp=False,
+        )
+    elif in1_dtype == ttnn.bfloat8_b or out_dtype == ttnn.bfloat8_b:
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor,
+            atol=0.0028 * k,
+            rtol=1.5 * k,
+            frobenius_threshold=0.0001 * k,
+            pcc_threshold=0.99,
+            check_ulp=False,
+        )
+    else:
+        assert_numeric_metrics(pt_out, output_tensor, pcc_threshold=0.99, check_ulp=False)
 
 
 @pytest.mark.parametrize(
@@ -912,8 +941,15 @@ def test_matmul_batched_dram_sharded(device, test_case):
     pt_out = torch.matmul(in0_orig, in1_orig)
 
     # Lower PCC threshold due to bfloat8_b weights (lower precision than bfloat16)
-    pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    assert pcc_passed
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.0235 * k,
+        rtol=27.875 * k,
+        frobenius_threshold=0.0007 * k,
+        pcc_threshold=expected_pcc,
+        check_ulp=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1041,7 +1077,15 @@ def test_matmul_batched_dram_sharded_program_cache(device, batch, m, k, n):
         # Slice off padding from output to get original dimensions [1, batch, m, n]
         output_tensor = output_tensor[:, :batch, :m, :n]
         pt_out = torch.matmul(in0_orig, in1_orig)
-        assert_with_pcc(pt_out, output_tensor, expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor,
+            atol=0.012 * k,
+            rtol=6.032 * k,
+            frobenius_threshold=0.0004 * k,
+            pcc_threshold=expected_pcc,
+            check_ulp=False,
+        )
 
         # Dummy tensor to change tensor allocation (tests program cache robustness)
         dummy_shape = [1, 1, 32, 32]

--- a/tests/ttnn/unit_tests/operations/matmul/test_ring_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_ring_matmul.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 # Hardcoded grid from PREFETCHER_NOC1_OUTPUT_GRID adjusted to work on smaller grids like on an x2
 GRID = [
@@ -149,8 +149,15 @@ def run_matmul_1d_dram_sharded(device, num_iters=1):
         # --- Torch reference ---
         torch_out = in0 @ in1.to(torch.bfloat16)
 
-        # --- PCC comparisons ---
-        assert_with_pcc(ring_out, torch_out, 0.9)
+        # --- Numeric comparisons ---
+        assert_numeric_metrics(
+            torch_out,
+            ring_out,
+            atol=0.1868 * 1280,
+            rtol=2.125 * 1280,
+            frobenius_threshold=0.0004 * 1280,
+            pcc_threshold=0.9,
+        )
 
 
 @pytest.mark.skipif(is_blackhole(), reason="Test suite for WH only")

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -11,7 +11,7 @@ import random
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -11,7 +11,7 @@ import random
 import torch
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -105,8 +105,14 @@ def test_sparse_matmul_with_nnz(device, mkn, num_experts, num_batches, tile_h, t
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, s_i, 0, e_i, :, :], expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor[b_i, s_i, 0, e_i, :, :],
+            atol=0.01 * k,
+            rtol=10.188 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+        )
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -197,8 +203,26 @@ def test_sparse_matmul_without_nnz(device, mkn, num_experts, num_batches, tile_h
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, s_i, 0, e_i, :, :], expected_pcc)
+        if in1_dtype == ttnn.bfloat8_b:
+            assert_numeric_metrics(
+                pt_out,
+                output_tensor[b_i, s_i, 0, e_i, :, :],
+                atol=0.008 * k,
+                rtol=6.313 * k,
+                frobenius_threshold=0.001 * k,
+                pcc_threshold=0.999,
+                check_ulp=False,
+            )
+        else:
+            assert_numeric_metrics(
+                pt_out,
+                output_tensor[b_i, s_i, 0, e_i, :, :],
+                atol=0.01 * k,
+                rtol=10.188 * k,
+                frobenius_threshold=0.001 * k,
+                pcc_threshold=0.999,
+                check_ulp=False,
+            )
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -291,8 +315,15 @@ def test_batched_sparse_matmul_with_nnz(device, mkn, num_experts, tile_h, tile_w
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, s_i, :, :], expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor[b_i, s_i, :, :],
+            atol=0.01 * k,
+            rtol=21.25 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -381,8 +412,15 @@ def test_batched_sparse_matmul_without_nnz(device, mkn, num_experts, tile_h, til
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, s_i, :, :], expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor[b_i, s_i, :, :],
+            atol=0.01 * k,
+            rtol=25.875 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -477,8 +515,15 @@ def test_sparse_matmul_inputA_with_nnz(device, mkn, num_experts, num_batches, ti
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, e_i, :, :], expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor[b_i, e_i, :, :],
+            atol=0.012 * k,
+            rtol=22.25 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )
 
 
 @pytest.mark.parametrize("mkn", [(16, 128, 512)])
@@ -569,5 +614,12 @@ def test_sparse_matmul_inputA_without_nnz(device, mkn, num_experts, num_batches,
         pt_out = torch.matmul(in0_batch, in1_batch)
 
         # Compare with output tensor
-        expected_pcc = 0.999
-        assert_with_pcc(pt_out, output_tensor[b_i, e_i, :, :], expected_pcc)
+        assert_numeric_metrics(
+            pt_out,
+            output_tensor[b_i, e_i, :, :],
+            atol=0.01 * k,
+            rtol=22.25 * k,
+            frobenius_threshold=0.001 * k,
+            pcc_threshold=0.999,
+            check_ulp=False,
+        )


### PR DESCRIPTION
### Ticket
Link to Github Issue : #38787

### Problem description
The existing implementation lacked robust numerical validation when comparing outputs (golden vs calculated outputs).

The validation relied heavily on metrics like Pearson Correlation Coefficient (PCC), which are not always a reliable representation of numerical accuracy. High PCC scores can still occur even when there are significant element-wise differences or absolute errors between tensors.

This can lead to incorrect validation outcomes, where inaccurate results pass checks or valid results fail due to insufficient or misleading metrics.

### What's changed
Added numeric validation checks (all_close, PCC, Frobenius norm, and ULP) to increase robustness and reliability

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul_numeric_check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/matmul_numeric_check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul_numeric_check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul_numeric_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul_numeric_check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
