### PR TITLE
[Sockets] Shared Memory Resource Cleanup

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/distributed/named_shm.hpp"
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/distributed/pcie_core_writer.hpp"
+#include "tt_metal/distributed/shm_resource_tracker.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
@@ -191,7 +192,9 @@ D2HSocket::~D2HSocket() noexcept {
             shm_->unlink();
         }
         if (!descriptor_path_.empty()) {
-            std::remove(descriptor_path_.c_str());
+            if (std::remove(descriptor_path_.c_str()) == 0 || errno == ENOENT) {
+                ShmResourceTracker::instance().untrack_file(descriptor_path_);
+            }
         }
     }
 }
@@ -318,6 +321,7 @@ std::string D2HSocket::export_descriptor(const std::string& socket_id) {
 
     descriptor_path_ = descriptor_path_for_socket("d2h", socket_id);
     desc.write_to_file(descriptor_path_);
+    ShmResourceTracker::instance().track_file(descriptor_path_);
     exported_ = true;
     return descriptor_path_;
 }

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -7,6 +7,7 @@
 #include "tt_metal/distributed/named_shm.hpp"
 #include "tt_metal/distributed/hd_socket_descriptor.hpp"
 #include "tt_metal/distributed/pcie_core_writer.hpp"
+#include "tt_metal/distributed/shm_resource_tracker.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
@@ -256,7 +257,9 @@ H2DSocket::~H2DSocket() noexcept {
             shm_->unlink();
         }
         if (!descriptor_path_.empty()) {
-            std::remove(descriptor_path_.c_str());
+            if (std::remove(descriptor_path_.c_str()) == 0 || errno == ENOENT) {
+                ShmResourceTracker::instance().untrack_file(descriptor_path_);
+            }
         }
     }
 }
@@ -361,6 +364,7 @@ std::string H2DSocket::export_descriptor(const std::string& socket_id) {
 
     descriptor_path_ = descriptor_path_for_socket("h2d", socket_id);
     desc.write_to_file(descriptor_path_);
+    ShmResourceTracker::instance().track_file(descriptor_path_);
     exported_ = true;
     return descriptor_path_;
 }

--- a/tt_metal/distributed/named_shm.cpp
+++ b/tt_metal/distributed/named_shm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/distributed/named_shm.hpp"
+#include "tt_metal/distributed/shm_resource_tracker.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <fmt/format.h>
@@ -68,6 +69,7 @@ NamedShm NamedShm::create(const std::string& name, size_t size) {
     }
 
     std::memset(ptr, 0, size);
+    ShmResourceTracker::instance().track_shm(name);
     return NamedShm(name, ptr, size);
 }
 
@@ -108,8 +110,11 @@ void NamedShm::close() {
 void NamedShm::unlink() {
     close();
     if (!name_.empty()) {
-        shm_unlink(name_.c_str());
-        name_.clear();
+        int rc = shm_unlink(name_.c_str());
+        if (rc == 0 || errno == ENOENT) {
+            ShmResourceTracker::instance().untrack_shm(name_);
+            name_.clear();
+        }
     }
 }
 

--- a/tt_metal/distributed/shm_resource_tracker.cpp
+++ b/tt_metal/distributed/shm_resource_tracker.cpp
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/distributed/shm_resource_tracker.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+#include <fmt/format.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <csignal>
+#include <dirent.h>
+#include <fstream>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+namespace tt::tt_metal::distributed {
+
+namespace {
+
+pid_t extract_pid_from_manifest_name(const std::string& filename) {
+    // Expected format: tt_socket_manifest_<pid>
+    const std::string prefix = "tt_socket_manifest_";
+    if (!filename.starts_with(prefix)) {
+        return 0;
+    }
+    try {
+        return static_cast<pid_t>(std::stol(filename.substr(prefix.size())));
+    } catch (...) {
+        return 0;
+    }
+}
+
+pid_t extract_pid_from_shm_name(const std::string& filename) {
+    // Expected format: tt_{prefix}_{pid}_{counter}
+    if (!filename.starts_with("tt_")) {
+        return 0;
+    }
+    auto first = filename.find('_', 3);
+    if (first == std::string::npos) {
+        return 0;
+    }
+    auto second = filename.find('_', first + 1);
+    if (second == std::string::npos) {
+        return 0;
+    }
+    try {
+        return static_cast<pid_t>(std::stol(filename.substr(first + 1, second - first - 1)));
+    } catch (...) {
+        return 0;
+    }
+}
+
+void atexit_handler() {
+    try {
+        ShmResourceTracker::instance().cleanup_all();
+    } catch (const std::exception& e) {
+        log_warning(LogMetal, "ShmResourceTracker atexit: cleanup failed: {}", e.what());
+    } catch (...) {
+        log_warning(LogMetal, "ShmResourceTracker atexit: cleanup failed with unknown exception");
+    }
+}
+
+struct sigaction prev_sigint, prev_sigterm;
+
+void invoke_previous_handler(int sig, const struct sigaction& prev) {
+    if (prev.sa_handler == SIG_IGN) {
+        return;
+    }
+    if (prev.sa_flags & SA_SIGINFO) {
+        // Restore the original SA_SIGINFO handler and re-raise so the kernel
+        // delivers the signal with a real siginfo_t and ucontext_t*.
+        struct sigaction restore = prev;
+        sigaction(sig, &restore, nullptr);
+        raise(sig);
+        return;
+    }
+    if (prev.sa_handler != SIG_DFL) {
+        prev.sa_handler(sig);
+        return;
+    }
+    // Previous handler was SIG_DFL or SIG_IGN (or null): restore default and re-raise
+    // so the process terminates with the correct signal exit status.
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+void signal_handler(int sig) {
+    // Use try_lock to avoid deadlock if the signal interrupted a thread
+    // holding mutex_. If we can't acquire the lock, the manifest file
+    // ensures the next process will clean up via stale-PID scan.
+    ShmResourceTracker::instance().cleanup_from_signal();
+
+    const struct sigaction& prev = (sig == SIGINT) ? prev_sigint : prev_sigterm;
+    invoke_previous_handler(sig, prev);
+}
+
+}  // namespace
+
+std::string ShmResourceTracker::manifest_path_for_pid(pid_t pid) {
+    return fmt::format("/dev/shm/tt_socket_manifest_{}", pid);
+}
+
+bool ShmResourceTracker::is_pid_alive(pid_t pid) {
+    if (pid <= 0) {
+        return false;
+    }
+    return kill(pid, 0) == 0 || errno == EPERM;
+}
+
+ShmResourceTracker::ShmResourceTracker() : manifest_path_(manifest_path_for_pid(getpid())) {
+    cleanup_stale_resources();
+    std::atexit(atexit_handler);
+
+    struct sigaction sa{};
+    sa.sa_handler = signal_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, &prev_sigint);
+    sigaction(SIGTERM, &sa, &prev_sigterm);
+}
+
+ShmResourceTracker& ShmResourceTracker::instance() {
+    static ShmResourceTracker tracker;
+    return tracker;
+}
+
+void ShmResourceTracker::track_shm(const std::string& shm_name) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    shm_names_.insert(shm_name);
+    flush_manifest();
+}
+
+void ShmResourceTracker::track_file(const std::string& file_path) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    file_paths_.insert(file_path);
+    flush_manifest();
+}
+
+void ShmResourceTracker::untrack_shm(const std::string& shm_name) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    shm_names_.erase(shm_name);
+    flush_manifest();
+}
+
+void ShmResourceTracker::untrack_file(const std::string& file_path) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    file_paths_.erase(file_path);
+    flush_manifest();
+}
+
+void ShmResourceTracker::flush_manifest() {
+    if (shm_names_.empty() && file_paths_.empty()) {
+        std::remove(manifest_path_.c_str());
+        return;
+    }
+    // Write to a temp file and atomically rename to avoid leaving a
+    // truncated manifest if the process is killed mid-write.
+    const std::string tmp_path = manifest_path_ + ".tmp";
+    std::ofstream ofs(tmp_path, std::ios::trunc);
+    if (!ofs) {
+        return;
+    }
+    for (const auto& name : shm_names_) {
+        ofs << "shm " << name << "\n";
+    }
+    for (const auto& path : file_paths_) {
+        ofs << "file " << path << "\n";
+    }
+    ofs.flush();
+    if (!ofs) {
+        std::remove(tmp_path.c_str());
+        return;
+    }
+    if (::rename(tmp_path.c_str(), manifest_path_.c_str()) != 0) {
+        std::remove(tmp_path.c_str());
+    }
+}
+
+void ShmResourceTracker::cleanup_all() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& name : shm_names_) {
+        if (shm_unlink(name.c_str()) == 0) {
+            log_debug(LogMetal, "ShmResourceTracker: cleaned up shm '{}'", name);
+        }
+    }
+    shm_names_.clear();
+
+    for (const auto& path : file_paths_) {
+        if (std::remove(path.c_str()) == 0) {
+            log_debug(LogMetal, "ShmResourceTracker: cleaned up file '{}'", path);
+        }
+    }
+    file_paths_.clear();
+
+    std::remove(manifest_path_.c_str());
+}
+
+void ShmResourceTracker::cleanup_from_signal() {
+    // try_lock avoids deadlock if the signal interrupted a thread holding mutex_.
+    // If we can't lock, leave the manifest intact so the next process can
+    // discover and clean up all resources via stale-PID scan.
+    if (!mutex_.try_lock()) {
+        return;
+    }
+
+    // Lock acquired. shm_unlink and unlink are async-signal-safe.
+    // Avoid logging here (not async-signal-safe).
+    for (const auto& name : shm_names_) {
+        shm_unlink(name.c_str());
+    }
+    shm_names_.clear();
+
+    for (const auto& path : file_paths_) {
+        ::unlink(path.c_str());
+    }
+    file_paths_.clear();
+
+    ::unlink(manifest_path_.c_str());
+    mutex_.unlock();
+}
+
+void ShmResourceTracker::cleanup_stale_resources() {
+    DIR* dir = opendir("/dev/shm");
+    if (!dir) {
+        return;
+    }
+
+    std::vector<std::string> stale_manifests;
+    std::vector<std::string> stale_shm_names;
+
+    pid_t my_pid = getpid();
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        std::string name(entry->d_name);
+
+        // Check for manifest files from dead processes
+        pid_t manifest_pid = extract_pid_from_manifest_name(name);
+        if (manifest_pid > 0 && manifest_pid != my_pid && !is_pid_alive(manifest_pid)) {
+            stale_manifests.push_back("/dev/shm/" + name);
+            continue;
+        }
+
+        // Check for orphaned shm objects from dead processes
+        // Pattern: tt_{h2d|d2h}_{pid}_{counter}
+        pid_t shm_pid = extract_pid_from_shm_name(name);
+        if (shm_pid > 0 && shm_pid != my_pid && !is_pid_alive(shm_pid)) {
+            stale_shm_names.push_back(name);
+        }
+    }
+    closedir(dir);
+
+    // Clean up resources listed in stale manifests
+    for (const auto& manifest : stale_manifests) {
+        std::ifstream ifs(manifest);
+        std::string line;
+        while (std::getline(ifs, line)) {
+            if (line.starts_with("shm ")) {
+                std::string shm_name = line.substr(4);
+                if (shm_unlink(shm_name.c_str()) == 0) {
+                    log_info(LogMetal, "ShmResourceTracker: removed stale shm '{}'", shm_name);
+                }
+            } else if (line.starts_with("file ")) {
+                std::string file_path = line.substr(5);
+                if (std::remove(file_path.c_str()) == 0) {
+                    log_info(LogMetal, "ShmResourceTracker: removed stale file '{}'", file_path);
+                }
+            }
+        }
+        std::remove(manifest.c_str());
+        log_info(LogMetal, "ShmResourceTracker: removed stale manifest '{}'", manifest);
+    }
+
+    // Clean up orphaned shm objects not covered by any manifest
+    for (const auto& name : stale_shm_names) {
+        std::string shm_name = "/" + name;
+        if (shm_unlink(shm_name.c_str()) == 0) {
+            log_info(LogMetal, "ShmResourceTracker: removed orphaned shm '{}'", shm_name);
+        }
+    }
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/shm_resource_tracker.hpp
+++ b/tt_metal/distributed/shm_resource_tracker.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+#include <set>
+#include <string>
+#include <sys/types.h>
+
+namespace tt::tt_metal::distributed {
+
+/**
+ * @brief Process-global tracker for POSIX shared memory objects and descriptor files.
+ *
+ * Ensures that /dev/shm resources created by H2D/D2H sockets are cleaned up even
+ * when the process exits abnormally. Two complementary mechanisms:
+ *
+ *  1. atexit handler  – cleans up resources on normal exit, uncaught exceptions,
+ *     std::exit(), and signals that cause exit() (SIGTERM, SIGINT default handlers).
+ *
+ *  2. Stale-PID cleanup – on first use, scans /dev/shm for resources whose owning
+ *     PID is no longer alive (handles SIGKILL, hard crashes, power loss).
+ *
+ * A manifest file /dev/shm/tt_socket_manifest_<pid> is maintained so that the
+ * stale cleanup can discover descriptor files (whose names don't embed a PID).
+ */
+class ShmResourceTracker {
+public:
+    static ShmResourceTracker& instance();
+
+    ShmResourceTracker(const ShmResourceTracker&) = delete;
+    ShmResourceTracker& operator=(const ShmResourceTracker&) = delete;
+
+    void track_shm(const std::string& shm_name);
+    void track_file(const std::string& file_path);
+
+    void untrack_shm(const std::string& shm_name);
+    void untrack_file(const std::string& file_path);
+
+    void cleanup_all();
+    void cleanup_from_signal();
+
+    static void cleanup_stale_resources();
+
+private:
+    ShmResourceTracker();
+
+    void flush_manifest();
+    static std::string manifest_path_for_pid(pid_t pid);
+    static bool is_pid_alive(pid_t pid);
+
+    std::mutex mutex_;
+    std::set<std::string> shm_names_;
+    std::set<std::string> file_paths_;
+    std::string manifest_path_;
+};
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/sources.cmake
+++ b/tt_metal/distributed/sources.cmake
@@ -24,6 +24,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/h2d_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/d2h_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/named_shm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/shm_resource_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hd_socket_descriptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pcie_core_writer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/experimental/blitz_decode_pipeline.cpp


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- H2D/D2H sockets create shared memory objects (`/dev/shm/tt_{h2d,d2h}_<pid>_<counter>`) and descriptor files (`/dev/shm/tt_{h2d,d2h}_<socket_id>.bin`) that are only cleaned up in the socket destructor
- If the process is killed (`Ctrl+C`, `SIGTERM`, `SIGKILL`, crash), destructors never run and causing a resource leak in `/dev/shm/`

### What's changed
- `ShmResourceTracker`: Singleton that tracks all shm objects and descriptor files created by `H2D`/`D2H` sockets
- Cleanup mechanisms:
   -  `atexit` handler: Cleans up all tracked resources on normal process exit, uncaught exceptions, or `exit()`
   - Signal handlers (`SIGINT`, `SIGTERM`): Clean up resources before re-raising the signal, preserving the correct exit status. Chains to any previously installed handler
   - Stale-PID cleanup on startup: scans `/dev/shm/` for resources belonging to dead processe. Handles `SIGKILL` and hard crashes where no in-process handler can run
- A manifest file (`/dev/shm/tt_socket_manifest_<pid>`) is maintained to track descriptor files whose names don't embed a PID
- Integrated tracking into `NamedShm::create()` / `NamedShm::unlink()` and `export_descriptor()` / destructor in both `H2DSocket` and `D2HSocket`

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/shm_cleanup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/shm_cleanup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/shm_cleanup)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/shm_cleanup)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/shm_cleanup)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/shm_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/shm_cleanup)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
