### PR TITLE
[skip ci] Add more common cruft to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ __cmake_systeminformation/
 **.swp
 **.swo
 **.swn
+**.orig
+**.bak
+
 
 *profile_log*.csv
 **/profiler/output/*
@@ -155,3 +158,4 @@ models/experimental/petr/resources/*.pth
 *.err
 
 .claude
+.cursor/.DS_store


### PR DESCRIPTION
### Ticket
N/A

### Problem description
.gitignore not ignoring merge conflict backups and cursor metadata

### What's changed
.orig, .bak, .cursor/.DS_store in .gitignore

