### PR TITLE
Optimise log1p

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-// SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -11,6 +11,65 @@
 namespace ckernel {
 namespace sfpu {
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
+    const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
+    const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
+
+    sfpi::vFloat u;
+    sfpi::vFloat s;
+    sfpi::vFloat m;
+    sfpi::vFloat r;
+    sfpi::vFloat t;
+
+    u = a + sfpi::vConst1;
+    r = std::numeric_limits<float>::quiet_NaN();
+
+    v_if(u >= 0.0f) {
+        sfpi::vFloat three_quarters = 0.75f;
+        sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
+
+        e = sfpi::reinterpret<sfpi::vInt>(u) - e;
+        e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
+
+        m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+        sfpi::vFloat four = 4.0f;
+        s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(four) - e);  // s' in [2**-126,2**26]
+
+        // t = 0.25f * s + sfpi::vConstNeg1;
+        sfpi::vFloat quarter = 0.25f;
+        sfpi::vFloat neg1 = sfpi::vConstNeg1;
+        t = __builtin_rvtt_sfpmad(quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        r = -0.04541015625f;  //-4.54559326e-2f;          // -0x1.746000p-5
+
+        m = m + t;
+        t = 0.10546875;  // 1.05529785e-1f;           //  0x1.b04000p-4
+
+        // approximate log(1+m) on [-0.25, 0.5]
+        s = m * m;
+        r = r * s + -1.32279143e-1f;  // -0x1.0ee85ep-3
+        t = t * s + 1.44911006e-1f;   //  0x1.28c71ap-3
+        r = r * s + -1.66416913e-1f;  // -0x1.54d264p-3
+        t = t * s + 1.99886635e-1f;   //  0x1.995e2ap-3
+        r = r * s + -2.50001878e-1f;  // -0x1.00007ep-2
+        sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+        r = t * m + r;
+        r = r * m + 3.33335280e-1f;   //  0x1.5555d8p-2
+        r = r * m + -5.00000000e-1f;  // -0x1.000000p-1
+        sfpi::vFloat e_float = sfpi::int32_to_float(__builtin_rvtt_sfpcast(e.get(), sfpi::SFPCAST_MOD1_INT32_TO_SM32));
+        // sfpi::vFloat e_float = sfpi::setsgn(sfpi::int32_to_float(sfpi::abs(e)), sfpi::reinterpret<sfpi::vFloat>(e));
+        r = r * s + m;
+        r = e_float * (LOG_TWO * TWO_TO_M23) + r;
+
+        // since u>=0, safely checks for u == NaN or u == inf
+        v_if(sfpi::reinterpret<sfpi::vInt>(u) >= sfpi::reinterpret<sfpi::vInt>(infinity)) { r = u; }
+        v_endif;
+    }
+    v_endif;
+
+    return r;
+}
+
 /*
  * This function implements ln(1+x) using Chebyshev approximation for bfloat16.
  * Uses 3rd order Chebyshev polynomial approximation with range reduction.
@@ -54,7 +113,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
  * @return sfpi::vFloat Result of ln(1+val)
  */
 template <bool is_fp32_dest_acc_en>
-sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
+sfpi_inline sfpi::vFloat calculate_log1p_fp32_old(sfpi::vFloat val) {
     sfpi::vFloat result = sfpi::vConst0;
 
     // Check for special cases

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: Apache-2.0
 
 /*
  * The log1p(x) code is derived from code by Norbert Juffa.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -98,7 +98,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + 0x1.274p-3f;
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
-            e_float = sfpi::int32_to_float(abs_e);
+            e_float = sfpi::int32_to_float(abs_e, 0);
             r = r * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -107,7 +107,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             m = m + t;
-            e_float = sfpi::int32_to_float(abs_e);
+            e_float = sfpi::int32_to_float(abs_e, 0);
             r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 /*
  * The log1p(x) code is derived from code by Norbert Juffa.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -72,7 +72,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
         sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
 
-        // Use -0.25 (instead of 0.25) so we can reuse as polynomial coefficient later.
+        // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
         sfpi::vFloat neg1 = sfpi::vConstNeg1;
         // t = -s' / 4 - 1 = 2^(-k) - 1
@@ -86,10 +86,10 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // bf16-rounded path. fp16 or bf16 constants are used where possible to
         // reduce instruction count.
         if constexpr (is_fp32_dest_acc_en) {
-            // log1p(x) = x + x*x * (
-            //   -0x1p-1 + x * (0x1.555566p-2 + x * (-0x1p-2 + x * (0x1.998p-3 +
-            //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
-            //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
+            // log1p(m) ~= m + m*m * (
+            //   -0x1p-1 + m * (0x1.555572p-2 + m * (-0x1.00001ap-2 + m * (0x1.998p-3 +
+            //   m * (-0x1.55p-3 + m * (0x1.274p-3 + m * (-0x1.0c4p-3 + m *
+            //   (0x1.b84p-4 + m * (-0x1.92cp-5)))))))))
 
             m = m + t;
             r = -0x1.92cp-5f;
@@ -99,9 +99,9 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
             e_float = sfpi::int32_to_float(abs_e);
-            r = r * m + neg_quarter;
-            s = m * m;
             r = r * m + sfpi::vConstFloatPrgm1;
+            s = m * m;
+            r = r * m + sfpi::vConstFloatPrgm2;
             r = r * m + -0.5f;
         } else {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
@@ -161,8 +161,10 @@ inline void log1p_init() {
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
-        // Horner coefficient used by fp32 polynomial
-        sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
+        // Stored separately because the tuned fp32 m^3 and m^4 coefficients are
+        // no longer the shared exact 1/3 and -1/4 values used in the bf16 path.
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
     } else {
         // Horner coefficients used by bf16 polynomial
         sfpi::vConstFloatPrgm1 = 0x1.744p-2f;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -78,6 +78,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // t = -s' / 4 - 1 = 2^(-k) - 1
         sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
+        sfpi::vInt abs_e = sfpi::abs(e);
+
         // Minimax approximations for log1p(m) on [-0.25, 0.5]. Both paths keep the
         // exact linear term m explicit and approximate only the nonlinear
         // correction m^2 * P(m); the fp32 path keeps more terms than the
@@ -89,32 +91,26 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
             //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
 
-            r = -0x1.92cp-5f;
             m = m + t;
-            t = 0x1.b84p-4f;
-
-            s = m * m;
-            r = r * s + -0x1.0c4p-3f;
-            t = t * s + 0x1.274p-3f;
-            r = r * s + -0x1.55p-3f;
-            t = t * s + 0x1.998p-3f;
-            sfpi::vInt abs_e = sfpi::abs(e);
-            r = r * s + neg_quarter;
+            r = -0x1.92cp-5f;
+            r = r * m + 0x1.b84p-4f;
+            r = r * m + -0x1.0c4p-3f;
+            r = r * m + 0x1.274p-3f;
+            r = r * m + -0x1.55p-3f;
+            r = r * m + 0x1.998p-3f;
             e_float = sfpi::int32_to_float(abs_e);
-            r = t * m + r;
+            r = r * m + neg_quarter;
+            s = m * m;
             r = r * m + sfpi::vConstFloatPrgm1;
             r = r * m + -0.5f;
         } else {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
-            sfpi::vInt abs_e = sfpi::abs(e);
             m = m + t;
             e_float = sfpi::int32_to_float(abs_e);
-
+            r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
-            r = neg_quarter;
-            r = r * m + 0x1.744p-2f;
-            r = r * m + -0x1.008p-1f;
+            r = r * m + sfpi::vConstFloatPrgm2;
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
@@ -165,8 +161,12 @@ inline void log1p_init() {
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
-        // Middle Horner coefficient used only by the fp32 polynomial.
+        // Horner coefficient used by fp32 polynomial
         sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
+    } else {
+        // Horner coefficients used by bf16 polynomial
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -1,6 +1,33 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
+// SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
+
+/*
+ * Copyright (c) 2015-2023, Norbert Juffa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -11,55 +38,89 @@
 namespace ckernel {
 namespace sfpu {
 
+// For inputs with u = 1 + a > 0, write u = 2^k * t with t chosen in [0.75, 1.5),
+// so m = t - 1 lies in [-0.25, 0.5). Then
+//   log1p(a) = log(u) = k * log(2) + log1p(m).
+// This implementation carries k in exponent-bit units (k << 23), which makes the
+// rescaling and final k * log(2) term cheaper on SFPU.
+// Inputs with 1 + a < 0 fall through to the default NaN.
+// The boundary case u == 0 (a == -1) is outside the 2^k * t derivation above;
+// it still evaluates to -inf via the same bit-level reduction path.
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
-    const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
-    const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
-
-    sfpi::vFloat u;
-    sfpi::vFloat s;
-    sfpi::vFloat m;
-    sfpi::vFloat r;
-    sfpi::vFloat t;
-
-    u = a + sfpi::vConst1;
-    r = std::numeric_limits<float>::quiet_NaN();
+    sfpi::vFloat u = a + sfpi::vConst1;
+    sfpi::vFloat r = std::numeric_limits<float>::quiet_NaN();
 
     v_if(u >= 0.0f) {
         sfpi::vFloat three_quarters = 0.75f;
         sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
+        sfpi::vFloat e_float;
 
+        // Subtracting the encoding of 0.75 and then zeroing the mantissa isolates
+        // the exponent-bit offset e = k << 23 for the unique k with
+        // 2^(-k) * u in [0.75, 1.5).
         e = sfpi::reinterpret<sfpi::vInt>(u) - e;
         e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
 
-        m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
-        sfpi::vFloat four = 4.0f;
-        s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(four) - e);  // s' in [2**-126,2**26]
+        // Reinterpreting a - e applies the same 2^(-k) scaling to a.
+        // Affine correction below reconstructs
+        //   m <- 2^(-k) * a + (2^(-k) - 1) = 2^(-k) * (1 + a) - 1.
+        sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+        sfpi::vFloat neg_four = -4.0f;
+        // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
+        sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
 
-        // t = 0.25f * s + sfpi::vConstNeg1;
-        sfpi::vFloat quarter = 0.25f;
+        // Use -0.25 (instead of 0.25) so we can reuse as polynomial coefficient later.
+        sfpi::vFloat neg_quarter = -0.25f;
         sfpi::vFloat neg1 = sfpi::vConstNeg1;
-        t = __builtin_rvtt_sfpmad(quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
-        r = -0.04541015625f;  //-4.54559326e-2f;          // -0x1.746000p-5
+        // t = -s' / 4 - 1 = 2^(-k) - 1
+        sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
-        m = m + t;
-        t = 0.10546875;  // 1.05529785e-1f;           //  0x1.b04000p-4
+        // Minimax approximations for log1p(m) on [-0.25, 0.5]. Both paths keep the
+        // exact linear term m explicit and approximate only the nonlinear
+        // correction m^2 * P(m); the fp32 path keeps more terms than the
+        // bf16-rounded path. fp16 or bf16 constants are used where possible to
+        // reduce instruction count.
+        if constexpr (is_fp32_dest_acc_en) {
+            // log1p(x) = x + x*x * (
+            //   -0x1p-1 + x * (0x1.555566p-2 + x * (-0x1p-2 + x * (0x1.998p-3 +
+            //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
+            //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
 
-        // approximate log(1+m) on [-0.25, 0.5]
-        s = m * m;
-        r = r * s + -1.32279143e-1f;  // -0x1.0ee85ep-3
-        t = t * s + 1.44911006e-1f;   //  0x1.28c71ap-3
-        r = r * s + -1.66416913e-1f;  // -0x1.54d264p-3
-        t = t * s + 1.99886635e-1f;   //  0x1.995e2ap-3
-        r = r * s + -2.50001878e-1f;  // -0x1.00007ep-2
-        sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
-        r = t * m + r;
-        r = r * m + 3.33335280e-1f;   //  0x1.5555d8p-2
-        r = r * m + -5.00000000e-1f;  // -0x1.000000p-1
-        sfpi::vFloat e_float = sfpi::int32_to_float(__builtin_rvtt_sfpcast(e.get(), sfpi::SFPCAST_MOD1_INT32_TO_SM32));
-        // sfpi::vFloat e_float = sfpi::setsgn(sfpi::int32_to_float(sfpi::abs(e)), sfpi::reinterpret<sfpi::vFloat>(e));
+            r = -0x1.92cp-5f;
+            m = m + t;
+            t = 0x1.b84p-4f;
+
+            s = m * m;
+            r = r * s + -0x1.0c4p-3f;
+            t = t * s + 0x1.274p-3f;
+            r = r * s + -0x1.55p-3f;
+            t = t * s + 0x1.998p-3f;
+            sfpi::vInt abs_e = sfpi::abs(e);
+            r = r * s + neg_quarter;
+            e_float = sfpi::int32_to_float(abs_e);
+            r = t * m + r;
+            r = r * m + sfpi::vConstFloatPrgm1;
+            r = r * m + -0.5f;
+        } else {
+            // log1p(x) = x + x*x * (
+            //   -0x1p-1 + x * (0x1.5ap-2 + x * (-0x1p-2 + x * 0x1.024p-3)))
+
+            sfpi::vInt abs_e = sfpi::abs(e);
+            m = m + t;
+            e_float = sfpi::int32_to_float(abs_e);
+
+            s = m * m;
+            r = 0x1.024p-3f;
+            r = r * s + neg_quarter;
+            r = r * m + -0.5f;
+        }
+        // int32_to_float returns |e| as a real number in exponent-bit units;
+        // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
+        e_float = sfpi::setsgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
         r = r * s + m;
-        r = e_float * (LOG_TWO * TWO_TO_M23) + r;
+        sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+        r = e_float * sfpi::vConstFloatPrgm0 + r;
 
         // since u>=0, safely checks for u == NaN or u == inf
         v_if(sfpi::reinterpret<sfpi::vInt>(u) >= sfpi::reinterpret<sfpi::vInt>(infinity)) { r = u; }
@@ -70,181 +131,9 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
     return r;
 }
 
-/*
- * This function implements ln(1+x) using Chebyshev approximation for bfloat16.
- * Uses 3rd order Chebyshev polynomial approximation with range reduction.
- *
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
- * @tparam is_fp32_dest_acc_en If false, round result to bfloat16
- * @param val The input value x
- * @return Result of ln(1+val)
- */
-template <bool FAST_APPROX, bool is_fp32_dest_acc_en>
-sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
-    sfpi::vFloat abs_x = sfpi::abs(val);
-    sfpi::vFloat result;
-    v_if(abs_x < 0.0078125) {  // use 2^(-7) as threshold value
-        result = val;          // log(1+x) ~ x for x < 0.01
-    }
-    v_else {
-        sfpi::vFloat in = val + sfpi::vConst1;
-        result = calculate_log_body<FAST_APPROX, /*HAS_BASE_SCALING*/ false, /*is_fp32_dest_acc_en*/ true>(in, 0);
-    }
-    v_endif;
-
-    if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
-
-    return result;
-}
-
-/*
- * This function implements ln(1+x) with accurate computation for small x.
- * Algorithm based on log1p_fp32 from operations.py:
- * 1. Handle special cases (x < -1, x == -1, infinity, NaN)
- * 2. For |x| < 0.3: Use 9-term polynomial series to avoid catastrophic cancellation
- * 3. For |x| >= 0.3: Use standard ln(1+x) computation (reuses blackhole's calculate_log_f32_body logic)
- *
- * The threshold of 0.3 and 9 terms work well enough to provide good accuracy
- * across the entire domain.
- *
- * @param val The input value (sfpi::vFloat vector), can be any floating point number > -1
- * @return sfpi::vFloat Result of ln(1+val)
- */
-template <bool is_fp32_dest_acc_en>
-sfpi_inline sfpi::vFloat calculate_log1p_fp32_old(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
-
-    // Check for special cases
-    sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
-
-    v_if(sfpi::reinterpret<sfpi::vInt>(val) == 0x7F800000) {
-        // If input is infinity, return infinity
-        result = std::numeric_limits<float>::infinity();
-    }
-    v_elseif(exp == 128 || val < -1.f) {                   // NaN or negative input -> NaN
-        result = std::numeric_limits<float>::quiet_NaN();  // returns nan
-    }
-    v_elseif(val == -1.f) {
-        // x = -1 input -> -inf
-        result = -std::numeric_limits<float>::infinity();
-    }
-    v_else {
-        // Normal computation
-        sfpi::vFloat abs_val = sfpi::abs(val);
-
-        constexpr float THRESHOLD = 0.3f;
-        v_if(abs_val < THRESHOLD) {
-            // For |x| < 0.3, use 9-term polynomial series (with 10 coefficients  including constant term)
-            // to avoid catastrophic cancellation
-            // Coefficients were computed using Sollya with the following command:
-            // > fpminimax(log(x+1), [|1,2,3,4,5,6,7,8,9|], [|single...|], [-0.3; -2^(-20)] + [2^(-20); 0.3], relative);
-            result = PolynomialEvaluator::eval(
-                val,
-                sfpi::vConst0,
-                sfpi::vConst1,
-                -0.4999997317790985107421875f,
-                0.333332836627960205078125f,
-                -0.250040113925933837890625f,
-                0.20005328953266143798828125f,
-                -0.1650786101818084716796875f,
-                0.14109231531620025634765625f,
-                -0.14774705469608306884765625f,
-                0.133655369281768798828125);
-        }
-        v_else {
-            // The following is the same approximation as calculate_log_f32_body from ckernel_sfpu_log.h.
-            // Ideally, we would like to call calculate_log_f32_body() directly.
-            // However, doing so leads to 'register spilling errors' due to interaction with the
-            // polynomial evaluation near 0.
-
-            // For |x| >= 0.3, use standard ln(1+x) computation
-            sfpi::vFloat one_plus_x = sfpi::vConst1 + val;
-
-            // Extract exponent (debiased) from (1+x)
-            exp = sfpi::exexp(one_plus_x);
-
-            // Extract mantissa and construct m in [1, 2)
-            // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
-            sfpi::vFloat m = sfpi::setexp(one_plus_x, 127);
-
-            // Step 2: Range reduction
-            // If m >= sqrt(2), divide by 2 and increment exponent
-            // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
-            // Use vConstFloatPrgm1 which is set to sqrt(2) in log_init
-            v_if(m >= sfpi::vConstFloatPrgm1) {
-                m = m * 0.5f;   // Divide by 2
-                exp = exp + 1;  // Increment exponent
-            }
-            v_endif;
-
-            // Step 3: Transform to z = (m - 1) / (m + 1)
-            // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
-            // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
-            sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
-            sfpi::vFloat m_plus_1 = m + sfpi::vConst1;
-
-            // Compute z = (m - 1) / (m + 1) using reciprocal
-            // z = m_minus_1 * (1 / m_plus_1)
-            sfpi::vFloat m_plus_1_recip = _sfpu_reciprocal_<2>(m_plus_1);
-            sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
-
-            // Compute z**2 for polynomial evaluation
-            sfpi::vFloat z2 = z * z;
-
-            // Step 4: Polynomial approximation using odd powers
-            // ln(m) = 2z(1 + (z**2)/3 + (z**4)/5 + (z**6)/7 + (z**8)/9 + (z**10)/11)
-            // Using Horner's method on z² with coefficients
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                z2,
-                sfpi::vConst1,
-                0.3333333333333333f,
-                0.2f,
-                0.14285714285714285f,
-                0.1111111111111111f,
-                .09090909090909091f);
-
-            // Final computation: ln(m) = 2 * z * p
-            sfpi::vFloat ln_m = 2.0f * (z * p);
-
-            // Convert exponent to float using sign-magnitude format
-            sfpi::vInt signmag_exp = exp;
-
-            // We want to convert exponent to floating point using int32 -> float conversion.
-            // However, int32_to_float takes a sign-magnitude
-            // This is not an issue for positive numbers (same representation)
-            // For negative numbers, we need to explicitly convert to sign-magnitude format
-            v_if(exp < 0) {
-                // Compute absolute value: ~exp + 1 (two's complement negation)
-                sfpi::vInt exp_abs = ~exp + 1;
-                // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
-                signmag_exp = sfpi::setsgn(exp_abs, 1);
-            }
-            v_endif;
-
-            // Convert to float - int32_to_float handles sign-magnitude format correctly
-            sfpi::vFloat expf = sfpi::int32_to_float(signmag_exp, 0);
-
-            // Step 5: Combine: ln(1+x) = exp×ln(2) + ln(m)
-            // Use vConstFloatPrgm2 which is set to ln(2) in log_init
-            result = expf * sfpi::vConstFloatPrgm2 + ln_m;
-        }
-        v_endif;
-    }
-    v_endif;
-
-    if constexpr (!is_fp32_dest_acc_en) {
-        // Convert to bfloat16 if needed using round-to-nearest-even
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
-
-    return result;
-}
-
 /**
- * @tparam APPROXIMATION_MODE If true, use approximation mode (for consistency with log kernel)
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
+ * @tparam APPROXIMATION_MODE Ignored
+ * @tparam FAST_APPROX Ignored
  * @tparam is_fp32_dest_acc_en If true, DEST registers are fp32, and output does not need to be rounded to bfloat16
  * @tparam ITERATIONS Number of iterations for given face
  */
@@ -252,12 +141,9 @@ template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, i
 inline void calculate_log1p() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result;
-        if constexpr (is_fp32_dest_acc_en) {
-            result = calculate_log1p_fp32<is_fp32_dest_acc_en>(in);
-        } else {
-            result = calculate_log1p_bf16<FAST_APPROX, is_fp32_dest_acc_en>(in);
+        sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -265,20 +151,21 @@ inline void calculate_log1p() {
 }
 
 /**
- * @tparam APPROXIMATION_MODE If true, use approximation mode (for consistency with log kernel)
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
+ * @tparam APPROXIMATION_MODE Ignored
+ * @tparam FAST_APPROX Ignored
  * @tparam is_fp32_dest_acc_en If true, DEST registers are fp32, and output does not need to be rounded to bfloat16
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
-    if constexpr (!is_fp32_dest_acc_en) {
-        log_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
-    } else {
-        // _init_sfpu_reciprocal_ sets vConstFloatPrgm0 to 2.0f
-        _init_sfpu_reciprocal_</*approximation_mode*/ false>();
-        // But we can use 2 other programmable constants:
-        sfpi::vConstFloatPrgm1 = 1.4142135381698608f;   // sqrt(2)
-        sfpi::vConstFloatPrgm2 = 0.69314718246459961f;  // log(2)
+    const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
+    const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
+    // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into
+    // the constant used for the final exponent contribution.
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        // Middle Horner coefficient used only by the fp32 polynomial.
+        sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
 
 /*
+ * The log1p(x) code is derived from code by Norbert Juffa.
+ *
  * Copyright (c) 2015-2023, Norbert Juffa
  * All rights reserved.
  *
@@ -103,17 +105,16 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + sfpi::vConstFloatPrgm1;
             r = r * m + -0.5f;
         } else {
-            // log1p(x) = x + x*x * (
-            //   -0x1p-1 + x * (0x1.5ap-2 + x * (-0x1p-2 + x * 0x1.024p-3)))
+            // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             sfpi::vInt abs_e = sfpi::abs(e);
             m = m + t;
             e_float = sfpi::int32_to_float(abs_e);
 
             s = m * m;
-            r = 0x1.024p-3f;
-            r = r * s + neg_quarter;
-            r = r * m + -0.5f;
+            r = neg_quarter;
+            r = r * m + 0x1.744p-2f;
+            r = r * m + -0x1.008p-1f;
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
-// SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: Apache-2.0
 
 /*
  * The log1p(x) code is derived from code by Norbert Juffa.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -1,7 +1,33 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
+
+/*
+ * Copyright (c) 2015-2023, Norbert Juffa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -12,6 +38,14 @@
 namespace ckernel {
 namespace sfpu {
 
+// For inputs with u = 1 + a > 0, write u = 2^k * t with t chosen in [0.75, 1.5),
+// so m = t - 1 lies in [-0.25, 0.5). Then
+//   log1p(a) = log(u) = k * log(2) + log1p(m).
+// This implementation carries k in exponent-bit units (k << 23), which makes the
+// rescaling and final k * log(2) term cheaper on SFPU.
+// Inputs with 1 + a < 0 fall through to the default NaN.
+// The boundary case u == 0 (a == -1) is outside the 2^k * t derivation above;
+// it still evaluates to -inf via the same bit-level reduction path.
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
     sfpi::vFloat u = a + sfpi::vConst1;
@@ -22,21 +56,37 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
         sfpi::vFloat e_float;
 
+        // Subtracting the encoding of 0.75 and then zeroing the mantissa isolates
+        // the exponent-bit offset e = k << 23 for the unique k with
+        // 2^(-k) * u in [0.75, 1.5).
         e = sfpi::reinterpret<sfpi::vInt>(u) - e;
         e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
 
+        // Reinterpreting a - e applies the same 2^(-k) scaling to a.
+        // Affine correction below reconstructs
+        //   m <- 2^(-k) * a + (2^(-k) - 1) = 2^(-k) * (1 + a) - 1.
         sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
         sfpi::vFloat neg_four = -4.0f;
-        sfpi::vFloat s =
-            sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);  // s' in [2**-126,2**26]
+        // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
+        sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
 
-        // t = 0.25f * s + sfpi::vConstNeg1;
+        // Use -0.25 (instead of 0.25) so we can reuse as polynomial coefficient later.
         sfpi::vFloat neg_quarter = -0.25f;
         sfpi::vFloat neg1 = sfpi::vConstNeg1;
+        // t = -s' / 4 - 1 = 2^(-k) - 1
         sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
-        // approximate log(1+m) on [-0.25, 0.5]
+        // Minimax approximations for log1p(m) on [-0.25, 0.5]. Both paths keep the
+        // exact linear term m explicit and approximate only the nonlinear
+        // correction m^2 * P(m); the fp32 path keeps more terms than the
+        // bf16-rounded path. fp16 or bf16 constants are used where possible to
+        // reduce instruction count.
         if constexpr (is_fp32_dest_acc_en) {
+            // log1p(x) = x + x*x * (
+            //   -0x1p-1 + x * (0x1.555566p-2 + x * (-0x1p-2 + x * (0x1.998p-3 +
+            //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
+            //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
+
             r = -0x1.92cp-5f;
             m = m + t;
             t = 0x1.b84p-4f;
@@ -53,6 +103,9 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + sfpi::vConstFloatPrgm1;
             r = r * m + -0.5f;
         } else {
+            // log1p(x) = x + x*x * (
+            //   -0x1p-1 + x * (0x1.5ap-2 + x * (-0x1p-2 + x * 0x1.024p-3)))
+
             sfpi::vInt abs_e = sfpi::abs(e);
             m = m + t;
             e_float = sfpi::int32_to_float(abs_e);
@@ -62,6 +115,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * s + neg_quarter;
             r = r * m + -0.5f;
         }
+        // int32_to_float returns |e| as a real number in exponent-bit units;
+        // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
         e_float = sfpi::setsgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
         r = r * s + m;
         sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
@@ -104,9 +159,12 @@ template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
     const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
     const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
+    // e represents k << 23 rather than k, so pre-fold the 2^(-23) factor into
+    // the constant used for the final exponent contribution.
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
+        // Middle Horner coefficient used only by the fp32 polynomial.
         sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -99,9 +99,9 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
             e_float = sfpi::int32_to_float(abs_e);
-            r = r * m + neg_quarter;
-            s = m * m;
             r = r * m + sfpi::vConstFloatPrgm1;
+            s = m * m;
+            r = r * m + sfpi::vConstFloatPrgm2;
             r = r * m + -0.5f;
         } else {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
@@ -161,8 +161,9 @@ inline void log1p_init() {
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
-        // Horner coefficient used by fp32 polynomial
-        sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
+        // Horner coefficients used by fp32 polynomial
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
     } else {
         // Horner coefficients used by bf16 polynomial
         sfpi::vConstFloatPrgm1 = 0x1.744p-2f;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,184 +12,73 @@
 namespace ckernel {
 namespace sfpu {
 
-/*
- * This function implements ln(1+x) using Chebyshev approximation for bfloat16.
- * Uses 3rd order Chebyshev polynomial approximation with range reduction.
- *
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
- * @tparam is_fp32_dest_acc_en If false, round result to bfloat16
- * @param val The input value x
- * @return Result of ln(1+val)
- */
-template <bool FAST_APPROX, bool is_fp32_dest_acc_en>
-sfpi_inline sfpi::vFloat calculate_log1p_bf16(sfpi::vFloat val) {
-    sfpi::vFloat abs_x = sfpi::abs(val);
-    sfpi::vFloat result;
-    v_if(abs_x < 0.0078125) {  // use 2^(-7) as threshold value
-        result = val;          // log(1+x) ~ x for x < 0.01
-    }
-    v_else {
-        sfpi::vFloat in = val + sfpi::vConst1;
-        result = calculate_log_body<FAST_APPROX, /*HAS_BASE_SCALING*/ false, /*is_fp32_dest_acc_en*/ true>(in, 0);
-    }
-    v_endif;
-
-    if constexpr (!is_fp32_dest_acc_en) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
-
-    return result;
-}
-
-/*
- * This function implements ln(1+x) with accurate computation for small x.
- * Algorithm based on log1p_fp32 from operations.py:
- * 1. Handle special cases (x < -1, x == -1, infinity, NaN)
- * 2. For |x| < 0.3: Use 9-term polynomial series to avoid catastrophic cancellation
- * 3. For |x| >= 0.3: Use standard ln(1+x) computation
- *
- * The threshold of 0.3 and 9 terms work well enough to provide good accuracy
- * across the entire domain.
- *
- * @param val The input value (sfpi::vFloat vector), can be any floating point number > -1
- * @return sfpi::vFloat Result of ln(1+val)
- */
 template <bool is_fp32_dest_acc_en>
-sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
-    sfpi::vFloat result = sfpi::vConst0;
+sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
+    sfpi::vFloat u = a + sfpi::vConst1;
+    sfpi::vFloat r = std::numeric_limits<float>::quiet_NaN();
 
-    // Check for special cases
-    sfpi::vInt exp = sfpi::exexp(val);  // Get debiased exponent
+    v_if(u >= 0.0f) {
+        sfpi::vFloat three_quarters = 0.75f;
+        sfpi::vInt e = sfpi::reinterpret<sfpi::vInt>(three_quarters);
+        sfpi::vFloat e_float;
 
-    v_if(sfpi::reinterpret<sfpi::vInt>(val) == 0x7F800000) {
-        // If input is infinity, return infinity
-        result = std::numeric_limits<float>::infinity();
-    }
-    v_elseif(exp == 128 || val < -1.f) {                   // NaN or negative input -> NaN
-        result = std::numeric_limits<float>::quiet_NaN();  // returns nan
-    }
-    v_elseif(val == -1.f) {
-        // x = -1 input -> -inf
-        result = -std::numeric_limits<float>::infinity();
-    }
-    v_else {
-        // Normal computation
-        sfpi::vFloat abs_val = sfpi::abs(val);
+        e = sfpi::reinterpret<sfpi::vInt>(u) - e;
+        e = sfpi::reinterpret<sfpi::vInt>(sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(e), 0));
 
-        constexpr float THRESHOLD = 0.3f;
-        v_if(abs_val < THRESHOLD) {
-            // For |x| < 0.3, use 9-term polynomial series (with 10 coefficients including constant term)
-            // to avoid catastrophic cancellation
-            // Coefficients were computed using Sollya with the following command:
-            // > fpminimax(log(x+1), [|1,2,3,4,5,6,7,8,9|], [|single...|], [-0.3; -2^(-20)] + [2^(-20); 0.3], relative);
-            result = PolynomialEvaluator::eval(
-                val,
-                sfpi::vConst0,
-                sfpi::vConst1,
-                -0.4999997317790985107421875f,
-                0.333332836627960205078125f,
-                -0.250040113925933837890625f,
-                0.20005328953266143798828125f,
-                -0.1650786101818084716796875f,
-                0.14109231531620025634765625f,
-                -0.14774705469608306884765625f,
-                0.133655369281768798828125);
+        sfpi::vFloat m = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(a) - e);
+        sfpi::vFloat neg_four = -4.0f;
+        sfpi::vFloat s =
+            sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);  // s' in [2**-126,2**26]
+
+        // t = 0.25f * s + sfpi::vConstNeg1;
+        sfpi::vFloat neg_quarter = -0.25f;
+        sfpi::vFloat neg1 = sfpi::vConstNeg1;
+        sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+
+        // approximate log(1+m) on [-0.25, 0.5]
+        if constexpr (is_fp32_dest_acc_en) {
+            r = -0x1.92cp-5f;
+            m = m + t;
+            t = 0x1.b84p-4f;
+
+            s = m * m;
+            r = r * s + -0x1.0c4p-3f;
+            t = t * s + 0x1.274p-3f;
+            r = r * s + -0x1.55p-3f;
+            t = t * s + 0x1.998p-3f;
+            sfpi::vInt abs_e = sfpi::abs(e);
+            r = r * s + neg_quarter;
+            e_float = sfpi::int32_to_float(abs_e);
+            r = t * m + r;
+            r = r * m + sfpi::vConstFloatPrgm1;
+            r = r * m + -0.5f;
+        } else {
+            sfpi::vInt abs_e = sfpi::abs(e);
+            m = m + t;
+            e_float = sfpi::int32_to_float(abs_e);
+
+            s = m * m;
+            r = 0x1.024p-3f;
+            r = r * s + neg_quarter;
+            r = r * m + -0.5f;
         }
-        v_else {
-            // The following is the same approximation as calculate_log_f32_body from ckernel_sfpu_log.h.
-            // Ideally, we would like to call calculate_log_f32_body() directly.
-            // However, doing so leads to 'register spilling errors' due to interaction with the
-            // polynomial evaluation near 0.
+        e_float = sfpi::setsgn(e_float, sfpi::reinterpret<sfpi::vFloat>(e));
+        r = r * s + m;
+        sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+        r = e_float * sfpi::vConstFloatPrgm0 + r;
 
-            // For |x| >= 0.3, use standard ln(1+x) computation
-            sfpi::vFloat one_plus_x = sfpi::vConst1 + val;
-
-            // Extract exponent (debiased) from (1+x)
-            exp = sfpi::exexp(one_plus_x);
-
-            // Extract mantissa and construct m in [1, 2)
-            // Use setexp to normalize to [1, 2) range by setting exponent to 127 (bias)
-            sfpi::vFloat m = sfpi::setexp(one_plus_x, 127);
-
-            // Step 2: Range reduction
-            // If m >= sqrt(2), divide by 2 and increment exponent
-            // This ensures m is in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
-            constexpr float SQRT2 = 1.4142135381698608f;  // sqrt(2)
-            v_if(m >= SQRT2) {
-                m = m * 0.5f;
-                exp = exp + 1;  // Increment exponent
-            }
-            v_endif;
-
-            // Transform to z = (m - 1) / (m + 1)
-            // This maps m ∈ [0.707, 1.414] to z ∈ [-0.172, 0.172]
-            // ln(m) = 2 × (z + z³/3 + z⁵/5 + z⁷/7 + ...)
-            sfpi::vFloat m_minus_1 = m - sfpi::vConst1;
-            sfpi::vFloat m_plus_1 = m + sfpi::vConst1;
-
-            // Compute z = (m - 1) / (m + 1) using reciprocal
-            // z = m_minus_1 * (1 / m_plus_1)
-            sfpi::vFloat m_plus_1_recip = ckernel::sfpu::_sfpu_reciprocal_<2>(m_plus_1);
-            sfpi::vFloat z = m_minus_1 * m_plus_1_recip;
-
-            // Compute z**2 for polynomial evaluation
-            sfpi::vFloat z2 = z * z;
-
-            // Step 4: Polynomial approximation using odd powers
-            // ln(m) = 2z(1 + (z**2)/3 + (z**4)/5 + (z**6)/7 + (z**8)/9 + (z**10)/11)
-            // Using Horner's method: p = 1 + z**2 * (c3 + z**2 * (c5 + z**2 * (c7 + z**2 * (c9 + z**2 * c11))))
-
-            // Polynomial coefficients for ln(m) where m in [sqrt(2)/2, sqrt(2)]
-            // ln(m) = 2z(1 + z²/3 + z⁴/5 + z⁶/7 + z⁸/9 + z¹⁰/11)
-            // where z = (m - 1) / (m + 1)
-            sfpi::vFloat p = PolynomialEvaluator::eval(
-                z2,
-                sfpi::vConst1,
-                0.3333333333333333f,
-                0.2f,
-                0.14285714285714285f,
-                0.1111111111111111f,
-                .09090909090909091f);
-
-            // Final computation: ln(m) = 2 * z * p
-            sfpi::vFloat ln_m = 2.f * z * p;
-
-            // Combine: ln(1+x) = exp×ln(2) + ln(m)
-            // Convert exponent to float using sign-magnitude format
-            sfpi::vInt signmag_exp = exp;
-
-            // We want to convert exponent to floating point using int32 -> float conversion.
-            // However, int32_to_float takes a sign-magnitude
-            // This is not an issue for positive numbers (same representation)
-            // For negative numbers, we need to explicitly convert to sign-magnitude format
-            v_if(exp < 0) {
-                sfpi::vInt exp_abs = ~exp + 1;  // Two's complement negation
-                // Convert to sign-magnitude negative: setsgn(value, 1) sets MSB to 1
-                signmag_exp = sfpi::setsgn(exp_abs, 1);
-            }
-            v_endif;
-
-            sfpi::vFloat expf = sfpi::int32_to_float(signmag_exp, 0);
-
-            // Step 5: Combine: ln(x) = exp×ln(2) + ln(m)
-            constexpr float LN2 = 0.69314718246459961f;  // log(2)
-            result = expf * LN2 + ln_m;                  // log(x) = log2(x) / log(2)
-        }
+        // since u>=0, safely checks for u == NaN or u == inf
+        v_if(sfpi::reinterpret<sfpi::vInt>(u) >= sfpi::reinterpret<sfpi::vInt>(infinity)) { r = u; }
         v_endif;
     }
     v_endif;
 
-    if constexpr (!is_fp32_dest_acc_en) {
-        // Convert to bfloat16 if needed using round-to-nearest-even
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
-
-    return result;
+    return r;
 }
 
 /**
- * @tparam APPROXIMATION_MODE If true, use approximation mode (for consistency with log kernel)
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
+ * @tparam APPROXIMATION_MODE Ignored
+ * @tparam FAST_APPROX Ignored
  * @tparam is_fp32_dest_acc_en If true, DEST registers are fp32, and output does not need to be rounded to bfloat16
  * @tparam ITERATIONS Number of iterations for given face
  */
@@ -196,12 +86,9 @@ template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, i
 inline void calculate_log1p() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result;
-        if constexpr (is_fp32_dest_acc_en) {
-            result = calculate_log1p_fp32<is_fp32_dest_acc_en>(in);
-        } else {
-            result = calculate_log1p_bf16<FAST_APPROX, is_fp32_dest_acc_en>(in);
+        sfpi::vFloat result = calculate_log1p_fp32<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
@@ -209,17 +96,18 @@ inline void calculate_log1p() {
 }
 
 /**
- * @tparam APPROXIMATION_MODE If true, use approximation mode (for consistency with log kernel)
- * @tparam FAST_APPROX If true, skip NaN check for negative inputs
+ * @tparam APPROXIMATION_MODE Ignored
+ * @tparam FAST_APPROX Ignored
  * @tparam is_fp32_dest_acc_en If true, DEST registers are fp32, and output does not need to be rounded to bfloat16
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void log1p_init() {
-    if constexpr (!is_fp32_dest_acc_en) {
-        log_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
-    } else {
-        _init_reciprocal_</*approximation_mode*/ false, /*legacy_compat*/ false>();
-        // Note: Unlike blackhole, _init_reciprocal_ uses 3 programmble constants
+    const float LOG_TWO = 0.693147182f;       // 0x1.62e430p-1
+    const float TWO_TO_M23 = 1.19209290e-7f;  // 0x1.0p-23
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -98,7 +98,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + 0x1.274p-3f;
             r = r * m + -0x1.55p-3f;
             r = r * m + 0x1.998p-3f;
-            e_float = sfpi::int32_to_float(abs_e);
+            e_float = sfpi::int32_to_float(abs_e, 0);
             r = r * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;
@@ -107,7 +107,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             m = m + t;
-            e_float = sfpi::int32_to_float(abs_e);
+            e_float = sfpi::int32_to_float(abs_e, 0);
             r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
             r = r * m + sfpi::vConstFloatPrgm2;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2015-2023 Norbert Juffa
 // SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
 //
-// SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 /*
  * The log1p(x) code is derived from code by Norbert Juffa.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -72,7 +72,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // Use s' = -4 * 2^(-k) instead of 4 * 2^(-k); see -0.25 for explanation.
         sfpi::vFloat s = sfpi::reinterpret<sfpi::vFloat>(sfpi::reinterpret<sfpi::vInt>(neg_four) - e);
 
-        // Use -0.25 (instead of 0.25) so we can reuse as polynomial coefficient later.
+        // Use -0.25 (instead of 0.25) so we can reuse it in the bf16 Horner step later.
         sfpi::vFloat neg_quarter = -0.25f;
         sfpi::vFloat neg1 = sfpi::vConstNeg1;
         // t = -s' / 4 - 1 = 2^(-k) - 1
@@ -86,10 +86,10 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // bf16-rounded path. fp16 or bf16 constants are used where possible to
         // reduce instruction count.
         if constexpr (is_fp32_dest_acc_en) {
-            // log1p(x) = x + x*x * (
-            //   -0x1p-1 + x * (0x1.555566p-2 + x * (-0x1p-2 + x * (0x1.998p-3 +
-            //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
-            //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
+            // log1p(m) ~= m + m*m * (
+            //   -0x1p-1 + m * (0x1.555572p-2 + m * (-0x1.00001ap-2 + m * (0x1.998p-3 +
+            //   m * (-0x1.55p-3 + m * (0x1.274p-3 + m * (-0x1.0c4p-3 + m *
+            //   (0x1.b84p-4 + m * (-0x1.92cp-5)))))))))
 
             m = m + t;
             r = -0x1.92cp-5f;
@@ -161,7 +161,8 @@ inline void log1p_init() {
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
-        // Horner coefficients used by fp32 polynomial
+        // Stored separately because the tuned fp32 m^3 and m^4 coefficients are
+        // no longer the shared exact 1/3 and -1/4 values used in the bf16 path.
         sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
         sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
     } else {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -78,6 +78,8 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
         // t = -s' / 4 - 1 = 2^(-k) - 1
         sfpi::vFloat t = __builtin_rvtt_sfpmad(neg_quarter.get(), s.get(), neg1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
 
+        sfpi::vInt abs_e = sfpi::abs(e);
+
         // Minimax approximations for log1p(m) on [-0.25, 0.5]. Both paths keep the
         // exact linear term m explicit and approximate only the nonlinear
         // correction m^2 * P(m); the fp32 path keeps more terms than the
@@ -89,31 +91,26 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             //   x * (-0x1.55p-3 + x * (0x1.274p-3 + x * (-0x1.0c4p-3 + x *
             //   (0x1.b84p-4 + x * (-0x1.92cp-5)))))))))
 
-            r = -0x1.92cp-5f;
             m = m + t;
-            t = 0x1.b84p-4f;
-
-            s = m * m;
-            r = r * s + -0x1.0c4p-3f;
-            t = t * s + 0x1.274p-3f;
-            r = r * s + -0x1.55p-3f;
-            t = t * s + 0x1.998p-3f;
-            sfpi::vInt abs_e = sfpi::abs(e);
-            r = r * s + neg_quarter;
+            r = -0x1.92cp-5f;
+            r = r * m + 0x1.b84p-4f;
+            r = r * m + -0x1.0c4p-3f;
+            r = r * m + 0x1.274p-3f;
+            r = r * m + -0x1.55p-3f;
+            r = r * m + 0x1.998p-3f;
             e_float = sfpi::int32_to_float(abs_e);
-            r = t * m + r;
+            r = r * m + neg_quarter;
+            s = m * m;
             r = r * m + sfpi::vConstFloatPrgm1;
             r = r * m + -0.5f;
         } else {
             // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
-            sfpi::vInt abs_e = sfpi::abs(e);
             m = m + t;
             e_float = sfpi::int32_to_float(abs_e);
-
+            r = neg_quarter * m + sfpi::vConstFloatPrgm1;
             s = m * m;
-            r = neg_quarter * m + 0x1.744p-2f;
-            r = r * m + -0x1.008p-1f;
+            r = r * m + sfpi::vConstFloatPrgm2;
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).
@@ -164,8 +161,12 @@ inline void log1p_init() {
     sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
 
     if constexpr (is_fp32_dest_acc_en) {
-        // Middle Horner coefficient used only by the fp32 polynomial.
+        // Horner coefficient used by fp32 polynomial
         sfpi::vConstFloatPrgm1 = 0x1.555566p-2f;
+    } else {
+        // Horner coefficients used by bf16 polynomial
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-2-Clause
 
 /*
+ * The log1p(x) code is derived from code by Norbert Juffa.
+ *
  * Copyright (c) 2015-2023, Norbert Juffa
  * All rights reserved.
  *
@@ -103,17 +105,16 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             r = r * m + sfpi::vConstFloatPrgm1;
             r = r * m + -0.5f;
         } else {
-            // log1p(x) = x + x*x * (
-            //   -0x1p-1 + x * (0x1.5ap-2 + x * (-0x1p-2 + x * 0x1.024p-3)))
+            // log1p(x) = x + x*x * (-0x1.008p-1 + x * (0x1.744p-2 + x * (-0x1p-2)))
 
             sfpi::vInt abs_e = sfpi::abs(e);
             m = m + t;
             e_float = sfpi::int32_to_float(abs_e);
 
             s = m * m;
-            r = 0x1.024p-3f;
-            r = r * s + neg_quarter;
-            r = r * m + -0.5f;
+            r = neg_quarter;
+            r = r * m + 0x1.744p-2f;
+            r = r * m + -0x1.008p-1f;
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;
         // restore sign and multiply by log(2) * 2^(-23) to recover k * log(2).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -112,8 +112,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat a) {
             e_float = sfpi::int32_to_float(abs_e);
 
             s = m * m;
-            r = neg_quarter;
-            r = r * m + 0x1.744p-2f;
+            r = neg_quarter * m + 0x1.744p-2f;
             r = r * m + -0x1.008p-1f;
         }
         // int32_to_float returns |e| as a real number in exponent-bit units;


### PR DESCRIPTION
### Ticket

Closes https://github.com/tenstorrent/tt-metal/issues/41028

### Problem description

log1p had room for optimisation.

### What's changed

- Reduce range to [-0.25, 0.5) and use minimax polynomials specialised for fp32 and bf16, with special attention paid to reuse and size of constants to reduce operation count.
- fp32 is now at 42 cycles (reduced from 130 cycles: 3.1x faster) with faithfully rounded results for all inputs.
- bf16 is now at 30 cycles (reduced from 58 cycles: 1.93x faster) with correctly rounded (round to nearest with ties away from zero) results for all inputs.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
