### PR TITLE
Restrict DeepSeek Galaxy confirmation to weka-mounted runners

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -148,7 +148,7 @@ jobs:
       - arch-wormhole_b0
       - topology-6u
       - bare-metal
-      - pipeline-functional
+      - pipeline-perf
       - in-service
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}


### PR DESCRIPTION
## Summary
- change the Galaxy DeepSeek confirmation job to use the workflow label that keeps it on the weka-mounted runner pool
- this matches the other DeepSeek Galaxy jobs in the same workflow

## Why
The confirmation job ran on a `UF-` host where `/mnt/MLPerf` was not usable for this test. That caused the DeepSeek model path under `/mnt/MLPerf/tt_dnn-models/...` to fail to load.

## Evidence
- failing run: [23831329883](https://github.com/tenstorrent/tt-metal/actions/runs/23831329883)
- failing job on `UF-EV-A12-GWH01`: [69467055852](https://github.com/tenstorrent/tt-metal/actions/runs/23831329883/job/69467055852)
- in the same run, the reusable DeepSeek Galaxy job used the perf-labeled runner pool and landed on a weka-mounted Galaxy host

## Change
- switch `(Galaxy) DeepSeek module confirmation` from `pipeline-functional` to `pipeline-perf`

## Testing
- `git diff --check -- .github/workflows/galaxy-deepseek-tests.yaml`
- repo commit hooks passed, including `Check Yaml` and `yamllint`

## CI Badge
[![(Galaxy) DeepSeek tests (yieldthought/deepseek-galaxy-weka-runners)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Fdeepseek-galaxy-weka-runners)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ayieldthought%2Fdeepseek-galaxy-weka-runners)

Run: [23841506459](https://github.com/tenstorrent/tt-metal/actions/runs/23841506459)
