### PR TITLE
[skip ci] Update cron job time in fabric tests

### DIFF
--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -2,7 +2,7 @@ name: "Fabric Test on a BH Quad"
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Runs weekdays at 10:00 AM GMT+1 (9:00 UTC)
+    - cron: "0 7 * * 1-5" # Runs weekdays at 8:00 AM GMT+1 (7:00 UTC/9:00 CEST)
   workflow_dispatch:
 
 run-name: Fabric Test on a BH Quad


### PR DESCRIPTION
### Problem description
Daylight Saving Time (DST) has started in Europe, resulting in a time shift

### What's changed
Updated the cron job start time to align with the new time

