### PR TITLE
Pass repeat_batches from arg

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -814,6 +814,7 @@ def main() -> None:
         stop_at_eos=bool(args.stop_at_eos),
         checkpoint_jsonl=args.checkpoint_jsonl,
         enable_mtp=(args.mtp == "on"),
+        repeat_batches=args.repeat_batches,
     )
 
     saved_output_path = _resolve_saved_output_path(prompts_file_path, args.output_path)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41135

### What's changed
Updates the DeepSeek-V3 demo CLI wiring so the `--repeat-batches` argument is actually propagated into the programmatic run_demo() entry-point, ensuring user-provided values take effect instead of always using the function default.

Changes:
  Pass `args.repeat_batches` from `main()` into `run_demo()`.
