### PR TITLE
[skip ci] Get Dual GLXs back in CI

### DIFF
--- a/tests/scripts/multihost/run_dual_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_dual_galaxy_tests.sh
@@ -17,11 +17,11 @@ run_dual_galaxy_unit_tests() {
   # tt-run --tcp-interface handles the extra mpi_run args
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="cnx1"
-  local mpi_args="--host g10glx03,g10glx04 $mpi_args_base"
-  local mpi_args_reversed="--host g10glx04,g10glx03 $mpi_args_base"
+  local mpi_args="--host g02glx01,g02glx02 $mpi_args_base"
+  local mpi_args_reversed="--host g02glx01,g02glx02 $mpi_args_base"
 
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
-  local mpirun_args="--host g10glx03,g10glx04 $mpirun_args_base"
+  local mpirun_args="--host g02glx01,g02glx02 $mpirun_args_base"
   local rank_binding="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?

--- a/tests/scripts/multihost/run_dual_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_dual_galaxy_tests.sh
@@ -18,7 +18,7 @@ run_dual_galaxy_unit_tests() {
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="cnx1"
   local mpi_args="--host g02glx01,g02glx02 $mpi_args_base"
-  local mpi_args_reversed="--host g02glx01,g02glx02 $mpi_args_base"
+  local mpi_args_reversed="--host g02glx02,g02glx01 $mpi_args_base"
 
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
   local mpirun_args="--host g02glx01,g02glx02 $mpirun_args_base"


### PR DESCRIPTION
Passing CI system: 

- [x] https://github.com/tenstorrent/tt-metal/actions/runs/23771555565 (passed on older commit)
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/23819993572 (failed due to perf not due to galaxy health)