### PR TITLE
Add Quasar mock device support

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -72,6 +72,11 @@ TEST_F(MockDeviceAPIFixture, BlackholeConfigurationsAreValid) {
     EXPECT_EQ(*experimental::get_mock_cluster_desc(), "blackhole_P300_both_mmio.yaml");
 }
 
+TEST_F(MockDeviceAPIFixture, QuasarConfigurationsAreValid) {
+    experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
+    EXPECT_EQ(*experimental::get_mock_cluster_desc(), "quasar_Q1.yaml");
+}
+
 TEST_F(MockDeviceAPIFixture, UnsupportedConfigurationThrows) {
     bool threw_during_configure = false;
     try {

--- a/tt_metal/impl/device/mock_device_util.cpp
+++ b/tt_metal/impl/device/mock_device_util.cpp
@@ -22,6 +22,11 @@ std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t nu
                 case 2: return "blackhole_P300_both_mmio.yaml";
                 default: return std::nullopt;
             }
+        case tt::ARCH::QUASAR:
+            switch (num_chips) {
+                case 1: return "quasar_Q1.yaml";
+                default: return std::nullopt;
+            }
         default: return std::nullopt;
     }
 }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -144,19 +144,30 @@ Kernel::Kernel(
 }
 
 void Kernel::register_kernel_with_watcher() {
+    // Watcher server may not exist yet if MetalContext hasn't been fully initialized
+    // (e.g., during mock device testing or before devices are opened)
+    auto& watcher = MetalContext::instance().watcher_server();
+    if (!watcher) {
+        this->watcher_kernel_id_ = -1;
+        return;
+    }
     if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
-        this->watcher_kernel_id_ =
-            MetalContext::instance().watcher_server()->register_kernel(this->kernel_src_.source_);
+        this->watcher_kernel_id_ = watcher->register_kernel(this->kernel_src_.source_);
     } else {
         TT_FATAL(this->kernel_src_.source_type_ == KernelSource::SOURCE_CODE, "Unsupported kernel source type!");
-        this->watcher_kernel_id_ = MetalContext::instance().watcher_server()->register_kernel(this->name());
+        this->watcher_kernel_id_ = watcher->register_kernel(this->name());
     }
 }
 
 void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device) const {
+    // Skip if watcher server not available (e.g., during mock device testing)
+    auto& watcher = MetalContext::instance().watcher_server();
+    if (!watcher) {
+        return;
+    }
     TT_ASSERT(!this->kernel_full_name_.empty(), "Kernel full name not set!");
     auto paths = this->file_paths(device);
-    MetalContext::instance().watcher_server()->register_kernel_elf_paths(this->watcher_kernel_id_, paths);
+    watcher->register_kernel_elf_paths(this->watcher_kernel_id_, paths);
 }
 
 std::string Kernel::name() const { return this->kernel_src_.name(); }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -145,7 +145,7 @@ Kernel::Kernel(
 
 void Kernel::register_kernel_with_watcher() {
     // Watcher server may not exist yet if MetalContext hasn't been fully initialized
-    // (e.g., during mock device testing or before devices are opened)
+    // (e.g., during mock device testing)
     auto& watcher = MetalContext::instance().watcher_server();
     if (!watcher) {
         this->watcher_kernel_id_ = -1;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -144,10 +144,12 @@ Kernel::Kernel(
 }
 
 void Kernel::register_kernel_with_watcher() {
-    // Watcher server may not exist yet if MetalContext hasn't been fully initialized
-    // (e.g., during mock device testing)
     auto& watcher = MetalContext::instance().watcher_server();
     if (!watcher) {
+        // Watcher server should always be available... unless the target is a mock device
+        TT_FATAL(
+            MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock,
+            "Watcher server is unavailable, and the target is not a mock device");
         this->watcher_kernel_id_ = -1;
         return;
     }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -62,7 +62,7 @@ inline std::string get_soc_description_file(
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0: file = "wormhole_b0_80_arch.yaml"; break;
         case tt::ARCH::BLACKHOLE: file = "blackhole_140_arch.yaml"; break;
-        case tt::ARCH::QUASAR:  // Quasar is currently only supported for simulation
+        case tt::ARCH::QUASAR: file = "quasar_32_arch.yaml"; break;
         default: throw std::runtime_error("Unsupported device arch");
     }
     path += file;


### PR DESCRIPTION
### Ticket
GitHub issue: https://github.com/tenstorrent/tt-metal/issues/40982
UMD PR: https://github.com/tenstorrent/tt-umd/pull/2396

### PR Type
New feature

### Problem description
We want a Quasar mock device to enable API testing (see https://github.com/tenstorrent/tt-metal/pull/41169). 
This gives us a functional HAL without requiring the Zebu emulator.

### What's changed

- Add a Quasar mock device, with:
     - SOC descriptor `quasar_32_arch.yaml` (pre-existing)
     - Fictional cluster descriptor `quasar_Q1.yaml` ([UMD PR](https://github.com/tenstorrent/tt-umd/pull/2396)).
- Add null checks for Watcher server in `kernel.cpp`. 
     - This was necessary to circumvent a crash when creating kernels in mock mode.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/quasar_mockdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/quasar_mockdevice)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/quasar_mockdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/quasar_mockdevice)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/quasar_mockdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/quasar_mockdevice)
- [x] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

