### PR TITLE
#0: Switch kv cache gather to use NCRISC for both send and recv

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/kernels/attention_block_kernel.cpp
@@ -229,21 +229,33 @@ void kernel_main() {
     // Matmul reader args (NCRISC is no-op)
     deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
 
-    // Gather sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
-        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
-        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_src_cb"),
-        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("dkv_gather_row_major"),
-        get_write_ptr(get_named_compile_time_arg_val(
-            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    // Gather args: both sender and receiver on NCRISC (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+                get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_src_cb"),
+                get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("dkv_gather_row_major"),
+                get_write_ptr(get_named_compile_time_arg_val(
+                    "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+            },
+        .receiver =
+            {
+                get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+                get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+            },
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -349,20 +361,24 @@ void kernel_main() {
 
     // Gather2 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather2_sender_idx, avoiding gaps from the non-rectangular kv_b2 grid)
-    deepseek_b1_ops::Gather::SenderArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_dest_noc_x"),
-        get_named_compile_time_arg_val("gather2_dest_noc_y"),
-        get_named_compile_time_arg_val("gather2_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_src_cb"),
-        get_named_compile_time_arg_val("gather2_src_num_pages"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather2_row_major"),
-        get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 2),  // gather2_receiver_data_addr
-        get_named_compile_time_arg_val("gather2_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather2_dest_noc_x"),
+                get_named_compile_time_arg_val("gather2_dest_noc_y"),
+                get_named_compile_time_arg_val("gather2_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_src_cb"),
+                get_named_compile_time_arg_val("gather2_src_num_pages"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather2_row_major"),
+                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 2),  // gather2_receiver_data_addr
+                get_named_compile_time_arg_val("gather2_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Mcast3 receiver args
@@ -378,20 +394,24 @@ void kernel_main() {
 
     // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
-    deepseek_b1_ops::Gather::SenderArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_dest_noc_x"),
-        get_named_compile_time_arg_val("gather3_dest_noc_y"),
-        get_named_compile_time_arg_val("gather3_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_src_cb"),
-        get_named_compile_time_arg_val("gather3_src_num_pages"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather3_row_major"),
-        get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
-        get_named_compile_time_arg_val("gather3_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather3_dest_noc_x"),
+                get_named_compile_time_arg_val("gather3_dest_noc_y"),
+                get_named_compile_time_arg_val("gather3_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_src_cb"),
+                get_named_compile_time_arg_val("gather3_src_num_pages"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather3_row_major"),
+                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
+                get_named_compile_time_arg_val("gather3_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // ========================================================================o
@@ -601,14 +621,10 @@ void kernel_main() {
     using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
 
-    // Gather receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
-        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    // Gather: BRISC is no-op (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender = {},
+        .receiver = {},
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -663,13 +679,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather2_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_dst_cb"),
-        get_named_compile_time_arg_val("gather2_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather2_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather2_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_dst_cb"),
+                get_named_compile_time_arg_val("gather2_dst_num_pages"),
+            },
     };
 
     // Mcast3 sender args
@@ -690,13 +710,17 @@ void kernel_main() {
     };
 
     // Gather3 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_dst_cb"),
-        get_named_compile_time_arg_val("gather3_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_dst_cb"),
+                get_named_compile_time_arg_val("gather3_dst_num_pages"),
+            },
     };
 
     // ========================================================================o
@@ -1330,7 +1354,8 @@ void kernel_main() {
                 // ================================================================
                 {
                     DeviceZoneScopedN("DKV_GATHER");
-                    deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+                    deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true, false, true>
+                        dkv_gather;
                     dkv_gather(dkv_gather_args);
                 }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1411,11 +1411,10 @@ class AttentionBlock:
             ("dkv_gather_sender_grid_end_x", dkv_gather_sender_grid_end_x),
             ("dkv_gather_sender_grid_end_y", dkv_gather_sender_grid_end_y),
             ("dkv_gather_row_major", 1),  # 1 = row-major linearization
-            ("dkv_gather_dst_cb", kv_rmsnorm_input_cb),  # Destination CB: write directly to kv_rmsnorm_input_cb
         ]
 
-        # Gather receiver compile-time args (named args for BRISC on kv rmsnorm core)
-        # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_id, noc1_receiver_semaphore_id
+        # Gather receiver compile-time args (now on NCRISC via ReceiverOnNCRISC mode)
+        # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_addr, noc1_receiver_semaphore_addr
         # Plus destination CB info for reserve/push
         # Writes directly to kv_rmsnorm_input_cb
         dkv_gather_receiver_named_compile_time_args = [
@@ -3077,6 +3076,7 @@ class AttentionBlock:
             + dkv_matmul_ncrisc_named_compile_time_args
             + kv_rmsnorm_ncrisc_named_compile_time_args
             + dkv_gather_sender_named_compile_time_args
+            + dkv_gather_receiver_named_compile_time_args
             + krope_ncrisc_named_compile_time_args
             + kv_cache_ncrisc_named_compile_time_args
             + mla_ncrisc_named_compile_time_args
@@ -3091,7 +3091,6 @@ class AttentionBlock:
             + mcast2_brisc_named_compile_time_args
             + matmul3_brisc_named_compile_time_args
             + qrope_brisc_named_compile_time_args
-            + dkv_gather_receiver_named_compile_time_args
             + kv_rmsnorm_brisc_named_compile_time_args
             + kv_cache_brisc_named_compile_time_args
             + mla_brisc_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -268,21 +268,33 @@ void kernel_main() {
     // Matmul reader args (NCRISC is no-op)
     deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
 
-    // Gather sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
-        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
-        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_src_cb"),
-        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("dkv_gather_row_major"),
-        get_write_ptr(get_named_compile_time_arg_val(
-            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    // Gather args: both sender and receiver on NCRISC (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+                get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_src_cb"),
+                get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("dkv_gather_row_major"),
+                get_write_ptr(get_named_compile_time_arg_val(
+                    "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+            },
+        .receiver =
+            {
+                get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+                get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+            },
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -388,20 +400,24 @@ void kernel_main() {
 
     // Gather2 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather2_sender_idx, avoiding gaps from the non-rectangular kv_b2 grid)
-    deepseek_b1_ops::Gather::SenderArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_dest_noc_x"),
-        get_named_compile_time_arg_val("gather2_dest_noc_y"),
-        get_named_compile_time_arg_val("gather2_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_src_cb"),
-        get_named_compile_time_arg_val("gather2_src_num_pages"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather2_row_major"),
-        get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 2),  // gather2_receiver_data_addr
-        get_named_compile_time_arg_val("gather2_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather2_dest_noc_x"),
+                get_named_compile_time_arg_val("gather2_dest_noc_y"),
+                get_named_compile_time_arg_val("gather2_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_src_cb"),
+                get_named_compile_time_arg_val("gather2_src_num_pages"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather2_row_major"),
+                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 2),  // gather2_receiver_data_addr
+                get_named_compile_time_arg_val("gather2_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Mcast3 receiver args
@@ -417,20 +433,24 @@ void kernel_main() {
 
     // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
-    deepseek_b1_ops::Gather::SenderArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_dest_noc_x"),
-        get_named_compile_time_arg_val("gather3_dest_noc_y"),
-        get_named_compile_time_arg_val("gather3_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_src_cb"),
-        get_named_compile_time_arg_val("gather3_src_num_pages"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather3_row_major"),
-        get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
-        get_named_compile_time_arg_val("gather3_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather3_dest_noc_x"),
+                get_named_compile_time_arg_val("gather3_dest_noc_y"),
+                get_named_compile_time_arg_val("gather3_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_src_cb"),
+                get_named_compile_time_arg_val("gather3_src_num_pages"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather3_row_major"),
+                get_common_arg_val<uint32_t>(bcast_writer_common_rt_count + 3),  // gather3_receiver_data_addr
+                get_named_compile_time_arg_val("gather3_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // ========================================================================o
@@ -640,14 +660,10 @@ void kernel_main() {
     using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
 
-    // Gather receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
-        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    // Gather: BRISC is no-op (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender = {},
+        .receiver = {},
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -702,13 +718,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather2_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_dst_cb"),
-        get_named_compile_time_arg_val("gather2_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather2_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather2_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_dst_cb"),
+                get_named_compile_time_arg_val("gather2_dst_num_pages"),
+            },
     };
 
     // Mcast3 sender args
@@ -729,13 +749,17 @@ void kernel_main() {
     };
 
     // Gather3 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_dst_cb"),
-        get_named_compile_time_arg_val("gather3_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_dst_cb"),
+                get_named_compile_time_arg_val("gather3_dst_num_pages"),
+            },
     };
 
     // ========================================================================o
@@ -2163,7 +2187,8 @@ void kernel_main() {
                 // ================================================================
                 {
                     DeviceZoneScopedN("DKV_GATHER");
-                    deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+                    deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true, false, true>
+                        dkv_gather;
                     dkv_gather(dkv_gather_args);
                 }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -71,20 +71,24 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
 
     // Gather sender args
-    deepseek_b1_ops::Gather::SenderArgs gather_args{
-        get_named_compile_time_arg_val("gather_dest_noc_x"),
-        get_named_compile_time_arg_val("gather_dest_noc_y"),
-        get_named_compile_time_arg_val("gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_src_cb"),
-        get_named_compile_time_arg_val("gather_src_num_pages"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather_row_major"),
-        get_named_compile_time_arg_val("gather_receiver_data_addr"),
-        get_named_compile_time_arg_val("gather_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                get_named_compile_time_arg_val("gather_receiver_data_addr"),
+                get_named_compile_time_arg_val("gather_sender_idx"),
+            },
+        .receiver = {},
     };
 
 // ============================================================================
@@ -139,13 +143,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
 
     // Gather receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather_args{
-        get_named_compile_time_arg_val("gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_dst_cb"),
-        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
 // ============================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -59,37 +59,45 @@ void kernel_main() {
 // ============================================================================
 #if defined(COMPILE_FOR_NCRISC)
     // Input gather g1 sender args
-    deepseek_b1_ops::Gather::SenderArgs ig_g1_args{
-        get_named_compile_time_arg_val("ig_g1_dest_noc_x"),
-        get_named_compile_time_arg_val("ig_g1_dest_noc_y"),
-        get_named_compile_time_arg_val("ig_g1_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("ig_g1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ig_g1_src_cb"),
-        get_named_compile_time_arg_val("ig_g1_src_num_pages"),
-        0,
-        0,
-        0,
-        0,
-        1,
-        get_named_compile_time_arg_val("ig_g1_receiver_data_addr"),
-        get_named_compile_time_arg_val("ig_g1_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs ig_g1_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("ig_g1_dest_noc_x"),
+                get_named_compile_time_arg_val("ig_g1_dest_noc_y"),
+                get_named_compile_time_arg_val("ig_g1_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("ig_g1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ig_g1_src_cb"),
+                get_named_compile_time_arg_val("ig_g1_src_num_pages"),
+                0,
+                0,
+                0,
+                0,
+                1,
+                get_named_compile_time_arg_val("ig_g1_receiver_data_addr"),
+                get_named_compile_time_arg_val("ig_g1_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Input gather g2 sender args
-    deepseek_b1_ops::Gather::SenderArgs ig_g2_args{
-        get_named_compile_time_arg_val("ig_g2_dest_noc_x"),
-        get_named_compile_time_arg_val("ig_g2_dest_noc_y"),
-        get_named_compile_time_arg_val("ig_g2_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("ig_g2_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ig_g2_src_cb"),
-        get_named_compile_time_arg_val("ig_g2_src_num_pages"),
-        0,
-        0,
-        0,
-        0,
-        1,
-        get_named_compile_time_arg_val("ig_g2_receiver_data_addr"),
-        get_named_compile_time_arg_val("ig_g2_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs ig_g2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("ig_g2_dest_noc_x"),
+                get_named_compile_time_arg_val("ig_g2_dest_noc_y"),
+                get_named_compile_time_arg_val("ig_g2_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("ig_g2_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ig_g2_src_cb"),
+                get_named_compile_time_arg_val("ig_g2_src_num_pages"),
+                0,
+                0,
+                0,
+                0,
+                1,
+                get_named_compile_time_arg_val("ig_g2_receiver_data_addr"),
+                get_named_compile_time_arg_val("ig_g2_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Gated reduce reader args (NCRISC no-op)
@@ -117,20 +125,24 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
 
     // Output gather sender args
-    deepseek_b1_ops::Gather::SenderArgs og_args{
-        get_named_compile_time_arg_val("gather_dest_noc_x"),
-        get_named_compile_time_arg_val("gather_dest_noc_y"),
-        get_named_compile_time_arg_val("gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_src_cb"),
-        get_named_compile_time_arg_val("gather_src_num_pages"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather_row_major"),
-        get_named_compile_time_arg_val("gather_receiver_data_addr"),
-        get_named_compile_time_arg_val("gather_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs og_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                get_named_compile_time_arg_val("gather_receiver_data_addr"),
+                get_named_compile_time_arg_val("gather_sender_idx"),
+            },
+        .receiver = {},
     };
 
 // ============================================================================
@@ -138,23 +150,31 @@ void kernel_main() {
 // ============================================================================
 #elif defined(COMPILE_FOR_BRISC)
     // Input gather g1 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs ig_g1_args{
-        get_named_compile_time_arg_val("ig_g1_noc0_num_senders"),
-        0,
-        get_semaphore(get_named_compile_time_arg_val("ig_g1_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("ig_g1_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ig_g1_dst_cb"),
-        get_named_compile_time_arg_val("ig_g1_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs ig_g1_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("ig_g1_noc0_num_senders"),
+                0,
+                get_semaphore(get_named_compile_time_arg_val("ig_g1_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("ig_g1_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ig_g1_dst_cb"),
+                get_named_compile_time_arg_val("ig_g1_dst_num_pages"),
+            },
     };
 
     // Input gather g2 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs ig_g2_args{
-        get_named_compile_time_arg_val("ig_g2_noc0_num_senders"),
-        0,
-        get_semaphore(get_named_compile_time_arg_val("ig_g2_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("ig_g2_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ig_g2_dst_cb"),
-        get_named_compile_time_arg_val("ig_g2_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs ig_g2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("ig_g2_noc0_num_senders"),
+                0,
+                get_semaphore(get_named_compile_time_arg_val("ig_g2_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("ig_g2_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ig_g2_dst_cb"),
+                get_named_compile_time_arg_val("ig_g2_dst_num_pages"),
+            },
     };
 
     // Gated reduce writer args (BRISC no-op)
@@ -207,13 +227,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
 
     // Output gather receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs og_args{
-        get_named_compile_time_arg_val("gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_dst_cb"),
-        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs og_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
 // ============================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -39,21 +39,33 @@ void kernel_main() {
     // Matmul reader args (NCRISC is no-op)
     deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
 
-    // Gather sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
-        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("dkv_gather_src_cb"),
-        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("dkv_gather_row_major"),
-        get_write_ptr(get_named_compile_time_arg_val(
-            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    // Gather args: both sender and receiver on NCRISC (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("dkv_gather_src_cb"),
+                get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("dkv_gather_row_major"),
+                get_write_ptr(get_named_compile_time_arg_val(
+                    "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+            },
+        .receiver =
+            {
+                get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+                get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+            },
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -92,14 +104,10 @@ void kernel_main() {
     // Matmul writer args (BRISC is no-op)
     deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
 
-    // Gather receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
-        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    // Gather: BRISC is no-op (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender = {},
+        .receiver = {},
     };
 
     deepseek_b1_ops::RMSNorm::WriterArgs kv_rmsnorm_args{};
@@ -205,7 +213,7 @@ void kernel_main() {
     // ========================================================================
     {
         DeviceZoneScopedN("DKV_GATHER");
-        deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+        deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true, false, true> dkv_gather;
         dkv_gather(dkv_gather_args);
     }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -239,10 +239,9 @@ class KVCacheBranch:
             ("dkv_gather_sender_grid_end_x", dkv_gather_sender_grid_end_x),
             ("dkv_gather_sender_grid_end_y", dkv_gather_sender_grid_end_y),
             ("dkv_gather_row_major", 1),  # 1 = row-major linearization
-            ("dkv_gather_dst_cb", kv_rmsnorm_input_cb),  # Destination CB: write directly to kv_rmsnorm_input_cb
         ]
 
-        # Gather receiver compile-time args (named args for BRISC on kv rmsnorm core)
+        # Gather receiver compile-time args (now on NCRISC via ReceiverOnNCRISC mode)
         # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_id, noc1_receiver_semaphore_id
         # Plus destination CB info for reserve/push
         # Writes directly to kv_rmsnorm_input_cb
@@ -437,13 +436,14 @@ class KVCacheBranch:
             kernel_source="models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp",
             core_ranges=input_core_grid,
             # NCRISC named compile-time args:
+            # dkv_gather receiver args on NCRISC (ReceiverOnNCRISC mode)
             ncrisc_named_compile_time_args=dkv_matmul_ncrisc_named_compile_time_args
             + kv_rmsnorm_ncrisc_named_compile_time_args
             + dkv_gather_sender_named_compile_time_args
+            + dkv_gather_receiver_named_compile_time_args
             + krope_ncrisc_named_compile_time_args,
             # BRISC named compile-time args
-            brisc_named_compile_time_args=dkv_gather_receiver_named_compile_time_args
-            + kv_rmsnorm_brisc_named_compile_time_args
+            brisc_named_compile_time_args=kv_rmsnorm_brisc_named_compile_time_args
             + krope_brisc_named_compile_time_args,
             # BRISC common runtime args: KV cache buffer address and write position
             brisc_common_runtime_args=[

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
@@ -75,20 +75,24 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // Gather (sender - compute cores send to sender core)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Gather::SenderArgs gather_args{
-        get_named_compile_time_arg_val("gather_dest_noc_x"),
-        get_named_compile_time_arg_val("gather_dest_noc_y"),
-        get_named_compile_time_arg_val("gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_src_cb"),
-        get_named_compile_time_arg_val("gather_src_num_pages"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather_row_major"),
-        get_named_compile_time_arg_val("gather_receiver_data_addr"),
-        0,  // sender_idx (unused when UsePerCoreSenderIdx=false)
+    deepseek_b1_ops::Gather::DMArgs gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                get_named_compile_time_arg_val("gather_receiver_data_addr"),
+                0,  // sender_idx (unused when UsePerCoreSenderIdx=false)
+            },
+        .receiver = {},
     };
 
     // ------------------------------------------------------------------------
@@ -164,21 +168,25 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // down_proj_gather (sender - gate_proj cores send fused output to sender core)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Gather::SenderArgs down_proj_gather_args{
-        get_named_compile_time_arg_val("down_proj_gather_dest_noc_x"),
-        get_named_compile_time_arg_val("down_proj_gather_dest_noc_y"),
-        get_named_compile_time_arg_val("down_proj_gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("down_proj_gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("down_proj_gather_src_cb"),
-        get_named_compile_time_arg_val("down_proj_gather_src_num_pages"),
-        get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("down_proj_gather_row_major"),
-        get_named_compile_time_arg_val("down_proj_gather_receiver_data_addr"),
-        get_named_compile_time_arg_val(
-            "down_proj_gather_sender_idx"),  // Explicit sender index (UsePerCoreSenderIdx=true)
+    deepseek_b1_ops::Gather::DMArgs down_proj_gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("down_proj_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("down_proj_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("down_proj_gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("down_proj_gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("down_proj_gather_src_cb"),
+                get_named_compile_time_arg_val("down_proj_gather_src_num_pages"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("down_proj_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("down_proj_gather_row_major"),
+                get_named_compile_time_arg_val("down_proj_gather_receiver_data_addr"),
+                get_named_compile_time_arg_val(
+                    "down_proj_gather_sender_idx"),  // Explicit sender index (UsePerCoreSenderIdx=true)
+            },
+        .receiver = {},
     };
 
     // ------------------------------------------------------------------------
@@ -309,13 +317,17 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // Gather (receiver - sender core receives from compute cores)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Gather::ReceiverArgs gather_args{
-        get_named_compile_time_arg_val("gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_dst_cb"),
-        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
     // ------------------------------------------------------------------------
@@ -380,13 +392,17 @@ void kernel_main() {
     // ------------------------------------------------------------------------
     // down_proj_gather (receiver - sender core receives fused output from gate_proj cores)
     // ------------------------------------------------------------------------
-    deepseek_b1_ops::Gather::ReceiverArgs down_proj_gather_args{
-        get_named_compile_time_arg_val("down_proj_gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("down_proj_gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("down_proj_gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("down_proj_gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("down_proj_gather_dst_cb"),
-        get_named_compile_time_arg_val("down_proj_gather_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs down_proj_gather_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("down_proj_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("down_proj_gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("down_proj_gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("down_proj_gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("down_proj_gather_dst_cb"),
+                get_named_compile_time_arg_val("down_proj_gather_dst_num_pages"),
+            },
     };
 
     // ------------------------------------------------------------------------

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -98,20 +98,24 @@ void kernel_main() {
 
     // Gather2 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather2_sender_idx, avoiding gaps from the non-rectangular kv_b2 grid)
-    deepseek_b1_ops::Gather::SenderArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_dest_noc_x"),
-        get_named_compile_time_arg_val("gather2_dest_noc_y"),
-        get_named_compile_time_arg_val("gather2_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_src_cb"),
-        get_named_compile_time_arg_val("gather2_src_num_pages"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather2_row_major"),
-        get_named_compile_time_arg_val("gather2_receiver_data_addr"),
-        get_named_compile_time_arg_val("gather2_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather2_dest_noc_x"),
+                get_named_compile_time_arg_val("gather2_dest_noc_y"),
+                get_named_compile_time_arg_val("gather2_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_src_cb"),
+                get_named_compile_time_arg_val("gather2_src_num_pages"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather2_row_major"),
+                get_named_compile_time_arg_val("gather2_receiver_data_addr"),
+                get_named_compile_time_arg_val("gather2_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Mcast3 receiver args
@@ -128,20 +132,24 @@ void kernel_main() {
 
     // Gather3 sender args (UsePerCoreSenderIdx: each core gets a contiguous index
     // via gather3_sender_idx, avoiding gaps from the non-rectangular o_proj grid)
-    deepseek_b1_ops::Gather::SenderArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_dest_noc_x"),
-        get_named_compile_time_arg_val("gather3_dest_noc_y"),
-        get_named_compile_time_arg_val("gather3_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_src_cb"),
-        get_named_compile_time_arg_val("gather3_src_num_pages"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather3_row_major"),
-        get_named_compile_time_arg_val("gather3_receiver_data_addr"),
-        get_named_compile_time_arg_val("gather3_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather3_dest_noc_x"),
+                get_named_compile_time_arg_val("gather3_dest_noc_y"),
+                get_named_compile_time_arg_val("gather3_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_src_cb"),
+                get_named_compile_time_arg_val("gather3_src_num_pages"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather3_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather3_row_major"),
+                get_named_compile_time_arg_val("gather3_receiver_data_addr"),
+                get_named_compile_time_arg_val("gather3_sender_idx"),
+            },
+        .receiver = {},
     };
 #ifndef SKIP_CCL
     // CCL Sender NCRISC CTArgs (reads from gather core)
@@ -179,13 +187,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul5_args{};
 
     // Gather2 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather2_args{
-        get_named_compile_time_arg_val("gather2_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather2_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather2_dst_cb"),
-        get_named_compile_time_arg_val("gather2_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather2_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather2_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather2_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather2_dst_cb"),
+                get_named_compile_time_arg_val("gather2_dst_num_pages"),
+            },
     };
 
     // Mcast3 sender args
@@ -211,13 +223,17 @@ void kernel_main() {
     };
 
     // Gather3 receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs gather3_args{
-        get_named_compile_time_arg_val("gather3_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather3_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather3_dst_cb"),
-        get_named_compile_time_arg_val("gather3_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs gather3_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather3_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather3_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather3_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather3_dst_cb"),
+                get_named_compile_time_arg_val("gather3_dst_num_pages"),
+            },
     };
 
 #ifndef SKIP_CCL

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -234,21 +234,33 @@ if constexpr (!Core::skip_ccl) {
     // Matmul reader args (NCRISC is no-op)
     deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
 
-    // Gather sender args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
-        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
-        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
-        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_src_cb"),
-        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("dkv_gather_row_major"),
-        get_write_ptr(get_named_compile_time_arg_val(
-            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    // Gather args: both sender and receiver on NCRISC (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+                get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+                get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+                get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_src_cb"),
+                get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("dkv_gather_row_major"),
+                get_write_ptr(get_named_compile_time_arg_val(
+                    "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+            },
+        .receiver =
+            {
+                get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+                get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
+                get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+                get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+            },
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -453,14 +465,10 @@ if constexpr (!Core::skip_ccl) {
     using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
     deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
 
-    // Gather receiver args (from compile-time args, passed to op as runtime args)
-    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
-        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
-        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_addr"),
-        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
-        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    // Gather: BRISC is no-op (ReceiverOnNCRISC mode)
+    deepseek_b1_ops::Gather::DMArgs dkv_gather_args{
+        .sender = {},
+        .receiver = {},
     };
 
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -986,7 +994,8 @@ if constexpr (!Core::skip_ccl) {
             // ================================================================
             {
                 DeviceZoneScopedN("DKV_GATHER");
-                deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+                deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true, false, true>
+                    dkv_gather;
                 dkv_gather(dkv_gather_args);
             }
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1030,11 +1030,10 @@ class PreSDPA:
             ("dkv_gather_sender_grid_end_x", dkv_gather_sender_grid_end_x),
             ("dkv_gather_sender_grid_end_y", dkv_gather_sender_grid_end_y),
             ("dkv_gather_row_major", 1),  # 1 = row-major linearization
-            ("dkv_gather_dst_cb", kv_rmsnorm_input_cb),  # Destination CB: write directly to kv_rmsnorm_input_cb
         ]
 
-        # Gather receiver compile-time args (named args for BRISC on kv rmsnorm core)
-        # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_id, noc1_receiver_semaphore_id
+        # Gather receiver compile-time args (now on NCRISC via ReceiverOnNCRISC mode)
+        # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_addr, noc1_receiver_semaphore_addr
         # Plus destination CB info for reserve/push
         # Writes directly to kv_rmsnorm_input_cb
         dkv_gather_receiver_named_compile_time_args = [
@@ -2085,6 +2084,7 @@ class PreSDPA:
                     + dkv_matmul_ncrisc_named_compile_time_args
                     + kv_rmsnorm_ncrisc_named_compile_time_args
                     + dkv_gather_sender_named_compile_time_args
+                    + dkv_gather_receiver_named_compile_time_args
                     + krope_ncrisc_named_compile_time_args
                     + krope_ncrisc_addr_args
                     + kv_cache_ncrisc_named_compile_time_args
@@ -2105,7 +2105,6 @@ class PreSDPA:
                     + mcast2_brisc_named_compile_time_args
                     + matmul3_brisc_named_compile_time_args
                     + qrope_brisc_named_compile_time_args
-                    + dkv_gather_receiver_named_compile_time_args
                     + kv_rmsnorm_brisc_named_compile_time_args
                     + kv_cache_brisc_named_compile_time_args
                     + kv_cache_sp_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -89,37 +89,45 @@ void kernel_main() {
     deepseek_b1_ops::GatedReduce::ReaderArgs gated_reduce_args{};
 
     // Gate gather (A) sender args
-    deepseek_b1_ops::Gather::SenderArgs ag_args{
-        get_named_compile_time_arg_val("ag_dest_noc_x"),
-        get_named_compile_time_arg_val("ag_dest_noc_y"),
-        get_named_compile_time_arg_val("ag_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("ag_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ag_src_cb"),
-        get_named_compile_time_arg_val("ag_src_num_pages"),
-        0,  // sender_grid_start_x (unused, per-core idx)
-        0,  // sender_grid_start_y
-        0,  // sender_grid_end_x
-        0,  // sender_grid_end_y
-        1,  // row_major
-        get_named_compile_time_arg_val("ag_receiver_data_addr"),
-        get_named_compile_time_arg_val("ag_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs ag_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("ag_dest_noc_x"),
+                get_named_compile_time_arg_val("ag_dest_noc_y"),
+                get_named_compile_time_arg_val("ag_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("ag_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ag_src_cb"),
+                get_named_compile_time_arg_val("ag_src_num_pages"),
+                0,  // sender_grid_start_x (unused, per-core idx)
+                0,  // sender_grid_start_y
+                0,  // sender_grid_end_x
+                0,  // sender_grid_end_y
+                1,  // row_major
+                get_named_compile_time_arg_val("ag_receiver_data_addr"),
+                get_named_compile_time_arg_val("ag_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Up gather (B) sender args
-    deepseek_b1_ops::Gather::SenderArgs bg_args{
-        get_named_compile_time_arg_val("bg_dest_noc_x"),
-        get_named_compile_time_arg_val("bg_dest_noc_y"),
-        get_named_compile_time_arg_val("bg_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("bg_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("bg_src_cb"),
-        get_named_compile_time_arg_val("bg_src_num_pages"),
-        0,  // sender_grid_start_x (unused, per-core idx)
-        0,  // sender_grid_start_y
-        0,  // sender_grid_end_x
-        0,  // sender_grid_end_y
-        1,  // row_major
-        get_named_compile_time_arg_val("bg_receiver_data_addr"),
-        get_named_compile_time_arg_val("bg_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs bg_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("bg_dest_noc_x"),
+                get_named_compile_time_arg_val("bg_dest_noc_y"),
+                get_named_compile_time_arg_val("bg_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("bg_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("bg_src_cb"),
+                get_named_compile_time_arg_val("bg_src_num_pages"),
+                0,  // sender_grid_start_x (unused, per-core idx)
+                0,  // sender_grid_start_y
+                0,  // sender_grid_end_x
+                0,  // sender_grid_end_y
+                1,  // row_major
+                get_named_compile_time_arg_val("bg_receiver_data_addr"),
+                get_named_compile_time_arg_val("bg_sender_idx"),
+            },
+        .receiver = {},
     };
 
     // Mcast1 receiver args (down proj activation)
@@ -146,20 +154,24 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
 
     // Output gather sender args
-    deepseek_b1_ops::Gather::SenderArgs og_args{
-        get_named_compile_time_arg_val("gather_dest_noc_x"),
-        get_named_compile_time_arg_val("gather_dest_noc_y"),
-        get_named_compile_time_arg_val("gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_src_cb"),
-        get_named_compile_time_arg_val("gather_src_num_pages"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather_row_major"),
-        get_named_compile_time_arg_val("gather_receiver_data_addr"),
-        get_named_compile_time_arg_val("gather_sender_idx"),
+    deepseek_b1_ops::Gather::DMArgs og_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                get_named_compile_time_arg_val("gather_receiver_data_addr"),
+                get_named_compile_time_arg_val("gather_sender_idx"),
+            },
+        .receiver = {},
     };
 
 // ============================================================================
@@ -193,23 +205,31 @@ void kernel_main() {
     deepseek_b1_ops::GatedReduce::WriterArgs gated_reduce_args{};
 
     // Gate gather (A) receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs ag_args{
-        get_named_compile_time_arg_val("ag_noc0_num_senders"),
-        0,
-        get_semaphore(get_named_compile_time_arg_val("ag_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("ag_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("ag_dst_cb"),
-        get_named_compile_time_arg_val("ag_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs ag_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("ag_noc0_num_senders"),
+                0,
+                get_semaphore(get_named_compile_time_arg_val("ag_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("ag_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("ag_dst_cb"),
+                get_named_compile_time_arg_val("ag_dst_num_pages"),
+            },
     };
 
     // Up gather (B) receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs bg_args{
-        get_named_compile_time_arg_val("bg_noc0_num_senders"),
-        0,
-        get_semaphore(get_named_compile_time_arg_val("bg_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("bg_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("bg_dst_cb"),
-        get_named_compile_time_arg_val("bg_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs bg_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("bg_noc0_num_senders"),
+                0,
+                get_semaphore(get_named_compile_time_arg_val("bg_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("bg_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("bg_dst_cb"),
+                get_named_compile_time_arg_val("bg_dst_num_pages"),
+            },
     };
 
     // Mcast1 sender args (down proj activation)
@@ -260,13 +280,17 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
 
     // Output gather receiver args
-    deepseek_b1_ops::Gather::ReceiverArgs og_args{
-        get_named_compile_time_arg_val("gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_dst_cb"),
-        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    deepseek_b1_ops::Gather::DMArgs og_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
 // ============================================================================

--- a/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
@@ -42,47 +42,51 @@ void kernel_main() {
         unified_kernels::setup_sharded_buffer(src_cb, src_num_pages);
     }
 
-    // Get receiver data address from runtime arg (dst CB doesn't exist on sender cores)
     uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
 
-    // Gather sender args (from compile-time args, passed to op as runtime args)
-    Gather::SenderArgs gather_args{
-        get_named_compile_time_arg_val("gather_dest_noc_x"),
-        get_named_compile_time_arg_val("gather_dest_noc_y"),
-        get_named_compile_time_arg_val("gather_data_size_bytes"),
-        get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_src_cb"),
-        get_named_compile_time_arg_val("gather_src_num_pages"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
-        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
-        get_named_compile_time_arg_val("gather_row_major"),
-        receiver_data_addr,  // receiver_data_addr from runtime arg (output tensor buffer address)
-        get_named_compile_time_arg_val("gather_sender_idx"),
+    Gather::DMArgs gather_args{
+        .sender =
+            {
+                get_named_compile_time_arg_val("gather_dest_noc_x"),
+                get_named_compile_time_arg_val("gather_dest_noc_y"),
+                get_named_compile_time_arg_val("gather_data_size_bytes"),
+                get_semaphore(get_named_compile_time_arg_val("gather_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_src_cb"),
+                get_named_compile_time_arg_val("gather_src_num_pages"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+                get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+                get_named_compile_time_arg_val("gather_row_major"),
+                receiver_data_addr,
+                get_named_compile_time_arg_val("gather_sender_idx"),
+            },
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
-// ============================================================================
-// BRISC (Receiver) - DataMovementProcessor.RISCV_0
-// Named compile-time args: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_id,
-//                          noc1_receiver_semaphore_id, dst_cb, dst_num_pages
-// ============================================================================
 #elif defined(COMPILE_FOR_BRISC)
-    // Gather receiver args (from compile-time args, passed to op as runtime args)
-    Gather::ReceiverArgs gather_args{
-        get_named_compile_time_arg_val("gather_noc0_num_senders"),
-        get_named_compile_time_arg_val("gather_noc1_num_senders"),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
-        get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
-        get_named_compile_time_arg_val("gather_dst_cb"),
-        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    Gather::DMArgs gather_args{
+        .sender = {},
+        .receiver =
+            {
+                get_named_compile_time_arg_val("gather_noc0_num_senders"),
+                get_named_compile_time_arg_val("gather_noc1_num_senders"),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id")),
+                get_semaphore(get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id")),
+                get_named_compile_time_arg_val("gather_dst_cb"),
+                get_named_compile_time_arg_val("gather_dst_num_pages"),
+            },
     };
 
-// ============================================================================
-// TRISC (Compute) - No-op (gather is dataflow only)
-// ============================================================================
 #elif defined(COMPILE_FOR_TRISC)
-    // Gather compute args (no-op for TRISC)
     Gather::ComputeArgs gather_args{};
 #endif
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
@@ -8,6 +8,7 @@
 
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
 #endif
 
 namespace deepseek_b1_ops {
@@ -16,13 +17,16 @@ namespace deepseek_b1_ops {
 // Gather micro-op
 //
 // Gathers data from multiple sender cores to a single receiver core.
-// Receiver runs on BRISC, Sender runs on NCRISC.
+// Default: Sender on NCRISC, Receiver on BRISC.
+// ReceiverOnNCRISC mode: Both sender and receiver on NCRISC, BRISC is no-op.
+//   Use when sender and receiver share a core (e.g. dkv_gather where
+//   kv_rmsnorm_core is also a knope sender core).
 //
 // CB States:
-//   NCRISC (Sender):
+//   Sender (NCRISC):
 //     - Waits: src_cb (src_num_pages)
 //     - Pops: src_cb (src_num_pages) if pop_src=true
-//   BRISC (Receiver):
+//   Receiver (BRISC, or NCRISC when ReceiverOnNCRISC=true):
 //     - Reserves: dst_cb (dst_num_pages)
 //     - Pushes: dst_cb (dst_num_pages)
 //   TRISC: No-op
@@ -37,11 +41,9 @@ namespace deepseek_b1_ops {
 // ============================================================================
 struct Gather {
     // ========================================================================
-    // Runtime args structs - different layout per RISC
+    // Runtime args structs
     // ========================================================================
 
-    // Receiver args (BRISC): [noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_addr,
-    //                         noc1_receiver_semaphore_addr, dst_cb, dst_num_pages]
     struct ReceiverArgs {
         uint32_t noc0_num_senders;
         uint32_t noc1_num_senders;
@@ -51,10 +53,6 @@ struct Gather {
         uint32_t dst_num_pages;
     };
 
-    // Sender args (NCRISC): [dest_noc_x, dest_noc_y, data_size_bytes, receiver_semaphore_addr,
-    //                        src_cb, src_num_pages, sender_grid_start_x, sender_grid_start_y,
-    //                        sender_grid_end_x, sender_grid_end_y, row_major, receiver_data_addr,
-    //                        sender_idx]
     struct SenderArgs {
         uint32_t dest_noc_x;
         uint32_t dest_noc_y;
@@ -71,11 +69,17 @@ struct Gather {
         uint32_t sender_idx;  // Per-core sender index (only used if UsePerCoreSenderIdx=true)
     };
 
+    // Unified dataflow args: both BRISC and NCRISC get the full set so the
+    // sender/receiver impl can be placed on either RISC without restructuring.
+    struct DMArgs {
+        SenderArgs sender;
+        ReceiverArgs receiver;
+    };
+
     // Compute args (TRISC) - not used for gather (dataflow only)
     struct ComputeArgs {};
 
-    // Note: For gather, NCRISC=Sender, BRISC=Receiver
-    using RTArgs = unified_kernels::SelectByRISCV<SenderArgs, ReceiverArgs, ComputeArgs>;
+    using RTArgs = unified_kernels::SelectByRISCV<DMArgs, DMArgs, ComputeArgs>;
 
     // ========================================================================
     // Op - the actual operation
@@ -84,77 +88,88 @@ struct Gather {
     // IsReceiverCore: compile-time flag for receiver cores
     // pop_src: whether to pop the source CB after sending
     // UsePerCoreSenderIdx: compile-time flag for scattered vs grid-based indexing
+    // ReceiverOnNCRISC: when true, receiver logic runs on NCRISC instead of BRISC.
+    //   Use for gathers where sender and receiver share a core (e.g. dkv_gather).
+    //   NCRISC does send-then-receive; BRISC is no-op.
     // ========================================================================
-    template <bool IsSenderCore, bool IsReceiverCore, bool pop_src, bool UsePerCoreSenderIdx = false>
+    template <
+        bool IsSenderCore,
+        bool IsReceiverCore,
+        bool pop_src,
+        bool UsePerCoreSenderIdx = false,
+        bool ReceiverOnNCRISC = false>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
 
     private:
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+        static void sender_impl(const SenderArgs& s) {
+            ASSERT(s.data_size_bytes > 0);
+            uint32_t core_index;
+            if constexpr (UsePerCoreSenderIdx) {
+                core_index = s.sender_idx;
+            } else {
+                core_index = unified_kernels::linear_id_in_grid<true>(
+                    s.sender_grid_start_x, s.sender_grid_start_y, s.sender_grid_end_x, s.sender_grid_end_y);
+            }
+            uint32_t offset = core_index * s.data_size_bytes;
+
+            const uint64_t dst_noc_coord = get_noc_addr(s.dest_noc_x, s.dest_noc_y, 0);
+            uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(s.receiver_data_addr + offset);
+            uint64_t dst_semaphore_noc_addr = dst_noc_coord | (uint64_t)s.receiver_semaphore_addr;
+
+            cb_wait_front(s.src_cb, s.src_num_pages);
+
+            uint32_t input_data_addr = get_read_ptr(s.src_cb);
+            noc_async_write_one_packet<true, true>(input_data_addr, dst_data_noc_addr, s.data_size_bytes);
+            // BH does not support posted atomics due to a bug
+            noc_semaphore_inc(dst_semaphore_noc_addr, 1);
+
+            if constexpr (pop_src) {
+                noc_async_posted_writes_flushed();
+                cb_pop_front(s.src_cb, s.src_num_pages);
+            }
+            noc_async_atomic_barrier();
+        }
+
+        static void receiver_impl(const ReceiverArgs& r) {
+            ASSERT(r.noc0_num_senders > 0 || r.noc1_num_senders > 0);
+            volatile tt_l1_ptr uint32_t* noc0_receiver_semaphore_addr_ptr =
+                (volatile tt_l1_ptr uint32_t*)r.noc0_receiver_semaphore_addr;
+
+            cb_reserve_back(r.dst_cb, r.dst_num_pages);
+            noc_semaphore_wait(noc0_receiver_semaphore_addr_ptr, r.noc0_num_senders);
+            noc_semaphore_set(noc0_receiver_semaphore_addr_ptr, 0);
+
+            if (r.noc1_num_senders > 0) {
+                volatile tt_l1_ptr uint32_t* noc1_receiver_semaphore_addr_ptr =
+                    (volatile tt_l1_ptr uint32_t*)r.noc1_receiver_semaphore_addr;
+                noc_semaphore_wait(noc1_receiver_semaphore_addr_ptr, r.noc1_num_senders);
+                noc_semaphore_set(noc1_receiver_semaphore_addr_ptr, 0);
+            }
+
+            cb_push_back(r.dst_cb, r.dst_num_pages);
+        }
+#endif
+
         void impl([[maybe_unused]] const RTArgs& args) {
 #if defined(COMPILE_FOR_NCRISC)
             // ================================================================
-            // NCRISC (Sender) - DataMovementProcessor.RISCV_1
+            // NCRISC: Sender always, Receiver when ReceiverOnNCRISC=true
             // ================================================================
             if constexpr (IsSenderCore) {
-                // Compute per-core offset using compile-time branching
-                // For scattered cores (UsePerCoreSenderIdx=true), use the provided sender_idx
-                // For rectangular grids (UsePerCoreSenderIdx=false), compute from grid position
-                uint32_t core_index;
-                if constexpr (UsePerCoreSenderIdx) {
-                    core_index = args.sender_idx;
-                } else {
-                    // Note: my_logical_x_/y_ are global variables set by firmware
-                    core_index = unified_kernels::linear_id_in_grid<true>(
-                        args.sender_grid_start_x,
-                        args.sender_grid_start_y,
-                        args.sender_grid_end_x,
-                        args.sender_grid_end_y);
-                }
-                uint32_t offset = core_index * args.data_size_bytes;
-
-                const uint64_t dst_noc_coord = get_noc_addr(args.dest_noc_x, args.dest_noc_y, 0);
-                uint64_t dst_data_noc_addr = dst_noc_coord | (uint64_t)(args.receiver_data_addr + offset);
-                uint64_t dst_semaphore_noc_addr = dst_noc_coord | (uint64_t)args.receiver_semaphore_addr;
-
-                // Wait for source CB data to be ready
-                cb_wait_front(args.src_cb, args.src_num_pages);
-
-                // Get source address from CB
-                uint32_t input_data_addr = get_read_ptr(args.src_cb);
-                noc_async_write_one_packet<true, true>(input_data_addr, dst_data_noc_addr, args.data_size_bytes);
-                // BH does not support posted atomics due to a bug
-                noc_semaphore_inc(dst_semaphore_noc_addr, 1);
-                noc_async_posted_writes_flushed();
-
-                // Pop the source CB after sending
-                if constexpr (pop_src) {
-                    cb_pop_front(args.src_cb, args.src_num_pages);
-                }
-                noc_async_atomic_barrier();
+                sender_impl(args.sender);
+            }
+            if constexpr (ReceiverOnNCRISC && IsReceiverCore) {
+                receiver_impl(args.receiver);
             }
 #elif defined(COMPILE_FOR_BRISC)
             // ================================================================
-            // BRISC (Receiver) - DataMovementProcessor.RISCV_0
+            // BRISC: Receiver when ReceiverOnNCRISC=false, no-op otherwise
             // ================================================================
-            if constexpr (IsReceiverCore) {
-                volatile tt_l1_ptr uint32_t* noc0_receiver_semaphore_addr_ptr =
-                    (volatile tt_l1_ptr uint32_t*)args.noc0_receiver_semaphore_addr;
-
-                // Reserve space in destination CB
-                cb_reserve_back(args.dst_cb, args.dst_num_pages);
-                noc_semaphore_wait(noc0_receiver_semaphore_addr_ptr, args.noc0_num_senders);
-                noc_semaphore_set(noc0_receiver_semaphore_addr_ptr, 0);
-
-                if (args.noc1_num_senders > 0) {
-                    volatile tt_l1_ptr uint32_t* noc1_receiver_semaphore_addr_ptr =
-                        (volatile tt_l1_ptr uint32_t*)args.noc1_receiver_semaphore_addr;
-                    noc_semaphore_wait(noc1_receiver_semaphore_addr_ptr, args.noc1_num_senders);
-                    noc_semaphore_set(noc1_receiver_semaphore_addr_ptr, 0);
-                }
-
-                // Push to destination CB after data arrived
-                cb_push_back(args.dst_cb, args.dst_num_pages);
+            if constexpr (!ReceiverOnNCRISC && IsReceiverCore) {
+                receiver_impl(args.receiver);
             }
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================


### PR DESCRIPTION
### Ticket
None

### Problem description
Initial kv cache read (old cache) for NOPE can be entirely prefetched if we move gather receiver logic onto the same RISC (ie. NCRISC). This PR refactors gather op to share send/recv args for both DMs and updates kv cache gather to use same RISC.

### What's changed

- Refactor gather API to have send/recv args for both dm
- Add flag to put receiver logic on NCRISC

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bliu/deepseek)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/23909657927
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
