### PR TITLE
[Feature]: Bringup Watcher Ringbuffer on Quasar

### DIFF
--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -20,7 +20,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     echo "Watcher dump all data test - Pass"
 
     # Check that stack dumping is working
-    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*TestWatcherRingBufferBrisc
+    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*WatcherRingBufferTest.TestWatcherRingBuffer/Brisc
     ./build/tools/watcher_dump -d=0 -w
     grep "BRISC highest stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
     echo "Watcher stack usage test - Pass"

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -24,6 +24,7 @@
 #include "impl/kernels/kernel.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/debug/debug_helpers.hpp"
+#include "hostdev/debug_ring_buffer_common.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.
@@ -31,289 +32,301 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-constexpr uint32_t NUM_PUSHES_SINGLE = 40;  // Single-thread tests push 40 values
-constexpr uint32_t NUM_PUSHES_MULTI = 4;    // Multi-DM test: 4 pushes per DM (8 DMs x 4 = 32 total)
+namespace {
+const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
 
-// Generate expected ring buffer data for TRISC/ERISC/BH/WH tests
-// Pattern: (idx << 16) | (idx + 1), buffer holds 32, newest first (40 down to 9)
-std::vector<uint32_t> get_expected_data() {
+// Overflow amount for single-processor tests
+constexpr uint32_t OVERFLOW_AMOUNT = 12;
+
+// Pushes per processor for multi-threaded test (24 x 5 = 120, fits in 128-element MPSC buffer)
+constexpr uint32_t PUSHES_PER_PROCESSOR_MULTI = 5;
+
+// Expected strings for single-processor tests (SPSC for WH/BH, MPSC for Quasar)
+// Pattern: SPSC uses (idx << 16) | (idx + 1), MPSC uses (thread_idx << 16) | seq
+// Newest first, limited to buffer capacity
+std::vector<std::string> get_expected_single_processor(
+    HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    uint32_t capacity = hal.get_ring_buffer_capacity();
+    uint32_t first_visible = (num_pushes > capacity) ? num_pushes - capacity : 0;
+
     std::vector<uint32_t> data;
-    for (uint32_t idx = NUM_PUSHES_SINGLE - 1; idx >= NUM_PUSHES_SINGLE - 32; idx--) {
-        data.push_back((idx << 16) | (idx + 1));
+    std::vector<uint32_t> thread_indices;
+    for (uint32_t seq = num_pushes - 1; seq >= first_visible && seq < num_pushes; seq--) {
+        if (is_quasar) {
+            data.push_back((thread_idx << 16) | seq);
+            thread_indices.push_back(thread_idx);
+        } else {
+            data.push_back((seq << 16) | (seq + 1));
+        }
     }
-    return data;
-}
 
-// Generate expected ring buffer data for Quasar single-DM tests
-// Pattern: (thread_idx << 16) | seq, buffer holds 32, newest first
-std::vector<uint32_t> get_expected_data_dm(uint32_t thread_idx) {
-    std::vector<uint32_t> data;
-    for (uint32_t seq = NUM_PUSHES_SINGLE - 1; seq >= NUM_PUSHES_SINGLE - 32; seq--) {
-        data.push_back((thread_idx << 16) | seq);
-    }
-    return data;
-}
-
-// Expected strings for BH/WH (SPSC format)
-std::vector<std::string> get_expected_spsc() {
-    auto data = get_expected_data();
     std::vector<std::string> result = {"debug_ring_buffer="};
-    auto lines = FormatRingBuffer(data);
+    auto lines = is_quasar ? FormatRingBuffer(data, thread_indices, core_type) : FormatRingBuffer(data);
     result.insert(result.end(), lines.begin(), lines.end());
     return result;
 }
 
-// Expected strings for Quasar single-DM (MPSC format with processor prefix)
-std::vector<std::string> get_expected_mpsc(HalProgrammableCoreType core_type, uint32_t thread_idx) {
-    auto data = get_expected_data_dm(thread_idx);
-    std::vector<uint32_t> thread_indices(data.size(), thread_idx);  // All from same thread in test
-    std::vector<std::string> result = {"debug_ring_buffer="};
-    auto lines = FormatRingBuffer(data, thread_indices, core_type);
-    result.insert(result.end(), lines.begin(), lines.end());
-    return result;
-}
+// Expected strings for Quasar multi-threaded test (all 24 processors)
+// Verifies all processors wrote all entries (order is non-deterministic)
+std::vector<std::string> get_expected_multi_threaded(
+    HalProgrammableCoreType core_type, uint32_t num_processors, uint32_t pushes_per_proc) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
 
-// Expected strings for Quasar multi-DM test (MPSC format)
-// Verifies all 8 DMs wrote entries with matching [DMx] prefix and data
-std::vector<std::string> get_expected_multi_dm() {
     std::vector<std::string> expected = {"debug_ring_buffer="};
-    for (uint32_t dm = 0; dm < 8; dm++) {
-        // First push from each DM: (dm << 16) | 0
-        expected.push_back(fmt::format("[DM{}]0x{:08x}", dm, (dm << 16) | 0));
+    for (uint32_t proc_idx = 0; proc_idx < num_processors; proc_idx++) {
+        auto proc_name = hal.get_processor_class_name(core_type, proc_idx, false);
+        for (uint32_t seq = 0; seq < pushes_per_proc; seq++) {
+            expected.push_back(fmt::format("[{}]0x{:08x}", proc_name, (proc_idx << 16) | seq));
+        }
     }
     return expected;
 }
 
-namespace {
+void RunMultiThreadedTest(
+    MeshWatcherFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    HalProgrammableCoreType core_type) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    uint32_t tensix_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t num_dm = hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::DM));
+    uint32_t num_triscs =
+        hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+    uint32_t num_neos = num_triscs / hal.get_processor_class_num_fw_binaries(
+                                         tensix_idx, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
+    uint32_t total_processors = num_dm + num_triscs;
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, {});
+    auto& program = workload.get_programs().at(device_range);
+    CoreCoord logical_core = {0, 0};
+
+    tt::tt_metal::experimental::quasar::CreateKernel(
+        program,
+        kernel,
+        logical_core,
+        tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = num_dm,
+            .compile_args = {PUSHES_PER_PROCESSOR_MULTI},
+            .defines = {{"MULTI_THREADED_TEST", "1"}}});
+
+    tt::tt_metal::experimental::quasar::CreateKernel(
+        program,
+        kernel,
+        logical_core,
+        tt::tt_metal::experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = num_neos,
+            .compile_args = {PUSHES_PER_PROCESSOR_MULTI},
+            .defines = {{"MULTI_THREADED_TEST", "1"}}});
+
+    log_info(LogTest, "Running multi-threaded test on all processors)...");
+    fixture->RunProgram(mesh_device, workload, true);
+
+    auto expected = get_expected_multi_threaded(core_type, total_processors, PUSHES_PER_PROCESSOR_MULTI);
+    EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected));
+}
 
 void RunTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    HalProcessorIdentifier processor,
-    bool multi_dm_test = false) {
-    // Set up program
+    HalProcessorIdentifier processor) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    uint32_t tensix_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, {});
     auto& program = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
-    bool is_quasar = device->arch() == tt::ARCH::QUASAR;
+    CoreCoord logical_core = {0, 0};
+    CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
 
-    // Depending on riscv type, choose one core to run the test on
-    // and set up the kernel on the correct risc
-    CoreCoord logical_core, virtual_core;
+    // Single-processor tests
+    uint32_t num_pushes = hal.get_ring_buffer_capacity() + OVERFLOW_AMOUNT;
+
     switch (processor.core_type) {
         case HalProgrammableCoreType::TENSIX:
-            logical_core = CoreCoord{0, 0};
-            virtual_core = device->worker_core_from_logical_core(logical_core);
             switch (processor.processor_class) {
-                case HalProcessorClassType::DM: {
+                case HalProcessorClassType::DM:
                     if (is_quasar) {
-                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
-                        std::vector<uint32_t> compile_args =
-                            multi_dm_test ? std::vector<uint32_t>{num_pushes}
-                                          : std::vector<uint32_t>{num_pushes, processor.processor_type};
-                        std::map<std::string, std::string> defines =
-                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
-                                          : std::map<std::string, std::string>{};
+                        uint32_t num_dm =
+                            hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::DM));
                         tt::tt_metal::experimental::quasar::CreateKernel(
                             program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            kernel,
                             logical_core,
                             tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                                .num_threads_per_cluster = 8, .compile_args = compile_args, .defines = defines});
+                                .num_threads_per_cluster = num_dm,
+                                .compile_args = {num_pushes, processor.processor_type}});
                     } else {
-                        DataMovementConfig dm_config{};
-                        dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
-                        dm_config.noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
-                                                                        : tt_metal::NOC::RISCV_1_default;
-                        dm_config.compile_args = {NUM_PUSHES_SINGLE};
-                        CreateKernel(
-                            program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                            logical_core,
-                            dm_config);
+                        DataMovementConfig dm_config{
+                            .processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type),
+                            .noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
+                                                                   : tt_metal::NOC::RISCV_1_default,
+                            .compile_args = {num_pushes}};
+                        CreateKernel(program, kernel, logical_core, dm_config);
                     }
                     break;
-                }
+
                 case HalProcessorClassType::COMPUTE:
                     if (is_quasar) {
-                        uint32_t num_threads = multi_dm_test ? 4 : 1;
-                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
-                        std::map<std::string, std::string> defines =
-                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
-                                          : std::map<std::string, std::string>{
-                                                {fmt::format("TRISC{}", processor.processor_type), "1"}};
                         tt::tt_metal::experimental::quasar::CreateKernel(
                             program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            kernel,
                             logical_core,
-                            experimental::quasar::QuasarComputeConfig{
-                                .num_threads_per_cluster = num_threads,
+                            tt::tt_metal::experimental::quasar::QuasarComputeConfig{
+                                .num_threads_per_cluster = 1,
                                 .compile_args = {num_pushes},
-                                .defines = defines});
+                                .defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     } else {
                         CreateKernel(
                             program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            kernel,
                             logical_core,
                             ComputeConfig{
-                                .compile_args = {NUM_PUSHES_SINGLE},
+                                .compile_args = {num_pushes},
                                 .defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     }
                     break;
+                default: TT_THROW("Unsupported processor class");
             }
             break;
-        case HalProgrammableCoreType::ACTIVE_ETH:
-            if (device->get_active_ethernet_cores(true).empty()) {
-                log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
-                GTEST_SKIP();
+
+        case HalProgrammableCoreType::ACTIVE_ETH: {
+            auto eth_cores = device->get_active_ethernet_cores(true);
+            if (eth_cores.empty()) {
+                GTEST_SKIP() << "Device has no active ethernet cores";
             }
-            logical_core = *(device->get_active_ethernet_cores(true).begin());
+            logical_core = *eth_cores.begin();
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                kernel,
                 logical_core,
-                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
-        case HalProgrammableCoreType::IDLE_ETH:
-            if (device->get_inactive_ethernet_cores().empty()) {
-                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
-                GTEST_SKIP();
+        }
+
+        case HalProgrammableCoreType::IDLE_ETH: {
+            auto eth_cores = device->get_inactive_ethernet_cores();
+            if (eth_cores.empty()) {
+                GTEST_SKIP() << "Device has no inactive ethernet cores";
             }
-            logical_core = *(device->get_inactive_ethernet_cores().begin());
+            logical_core = *eth_cores.begin();
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                kernel,
                 logical_core,
-                EthernetConfig{
-                    .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
+                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
-        case HalProgrammableCoreType::DRAM:
+        }
+
+        case HalProgrammableCoreType::DRAM: {
             log_info(LogTest, "Skipping: DRAM cores do not support watcher ring buffer tests.");
             GTEST_SKIP();
-        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported core type");
-    }
-    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
-
-    // Run the program
-    fixture->RunProgram(mesh_device, workload, true);
-
-    log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
-
-    // Check log
-    if (is_quasar) {
-        if (multi_dm_test) {
-            EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, get_expected_multi_dm()));
-        } else {
-            // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
-            uint32_t thread_idx = processor.processor_type;
-            if (processor.processor_class == HalProcessorClassType::COMPUTE) {
-                // Compute processors start after DM processors in the HAL index
-                const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-                thread_idx =
-                    hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
-            }
-            EXPECT_TRUE(FileContainsAllStringsInOrder(
-                fixture->log_file_name, get_expected_mpsc(processor.core_type, thread_idx)));
         }
-    } else {
-        EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, get_expected_spsc()));
+
+        default: TT_THROW("Unsupported core type");
+    }
+
+    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
+    fixture->RunProgram(mesh_device, workload, true);
+    log_info(LogTest, "Checking file: {}", fixture->log_file_name);
+
+    // Validate output
+    uint32_t thread_idx = processor.processor_type;
+    if (is_quasar && processor.processor_class == HalProcessorClassType::COMPUTE) {
+        thread_idx = hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+    }
+    EXPECT_TRUE(FileContainsAllStringsInOrder(
+        fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
+}
+
+}  // namespace
+
+// Test parameters
+struct RingBufferTestParams {
+    std::string test_name;
+    HalProcessorIdentifier processor;
+    bool multi_threaded = false;
+};
+
+class WatcherRingBufferTest : public MeshWatcherFixture, public ::testing::WithParamInterface<RingBufferTestParams> {};
+
+TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
+    const auto& params = GetParam();
+    const auto& hal = MetalContext::instance().hal();
+
+    // Skip if processor type not available on this architecture
+    uint32_t core_type_index = hal.get_programmable_core_type_index(params.processor.core_type);
+    uint32_t available_processors =
+        hal.get_processor_types_count(core_type_index, static_cast<uint32_t>(params.processor.processor_class));
+
+    if (params.processor.processor_type >= available_processors) {
+        GTEST_SKIP() << "Test " << params.test_name << " requires processor type " << params.processor.processor_type
+                     << " but only " << available_processors << " available on this architecture";
+    }
+
+    // Multi-threaded test is Quasar-only
+    if (params.multi_threaded && hal.get_arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Multi-threaded test is Quasar-only";
+    }
+
+    // IDLE_ETH requires slow dispatch
+    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    if (is_idle_eth && !this->IsSlowDispatch()) {
+        GTEST_SKIP() << "IDLE_ETH requires Slow Dispatch";
+    }
+
+    // Slow dispatch tests only on Quasar or IDLE_ETH
+    bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
+    if (this->IsSlowDispatch() && !is_quasar && !is_idle_eth) {
+        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+    }
+
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                if (params.multi_threaded) {
+                    RunMultiThreadedTest(fixture, mesh_device, params.processor.core_type);
+                } else {
+                    RunTest(fixture, mesh_device, params.processor);
+                }
+            },
+            mesh_device);
     }
 }
 
 using enum HalProgrammableCoreType;
 using enum HalProcessorClassType;
 
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferBrisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferNCrisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 1});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc0) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc1) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 1});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc2) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 2});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferErisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {ACTIVE_ETH, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferIErisc) {
-    if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
-        GTEST_SKIP();
-    }
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {IDLE_ETH, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiDM) {
-    for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        if (device->arch() != tt::ARCH::QUASAR) {
-            GTEST_SKIP() << "Multi-DM MPSC test is Quasar-only";
-        }
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 0}, /*multi_dm_test=*/true);
-            },
-            mesh_device);
-    }
-}
-
-}  // namespace
+INSTANTIATE_TEST_SUITE_P(
+    WatcherRingBufferTests,
+    WatcherRingBufferTest,
+    ::testing::Values(
+        // DM processors
+        RingBufferTestParams{"Brisc", {TENSIX, DM, 0}},
+        RingBufferTestParams{"NCrisc", {TENSIX, DM, 1}},
+        RingBufferTestParams{"DM2", {TENSIX, DM, 2}},
+        RingBufferTestParams{"DM3", {TENSIX, DM, 3}},
+        RingBufferTestParams{"DM4", {TENSIX, DM, 4}},
+        RingBufferTestParams{"DM5", {TENSIX, DM, 5}},
+        RingBufferTestParams{"DM6", {TENSIX, DM, 6}},
+        RingBufferTestParams{"DM7", {TENSIX, DM, 7}},
+        // TRISC processors
+        RingBufferTestParams{"Trisc0", {TENSIX, COMPUTE, 0}},
+        RingBufferTestParams{"Trisc1", {TENSIX, COMPUTE, 1}},
+        RingBufferTestParams{"Trisc2", {TENSIX, COMPUTE, 2}},
+        RingBufferTestParams{"Trisc3", {TENSIX, COMPUTE, 3}},  // Quasar only
+        // Ethernet processors
+        RingBufferTestParams{"Erisc", {ACTIVE_ETH, DM, 0}},
+        RingBufferTestParams{"IErisc", {IDLE_ETH, DM, 0}},
+        // Multi-threaded test (Quasar only, all 24 processors)
+        RingBufferTestParams{"MultiThreaded", {TENSIX, DM, 0}, /*multi_threaded=*/true}),
+    [](const ::testing::TestParamInfo<RingBufferTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -20,7 +20,10 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include "impl/kernels/kernel.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/debug/debug_helpers.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.
@@ -28,21 +31,66 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-std::vector<std::string> expected = {
-    "debug_ring_buffer=",
-    "[0x00270028,0x00260027,0x00250026,0x00240025,0x00230024,0x00220023,0x00210022,0x00200021,",
-    " 0x001f0020,0x001e001f,0x001d001e,0x001c001d,0x001b001c,0x001a001b,0x0019001a,0x00180019,",
-    " 0x00170018,0x00160017,0x00150016,0x00140015,0x00130014,0x00120013,0x00110012,0x00100011,",
-    " 0x000f0010,0x000e000f,0x000d000e,0x000c000d,0x000b000c,0x000a000b,0x0009000a,0x00080009,",
-    "]"
-};
+constexpr uint32_t NUM_PUSHES_SINGLE = 40;  // Single-thread tests push 40 values
+constexpr uint32_t NUM_PUSHES_MULTI = 4;    // Multi-DM test: 4 pushes per DM (8 DMs x 4 = 32 total)
+
+// Generate expected ring buffer data for TRISC/ERISC/BH/WH tests
+// Pattern: (idx << 16) | (idx + 1), buffer holds 32, newest first (40 down to 9)
+std::vector<uint32_t> get_expected_data() {
+    std::vector<uint32_t> data;
+    for (uint32_t idx = NUM_PUSHES_SINGLE - 1; idx >= NUM_PUSHES_SINGLE - 32; idx--) {
+        data.push_back((idx << 16) | (idx + 1));
+    }
+    return data;
+}
+
+// Generate expected ring buffer data for Quasar single-DM tests
+// Pattern: (thread_idx << 16) | seq, buffer holds 32, newest first
+std::vector<uint32_t> get_expected_data_dm(uint32_t thread_idx) {
+    std::vector<uint32_t> data;
+    for (uint32_t seq = NUM_PUSHES_SINGLE - 1; seq >= NUM_PUSHES_SINGLE - 32; seq--) {
+        data.push_back((thread_idx << 16) | seq);
+    }
+    return data;
+}
+
+// Expected strings for BH/WH (SPSC format)
+std::vector<std::string> get_expected_spsc() {
+    auto data = get_expected_data();
+    std::vector<std::string> result = {"debug_ring_buffer="};
+    auto lines = FormatRingBuffer(data);
+    result.insert(result.end(), lines.begin(), lines.end());
+    return result;
+}
+
+// Expected strings for Quasar single-DM (MPSC format with processor prefix)
+std::vector<std::string> get_expected_mpsc(HalProgrammableCoreType core_type, uint32_t thread_idx) {
+    auto data = get_expected_data_dm(thread_idx);
+    std::vector<uint32_t> thread_indices(data.size(), thread_idx);  // All from same thread in test
+    std::vector<std::string> result = {"debug_ring_buffer="};
+    auto lines = FormatRingBuffer(data, thread_indices, core_type);
+    result.insert(result.end(), lines.begin(), lines.end());
+    return result;
+}
+
+// Expected strings for Quasar multi-DM test (MPSC format)
+// Verifies all 8 DMs wrote entries with matching [DMx] prefix and data
+std::vector<std::string> get_expected_multi_dm() {
+    std::vector<std::string> expected = {"debug_ring_buffer="};
+    for (uint32_t dm = 0; dm < 8; dm++) {
+        // First push from each DM: (dm << 16) | 0
+        expected.push_back(fmt::format("[DM{}]0x{:08x}", dm, (dm << 16) | 0));
+    }
+    return expected;
+}
 
 namespace {
 
 void RunTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    HalProcessorIdentifier processor) {
+    HalProcessorIdentifier processor,
+    bool multi_dm_test = false) {
     // Set up program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -50,6 +98,7 @@ void RunTest(
     workload.add_program(device_range, {});
     auto& program = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
+    bool is_quasar = device->arch() == tt::ARCH::QUASAR;
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc
@@ -60,31 +109,59 @@ void RunTest(
             virtual_core = device->worker_core_from_logical_core(logical_core);
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM: {
-                    DataMovementConfig dm_config{};
-                    switch (processor.processor_type) {
-                        case 0:
-                            dm_config.processor = tt_metal::DataMovementProcessor::RISCV_0;
-                            dm_config.noc = tt_metal::NOC::RISCV_0_default;
-                            break;
-                        case 1:
-                            dm_config.processor = tt_metal::DataMovementProcessor::RISCV_1;
-                            dm_config.noc = tt_metal::NOC::RISCV_1_default;
-                            break;
-                        default: TT_THROW("Unsupported DM processor type {}", processor.processor_type);
+                    if (is_quasar) {
+                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
+                        std::vector<uint32_t> compile_args =
+                            multi_dm_test ? std::vector<uint32_t>{num_pushes}
+                                          : std::vector<uint32_t>{num_pushes, processor.processor_type};
+                        std::map<std::string, std::string> defines =
+                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
+                                          : std::map<std::string, std::string>{};
+                        tt::tt_metal::experimental::quasar::CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                                .num_threads_per_cluster = 8, .compile_args = compile_args, .defines = defines});
+                    } else {
+                        DataMovementConfig dm_config{};
+                        dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
+                        dm_config.noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
+                                                                        : tt_metal::NOC::RISCV_1_default;
+                        dm_config.compile_args = {NUM_PUSHES_SINGLE};
+                        CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            dm_config);
                     }
-                    CreateKernel(
-                        program,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                        logical_core,
-                        dm_config);
                     break;
                 }
                 case HalProcessorClassType::COMPUTE:
-                    CreateKernel(
-                        program,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                        logical_core,
-                        ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
+                    if (is_quasar) {
+                        uint32_t num_threads = multi_dm_test ? 4 : 1;
+                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
+                        std::map<std::string, std::string> defines =
+                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
+                                          : std::map<std::string, std::string>{
+                                                {fmt::format("TRISC{}", processor.processor_type), "1"}};
+                        tt::tt_metal::experimental::quasar::CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            experimental::quasar::QuasarComputeConfig{
+                                .num_threads_per_cluster = num_threads,
+                                .compile_args = {num_pushes},
+                                .defines = defines});
+                    } else {
+                        CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            ComputeConfig{
+                                .compile_args = {NUM_PUSHES_SINGLE},
+                                .defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
+                    }
                     break;
             }
             break;
@@ -99,7 +176,7 @@ void RunTest(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
                 logical_core,
-                EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
             break;
         case HalProgrammableCoreType::IDLE_ETH:
             if (device->get_inactive_ethernet_cores().empty()) {
@@ -112,7 +189,8 @@ void RunTest(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
                 logical_core,
-                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+                EthernetConfig{
+                    .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
             break;
         case HalProgrammableCoreType::DRAM:
             log_info(LogTest, "Skipping: DRAM cores do not support watcher ring buffer tests.");
@@ -127,12 +205,24 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Check log
-    EXPECT_TRUE(
-        FileContainsAllStringsInOrder(
-            fixture->log_file_name,
-            expected
-        )
-    );
+    if (is_quasar) {
+        if (multi_dm_test) {
+            EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, get_expected_multi_dm()));
+        } else {
+            // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
+            uint32_t thread_idx = processor.processor_type;
+            if (processor.processor_class == HalProcessorClassType::COMPUTE) {
+                // Compute processors start after DM processors in the HAL index
+                const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+                thread_idx =
+                    hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+            }
+            EXPECT_TRUE(FileContainsAllStringsInOrder(
+                fixture->log_file_name, get_expected_mpsc(processor.core_type, thread_idx)));
+        }
+    } else {
+        EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, get_expected_spsc()));
+    }
 }
 
 using enum HalProgrammableCoreType;
@@ -207,6 +297,20 @@ TEST_F(MeshWatcherFixture, TestWatcherRingBufferIErisc) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                 RunTest(fixture, mesh_device, {IDLE_ETH, DM, 0});
+            },
+            mesh_device);
+    }
+}
+
+TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiDM) {
+    for (auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        if (device->arch() != tt::ARCH::QUASAR) {
+            GTEST_SKIP() << "Multi-DM MPSC test is Quasar-only";
+        }
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunTest(fixture, mesh_device, {TENSIX, DM, 0}, /*multi_dm_test=*/true);
             },
             mesh_device);
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -233,6 +233,7 @@ class WatcherRingBufferTest : public MeshWatcherFixture, public ::testing::WithP
 TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
     const auto& params = GetParam();
     const auto& hal = MetalContext::instance().hal();
+    bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
 
     // Skip if processor type not available on this architecture
     uint32_t core_type_index = hal.get_programmable_core_type_index(params.processor.core_type);
@@ -245,12 +246,11 @@ TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
     }
 
     // Multi-threaded test is Quasar-only
-    if (params.multi_threaded && hal.get_arch() != tt::ARCH::QUASAR) {
+    if (params.multi_threaded && !is_quasar) {
         GTEST_SKIP() << "Multi-threaded test is Quasar-only";
     }
 
     // Quasar and IDLE_ETH require slow dispatch
-    bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
     bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
     if ((is_quasar || is_idle_eth) && !this->IsSlowDispatch()) {
         GTEST_SKIP() << "Quasar and IDLE_ETH require Slow Dispatch";

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -35,40 +35,32 @@ using namespace tt::tt_metal;
 namespace {
 const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
 
-// Overflow amount for single-processor tests
-constexpr uint32_t OVERFLOW_AMOUNT = 12;
-
 // Pushes per processor for multi-threaded test (24 x 5 = 120, fits in 128-element MPSC buffer)
 constexpr uint32_t PUSHES_PER_PROCESSOR_MULTI = 5;
 
-// Expected strings for single-processor tests (SPSC for WH/BH, MPSC for Quasar)
+// Expected strings for single-processor tests
 // Pattern: SPSC uses (idx << 16) | (idx + 1), MPSC uses (thread_idx << 16) | seq
 // Newest first, limited to buffer capacity
 std::vector<std::string> get_expected_single_processor(
     HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    bool is_mpsc = hal.has_mpsc_ring_buffer();
     uint32_t capacity = hal.get_ring_buffer_capacity();
     uint32_t first_visible = (num_pushes > capacity) ? num_pushes - capacity : 0;
 
-    std::vector<uint32_t> data;
-    std::vector<uint32_t> thread_indices;
+    std::vector<std::string> result = {"debug_ring_buffer="};
     for (uint32_t seq = num_pushes - 1; seq >= first_visible && seq < num_pushes; seq--) {
-        if (is_quasar) {
-            data.push_back((thread_idx << 16) | seq);
-            thread_indices.push_back(thread_idx);
+        if (is_mpsc) {
+            auto proc_name = hal.get_processor_class_name(core_type, thread_idx, false);
+            result.push_back(fmt::format("[{}]0x{:08x}", proc_name, (thread_idx << 16) | seq));
         } else {
-            data.push_back((seq << 16) | (seq + 1));
+            result.push_back(fmt::format("0x{:08x}", (seq << 16) | (seq + 1)));
         }
     }
-
-    std::vector<std::string> result = {"debug_ring_buffer="};
-    auto lines = is_quasar ? FormatRingBuffer(data, thread_indices, core_type) : FormatRingBuffer(data);
-    result.insert(result.end(), lines.begin(), lines.end());
     return result;
 }
 
-// Expected strings for Quasar multi-threaded test (all 24 processors)
+// Expected strings for Quasar multi-threaded test (all DMs + TRISCs)
 // Verifies all processors wrote all entries (order is non-deterministic)
 std::vector<std::string> get_expected_multi_threaded(
     HalProgrammableCoreType core_type, uint32_t num_processors, uint32_t pushes_per_proc) {
@@ -89,13 +81,7 @@ void RunMultiThreadedTest(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     HalProgrammableCoreType core_type) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    uint32_t tensix_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-    uint32_t num_dm = hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::DM));
-    uint32_t num_triscs =
-        hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
-    uint32_t num_neos = num_triscs / hal.get_processor_class_num_fw_binaries(
-                                         tensix_idx, static_cast<uint32_t>(HalProcessorClassType::COMPUTE));
-    uint32_t total_processors = num_dm + num_triscs;
+    uint32_t total_processors = hal.get_max_processors_per_core();
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -109,7 +95,7 @@ void RunMultiThreadedTest(
         kernel,
         logical_core,
         tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = num_dm,
+            .num_threads_per_cluster = 8,
             .compile_args = {PUSHES_PER_PROCESSOR_MULTI},
             .defines = {{"MULTI_THREADED_TEST", "1"}}});
 
@@ -118,7 +104,7 @@ void RunMultiThreadedTest(
         kernel,
         logical_core,
         tt::tt_metal::experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = num_neos,
+            .num_threads_per_cluster = 4,
             .compile_args = {PUSHES_PER_PROCESSOR_MULTI},
             .defines = {{"MULTI_THREADED_TEST", "1"}}});
 
@@ -135,7 +121,6 @@ void RunTest(
     HalProcessorIdentifier processor) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
-    uint32_t tensix_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -146,23 +131,19 @@ void RunTest(
     CoreCoord logical_core = {0, 0};
     CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
 
-    // Single-processor tests
-    uint32_t num_pushes = hal.get_ring_buffer_capacity() + OVERFLOW_AMOUNT;
+    uint32_t num_pushes = hal.get_ring_buffer_capacity() + 12;  // overflow to test wraparound
 
     switch (processor.core_type) {
         case HalProgrammableCoreType::TENSIX:
             switch (processor.processor_class) {
-                case HalProcessorClassType::DM:
+                case HalProcessorClassType::DM: {
                     if (is_quasar) {
-                        uint32_t num_dm =
-                            hal.get_processor_types_count(tensix_idx, static_cast<uint32_t>(HalProcessorClassType::DM));
                         tt::tt_metal::experimental::quasar::CreateKernel(
                             program,
                             kernel,
                             logical_core,
                             tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                                .num_threads_per_cluster = num_dm,
-                                .compile_args = {num_pushes, processor.processor_type}});
+                                .num_threads_per_cluster = 8, .compile_args = {num_pushes, processor.processor_type}});
                     } else {
                         DataMovementConfig dm_config{
                             .processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type),
@@ -172,7 +153,7 @@ void RunTest(
                         CreateKernel(program, kernel, logical_core, dm_config);
                     }
                     break;
-
+                }
                 case HalProcessorClassType::COMPUTE:
                     if (is_quasar) {
                         tt::tt_metal::experimental::quasar::CreateKernel(
@@ -193,16 +174,14 @@ void RunTest(
                                 .defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     }
                     break;
-                default: TT_THROW("Unsupported processor class");
             }
             break;
-
-        case HalProgrammableCoreType::ACTIVE_ETH: {
-            auto eth_cores = device->get_active_ethernet_cores(true);
-            if (eth_cores.empty()) {
-                GTEST_SKIP() << "Device has no active ethernet cores";
+        case HalProgrammableCoreType::ACTIVE_ETH:
+            if (device->get_active_ethernet_cores(true).empty()) {
+                log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+                GTEST_SKIP();
             }
-            logical_core = *eth_cores.begin();
+            logical_core = *(device->get_active_ethernet_cores(true).begin());
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
@@ -210,14 +189,12 @@ void RunTest(
                 logical_core,
                 EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
-        }
-
-        case HalProgrammableCoreType::IDLE_ETH: {
-            auto eth_cores = device->get_inactive_ethernet_cores();
-            if (eth_cores.empty()) {
-                GTEST_SKIP() << "Device has no inactive ethernet cores";
+        case HalProgrammableCoreType::IDLE_ETH:
+            if (device->get_inactive_ethernet_cores().empty()) {
+                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+                GTEST_SKIP();
             }
-            logical_core = *eth_cores.begin();
+            logical_core = *(device->get_inactive_ethernet_cores().begin());
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
@@ -225,19 +202,17 @@ void RunTest(
                 logical_core,
                 EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
-        }
-
-        case HalProgrammableCoreType::DRAM: {
+        case HalProgrammableCoreType::DRAM:
             log_info(LogTest, "Skipping: DRAM cores do not support watcher ring buffer tests.");
             GTEST_SKIP();
-        }
-
-        default: TT_THROW("Unsupported core type");
+        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported core type");
     }
-
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
+
+    // Run the program
     fixture->RunProgram(mesh_device, workload, true);
-    log_info(LogTest, "Checking file: {}", fixture->log_file_name);
+
+    log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Validate output
     uint32_t thread_idx = processor.processor_type;
@@ -247,8 +222,6 @@ void RunTest(
     EXPECT_TRUE(FileContainsAllStringsInOrder(
         fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
 }
-
-}  // namespace
 
 // Test parameters
 struct RingBufferTestParams {
@@ -278,16 +251,11 @@ TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
         GTEST_SKIP() << "Multi-threaded test is Quasar-only";
     }
 
-    // IDLE_ETH requires slow dispatch
-    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
-    if (is_idle_eth && !this->IsSlowDispatch()) {
-        GTEST_SKIP() << "IDLE_ETH requires Slow Dispatch";
-    }
-
-    // Slow dispatch tests only on Quasar or IDLE_ETH
+    // Quasar and IDLE_ETH require slow dispatch
     bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
-    if (this->IsSlowDispatch() && !is_quasar && !is_idle_eth) {
-        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    if ((is_quasar || is_idle_eth) && !this->IsSlowDispatch()) {
+        GTEST_SKIP() << "Quasar and IDLE_ETH require Slow Dispatch";
     }
 
     for (auto& mesh_device : this->devices_) {
@@ -330,3 +298,5 @@ INSTANTIATE_TEST_SUITE_P(
         // Multi-threaded test (Quasar only, all 24 processors)
         RingBufferTestParams{"MultiThreaded", {TENSIX, DM, 0}, /*multi_threaded=*/true}),
     [](const ::testing::TestParamInfo<RingBufferTestParams>& info) { return info.param.test_name; });
+
+}  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -215,10 +215,8 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Validate output
-    uint32_t thread_idx = processor.processor_type;
-    if (is_quasar && processor.processor_class == HalProcessorClassType::COMPUTE) {
-        thread_idx = hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
-    }
+    uint32_t thread_idx =
+        hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
     EXPECT_TRUE(FileContainsAllStringsInOrder(
         fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -5,72 +5,50 @@
 #include <cstdint>
 #include "api/debug/ring_buffer.h"
 #include "api/compile_time_args.h"
-#if defined(ARCH_QUASAR)
-// Use internal_::get_hw_thread_idx() to get HAL processor index (0-7 for DM, 8+ for TRISC).
-// This matches the thread_idx embedded in MPSC write_id by ring_buffer.h, ensuring the
-// data payload's thread_idx matches the prefix shown in watcher output (e.g., [Neo0TRISC0]).
-// Note: get_my_thread_id() returns a different value (processor-local index) and would mismatch.
+
+/*
+ * A test for the watcher ringbuffer feature.
+*/
+#ifdef COMPILE_FOR_TRISC
+#include "api/compute/common.h"
+#endif
+#ifdef MPSC_RING_BUFFER
 #include "internal/hw_thread.h"
 #endif
 
-/*
- * A test for the watcher ring buffer feature.
-*/
-#if defined(COMPILE_FOR_TRISC)
-#include "api/compute/common.h"
+// Single-TRISC filter: match UCK binary type to target TRISCx define
+#if defined(COMPILE_FOR_TRISC) && !defined(MULTI_THREADED_TEST)
+#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
+    (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
+    (defined(UCK_CHLKC_PACK) && defined(TRISC2)) || \
+    (defined(UCK_CHLKC_ISOLATE_SFPU) && defined(TRISC3))
+#define IS_TARGET_TRISC
+#endif
 #endif
 
 void kernel_main() {
     constexpr uint32_t num_pushes = get_compile_time_arg_val(0);
 
-#if defined(COMPILE_FOR_DM)
+#ifdef MPSC_RING_BUFFER
+    // MPSC: push (thread_idx << 16) | seq
     uint32_t thread_idx = internal_::get_hw_thread_idx();
-#if !defined(MULTI_THREADED_TEST)
-    // Single-DM test: only specified DM runs
-    constexpr uint32_t dm_id = get_compile_time_arg_val(1);
-    if (dm_id != thread_idx) {
-        return;
-    }
+
+#if defined(COMPILE_FOR_DM) && !defined(MULTI_THREADED_TEST)
+    constexpr uint32_t target_dm = get_compile_time_arg_val(1);
+    if (target_dm != thread_idx) return;
 #endif
+
+#if !defined(COMPILE_FOR_TRISC) || defined(MULTI_THREADED_TEST) || defined(IS_TARGET_TRISC)
     for (uint32_t seq = 0; seq < num_pushes; seq++) {
         WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
     }
 #endif
 
-#if defined(COMPILE_FOR_TRISC)
-#if defined(MULTI_THREADED_TEST)
-    // Multi-threaded test: all TRISCs run
-    uint32_t thread_idx = internal_::get_hw_thread_idx();
-    for (uint32_t seq = 0; seq < num_pushes; seq++) {
-        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
-    }
-#elif defined(ARCH_QUASAR)
-    // Quasar single-TRISC: filter by TRISCx define
-#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
-    (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
-    (defined(UCK_CHLKC_PACK) && defined(TRISC2)) || \
-    (defined(UCK_CHLKC_UNPACK) && defined(TRISC3))
-    uint32_t thread_idx = internal_::get_hw_thread_idx();
-    for (uint32_t seq = 0; seq < num_pushes; seq++) {
-        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
-    }
-#endif
-#else
-    // WH/BH SPSC: use idx pattern
-#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
-    (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
-    (defined(UCK_CHLKC_PACK) && defined(TRISC2))
+#else  // SPSC: push (idx << 16) | (idx + 1)
+#if !defined(COMPILE_FOR_TRISC) || defined(IS_TARGET_TRISC)
     for (uint32_t idx = 0; idx < num_pushes; idx++) {
-        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
+        WATCHER_RING_BUFFER_PUSH((idx << 16) | (idx + 1));
     }
 #endif
-#endif
-#endif
-
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
-    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    for (uint32_t idx = 0; idx < num_pushes; idx++) {
-        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
-    }
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -4,22 +4,60 @@
 
 #include <cstdint>
 #include "api/debug/ring_buffer.h"
+#include "api/compile_time_args.h"
+#if defined(ARCH_QUASAR)
+// Use internal_::get_hw_thread_idx() to get HAL processor index (0-7 for DM, 8+ for TRISC).
+// This matches the thread_idx embedded in MPSC write_id by ring_buffer.h, ensuring the
+// data payload's thread_idx matches the prefix shown in watcher output (e.g., [Neo0TRISC0]).
+// Note: get_my_thread_id() returns a different value (processor-local index) and would mismatch.
+#include "internal/hw_thread.h"
+#endif
 
 /*
- * A test for the watcher waypointing feature.
+ * A test for the watcher ring buffer feature.
 */
-#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && \
-    !defined(COMPILE_FOR_IDLE_ERISC)
+#if defined(COMPILE_FOR_TRISC)
 #include "api/compute/common.h"
 #endif
 
 void kernel_main() {
-    // Conditionally enable using defines for each trisc
-#if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
-    (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
-    (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
-    for (uint32_t idx = 0; idx < 40; idx++) {
+    constexpr uint32_t num_pushes = get_compile_time_arg_val(0);
+
+#if defined(COMPILE_FOR_DM)
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+#if !defined(MULTI_DM_TEST)
+    // Single-DM test: only specified DM runs
+    constexpr uint32_t dm_id = get_compile_time_arg_val(1);
+    if (dm_id != thread_idx) {
+        return;
+    }
+#endif
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+    return;
+#endif
+
+#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
+      (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
+      (defined(UCK_CHLKC_PACK) && defined(TRISC2))
+#if defined(ARCH_QUASAR)
+    // Quasar: use HAL thread_idx for MPSC verification
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+#else
+    // WH/BH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
+    for (uint32_t idx = 0; idx < num_pushes; idx++) {
+        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
+    }
+#endif
+#endif
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
+    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+    for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
 
 #if defined(COMPILE_FOR_DM)
     uint32_t thread_idx = internal_::get_hw_thread_idx();
-#if !defined(MULTI_DM_TEST)
+#if !defined(MULTI_THREADED_TEST)
     // Single-DM test: only specified DM runs
     constexpr uint32_t dm_id = get_compile_time_arg_val(1);
     if (dm_id != thread_idx) {
@@ -35,23 +35,35 @@ void kernel_main() {
     for (uint32_t seq = 0; seq < num_pushes; seq++) {
         WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
     }
-    return;
 #endif
 
-#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
-      (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
-      (defined(UCK_CHLKC_PACK) && defined(TRISC2))
-#if defined(ARCH_QUASAR)
-    // Quasar: use HAL thread_idx for MPSC verification
+#if defined(COMPILE_FOR_TRISC)
+#if defined(MULTI_THREADED_TEST)
+    // Multi-threaded test: all TRISCs run
     uint32_t thread_idx = internal_::get_hw_thread_idx();
     for (uint32_t seq = 0; seq < num_pushes; seq++) {
         WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
     }
+#elif defined(ARCH_QUASAR)
+    // Quasar single-TRISC: filter by TRISCx define
+#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
+    (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
+    (defined(UCK_CHLKC_PACK) && defined(TRISC2)) || \
+    (defined(UCK_CHLKC_UNPACK) && defined(TRISC3))
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+#endif
 #else
-    // WH/BH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
+    // WH/BH SPSC: use idx pattern
+#if (defined(UCK_CHLKC_UNPACK) && defined(TRISC0)) || \
+    (defined(UCK_CHLKC_MATH) && defined(TRISC1)) || \
+    (defined(UCK_CHLKC_PACK) && defined(TRISC2))
     for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
+#endif
 #endif
 #endif
 

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -4,30 +4,75 @@
 
 #pragma once
 
-// We use a magic value to initialize the ring buffer to, so that we can avoid printing it to the
-// watcher log if no ring buffer data has been written. Choose -1 so that we can increment it to
-// 0 and immediately use it as an index for the first write.
-constexpr static int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
-
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "hostdev/dev_msgs.h"
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
-void push_to_ring_buffer(uint32_t val) {
-    auto buf = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+// Ring buffer modes:
+// - Quasar: MPSC (32-bit atomics, lock-free) - works on both DM (tt-qsr64) and TRISC (tt-qsr32)
+// - WH/BH: SPSC
+
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+#include "internal/hw_thread.h"
+
+inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
+    asm volatile("fence" ::: "memory");
+    volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
+    *flush_reg = static_cast<uint64_t>(addr);
+    asm volatile("fence" ::: "memory");
+}
+
+// Must be inline - DM stack is only 1KB, can't afford function call overhead
+inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
+    auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+    auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
+
+    // Remap to cached for atomics
+    uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
+    if (addr >= MEM_L1_UNCACHED_BASE) {
+        buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
+    }
+
+    // Atomically claim a slot
+    uint32_t pos = __atomic_fetch_add(&buf->head, 1, __ATOMIC_RELAXED);
+    uint32_t idx = pos & DEBUG_RING_BUFFER_MASK;
+
+    // Write data
+    buf->slots[idx].data = val;
+
+    // Publish with thread ID + position (for host validation & hole detection)
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    uint32_t write_id = (thread_idx << DEBUG_RING_BUFFER_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_POS_MASK);
+    __atomic_store_n(&buf->slots[idx].write_id, write_id, __ATOMIC_RELEASE);
+
+    // Flush cache line for host visibility
+    // TODO: can this be optimized by flushing only after N amount of heads
+    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));
+    // Head needs to be flushed separately since it lies on a different cache line
+    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->head));
+}
+
+#else  // WH/BH: SPSC ring buffer
+
+inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
+    auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+    auto* buf = reinterpret_cast<debug_spsc_ring_buf_msg_t tt_l1_ptr*>(wrapper->data);
     volatile tt_l1_ptr int16_t* curr_ptr = &buf->current_ptr;
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;
 
-    // Bounds check, set to -1 to wrap since we increment before using.
+    // Bounds check, set to -1 to wrap since we increment before using
     if (*curr_ptr >= DEBUG_RING_BUFFER_ELEMENTS - 1) {
         *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
         *wrapped = 1;
     }
     data[++(*curr_ptr)] = val;
 }
+
+#endif  // ARCH_QUASAR
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
 #else  // !defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -17,42 +17,36 @@
 #if defined(ARCH_QUASAR)
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
 #include "internal/hw_thread.h"
+#include "risc_common.h"
 
-inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
-    asm volatile("fence" ::: "memory");
-    volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
-    *flush_reg = static_cast<uint64_t>(addr);
-    asm volatile("fence" ::: "memory");
-}
-
-// Must be inline - DM stack is only 1KB, can't afford function call overhead
+// MPSC ring buffer for Quasar watcher debug
+// Strategy: Use cached memory for atomic slot reservation (atomics on RISC-V require cache),
+// but write data to uncached memory for immediate host visibility without flush overhead
+// Uncached writes are much faster than cache + flush per entry
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
-
-    // Remap to cached for atomics
     uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
-    if (addr >= MEM_L1_UNCACHED_BASE) {
-        buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
-    }
+
+    // Cached for atomics (required by hardware), uncached for data (host visibility)
+    auto* cached_buf = (addr >= MEM_L1_UNCACHED_BASE)
+                           ? reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE)
+                           : buf;
+    auto* uncached_buf =
+        (addr < MEM_L1_UNCACHED_BASE) ? reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr + MEM_L1_UNCACHED_BASE) : buf;
 
     // Atomically claim a slot
-    uint32_t pos = __atomic_fetch_add(&buf->head, 1, __ATOMIC_RELAXED);
-    uint32_t idx = pos & DEBUG_RING_BUFFER_MASK;
+    uint32_t pos = __atomic_fetch_add(&cached_buf->head, 1, __ATOMIC_RELAXED);
+    uint32_t idx = pos & DEBUG_RING_BUFFER_MPSC_MASK;
 
-    // Write data
-    buf->slots[idx].data = val;
+    // Write to uncached: immediately visible to host, no flush needed
+    uncached_buf->slots[idx].data = val;
 
-    // Publish with thread ID + position (for host validation & hole detection)
+    // Publish write_id (host uses this to detect valid vs in-flight entries)
     uint32_t thread_idx = internal_::get_hw_thread_idx();
-    uint32_t write_id = (thread_idx << DEBUG_RING_BUFFER_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_POS_MASK);
-    __atomic_store_n(&buf->slots[idx].write_id, write_id, __ATOMIC_RELEASE);
-
-    // Flush cache line for host visibility
-    // TODO: can this be optimized by flushing only after N amount of heads
-    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));
-    // Head needs to be flushed separately since it lies on a different cache line
-    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->head));
+    uint32_t write_id =
+        (thread_idx << DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
+    uncached_buf->slots[idx].write_id = write_id;
 }
 
 #else  // WH/BH: SPSC ring buffer
@@ -65,7 +59,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     uint32_t* data = buf->data;
 
     // Bounds check, set to -1 to wrap since we increment before using
-    if (*curr_ptr >= DEBUG_RING_BUFFER_ELEMENTS - 1) {
+    if (*curr_ptr >= static_cast<int16_t>(DEBUG_RING_BUFFER_ELEMENTS - 1)) {
         *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
         *wrapped = 1;
     }

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -11,13 +11,17 @@
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
 #ifdef MPSC_RING_BUFFER
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+#endif  // ARCH_QUASAR
 #include "internal/hw_thread.h"
 #include "risc_common.h"
+#endif  // MPSC_RING_BUFFER
 
 // MPSC: Use cached memory for atomic slot reservation, uncached for data (host visibility)
-inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
+void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+#ifdef MPSC_RING_BUFFER
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
     uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
 
@@ -40,12 +44,8 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     uint32_t write_id =
         (thread_idx << DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
     uncached_buf->slots[idx].write_id = write_id;
-}
 
-#else  // SPSC ring buffer
-
-inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
-    auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+#else   // SPSC ring buffer
     auto* buf = reinterpret_cast<debug_spsc_ring_buf_msg_t tt_l1_ptr*>(wrapper->data);
     volatile tt_l1_ptr int16_t* curr_ptr = &buf->current_ptr;
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
@@ -57,9 +57,8 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
         *wrapped = 1;
     }
     data[++(*curr_ptr)] = val;
-}
-
 #endif  // MPSC_RING_BUFFER
+}
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
 #else  // !defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -10,25 +10,18 @@
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
-// Ring buffer modes:
-// - Quasar: MPSC (32-bit atomics, lock-free) - works on both DM (tt-qsr64) and TRISC (tt-qsr32)
-// - WH/BH: SPSC
-
-#if defined(ARCH_QUASAR)
+#ifdef MPSC_RING_BUFFER
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
 #include "internal/hw_thread.h"
 #include "risc_common.h"
 
-// MPSC ring buffer for Quasar watcher debug
-// Strategy: Use cached memory for atomic slot reservation (atomics on RISC-V require cache),
-// but write data to uncached memory for immediate host visibility without flush overhead
-// Uncached writes are much faster than cache + flush per entry
+// MPSC: Use cached memory for atomic slot reservation, uncached for data (host visibility)
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
     uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
 
-    // Cached for atomics (required by hardware), uncached for data (host visibility)
+    // TODO: Remove remap once mailbox uses cached access
     auto* cached_buf = (addr >= MEM_L1_UNCACHED_BASE)
                            ? reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE)
                            : buf;
@@ -49,7 +42,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     uncached_buf->slots[idx].write_id = write_id;
 }
 
-#else  // WH/BH: SPSC ring buffer
+#else  // SPSC ring buffer
 
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
@@ -58,7 +51,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;
 
-    // Bounds check, set to -1 to wrap since we increment before using
+    // Bounds check, set to -1 to wrap since we increment before using.
     if (*curr_ptr >= static_cast<int16_t>(DEBUG_RING_BUFFER_ELEMENTS - 1)) {
         *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
         *wrapped = 1;
@@ -66,7 +59,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     data[++(*curr_ptr)] = val;
 }
 
-#endif  // ARCH_QUASAR
+#endif  // MPSC_RING_BUFFER
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
 #else  // !defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -6,9 +6,19 @@
 
 #include <cstdint>
 
+// Debug ring buffer to be used on Kernels.
+// We use a  SPSC on WH/BH since no atomics are supported but MPSC on quasar's threaded model.
+
+// MPSC protocol:
+// 1. Atomically claim slot via fetch_add on head
+// 2. Write data to claimed slot (uncached)
+// 3. Publish via write_id (encodes thread_idx + position idx for validation)
+// 4. Host validates empty/full slots by matching written position idx from write_id with expected position idx
+// 5. Overwriting is ok - host stores recent entries for display
+
 // SPSC (WH/BH)
 constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
-constexpr int DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
+constexpr uint32_t DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
 
 struct debug_spsc_ring_buf_msg_t {
     int16_t current_ptr;
@@ -16,13 +26,15 @@ struct debug_spsc_ring_buf_msg_t {
     uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
 };
 
-// MPSC (Quasar) - lock-free ring buffer for concurrent writes using 32-bit atomics
-// Works on both tt-qsr64 (DM) and tt-qsr32 (TRISC)
-constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = 32;
+// MPSC (Quasar): lock-free ring buffer for concurrent writes using 32-bit atomics
+// Works on both DMs (tt-qsr64) and TRISCs (tt-qsr32)
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_ELEMENTS = 128;
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx (0-31)
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position idx
 
+// Per-entry slot in MPSC
+// Consists of 32-bit data entry + write_id metadata
 struct debug_mpsc_ring_buf_slot_t {
     uint32_t data;
     uint32_t write_id;  // [31:27] thread_idx | [26:0] (pos+1)
@@ -30,31 +42,31 @@ struct debug_mpsc_ring_buf_slot_t {
 
 struct debug_mpsc_ring_buf_msg_t {
     uint32_t head;
-    uint8_t _pad[60];  // Pad to 64-byte cache line
+    uint8_t _pad[60];  // Pad to 64-byte cache line (prevents false sharing as head will be updated on multiple cores)
     debug_mpsc_ring_buf_slot_t slots[DEBUG_RING_BUFFER_MPSC_ELEMENTS];
 };
 
 // Host-side MPSC helpers
+
+// Extract 5-bit thread_idx from write_id
 inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) {
     return write_id >> DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
 }
 
-inline uint32_t debug_ring_buffer_get_position(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
+inline uint32_t debug_ring_buffer_get_pos_idx(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
 
+// Checks if the written pos idx from device matches with expected pos idx on host
 inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected_pos) {
-    return debug_ring_buffer_get_position(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
+    return debug_ring_buffer_get_pos_idx(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
 }
 
 // Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #if defined(ARCH_QUASAR)
-constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
-constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_MASK;
-constexpr uint32_t DEBUG_RING_BUFFER_THREAD_ID_SHIFT = DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
-constexpr uint32_t DEBUG_RING_BUFFER_POS_MASK = DEBUG_RING_BUFFER_MPSC_POS_MASK;
+constexpr uint32_t DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
 #else
-constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+constexpr uint32_t DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
 #endif
 
 #endif  // KERNEL_BUILD || FW_BUILD

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -17,7 +17,7 @@
 
 // 27-bit position_idx makes ABA impractical (2^27 entries between collisions)
 
-// SPSC (WH/BH)
+// SPSC
 constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 constexpr uint32_t DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
 
@@ -27,7 +27,7 @@ struct debug_spsc_ring_buf_msg_t {
     uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
 };
 
-// MPSC (Quasar): lock-free ring buffer for concurrent writes using 32-bit atomics
+// MPSC: lock-free ring buffer for concurrent writes using 32-bit atomics
 // Works on both DMs (tt-qsr64) and TRISCs (tt-qsr32)
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_ELEMENTS = 128;
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// SPSC (WH/BH)
+constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
+constexpr int DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
+
+struct debug_spsc_ring_buf_msg_t {
+    int16_t current_ptr;
+    uint16_t wrapped;
+    uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
+};
+
+// MPSC (Quasar) - lock-free ring buffer for concurrent writes using 32-bit atomics
+// Works on both tt-qsr64 (DM) and tt-qsr32 (TRISC)
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = 32;
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx (0-31)
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position
+
+struct debug_mpsc_ring_buf_slot_t {
+    uint32_t data;
+    uint32_t write_id;  // [31:27] thread_idx | [26:0] (pos+1)
+};
+
+struct debug_mpsc_ring_buf_msg_t {
+    uint32_t head;
+    uint8_t _pad[60];  // Pad to 64-byte cache line
+    debug_mpsc_ring_buf_slot_t slots[DEBUG_RING_BUFFER_MPSC_ELEMENTS];
+};
+
+// Host-side MPSC helpers
+inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) {
+    return write_id >> DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
+}
+
+inline uint32_t debug_ring_buffer_get_position(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
+
+inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected_pos) {
+    return debug_ring_buffer_get_position(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
+}
+
+// Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+
+#if defined(ARCH_QUASAR)
+constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
+constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_MASK;
+constexpr uint32_t DEBUG_RING_BUFFER_THREAD_ID_SHIFT = DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
+constexpr uint32_t DEBUG_RING_BUFFER_POS_MASK = DEBUG_RING_BUFFER_MPSC_POS_MASK;
+#else
+constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+#endif
+
+#endif  // KERNEL_BUILD || FW_BUILD

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -6,15 +6,16 @@
 
 #include <cstdint>
 
-// Debug ring buffer to be used on Kernels.
-// We use a  SPSC on WH/BH since no atomics are supported but MPSC on quasar's threaded model.
+// Debug ring buffer: MPSC or SPSC, selected via HAL
 
 // MPSC protocol:
 // 1. Atomically claim slot via fetch_add on head
 // 2. Write data to claimed slot (uncached)
-// 3. Publish via write_id (encodes thread_idx + position idx for validation)
-// 4. Host validates empty/full slots by matching written position idx from write_id with expected position idx
+// 3. Publish via write_id (encodes thread_idx + position_idx for validation)
+// 4. Host validates slots (valid vs in-flight) by matching position_idx in write_id with expected
 // 5. Overwriting is ok - host stores recent entries for display
+
+// 27-bit position_idx makes ABA impractical (2^27 entries between collisions)
 
 // SPSC (WH/BH)
 constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
@@ -31,7 +32,7 @@ struct debug_spsc_ring_buf_msg_t {
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_ELEMENTS = 128;
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position idx
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position_idx
 
 // Per-entry slot in MPSC
 // Consists of 32-bit data entry + write_id metadata
@@ -55,7 +56,7 @@ inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) {
 
 inline uint32_t debug_ring_buffer_get_pos_idx(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
 
-// Checks if the written pos idx from device matches with expected pos idx on host
+// Validates slot: producer stores (pos+1) so valid slots are never zero (distinguishes from zero-init)
 inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected_pos) {
     return debug_ring_buffer_get_pos_idx(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
 }
@@ -63,7 +64,7 @@ inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected
 // Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
-#if defined(ARCH_QUASAR)
+#if defined(MPSC_RING_BUFFER)
 constexpr uint32_t DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
 #else
 constexpr uint32_t DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -30,6 +30,7 @@
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
 #include "hostdev/device_print_common.h"
+#include "hostdev/debug_ring_buffer_common.h"
 
 #ifdef HAL_BUILD
 // HAL will include this file for different arch/cores, resulting in conflicting definitions that
@@ -291,12 +292,8 @@ struct debug_pause_msg_t {
     uint8_t pad[3];  // CODEGEN:skip
 };
 
-constexpr static int DEBUG_RING_BUFFER_ELEMENTS = 32;
-constexpr static int DEBUG_RING_BUFFER_SIZE = DEBUG_RING_BUFFER_ELEMENTS * sizeof(uint32_t);
 struct debug_ring_buf_msg_t {
-    int16_t current_ptr;
-    uint16_t wrapped;
-    uint32_t data[DEBUG_RING_BUFFER_ELEMENTS];
+    uint8_t data[debug_ring_buf_size];
 };
 
 struct debug_stack_usage_per_cpu_t {

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -42,5 +42,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -40,3 +41,6 @@ constexpr uint8_t tensix_harvest_axis = 0x2;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
@@ -40,5 +40,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 5
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -38,3 +39,6 @@ constexpr uint8_t tensix_harvest_axis = 0x1;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 5
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -102,5 +102,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6  // TODO: verify
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -100,3 +101,6 @@ constexpr uint8_t tensix_harvest_axis = 0x2;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6  // TODO: verify
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -99,7 +99,7 @@
 #define MEM_MAILBOX_BASE 16
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 57888
+#define MEM_MAILBOX_SIZE 58656
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -99,7 +99,7 @@
 #define MEM_MAILBOX_BASE 16
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 57696
+#define MEM_MAILBOX_SIZE 57888
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -133,6 +133,7 @@ set(HW_JIT_API_HEADERS
     inc/experimental/endpoints.h
     inc/experimental/core_local_mem.h
     inc/experimental/tensor.h
+    inc/hostdev/debug_ring_buffer_common.h
     inc/hostdev/dev_msgs.h
     inc/hostdev/device_print_common.h
     inc/hostdev/device_print_structures.h

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <set>
+#include <span>
 #include <vector>
 #include <cctype>
 #include <fmt/core.h>
@@ -217,4 +218,39 @@ inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_ty
     }
     return info;
 }
+
+// Format ring buffer output - auto-detects SPSC (WH/BH) vs MPSC (Quasar) based on arch
+// For MPSC, thread_indices and core_type are used to prefix entries with processor name
+// Returns vector of lines like ["[0x00270028,...,", " 0x001f0020,...,", "]"]
+// or for MPSC: ["[[DM0]0x00270028,...,", " [DM0]0x001f0020,...,", "]"]
+inline std::vector<std::string> FormatRingBuffer(
+    std::span<const uint32_t> data,
+    std::span<const uint32_t> thread_indices = {},
+    HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
+    if (data.empty()) {
+        return {};
+    }
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR);
+
+    std::vector<std::string> lines;
+    std::string line = "[";
+    for (size_t i = 0; i < data.size(); i++) {
+        if (is_mpsc && !thread_indices.empty()) {
+            auto name = hal.get_processor_class_name(core_type, thread_indices[i], false);
+            line += fmt::format("[{}]0x{:08x},", name, data[i]);
+        } else {
+            line += fmt::format("0x{:08x},", data[i]);
+        }
+        if ((i + 1) % 8 == 0 && i + 1 < data.size()) {
+            lines.push_back(line);
+            line = " ";  // Continuation lines start with space
+        }
+    }
+    line.pop_back();  // Remove trailing comma
+    line += "]";
+    lines.push_back(line);
+    return lines;
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -220,11 +220,9 @@ inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_ty
     return info;
 }
 
-// Format ring buffer output - auto-detects SPSC (WH/BH) vs MPSC (Quasar) based on arch
-// For MPSC, thread_indices and core_type are used to prefix entries with processor name
-// Returns vector of lines like ["[0x00270028,...,", " 0x001f0020,...,", "]"]
-// or for MPSC: ["[[DM0]0x00270028,...,", " [DM0]0x001f0020,...,", "]"]
-inline std::vector<std::string> FormatRingBuffer(
+// Format ring buffer data as hex values, 8 per line
+// If thread_indices provided (MPSC), prefixes each entry with processor name like [DM0]
+inline std::string FormatRingBuffer(
     std::span<const uint32_t> data,
     std::span<const uint32_t> thread_indices = {},
     HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
@@ -232,45 +230,23 @@ inline std::vector<std::string> FormatRingBuffer(
         return {};
     }
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR);
+    const bool is_mpsc = hal.has_mpsc_ring_buffer();
 
-    std::vector<std::string> lines;
-    std::string line = "[";
+    std::string result = "\n\tdebug_ring_buffer=\n\t[";
     for (size_t i = 0; i < data.size(); i++) {
         if (is_mpsc && !thread_indices.empty()) {
             auto name = hal.get_processor_class_name(core_type, thread_indices[i], false);
-            line += fmt::format("[{}]0x{:08x},", name, data[i]);
+            result += fmt::format("[{}]0x{:08x},", name, data[i]);
         } else {
-            line += fmt::format("0x{:08x},", data[i]);
+            result += fmt::format("0x{:08x},", data[i]);
         }
         if ((i + 1) % 8 == 0 && i + 1 < data.size()) {
-            lines.push_back(line);
-            line = " ";  // Continuation lines start with space
+            result += "\n\t ";  // Newline + indent for continuation
         }
     }
-    line.pop_back();  // Remove trailing comma
-    line += "]";
-    lines.push_back(line);
-    return lines;
-}
-
-// SPSC overload - extracts data in newest-first order and formats
-inline std::vector<std::string> FormatRingBuffer(
-    const debug_spsc_ring_buf_msg_t& buf, HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
-    if (buf.current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
-        return {};
-    }
-    // Extract newest-first: walk backwards from current_ptr, wrap at 0
-    std::vector<uint32_t> data;
-    int16_t ptr = buf.current_ptr;
-    int16_t count = buf.wrapped ? DEBUG_RING_BUFFER_SPSC_ELEMENTS : (ptr + 1);
-    for (int16_t i = 0; i < count; i++) {
-        data.push_back(buf.data[ptr]);
-        if (--ptr < 0) {
-            ptr = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
-        }
-    }
-    return FormatRingBuffer(data, {}, core_type);
+    result.pop_back();  // Remove trailing comma
+    result += "]";
+    return result;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -23,6 +23,7 @@
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
 #include "llrt/hal.hpp"
+#include "hostdev/debug_ring_buffer_common.h"
 
 namespace tt::tt_metal {
 
@@ -251,6 +252,25 @@ inline std::vector<std::string> FormatRingBuffer(
     line += "]";
     lines.push_back(line);
     return lines;
+}
+
+// SPSC overload - extracts data in newest-first order and formats
+inline std::vector<std::string> FormatRingBuffer(
+    const debug_spsc_ring_buf_msg_t& buf, HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
+    if (buf.current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
+        return {};
+    }
+    // Extract newest-first: walk backwards from current_ptr, wrap at 0
+    std::vector<uint32_t> data;
+    int16_t ptr = buf.current_ptr;
+    int16_t count = buf.wrapped ? DEBUG_RING_BUFFER_SPSC_ELEMENTS : (ptr + 1);
+    for (int16_t i = 0; i < count; i++) {
+        data.push_back(buf.data[ptr]);
+        if (--ptr < 0) {
+            ptr = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
+        }
+    }
+    return FormatRingBuffer(data, {}, core_type);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -875,35 +875,14 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
     string out;
-    if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {
-        out += "\n\tdebug_ring_buffer=\n\t[";
-        int curr_idx = ring_buf_data->current_ptr;
-        size_t ring_buffer_elements = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
-        for (int count = 1; count <= ring_buffer_elements; count++) {
-            out += fmt::format("0x{:08x},", ring_buf_data->data[curr_idx]);
-            if (count % 8 == 0) {
-                out += "\n\t ";
-            }
-            if (curr_idx == 0) {
-                if (ring_buf_data->wrapped == 0) {
-                    break;  // No wrapping, so no extra data available
-                }
-                curr_idx = ring_buffer_elements - 1;  // Loop
-            } else {
-                curr_idx--;
-            }
-        }
-        // Remove the last comma
-        out.pop_back();
-        out += "]";
+    auto lines = FormatRingBuffer(*ring_buf_data, programmable_core_type_);
+    if (!lines.empty()) {
+        out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
     }
 
     // This function can either dump to stdout or the log file.
     if (to_stdout) {
-        if (!out.empty()) {
-            out = string("Last ring buffer status: ") + out;
-            log_info(tt::LogMetal, "{}", out);
-        }
+        log_info(tt::LogMetal, "Last ring buffer status: {}", out);
     } else {
         fprintf(reader_.f, "%s", out.c_str());
     }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -916,8 +916,19 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
         const uint32_t pos = start_pos + i;
         const auto& slot = rb->slots[pos & mask];
 
-        // Slot not published yet (empty or in-flight). Fetch rest next poll.
         if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
+            if (slot.write_id != 0) {
+                // Convert pos_idx back to actual position (pos_idx = actual_pos + 1)
+                uint32_t actual_pos =
+                    (debug_ring_buffer_get_pos_idx(slot.write_id) - 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK;
+                uint32_t expected_pos = pos & DEBUG_RING_BUFFER_MPSC_POS_MASK;
+                if (actual_pos > expected_pos) {
+                    // producer Lapped consumer: resync to producer's actual position
+                    last_pos = actual_pos;
+                    log_warning(tt::LogMetal, "MPSC ring buffer overrun on {}, resyncing", core_str_);
+                }
+            }
+            // write_id == 0: empty or in-flight, wait for next poll
             break;
         }
         uint32_t thread_idx = debug_ring_buffer_get_thread_idx(slot.write_id);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -864,23 +864,32 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto& hal = reader_.env.get_hal();
 
-    // On Quasar, use MPSC ring buffer format
-    if (hal.get_arch() == tt::ARCH::QUASAR) {
+    if (hal.has_mpsc_ring_buffer()) {
         DumpMpscRingBuffer(to_stdout);
         return;
     }
 
-    // WH/BH: SPSC ring buffer - cast byte array wrapper to impl struct
-    const auto* ring_buf_data =
+    // SPSC ring buffer - cast byte array wrapper to impl struct
+    const auto* rb =
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
-    string out;
-    auto lines = FormatRingBuffer(*ring_buf_data, programmable_core_type_);
-    if (!lines.empty()) {
-        out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
+    if (rb->current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
+        return;  // No data
     }
 
-    // This function can either dump to stdout or the log file.
+    // Extract newest-first: walk backwards from current_ptr, wrap at 0
+    uint32_t capacity = hal.get_ring_buffer_capacity();
+    uint32_t mask = hal.get_ring_buffer_mask();
+    uint32_t count = rb->wrapped ? capacity : static_cast<uint32_t>(rb->current_ptr + 1);
+    uint32_t curr = static_cast<uint32_t>(rb->current_ptr);
+
+    std::vector<uint32_t> data;
+    data.reserve(count);
+    for (uint32_t i = 0; i < count; i++) {
+        data.push_back(rb->data[(curr + capacity - i) & mask]);
+    }
+
+    std::string out = FormatRingBuffer(data, {}, programmable_core_type_);
     if (to_stdout) {
         log_info(tt::LogMetal, "Last ring buffer status: {}", out);
     } else {
@@ -888,20 +897,13 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     }
 }
 
-// TODO: add some TT_FATALs to check metadata corruption
 void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
-    // Quasar MPSC ring buffer
     const auto& hal = reader_.env.get_hal();
-    auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type_);
-    auto watcher_offset = dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher);
-    auto ring_buf_field_offset =
-        dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::debug_ring_buf);
-    auto ring_buf_offset = watcher_offset + ring_buf_field_offset;
-    const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
-    const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
+    const auto* rb =
+        reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
-    constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
-    constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
+    uint32_t capacity = hal.get_ring_buffer_capacity();
+    uint32_t mask = hal.get_ring_buffer_mask();
 
     // Track position and buffer per core
     uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
@@ -909,14 +911,22 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
 
     // Collect new valid entries (oldest to newest)
     std::vector<MpscRingBufEntry> new_entries;
-    for (uint32_t pos = last_pos; pos < last_pos + capacity; pos++) {
+    const uint32_t start_pos = last_pos;
+    for (uint32_t i = 0; i < capacity; i++) {
+        const uint32_t pos = start_pos + i;
         const auto& slot = rb->slots[pos & mask];
 
-        // Detected empty slot/in-flight write. Break and fetch remaining entries next poll
+        // Slot not published yet (empty or in-flight). Fetch rest next poll.
         if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
             break;
         }
-        new_entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
+        uint32_t thread_idx = debug_ring_buffer_get_thread_idx(slot.write_id);
+        TT_FATAL(
+            thread_idx < hal.get_max_processors_per_core(),
+            "Invalid thread_idx {} in MPSC ring buffer (max {})",
+            thread_idx,
+            hal.get_max_processors_per_core());
+        new_entries.push_back({slot.data, thread_idx});
         last_pos = pos + 1;
     }
 
@@ -930,25 +940,24 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
         }
     }
 
-    // Output full buffer if non-empty
-    if (!entries.empty()) {
-        // Extract data and thread indices for formatter
-        std::vector<uint32_t> data, thread_indices;
-        data.reserve(entries.size());
-        thread_indices.reserve(entries.size());
-        for (const auto& e : entries) {
-            data.push_back(e.data);
-            thread_indices.push_back(e.thread_idx);
-        }
+    if (entries.empty()) {
+        return;
+    }
 
-        auto lines = FormatRingBuffer(data, thread_indices, programmable_core_type_);
-        string out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
+    // Extract data and thread indices for formatter
+    std::vector<uint32_t> data, thread_indices;
+    data.reserve(entries.size());
+    thread_indices.reserve(entries.size());
+    for (const auto& e : entries) {
+        data.push_back(e.data);
+        thread_indices.push_back(e.thread_idx);
+    }
 
-        if (to_stdout) {
-            log_info(tt::LogMetal, "Last ring buffer status: {}", out);
-        } else {
-            fprintf(reader_.f, "%s", out.c_str());
-        }
+    std::string out = FormatRingBuffer(data, thread_indices, programmable_core_type_);
+    if (to_stdout) {
+        log_info(tt::LogMetal, "{}", out);
+    } else {
+        fprintf(reader_.f, "%s", out.c_str());
     }
 }
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -888,6 +888,7 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     }
 }
 
+// TODO: add some TT_FATALs to check metadata corruption
 void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     // Quasar MPSC ring buffer
     const auto& hal = reader_.env.get_hal();
@@ -899,7 +900,6 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
     const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
 
-    const uint32_t head = rb->head;
     constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
     constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
 
@@ -907,17 +907,14 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
     auto& entries = reader_.mpsc_ring_buf_entries_[virtual_coord_];
 
-    // If buffer overflowed, advance to oldest valid position
-    if (head > last_pos + capacity) {
-        last_pos = head - capacity;
-    }
-
     // Collect new valid entries (oldest to newest)
     std::vector<MpscRingBufEntry> new_entries;
-    for (uint32_t pos = last_pos; pos < head; pos++) {
+    for (uint32_t pos = last_pos; pos < last_pos + capacity; pos++) {
         const auto& slot = rb->slots[pos & mask];
+
+        // Detected empty slot/in-flight write. Break and fetch remaining entries next poll
         if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
-            break;  // Hole - in-flight write, resume next poll
+            break;
         }
         new_entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
         last_pos = pos + 1;

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -906,8 +906,9 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     uint32_t mask = hal.get_ring_buffer_mask();
 
     // Track position and buffer per core
-    uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
-    auto& entries = reader_.mpsc_ring_buf_entries_[virtual_coord_];
+    auto& state = reader_.mpsc_ring_buf_entries_[virtual_coord_];
+    uint32_t& last_pos = state.last_pos;
+    auto& entries = state.entries;
 
     // Collect new valid entries (oldest to newest)
     std::vector<MpscRingBufEntry> new_entries;

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -32,6 +32,7 @@
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "api/debug/ring_buffer.h"
+#include "hostdev/debug_ring_buffer_common.h"
 #include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
 #include <impl/debug/watcher_server.hpp>
@@ -276,6 +277,7 @@ private:
     void DumpPauseStatus() const;
     void DumpEthLinkStatus() const;
     void DumpRingBuffer(bool to_stdout = false) const;
+    void DumpMpscRingBuffer(bool to_stdout = false) const;
     void DumpRunState(uint32_t state) const;
     void DumpLaunchMessage() const;
     void DumpWaypoints(bool to_stdout = false) const;
@@ -860,24 +862,33 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 }
 
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
-    auto ring_buf_data = mbox_data_.watcher().debug_ring_buf();
+    const auto& hal = reader_.env.get_hal();
+
+    // On Quasar, use MPSC ring buffer format
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        DumpMpscRingBuffer(to_stdout);
+        return;
+    }
+
+    // WH/BH: SPSC ring buffer - cast byte array wrapper to impl struct
+    const auto* ring_buf_data =
+        reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
+
     string out;
-    if (ring_buf_data.current_ptr() != DEBUG_RING_BUFFER_STARTING_INDEX) {
-        // Latest written idx is one less than the index read out of L1.
+    if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {
         out += "\n\tdebug_ring_buffer=\n\t[";
-        int curr_idx = ring_buf_data.current_ptr();
-        size_t ring_buffer_elements = ring_buf_data.data().size();
+        int curr_idx = ring_buf_data->current_ptr;
+        size_t ring_buffer_elements = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
         for (int count = 1; count <= ring_buffer_elements; count++) {
-            out += fmt::format("0x{:08x},", ring_buf_data.data()[curr_idx]);
+            out += fmt::format("0x{:08x},", ring_buf_data->data[curr_idx]);
             if (count % 8 == 0) {
                 out += "\n\t ";
             }
             if (curr_idx == 0) {
-                if (ring_buf_data.wrapped() == 0) {
+                if (ring_buf_data->wrapped == 0) {
                     break;  // No wrapping, so no extra data available
                 }
                 curr_idx = ring_buffer_elements - 1;  // Loop
-
             } else {
                 curr_idx--;
             }
@@ -895,6 +906,73 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
         }
     } else {
         fprintf(reader_.f, "%s", out.c_str());
+    }
+}
+
+void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
+    // Quasar MPSC ring buffer
+    const auto& hal = reader_.env.get_hal();
+    auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type_);
+    auto watcher_offset = dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher);
+    auto ring_buf_field_offset =
+        dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::debug_ring_buf);
+    auto ring_buf_offset = watcher_offset + ring_buf_field_offset;
+    const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
+    const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
+
+    const uint32_t head = rb->head;
+    constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
+    constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
+
+    // Track position and buffer per core
+    uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
+    auto& entries = reader_.mpsc_ring_buf_entries_[virtual_coord_];
+
+    // If buffer overflowed, advance to oldest valid position
+    if (head > last_pos + capacity) {
+        last_pos = head - capacity;
+    }
+
+    // Collect new valid entries (oldest to newest)
+    std::vector<MpscRingBufEntry> new_entries;
+    for (uint32_t pos = last_pos; pos < head; pos++) {
+        const auto& slot = rb->slots[pos & mask];
+        if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
+            break;  // Hole - in-flight write, resume next poll
+        }
+        new_entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
+        last_pos = pos + 1;
+    }
+
+    // Insert new entries at the front (newest first)
+    if (!new_entries.empty()) {
+        // Reverse new_entries so newest is first, then prepend to existing
+        entries.insert(entries.begin(), new_entries.rbegin(), new_entries.rend());
+        // Trim to capacity
+        if (entries.size() > capacity) {
+            entries.resize(capacity);
+        }
+    }
+
+    // Output full buffer if non-empty
+    if (!entries.empty()) {
+        // Extract data and thread indices for formatter
+        std::vector<uint32_t> data, thread_indices;
+        data.reserve(entries.size());
+        thread_indices.reserve(entries.size());
+        for (const auto& e : entries) {
+            data.push_back(e.data);
+            thread_indices.push_back(e.thread_idx);
+        }
+
+        auto lines = FormatRingBuffer(data, thread_indices, programmable_core_type_);
+        string out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
+
+        if (to_stdout) {
+            log_info(tt::LogMetal, "Last ring buffer status: {}", out);
+        } else {
+            fprintf(reader_.f, "%s", out.c_str());
+        }
     }
 }
 

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -29,6 +29,11 @@ struct MpscRingBufEntry {
     uint32_t thread_idx;  // Needed for [DM0] prefix in output
 };
 
+struct MpscRingBufState {
+    uint32_t last_pos = 0;
+    std::vector<MpscRingBufEntry> entries;
+};
+
 class WatcherDeviceReader {
 public:
     WatcherDeviceReader(
@@ -60,8 +65,7 @@ private:
 
     // MPSC state cached on host: slots get overwritten (lock-free), so we track position and
     // buffer history per core. SPSC doesn't need this since current_ptr/wrapped give full state.
-    mutable std::map<CoreCoord, uint32_t> mpsc_last_consumed_pos_;
-    mutable std::map<CoreCoord, std::vector<MpscRingBufEntry>> mpsc_ring_buf_entries_;
+    mutable std::map<CoreCoord, MpscRingBufState> mpsc_ring_buf_entries_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -58,11 +58,9 @@ private:
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
     std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;
 
-    // MPSC ring buffer reader state (Quasar only) - tracks last consumed position per core
-    // Mutable because this is reader state updated during const Dump operations
+    // MPSC state cached on host: slots get overwritten (lock-free), so we track position and
+    // buffer history per core. SPSC doesn't need this since current_ptr/wrapped give full state.
     mutable std::map<CoreCoord, uint32_t> mpsc_last_consumed_pos_;
-    // MPSC ring buffer entries (Quasar only) - maintains full buffer contents per core for display
-    // Stores entries newest-first, limited to buffer capacity (32 entries)
     mutable std::map<CoreCoord, std::vector<MpscRingBufEntry>> mpsc_ring_buf_entries_;
 };
 

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -23,6 +23,12 @@ constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
 constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
+// MPSC ring buffer entry for host-side tracking (data + thread for display)
+struct MpscRingBufEntry {
+    uint32_t data;
+    uint32_t thread_idx;  // Needed for [DM0] prefix in output
+};
+
 class WatcherDeviceReader {
 public:
     WatcherDeviceReader(
@@ -51,6 +57,13 @@ private:
     const std::vector<std::string>& kernel_names;
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
     std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;
+
+    // MPSC ring buffer reader state (Quasar only) - tracks last consumed position per core
+    // Mutable because this is reader state updated during const Dump operations
+    mutable std::map<CoreCoord, uint32_t> mpsc_last_consumed_pos_;
+    // MPSC ring buffer entries (Quasar only) - maintains full buffer contents per core for display
+    // Stores entries newest-first, limited to buffer capacity (32 entries)
+    mutable std::map<CoreCoord, std::vector<MpscRingBufEntry>> mpsc_ring_buf_entries_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -25,7 +25,6 @@
 #include <tt_stl/fmt.hpp>
 #include "context/metal_env_impl.hpp"
 #include "core_coord.hpp"
-#include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
@@ -39,6 +38,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "rtoptions.hpp"
 #include "watcher_device_reader.hpp"
+#include "hostdev/debug_ring_buffer_common.h"
 
 using namespace tt::tt_metal;
 
@@ -390,10 +390,13 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
         data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 
-        // Initialize debug ring buffer to a known init val, we'll check against this to see if any
-        // data has been written.
-        data.debug_ring_buf().current_ptr() = DEBUG_RING_BUFFER_STARTING_INDEX;
-        data.debug_ring_buf().wrapped() = 0;
+        // Initialize debug ring buffer. Quasar MPSC buffer is already zeroed on create.
+        // WH/BH SPSC buffer needs current_ptr set to -1 as sentinel.
+        if (hal.get_arch() != tt::ARCH::QUASAR) {
+            auto* ring_buf = reinterpret_cast<debug_spsc_ring_buf_msg_t*>(data.debug_ring_buf().data().data());
+            ring_buf->current_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
+            ring_buf->wrapped = 0;
+        }
     }
 
     // Initialize Debug Delay feature

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -390,9 +390,9 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
         data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 
-        // Initialize debug ring buffer. Quasar MPSC buffer is already zeroed on create.
-        // WH/BH SPSC buffer needs current_ptr set to -1 as sentinel.
-        if (hal.get_arch() != tt::ARCH::QUASAR) {
+        // Initialize debug ring buffer. MPSC buffer is zeroed on create.
+        // SPSC buffer needs current_ptr set to -1 as sentinel.
+        if (!hal.has_mpsc_ring_buffer()) {
             auto* ring_buf = reinterpret_cast<debug_spsc_ring_buf_msg_t*>(data.debug_ring_buf().data().data());
             ring_buf->current_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
             ring_buf->wrapped = 0;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -360,6 +360,9 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
             fmt::format_to(it, "-D{} ", define);
         }
         fmt::format_to(it, "-DDISPATCH_MESSAGE_ADDR={} ", build_config.dispatch_message_addr);
+        if (hal.has_mpsc_ring_buffer()) {
+            fmt::format_to(it, "-DMPSC_RING_BUFFER ");
+        }
     }
     if (this->is_fw_) {
         this->defines_ += "-DFW_BUILD ";

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -375,10 +375,11 @@ public:
 
     tt::ARCH get_arch() const { return arch_; }
 
-    // Returns ring buffer capacity based on architecture (MPSC for Quasar, SPSC for others)
+    bool has_mpsc_ring_buffer() const { return arch_ == tt::ARCH::QUASAR; }
     uint32_t get_ring_buffer_capacity() const {
-        return (arch_ == tt::ARCH::QUASAR) ? DEBUG_RING_BUFFER_MPSC_ELEMENTS : DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+        return has_mpsc_ring_buffer() ? DEBUG_RING_BUFFER_MPSC_ELEMENTS : DEBUG_RING_BUFFER_SPSC_ELEMENTS;
     }
+    uint32_t get_ring_buffer_mask() const { return get_ring_buffer_capacity() - 1; }
 
     // Returns the NoC topology type (MESH or TORUS)
     NoCTopologyType get_noc_topology() const { return noc_topology_; }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -29,6 +29,7 @@
 #include "tt_memory.h"
 #include "hal/generated/dev_msgs.hpp"          // IWYU pragma: export
 #include "hal/generated/fabric_telemetry.hpp"  // IWYU pragma: export
+#include "hostdev/debug_ring_buffer_common.h"
 
 #include <tt_stl/overloaded.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -373,6 +374,11 @@ public:
         bool enable_blackhole_dram_programmable_cores = false);
 
     tt::ARCH get_arch() const { return arch_; }
+
+    // Returns ring buffer capacity based on architecture (MPSC for Quasar, SPSC for others)
+    uint32_t get_ring_buffer_capacity() const {
+        return (arch_ == tt::ARCH::QUASAR) ? DEBUG_RING_BUFFER_MPSC_ELEMENTS : DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+    }
 
     // Returns the NoC topology type (MESH or TORUS)
     NoCTopologyType get_noc_topology() const { return noc_topology_; }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
Quasar has 24 processors per Tensix (8 DMs + 16 TRISCs) that can all write to the watcher debug ring buffer concurrently. The existing SPSC ring buffer doesn't support concurrent writes.

### What's changed
Implemented a lock free MPSC ring buffer for Quasar using 32-bit atomics:

Device side:
- Atomically claim slots via `__atomic_fetch_add` on cached memory
- Write data to uncached memory for immediate host visibility
- Publish `write_id` encoding `(thread_idx << 27) | (pos+1)` to pass thread_ID + sequence ticket to host.
- 27-bit position_idx (sequence ticket) makes ABA impractical (2^27 entries between collisions)

Host side:
- Incrementally read new entries since last poll via position tracking and validate slots using position_idx to detect in-flight writes.
- Maintain newest-first history buffer across polls: MPSC can have in-flight entries (slot claimed but `data` + `write_id` not yet published). Without history, gaps from in-flight entries would break temporal ordering across polls. The history buffer ensures a consistent newest first view across polls, matching SPSC's "always dump full buffer in log" behavior

HAL integration on host side:
- `has_mpsc_ring_buffer()`, ` get_ring_buffer_capacity()`, `get_ring_buffer_mask()` helpers for runtime mode selection
- `MPSC_RING_BUFFER` compile-time define injected via JIT build

Testing: 
- Extended single processor tests for all DM/TRISCs on Quasar
- Added new multi-threaded test validating all 24 Quasar processors writing concurrently

Note: MPSC can be supported on BH too, which will be done in a follow-up PR.

Quasar test runs along with ring buffer in watcher log: https://gist.github.com/sidnadTT/35ae2097d53078b25f8b7552575e060a

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_watcher_rb)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_watcher_rb)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_watcher_rb)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
