### PR TITLE
#41136: port more fused and matmul kernel code to device 2.0 api

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -182,6 +182,9 @@ void kernel_main() {
                     in0_mcast_dest_noc_end_x,
                     in0_mcast_dest_noc_end_y,
                     in0_mcast_num_cores);
+                // Flush to ensure the NoC has read the VALID value from receiver_sem's L1
+                // address before the next iteration overwrites it with INVALID.
+                noc.async_writes_flushed();
 
                 local_read_addr += in0_block_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -21,7 +21,6 @@ void kernel_main() {
     constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(2);
     constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(3);
     // in0 mcast args
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(6);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(7);
     // block args
@@ -31,9 +30,6 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_dest_noc_start_y = get_compile_time_arg_val(10);
     constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(12);
-    // in0 semaphore always valid
-    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(13));
-
     constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(14);
     constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;
 
@@ -69,13 +65,6 @@ void kernel_main() {
     receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
     // to receive the mcast
-
-    const uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
 
     uint32_t local_read_addr = cb_in2.get_read_ptr();
 
@@ -185,8 +174,14 @@ void kernel_main() {
                      .addr = l1_write_addr_in0},
                     true);
 #endif
-                noc_semaphore_set_multicast_loopback_src(
-                    in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
+                receiver_sem.set(VALID);
+                receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                    noc,
+                    in0_mcast_dest_noc_start_x,
+                    in0_mcast_dest_noc_start_y,
+                    in0_mcast_dest_noc_end_x,
+                    in0_mcast_dest_noc_end_y,
+                    in0_mcast_num_cores);
 
                 local_read_addr += in0_block_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < in0_B; ++b) {
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
             noc.async_read_barrier();
         }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -306,12 +306,12 @@ void kernel_main() {
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                         // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                         // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
-                        // which means data could be changed before
-                        //  write is issued.
+
+                        // Flush is required because the semaphore multicast reads receiver_sem's L1
+                        // address as the source value. Without a flush, the CPU can proceed to the next
+                        // iteration and overwrite receiver_sem to INVALID before the NoC has read the
+                        // VALID value from L1, causing receivers to see INVALID and hang.
                         noc.async_writes_flushed();
-#endif
 
                     } else if constexpr (core_in_in0_receiver_mcast_grid) {
                         // Increment remote sender's semaphore using pre-computed coordinates

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -28,8 +28,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(7);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(8);
     // in0 mcast args
-    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(11);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(12);
     constexpr uint32_t num_x = get_compile_time_arg_val(13);
@@ -76,16 +74,6 @@ void kernel_main() {
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
     experimental::Semaphore<> receiver_sem(get_compile_time_arg_val(10));
 
-    // L1 array for valid semaphore value
-    constexpr uint32_t cb_l1_array = get_named_compile_time_arg_val("cb_l1_array");
-    experimental::CircularBuffer cb_l1(cb_l1_array);
-    uint32_t in0_mcast_sender_semaphore_valid_addr = cb_l1.get_write_ptr();
-    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_valid_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_valid_addr);
-    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
-    in0_mcast_sender_semaphore_valid_addr_ptr[0] =
-        VALID;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
-
     constexpr uint32_t num_remote_senders = (num_blocks_inner_dim + num_blocks_per_shard - 1) / num_blocks_per_shard;
     uint32_t remote_sender_noc_x[num_remote_senders];
     uint32_t remote_sender_noc_y[num_remote_senders];
@@ -112,13 +100,6 @@ void kernel_main() {
             }
         }
     }
-    uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
-        in0_mcast_dest_noc_start_x,
-        in0_mcast_dest_noc_start_y,
-        in0_mcast_dest_noc_end_x,
-        in0_mcast_dest_noc_end_y,
-        in0_mcast_receiver_semaphore_addr);
-
     receiver_sem.set(VALID);
 
     cb_in2.reserve_back(batch * in0_block_num_tiles);
@@ -285,15 +266,14 @@ void kernel_main() {
                             }
 
                             // We should also multicast the flag to destinations
-                            if constexpr (in0_mcast_num_cores == 1) {
-                                // All work is done on one core (the current one).
-                                // noc_semaphore_set_multicast_loopback_src is a no-op in this case.
-                                // Data needs to be written directly in the core.
-                                receiver_sem.set(VALID);
-                            } else {
-                                noc_semaphore_set_multicast_loopback_src(
-                                    in0_mcast_sender_semaphore_valid_addr,
-                                    in0_mcast_receiver_semaphore_noc_addr,
+                            receiver_sem.set(VALID);
+                            if constexpr (in0_mcast_num_cores > 1) {
+                                receiver_sem.set_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                                    noc,
+                                    in0_mcast_dest_noc_start_x,
+                                    in0_mcast_dest_noc_start_y,
+                                    in0_mcast_dest_noc_end_x,
+                                    in0_mcast_dest_noc_end_y,
                                     in0_mcast_num_cores);
                             }
                         } else {
@@ -314,9 +294,13 @@ void kernel_main() {
                                 true);
 
                             // We should also multicast the flag to destinations
-                            noc_semaphore_set_multicast(
-                                in0_mcast_sender_semaphore_valid_addr,
-                                in0_mcast_receiver_semaphore_noc_addr,
+                            receiver_sem.set(VALID);
+                            receiver_sem.set_multicast(
+                                noc,
+                                in0_mcast_dest_noc_start_x,
+                                in0_mcast_dest_noc_start_y,
+                                in0_mcast_dest_noc_end_x,
+                                in0_mcast_dest_noc_end_y,
                                 in0_mcast_num_cores);
                         }
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -13,6 +13,8 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/noc_semaphore.h"
 #include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
@@ -45,7 +47,6 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
     experimental::Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
@@ -55,13 +56,13 @@ void do_signaling(const experimental::Noc& noc, uint32_t& rt_args_idx) {
         const uint32_t multicast_end_x = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
-        const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        const uint64_t signalling_semaphore_address =
-            get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
-            signalling_semaphore;
+        const uint32_t signalling_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+        experimental::Semaphore<> sig_sem(signalling_semaphore_id);
         pv_sem.wait(target_sem_value);
         pv_sem.set(1);
-        noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
+        sig_sem.set(1);
+        sig_sem.set_multicast(
+            noc, multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, num_signalling_semaphores);
     } else {
         pv_sem.up(noc, pv_core_x, pv_core_y, 1);
         noc.async_atomic_barrier();
@@ -169,15 +170,21 @@ void kernel_main() {
                 cb_in1.reserve_back(in1_block_num_tiles);
                 l1_write_addr_in1 = cb_in1.get_write_ptr();
 
+                experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-                        noc_async_read_one_packet_set_state<true>(in1_base_addr, curr_page_size, vc);
-                        noc_async_read_one_packet_with_state<true, true>(
-                            in1_base_addr + curr_l1_read_addr_in1, l1_write_addr_in1, vc);
+                        noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            dram_bank, curr_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
+                        noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            dram_bank,
+                            experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                            curr_page_size,
+                            {.bank_id = dram_bank_id, .addr = in1_tensor_addr + curr_l1_read_addr_in1},
+                            {},
+                            vc);
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -72,8 +72,9 @@ void kernel_main() {
     uint32_t l1_read_addr_in1 = 0;
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
-    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_page_size, vc);
+    experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
+    noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
 
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -82,7 +83,13 @@ void kernel_main() {
         l1_write_addr_in1 = cb_in1.get_write_ptr();
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state<true, true>(in1_base_addr + l1_read_addr_in1, l1_write_addr_in1, vc);
+            noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                vc);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -102,17 +109,21 @@ void kernel_main() {
     uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
     l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        noc_async_read_set_trid(curr_block_trid);
-
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc_async_read_one_packet_with_state_with_trid(
-                in1_base_addr, l1_read_addr_in1, l1_write_addr_in1, curr_block_trid);
+            noc.async_read<experimental::Noc::TxnIdMode::ENABLED, NOC_MAX_BURST_SIZE>(
+                dram_bank,
+                experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1),
+                in1_page_size,
+                {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
+                {},
+                vc,
+                curr_block_trid);
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
 
         if (num_free_blocks_in_buffer == 2) {
-            noc_async_read_barrier_with_trid(block_trid_to_wait);
+            noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
             cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
@@ -132,7 +143,7 @@ void kernel_main() {
         l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
     }
     // last block to wait
-    noc_async_read_barrier_with_trid(block_trid_to_wait);
+    noc.async_read_barrier<experimental::Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
     cb_in1.push_back(in1_block_num_tiles);
 #endif
 
@@ -142,11 +153,17 @@ void kernel_main() {
     uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
     uint32_t l1_read_addr_in3 = 0;
 
-    uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-    noc_async_read_one_packet_set_state<true>(in3_base_addr, in3_page_size, vc);
+    noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+        dram_bank, in3_page_size, {.bank_id = dram_bank_id, .addr = in3_tensor_addr}, vc);
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc_async_read_one_packet_with_state<true, true>(in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+        noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+            dram_bank,
+            experimental::CoreLocalMem<uint32_t>(l1_write_addr_in3),
+            in3_page_size,
+            {.bank_id = dram_bank_id, .addr = in3_tensor_addr + l1_read_addr_in3},
+            {},
+            vc);
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -245,7 +245,7 @@ void kernel_main() {
 #endif  // IN1_DRAM_HEIGHT_SHARDED
 
         if constexpr (batchB > 0) {
-            noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
+            noc.async_read(s_sparsity, cb_sparsity, sparsity_pagesize, {.page_id = b}, {.offset_bytes = 0});
             noc.async_read_barrier();
         }
 
@@ -290,14 +290,18 @@ void kernel_main() {
                         uint32_t l1_write_addr_in1_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> dram_bank;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in1_tensor_addr);
-
+                            uint32_t shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t shard_base_addr = in1_tensor_addr;
                             if (i == 0) {
-                                in1_base_addr += dram_tensor_start_offset;
+                                shard_base_addr += dram_tensor_start_offset;
                             }
-                            noc_async_read_one_packet_set_state<true>(in1_base_addr, in1_single_tile_size_bytes, vc);
+                            noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                dram_bank,
+                                in1_single_tile_size_bytes,
+                                {.bank_id = shard_bank_id, .addr = shard_base_addr},
+                                vc);
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
                             uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
@@ -309,8 +313,15 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc_async_read_one_packet_with_state<true, true>(
-                                        in1_base_addr + l1_read_addr_in1_temp, l1_write_addr_in1_temp, vc);
+                                    noc.async_read_with_state<
+                                        experimental::Noc::VcSelection::CUSTOM,
+                                        NOC_MAX_BURST_SIZE>(
+                                        dram_bank,
+                                        experimental::CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
+                                        in1_single_tile_size_bytes,
+                                        {.bank_id = shard_bank_id, .addr = shard_base_addr + l1_read_addr_in1_temp},
+                                        {},
+                                        vc);
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -476,18 +487,22 @@ void kernel_main() {
                         uint32_t l1_write_addr_in3_offset = 0;
                         uint32_t next_bank_id_and_dram_stride_index = 0;
 
+                        experimental::AllocatorBank<experimental::AllocatorBankType::DRAM> bias_dram_bank;
                         for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint64_t in3_base_addr = get_noc_addr_from_bank_id<true>(
-                                current_dram_bank_id[next_bank_id_and_dram_stride_index], in3_tensor_addr);
-
+                            uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                            uint32_t bias_shard_base_addr = in3_tensor_addr;
                             if (i == 0) {
                                 // dram_tensor_start_offset is in in1 tile bytes; convert to
                                 // bias tile bytes since bias_dtype may differ from in1_dtype.
-                                in3_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
-                                                 bias_single_tile_size_bytes;
+                                bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                        bias_single_tile_size_bytes;
                             }
 
-                            noc_async_read_one_packet_set_state<true>(in3_base_addr, bias_single_tile_size_bytes, vc);
+                            noc.set_async_read_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                bias_dram_bank,
+                                bias_single_tile_size_bytes,
+                                {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
+                                vc);
 
                             uint32_t l1_read_addr_in3 = 0;
                             l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
@@ -498,8 +513,13 @@ void kernel_main() {
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc_async_read_one_packet_with_state<true, true>(
-                                    in3_base_addr + l1_read_addr_in3, l1_write_addr_in3, vc);
+                                noc.async_read_with_state<experimental::Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                    bias_dram_bank,
+                                    experimental::CoreLocalMem<uint32_t>(l1_write_addr_in3),
+                                    bias_single_tile_size_bytes,
+                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
+                                    {},
+                                    vc);
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -101,9 +101,6 @@ void kernel_main() {
         noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_mcast_cores));
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
     experimental::Noc noc;
     experimental::Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
     experimental::Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
@@ -182,15 +179,20 @@ void kernel_main() {
                 reduce_receiver_sem.wait(num_mcast_cores - 1);
                 reduce_receiver_sem.set(0);
 
+                experimental::UnicastEndpoint remote_core;
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
-                    noc_async_read_one_packet(
-                        multicast_data_noc | global_means_ptr,
-                        global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES,
-                        NOC_L1_READ_ALIGNMENT_BYTES);
-                    noc_async_read_one_packet(
-                        multicast_data_noc | global_vars_ptr,
-                        global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES,
-                        NOC_L1_READ_ALIGNMENT_BYTES);
+                    noc.async_read(
+                        remote_core,
+                        experimental::CoreLocalMem<uint32_t>(global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
+                        NOC_L1_READ_ALIGNMENT_BYTES,
+                        {.noc_x = noc_coord_x[i], .noc_y = noc_coord_y[i], .addr = global_means_ptr},
+                        {});
+                    noc.async_read(
+                        remote_core,
+                        experimental::CoreLocalMem<uint32_t>(global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
+                        NOC_L1_READ_ALIGNMENT_BYTES,
+                        {.noc_x = noc_coord_x[i], .noc_y = noc_coord_y[i], .addr = global_vars_ptr},
+                        {});
                 }
                 noc.async_read_barrier();
             }

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/dataflow/custom_tiles.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/dataflow/custom_tiles.h
@@ -56,7 +56,7 @@ FORCE_INLINE void generate_partial_reduce_scaler(
             self,
             experimental::CoreLocalMem<uint32_t>(write_addr),
             MEM_ZEROS_SIZE,
-            {.noc_x = 0, .noc_y = 0, .addr = MEM_ZEROS_BASE},
+            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = MEM_ZEROS_BASE},
             {});
         write_addr += MEM_ZEROS_SIZE;
     }

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/dataflow/custom_tiles.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/dataflow/custom_tiles.h
@@ -13,6 +13,10 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/constants.hpp>
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 namespace norm::kernel_util::dataflow {
 
@@ -31,23 +35,32 @@ FORCE_INLINE void generate_partial_reduce_scaler(
     const uint32_t num_cols,
     const uint32_t tile_height = 32,
     const uint32_t tile_width = 32) {
-    cb_reserve_back(cb_id, 1);
+    experimental::Noc noc;
+    experimental::CircularBuffer cb(cb_id);
+
+    cb.reserve_back(1);
 
     const uint16_t scaler_uint16 = scaler >> 16;
 
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
     static_assert(num_zeros_reads > 0, "num_zeros_reads must be greater than 0");
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t write_addr = get_write_ptr(cb_id);
+    uint32_t write_addr = cb.get_write_ptr();
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(write_addr);
 
-    // Fill tile with zeros
-    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    // Fill tile with zeros via state-based reads from the local L1 zeros region
+    experimental::UnicastEndpoint self;
+    noc.set_async_read_state<experimental::Noc::VcSelection::DEFAULT, NOC_MAX_BURST_SIZE>(
+        self, MEM_ZEROS_SIZE, {.noc_x = my_x[0], .noc_y = my_y[0], .addr = MEM_ZEROS_BASE});
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read_one_packet_with_state(zeros_noc_addr, write_addr);
+        noc.async_read_with_state<experimental::Noc::VcSelection::DEFAULT, NOC_MAX_BURST_SIZE>(
+            self,
+            experimental::CoreLocalMem<uint32_t>(write_addr),
+            MEM_ZEROS_SIZE,
+            {.noc_x = 0, .noc_y = 0, .addr = MEM_ZEROS_BASE},
+            {});
         write_addr += MEM_ZEROS_SIZE;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     // Iterate over first two faces (top two) then
     // second two faces (bottom two)
@@ -71,7 +84,7 @@ FORCE_INLINE void generate_partial_reduce_scaler(
         }
     }
 
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 }  // namespace norm::kernel_util::dataflow

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/layernorm_dataflow_utils.h
@@ -187,7 +187,7 @@ inline void read_block_to_cb(
 }
 
 /**
- * @brief Read one column block of row-major input data from DRAM into cb_id_in_rm.
+ * @brief Read one column block of row-major input data from DRAM into a CB.
  *
  * Reads `num_valid_rows` rows, each of width `block.size() * tile_stride_bytes` bytes, starting
  * at column `block.start() * tile_stride_bytes` within each row. Rows are written into L1
@@ -196,7 +196,8 @@ inline void read_block_to_cb(
  */
 template <typename T, typename Block, uint32_t TILE_W, uint32_t TILE_H>
 inline void read_row_major_block_to_cb(
-    const uint32_t cb_id_in_rm,
+    experimental::Noc& noc,
+    experimental::CircularBuffer& cb,
     const T& src_a,
     const uint32_t curr_tile_row,
     const uint32_t num_valid_rows,
@@ -205,21 +206,27 @@ inline void read_row_major_block_to_cb(
     const Block& block) {
     const uint32_t col_byte_offset = block.start() * tile_stride_bytes;
     const uint32_t row_read_bytes = block.size() * tile_stride_bytes;
-    cb_reserve_back(cb_id_in_rm, block.full_block_size());
+    cb.reserve_back(block.full_block_size());
 
-    uint32_t l1_ptr = get_write_ptr(cb_id_in_rm);
     for (uint32_t row = 0; row < num_valid_rows; ++row) {
-        const uint64_t noc_addr = get_noc_addr(curr_tile_row * TILE_H + row, src_a) + col_byte_offset;
-        noc_async_read(noc_addr, l1_ptr, row_read_bytes);
-        l1_ptr += rm_row_stride_bytes;
+        noc.async_read(
+            src_a,
+            cb,
+            row_read_bytes,
+            {.page_id = curr_tile_row * TILE_H + row, .offset_bytes = col_byte_offset},
+            {.offset_bytes = row * rm_row_stride_bytes});
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_id_in_rm, block.full_block_size());
+    noc.async_read_barrier();
+    cb.push_back(block.full_block_size());
 }
 
+/**
+ * @brief Write one column block of row-major output data from a CB to DRAM.
+ */
 template <typename T, typename Block, uint32_t TILE_W, uint32_t TILE_H>
 inline void write_row_major_block_from_cb(
-    const uint32_t cb_id_out_rm,
+    experimental::Noc& noc,
+    experimental::CircularBuffer& cb,
     const T& dst_a,
     const uint32_t abs_row_base,
     const uint32_t num_valid_rows,
@@ -228,8 +235,7 @@ inline void write_row_major_block_from_cb(
     const Block& block) {
     // Compute produces block_size tiles (full_block_size) in cb_out_rm; the last block
     // may have fewer valid tiles (block.size() <= blk), but blk slots are reserved.
-    cb_wait_front(cb_id_out_rm, block.full_block_size());
-    const uint32_t l1_base = get_read_ptr(cb_id_out_rm);
+    cb.wait_front(block.full_block_size());
 
     // Column byte offset in the output row where this block starts.
     const uint32_t col_byte_offset = block.start() * tile_width_bytes;
@@ -237,24 +243,28 @@ inline void write_row_major_block_from_cb(
     const uint32_t valid_bytes = block.size() * tile_width_bytes;
 
     for (uint32_t r = 0; r < num_valid_rows; r++) {
-        const uint32_t l1_src = l1_base + r * block_row_stride_bytes;
-        const uint64_t noc_dst = get_noc_addr(abs_row_base + r, dst_a) + col_byte_offset;
-        noc_async_write(l1_src, noc_dst, valid_bytes);
+        noc.async_write(
+            experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb),
+            dst_a,
+            valid_bytes,
+            {.offset_bytes = r * block_row_stride_bytes},
+            {.page_id = abs_row_base + r, .offset_bytes = col_byte_offset});
     }
-    noc_async_write_barrier();
-    cb_pop_front(cb_id_out_rm, block.full_block_size());
+    noc.async_write_barrier();
+    cb.pop_front(block.full_block_size());
 }
 
 /**
- * @brief Push all column blocks of one tile-row of row-major input data into cb_id_in_rm.
+ * @brief Push all column blocks of one tile-row of row-major input data into a CB.
  *
  * Iterates over all blocks (via `generic::blocks(Wt, block_size)`) and reads each block from DRAM
- * into cb_id_in_rm. Only `num_valid_rows` rows are read per block; padding rows are zero-filled
+ * into the CB. Only `num_valid_rows` rows are read per block; padding rows are zero-filled
  * by the tilize step in the compute kernel. Handles the case where H is not tile-aligned.
  */
 template <typename T, uint32_t TILE_W, uint32_t TILE_H>
 inline void push_row_major_blocks_to_cb(
-    const uint32_t cb_id_in_rm,
+    experimental::Noc& noc,
+    experimental::CircularBuffer& cb,
     const T& src_a,
     const uint32_t Wt,
     const uint32_t block_size,
@@ -278,17 +288,19 @@ inline void push_row_major_blocks_to_cb(
         const uint32_t col_byte_offset = block.start() * tile_stride_bytes;
         const uint32_t row_read_bytes = block.size() * tile_stride_bytes;
 
-        cb_reserve_back(cb_id_in_rm, block.full_block_size());
+        cb.reserve_back(block.full_block_size());
 
-        uint32_t l1_ptr = get_write_ptr(cb_id_in_rm);
         for (uint32_t row = 0; row < num_valid_rows; ++row) {
-            const uint64_t noc_addr = get_noc_addr(curr_tile_row * TILE_H + row, src_a) + col_byte_offset;
-            noc_async_read(noc_addr, l1_ptr, row_read_bytes);
-            l1_ptr += rm_row_stride_bytes;
+            noc.async_read(
+                src_a,
+                cb,
+                row_read_bytes,
+                {.page_id = curr_tile_row * TILE_H + row, .offset_bytes = col_byte_offset},
+                {.offset_bytes = row * rm_row_stride_bytes});
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        cb_push_back(cb_id_in_rm, block.full_block_size());
+        cb.push_back(block.full_block_size());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -97,6 +97,7 @@ void kernel_main() {
 
     constexpr uint32_t rm_row_stride_bytes = block_size * TILE_W * elem_size_bytes;
     constexpr uint32_t cb_id_in_rm = get_named_compile_time_arg_val("cb_in_rm");
+    experimental::CircularBuffer cb_in_rm(cb_id_in_rm);
 
     const uint32_t src0_page_bytes = W * elem_size_bytes;
 #else
@@ -145,7 +146,7 @@ void kernel_main() {
         // ROW_MAJOR: push one tile-row of row-major data into cb_in_rm (block-by-block).
         // The compute kernel's TILIZE_IN block converts cb_in_rm → cb_in before processing.
         layernorm_dataflow_utils::push_row_major_blocks_to_cb<decltype(src_a), TILE_W, TILE_H>(
-            cb_id_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
+            noc, cb_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
 
 #ifdef FUSE_PRE_ADD
         for (auto block : generic::blocks(Wt, block_size)) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
@@ -96,6 +96,7 @@ void kernel_main() {
 
     constexpr uint32_t rm_row_stride_bytes = block_size * TILE_W * elem_size_bytes;
     constexpr uint32_t cb_id_in_rm = get_named_compile_time_arg_val("cb_in_rm");
+    experimental::CircularBuffer cb_in_rm(cb_id_in_rm);
 
     const uint32_t src0_page_bytes = W_logical * elem_size_bytes;
 #else
@@ -140,7 +141,7 @@ void kernel_main() {
         // Pass 0: Data for calculating E[X]
 #ifdef TILIZE_IN
         layernorm_dataflow_utils::push_row_major_blocks_to_cb<decltype(src_a), TILE_W, TILE_H>(
-            cb_id_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
+            noc, cb_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
 #else
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
@@ -163,7 +164,7 @@ void kernel_main() {
 //   once the buffer is full while compute waits for in1 — circular wait.
 #ifdef TILIZE_IN
         layernorm_dataflow_utils::push_row_major_blocks_to_cb<decltype(src_a), TILE_W, TILE_H>(
-            cb_id_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
+            noc, cb_in_rm, src_a, Wt, block_size, curr_tile_row, elem_size_bytes, rm_row_stride_bytes, H_logical);
 #ifdef FUSE_PRE_ADD
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::read_block_to_cb(
@@ -203,7 +204,8 @@ void kernel_main() {
             // Pass 2 input for this block
 #ifdef TILIZE_IN
             layernorm_dataflow_utils::read_row_major_block_to_cb<decltype(src_a), decltype(block), TILE_W, TILE_H>(
-                cb_id_in_rm,
+                noc,
+                cb_in_rm,
                 src_a,
                 curr_tile_row,
                 num_valid_rows_pass2,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_rm_output.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_rm_output.cpp
@@ -31,6 +31,8 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/constants.hpp>
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
 #include "ttnn/operations/normalization/kernel_util/generic/blocked_range.h"
 #include "layernorm_dataflow_utils.h"
 
@@ -49,6 +51,9 @@ void kernel_main() {
     constexpr uint32_t elem_size_bytes = get_compile_time_arg_val(dst_args.next_compile_time_args_offset());
 
     constexpr uint32_t cb_id_out_rm = get_named_compile_time_arg_val("cb_out_rm");
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out_rm(cb_id_out_rm);
 
     constexpr uint32_t TILE_H = tt::constants::TILE_HEIGHT;
     constexpr uint32_t TILE_W = tt::constants::TILE_WIDTH;
@@ -78,7 +83,7 @@ void kernel_main() {
 
         for (auto block : generic::blocks(Wt, block_size)) {
             layernorm_dataflow_utils::write_row_major_block_from_cb<decltype(dst_a), decltype(block), TILE_W, TILE_H>(
-                cb_id_out_rm, dst_a, abs_row_base, num_valid_rows, tile_width_bytes, block_row_stride_bytes, block);
+                noc, cb_out_rm, dst_a, abs_row_base, num_valid_rows, tile_width_bytes, block_row_stride_bytes, block);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
@@ -11,6 +11,12 @@
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/noc_semaphore.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);     // Source address in dram
@@ -35,16 +41,17 @@ void kernel_main() {
     const uint32_t onetile = 1;
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);
-    uint32_t reducer_semaphore_addr = get_semaphore(get_compile_time_arg_val(1));  // semaphore for reducer
+    constexpr uint32_t reducer_semaphore_id = get_compile_time_arg_val(1);
     constexpr uint32_t num_cores_to_wait = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
 
-    const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, reducer_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reducer_semaphore_addr);
-
     const auto src_a = TensorAccessor(src_args, src_addr, src0_tile_bytes);
+
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_inp_buf(cb_inp);
+    experimental::CircularBuffer cb_out_buf(cb_out);
+    experimental::CircularBuffer cb_x2_merge_buf(cb_x2_merge);
+    experimental::Semaphore<> reducer_sem(reducer_semaphore_id);
 
     // Generate constant tiles for reduce scalar
     uint32_t scaler = get_arg_val<uint32_t>(8);
@@ -59,41 +66,50 @@ void kernel_main() {
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // read input tiles
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            cb_reserve_back(cb_inp, blk);
-            uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
+            cb_inp_buf.reserve_back(blk);
 
             for (uint32_t r = 0; r < blk; r++) {
-                noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
-                inp_wr_ptr += src0_tile_bytes;
+                noc.async_read(
+                    src_a,
+                    cb_inp_buf,
+                    src0_tile_bytes,
+                    {.page_id = inp_tile_idx},
+                    {.offset_bytes = r * src0_tile_bytes});
                 inp_tile_idx++;
             }
-            noc_async_read_barrier();
+            noc.async_read_barrier();
 
-            cb_push_back(cb_inp, blk);
+            cb_inp_buf.push_back(blk);
 
         }  // wt loop
 
     }  // ncht loop
 
     // wait on cb_out and then write to merge core over noc
-    cb_wait_front(cb_out, onetile);
+    cb_out_buf.wait_front(onetile);
 
     uint32_t o_write_size = BF16_TILE_BYTES;
     uint32_t worker_offset = o_write_size * y;
-    uint64_t output_write_addr =
-        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, get_write_ptr(cb_x2_merge)) + worker_offset;
 
-    noc_async_write(get_read_ptr(cb_out), output_write_addr, o_write_size);
-    noc_async_write_barrier();
-    cb_pop_front(cb_out, onetile);
+    experimental::UnicastEndpoint reduce_ep;
+    noc.async_write(
+        experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out_buf),
+        reduce_ep,
+        o_write_size,
+        {.offset_bytes = 0},
+        {.noc_x = reduce_core_noc_x,
+         .noc_y = reduce_core_noc_y,
+         .addr = cb_x2_merge_buf.get_write_ptr() + worker_offset});
+    noc.async_write_barrier();
+    cb_out_buf.pop_front(onetile);
 
     // increase semaphore
-    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-    noc_async_atomic_barrier();
+    reducer_sem.up(noc, reduce_core_noc_x, reduce_core_noc_y, 1);
+    noc.async_atomic_barrier();
 
     if (is_merge_core) {
-        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, num_cores_to_wait);
-        cb_push_back(cb_x2_merge, num_cores_to_wait);
-        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+        reducer_sem.wait(num_cores_to_wait);
+        cb_x2_merge_buf.push_back(num_cores_to_wait);
+        reducer_sem.set(0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -11,9 +11,41 @@
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "experimental/core_local_mem.h"
 
-template <uint32_t t>
-void async_read_row_to_tile(const uint64_t DRAM_src_addr, uint32_t L1_dst_addr);
+template <uint32_t t, typename AccessorType>
+void async_read_row_to_tile(
+    const experimental::Noc& noc, const AccessorType& accessor, uint32_t page_id, uint32_t L1_dst_addr) {
+    // Read 64 bytes (32 bfloat16 elements) from the start of the page
+    noc.async_read(accessor, experimental::CoreLocalMem<uint32_t>(L1_dst_addr), 64, {.page_id = page_id}, {});
+
+    if constexpr (t == 0) {  // TILE LAYOUT
+        // Read 64 bytes from offset 512 within the same page (second tile face)
+        noc.async_read(
+            accessor,
+            experimental::CoreLocalMem<uint32_t>(L1_dst_addr + 512),
+            64,
+            {.page_id = page_id, .offset_bytes = 512},
+            {});
+    } else if constexpr (t == 1) {  // ROW MAJOR LAYOUT
+        noc.async_read_barrier();
+        // L1→L1 copy: rearrange 64 bytes from L1_dst_addr+32 into L1_dst_addr+512
+        experimental::UnicastEndpoint self;
+        noc.async_read(
+            self,
+            experimental::CoreLocalMem<uint32_t>(L1_dst_addr + 512),
+            64,
+            {.noc_x = my_x[0], .noc_y = my_y[0], .addr = L1_dst_addr + 32},
+            {});
+    } else {
+        static_assert(t == 0 || t == 1, "Layout must be ROW_MAJOR(t == 1) or TILE_LAYOUT(t == 0)");
+    }
+}
+
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);     // Source address in dram
     const uint32_t NCHt = get_arg_val<uint32_t>(1);         // Number of NCH tiles
@@ -69,6 +101,16 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(6);
     generate_bcast_col_scalar(cb_eps, eps);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_inp_buf(cb_inp);
+    experimental::CircularBuffer cb_stats_buf(cb_stats);
+#ifdef FUSE_GAMMA
+    experimental::CircularBuffer cb_gamma_buf(cb_gamma);
+#endif
+#ifdef FUSE_BETA
+    experimental::CircularBuffer cb_beta_buf(cb_beta);
+#endif
+
     uint32_t inp_tile_idx = tile_offset;
     uint32_t stats_tile_idx = stats_tile_offset;
 
@@ -78,99 +120,85 @@ void kernel_main() {
     constexpr uint32_t blk_leftovers = cb_length % blk;
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // Read stats tiles
-        cb_reserve_back(cb_stats, stats_tiles_cols);
-        uint32_t stats_wr_ptr = get_write_ptr(cb_stats);
+        cb_stats_buf.reserve_back(stats_tiles_cols);
+        uint32_t stats_write_offset = 0;
         for (uint32_t st = 0; st < stats_tiles_cols; ++st) {
-            noc_async_read_tile(stats_tile_idx, src_stats, stats_wr_ptr);
-            stats_wr_ptr += stats_tile_bytes;
+            noc.async_read(
+                src_stats,
+                cb_stats_buf,
+                stats_tile_bytes,
+                {.page_id = stats_tile_idx},
+                {.offset_bytes = stats_write_offset});
+            stats_write_offset += stats_tile_bytes;
             stats_tile_idx++;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_stats, stats_tiles_cols);
+        noc.async_read_barrier();
+        cb_stats_buf.push_back(stats_tiles_cols);
         uint32_t gamma_tile_count = 0;
         uint32_t beta_tile_count = 0;
         for (uint32_t i = 0; i < cb_iterations; i++) {
             for (uint32_t j = 0; j < cb_length; j++) {
-                cb_reserve_back(cb_inp, 1);
-                uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
-                noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
+                cb_inp_buf.reserve_back(1);
+                noc.async_read(src_a, cb_inp_buf, src0_tile_bytes, {.page_id = inp_tile_idx}, {.offset_bytes = 0});
                 inp_tile_idx++;
-                noc_async_read_barrier();
-                cb_push_back(cb_inp, 1);
+                noc.async_read_barrier();
+                cb_inp_buf.push_back(1);
             }
             if (ncht == 0 or cb_iterations != 1) {
 #if defined FUSE_GAMMA || defined FUSE_BETA
 #ifdef FUSE_GAMMA
                 for (uint32_t j = 0; j < cb_length; j++) {
-                    cb_reserve_back(cb_gamma, 1);
-                    uint32_t l1_write_addr = get_write_ptr(cb_gamma);
-                    uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
+                    cb_gamma_buf.reserve_back(1);
+                    uint32_t l1_write_addr = cb_gamma_buf.get_write_ptr();
+                    async_read_row_to_tile<gamma_is_row_major>(noc, addrg, gamma_tile_count, l1_write_addr);
                     gamma_tile_count++;
-                    async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_gamma, 1);
+                    noc.async_read_barrier();
+                    cb_gamma_buf.push_back(1);
                 }
 #endif
 #ifdef FUSE_BETA
                 for (uint32_t j = 0; j < cb_length; j++) {
-                    cb_reserve_back(cb_beta, 1);
-                    uint32_t l1_write_addr = get_write_ptr(cb_beta);
-                    uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
+                    cb_beta_buf.reserve_back(1);
+                    uint32_t l1_write_addr = cb_beta_buf.get_write_ptr();
+                    async_read_row_to_tile<beta_is_row_major>(noc, addrb, beta_tile_count, l1_write_addr);
                     beta_tile_count++;
-                    async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_beta, 1);
+                    noc.async_read_barrier();
+                    cb_beta_buf.push_back(1);
                 }
 #endif
 #endif
             }
         }
         for (uint32_t i = 0; i < cb_leftovers; i++) {
-            cb_reserve_back(cb_inp, 1);
-            uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
-            noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
+            cb_inp_buf.reserve_back(1);
+            noc.async_read(src_a, cb_inp_buf, src0_tile_bytes, {.page_id = inp_tile_idx}, {.offset_bytes = 0});
             inp_tile_idx++;
-            noc_async_read_barrier();
-            cb_push_back(cb_inp, 1);
+            noc.async_read_barrier();
+            cb_inp_buf.push_back(1);
         }
         if (ncht == 0 or cb_iterations != 1) {
 #if defined FUSE_GAMMA || defined FUSE_BETA
 #ifdef FUSE_GAMMA
             for (uint32_t i = 0; i < cb_leftovers; i++) {
-                cb_reserve_back(cb_gamma, 1);
-                uint32_t l1_write_addr = get_write_ptr(cb_gamma);
-                uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
+                cb_gamma_buf.reserve_back(1);
+                uint32_t l1_write_addr = cb_gamma_buf.get_write_ptr();
+                async_read_row_to_tile<gamma_is_row_major>(noc, addrg, gamma_tile_count, l1_write_addr);
                 gamma_tile_count++;
-                async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_gamma, 1);
+                noc.async_read_barrier();
+                cb_gamma_buf.push_back(1);
             }
 #endif
 #ifdef FUSE_BETA
             for (uint32_t i = 0; i < cb_leftovers; i++) {
-                cb_reserve_back(cb_beta, 1);
-                uint32_t l1_write_addr = get_write_ptr(cb_beta);
-                uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
+                cb_beta_buf.reserve_back(1);
+                uint32_t l1_write_addr = cb_beta_buf.get_write_ptr();
+                async_read_row_to_tile<beta_is_row_major>(noc, addrb, beta_tile_count, l1_write_addr);
                 beta_tile_count++;
-                async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_beta, 1);
+                noc.async_read_barrier();
+                cb_beta_buf.push_back(1);
             }
 #endif
 #endif
         }
     }  // ncht loop
-}
-template <uint32_t t>
-void async_read_row_to_tile(const uint64_t DRAM_src_addr, uint32_t L1_dst_addr) {
-    noc_async_read(DRAM_src_addr, L1_dst_addr, 32 * 2);  // reads 32 elements (64 bytes) 16 useful, the next bad
-    if constexpr (t == 0) {                              // TILE LAYOUT
-        noc_async_read(DRAM_src_addr + 512, L1_dst_addr + 512, 64);  // Fills the second face with next 16 elements
-    } else if constexpr (t == 1) {                                   // ROW MAJOR LAYOUT
-        noc_async_read_barrier();
-        uint64_t noc_addr = get_noc_addr(L1_dst_addr + 32);  // 16 elements from DRAM to L1.  L1->L1
-        noc_async_read(noc_addr, L1_dst_addr + 512, 64);
-    } else {
-        static_assert(t == 0 || t == 1, "Layout must be ROW_MAJOR(t == 1) or TILE_LAYOUT(t == 0)");
-    }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp
@@ -11,6 +11,9 @@
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);     // Source address in dram
@@ -31,23 +34,20 @@ void kernel_main() {
 
     const auto src_a = TensorAccessor(src_args, src_addr, src0_tile_bytes);
 
-    // Generate constant tiles for reduce scalar
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_inp_buf(cb_inp);
+
     uint32_t inp_tile_idx = tile_offset;
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
-        // read input tiles
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
-            uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
             for (uint32_t r = 0; r < blk; r++) {
-                cb_reserve_back(cb_inp, 1);
-                noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
-                inp_wr_ptr += src0_tile_bytes;
+                cb_inp_buf.reserve_back(1);
+                noc.async_read(src_a, cb_inp_buf, src0_tile_bytes, {.page_id = inp_tile_idx}, {.offset_bytes = 0});
                 inp_tile_idx++;
-                noc_async_read_barrier();
-                cb_push_back(cb_inp, 1);
+                noc.async_read_barrier();
+                cb_inp_buf.push_back(1);
             }
-
         }  // wt loop
-
     }  // ncht loop
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);     // Destination address in dram
@@ -22,16 +25,24 @@ void kernel_main() {
 
     const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
+    experimental::Noc noc;
+    experimental::CircularBuffer cb_out_buf(cb_out);
+
     uint32_t tile_id = tile_offset;
     for (uint32_t i = 0; i < num_tiles; i += blk) {
-        cb_wait_front(cb_out, blk);
-        uint32_t l1_read_addr = get_read_ptr(cb_out);
+        cb_out_buf.wait_front(blk);
+        uint32_t write_offset = 0;
         for (uint32_t j = 0; j < blk; j++) {
-            noc_async_write_tile(tile_id, s, l1_read_addr);
+            noc.async_write(
+                experimental::use<experimental::CircularBuffer::AddrSelector::READ_PTR>(cb_out_buf),
+                s,
+                tile_bytes,
+                {.offset_bytes = write_offset},
+                {.page_id = tile_id});
             tile_id++;
-            l1_read_addr += tile_bytes;
+            write_offset += tile_bytes;
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_out, blk);
+        noc.async_write_barrier();
+        cb_out_buf.pop_front(blk);
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #41136

### Problem description
A new device 1.1 / 2.0 api has been created. Initial port PRs missed some code.

### What's changed
Migrate more code to the new api.
- use the new apis
- add a couple of async_writes_flushed() calls that are now needed. Explanation from AI:
Here is the explanation.
The receiver_sem.set(VALID) calls were added in the migrated code at lines 269 and 297 because the migration changed which L1 address is used as the source for the semaphore multicast, which required explicitly writing VALID to the receiver semaphore before each multicast.
Original code
The original code used a separate, immutable L1 location (in0_mcast_sender_semaphore_valid_addr, obtained from cb_l1_array) as the source for the multicast:
```
// Initialization (once, before the loop):
in0_mcast_sender_semaphore_valid_addr_ptr[0] = VALID;
// In the loop (sender path, core_in_in0_receiver_mcast_grid):
if constexpr (in0_mcast_num_cores == 1) {
    receiver_sem.set(VALID);  // direct local write for single-core case
} else {
    noc_semaphore_set_multicast_loopback_src(
        in0_mcast_sender_semaphore_valid_addr,   // <-- reads from SEPARATE L1 addr (always VALID)
        in0_mcast_receiver_semaphore_noc_addr,   // <-- writes to receiver sem on all cores
        in0_mcast_num_cores);
}
```

The noc_semaphore_set_multicast_loopback_src reads 4 bytes from in0_mcast_sender_semaphore_valid_addr (a CB write pointer that was set to VALID once and never modified) and multicasts that value to the receiver semaphore address on all cores. Since the loopback variant includes the source core as a destination, the sender's own receiver semaphore was set to VALID via the NoC write — no explicit receiver_sem.set(VALID) was needed (except for the trivial in0_mcast_num_cores == 1 case).
Migrated code
The migration eliminated the separate cb_l1_array storage and instead uses receiver_sem.set_multicast(...), which reads from the receiver semaphore's own L1 address as the source:
```
// In the loop (sender path, core_in_in0_receiver_mcast_grid):
receiver_sem.set(VALID);   // <-- MUST explicitly write VALID here first
if constexpr (in0_mcast_num_cores > 1) {
    receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(...);
    // reads from receiver_sem's L1 addr and multicasts to all cores
}
```
Semaphore::set_multicast reads the value to multicast from the semaphore object's own local_l1_addr_ (i.e., the receiver semaphore itself). Since receiver_sem.set(INVALID) is called at the start of each iteration (line 141), the receiver semaphore contains INVALID at the point where the multicast happens. Therefore, receiver_sem.set(VALID) must be called immediately before set_multicast to ensure the NoC reads VALID (not INVALID) from that L1 address.
The same logic applies to the not-in-receiver-grid path (line 297): even though EXCLUDE_SRC mode is used (so the sender doesn't receive the loopback write), the set_multicast still reads from receiver_sem's L1 address as the source value, so it must contain VALID.
Summary
The receiver_sem.set(VALID) calls at lines 269 and 297 are necessary because Semaphore::set_multicast uses the semaphore's own L1 address as both the source to read from and the destination to write to on remote cores. Since the semaphore is reset to INVALID at each loop iteration start, VALID must be written to it before each multicast so the NoC reads the correct value.[4:43 PM]The migration changed the multicast source to receiver_sem's own L1 address. This address is not immutable — it is overwritten to INVALID at the start of the next loop iteration (line 141: receiver_sem.set(INVALID)). This creates a race:

CPU writes the set_multicast command to the NoC write command buffer (source = receiver_sem's L1 addr, which currently contains VALID)
CPU continues executing — passes receiver_sem.wait(VALID) immediately (the local value is already VALID), does cb_in0.push_back(), enters the next iteration
CPU executes receiver_sem.set(INVALID) — overwrites the source L1 address
NoC hardware finally processes the multicast command, reads from the source L1 address — but it now contains INVALID
NoC multicasts INVALID to all receivers — they wait forever
On Wormhole, this race can manifest because the CPU can run ahead of the NoC command buffer processing. The original code was immune because the source address was constant.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-41136_mm_fused_m20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-41136_mm_fused_m20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-41136_mm_fused_m20)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-41136_mm_fused_m20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-41136_mm_fused_m20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-41136_mm_fused_m20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-41136_mm_fused_m20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
