### PR TITLE
#32376: Move simulator skip logic from in-test skipif to ttsim-skip-list.yaml

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -69,6 +69,12 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
   - tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
   - tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py  #38203
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_sharded_interleaved  #39185
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_row_major_sharded  #39185
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py  #38203
+  - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::test_resnet50_e2e_graph_capture  # ResNet-50 uses ops unsupported by ttsim
+  - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestFastOperationGraphTracking  # Fast dispatch with ttnn.add crashes ttsim worker on teardown
 
   # Pool tests
   - tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -123,6 +129,7 @@ blackhole:
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
   - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+  - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestFastOperationGraphTracking  # Fast dispatch with ttnn.add crashes ttsim worker on teardown
 
   # Slow tests (Tier 3-4: 5-20+ minutes, would cause CI timeouts)
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -11,7 +11,6 @@ This tests the decoupled workflow:
 """
 
 import json
-import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -29,10 +28,6 @@ import graph_report
 # Now import ttnn for device tests
 import ttnn
 from models.common.utility_functions import is_wormhole_b0
-
-
-def is_simulator():
-    return os.environ.get("TT_METAL_SIMULATOR") is not None
 
 
 @pytest.fixture
@@ -2252,7 +2247,6 @@ def imagenet_label_dict():
 
 
 @pytest.mark.skipif(not is_wormhole_b0(), reason="Requires Wormhole B0")
-@pytest.mark.skipif(is_simulator(), reason="ResNet-50 uses ops unsupported by ttsim")
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
@@ -3095,7 +3089,6 @@ class TestCapturedGraphFallbackExtraction:
         conn.close()
 
 
-@pytest.mark.skipif(is_simulator(), reason="Fast dispatch with ttnn.add crashes ttsim worker on teardown")
 class TestFastOperationGraphTracking:
     """Tests that FastOperation emits track_function_start/end during graph capture."""
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -24,17 +24,11 @@ Fields correctly excluded from hash (handled by override_runtime_arguments):
   tensor dtypes directly
 """
 
-import os
 import pytest
 import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.common.utility_functions import is_wormhole_b0
-
-
-def is_simulator():
-    return os.environ.get("TT_METAL_SIMULATOR") != None
 
 
 @pytest.fixture
@@ -87,7 +81,6 @@ def run_scalar_ng_op(device, op, shape, scalar, dtype=ttnn.bfloat16, memory_conf
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_reuse_same_config(device, isolate_program_cache):
     """Same op, same shapes, same dtypes run twice -> 1 cache entry, different outputs."""
     shape = [1, 1, 32, 64]
@@ -104,7 +97,6 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
     assert not torch.equal(tt_out1, tt_out2)
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_reuse_scalar_different_values(device, isolate_program_cache):
     """Different scalar values but same op -> 1 cache entry, different outputs."""
     shape = [1, 1, 32, 64]
@@ -124,7 +116,6 @@ def test_ng_cache_reuse_scalar_different_values(device, isolate_program_cache):
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_op_types(device, isolate_program_cache):
     """Different binary op types -> different cache entries."""
     shape = [1, 1, 32, 64]
@@ -138,7 +129,6 @@ def test_ng_cache_miss_different_op_types(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_input_dtypes(device, isolate_program_cache):
     """Different input dtypes -> different cache entries.
     Differentiated via input tensor dtype in compute_program_hash()."""
@@ -153,7 +143,6 @@ def test_ng_cache_miss_different_input_dtypes(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_memory_configs(device, isolate_program_cache):
     """Different memory configs -> different cache entries."""
     shape = [1, 1, 32, 64]
@@ -171,7 +160,6 @@ def test_ng_cache_miss_different_memory_configs(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_subtile_broadcast(device, isolate_program_cache):
     """Different subtile broadcast types -> different cache entries.
     subtile_broadcast_type is in to_hash() and depends on last-2-dim shapes."""
@@ -186,7 +174,6 @@ def test_ng_cache_miss_different_subtile_broadcast(device, isolate_program_cache
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_output_dtypes(device, isolate_program_cache):
     """Different output dtypes -> different cache entries."""
     shape = [1, 1, 32, 64]
@@ -216,7 +203,6 @@ def test_ng_cache_miss_different_output_dtypes(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache):
     """Scalar op vs tensor op -> different cache entries.
     scalar.has_value() is not in to_hash(), but compute_program_hash()
@@ -235,7 +221,6 @@ def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
     """Different sub_core_grids -> different cache entries.
     sub_core_grids is in to_hash() and directly determines worker_grid."""
@@ -266,7 +251,6 @@ def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cache):
     """Different input dtypes with same output dtype -> different cache entries.
     input_dtype is not in to_hash(), but compute_program_hash() includes
@@ -307,7 +291,6 @@ def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cac
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_reuse_different_logical_shapes(device, isolate_program_cache):
     """Different logical shapes share 1 cache entry, different outputs (by design).
     logical_shape is correctly excluded from compute_program_hash();
@@ -322,7 +305,6 @@ def test_ng_cache_reuse_different_logical_shapes(device, isolate_program_cache):
     assert tt_out1.shape != tt_out2.shape
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_reuse_different_logical_shapes_correctness(device, isolate_program_cache):
     """Correctness across multiple logical shapes sharing a single cache entry.
     override_runtime_arguments correctly updates runtime args for each shape."""
@@ -348,7 +330,6 @@ def test_ng_cache_reuse_different_logical_shapes_correctness(device, isolate_pro
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_correctness_repeated_runs(device, isolate_program_cache):
     """Run same op 5 times with different data -> all results correct."""
     shape = [1, 1, 32, 64]
@@ -357,7 +338,6 @@ def test_ng_cache_correctness_repeated_runs(device, isolate_program_cache):
         assert_with_pcc(torch_ref, tt_out, 0.9999)
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_correctness_scalar_repeated(device, isolate_program_cache):
     """Scalar ops with varying values -> all numerically correct."""
     shape = [1, 1, 32, 64]
@@ -367,7 +347,6 @@ def test_ng_cache_correctness_scalar_repeated(device, isolate_program_cache):
         assert_with_pcc(torch_ref, tt_out, 0.999)
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_ng_cache_correctness_broadcast_repeated(device, isolate_program_cache):
     """Broadcast operations with cache reuse -> all results correct."""
     shape_a = [1, 1, 64, 64]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
@@ -2,16 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import pytest
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_ulp
-from models.common.utility_functions import is_wormhole_b0
-
-
-def is_simulator():
-    return os.environ.get("TT_METAL_SIMULATOR") is not None
 
 
 height_sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -69,22 +63,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     "ttnn_op, torch_dtype, ttnn_dtype",
     [
         (ttnn.relu, torch.bfloat16, ttnn.bfloat16),
-        pytest.param(
-            ttnn.square,
-            torch.float32,
-            ttnn.float32,
-            marks=pytest.mark.skipif(
-                is_simulator() and is_wormhole_b0(), reason="tt-sim + Wormhole float32 failure #39185"
-            ),
-        ),
-        pytest.param(
-            ttnn.abs,
-            torch.int32,
-            ttnn.int32,
-            marks=pytest.mark.skipif(
-                is_simulator() and is_wormhole_b0(), reason="tt-sim + Wormhole float32 failure #39185"
-            ),
-        ),
+        (ttnn.square, torch.float32, ttnn.float32),
+        (ttnn.abs, torch.int32, ttnn.int32),
     ],
 )
 def test_unary_sharded_interleaved(input_shape, input_config, out_config, ttnn_op, torch_dtype, ttnn_dtype, device):
@@ -241,13 +221,7 @@ def test_unary_ng_uneven_sharding_fallback(ttnn_op, device):
     "torch_dtype, ttnn_dtype",
     [
         (torch.bfloat16, ttnn.bfloat16),
-        pytest.param(
-            torch.float32,
-            ttnn.float32,
-            marks=pytest.mark.skipif(
-                is_simulator() and is_wormhole_b0(), reason="tt-sim + Wormhole float32 failure #39185"
-            ),
-        ),
+        (torch.float32, ttnn.float32),
     ],
 )
 def test_unary_ng_row_major_sharded(input_shape, shard_shape, core_grid, strategy, device, torch_dtype, ttnn_dtype):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -26,17 +26,11 @@ work distribution, so different shapes with same volume correctly share a
 cache entry.
 """
 
-import os
 import pytest
 import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.common.utility_functions import is_wormhole_b0
-
-
-def is_simulator():
-    return os.environ.get("TT_METAL_SIMULATOR") != None
 
 
 def run_unary_op(device, op, shape, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG):
@@ -62,7 +56,6 @@ def run_unary_op(device, op, shape, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_reuse_same_config(device):
     """Same op, same shape, same dtype run twice -> 1 cache entry, different outputs."""
     device.cache_entries_counter.reset()
@@ -80,7 +73,6 @@ def test_unary_cache_reuse_same_config(device):
     assert not torch.equal(tt_out1, tt_out2)
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_reuse_same_volume_different_shapes(device):
     """TILE layout: same volume, different shapes -> 1 cache entry.
     unary_ng doesn't hash volume or shape; tile counts are runtime args,
@@ -96,7 +88,6 @@ def test_unary_cache_reuse_same_volume_different_shapes(device):
     assert device.cache_entries_counter.total == 1
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_reuse_different_volumes(device):
     """TILE layout: different volumes -> still 1 cache entry.
     unary_ng uses runtime tile counts (not compile-time), so different volumes
@@ -118,7 +109,6 @@ def test_unary_cache_reuse_different_volumes(device):
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_miss_different_op_types(device):
     """Different unary op types -> different cache entries."""
     device.cache_entries_counter.reset()
@@ -133,7 +123,6 @@ def test_unary_cache_miss_different_op_types(device):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_miss_different_input_dtypes(device):
     """Different input dtypes -> different cache entries."""
     device.cache_entries_counter.reset()
@@ -148,7 +137,6 @@ def test_unary_cache_miss_different_input_dtypes(device):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_miss_different_memory_configs(device):
     """Different memory configs -> different cache entries."""
     device.cache_entries_counter.reset()
@@ -167,7 +155,6 @@ def test_unary_cache_miss_different_memory_configs(device):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_miss_different_sub_core_grids(device):
     """Different sub_core_grids -> different cache entries.
     sub_core_grids is part of UnaryParams (hashed via args) and also hashed explicitly.
@@ -194,7 +181,6 @@ def test_unary_cache_miss_different_sub_core_grids(device):
     assert device.cache_entries_counter.total == 2
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_miss_different_factories(device):
     """Interleaved vs sub_core_grids factory -> different cache entries.
     factory_index is included in the hash.
@@ -223,7 +209,6 @@ def test_unary_cache_miss_different_factories(device):
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_correctness_repeated_runs(device):
     """Run same op 5 times with different data -> all results correct."""
     device.cache_entries_counter.reset()
@@ -235,7 +220,6 @@ def test_unary_cache_correctness_repeated_runs(device):
     assert device.cache_entries_counter.total == 1
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_correctness_same_volume_different_shapes(device):
     """Same volume, different shapes all produce correct results via cache reuse."""
     device.cache_entries_counter.reset()
@@ -251,7 +235,6 @@ def test_unary_cache_correctness_same_volume_different_shapes(device):
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_cache_rm_different_widths_need_separate_entries(device):
     """ROW_MAJOR interleaved tensors with different widths have different page sizes,
     so compute_program_hash must produce distinct keys for each shape."""
@@ -278,7 +261,6 @@ def test_unary_cache_rm_different_widths_need_separate_entries(device):
 # =============================================================================
 
 
-@pytest.mark.skipif(is_simulator() and is_wormhole_b0(), reason="Issue #38203")
 def test_unary_sharded_cache_correctness_different_grids(device):
     """Sharded ttnn.abs with different grid configs must produce correct results.
     Reproduces GitHub issue #33910: ttnn.abs ProgramCache data corruption.


### PR DESCRIPTION


### Ticket
Link to Github Issue 


### What's changed
Move simulator skip logic from in-test skipif to ttsim-skip-list.yaml

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tt_sim)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/tt_sim)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tt_sim)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tt_sim)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tt_sim)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tt_sim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tt_sim)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
