### PR TITLE
ttsim: add @skip_for_slow_dispatch() to trace and sub-device tests

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -14,12 +14,6 @@ wormhole_b0:
   # Multi-device tests
   - tests/ttnn/unit_tests/base_functionality/test_multi_device.py
 
-  # Trace tests - require fast dispatch mode
-  - tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
-
-  # Sub-device tests - require fast dispatch mode
-  - tests/ttnn/unit_tests/base_functionality/test_sub_device.py
-
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
   - tests/ttnn/unit_tests/base_functionality/test_expand.py
@@ -125,12 +119,6 @@ blackhole:
 
   # Multi-device tests
   - tests/ttnn/unit_tests/base_functionality/test_multi_device.py
-
-  # Trace tests - require fast dispatch mode
-  - tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
-
-  # Sub-device tests - require fast dispatch mode
-  - tests/ttnn/unit_tests/base_functionality/test_sub_device.py
 
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_chunked.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_chunked.py
@@ -11,6 +11,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 import ttnn
 from loguru import logger
 import pytest
+from models.common.utility_functions import is_slow_dispatch
 
 
 def fa_rand(*shape):
@@ -280,6 +281,8 @@ def test_sdpa_chunked(
     When trace=True, device is created with trace_region_size; test captures one SDPA then replays per chunk."""
     if trace and not flexible:
         pytest.skip("Trace is not supported for legacy chunked SDPA")
+    if trace and is_slow_dispatch():
+        pytest.skip("Trace is not supported for slow dispatch")
     for _ in range(2):
         run_test_chunked_sdpa(
             device,

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -12,7 +12,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 import ttnn
 from loguru import logger
 import pytest
-from models.common.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
+from models.common.utility_functions import skip_for_wormhole_b0, skip_for_blackhole, is_slow_dispatch
 
 
 def fa_rand(*shape):
@@ -769,6 +769,8 @@ def test_sdpa_chunked(
     When trace=True, device is created with trace_region_size; test captures one SDPA then replays per chunk."""
     if trace and not flexible:
         pytest.skip("Trace is not supported for legacy chunked SDPA")
+    if trace and is_slow_dispatch():
+        pytest.skip("Trace is not supported for slow dispatch")
     for _ in range(2):
         run_test_chunked_sdpa(
             device,

--- a/tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
@@ -9,8 +9,10 @@ import ttnn
 import tempfile
 from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.common.utility_functions import skip_for_slow_dispatch
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
@@ -66,6 +68,7 @@ def test_single_device_single_trace(device, shape, blocking):
     ttnn.release_trace(device, tid)
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)

--- a/tests/ttnn/unit_tests/base_functionality/test_sub_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_sub_device.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import ttnn
+from models.common.utility_functions import skip_for_slow_dispatch
 
 
 def run_sub_devices(device):
@@ -127,17 +128,21 @@ def run_sub_devices_program(device):
     device.remove_sub_device_manager(sub_device_manager)
 
 
+@skip_for_slow_dispatch()
 def test_sub_devices(device):
     run_sub_devices(device)
 
 
+@skip_for_slow_dispatch()
 def test_sub_devices_mesh(mesh_device):
     run_sub_devices(mesh_device)
 
 
+@skip_for_slow_dispatch()
 def test_sub_device_program(device):
     run_sub_devices_program(device)
 
 
+@skip_for_slow_dispatch()
 def test_sub_device_program_mesh(mesh_device):
     run_sub_devices_program(mesh_device)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -15,6 +15,7 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 from tracy import signpost
 
 from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
+from models.common.utility_functions import skip_for_slow_dispatch
 
 shapes = [[[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 7328]]]
 
@@ -311,6 +312,7 @@ def test_from_torch_conversion_deep_seek_mc_large_number_of_pages_per_row(
     ],
     indirect=True,
 )
+@skip_for_slow_dispatch()
 def test_deepseek_v3_mla_tilize_trace_mode(
     device,
     batch_size,


### PR DESCRIPTION
## Summary
- `test_single_device_trace.py` and `test_sub_device.py` use fast-dispatch-only APIs (`ttnn.begin_trace_capture`, `ttnn.execute_trace`, `ttnn.SubDevice`) and will never pass in slow dispatch mode
- Add `@skip_for_slow_dispatch()` so they self-skip when `TT_METAL_SLOW_DISPATCH_MODE=1` (which is always set in ttsim CI)
- Remove them from the ttsim skip list — the decorator handles it now

## Test plan
- [ ] Ttsim CI should show these tests as SKIPPED instead of failing/deselected
- [ ] Fast-dispatch silicon CI should still run these tests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)