### PR TITLE
Quick fix for pinnings in multi-mesh solver

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -968,6 +968,81 @@ TEST_F(TopologyMapperUtilsTest, Pinning_NodeNotInMesh_Fails) {
     EXPECT_THAT(result.error_message, ::testing::HasSubstr("not found"));
 }
 
+TEST_F(TopologyMapperUtilsTest, Pinning_MapMultiMeshToPhysical_MeshLevelPinningsAppliedFirst) {
+    // Two logical meshes (two 2-node chains) paired with two physical meshes of matching sizes so
+    // inter-mesh assignment is unique; rank bindings + pinnings constrain mesh pairing and intra-mesh placement.
+    using namespace ::tt::tt_fabric;
+
+    const MeshId lm0{0};
+    const MeshId lm1{1};
+    const MeshId pm0{0};
+    const MeshId pm1{1};
+
+    const std::vector<FabricNodeId> ln0 = {FabricNodeId(lm0, 0), FabricNodeId(lm0, 1)};
+    const std::vector<FabricNodeId> ln1 = {FabricNodeId(lm1, 0), FabricNodeId(lm1, 1)};
+
+    LogicalMultiMeshGraph logical;
+    logical.mesh_adjacency_graphs_[lm0] = AdjacencyGraph<FabricNodeId>(build_chain_adjacency(ln0));
+    logical.mesh_adjacency_graphs_[lm1] = AdjacencyGraph<FabricNodeId>(build_chain_adjacency(ln1));
+
+    AdjacencyGraph<MeshId>::AdjacencyMap mesh_level;
+    mesh_level[lm0] = {lm1};
+    mesh_level[lm1] = {lm0};
+    logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(mesh_level);
+
+    const tt::tt_metal::AsicID a100{100};
+    const tt::tt_metal::AsicID a101{101};
+    const tt::tt_metal::AsicID a200{200};
+    const tt::tt_metal::AsicID a201{201};
+
+    PhysicalAdjacencyMap pa0;
+    pa0[a100] = {a101};
+    pa0[a101] = {a100};
+    PhysicalAdjacencyMap pa1;
+    pa1[a200] = {a201};
+    pa1[a201] = {a200};
+
+    PhysicalMultiMeshGraph physical;
+    physical.mesh_level_graph_ = AdjacencyGraph<MeshId>(mesh_level);
+    physical.mesh_adjacency_graphs_[pm0] = AdjacencyGraph<tt::tt_metal::AsicID>(pa0);
+    physical.mesh_adjacency_graphs_[pm1] = AdjacencyGraph<tt::tt_metal::AsicID>(pa1);
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (const auto& node : ln0) {
+        fabric_node_id_to_mesh_rank[lm0][node] = rank0_;
+    }
+    for (const auto& node : ln1) {
+        fabric_node_id_to_mesh_rank[lm1][node] = rank0_;
+    }
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank = {};
+
+    TopologyMappingConfig config;
+    config.inter_mesh_validation_mode = ConnectionValidationMode::RELAXED;
+
+    const AsicPosition pos100{tt::tt_metal::TrayID{1}, tt::tt_metal::ASICLocation{0}};
+    const AsicPosition pos101{tt::tt_metal::TrayID{1}, tt::tt_metal::ASICLocation{1}};
+    const AsicPosition pos200{tt::tt_metal::TrayID{2}, tt::tt_metal::ASICLocation{0}};
+    const AsicPosition pos201{tt::tt_metal::TrayID{2}, tt::tt_metal::ASICLocation{1}};
+    config.asic_positions[a100] = pos100;
+    config.asic_positions[a101] = pos101;
+    config.asic_positions[a200] = pos200;
+    config.asic_positions[a201] = pos201;
+
+    // Logical mesh 0 has no pinnings. It will be placed on the first available physical mesh, if the pinnings are
+    // applied only at the intra-mesh level. Pin logical mesh 1, such that it has to land on physical mesh 0. This
+    // will make sure we apply mesh-level pinnings before inter-mesh mapping.
+    config.pinnings.emplace_back(pos100, ln1[0]);
+
+    const auto result =
+        map_multi_mesh_to_physical(logical, physical, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+    EXPECT_EQ(result.fabric_node_to_asic.size(), 4u);
+    EXPECT_EQ(result.fabric_node_to_asic.at(ln0[0]), a200);
+}
+
 // =============================================================================
 // Failure Case Tests
 // =============================================================================

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -761,6 +761,21 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
     }
 }
 
+// Helper function to build ASIC positions to ASIC IDs map
+std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
+    const ::tt::tt_fabric::AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph, const TopologyMappingConfig& config) {
+    std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> asic_positions_to_asic_ids;
+    if (!config.asic_positions.empty()) {
+        for (const auto& asic_id : physical_graph.get_nodes()) {
+            auto pos_it = config.asic_positions.find(asic_id);
+            if (pos_it != config.asic_positions.end()) {
+                asic_positions_to_asic_ids[pos_it->second].insert(asic_id);
+            }
+        }
+    }
+    return asic_positions_to_asic_ids;
+}
+
 // Helper function to build inter-mesh constraints
 // Maps logical meshes to physical meshes based on matching mesh host ranks
 // A logical mesh maps to a physical mesh if the ASICs in that physical mesh have matching ranks
@@ -777,6 +792,21 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
         add_inter_mesh_minimal_host_cover_from_hostname_map(
             config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
         return inter_mesh_constraints;
+    }
+
+    std::map<MeshId, std::set<MeshId>> mesh_level_pinnings;
+    for (const auto& [pos, fabric_node] : config.pinnings) {
+        for (const auto& [physical_mesh_id, physical_mesh_graph] : physical_graph.mesh_adjacency_graphs_) {
+            auto asic_position_map = build_asic_positions_map(physical_mesh_graph, config);
+            if (asic_position_map.contains(pos)) {
+                mesh_level_pinnings[fabric_node.mesh_id].insert(physical_mesh_id);
+            }
+        }
+    }
+    for (const auto& [mesh_id, physical_meshes] : mesh_level_pinnings) {
+        if (!physical_meshes.empty()) {
+            inter_mesh_constraints.add_required_constraint(mesh_id, physical_meshes);
+        }
     }
 
     // Find the Physical graph mesh ID to asic id to mesh rank mapping based on the asics in the physical graph
@@ -837,21 +867,6 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
         return config_mode_it->second;
     }
     return ::tt::tt_fabric::ConnectionValidationMode::RELAXED;
-}
-
-// Helper function to build ASIC positions to ASIC IDs map
-std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
-    const ::tt::tt_fabric::AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph, const TopologyMappingConfig& config) {
-    std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> asic_positions_to_asic_ids;
-    if (!config.asic_positions.empty()) {
-        for (const auto& asic_id : physical_graph.get_nodes()) {
-            auto pos_it = config.asic_positions.find(asic_id);
-            if (pos_it != config.asic_positions.end()) {
-                asic_positions_to_asic_ids[pos_it->second].insert(asic_id);
-            }
-        }
-    }
-    return asic_positions_to_asic_ids;
 }
 
 // Helper function to add rank binding constraints. Only called when config.disable_rank_bindings is false.
@@ -1521,7 +1536,14 @@ TopologyMappingResult map_multi_mesh_to_physical(
         // Step 2: For each mesh mapping, do the sub mapping for fabric node id to asic id
         std::unordered_map<MeshId, MeshId> mesh_mappings(
             solver_result.target_to_global.begin(), solver_result.target_to_global.end());
+        log_info(tt::LogFabric, "Attempt {}: Mapping {} mesh pair(s)", retry_attempt, mesh_mappings.size());
         for (const auto& [logical_mesh_id, physical_mesh_id] : mesh_mappings) {
+            log_info(
+                tt::LogFabric,
+                "Attempt {}: Mapping mesh {} -> {}",
+                retry_attempt,
+                logical_mesh_id.get(),
+                physical_mesh_id.get());
             // Get the logical graph and the physical graph
             const auto& logical_graph = adjacency_map_logical.mesh_adjacency_graphs_.at(logical_mesh_id);
             const auto& physical_graph = adjacency_map_physical.mesh_adjacency_graphs_.at(physical_mesh_id);


### PR DESCRIPTION
### Problem description
Currently user-specified pinnings are applied when the topology solver performs the intra-mesh mapping. This has a high likelihood of failing. Inter-mesh mapping is performed first, which means by the time the pinnings are applied, logical to physical mesh mappings are established, and the mapper may be blocked from exploring solutions which satisfy the pinnings.

### What's changed
Apply mesh-level pinnings before doing the inter-mesh level solve, as well as at intra-mesh level.
