### PR TITLE
Move prefill kv cache to migration friendly format

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -102,11 +102,9 @@ def random_weights(config_only):
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 16 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
 @pytest.mark.parametrize("skip_host_comparison", [False, True], ids=["check_pcc", "skip_check"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
-# kv_cache is single user at the moment
-# @pytest.mark.parametrize("compare_pcc_kv_cache")
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
 def test_mla(
     use_pretrained,
@@ -177,15 +175,18 @@ def test_mla(
     num_layers = 1
     kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
     seq_len_local = seq_len // mesh_shape[sp_axis]
-    torch_kv_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
+    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
 
+    BH_NUM_DRAM_BANKS = 8
     core_ranges = [
-        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in [0, 1, 2, 3, 4, 5, 6, 7]
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
     ]
     grid = ttnn.CoreRangeSet(core_ranges)
 
+    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32  # this is a predefined constant
+
     kv_nd_shard_spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, 32, 576],
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
         grid=grid,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
@@ -196,7 +197,7 @@ def test_mla(
     )
 
     tt_kvpe_cache = ttnn.from_torch(
-        torch_kv_cache,
+        torch_kvpe_cache,
         dtype=ttnn.bfloat8_b,
         device=mesh_device,
         layout=ttnn.TILE_LAYOUT,

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -102,9 +102,11 @@ def random_weights(config_only):
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.parametrize("seq_len", [128 * 1024, 16 * 1024], ids=["seq128k", "seq100k"])
 @pytest.mark.parametrize("skip_host_comparison", [False, True], ids=["check_pcc", "skip_check"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
+# kv_cache is single user at the moment
+# @pytest.mark.parametrize("compare_pcc_kv_cache")
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
 def test_mla(
     use_pretrained,
@@ -170,6 +172,38 @@ def test_mla(
 
     # Create TT MLA
     logger.info("Creating TT MLA...")
+
+    # hack in num_layers into batch size, so they are contiguous in memory
+    num_layers = 1
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
+    seq_len_local = seq_len // mesh_shape[sp_axis]
+    torch_kv_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
+
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in [0, 1, 2, 3, 4, 5, 6, 7]
+    ]
+    grid = ttnn.CoreRangeSet(core_ranges)
+
+    kv_nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, 32, 576],
+        grid=grid,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    kv_mem_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.DRAM,
+        nd_shard_spec=kv_nd_shard_spec,
+    )
+
+    tt_kvpe_cache = ttnn.from_torch(
+        torch_kv_cache,
+        dtype=ttnn.bfloat8_b,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
     mla_tt = ttMLA(
         config,
         weights,
@@ -265,6 +299,7 @@ def test_mla(
     tt_output = mla_tt.forward(
         hidden_states=tt_hidden_states,
         rope_tensors=rope_tensors,
+        kvpe_cache=tt_kvpe_cache,
     )
 
     if skip_host_comparison == False:
@@ -284,23 +319,23 @@ def test_mla(
 
         # Read back KVPE cache from device
         # Cache is replicated across TP, so concat TP replicas on dim 1 (unused) and discard extras
-        tt_kvpe_cache = ttnn.to_torch(
-            mla_tt.kvpe_cache,
+        tt_kvpe_cache_torch = ttnn.to_torch(
+            tt_kvpe_cache,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
         ).to(torch.bfloat16)
-        tt_kvpe_cache = tt_kvpe_cache[:, :1, :, :]
+        tt_kvpe_cache_torch = tt_kvpe_cache_torch[:, :1, :, :]
 
         if is_balanced:
-            tt_kvpe_cache = reverse_reorder_tensor_chunks(tt_kvpe_cache, chunk_order, seq_dim=2)
+            tt_kvpe_cache_torch = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch, chunk_order, seq_dim=2)
 
         # Check PCC separately for KV (latent) and PE (rope) parts
         kv_lora_rank = config.kv_lora_rank
         _, kv_pcc_message = assert_with_pcc(
-            ref_kvpe[:, :, :, :kv_lora_rank], tt_kvpe_cache[:, :, :, :kv_lora_rank], 0.99
+            ref_kvpe[:, :, :, :kv_lora_rank], tt_kvpe_cache_torch[:, :, :, :kv_lora_rank], 0.99
         )
         logger.info(f"KVPE cache KV part PCC is {kv_pcc_message}")
         _, pe_pcc_message = assert_with_pcc(
-            ref_kvpe[:, :, :, kv_lora_rank:], tt_kvpe_cache[:, :, :, kv_lora_rank:], 0.99
+            ref_kvpe[:, :, :, kv_lora_rank:], tt_kvpe_cache_torch[:, :, :, kv_lora_rank:], 0.99
         )
         logger.info(f"KVPE cache PE part PCC is {pe_pcc_message}")
     else:

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -121,20 +121,6 @@ class ttMLA:
             ),
         )
 
-        # KV cache for prefill — each SP device holds its local chunk of the cache
-        # Replicated across the mesh since each device stores only its local seq portion
-        sp_factor = mesh_device.shape[sp_axis]
-        seq_len_local = seq_len // sp_factor
-
-        self.kvpe_cache = ttnn.from_torch(
-            torch.zeros(1, 1, seq_len_local, self.kv_lora_rank + self.qk_rope_head_dim),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-        )
-
         # Pre-allocate dummy joint tensors for ring_joint_scaled_dot_product_attention (seq_len=0)
         num_heads_local = self.num_heads // self.tp_factor
         joint_shard_dims = [None, None]
@@ -314,7 +300,7 @@ class ttMLA:
             return {"memory_config": ttnn.DRAM_MEMORY_CONFIG, "dtype": self.MM_DEFAULT_DTYPES[weight_name]}
         return {
             "memory_config": cfg["out_mem_config"],
-            "program_config": cfg["program_config"],
+            "program_config": None,
             "dtype": cfg["out_dtype"],
         }
 
@@ -332,7 +318,7 @@ class ttMLA:
 
     # Expects ativation in form of:
     # [1, batch_size == 1, seq_len // sp_factor, hidden_size // tp_factor]
-    def forward(self, hidden_states: ttnn.Tensor, rope_tensors: dict) -> ttnn.Tensor:
+    def forward(self, hidden_states: ttnn.Tensor, rope_tensors: dict, kvpe_cache: ttnn.Tensor) -> ttnn.Tensor:
         mesh_size = self.mesh_device.shape
         sp_factor = mesh_size[0]
         tp_factor = mesh_size[1]
@@ -475,7 +461,7 @@ class ttMLA:
         tt_kvpe = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
 
         # Update KV cache with compressed latent representation
-        ttnn.kv_cache.fill_cache_for_user_(self.kvpe_cache, tt_kvpe, 0)
+        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, 0)
 
         # expand v with wkv_b2
         # TODO: workaround for #37416, remove when resolved

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -300,7 +300,7 @@ class ttMLA:
             return {"memory_config": ttnn.DRAM_MEMORY_CONFIG, "dtype": self.MM_DEFAULT_DTYPES[weight_name]}
         return {
             "memory_config": cfg["out_mem_config"],
-            "program_config": None,
+            "program_config": cfg["program_config"],
             "dtype": cfg["out_dtype"],
         }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -57,8 +57,9 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         input_tensor.padded_shape()[1],
         cache_tensor.padded_shape()[1]);
     TT_FATAL(
-        cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Cache tensor memory layout must be INTERLEAVED but got {}",
+        cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
+            cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
+        "Cache tensor memory layout must be INTERLEAVED or ND_SHARDED but got {}",
         cache_tensor.memory_config().memory_layout());
     if (args.op_type == UpdateCacheOpType::FILL) {
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion


### PR DESCRIPTION
### Ticket
#41099 

### Problem description
KV cache needs to be in decode/migration friendly format

### What's changed


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppopovic/kv_cache_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppopovic/kv_cache_format)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppopovic/kv_cache_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppopovic/kv_cache_format)

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

  - [x] `t3k e2e` [[link](https://github.com/tenstorrent/tt-metal/actions/runs/23795498144)]
  - [x] `bh_e2e_deepseek prefill` [link](https://github.com/tenstorrent/tt-metal/actions/runs/23795574461)

