### PR TITLE
[skip ci] Run clang-tidy-pr-comments action on forks

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -407,6 +407,8 @@ jobs:
         # [[ -s clang-tidy-result/fixes.yml ]] && exit 42
     - name: Run clang-tidy-pr-comments action
       if: ${{ !cancelled() }}
+      # Do not fail the gate if the action fails
+      continue-on-error: true
       # v1.8.0
       uses: platisd/clang-tidy-pr-comments@28cfb84edafa771c044bde7e4a2a3fae57463818
       with:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -406,7 +406,7 @@ jobs:
         # # to be addressed.
         # [[ -s clang-tidy-result/fixes.yml ]] && exit 42
     - name: Run clang-tidy-pr-comments action
-      if: ${{ !cancelled() && github.event.pull_request.head.repo.fork == false }}
+      if: ${{ !cancelled() }}
       # v1.8.0
       uses: platisd/clang-tidy-pr-comments@28cfb84edafa771c044bde7e4a2a3fae57463818
       with:


### PR DESCRIPTION
### Ticket
None

### Problem description
clang-tidy-light runs on external PRs (on fork PRs) but the comment that suggests fixes doesn't run so external contributors have no signal if there's potential clang tidy issues until the full clang-tidy suite runs in merge gate.

### What's changed
Run the clang-tidy-pr-comments action on all PRs (prev. excluded forks)

### Checklist

- [x] None
