### PR TITLE
Fix unit test num_program_cache_entries and custom tile regression

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -364,6 +364,9 @@ def run_all_to_all_dispatch_test(
     random.seed(2005)
     mesh_device.enable_program_cache()
     devices = mesh_shape[0] * mesh_shape[1]
+    from tests.tests_common.cache_entries_counter import CacheEntriesCounter
+
+    mesh_device.cache_entries_counter = CacheEntriesCounter(mesh_device)
 
     # input, output, interm core range set
     compute_grid = (mesh_device.compute_with_storage_grid_size().x, mesh_device.compute_with_storage_grid_size().y)

--- a/tests/nightly/t3000/ccl/test_new_all_broadcast.py
+++ b/tests/nightly/t3000/ccl/test_new_all_broadcast.py
@@ -185,33 +185,34 @@ def run_all_broadcast_impl(
         input_tensor_mesh_list.append(input_tensor_mesh)
 
     tt_out_tensor_list = []
-    if trace_mode:
-        tt_out_tensor = run_with_trace(
-            mesh_device,
-            all_broadcast_topology,
-            input_tensor_mesh_list[0],
-            num_links,
-            output_mem_config,
-            cluster_axis=cluster_axis,
-            num_iter=num_iters,
-            subdevice_id=worker_sub_device_id,
-        )
-        tt_out_tensor_list.append(tt_out_tensor)
-    else:
-        for i in range(num_iters):
-            tt_out_tensors = ttnn.all_broadcast(
-                input_tensor_mesh_list[i],
-                num_links=num_links,
-                memory_config=output_mem_config,
+    with mesh_device.cache_entries_counter.measure():
+        if trace_mode:
+            tt_out_tensor = run_with_trace(
+                mesh_device,
+                all_broadcast_topology,
+                input_tensor_mesh_list[0],
+                num_links,
+                output_mem_config,
                 cluster_axis=cluster_axis,
-                topology=all_broadcast_topology,
+                num_iter=num_iters,
                 subdevice_id=worker_sub_device_id,
             )
-            tt_out_tensor_list.append(tt_out_tensors)
+            tt_out_tensor_list.append(tt_out_tensor)
+        else:
+            for i in range(num_iters):
+                tt_out_tensors = ttnn.all_broadcast(
+                    input_tensor_mesh_list[i],
+                    num_links=num_links,
+                    memory_config=output_mem_config,
+                    cluster_axis=cluster_axis,
+                    topology=all_broadcast_topology,
+                    subdevice_id=worker_sub_device_id,
+                )
+                tt_out_tensor_list.append(tt_out_tensors)
 
-        logger.info(f"Waiting for op")
-        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-        logger.info(f"Done op")
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
 
     passed = True
     for tensor_index in range(len(tt_out_tensor_list)):
@@ -231,8 +232,8 @@ def run_all_broadcast_impl(
                     passed = False
                     assert eq, f"{i} FAILED: {output}"
     assert (
-        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 or mesh_device.cache_entries_counter.total == num_iters
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
     mesh_device.reset_sub_device_stall_group()
     if use_sub_devices:
         mesh_device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all.py
@@ -220,41 +220,42 @@ def run_all_to_all_impl(
         input_tensor_mesh_list.append(input_tensor_mesh)
 
     tt_out_tensor_list = []
-    if trace_mode:
-        tt_out_tensor = run_with_trace(
-            mesh_device,
-            topology,
-            input_tensor_mesh_list[0],
-            persistent_intermediate_buffers[0],
-            persistent_output_buffers[0],
-            in_dim,
-            out_dim,
-            num_links,
-            output_mem_config,
-            multi_device_global_semaphore=ccl_semaphore_handles[0],
-            num_iter=num_iters,
-            subdevice_id=worker_sub_device_id,
-        )
-        tt_out_tensor_list.append(tt_out_tensor)
-    else:
-        for i in range(num_iters):
-            tt_out_tensor = ttnn.experimental.all_to_all_async(
-                input_tensor_mesh_list[i if not reuse_inputs else 0],
-                persistent_intermediate_buffer=persistent_intermediate_buffers[i],
-                persistent_output_buffer=persistent_output_buffers[i],
-                in_dim=in_dim,
-                out_dim=out_dim,
-                multi_device_global_semaphore=ccl_semaphore_handles[i],
-                num_links=num_links,
-                memory_config=output_mem_config,
-                topology=topology,
+    with mesh_device.cache_entries_counter.measure():
+        if trace_mode:
+            tt_out_tensor = run_with_trace(
+                mesh_device,
+                topology,
+                input_tensor_mesh_list[0],
+                persistent_intermediate_buffers[0],
+                persistent_output_buffers[0],
+                in_dim,
+                out_dim,
+                num_links,
+                output_mem_config,
+                multi_device_global_semaphore=ccl_semaphore_handles[0],
+                num_iter=num_iters,
                 subdevice_id=worker_sub_device_id,
             )
-            tt_out_tensor_list.append(persistent_output_buffers[i])
+            tt_out_tensor_list.append(tt_out_tensor)
+        else:
+            for i in range(num_iters):
+                tt_out_tensor = ttnn.experimental.all_to_all_async(
+                    input_tensor_mesh_list[i if not reuse_inputs else 0],
+                    persistent_intermediate_buffer=persistent_intermediate_buffers[i],
+                    persistent_output_buffer=persistent_output_buffers[i],
+                    in_dim=in_dim,
+                    out_dim=out_dim,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i],
+                    num_links=num_links,
+                    memory_config=output_mem_config,
+                    topology=topology,
+                    subdevice_id=worker_sub_device_id,
+                )
+                tt_out_tensor_list.append(persistent_output_buffers[i])
 
-        logger.info(f"Waiting for op")
-        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-        logger.info(f"Done op")
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
 
     passed = True
     if do_check:
@@ -274,8 +275,8 @@ def run_all_to_all_impl(
                     passed = False
 
     assert (
-        mesh_device.num_program_cache_entries() == 1
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all.py
@@ -143,6 +143,10 @@ def run_all_to_all_impl(
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
 
+    from tests.tests_common.cache_entries_counter import CacheEntriesCounter
+
+    mesh_device.cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
@@ -23,19 +23,7 @@ def run_with_trace(
 ):
     # Compile Run
     logger.info("Compiling model")
-    tt_out_tensor = ttnn.all_broadcast(
-        input_tensor_mesh,
-        num_links=num_links,
-        memory_config=output_mem_config,
-        topology=all_broadcast_topology,
-        subdevice_id=subdevice_id,
-    )
-    ttnn.synchronize_device(mesh_device)
-
-    # Capture trace
-    logger.info("Capturing trace")
-    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    for i in range(num_iter):
+    with mesh_device.cache_entries_counter.measure():
         tt_out_tensor = ttnn.all_broadcast(
             input_tensor_mesh,
             num_links=num_links,
@@ -43,6 +31,20 @@ def run_with_trace(
             topology=all_broadcast_topology,
             subdevice_id=subdevice_id,
         )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    with mesh_device.cache_entries_counter.measure():
+        for i in range(num_iter):
+            tt_out_tensor = ttnn.all_broadcast(
+                input_tensor_mesh,
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_broadcast_topology,
+                subdevice_id=subdevice_id,
+            )
     ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
     ttnn.synchronize_device(mesh_device)
 
@@ -224,8 +226,8 @@ def run_all_broadcast_impl(
                     passed = False
                     assert eq, f"{i} FAILED: {output}"
     assert (
-        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 or mesh_device.cache_entries_counter.total == num_iters
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()
     if not passed:

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
@@ -198,15 +198,16 @@ def run_all_broadcast_impl(
         )
         tt_out_tensor_list.append(tt_out_tensor)
     else:
-        for i in range(num_iters):
-            tt_out_tensors = ttnn.all_broadcast(
-                input_tensor_mesh_list[i],
-                num_links=num_links,
-                memory_config=output_mem_config,
-                topology=all_broadcast_topology,
-                subdevice_id=worker_sub_device_id,
-            )
-            tt_out_tensor_list.append(tt_out_tensors)
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(num_iters):
+                tt_out_tensors = ttnn.all_broadcast(
+                    input_tensor_mesh_list[i],
+                    num_links=num_links,
+                    memory_config=output_mem_config,
+                    topology=all_broadcast_topology,
+                    subdevice_id=worker_sub_device_id,
+                )
+                tt_out_tensor_list.append(tt_out_tensors)
 
         logger.info(f"Waiting for op")
         ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_broadcast.py
@@ -80,6 +80,10 @@ def run_all_broadcast_impl(
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
 
+    from tests.tests_common.cache_entries_counter import CacheEntriesCounter
+
+    mesh_device.cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_reduce.py
@@ -185,30 +185,31 @@ def run_all_reduce_impl(
 
     def run_op(n_iters, store_all_results=True):
         outs = []
-        for i in range(n_iters):
-            if i % loopback_size == 0:
-                tt_input = tt_input_tensor
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(n_iters):
+                if i % loopback_size == 0:
+                    tt_input = tt_input_tensor
 
-            out = ttnn.experimental.all_reduce_async(
-                tt_input,
-                tt_intermediate_tensors[i % num_buffers],
-                cluster_axis=cluster_axis,
-                mesh_device=mesh_device,
-                multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
-                memory_config=output_mem_config,
-                dtype=output_dtype,
-                topology=all_reduce_topology,
-                num_links=num_links,
-                subdevice_id=worker_sub_device_id,
-            )
-            if not trace_mode:
-                ttnn.synchronize_device(mesh_device)
-            if store_all_results:
-                outs.append(out)
+                out = ttnn.experimental.all_reduce_async(
+                    tt_input,
+                    tt_intermediate_tensors[i % num_buffers],
+                    cluster_axis=cluster_axis,
+                    mesh_device=mesh_device,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
+                    memory_config=output_mem_config,
+                    dtype=output_dtype,
+                    topology=all_reduce_topology,
+                    num_links=num_links,
+                    subdevice_id=worker_sub_device_id,
+                )
+                if not trace_mode:
+                    ttnn.synchronize_device(mesh_device)
+                if store_all_results:
+                    outs.append(out)
 
-            # Loop back the output to the input
-            if loopback_size != 1:
-                tt_input = ttnn.reshard(out, input_mem_config)
+                # Loop back the output to the input
+                if loopback_size != 1:
+                    tt_input = ttnn.reshard(out, input_mem_config)
 
         if store_all_results:
             return outs
@@ -295,9 +296,9 @@ def run_all_reduce_impl(
 
     reshard_op_cnt = 1 if loopback_size > 1 else 0
     assert (
-        mesh_device.num_program_cache_entries() == 1 + reshard_op_cnt
-        or mesh_device.num_program_cache_entries() == num_iters + reshard_op_cnt
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 + reshard_op_cnt
+        or mesh_device.cache_entries_counter.total == num_iters + reshard_op_cnt
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
 

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_new_all_reduce.py
@@ -89,6 +89,10 @@ def run_all_reduce_impl(
         all_reduce_topology = ttnn.Topology.Ring
         wrap_mesh = False
 
+    from tests.tests_common.cache_entries_counter import CacheEntriesCounter
+
+    mesh_device.cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     worker_sub_device = ttnn.SubDevice([SUB_DEVICE_CRS])
 
     worker_sub_device_id = ttnn.SubDeviceId(0)

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -152,8 +152,12 @@ Tensor create_tt_tensor_from_host_data(
         if (mesh_mapper != nullptr) {
             TensorLayout src_tensor_layout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config);
 
-            const bool construct_on_device = device != nullptr && !device->is_remote_only() && enable_device_typecast &&
-                                             !preserve_nan_values && tensor_shape.volume() > 0;
+            const bool construct_on_device =
+                device != nullptr && !device->is_remote_only() && enable_device_typecast && !preserve_nan_values &&
+                tensor_shape.volume() > 0 &&
+                (optional_tile.has_value() ? (optional_tile->get_width() % tt::constants::TILE_WIDTH == 0 &&
+                                              optional_tile->get_height() % tt::constants::TILE_HEIGHT == 0)
+                                           : true);
             return ttnn::distributed::create_distributed_tensor(
                 host_buffer.view_as<T>(),
                 tensor_shape,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Fix CI failures:

- https://github.com/tenstorrent/tt-metal/actions/runs/23817426063/job/69421801724
- https://github.com/tenstorrent/tt-metal/actions/runs/23817167564

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/fix-test-all-broadcast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/fix-test-all-broadcast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/fix-test-all-broadcast)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

[(WH Galaxy) Quick](https://github.com/tenstorrent/tt-metal/actions/runs/23821232515). Passed

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/fix-test-all-broadcast)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/fix-test-all-broadcast)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/fix-test-all-broadcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/fix-test-all-broadcast)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
