### PR TITLE
Using dual machine for Deepseek dual tests, because quad is broken

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -94,8 +94,13 @@ jobs:
     if: ${{ github.event_name == 'schedule' || inputs.deepseekv3_unit_tests || inputs.deepseekv3_module_tests || inputs.teacher_forced || inputs.demo || inputs.demo_stress }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON((github.event_name == 'schedule' && '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') || (inputs.setup == 'dual' && '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') || (inputs.setup == 'quad' && '{"include":[{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') || '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]},{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') }}
-    runs-on: ${{ matrix.runs_on }}
+      matrix:
+        setup: ${{ fromJSON(((github.event_name == 'schedule' || inputs.setup == 'dual') && '["dual"]') || (inputs.setup == 'quad' && '["quad"]') || '["dual", "quad"]') }}
+    runs-on:
+      - arch-wormhole_b0
+      - ${{ matrix.setup == 'quad' && 'multi-host-glx-4x' || 'multi-host-galaxy' }}
+      - bare-metal
+      - in-service
     needs: build-artifact
     steps:
       - name: ⬇️ Checkout

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -94,18 +94,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || inputs.deepseekv3_unit_tests || inputs.deepseekv3_module_tests || inputs.teacher_forced || inputs.demo || inputs.demo_stress }}
     strategy:
       fail-fast: false
-      matrix: >-
-        ${{
-          fromJSON(
-            (github.event_name == 'schedule' &&
-              '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
-            (inputs.setup == 'dual' &&
-              '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
-            (inputs.setup == 'quad' &&
-              '{"include":[{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
-            '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]},{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}'
-          )
-        }}
+      matrix: ${{ fromJSON((github.event_name == 'schedule' && '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') || (inputs.setup == 'dual' && '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') || (inputs.setup == 'quad' && '{"include":[{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') || '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]},{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') }}
     runs-on: ${{ matrix.runs_on }}
     needs: build-artifact
     steps:

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -92,11 +92,21 @@ jobs:
 
   deepseekv3-tests:
     if: ${{ github.event_name == 'schedule' || inputs.deepseekv3_unit_tests || inputs.deepseekv3_module_tests || inputs.teacher_forced || inputs.demo || inputs.demo_stress }}
-    runs-on:
-      - multi-host-glx-4x
-      - arch-wormhole_b0
-      - bare-metal
-      - in-service
+    strategy:
+      fail-fast: false
+      matrix: >-
+        ${{
+          fromJSON(
+            (github.event_name == 'schedule' &&
+              '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
+            (inputs.setup == 'dual' &&
+              '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
+            (inputs.setup == 'quad' &&
+              '{"include":[{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}') ||
+            '{"include":[{"setup":"dual","runs_on":["multi-host-galaxy","arch-wormhole_b0","bare-metal","in-service"]},{"setup":"quad","runs_on":["multi-host-glx-4x","arch-wormhole_b0","bare-metal","in-service"]}]}'
+          )
+        }}
+    runs-on: ${{ matrix.runs_on }}
     needs: build-artifact
     steps:
       - name: ⬇️ Checkout
@@ -156,7 +166,7 @@ jobs:
 
       # ── DeepSeek V3 unit tests ──────────────────────────────────────────
       - name: Run dual DeepSeek V3 unit tests
-        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'dual' && inputs.deepseekv3_unit_tests }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 60
         with:
@@ -180,7 +190,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
 
       - name: Run quad DeepSeek V3 unit tests
-        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_unit_tests }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 60
         with:
@@ -205,7 +215,7 @@ jobs:
 
       # ── DeepSeek V3 module tests ────────────────────────────────────────
       - name: Run dual DeepSeek V3 module tests
-        if: ${{ (inputs.deepseekv3_module_tests && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ matrix.setup == 'dual' && (inputs.deepseekv3_module_tests || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 150
         with:
@@ -229,7 +239,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
 
       - name: Run quad DeepSeek V3 module tests
-        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.deepseekv3_module_tests }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 150
         with:
@@ -254,7 +264,7 @@ jobs:
 
       # ── Teacher forced accuracy tests ───────────────────────────────────
       - name: Run dual teacher forced accuracy test
-        if: ${{ (inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ matrix.setup == 'dual' && (inputs.teacher_forced || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
         with:
@@ -278,7 +288,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
 
       - name: Upload dual teacher forced accuracy artifacts
-        if: ${{ always() && ((inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && matrix.setup == 'dual' && (inputs.teacher_forced || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-teacher-forced-accuracy-${{ github.run_id }}
@@ -288,7 +298,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Run quad teacher forced accuracy test
-        if: ${{ inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.teacher_forced }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
         with:
@@ -312,7 +322,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
 
       - name: Upload quad teacher forced accuracy artifacts
-        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ always() && matrix.setup == 'quad' && inputs.teacher_forced }}
         uses: actions/upload-artifact@v4
         with:
           name: quad-teacher-forced-accuracy-${{ github.run_id }}
@@ -323,7 +333,7 @@ jobs:
 
       # ── Demo tests ──────────────────────────────────────────────────────
       - name: Run dual demo test (256 prompts, 1 batch)
-        if: ${{ (inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -347,7 +357,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
 
       - name: Upload dual demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-output-${{ github.run_id }}
@@ -357,7 +367,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Run dual MTP demo parity smoke test
-        if: ${{ ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 400 || 40 }}
         with:
@@ -381,7 +391,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_mtp
 
       - name: Upload dual MTP demo output artifacts
-        if: ${{ always() && ((inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && matrix.setup == 'dual' && (inputs.demo || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-mtp-output-${{ github.run_id }}
@@ -391,7 +401,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Run quad demo test (512 prompts, 1 batch)
-        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.demo }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
         with:
@@ -415,7 +425,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
 
       - name: Upload quad demo output artifacts
-        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
         uses: actions/upload-artifact@v4
         with:
           name: quad-demo-output-${{ github.run_id }}
@@ -425,7 +435,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Run quad MTP demo parity smoke test
-        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.demo }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 420 || 60 }}
         with:
@@ -449,7 +459,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_mtp
 
       - name: Upload quad MTP demo output artifacts
-        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ always() && matrix.setup == 'quad' && inputs.demo }}
         uses: actions/upload-artifact@v4
         with:
           name: quad-demo-mtp-output-${{ github.run_id }}
@@ -460,7 +470,7 @@ jobs:
 
       # ── Demo stress tests ───────────────────────────────────────────────
       - name: Run dual demo stress test (56 prompts, 20 batches)
-        if: ${{ (inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule' }}
+        if: ${{ matrix.setup == 'dual' && (inputs.demo_stress || github.event_name == 'schedule') }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
         with:
@@ -484,7 +494,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
 
       - name: Upload dual demo stress output artifacts
-        if: ${{ always() && ((inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both')) || github.event_name == 'schedule') }}
+        if: ${{ always() && matrix.setup == 'dual' && (inputs.demo_stress || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-stress-output-${{ github.run_id }}
@@ -494,7 +504,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Run quad demo stress test (56 prompts, 20 batches)
-        if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ matrix.setup == 'quad' && inputs.demo_stress }}
         uses: ./.github/actions/docker-run
         timeout-minutes: ${{ inputs.recalculate_weights_cache == 'Yes' && 480 || 120 }}
         with:
@@ -518,7 +528,7 @@ jobs:
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
 
       - name: Upload quad demo stress output artifacts
-        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        if: ${{ always() && matrix.setup == 'quad' && inputs.demo_stress }}
         uses: actions/upload-artifact@v4
         with:
           name: quad-demo-stress-output-${{ github.run_id }}

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -66,12 +66,15 @@ _resolve_deepseekv3_cache() {
 
 setup_dual_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
-    export HOSTS="g05glx01,g05glx02"
-    export RANKFILE=/etc/mpirun/rankfile_g05glx01_g05glx02
+    export HOSTS="g02glx01,g02glx02"
+    export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
     export TCP_INTERFACE="cnx1"
     mkdir -p logs
     mkdir -p generated/artifacts
+
+    echo "Using dual Galaxy hosts: ${HOSTS}"
+    echo "Using dual Galaxy rankfile: ${RANKFILE}"
 
     if ! test -f "$RANKFILE"; then
         echo "File '$RANKFILE' does not exist."


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41168

### Problem description
Quad is broken, ie. produces ND hangs and ND PCC issues, due to some hardware faults.

### What's changed
Switching Deepseek dual CI tests to use dual machine instead of being run on quad machine. 

### Checklist

[![DeepSeek Multihost Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml/badge.svg?branch=ds-use-dual-for-CI)](https://github.com/tenstorrent/tt-metal/actions/workflows/multi-host-deepseekv3.yaml?query=branch:ds-use-dual-for-CI)