### PR TITLE
Support launching and remotely connecting to Deepseek pipeline

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -114,6 +114,18 @@ def create_parser() -> argparse.ArgumentParser:
         metavar="ID",
         help="Force all MoE stages to use this layer id (e.g. 3); default: use stage-dependent layer ids",
     )
+    parser.add_argument(
+        "--launch-only",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Only launch the pipeline, export H2D/D2H socket descriptors on mesh id 0, and keep the pipeline alive.",
+    )
+    parser.add_argument(
+        "--io-socket-descriptor-prefix",
+        type=str,
+        default="deepseek_v3_b1",
+        help="Prefix used when exporting H2D/D2H socket descriptors; sockets will be named <prefix>_h2d and <prefix>_d2h.",
+    )
     return parser
 
 
@@ -133,6 +145,8 @@ def run_demo(
     lm_head_persistent_mode: bool = True,
     dense_layer_id_override: int | None = None,
     moe_layer_id_override: int | None = None,
+    launch_only: bool = False,
+    io_socket_descriptor_prefix: str | None = None,
 ) -> None:
     """Run the pod pipeline. Requires 4, 16, or 64 distributed processes."""
     iterations = max_new_tokens
@@ -149,10 +163,11 @@ def run_demo(
             lm_head_persistent_mode=lm_head_persistent_mode,
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
+            io_socket_descriptor_prefix=io_socket_descriptor_prefix,
         )
 
         my_mesh_id = mesh_device.get_system_mesh_id()
-        if my_mesh_id == 0:
+        if my_mesh_id == 0 and not launch_only:
             tokenizer = load_tokenizer(tokenizer_name_or_path)
             messages = [{"role": "user", "content": prompt}]
             prompt = tokenizer.apply_chat_template(
@@ -178,7 +193,17 @@ def run_demo(
             generated_text = tokenizer.decode(generated_tokens, skip_special_tokens=True)
             logger.info("Output ({} tokens): {}", len(generated_tokens), generated_text)
 
-        model_pipeline.barrier()
+        if launch_only and my_mesh_id == 0:
+            # Keep process/pipeline alive until user interrupts
+            # Only runs on mesh 0, all other processes wait for a barrier
+            logger.info("Pipeline launched; keeping sockets alive until interrupted.")
+            try:
+                while True:
+                    time.sleep(3600)
+            except KeyboardInterrupt:
+                logger.info("Shutting down launch-only pipeline after interrupt.")
+
+    model_pipeline.barrier()
     logger.info("Pod pipeline complete")
 
 
@@ -207,6 +232,8 @@ def main(argv: list[str] | None = None) -> int:
         lm_head_persistent_mode=args.persistent_mode,
         dense_layer_id_override=args.dense_layer_id_override,
         moe_layer_id_override=args.moe_layer_id_override,
+        launch_only=args.launch_only,
+        io_socket_descriptor_prefix=args.io_socket_descriptor_prefix,
     )
     print(file=sys.stdout, flush=True)
     return 0

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -35,6 +35,7 @@ class ModelPipeline:
         lm_head_persistent_mode: bool = True,
         dense_layer_id_override: int | None = None,
         moe_layer_id_override: int | None = None,
+        io_socket_descriptor_prefix: str | None = None,
     ):
         logger.info(
             "Initializing DeepSeek V3 B1 pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={})",
@@ -92,6 +93,15 @@ class ModelPipeline:
                 batch_size=1,
                 pipeline_depth=config.num_stages,
             )
+
+            if io_socket_descriptor_prefix is not None:
+                pipeline_block = self.pipeline._pipeline_block
+                if pipeline_block is None:
+                    raise RuntimeError(
+                        "Pipeline.setup_and_run() must complete before exporting host socket descriptors"
+                    )
+                pipeline_block.export_host_socket_descriptors(io_socket_descriptor_prefix)
+
         logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
 
     def prefill_forward(self, tokens: list[int]) -> int:

--- a/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/pipeline_block/op.py
@@ -371,3 +371,11 @@ class PipelineBlock:
     def get_upstream_sockets(self):
         """Return list of sender sockets for multi-upstream exit SocketInterface."""
         return self.exit_socket_interface.get_upstream_sockets()
+
+    def export_host_socket_descriptors(self, io_socket_descriptor_prefix: str) -> None:
+        assert self.is_first_pipeline_stage(), "Host socket descriptors can only be exported from the first stage"
+        assert self.h2d_socket is not None, "Expected H2D socket on the first pipeline stage"
+        assert self.d2h_socket is not None, "Expected D2H socket on the first pipeline stage"
+
+        self.h2d_socket.export_descriptor(f"{io_socket_descriptor_prefix}_h2d")
+        self.d2h_socket.export_descriptor(f"{io_socket_descriptor_prefix}_d2h")

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/vector.h>
 
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
@@ -160,6 +161,24 @@ void py_module_types(nb::module_& mod) {
 
                 Returns:
                     H2DMode: The transfer mode (HOST_PUSH or DEVICE_PULL).
+            )doc")
+        .def(
+            "export_descriptor",
+            &tt::tt_metal::distributed::H2DSocket::export_descriptor,
+            nb::arg("socket_id"),
+            R"doc(
+                Exports a descriptor file for cross-process socket attachment.
+
+                Args:
+                    socket_id (str): A user-provided identifier used in the descriptor filename.
+            )doc")
+        .def_static(
+            "connect",
+            &tt::tt_metal::distributed::H2DSocket::connect,
+            nb::arg("socket_id"),
+            nb::arg("timeout_ms") = nb::none(),
+            R"doc(
+                Connects to an existing H2DSocket from another process.
             )doc");
 
     nb::class_<tt::tt_metal::distributed::D2HSocket>(mod, "D2HSocket")
@@ -281,6 +300,21 @@ void py_module_types(nb::module_& mod) {
 
                 Returns:
                     MeshDevice: The mesh device this socket is bound to.
+            )doc")
+        .def(
+            "export_descriptor",
+            &tt::tt_metal::distributed::D2HSocket::export_descriptor,
+            nb::arg("socket_id"),
+            R"doc(
+                Exports a descriptor file for cross-process socket attachment.
+            )doc")
+        .def_static(
+            "connect",
+            &tt::tt_metal::distributed::D2HSocket::connect,
+            nb::arg("socket_id"),
+            nb::arg("timeout_ms") = nb::none(),
+            R"doc(
+                Connects to an existing D2HSocket from another process.
             )doc");
 }
 


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
- The Deepseek model runner needs to support a 'launch only' mode for integration with the `PipelineManager`
- In this case, the runner is invoked with `--launch-only` and `--io-descriptor-prefix`
- The runner then simply launches the pipeline and exports socket descriptors for it. No IO is performed
- The expectation is for a remote process using the `PipelineManager` to connect to the pipeline using the socket descriptors

### What's changed
- Add launch only mode to the `cli.py` script
- Expose `export_descriptor` H2D and D2H APIs to Python + propagate to `PipelineBlock` op


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/pipeline_launch)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/pipeline_launch)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/pipeline_launch)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/pipeline_launch)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/pipeline_launch)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/pipeline_launch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/pipeline_launch)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
