### PR TITLE
[DS Blaze] Allow host to perform accept/reject for spec decode

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -175,7 +175,6 @@ class ModelPipeline:
         while len(generated_tokens) < max_new_tokens:
             result = pending.popleft() if pending else self.model.read_result()
 
-            # On last step of prefill, we get base token + first spec token (needs to be verified)
             if not unverified_spec_tokens:
                 unverified_spec_tokens.append(result.token_1)
                 emit(result.token_0)

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -177,7 +177,7 @@ class ModelPipeline:
 
             # On last step of prefill, we get base token + first spec token (needs to be verified)
             if not unverified_spec_tokens:
-                unverified_spec_tokens.append({result.token_1: result.token_1_pos})
+                unverified_spec_tokens.append(result.token_1)
                 emit(result.token_0)
             else:
                 if result.token_0_type == TokenType.BASE:

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -21,14 +21,7 @@ from models.demos.deepseek_v3_b1.demo.weight_provider import (
     SyntheticWeightProvider,
     WeightProvider,
 )
-from models.demos.deepseek_v3_b1.model import (
-    TOKEN_ID_BYTES,
-    DecodeResult,
-    DeepSeekV3,
-    NumTokens,
-    page_size_bytes,
-    to_spec_input,
-)
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DecodeResult, DeepSeekV3, page_size_bytes, to_spec_input
 
 
 class ModelPipeline:
@@ -158,13 +151,18 @@ class ModelPipeline:
         assert max_new_tokens >= 1, f"max_new_tokens must be >= 1, got {max_new_tokens}"
 
         generated_tokens: list[int] = []
+        verified_spec_tokens: list[int] = []
+        unverified_spec_tokens: list[int] = []
 
-        def emit(token_id: int) -> bool:
-            """Emit a token to the caller. Returns True if EOS was hit."""
+        def is_eos(token_id: int) -> bool:
+            """Returns True if a token is the EOS token"""
+            return eos_token_id is not None and token_id == eos_token_id
+
+        def emit(token_id: int) -> None:
+            """Emit a token to the caller"""
             if on_token is not None:
                 on_token(token_id)
             generated_tokens.append(token_id)
-            return eos_token_id is not None and token_id == eos_token_id
 
         # --- Prefill --------------------------------------------------------
         prefill_results = self.prefill_forward(prompt_token_ids)
@@ -177,17 +175,34 @@ class ModelPipeline:
         while len(generated_tokens) < max_new_tokens:
             result = pending.popleft() if pending else self.model.read_result()
 
-            if result.num_tokens == NumTokens.STALE:
-                continue
+            # On last step of prefill, we get base token + first spec token (needs to be verified)
+            if not unverified_spec_tokens:
+                unverified_spec_tokens.append({result.token_1: result.token_1_pos})
+                emit(result.token_0)
+            else:
+                if result.token_0_type == TokenType.BASE:
+                    # On acceptance, we check that the base token matches the first token of the last unverified spec token
+                    if result.token_0 == unverified_spec_tokens[-1]:
+                        verified_spec_tokens.append(unverified_spec_tokens.pop())
+                        emit(result.token_0)
+                        continue
+                    # On rejection, we discard the last unverified spec token and populate the new spec token
+                    else:
+                        unverified_spec_tokens.pop()
+                        unverified_spec_tokens.append(result.token_1)
+                        emit(result.token_0)
+                if result.token_0_type == TokenType.SPEC:
+                    # If we have a verified spec token it means we have an acceptance case, remove it and emit the token
+                    if verified_spec_tokens:
+                        verified_spec_tokens.pop()
+                        unverified_spec_tokens.append(result.token_1)
+                        emit(result.token_0)
+                    else:
+                        continue
 
-            if result.num_tokens == NumTokens.ACCEPT:
-                if emit(result.token_0) or len(generated_tokens) >= max_new_tokens:
-                    break
-                continue
-
-            # num_tokens == 2: CONTINUE (after ACCEPT) or REJECT
-            if emit(result.token_0) or len(generated_tokens) >= max_new_tokens:
+            if is_eos(result.token_0) or len(generated_tokens) >= max_new_tokens:
                 break
+
             self._write_spec_pair(
                 result.token_0,
                 result.token_0_pos,

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -209,9 +209,8 @@ class DeepSeekV3:
         if len(prompt_tokens) == 0:
             raise ValueError("Expected at least one prompt token")
 
-        READS_PER_WRITE = 2
         num_writes_before_readback = min(self._pipeline_depth, len(prompt_tokens))
-        total_reads = len(prompt_tokens) * READS_PER_WRITE
+        total_reads = len(prompt_tokens)
 
         write_idx = 0
         read_count = 0
@@ -221,20 +220,19 @@ class DeepSeekV3:
             self._write_fn(prompt_tokens[write_idx])
             write_idx += 1
 
-        # Phase 2: overlap — drain READS_PER_WRITE outputs, then send next token
+        # Phase 2: overlap — drain outputs and issue remaining writes in steady state
         while write_idx < len(prompt_tokens):
-            for _ in range(READS_PER_WRITE):
-                self._read_fn(self._output_buffer)
-                read_count += 1
+            self._read_fn(self._output_buffer)
+            read_count += 1
             self._write_fn(prompt_tokens[write_idx])
             write_idx += 1
 
-        # Phase 3: drain remaining outputs; save the last READS_PER_WRITE
+        # Phase 3: drain remaining outputs; save the last output 
         last_results: list[DecodeResult] = []
         while read_count < total_reads:
             self._read_fn(self._output_buffer)
             read_count += 1
-            if read_count > total_reads - READS_PER_WRITE:
+            if read_count > total_reads - 1:
                 last_results.append(parse_output_page(self._output_buffer))
 
         self._position += len(prompt_tokens)


### PR DESCRIPTION
### Problem description
Since the spec decode FSM is on host it makes slightly more sense for host to perform the token accept and reject logic since if device does so the spec LM head stage needs to keep track of which tokens were accepted or rejected which has some complications. 

### What's changed
- created seperate function for `is_eos`, decouple checking `eos` from `emit` 
- modified FSM loop to perform acceptance and rejection based on incoming tokens.

