### PR TITLE
Add has_data() API to D2H socket

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -148,6 +148,19 @@ public:
     void set_page_size(uint32_t page_size);
 
     /**
+     * @brief Non-blocking check for available data.
+     *
+     * Returns true if at least one page of data is available in the FIFO
+     * without blocking. Useful for poll-based readers that need to check
+     * a shutdown flag between iterations.
+     *
+     * @return true if at least one page can be read immediately.
+     *
+     * @throws TT_FATAL if page_size has not been set.
+     */
+    bool has_data();
+
+    /**
      * @brief Reads data pages from the socket FIFO.
      *
      * Blocks until the requested number of pages are available in the FIFO.

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -222,6 +222,19 @@ void D2HSocket::set_page_size(uint32_t page_size) {
     fifo_curr_size_ = fifo_page_aligned_size;
 }
 
+bool D2HSocket::has_data() {
+    TT_FATAL(page_size_ > 0, "Page size must be set before checking for data.");
+    uint32_t num_bytes = page_size_;
+    if (read_ptr_ + num_bytes >= fifo_curr_size_) {
+        num_bytes += fifo_size_ - fifo_curr_size_;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_sent_value = bytes_sent_ptr_[0];
+    bytes_sent_ = bytes_sent_value;
+    uint32_t bytes_recv = bytes_sent_value - bytes_acked_;
+    return bytes_recv >= num_bytes;
+}
+
 void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     if (read_ptr_ + num_bytes >= fifo_curr_size_) {
         num_bytes += fifo_size_ - fifo_curr_size_;


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
 - Certain D2H socket clients need a non blocking API to check if the socket contains data
 
### What's changed
 - Add `has_data()` API to D2H socket

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/d2h_nb_check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/d2h_nb_check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/d2h_nb_check)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/d2h_nb_check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/d2h_nb_check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/d2h_nb_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/d2h_nb_check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
