### PR TITLE
[QSR] Enable DstSync::Half and 32bit dest test combos

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -315,11 +315,6 @@ TEST_F(MeshDeviceFixture, TensixComputeCopyBlockMultiple) {
 TEST_F(MeshDeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
     for (bool fp32_dest_acc_en : {true, false}) {
         for (bool dst_full_sync_en : {true, false}) {
-            if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR && fp32_dest_acc_en &&
-                !dst_full_sync_en) {
-                // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                continue;
-            }
             log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
             unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
                 .num_tiles = 8,

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -608,10 +608,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceH) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {
@@ -650,10 +646,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceW) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {
@@ -697,10 +689,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHW) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {
@@ -743,10 +731,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHMathOnly) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {
@@ -786,10 +770,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceWMathOnly) {
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {
@@ -833,10 +813,6 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHWMathOnly) {
                     continue;
                 }
                 for (bool dst_full_sync_en : {true, false}) {
-                    if (this->arch_ == tt::ARCH::QUASAR && fp32_dest_acc_en && !dst_full_sync_en) {
-                        // TODO (#40827): AM; Remove when correct 32bit dest address is used
-                        continue;
-                    }
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
                           math_fid == uint8_t(MathFidelity::HiFi4))) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -112,9 +112,11 @@ inline void llk_math_wait_for_dest_available() {
 /**
  * @brief Signals that the current destination section is done.
  * After math is done, posts to the MATH_PACK semaphore so the packer can proceed;
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
  */
+template <bool EN_32BIT_DEST>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DST_SYNC_MODE>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, EN_32BIT_DEST>();
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/reg_api.h
+++ b/tt_metal/hw/inc/api/compute/reg_api.h
@@ -67,11 +67,7 @@ ALWI void tile_regs_wait() {
  */
 [[deprecated("Use tile_regs_release() instead")]]
 ALWI void release_dst() {
-#ifndef ARCH_QUASAR
     MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
-#else
-    MATH((llk_math_dest_section_done()));
-#endif
     PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
 }
 
@@ -83,8 +79,6 @@ ALWI void release_dst() {
 ALWI void tile_regs_commit() {
 #ifndef ARCH_QUASAR
     MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
-#else
-    MATH((llk_math_dest_section_done()));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/reg_api.h
+++ b/tt_metal/hw/inc/api/compute/reg_api.h
@@ -76,11 +76,7 @@ ALWI void release_dst() {
 /**
  * Release lock on DST register by MATH thread. The lock had to be previously acquired with tile_regs_acquire.
  */
-ALWI void tile_regs_commit() {
-#ifndef ARCH_QUASAR
-    MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
-#endif
-}
+ALWI void tile_regs_commit() { MATH((llk_math_dest_section_done<DST_ACCUM_MODE>())); }
 
 /**
  * Release lock on DST register by PACK thread. The lock had to be previously acquired with tile_regs_wait.


### PR DESCRIPTION
### Ticket
#40827 

### Problem description
tt-llk match PR: tenstorrent/tt-llk#1573

The dest register address offset should be 256, not 512 when the dest is in 32bit mode. Changes for this were needed in tt-llk in order to enable DstSync::Half and 32bit dest test combos.

### What's changed
Added an EN_32BIT_DEST parameter to llk_math_dest_section_done and removed the skips for mentioned test combos in test_reduce.cpp and and test_copy_block_matmul_partials.cpp

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/enable_sync_half_32bit_dest_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/enable_sync_half_32bit_dest_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
