### PR TITLE
Support UINT8/UINT16 in ttnn.reshape for row-major tensors

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -729,12 +729,13 @@ def test_bf8_support(input_shape, output_shape, device):
     ],
 )
 def test_uint8_rm_reshape(input_shape, output_shape, device):
-    torch_input_tensor = torch.randint(0, 255, input_shape, dtype=torch.uint8)
+    torch_input_tensor = torch.randint(0, 256, input_shape, dtype=torch.uint8)
     torch_result = torch_input_tensor.reshape(output_shape)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -722,6 +722,33 @@ def test_bf8_support(input_shape, output_shape, device):
 @pytest.mark.parametrize(
     "input_shape, output_shape",
     [
+        ((4,), (1, 1, 2, 2)),
+        ((2, 3), (3, 2)),
+        ((1, 6), (2, 3)),
+        ((12,), (3, 4)),
+    ],
+)
+def test_uint8_rm_reshape(input_shape, output_shape, device):
+    torch_input_tensor = torch.randint(0, 255, input_shape, dtype=torch.uint8)
+    torch_result = torch_input_tensor.reshape(output_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.uint8,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_output = ttnn.reshape(input_tensor, output_shape)
+
+    output = ttnn.to_torch(ttnn_output)
+
+    assert torch.equal(torch_result, output)
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape",
+    [
         ([0], [0, 1]),
         ([0], [1, 0]),
         ([0, 5], [0, 0, 5]),

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -719,6 +719,8 @@ def test_bf8_support(input_shape, output_shape, device):
     assert_with_pcc(torch_result, output, 0.9999)
 
 
+# Note: UINT16 reshape is also supported in validation but not tested here
+# because ttnn.to_torch has known uint16 round-trip issues (converts to int16 then int32).
 @pytest.mark.parametrize(
     "input_shape, output_shape",
     [
@@ -726,9 +728,14 @@ def test_bf8_support(input_shape, output_shape, device):
         ((2, 3), (3, 2)),
         ((1, 6), (2, 3)),
         ((12,), (3, 4)),
+        ((256, 128), (128, 256)),
     ],
 )
-def test_uint8_rm_reshape(input_shape, output_shape, device):
+@pytest.mark.parametrize(
+    "memory_config",
+    [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+)
+def test_uint8_rm_reshape(input_shape, output_shape, memory_config, device):
     torch_input_tensor = torch.randint(0, 256, input_shape, dtype=torch.uint8)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -737,7 +744,7 @@ def test_uint8_rm_reshape(input_shape, output_shape, device):
         dtype=ttnn.uint8,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config=memory_config,
     )
 
     ttnn_output = ttnn.reshape(input_tensor, output_shape)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -24,8 +24,9 @@ void ReshapeViewDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::UINT32 or
-            input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32,
-        "Can only work with bfloat16/float32 or int32/uint32 tensors");
+            input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32 or
+            input_tensor_a.dtype() == DataType::UINT8 or input_tensor_a.dtype() == DataType::UINT16,
+        "Can only work with bfloat16/float32, int32/uint32, or uint8/uint16 tensors");
 }
 
 ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -27,6 +27,11 @@ void ReshapeViewDeviceOperation::validate_on_program_cache_miss(
             input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::INT32 or
             input_tensor_a.dtype() == DataType::UINT8 or input_tensor_a.dtype() == DataType::UINT16,
         "Can only work with bfloat16/float32, int32/uint32, or uint8/uint16 tensors");
+    if (input_tensor_a.dtype() == DataType::UINT8 or input_tensor_a.dtype() == DataType::UINT16) {
+        TT_FATAL(
+            input_tensor_a.layout() == Layout::ROW_MAJOR,
+            "UINT8 and UINT16 reshape only supported for row-major layout");
+    }
 }
 
 ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::compute_output_specs(


### PR DESCRIPTION
## Summary
- Adds UINT8 and UINT16 to the allowed dtype validation in the reshape device operation
- The row-major program factory and kernel are already dtype-agnostic (byte-based via `element_size()`), so only the validation check needed updating
- Adds regression test for UINT8 row-major reshape

Closes #27843

## Test plan
- [x] `test_uint8_rm_reshape` passes locally (4 shape combinations)
- [ ] [PR Gate](https://github.com/tenstorrent/tt-metal/actions/runs/23810007567)
- [ ] [Merge Gate](https://github.com/tenstorrent/tt-metal/actions/runs/23810011371)