### PR TITLE
Improve TTFT for llama 70b model using fused op AG+MM 

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -1198,6 +1198,82 @@ class TT_CCL:
         self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
         return ttnn_tensor_out
 
+    def line_all_gather_matmul(
+        self,
+        input_tensor_mesh,
+        weight_tensor,
+        dim,
+        cluster_axis,
+        memory_config,
+        matmul_config,
+        compute_kernel_config,
+        dtype=ttnn.bfloat8_b,
+    ):
+        """
+        Fused AllGather + MatMul for prefill using all_gather_minimal_matmul_async.
+
+        Uses 6-column grids (6×8 or 6×9) to enable 3 links for better AllGather bandwidth.
+        The grid column count must be divisible by num_links (6 % 3 == 0).
+
+        Performance: ~17% faster than separate AG + MM for FF2 step.
+        """
+        topology = ttnn.Topology.Ring
+        force_transpose = True
+
+        # Reshape input to [1, 1, S, x] for prefill
+        B = input_tensor_mesh.shape[1]
+        input_tensor_mesh = ttnn.reshape(
+            input_tensor_mesh, (1, 1, B * input_tensor_mesh.shape[-2], input_tensor_mesh.shape[-1])
+        )
+
+        # Get grid size from matmul config
+        grid_size = matmul_config.compute_with_storage_grid_size
+        if hasattr(grid_size, "x"):
+            core_grid = ttnn.CoreCoord(grid_size.x, grid_size.y)
+        else:
+            core_grid = ttnn.CoreCoord(grid_size[0], grid_size[1])
+
+        # Find maximum num_links that divides the grid axis evenly
+        # For 6-column grid: 6 % 3 == 0, so num_links = 3
+        # For 7-column grid: 7 is prime, so num_links = 1
+        div_axis = core_grid.x if force_transpose else core_grid.y
+        num_links = 1
+        for nl in [4, 3, 2, 1]:
+            if div_axis % nl == 0:
+                num_links = nl
+                break
+
+        # num_workers_per_link calculation
+        max_workers_total = core_grid.x if force_transpose else core_grid.y
+        num_workers_per_link = max(1, min(8 // num_links, max_workers_total // num_links))
+
+        # Semaphores: op expects list of 2
+        sem_current = self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]]
+        sem_next = self.gather_semaphore_handles[cluster_axis][(self.gather_idx[cluster_axis] + 1) % self.num_cbs]
+        if isinstance(sem_current, list):
+            semaphores = sem_current + sem_next
+        else:
+            semaphores = [sem_current, sem_next]
+
+        output = ttnn.experimental.all_gather_minimal_matmul_async(
+            input_tensor=input_tensor_mesh,
+            weight_tensor=weight_tensor,
+            config=matmul_config,
+            compute_kernel_config=compute_kernel_config,
+            multi_device_global_semaphore=semaphores,
+            num_links=num_links,
+            topology=topology,
+            cluster_axis=cluster_axis,
+            memory_config=memory_config,
+            dtype=dtype,
+            force_transpose=force_transpose,
+            num_workers_per_link=num_workers_per_link,
+            num_buffers_per_channel=8,
+        )
+
+        self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
+        return output[0]
+
     def all_gather_concat(
         self, input_tensor_mesh, dim, cluster_axis, memory_config, num_links=1, num_heads=8, use_noc1_only=False
     ):

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -286,13 +286,13 @@ class TtLlamaMLP(LightweightModule):
             dtype=ttnn.bfloat8_b,
             memory_config=w1_out.memory_config(),
         )
-        w2_in_gathered = self.tt_ccl.line_all_gather(
-            w2_in, cluster_axis=1, num_links=3, memory_config=w3_out.memory_config(), buffer_key="FF3", dim=3
-        )
-        ttnn.deallocate(w2_in)
-
-        # For shorter sequence lengths use the original matmul since it performs better than the minimal matmul
-        if seq_len < 4096 or batch_size > 1:
+        # For very short sequences use separate AllGather + MatMul
+        # For sequences >= 4096, use fused AllGather+MatMul for ~17% FF2 speedup
+        if seq_len < 2048 or batch_size > 1:
+            w2_in_gathered = self.tt_ccl.line_all_gather(
+                w2_in, cluster_axis=1, num_links=3, memory_config=w3_out.memory_config(), buffer_key="FF3", dim=3
+            )
+            ttnn.deallocate(w2_in)
             w2_out = ttnn.linear(
                 w2_in_gathered,
                 self.w2_interleaved,
@@ -302,13 +302,18 @@ class TtLlamaMLP(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
         else:
-            w2_out = ttnn.experimental.minimal_matmul(
-                input_tensor=w2_in_gathered,
-                weight_tensor=self.w2_interleaved,
-                config=minimal_pc_2,
-                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+            # Fused AllGather + MatMul: uses 6×8/6×9 grid with 3 links for better AG bandwidth
+            w2_out = self.tt_ccl.line_all_gather_matmul(
+                w2_in,
+                self.w2_interleaved,
+                dim=3,
+                cluster_axis=1,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                matmul_config=minimal_pc_2,
+                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+                dtype=ttnn.bfloat8_b,
             )
+            ttnn.deallocate(w2_in)
 
         w2_out_reduced = self.tt_ccl.line_all_reduce(
             w2_out,

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -918,6 +918,9 @@ class TtModelArgs:
                 """
                 Returns the best minimal matmul config for prefill FF2 based on sequence length.
                 Configurations are optimized based on sweep results.
+
+                Uses 6-column grids (6×8 or 6×9) to enable 3 links in the fused
+                AllGather+MatMul op for better performance (~17% FF2 speedup, ~3.4% TTFT improvement).
                 """
                 # Best configurations from sweep results for each M value
                 if seq_len <= 4096:
@@ -925,45 +928,60 @@ class TtModelArgs:
                         M_block_size=8,
                         K_block_size=8,
                         N_block_size=8,
-                        subblock_h=4,
-                        subblock_w=2,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 9),
+                        subblock_h=1,
+                        subblock_w=4,
+                        # 6×8 grid enables 3 links for fused AGMM
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
                     )
-                elif seq_len <= 16384:  # Both 8K and 16K share the same config
+                elif seq_len <= 8192:  # 8K
                     return ttnn.MinimalMatmulConfig(
                         M_block_size=8,
                         K_block_size=8,
                         N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                        # 6×8 grid enables 3 links
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
+                    )
+                elif seq_len <= 16384:  # 16K
+                    return ttnn.MinimalMatmulConfig(
+                        M_block_size=8,
+                        K_block_size=8,
+                        N_block_size=8,
+                        subblock_h=1,
+                        subblock_w=4,
+                        # 6×8 grid enables 3 links
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
                     )
                 elif seq_len <= 32768:
                     return ttnn.MinimalMatmulConfig(
                         M_block_size=8,
                         K_block_size=8,
                         N_block_size=8,
-                        subblock_h=4,
-                        subblock_w=2,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                        subblock_h=1,
+                        subblock_w=4,
+                        # 6×8 grid enables 3 links
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
                     )
                 elif seq_len <= 65536:
                     return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
+                        M_block_size=16,
                         K_block_size=8,
                         N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 8),
+                        # 6×8 grid enables 3 links
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 8),
                     )
                 else:  # For seq_len >= 131072
                     return ttnn.MinimalMatmulConfig(
-                        M_block_size=8,
+                        M_block_size=16,
                         K_block_size=8,
                         N_block_size=8,
-                        subblock_h=2,
+                        subblock_h=1,
                         subblock_w=4,
-                        compute_with_storage_grid_size=ttnn.CoreCoord(7, 9),
+                        # 6×9 grid enables 3 links
+                        compute_with_storage_grid_size=ttnn.CoreCoord(6, 9),
                     )
 
             self.model_config["PREFILL_FF2_MINIMAL_MATMUL_CONFIG"] = prefill_ff2_minimal_matmul_config


### PR DESCRIPTION
### Ticket
This PR depends on [#36711 ](https://github.com/tenstorrent/tt-metal/pull/36711)

### Problem description
 Optimize Llama 70B Galaxy TTFT with fused  AGMM
 
### Summary
This PR uses the optimized All-Gather Minimal MatMul (AGMM) operation for Llama 70B Galaxy through comprehensive sweep analysis and configuration tuning, achieving **consistent 3.1-3.4% TTFT improvements** across all sequence lengths.

### Performance Results

| ISL | TTFT Non-Fused (ms) | TTFT Fused (ms) | Improvement |
|-----|---------------------|------------------|-------------|
| **4K** | 621.21 | **601.62** | **-19.59ms (-3.2%)** |
| **8K** | 989.40 | **963.14** | **-26.26ms (-2.7%)** |
| **16K** | 1936.00 | **1876.20** | **-59.80ms (-3.1%)** |
| **32K** | 4300.00 | **4161.62** | **-138.38ms (-3.2%)** |
| **64K** | 10638.00 | **10276.39** | **-361.61ms (-3.4%)** |
| **128K** | 29680.00 | **28716.98** | **-963.02ms (-3.2%)** |

### Fused op Configurations used : 


| ISL | **M×K×N Blocks** | **Subblock (h×w)** | **Grid** | **Links** |
|-----|------------------|---------------------|----------|-----------|
| **4K** | 8×8×8 | (1,4) | 6×8 | 3 |
| **8K** | 8×8×8 | (1,4) | 6×8 | 3 |
| **16K** | 8×8×8 | (1,4) | 6×8 | 3 |
| **32K** | 8×8×8 | (1,4) | 6×8 | 3 |
| **64K** | **16×8×8** | (1,4) | 6×8 | 3 |
| **128K** | **16×8×8** | (1,4) | **6×9** | 3 |

**Key highlights:**

- Consistent 3%+ improvements across all sequence lengths
- Largest absolute gain: 963ms for 128K sequences
- Fused AGMM = AllGather+MatMul + sweep-optimized configurations

**Files Modified:**
- `models/demos/llama3_70b_galaxy/tt/model_config.py` - Updated prefill_ff2_minimal_matmul_config
- `models/demos/llama3_70b_galaxy/tt/llama_mlp.py` - Extended fused path to 4K sequences  
- `models/demos/llama3_70b_galaxy/tt/llama_ccl.py` - used AllGather+MatMul 


### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
