### PR TITLE
40894: Fix row_major layout in unary_ng

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -72,6 +72,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py  #38203
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_sharded_interleaved  #39185
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_row_major_sharded  #39185
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_rm_interleaved  #39185
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py  #38203
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::test_resnet50_e2e_graph_capture  # ResNet-50 uses ops unsupported by ttsim
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestFastOperationGraphTracking  # Fast dispatch with ttnn.add crashes ttsim worker on teardown

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
@@ -403,3 +403,37 @@ def test_unary_ng_reshard(device):
 
     ttnn_output = ttnn.to_torch(ttnn.relu(ttnn_input, memory_config=output_shard_config))
     assert torch.equal(ttnn_output, torch_output)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # Wide rows (row_width > tile_size): chunked across width
+        (1, 1032),
+        (1, 2048),
+        (2, 3000),
+        (1, 1, 1024, 3000),
+        # Narrow rows (row_width < tile_size): multiple rows packed per tile
+        (1024, 16),
+        (512, 32),
+        (100, 64),
+        (33, 128),
+        (1, 1, 64, 128),
+        (2, 3, 16, 64),
+        (1, 1, 1, 1),
+        (1, 1, 1, 512),
+    ],
+)
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32)])
+def test_unary_ng_rm_interleaved(device, shape, torch_dtype, ttnn_dtype):
+    """Test that unary_ng correctly handles ROW_MAJOR interleaved tensors.
+
+    Wide rows (row_width > tile_size) are chunked across the width.
+    Narrow rows (row_width < tile_size) are packed multiple-per-tile to amortize CB overhead.
+    Partial last blocks (non-tile-aligned row counts) are also covered.
+    """
+    torch_input = torch.randn(shape, dtype=torch_dtype)
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn_dtype, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_output = ttnn.to_torch(ttnn.abs(ttnn_input))
+    golden_output = torch.abs(torch_input)
+    assert torch.equal(ttnn_output, golden_output)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/reader_unary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/reader_unary_ng.cpp
@@ -23,15 +23,44 @@ void kernel_main() {
 #else
     constexpr uint32_t onepage = 1;
     constexpr auto src_args = TensorAccessorArgs<0, 0>();
-    const uint32_t page_bytes = get_local_cb_interface(cb_id_src).fifo_page_size;
-    const auto src = TensorAccessor(src_args, src_addr, page_bytes);
+    const auto src = TensorAccessor(src_args, src_addr);
 
     uint32_t end_id = start_id + num_pages;
+#if RM_INTERLEAVED
+    const uint32_t chunks_per_row = get_arg_val<uint32_t>(3);
+    const uint32_t chunk_size = get_arg_val<uint32_t>(4);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(5);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(6);
+    const uint32_t total_rows = get_arg_val<uint32_t>(7);
+
+    for (uint32_t block = start_id; block < end_id; ++block) {
+        uint32_t base_page = block * rows_per_tile;
+        uint32_t remaining = total_rows - base_page;
+        uint32_t actual_rows = (rows_per_tile < remaining) ? rows_per_tile : remaining;
+
+        for (uint32_t j = 0; j < chunks_per_row; ++j) {
+            uint32_t bytes = (j == chunks_per_row - 1) ? last_chunk_size : chunk_size;
+            cb_src.reserve_back(onepage);
+            for (uint32_t r = 0; r < actual_rows; ++r) {
+                noc.async_read(
+                    src,
+                    cb_src,
+                    bytes,
+                    {.page_id = base_page + r, .offset_bytes = j * chunk_size},
+                    {.offset_bytes = r * bytes});
+            }
+            noc.async_read_barrier();
+            cb_src.push_back(onepage);
+        }
+    }
+#else
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_src).fifo_page_size;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_src.reserve_back(onepage);
         noc.async_read(src, cb_src, page_bytes, {.page_id = i}, {.offset_bytes = 0});
         noc.async_read_barrier();
         cb_src.push_back(onepage);
     }
+#endif
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/writer_unary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/kernels/dataflow/writer_unary_ng.cpp
@@ -12,7 +12,6 @@ void kernel_main() {
     const uint32_t num_pages = get_arg_val<uint32_t>(1);
     const uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t onepage = 1;
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 
     experimental::Noc noc;
@@ -21,11 +20,41 @@ void kernel_main() {
 #if DST_SHARDED
     cb_dst.wait_front(num_pages);
 #else
+    constexpr uint32_t onepage = 1;
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();
-    const uint32_t page_bytes = get_local_cb_interface(cb_id_dst).fifo_page_size;
-    const auto dst = TensorAccessor(dst_args, dst_addr, page_bytes);
+    const auto dst = TensorAccessor(dst_args, dst_addr);
 
     uint32_t end_id = start_id + num_pages;
+#if RM_INTERLEAVED
+    const uint32_t chunks_per_row = get_arg_val<uint32_t>(3);
+    const uint32_t chunk_size = get_arg_val<uint32_t>(4);
+    const uint32_t last_chunk_size = get_arg_val<uint32_t>(5);
+    const uint32_t rows_per_tile = get_arg_val<uint32_t>(6);
+    const uint32_t total_rows = get_arg_val<uint32_t>(7);
+
+    for (uint32_t block = start_id; block < end_id; ++block) {
+        uint32_t base_page = block * rows_per_tile;
+        uint32_t remaining = total_rows - base_page;
+        uint32_t actual_rows = (rows_per_tile < remaining) ? rows_per_tile : remaining;
+
+        for (uint32_t j = 0; j < chunks_per_row; ++j) {
+            uint32_t bytes = (j == chunks_per_row - 1) ? last_chunk_size : chunk_size;
+            cb_dst.wait_front(onepage);
+            for (uint32_t r = 0; r < actual_rows; ++r) {
+                noc.async_write(
+                    cb_dst,
+                    dst,
+                    bytes,
+                    {.offset_bytes = r * bytes},
+                    {.page_id = base_page + r, .offset_bytes = j * chunk_size});
+            }
+            noc.async_writes_flushed();
+            cb_dst.pop_front(onepage);
+        }
+    }
+    noc.async_write_barrier();
+#else
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_dst).fifo_page_size;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_dst.wait_front(onepage);
         noc.async_write(cb_dst, dst, page_bytes, {}, {.page_id = i});
@@ -33,5 +62,6 @@ void kernel_main() {
         cb_dst.pop_front(onepage);
     }
     noc.async_write_barrier();
+#endif
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
@@ -143,7 +143,35 @@ void set_or_update_runtime_arguments(
     const uint32_t tile_hw = tile_height * tile_width;
 
     const bool rm_interleaved = is_row_major && !has_sharding;
-    const uint32_t out_num_tiles = rm_interleaved ? output.buffer()->num_pages() : output.physical_volume() / tile_hw;
+
+    const auto input_df = datatype_to_dataformat_converter(input.dtype());
+    const auto output_df = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t input_tile_bytes = tile_size(input_df);
+    const uint32_t output_tile_bytes = tile_size(output_df);
+
+    const uint32_t input_page_bytes = rm_interleaved ? static_cast<uint32_t>(input.buffer()->page_size()) : 0;
+    const uint32_t output_page_bytes = rm_interleaved ? static_cast<uint32_t>(output.buffer()->page_size()) : 0;
+    const uint32_t chunks_per_row = rm_interleaved ? (input_page_bytes + input_tile_bytes - 1) / input_tile_bytes : 1;
+    const uint32_t input_chunk_size = input_tile_bytes;
+    const uint32_t input_last_chunk_size =
+        rm_interleaved ? input_page_bytes - ((chunks_per_row - 1) * input_tile_bytes) : input_tile_bytes;
+    const uint32_t output_chunk_size = output_tile_bytes;
+    const uint32_t output_last_chunk_size =
+        rm_interleaved ? output_page_bytes - ((chunks_per_row - 1) * output_tile_bytes) : output_tile_bytes;
+
+    const uint32_t total_rows = rm_interleaved ? output.buffer()->num_pages() : 0;
+    uint32_t rows_per_tile = 1;
+    if (rm_interleaved && input_page_bytes > 0 && input_page_bytes < input_tile_bytes) {
+        const uint32_t input_element_size = datum_size(input_df);
+        const uint32_t row_width_elements = input_page_bytes / input_element_size;
+        const uint32_t aligned_page_size = static_cast<uint32_t>(input.buffer()->aligned_page_size());
+        if (input_page_bytes == aligned_page_size && row_width_elements > 0) {
+            rows_per_tile = tile_hw / row_width_elements;
+        }
+    }
+
+    const uint32_t out_num_tiles =
+        rm_interleaved ? (total_rows + rows_per_tile - 1) / rows_per_tile : output.physical_volume() / tile_hw;
     uint32_t out_shard_height{}, out_shard_width{}, num_shards_per_width{};
 
     const uint32_t oWt = output.padded_shape()[-1] / output.tensor_spec().tile().get_width();
@@ -280,20 +308,47 @@ void set_or_update_runtime_arguments(
             } else if (core_group_2.contains(core)) {
                 npc = num_tiles_per_core_group_2;
             } else {
-                handle_args(program, reader_kernel_id, core, std::array<uint32_t, 3>{0});
-                handle_args(program, writer_kernel_id, core, std::array<uint32_t, 3>{0});
+                handle_args(program, reader_kernel_id, core, std::array<uint32_t, 8>{0});
+                handle_args(program, writer_kernel_id, core, std::array<uint32_t, 8>{0});
                 handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
                 continue;
             }
 
-            std::array reader_runtime_args = {input.buffer()->address(), npc, start_tile_id};
-            handle_args(program, reader_kernel_id, core, reader_runtime_args);
+            if (rm_interleaved) {
+                std::array reader_runtime_args = {
+                    input.buffer()->address(),
+                    npc,
+                    start_tile_id,
+                    chunks_per_row,
+                    input_chunk_size,
+                    input_last_chunk_size,
+                    rows_per_tile,
+                    total_rows};
+                handle_args(program, reader_kernel_id, core, reader_runtime_args);
 
-            std::array writer_runtime_args = {output.buffer()->address(), npc, start_tile_id};
-            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+                std::array writer_runtime_args = {
+                    output.buffer()->address(),
+                    npc,
+                    start_tile_id,
+                    chunks_per_row,
+                    output_chunk_size,
+                    output_last_chunk_size,
+                    rows_per_tile,
+                    total_rows};
+                handle_args(program, writer_kernel_id, core, writer_runtime_args);
 
-            std::array compute_runtime_args = {npc, packed_scalar1, packed_scalar2};
-            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+                std::array compute_runtime_args = {npc * chunks_per_row, packed_scalar1, packed_scalar2};
+                handle_args(program, compute_kernel_id, core, compute_runtime_args);
+            } else {
+                std::array reader_runtime_args = {input.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u};
+                handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+                std::array writer_runtime_args = {output.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u};
+                handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+                std::array compute_runtime_args = {npc, packed_scalar1, packed_scalar2};
+                handle_args(program, compute_kernel_id, core, compute_runtime_args);
+            }
 
             start_tile_id += npc;
         }
@@ -335,21 +390,11 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
     const bool src_sharded = has_sharding && input.is_sharded();
     const bool dst_sharded = has_sharding && output.is_sharded();
 
-    // For sharded ROW_MAJOR: use tile-sized CB pages and pack shard bytes into tile-sized chunks.
-    // For interleaved ROW_MAJOR: use row-sized pages.
+    // For ROW_MAJOR interleaved: use tile_size CB pages and group/chunk rows.
+    // For sharded ROW_MAJOR or TILE layout: CB page is always tile_size.
     const bool rm_interleaved = is_row_major && !has_sharding;
-    const uint32_t input_cb_page_size = rm_interleaved ? src_buffer->page_size() : single_tile_size;
-    const uint32_t output_cb_page_size = rm_interleaved ? dst_buffer->page_size() : single_tile_size_output;
-
-    // TODO: Support wide ROW_MAJOR interleaved tensors (#40894)
-    if (rm_interleaved) {
-        TT_FATAL(
-            input_cb_page_size <= single_tile_size,
-            "UnaryNg: ROW_MAJOR interleaved page size ({} bytes) exceeds tile size ({} bytes). "
-            "Input tensor row is too wide for the current circular buffer allocation.",
-            input_cb_page_size,
-            single_tile_size);
-    }
+    const uint32_t input_cb_page_size = single_tile_size;
+    const uint32_t output_cb_page_size = single_tile_size_output;
 
     auto shard_pages = [](const tt::tt_metal::ShardSpec& spec, const Tensor& t, bool rm) -> uint32_t {
         if (rm) {
@@ -423,6 +468,7 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
     // --- Reader Kernel ---
     std::map<std::string, std::string> reader_defines;
     reader_defines["SRC_SHARDED"] = src_sharded ? "1" : "0";
+    reader_defines["RM_INTERLEAVED"] = rm_interleaved ? "1" : "0";
 
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> reader_common_runtime_args;
@@ -439,6 +485,7 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
     // --- Writer Kernel ---
     std::map<std::string, std::string> writer_defines;
     writer_defines["DST_SHARDED"] = dst_sharded ? "1" : "0";
+    writer_defines["RM_INTERLEAVED"] = rm_interleaved ? "1" : "0";
 
     std::vector<uint32_t> writer_compile_time_args;
     std::vector<uint32_t> writer_common_runtime_args;


### PR DESCRIPTION
### Ticket
Link to Github Issue #40894 

### Problem description
Previously, unary infra had no native handling for ROW_MAJOR interleaved tensors. Wide rows (row width in bytes larger than tile_size) would allocate an oversized CB page causing L1 memory blowup. Narrow rows (row width smaller than tile_size) created undersized CB pages, leading to compute reading garbage data beyond the valid row. Both cases could result in silent data corruption

### What's changed
The fix introduces a unified streaming design for all RM interleaved cases. The CB page size is always exactly tile_size. Depending on the row width relative to tile_size, rows are either:

- Wide rows: split into multiple tile-sized chunks read sequentially per row
- Narrow rows: packed multiple-per-tile into a single tile-sized CB slot
- Exact rows (row width == tile_size): one row maps to one tile — unchanged behavior

Please refer to the following document for the fix logic:
https://docs.google.com/document/d/14ANFCBCHWBtes39GjOhLcEsVl14u8xW_fvzQazfcOR8/edit?usp=sharing

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/unary_ng_rm_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/unary_ng_rm_fix)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/unary_ng_rm_fix)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/unary_ng_rm_fix)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/unary_ng_rm_fix)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/unary_ng_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/unary_ng_rm_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
