### PR TITLE
MoE Dispatch and Combine DRAM Read optimization

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -11,12 +11,12 @@ import torch
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     create_fabric_router_config,
     create_gate_weights,
     get_ep_mesh_composer,
     get_gate_outputs,
+    get_max_payload_size,
     get_sp_mesh_composer,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
@@ -44,7 +44,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -55,7 +55,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -66,7 +66,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -77,7 +77,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (8, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -11,6 +11,7 @@ import torch
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     create_fabric_router_config,
     create_gate_weights,
@@ -43,7 +44,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -54,7 +55,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -65,7 +66,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -76,7 +77,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_test
             (8, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
@@ -14,7 +14,11 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE,
+    create_fabric_router_config,
+    extract_mesh_config,
+)
 
 
 def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -50,7 +54,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -61,7 +65,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -72,7 +76,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -83,7 +87,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_offset_cumsum.py
@@ -15,9 +15,9 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE,
     create_fabric_router_config,
     extract_mesh_config,
+    get_max_payload_size,
 )
 
 
@@ -54,7 +54,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -65,7 +65,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -76,7 +76,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -87,7 +87,7 @@ def torch_offset_cumsum(histograms: torch.Tensor) -> tuple[torch.Tensor, torch.T
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -19,7 +19,6 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -28,6 +27,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_ep_mesh_mapper,
     get_expert_token_counts_mesh_mapper,
     get_gate_outputs,
+    get_max_payload_size,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
@@ -54,7 +54,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -65,7 +65,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -76,7 +76,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -87,7 +87,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -98,7 +98,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -109,7 +109,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -120,7 +120,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -131,7 +131,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -142,7 +142,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -153,7 +153,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -164,7 +164,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -175,7 +175,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -186,7 +186,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -19,6 +19,7 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -53,7 +54,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -64,7 +65,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -75,7 +76,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -86,7 +87,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -97,7 +98,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -108,7 +109,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -119,7 +120,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -130,7 +131,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -141,7 +142,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -152,7 +153,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -163,7 +164,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -174,7 +175,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -185,7 +186,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -17,7 +17,6 @@ from tracy import signpost
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -25,6 +24,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_dispatch_input_mesh_mapper,
     get_ep_mesh_composer,
     get_gate_outputs,
+    get_max_payload_size,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
@@ -100,7 +100,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -111,7 +111,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -122,7 +122,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -133,7 +133,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -144,7 +144,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -155,7 +155,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -166,7 +166,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -177,7 +177,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -188,7 +188,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -199,7 +199,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -210,7 +210,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -221,7 +221,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -232,7 +232,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -17,6 +17,7 @@ from tracy import signpost
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -99,7 +100,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -110,7 +111,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -121,7 +122,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -132,7 +133,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -143,7 +144,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -154,7 +155,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -165,7 +166,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -176,7 +177,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -187,7 +188,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -198,7 +199,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -209,7 +210,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -220,7 +221,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -231,7 +232,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -19,7 +19,6 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -27,6 +26,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_dispatch_input_mesh_mapper,
     get_ep_mesh_composer,
     get_gate_outputs,
+    get_max_payload_size,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
@@ -57,7 +57,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -68,7 +68,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -79,7 +79,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -90,7 +90,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -101,7 +101,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -112,7 +112,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -123,7 +123,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -134,7 +134,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Linear,
@@ -145,7 +145,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Ring,
@@ -156,7 +156,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             2,
             ttnn.Topology.Ring,
@@ -167,7 +167,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -178,7 +178,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -189,7 +189,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -200,7 +200,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -504,7 +504,7 @@ def test_ttnn_dispatch_combine(
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,
@@ -650,7 +650,7 @@ def test_ttnn_dispatch_combine_overflow(
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -504,7 +504,7 @@ def test_ttnn_dispatch_combine(
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -641,3 +641,35 @@ def test_ttnn_dispatch_combine_overflow(
     tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
     ttnn.synchronize_device(mesh_device)
     logger.info("[overflow test] Combine completed (did not hang)")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-1link",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_ttnn_dispatch_combine_top4(mesh_device, num_links, topology):
+    """Regression test for num_experts_per_tok > 2 (previously caused hangs due to undersized CB buffering)."""
+    test_ttnn_dispatch_combine(
+        mesh_device=mesh_device,
+        seq_len_per_chip=1600,
+        emb_dim=7168,
+        num_routed_experts=64,
+        num_experts_per_tok=4,
+        capacity_factor=2,
+        num_links=num_links,
+        topology=topology,
+        use_predictable_data=True,
+    )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -19,6 +19,7 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -56,7 +57,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -67,7 +68,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -78,7 +79,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -89,7 +90,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -100,7 +101,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -111,7 +112,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -122,7 +123,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -133,7 +134,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Linear,
@@ -144,7 +145,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Ring,
@@ -155,7 +156,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 1),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             2,
             ttnn.Topology.Ring,
@@ -166,7 +167,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -177,7 +178,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (4, 2),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -188,7 +189,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (2, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,
@@ -199,7 +200,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
             (8, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+                "fabric_router_config": create_fabric_router_config(max_payload_size=MAX_PAYLOAD_SIZE),
             },
             1,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -1,0 +1,604 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Performance test for dispatch and combine operations.
+
+Measures host-side wall-clock time for dispatch and combine operations
+across Linear vs Ring topologies to quantify the performance delta.
+
+Usage:
+    # Run on 8-chip linear:
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "linear-8" -s
+
+    # Run on 8-chip ring:
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "ring-8" -s
+
+    # Run all configurations:
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -s
+
+    # With device-side DPRINT cycle counters (requires ENABLE_PERF_TRACE=1 in kernel .cpp files):
+    TT_METAL_DPRINT_CORES="0,0" TT_METAL_DPRINT_CHIPS=0 \
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -s
+
+    DPRINT output is auto-redirected to a temp file for parsing.  The test
+    prints a per-kernel cycle breakdown after each config and a device-cycle
+    comparison table in the final summary.
+"""
+
+import os
+import re
+import tempfile
+import time
+from collections import defaultdict
+
+# Auto-redirect DPRINT to a parseable file when DPRINT is enabled.
+# Must happen before ttnn import so the DPRINT server picks up the path.
+_DPRINT_FILE: str | None = os.environ.get("TT_METAL_DPRINT_FILE")
+if _DPRINT_FILE is None and os.environ.get("TT_METAL_DPRINT_CORES"):
+    _DPRINT_FILE = os.path.join(tempfile.gettempdir(), f"dprint_perf_{os.getpid()}.log")
+    os.environ["TT_METAL_DPRINT_FILE"] = _DPRINT_FILE
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    create_fabric_router_config,
+    extract_mesh_config,
+    get_dispatch_input_mesh_mapper,
+    get_ep_mesh_mapper,
+    get_gate_outputs,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
+from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+
+WARMUP_ITERS = 2
+MEASURE_ITERS = 5
+
+SEQ_LEN_PER_CHIP = 3200
+EMB_DIM = 7168
+NUM_ROUTED_EXPERTS = 64
+NUM_EXPERTS_PER_TOK = 2
+CAPACITY_FACTOR = 2
+
+_collected_results: list[dict] = []
+
+# ---------------------------------------------------------------------------
+# DPRINT parsing helpers
+# ---------------------------------------------------------------------------
+
+_PERF_RE = re.compile(r"PERF\s+(\w+)\s+(.*?)$", re.MULTILINE)
+_KV_RE = re.compile(r"(\w+)=(\d+)")
+_COUNTER_FIELDS = frozenset({"chip", "core", "total", "n_local", "n_remote", "n_sends"})
+
+
+def _dprint_file_pos() -> int:
+    if not _DPRINT_FILE or not os.path.exists(_DPRINT_FILE):
+        return 0
+    return os.path.getsize(_DPRINT_FILE)
+
+
+def _read_perf_entries(start_pos: int) -> list[tuple[str, dict[str, int]]]:
+    """Read PERF lines from the DPRINT file starting at *start_pos*."""
+    if not _DPRINT_FILE or not os.path.exists(_DPRINT_FILE):
+        return []
+    with open(_DPRINT_FILE) as f:
+        f.seek(start_pos)
+        text = f.read()
+    entries = []
+    for m in _PERF_RE.finditer(text):
+        kernel = m.group(1)
+        fields = {k: int(v) for k, v in _KV_RE.findall(m.group(2))}
+        entries.append((kernel, fields))
+    return entries
+
+
+def _median(values: list[int]) -> int:
+    s = sorted(values)
+    return s[len(s) // 2]
+
+
+def _summarize_perf(entries: list[tuple[str, dict[str, int]]]) -> dict[str, dict]:
+    """Group PERF entries by kernel and compute median cycles + breakdown."""
+    by_kernel: dict[str, list[dict[str, int]]] = defaultdict(list)
+    for kernel, fields in entries:
+        by_kernel[kernel].append(fields)
+
+    results = {}
+    for kernel in sorted(by_kernel):
+        samples = by_kernel[kernel]
+        total_med = _median([s.get("total", 0) for s in samples])
+
+        all_fields = set()
+        for s in samples:
+            all_fields.update(s.keys())
+
+        cycle_fields = {}
+        counter_fields = {}
+        for field in sorted(all_fields):
+            vals = [s.get(field, 0) for s in samples]
+            med = _median(vals)
+            if field in _COUNTER_FIELDS:
+                counter_fields[field] = med
+            else:
+                cycle_fields[field] = med
+
+        results[kernel] = {
+            "total": total_med,
+            "cycles": cycle_fields,
+            "counters": counter_fields,
+            "n_samples": len(samples),
+        }
+    return results
+
+
+def _format_kernel_perf(perf: dict[str, dict]) -> str:
+    """Format per-kernel perf breakdown for a single test config."""
+    if not perf:
+        return ""
+    lines = [
+        f"  {'Kernel':<20} {'Total':>10} {'N':>4}  Breakdown (% of total)",
+        f"  {'-'*20} {'-'*10} {'-'*4}  {'-'*55}",
+    ]
+    for kernel in sorted(perf):
+        r = perf[kernel]
+        total = r["total"]
+        n = r["n_samples"]
+        breakdown = sorted(r["cycles"].items(), key=lambda kv: -kv[1])
+        parts = []
+        for field, val in breakdown:
+            pct = val * 100.0 / total if total else 0
+            parts.append(f"{field}={pct:.0f}%")
+        lines.append(f"  {kernel:<20} {total:>10} {n:>4}  {' '.join(parts)}")
+        counters = {k: v for k, v in r["counters"].items() if k not in ("chip", "core")}
+        if counters:
+            cstr = " ".join(f"{k}={v}" for k, v in counters.items())
+            lines.append(f"  {'':<20} {'':<10} {'':<4}  ({cstr})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def print_summary():
+    """Print a comparison summary table after all parametrized tests in this module complete."""
+    _collected_results.clear()
+    if _DPRINT_FILE:
+        logger.info(f"DPRINT output file: {_DPRINT_FILE}")
+    yield
+    if not _collected_results:
+        return
+
+    # --- Wall-clock summary ---
+    header = (
+        f"\n{'='*90}\n"
+        f"  COMPARISON SUMMARY  (median us, {MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
+        f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
+        f"{'='*90}\n"
+        f"  {'Config':<22} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
+        f"  {'-'*22} {'-'*12} {'-'*12} {'-'*12}"
+    )
+    rows = []
+    for r in _collected_results:
+        rows.append(
+            f"  {r['config']:<22} {r['dispatch_med']:>12.1f} {r['combine_med']:>12.1f} {r['roundtrip_med']:>12.1f}"
+        )
+
+    speedup_lines = []
+    lookup: dict[tuple, dict] = {}
+    for r in _collected_results:
+        lookup[(r["num_devices"], r["topo"], r["num_links"])] = r
+
+    def fmt_speedup(base, fast):
+        d_sp = base["dispatch_med"] / fast["dispatch_med"] if fast["dispatch_med"] else 0
+        c_sp = base["combine_med"] / fast["combine_med"] if fast["combine_med"] else 0
+        r_sp = base["roundtrip_med"] / fast["roundtrip_med"] if fast["roundtrip_med"] else 0
+        return f"{d_sp:>12.2f}x {c_sp:>12.2f}x {r_sp:>12.2f}x"
+
+    seen_devices = sorted({r["num_devices"] for r in _collected_results})
+    for ndev in seen_devices:
+        for nlinks in (1, 2):
+            lin = lookup.get((ndev, "Linear", nlinks))
+            ring = lookup.get((ndev, "Ring", nlinks))
+            if lin and ring:
+                label = f"Ring/Lin {ndev}dev {nlinks}L"
+                speedup_lines.append(f"  {label:<22} {fmt_speedup(lin, ring)}")
+        for topo in ("Linear", "Ring"):
+            one = lookup.get((ndev, topo, 1))
+            two = lookup.get((ndev, topo, 2))
+            if one and two:
+                label = f"2L/1L {topo[:3]} {ndev}dev"
+                speedup_lines.append(f"  {label:<22} {fmt_speedup(one, two)}")
+
+    summary = "\n".join([header] + rows)
+    if speedup_lines:
+        summary += (
+            f"\n\n  {'Speedup':<22} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
+            f"  {'-'*22} {'-'*12} {'-'*12} {'-'*12}\n" + "\n".join(speedup_lines)
+        )
+    summary += f"\n{'='*90}"
+    logger.info(summary)
+
+    # --- Device cycle summary (if DPRINT data was collected) ---
+    has_perf = any(r.get("device_perf") for r in _collected_results)
+    if not has_perf:
+        return
+
+    kernels = sorted({k for r in _collected_results if r.get("device_perf") for k in r["device_perf"]})
+
+    for kernel in kernels:
+        # Collect all cycle-breakdown fields across configs for this kernel
+        all_fields: list[str] = []
+        seen: set[str] = set()
+        for r in _collected_results:
+            kp = r.get("device_perf", {}).get(kernel)
+            if not kp:
+                continue
+            for field, _ in sorted(kp["cycles"].items(), key=lambda kv: -kv[1]):
+                if field not in seen:
+                    all_fields.append(field)
+                    seen.add(field)
+
+        col_w = 8
+        hdr_config = f"  {'Config':<22} {'total':>10}"
+        hdr_fields = "".join(f" {f:>{col_w}}" for f in all_fields)
+        sep_config = f"  {'-'*22} {'-'*10}"
+        sep_fields = (f" {'-'*col_w}") * len(all_fields)
+
+        lines = [
+            f"\n{'='*(35 + (col_w + 1) * len(all_fields))}",
+            f"  DEVICE CYCLES: {kernel}  (median, % of total)",
+            f"{'='*(35 + (col_w + 1) * len(all_fields))}",
+            hdr_config + hdr_fields,
+            sep_config + sep_fields,
+        ]
+        for r in _collected_results:
+            kp = r.get("device_perf", {}).get(kernel)
+            if not kp:
+                row = f"  {r['config']:<22} {'N/A':>10}" + (f" {'':>{col_w}}") * len(all_fields)
+            else:
+                total = kp["total"]
+                row = f"  {r['config']:<22} {total:>10}"
+                for f in all_fields:
+                    val = kp["cycles"].get(f, 0)
+                    pct = val * 100.0 / total if total else 0
+                    row += f" {pct:>{col_w - 1}.0f}%"
+            lines.append(row)
+
+        # Add counter row if available
+        counter_keys: list[str] = []
+        counter_seen: set[str] = set()
+        for r in _collected_results:
+            kp = r.get("device_perf", {}).get(kernel)
+            if kp:
+                for ck in kp["counters"]:
+                    if ck not in ("chip", "core", "total") and ck not in counter_seen:
+                        counter_keys.append(ck)
+                        counter_seen.add(ck)
+        if counter_keys:
+            lines.append("")
+            lines.append(f"  {'Config':<22} " + "".join(f" {ck:>{col_w}}" for ck in counter_keys))
+            lines.append(f"  {'-'*22} " + (f" {'-'*col_w}") * len(counter_keys))
+            for r in _collected_results:
+                kp = r.get("device_perf", {}).get(kernel)
+                row = f"  {r['config']:<22} "
+                if kp:
+                    for ck in counter_keys:
+                        row += f" {kp['counters'].get(ck, 0):>{col_w}}"
+                lines.append(row)
+
+        lines.append(f"{'='*(35 + (col_w + 1) * len(all_fields))}")
+        logger.info("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
+            id="linear-4-2link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="ring-4-1link",
+        ),
+        pytest.param(
+            (4, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="ring-4-2link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-2link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="ring-8-1link",
+        ),
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="ring-8-2link",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_dispatch_combine_perf(
+    mesh_device,
+    num_links,
+    topology,
+):
+    num_devices = mesh_device.get_num_devices()
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
+        SEQ_LEN_PER_CHIP, NUM_ROUTED_EXPERTS, NUM_EXPERTS_PER_TOK, num_devices, dispatch_group_size, CAPACITY_FACTOR
+    )
+
+    topo_name = "Ring" if topology == ttnn.Topology.Ring else "Linear"
+    logger.info(
+        f"\n{'='*70}\n"
+        f"  PERF TEST: {topo_name} topology, {num_devices} devices, {num_links} link(s)\n"
+        f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
+        f"  experts_per_chip={experts_per_chip}, max_tok_per_expert={max_dispatched_tokens_per_expert}\n"
+        f"  dispatch_group_size={dispatch_group_size}, num_dispatch_groups={num_dispatch_groups}\n"
+        f"{'='*70}"
+    )
+
+    x, weights, indices = initialize_test_inputs(
+        dispatch_group_size=dispatch_group_size,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        emb_dim=EMB_DIM,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        seed=42,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    mesh_mapper_dispatch_inputs = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
+
+    tt_x = ttnn.from_torch(
+        x,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    tt_weights = ttnn.from_torch(
+        weights,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    tt_indices = ttnn.from_torch(
+        indices,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+
+    expert_offsets, expert_token_counts, _ = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        NUM_ROUTED_EXPERTS,
+        experts_per_chip,
+        SEQ_LEN_PER_CHIP,
+        NUM_EXPERTS_PER_TOK,
+    )
+
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    tt_expert_offsets = TtDispatchModule.shard_expert_offsets(mesh_device, expert_offsets)
+    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
+
+    mesh_mapper_combine_counter = get_ep_mesh_mapper(mesh_device)
+    tt_expert_token_counts = ttnn.from_torch(
+        expert_token_counts,
+        mesh_mapper=mesh_mapper_combine_counter,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+
+    tt_dispatch_module = TtDispatchModule(
+        mesh_device=mesh_device,
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        metadata_len=metadata_len,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        emb_dim=EMB_DIM,
+        cluster_axis=sp_axis,
+        num_links=num_links,
+        topology=topology,
+    )
+
+    tt_combine_module = TtCombineModule(
+        mesh_device=mesh_device,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+        experts_per_chip=experts_per_chip,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        cluster_axis=sp_axis,
+        num_links=num_links,
+        topology=topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        init_zeros=True,
+    )
+
+    # Warmup
+    for i in range(WARMUP_ITERS):
+        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
+            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
+        )
+        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
+        ttnn.synchronize_device(mesh_device)
+
+    # Record DPRINT file position after warmup so we only parse measurement entries
+    dprint_pos = _dprint_file_pos()
+
+    # Measure dispatch
+    dispatch_times = []
+    for i in range(MEASURE_ITERS):
+        ttnn.synchronize_device(mesh_device)
+        t0 = time.perf_counter()
+        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
+            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
+        )
+        ttnn.synchronize_device(mesh_device)
+        t1 = time.perf_counter()
+        dispatch_times.append((t1 - t0) * 1e6)
+
+    # Measure combine
+    combine_times = []
+    for i in range(MEASURE_ITERS):
+        ttnn.synchronize_device(mesh_device)
+        t0 = time.perf_counter()
+        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
+        ttnn.synchronize_device(mesh_device)
+        t1 = time.perf_counter()
+        combine_times.append((t1 - t0) * 1e6)
+
+    # Measure dispatch+combine together
+    roundtrip_times = []
+    for i in range(MEASURE_ITERS):
+        ttnn.synchronize_device(mesh_device)
+        t0 = time.perf_counter()
+        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
+            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
+        )
+        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
+        ttnn.synchronize_device(mesh_device)
+        t1 = time.perf_counter()
+        roundtrip_times.append((t1 - t0) * 1e6)
+
+    def stats(times):
+        times_sorted = sorted(times)
+        median = times_sorted[len(times_sorted) // 2]
+        return min(times), median, max(times), sum(times) / len(times)
+
+    d_min, d_med, d_max, d_avg = stats(dispatch_times)
+    c_min, c_med, c_max, c_avg = stats(combine_times)
+    r_min, r_med, r_max, r_avg = stats(roundtrip_times)
+
+    config_label = f"{topo_name}-{num_devices} ({num_links}L)"
+    logger.info(
+        f"\n{'='*70}\n"
+        f"  RESULTS: {topo_name} | {num_devices} devices | {num_links} link(s)\n"
+        f"  Iterations: {MEASURE_ITERS} (after {WARMUP_ITERS} warmup)\n"
+        f"{'='*70}\n"
+        f"  {'Operation':<20} {'Min (us)':>12} {'Median (us)':>12} {'Avg (us)':>12} {'Max (us)':>12}\n"
+        f"  {'-'*20} {'-'*12} {'-'*12} {'-'*12} {'-'*12}\n"
+        f"  {'Dispatch':<20} {d_min:>12.1f} {d_med:>12.1f} {d_avg:>12.1f} {d_max:>12.1f}\n"
+        f"  {'Combine':<20} {c_min:>12.1f} {c_med:>12.1f} {c_avg:>12.1f} {c_max:>12.1f}\n"
+        f"  {'Dispatch+Combine':<20} {r_min:>12.1f} {r_med:>12.1f} {r_avg:>12.1f} {r_max:>12.1f}\n"
+        f"{'='*70}"
+    )
+
+    # Parse DPRINT PERF entries collected during measurements
+    perf_entries = _read_perf_entries(dprint_pos)
+    device_perf = _summarize_perf(perf_entries) if perf_entries else {}
+
+    if device_perf:
+        logger.info(f"\n  DEVICE CYCLES: {config_label}\n" + _format_kernel_perf(device_perf))
+
+    _collected_results.append(
+        {
+            "config": config_label,
+            "topo": topo_name,
+            "num_devices": num_devices,
+            "num_links": num_links,
+            "dispatch_med": d_med,
+            "combine_med": c_med,
+            "roundtrip_med": r_med,
+            "device_perf": device_perf,
+        }
+    )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -88,7 +88,7 @@ def _check_profiler_env():
     """Raise if the required profiler environment variables are not set."""
     missing = [v for v in _REQUIRED_PROFILER_ENV_VARS if os.environ.get(v) != "1"]
     if missing:
-        pytest.fail(
+        pytest.skip(
             f"Device profiler not configured. Set these env vars before device open: "
             f"{', '.join(f'{v}=1' for v in missing)}"
         )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -5,6 +5,9 @@
 """
 Performance test for dispatch and combine operations.
 
+TODO: Refactor to use run_model_device_perf_test_with_merge from models.perf.device_perf_utils
+once it is upstreamed from mbezulj/2603-moe-glx-perf-test branch. Also add perf test to BH LB CI pipeline.
+
 Measures device-side kernel durations via the Tracy device profiler for
 dispatch and combine operations across Linear vs Ring topologies.
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -5,8 +5,8 @@
 """
 Performance test for dispatch and combine operations.
 
-Measures host-side wall-clock time for dispatch and combine operations
-across Linear vs Ring topologies to quantify the performance delta.
+Measures device-side kernel durations via the Tracy device profiler for
+dispatch and combine operations across Linear vs Ring topologies.
 
 Usage:
     # Run on 8-chip linear:
@@ -18,33 +18,28 @@ Usage:
     # Run all configurations:
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -s
 
-    # With device-side DPRINT cycle counters (requires ENABLE_PERF_TRACE=1 in kernel .cpp files):
-    TT_METAL_DPRINT_CORES="0,0" TT_METAL_DPRINT_CHIPS=0 \
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -s
+    # Run linear-8, 1-link configs (both payload sizes; 14K variant auto-skips on Wormhole):
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -k "linear-8 and 1link" -s
 
-    DPRINT output is auto-redirected to a temp file for parsing.  The test
-    prints a per-kernel cycle breakdown after each config and a device-cycle
-    comparison table in the final summary.
+Device profiling requires these environment variables to be set before device open:
+    TT_METAL_DEVICE_PROFILER=1          (required)
+    TT_METAL_PROFILER_MID_RUN_DUMP=1    (required)
+    TT_METAL_PROFILER_CPP_POST_PROCESS=1 (required)
+    TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES=1  (optional, suppresses file output)
+
+Durations are read programmatically through ttnn.ReadDeviceProfiler().
 """
 
 import os
-import re
-import tempfile
-import time
-from collections import defaultdict
-
-# Auto-redirect DPRINT to a parseable file when DPRINT is enabled.
-# Must happen before ttnn import so the DPRINT server picks up the path.
-_DPRINT_FILE: str | None = os.environ.get("TT_METAL_DPRINT_FILE")
-if _DPRINT_FILE is None and os.environ.get("TT_METAL_DPRINT_CORES"):
-    _DPRINT_FILE = os.path.join(tempfile.gettempdir(), f"dprint_perf_{os.getpid()}.log")
-    os.environ["TT_METAL_DPRINT_FILE"] = _DPRINT_FILE
 
 import pytest
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    MAX_PAYLOAD_SIZE_BH,
+    MAX_PAYLOAD_SIZE_WH,
     ExpertMapping,
     compute_constants,
     create_fabric_router_config,
@@ -59,6 +54,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 
 WARMUP_ITERS = 2
 MEASURE_ITERS = 5
+assert MEASURE_ITERS % 2 == 1, "MEASURE_ITERS must be odd for _median to return the exact median"
 
 SEQ_LEN_PER_CHIP = 3200
 EMB_DIM = 7168
@@ -66,100 +62,87 @@ NUM_ROUTED_EXPERTS = 64
 NUM_EXPERTS_PER_TOK = 2
 CAPACITY_FACTOR = 2
 
+# Key analysis names from the device profiler (see cpp_device_analyses.json).
+DEVICE_KERNEL_DURATION = "DEVICE KERNEL DURATION [ns]"
+
+_REQUIRED_PROFILER_ENV_VARS = [
+    "TT_METAL_DEVICE_PROFILER",
+    "TT_METAL_PROFILER_MID_RUN_DUMP",
+    "TT_METAL_PROFILER_CPP_POST_PROCESS",
+]
+
+# Populated by test_dispatch_combine_perf; consumed by the print_summary fixture.
 _collected_results: list[dict] = []
 
+
+def _payload_label(payload_size: int) -> str:
+    return f"{payload_size // 1024}K"
+
+
 # ---------------------------------------------------------------------------
-# DPRINT parsing helpers
+# Device profiler helpers
 # ---------------------------------------------------------------------------
 
-_PERF_RE = re.compile(r"PERF\s+(\w+)\s+(.*?)$", re.MULTILINE)
-_KV_RE = re.compile(r"(\w+)=(\d+)")
-_COUNTER_FIELDS = frozenset({"chip", "core", "total", "n_local", "n_remote", "n_sends"})
+
+def _check_profiler_env():
+    """Raise if the required profiler environment variables are not set."""
+    missing = [v for v in _REQUIRED_PROFILER_ENV_VARS if os.environ.get(v) != "1"]
+    if missing:
+        pytest.fail(
+            f"Device profiler not configured. Set these env vars before device open: "
+            f"{', '.join(f'{v}=1' for v in missing)}"
+        )
 
 
-def _dprint_file_pos() -> int:
-    if not _DPRINT_FILE or not os.path.exists(_DPRINT_FILE):
-        return 0
-    return os.path.getsize(_DPRINT_FILE)
+def _read_device_duration(mesh_device, analysis_name: str = DEVICE_KERNEL_DURATION) -> float:
+    """Read device profiler and return the op duration (us) for the given analysis.
+
+    Calls ReadDeviceProfiler to flush profiler data, then reads the latest
+    programs.  Devices execute in parallel, so the duration is the max across
+    all devices (the slowest device determines the actual wall-clock time).
+    Within each device, program durations are summed (sequential programs).
+    """
+    ttnn.ReadDeviceProfiler(mesh_device)
+    latest = ttnn.get_latest_programs_perf_data()
+
+    if not latest:
+        pytest.fail("ReadDeviceProfiler returned no data -- is TT_METAL_DEVICE_PROFILER=1?")
+
+    # Sum program durations within each device, then take the max across devices.
+    max_device_dur = 0.0
+    for _device_id, programs in latest.items():
+        device_dur = 0.0
+        for program in programs:
+            analysis = program.program_analyses_results.get(analysis_name)
+            if analysis is not None:
+                device_dur += analysis.duration / 1000.0  # ns -> us
+        max_device_dur = max(max_device_dur, device_dur)
+    return max_device_dur
 
 
-def _read_perf_entries(start_pos: int) -> list[tuple[str, dict[str, int]]]:
-    """Read PERF lines from the DPRINT file starting at *start_pos*."""
-    if not _DPRINT_FILE or not os.path.exists(_DPRINT_FILE):
-        return []
-    with open(_DPRINT_FILE) as f:
-        f.seek(start_pos)
-        text = f.read()
-    entries = []
-    for m in _PERF_RE.finditer(text):
-        kernel = m.group(1)
-        fields = {k: int(v) for k, v in _KV_RE.findall(m.group(2))}
-        entries.append((kernel, fields))
-    return entries
+def _measure_op(mesh_device, op_fn, num_iters: int) -> list[float]:
+    """Run *op_fn* for *num_iters* and return the device kernel duration (us) per iteration.
+
+    Each iteration: run op -> synchronize -> ReadDeviceProfiler -> max across devices.
+    """
+    iter_durations: list[float] = []
+    for _ in range(num_iters):
+        op_fn()
+        ttnn.synchronize_device(mesh_device)
+        iter_durations.append(_read_device_duration(mesh_device))
+    return iter_durations
 
 
-def _median(values: list[int]) -> int:
+def _median(values: list[float]) -> float:
+    # MEASURE_ITERS is odd, so s[len(s)//2] is the exact median.
     s = sorted(values)
     return s[len(s) // 2]
 
 
-def _summarize_perf(entries: list[tuple[str, dict[str, int]]]) -> dict[str, dict]:
-    """Group PERF entries by kernel and compute median cycles + breakdown."""
-    by_kernel: dict[str, list[dict[str, int]]] = defaultdict(list)
-    for kernel, fields in entries:
-        by_kernel[kernel].append(fields)
-
-    results = {}
-    for kernel in sorted(by_kernel):
-        samples = by_kernel[kernel]
-        total_med = _median([s.get("total", 0) for s in samples])
-
-        all_fields = set()
-        for s in samples:
-            all_fields.update(s.keys())
-
-        cycle_fields = {}
-        counter_fields = {}
-        for field in sorted(all_fields):
-            vals = [s.get(field, 0) for s in samples]
-            med = _median(vals)
-            if field in _COUNTER_FIELDS:
-                counter_fields[field] = med
-            else:
-                cycle_fields[field] = med
-
-        results[kernel] = {
-            "total": total_med,
-            "cycles": cycle_fields,
-            "counters": counter_fields,
-            "n_samples": len(samples),
-        }
-    return results
-
-
-def _format_kernel_perf(perf: dict[str, dict]) -> str:
-    """Format per-kernel perf breakdown for a single test config."""
-    if not perf:
-        return ""
-    lines = [
-        f"  {'Kernel':<20} {'Total':>10} {'N':>4}  Breakdown (% of total)",
-        f"  {'-'*20} {'-'*10} {'-'*4}  {'-'*55}",
-    ]
-    for kernel in sorted(perf):
-        r = perf[kernel]
-        total = r["total"]
-        n = r["n_samples"]
-        breakdown = sorted(r["cycles"].items(), key=lambda kv: -kv[1])
-        parts = []
-        for field, val in breakdown:
-            pct = val * 100.0 / total if total else 0
-            parts.append(f"{field}={pct:.0f}%")
-        lines.append(f"  {kernel:<20} {total:>10} {n:>4}  {' '.join(parts)}")
-        counters = {k: v for k, v in r["counters"].items() if k not in ("chip", "core")}
-        if counters:
-            cstr = " ".join(f"{k}={v}" for k, v in counters.items())
-            lines.append(f"  {'':<20} {'':<10} {'':<4}  ({cstr})")
-    return "\n".join(lines)
+def _stats(times: list[float]) -> tuple[float, float, float, float]:
+    """Return (min, median, avg, max) for *times*."""
+    median = _median(times)
+    return min(times), median, sum(times) / len(times), max(times)
 
 
 # ---------------------------------------------------------------------------
@@ -171,31 +154,28 @@ def _format_kernel_perf(perf: dict[str, dict]) -> str:
 def print_summary():
     """Print a comparison summary table after all parametrized tests in this module complete."""
     _collected_results.clear()
-    if _DPRINT_FILE:
-        logger.info(f"DPRINT output file: {_DPRINT_FILE}")
     yield
     if not _collected_results:
         return
 
-    # --- Wall-clock summary ---
     header = (
-        f"\n{'='*90}\n"
-        f"  COMPARISON SUMMARY  (median us, {MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
+        f"\n{'='*100}\n"
+        f"  COMPARISON SUMMARY  (device kernel duration, median us, {MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
         f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
-        f"{'='*90}\n"
-        f"  {'Config':<22} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
-        f"  {'-'*22} {'-'*12} {'-'*12} {'-'*12}"
+        f"{'='*100}\n"
+        f"  {'Config':<30} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
+        f"  {'-'*30} {'-'*12} {'-'*12} {'-'*12}"
     )
     rows = []
     for r in _collected_results:
         rows.append(
-            f"  {r['config']:<22} {r['dispatch_med']:>12.1f} {r['combine_med']:>12.1f} {r['roundtrip_med']:>12.1f}"
+            f"  {r['config']:<30} {r['dispatch_med']:>12.1f} {r['combine_med']:>12.1f} {r['roundtrip_med']:>12.1f}"
         )
 
     speedup_lines = []
     lookup: dict[tuple, dict] = {}
     for r in _collected_results:
-        lookup[(r["num_devices"], r["topo"], r["num_links"])] = r
+        lookup[(r["num_devices"], r["topo"], r["num_links"], r["payload_size"])] = r
 
     def fmt_speedup(base, fast):
         d_sp = base["dispatch_med"] / fast["dispatch_med"] if fast["dispatch_med"] else 0
@@ -204,99 +184,89 @@ def print_summary():
         return f"{d_sp:>12.2f}x {c_sp:>12.2f}x {r_sp:>12.2f}x"
 
     seen_devices = sorted({r["num_devices"] for r in _collected_results})
+    seen_payloads = sorted({r["payload_size"] for r in _collected_results})
+
     for ndev in seen_devices:
-        for nlinks in (1, 2):
-            lin = lookup.get((ndev, "Linear", nlinks))
-            ring = lookup.get((ndev, "Ring", nlinks))
-            if lin and ring:
-                label = f"Ring/Lin {ndev}dev {nlinks}L"
-                speedup_lines.append(f"  {label:<22} {fmt_speedup(lin, ring)}")
+        for ps in seen_payloads:
+            # Ring vs Linear comparison (same link count, same payload size)
+            for nlinks in (1, 2):
+                lin = lookup.get((ndev, "Linear", nlinks, ps))
+                ring = lookup.get((ndev, "Ring", nlinks, ps))
+                if lin and ring:
+                    label = f"Ring/Lin {ndev}dev {nlinks}L {_payload_label(ps)}"
+                    speedup_lines.append(f"  {label:<30} {fmt_speedup(lin, ring)}")
+            # 2-link vs 1-link comparison (same topology, same payload size)
+            for topo in ("Linear", "Ring"):
+                one = lookup.get((ndev, topo, 1, ps))
+                two = lookup.get((ndev, topo, 2, ps))
+                if one and two:
+                    label = f"2L/1L {topo[:3]} {ndev}dev {_payload_label(ps)}"
+                    speedup_lines.append(f"  {label:<30} {fmt_speedup(one, two)}")
+
+        # 14K vs 7K payload comparison (same topology, same link count)
         for topo in ("Linear", "Ring"):
-            one = lookup.get((ndev, topo, 1))
-            two = lookup.get((ndev, topo, 2))
-            if one and two:
-                label = f"2L/1L {topo[:3]} {ndev}dev"
-                speedup_lines.append(f"  {label:<22} {fmt_speedup(one, two)}")
+            for nlinks in (1, 2):
+                small = lookup.get((ndev, topo, nlinks, MAX_PAYLOAD_SIZE_WH))
+                large = lookup.get((ndev, topo, nlinks, MAX_PAYLOAD_SIZE_BH))
+                if small and large:
+                    label = f"14K/7K {topo[:3]} {ndev}dev {nlinks}L"
+                    speedup_lines.append(f"  {label:<30} {fmt_speedup(small, large)}")
 
     summary = "\n".join([header] + rows)
     if speedup_lines:
         summary += (
-            f"\n\n  {'Speedup':<22} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
-            f"  {'-'*22} {'-'*12} {'-'*12} {'-'*12}\n" + "\n".join(speedup_lines)
+            f"\n\n  {'Speedup':<30} {'Dispatch':>12} {'Combine':>12} {'Round-trip':>12}\n"
+            f"  {'-'*30} {'-'*12} {'-'*12} {'-'*12}\n" + "\n".join(speedup_lines)
         )
-    summary += f"\n{'='*90}"
+    summary += f"\n{'='*100}"
     logger.info(summary)
 
-    # --- Device cycle summary (if DPRINT data was collected) ---
-    has_perf = any(r.get("device_perf") for r in _collected_results)
-    if not has_perf:
-        return
 
-    kernels = sorted({k for r in _collected_results if r.get("device_perf") for k in r["device_perf"]})
+# ---------------------------------------------------------------------------
+# Test parameters
+# ---------------------------------------------------------------------------
 
-    for kernel in kernels:
-        # Collect all cycle-breakdown fields across configs for this kernel
-        all_fields: list[str] = []
-        seen: set[str] = set()
-        for r in _collected_results:
-            kp = r.get("device_perf", {}).get(kernel)
-            if not kp:
-                continue
-            for field, _ in sorted(kp["cycles"].items(), key=lambda kv: -kv[1]):
-                if field not in seen:
-                    all_fields.append(field)
-                    seen.add(field)
 
-        col_w = 8
-        hdr_config = f"  {'Config':<22} {'total':>10}"
-        hdr_fields = "".join(f" {f:>{col_w}}" for f in all_fields)
-        sep_config = f"  {'-'*22} {'-'*10}"
-        sep_fields = (f" {'-'*col_w}") * len(all_fields)
+def _make_params(mesh_shape, fabric_config, payload_size, num_links, topology, ring_or_linear):
+    """Build a single pytest.param entry.
 
-        lines = [
-            f"\n{'='*(35 + (col_w + 1) * len(all_fields))}",
-            f"  DEVICE CYCLES: {kernel}  (median, % of total)",
-            f"{'='*(35 + (col_w + 1) * len(all_fields))}",
-            hdr_config + hdr_fields,
-            sep_config + sep_fields,
-        ]
-        for r in _collected_results:
-            kp = r.get("device_perf", {}).get(kernel)
-            if not kp:
-                row = f"  {r['config']:<22} {'N/A':>10}" + (f" {'':>{col_w}}") * len(all_fields)
-            else:
-                total = kp["total"]
-                row = f"  {r['config']:<22} {total:>10}"
-                for f in all_fields:
-                    val = kp["cycles"].get(f, 0)
-                    pct = val * 100.0 / total if total else 0
-                    row += f" {pct:>{col_w - 1}.0f}%"
-            lines.append(row)
+    Attaches requires_mesh_topology mark, and a skipif mark for 14K payloads
+    on non-Blackhole architectures (exceeds Wormhole hardware limit).
+    Test ID format: "{topology}-{ndev}-{nlinks}link-{payload_label}".
+    """
+    ps_label = _payload_label(payload_size)
+    marks = [pytest.mark.requires_mesh_topology(mesh_shape=mesh_shape, topology=ring_or_linear)]
+    if payload_size > MAX_PAYLOAD_SIZE_WH:
+        marks.append(
+            pytest.mark.skipif(
+                not is_blackhole(),
+                reason=f"14K payload exceeds Wormhole limit (MAX_PAYLOAD_SIZE_WH={MAX_PAYLOAD_SIZE_WH})",
+            )
+        )
+    ndev = mesh_shape[0] * mesh_shape[1]
+    return pytest.param(
+        mesh_shape,
+        {
+            "fabric_config": fabric_config,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=payload_size),
+        },
+        num_links,
+        topology,
+        payload_size,
+        marks=marks,
+        id=f"{ring_or_linear}-{ndev}-{num_links}link-{ps_label}",
+    )
 
-        # Add counter row if available
-        counter_keys: list[str] = []
-        counter_seen: set[str] = set()
-        for r in _collected_results:
-            kp = r.get("device_perf", {}).get(kernel)
-            if kp:
-                for ck in kp["counters"]:
-                    if ck not in ("chip", "core", "total") and ck not in counter_seen:
-                        counter_keys.append(ck)
-                        counter_seen.add(ck)
-        if counter_keys:
-            lines.append("")
-            lines.append(f"  {'Config':<22} " + "".join(f" {ck:>{col_w}}" for ck in counter_keys))
-            lines.append(f"  {'-'*22} " + (f" {'-'*col_w}") * len(counter_keys))
-            for r in _collected_results:
-                kp = r.get("device_perf", {}).get(kernel)
-                row = f"  {r['config']:<22} "
-                if kp:
-                    for ck in counter_keys:
-                        row += f" {kp['counters'].get(ck, 0):>{col_w}}"
-                lines.append(row)
 
-        lines.append(f"{'='*(35 + (col_w + 1) * len(all_fields))}")
-        logger.info("\n".join(lines))
+_TEST_PARAMS = []
+for mesh, fab_1d, fab_ring, topo_lin, topo_ring in [
+    ((4, 1), ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING, ttnn.Topology.Linear, ttnn.Topology.Ring),
+    ((8, 1), ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING, ttnn.Topology.Linear, ttnn.Topology.Ring),
+]:
+    for nlinks in (1, 2):
+        for ps in (MAX_PAYLOAD_SIZE_WH, MAX_PAYLOAD_SIZE_BH):
+            _TEST_PARAMS.append(_make_params(mesh, fab_1d, ps, nlinks, topo_lin, "linear"))
+            _TEST_PARAMS.append(_make_params(mesh, fab_ring, ps, nlinks, topo_ring, "ring"))
 
 
 # ---------------------------------------------------------------------------
@@ -305,104 +275,18 @@ def print_summary():
 
 
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4-1link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4-2link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4-1link",
-        ),
-        pytest.param(
-            (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            2,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
-            id="ring-4-2link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-2link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8-1link",
-        ),
-        pytest.param(
-            (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
-            2,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
-            id="ring-8-2link",
-        ),
-    ],
+    "mesh_device, device_params, num_links, topology, payload_size",
+    _TEST_PARAMS,
     indirect=["mesh_device", "device_params"],
 )
 def test_dispatch_combine_perf(
     mesh_device,
     num_links,
     topology,
+    payload_size,
 ):
+    _check_profiler_env()
+
     num_devices = mesh_device.get_num_devices()
     mesh_config = extract_mesh_config(mesh_device)
     sp_axis = mesh_config.sp_axis
@@ -414,9 +298,10 @@ def test_dispatch_combine_perf(
     )
 
     topo_name = "Ring" if topology == ttnn.Topology.Ring else "Linear"
+    ps_label = _payload_label(payload_size)
     logger.info(
         f"\n{'='*70}\n"
-        f"  PERF TEST: {topo_name} topology, {num_devices} devices, {num_links} link(s)\n"
+        f"  PERF TEST: {topo_name} topology, {num_devices} devices, {num_links} link(s), payload={ps_label}\n"
         f"  seq_len={SEQ_LEN_PER_CHIP}, emb_dim={EMB_DIM}, experts={NUM_ROUTED_EXPERTS}, top-k={NUM_EXPERTS_PER_TOK}\n"
         f"  experts_per_chip={experts_per_chip}, max_tok_per_expert={max_dispatched_tokens_per_expert}\n"
         f"  dispatch_group_size={dispatch_group_size}, num_dispatch_groups={num_dispatch_groups}\n"
@@ -514,66 +399,45 @@ def test_dispatch_combine_perf(
         init_zeros=True,
     )
 
-    # Warmup
-    for i in range(WARMUP_ITERS):
+    # Warmup (no profiler reads)
+    for _ in range(WARMUP_ITERS):
         tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
             tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
         )
         tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
         ttnn.synchronize_device(mesh_device)
 
-    # Record DPRINT file position after warmup so we only parse measurement entries
-    dprint_pos = _dprint_file_pos()
+    # Flush any warmup profiler data
+    ttnn.ReadDeviceProfiler(mesh_device)
 
-    # Measure dispatch
-    dispatch_times = []
-    for i in range(MEASURE_ITERS):
-        ttnn.synchronize_device(mesh_device)
-        t0 = time.perf_counter()
+    # Measure dispatch (device kernel duration per iteration)
+    def run_dispatch():
+        nonlocal tt_dispatched_buffer, tt_metadata
         tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
             tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
         )
-        ttnn.synchronize_device(mesh_device)
-        t1 = time.perf_counter()
-        dispatch_times.append((t1 - t0) * 1e6)
 
-    # Measure combine
-    combine_times = []
-    for i in range(MEASURE_ITERS):
-        ttnn.synchronize_device(mesh_device)
-        t0 = time.perf_counter()
+    def run_combine():
+        nonlocal tt_output
         tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
-        ttnn.synchronize_device(mesh_device)
-        t1 = time.perf_counter()
-        combine_times.append((t1 - t0) * 1e6)
 
-    # Measure dispatch+combine together
-    roundtrip_times = []
-    for i in range(MEASURE_ITERS):
-        ttnn.synchronize_device(mesh_device)
-        t0 = time.perf_counter()
-        tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
-            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
-        )
-        tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
-        ttnn.synchronize_device(mesh_device)
-        t1 = time.perf_counter()
-        roundtrip_times.append((t1 - t0) * 1e6)
+    def run_roundtrip():
+        run_dispatch()
+        run_combine()
 
-    def stats(times):
-        times_sorted = sorted(times)
-        median = times_sorted[len(times_sorted) // 2]
-        return min(times), median, max(times), sum(times) / len(times)
+    dispatch_durations = _measure_op(mesh_device, run_dispatch, MEASURE_ITERS)
+    combine_durations = _measure_op(mesh_device, run_combine, MEASURE_ITERS)
+    roundtrip_durations = _measure_op(mesh_device, run_roundtrip, MEASURE_ITERS)
 
-    d_min, d_med, d_max, d_avg = stats(dispatch_times)
-    c_min, c_med, c_max, c_avg = stats(combine_times)
-    r_min, r_med, r_max, r_avg = stats(roundtrip_times)
+    d_min, d_med, d_avg, d_max = _stats(dispatch_durations)
+    c_min, c_med, c_avg, c_max = _stats(combine_durations)
+    r_min, r_med, r_avg, r_max = _stats(roundtrip_durations)
 
-    config_label = f"{topo_name}-{num_devices} ({num_links}L)"
+    config_label = f"{topo_name}-{num_devices} ({num_links}L {ps_label})"
     logger.info(
         f"\n{'='*70}\n"
-        f"  RESULTS: {topo_name} | {num_devices} devices | {num_links} link(s)\n"
-        f"  Iterations: {MEASURE_ITERS} (after {WARMUP_ITERS} warmup)\n"
+        f"  RESULTS: {topo_name} | {num_devices} devices | {num_links} link(s) | payload={ps_label}\n"
+        f"  Device kernel durations ({MEASURE_ITERS} iters after {WARMUP_ITERS} warmup)\n"
         f"{'='*70}\n"
         f"  {'Operation':<20} {'Min (us)':>12} {'Median (us)':>12} {'Avg (us)':>12} {'Max (us)':>12}\n"
         f"  {'-'*20} {'-'*12} {'-'*12} {'-'*12} {'-'*12}\n"
@@ -583,22 +447,15 @@ def test_dispatch_combine_perf(
         f"{'='*70}"
     )
 
-    # Parse DPRINT PERF entries collected during measurements
-    perf_entries = _read_perf_entries(dprint_pos)
-    device_perf = _summarize_perf(perf_entries) if perf_entries else {}
-
-    if device_perf:
-        logger.info(f"\n  DEVICE CYCLES: {config_label}\n" + _format_kernel_perf(device_perf))
-
     _collected_results.append(
         {
             "config": config_label,
             "topo": topo_name,
             "num_devices": num_devices,
             "num_links": num_links,
+            "payload_size": payload_size,
             "dispatch_med": d_med,
             "combine_med": c_med,
             "roundtrip_med": r_med,
-            "device_perf": device_perf,
         }
     )

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -21,10 +21,14 @@ from tqdm import tqdm
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-# Blackhole supports larger fabric packets (max 15232 bytes) vs Wormhole (max 7616 bytes).
-MAX_PAYLOAD_SIZE_BH = 14 * 1024
-MAX_PAYLOAD_SIZE_WH = 7 * 1024
-MAX_PAYLOAD_SIZE = MAX_PAYLOAD_SIZE_BH if is_blackhole() else MAX_PAYLOAD_SIZE_WH
+# Fabric packet payload limits (conservative round values below hardware maximums).
+MAX_PAYLOAD_SIZE_BH = 14 * 1024  # Blackhole hardware max ~15232 B
+MAX_PAYLOAD_SIZE_WH = 7 * 1024  # Wormhole hardware max ~7616 B
+
+
+def get_max_payload_size() -> int:
+    """Return the arch-appropriate fabric payload size. Deferred to avoid probing hardware at import time."""
+    return MAX_PAYLOAD_SIZE_BH if is_blackhole() else MAX_PAYLOAD_SIZE_WH
 
 
 @dataclass

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -19,6 +19,12 @@ from loguru import logger
 from tqdm import tqdm
 
 import ttnn
+from models.common.utility_functions import is_blackhole
+
+# Blackhole supports larger fabric packets (max 15232 bytes) vs Wormhole (max 7616 bytes).
+MAX_PAYLOAD_SIZE_BH = 14 * 1024
+MAX_PAYLOAD_SIZE_WH = 7 * 1024
+MAX_PAYLOAD_SIZE = MAX_PAYLOAD_SIZE_BH if is_blackhole() else MAX_PAYLOAD_SIZE_WH
 
 
 @dataclass

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -376,6 +376,7 @@ def initialize_test_inputs(
     validate: bool = True,
     num_dispatch_groups: int = 1,
     skip_x_initialization: bool = False,
+    seed: int = None,
 ):
     """
     Initialize test inputs (x, weights, indices) with random data.
@@ -395,6 +396,9 @@ def initialize_test_inputs(
         weights: Router weights (num_dispatch_groups, dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
         indices: Expert indices (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
     """
+
+    if seed is not None:
+        torch.manual_seed(seed)
 
     input_shape = (dispatch_group_size, seq_len_per_chip, emb_dim)
     x = torch.randn(input_shape, dtype=torch.bfloat16) if not skip_x_initialization else None

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -144,7 +144,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto max_dispatched_tokens_per_expert = dispatched_shape[-2];
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    // Maximum worker cores: one per fabric link direction.
+    // Maximum worker cores: one per fabric link.
     constexpr uint32_t MAX_WORKER_CORES = 4;
     uint32_t effective_num_links = std::min(num_links, MAX_WORKER_CORES);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -148,11 +148,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     constexpr uint32_t MAX_WORKER_CORES = 4;
     uint32_t effective_num_links = std::min(num_links, MAX_WORKER_CORES);
     TT_FATAL(
-        effective_num_links <= MAX_WORKER_CORES,
-        "effective_num_links {} exceeds MAX_WORKER_CORES {} (kernel barrier array limit)",
-        effective_num_links,
-        MAX_WORKER_CORES);
-    TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",
         subdevice_cores.size(),
@@ -176,7 +171,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    constexpr uint32_t read_batch_size = 8;
+    constexpr uint32_t read_batch_size = 8;  // matches BH DRAM bank count for full bandwidth utilization
 
     // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -144,14 +144,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto max_dispatched_tokens_per_expert = dispatched_shape[-2];
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    // MAX_BARRIER_CORES: kernel writer_combine.cpp sizes its barrier address array to this limit.
-    constexpr uint32_t MAX_BARRIER_CORES = 4;
-    uint32_t effective_num_links = std::min(num_links, MAX_BARRIER_CORES);
+    // Maximum worker cores: one per fabric link direction.
+    constexpr uint32_t MAX_WORKER_CORES = 4;
+    uint32_t effective_num_links = std::min(num_links, MAX_WORKER_CORES);
     TT_FATAL(
-        effective_num_links <= MAX_BARRIER_CORES,
-        "effective_num_links {} exceeds MAX_BARRIER_CORES {} (kernel barrier array limit)",
+        effective_num_links <= MAX_WORKER_CORES,
+        "effective_num_links {} exceeds MAX_WORKER_CORES {} (kernel barrier array limit)",
         effective_num_links,
-        MAX_BARRIER_CORES);
+        MAX_WORKER_CORES);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",
@@ -176,7 +176,6 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
-    // Must match the read_batch_size constexpr in reader_combine.cpp kernel.
     constexpr uint32_t read_batch_size = 8;
 
     // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
@@ -294,6 +293,9 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         l1_alignment,
         static_cast<uint32_t>(num_links),
         static_cast<uint32_t>(topology),
+
+        // Batch configuration (1)
+        read_batch_size,
     };
 
     // Append TensorAccessorArgs for all 4 tensors

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -204,29 +204,23 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         /*cb_id=*/tt::CBIndex::c_2,
         "expert_token_counts");
 
-    // c_3: route_info (reader->writer, 4 x uint32_t per entry)
-    // Must hold at least read_batch_size entries to avoid deadlock:
-    // the reader pushes all route_info entries for a batch before starting the L1 payload copy,
-    // so the CB must not fill up before the writer can consume (which requires payload data).
+    // c_3, c_4: reader→writer CBs for (route_info, output) per remote entry.
+    // The reader pushes both per entry in lockstep, so small buffering (2) suffices.
     {
+        constexpr uint32_t rw_buffering = 2;
+
         uint32_t route_info_page_size = l1_alignment;
-        uint32_t route_info_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         tt::tt_metal::CircularBufferConfig route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
-                route_info_buffering * route_info_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
+                rw_buffering * route_info_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
                 .set_page_size(tt::CBIndex::c_3, route_info_page_size);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
-    }
 
-    // c_4: output_for_writer (reader->writer, output pages for fabric sends)
-    // Same buffering rationale as route_info (see c_3 comment for deadlock analysis).
-    {
-        uint32_t output_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         detail::create_tensor_cb(
             program,
             sender_core_grid,
             dispatched_buffer,
-            /*buffering_factor=*/output_buffering,
+            /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_4,
             "output_for_writer");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -144,7 +144,14 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto max_dispatched_tokens_per_expert = dispatched_shape[-2];
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    uint32_t effective_num_links = std::min(num_links, 4u);
+    // MAX_BARRIER_CORES: kernel writer_combine.cpp sizes its barrier address array to this limit.
+    constexpr uint32_t MAX_BARRIER_CORES = 4;
+    uint32_t effective_num_links = std::min(num_links, MAX_BARRIER_CORES);
+    TT_FATAL(
+        effective_num_links <= MAX_BARRIER_CORES,
+        "effective_num_links {} exceeds MAX_BARRIER_CORES {} (kernel barrier array limit)",
+        effective_num_links,
+        MAX_BARRIER_CORES);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",
@@ -169,6 +176,7 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     auto zero_init_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
     auto zero_init_barrier_semaphore_id = tt::tt_metal::CreateSemaphore(program, sender_core_grid, 0);
 
+    // Must match the read_batch_size constexpr in reader_combine.cpp kernel.
     constexpr uint32_t read_batch_size = 8;
 
     // c_0: dispatched_buffer scratch (reader-only, batched DRAM reads)
@@ -197,9 +205,12 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
         "expert_token_counts");
 
     // c_3: route_info (reader->writer, 4 x uint32_t per entry)
+    // Must hold at least read_batch_size entries to avoid deadlock:
+    // the reader pushes all route_info entries for a batch before starting the L1 payload copy,
+    // so the CB must not fill up before the writer can consume (which requires payload data).
     {
         uint32_t route_info_page_size = l1_alignment;
-        constexpr uint32_t route_info_buffering = 16;
+        uint32_t route_info_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         tt::tt_metal::CircularBufferConfig route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
                 route_info_buffering * route_info_page_size, {{tt::CBIndex::c_3, tt::DataFormat::UInt8}})
@@ -208,13 +219,17 @@ ttnn::device_operation::CachedProgram<CombineSharedVariables> CombineProgramFact
     }
 
     // c_4: output_for_writer (reader->writer, output pages for fabric sends)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        dispatched_buffer,
-        /*buffering_factor=*/16,
-        /*cb_id=*/tt::CBIndex::c_4,
-        "output_for_writer");
+    // Same buffering rationale as route_info (see c_3 comment for deadlock analysis).
+    {
+        uint32_t output_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            dispatched_buffer,
+            /*buffering_factor=*/output_buffering,
+            /*cb_id=*/tt::CBIndex::c_4,
+            "output_for_writer");
+    }
 
     // c_5: packet header CB for fabric sends (writer-only)
     if (num_links > 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -18,16 +18,6 @@
     DebugPrinter()
 #endif
 
-#define ENABLE_PERF_TRACE 1
-#if ENABLE_PERF_TRACE
-inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
-#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
-#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
-#else
-#define PERF_BEGIN(var)
-#define PERF_END(var, accum)
-#endif
-
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -114,21 +104,6 @@ void kernel_main() {
     DPRINT_COMBINE << "Combine Reader: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
                    << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total_start = read_wall_clock();
-    uint32_t perf_init_cycles = 0;
-    uint32_t perf_dram_read_cycles = 0;
-    uint32_t perf_local_write_cycles = 0;
-    uint32_t perf_l1_copy_cycles = 0;
-    uint32_t perf_cb_route_cycles = 0;
-    uint32_t perf_local_barrier_cycles = 0;
-    uint32_t perf_next_batch_read_cycles = 0;
-    uint32_t perf_next_batch_barrier_cycles = 0;
-    uint32_t perf_num_local = 0;
-    uint32_t perf_num_remote = 0;
-    PERF_BEGIN(init);
-#endif
-
     const auto output_addr_gen = TensorAccessor(output_args, output_addr, aligned_output_page_size);
 
 #if INIT_ZEROS
@@ -163,8 +138,6 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_barrier_address);
     noc_semaphore_wait(barrier_sem_ptr, num_cores);
     noc_semaphore_set(barrier_sem_ptr, 0);
-
-    PERF_END(init, perf_init_cycles);
 
     // Read expert token counts
     const auto experts_tok_counter_addr_gen =
@@ -216,7 +189,6 @@ void kernel_main() {
         uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
         uint32_t first_batch_count = first_batch_end - start_page;
         if (first_batch_count > 0) {
-            PERF_BEGIN(dram_prefetch);
             for (uint32_t t = 0; t < first_batch_count; t++) {
                 noc_async_read_page(
                     start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
@@ -226,7 +198,6 @@ void kernel_main() {
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
             noc_async_read_barrier();
-            PERF_END(dram_prefetch, perf_dram_read_cycles);
         }
 
         for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
@@ -249,21 +220,15 @@ void kernel_main() {
                 uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
 
                 if (dst_chip == linearized_mesh_coord) {
-                    PERF_BEGIN(local_wr);
                     noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
                     noc_async_writes_flushed();
-                    PERF_END(local_wr, perf_local_write_cycles);
                     batch_did_local_write = true;
-#if ENABLE_PERF_TRACE
-                    perf_num_local++;
-#endif
                 } else {
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
 
-                        PERF_BEGIN(cb_route);
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -272,19 +237,14 @@ void kernel_main() {
                         route_info[2] = output_page_idx;
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
-                        PERF_END(cb_route, perf_cb_route_cycles);
 
                         remote_src_addrs[remote_count] = buffer_scratch_addr;
                         remote_count++;
-#if ENABLE_PERF_TRACE
-                        perf_num_remote++;
-#endif
                     }
                 }
             }
 
             if (remote_count > 0) {
-                PERF_BEGIN(l1_copy);
                 uint32_t sent = 0;
                 while (sent < remote_count) {
                     uint32_t fifo_lim = get_local_cb_interface(cb_output_for_writer_id).fifo_limit;
@@ -306,14 +266,12 @@ void kernel_main() {
                     cb_push_back(cb_output_for_writer_id, chunk);
                     sent += chunk;
                 }
-                PERF_END(l1_copy, perf_l1_copy_cycles);
             }
 
             // Issue next batch reads BEFORE write barrier
             uint32_t next_batch_start = batch_start + read_batch_size;
             bool has_next_batch = (next_batch_start < end_page);
             if (has_next_batch) {
-                PERF_BEGIN(next_batch_rd);
                 uint32_t next_batch_end =
                     (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
                 uint32_t next_batch_count = next_batch_end - next_batch_start;
@@ -327,19 +285,14 @@ void kernel_main() {
                         dispatched_metadata_addr_gen,
                         metadata_base + t * aligned_dispatched_metadata_page_size);
                 }
-                PERF_END(next_batch_rd, perf_next_batch_read_cycles);
             }
 
             if (batch_did_local_write) {
-                PERF_BEGIN(local_barr);
                 noc_async_write_barrier();
-                PERF_END(local_barr, perf_local_barrier_cycles);
             }
 
             if (has_next_batch) {
-                PERF_BEGIN(next_barr);
                 noc_async_read_barrier();
-                PERF_END(next_barr, perf_next_batch_barrier_cycles);
             }
         }
     }
@@ -353,14 +306,4 @@ void kernel_main() {
     route_info[2] = 0;
     route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
-
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total = read_wall_clock() - perf_total_start;
-    DPRINT << "PERF combine_reader chip=" << linearized_mesh_coord << " total=" << perf_total
-           << " init=" << perf_init_cycles << " dram_read=" << perf_dram_read_cycles
-           << " local_wr=" << perf_local_write_cycles << " l1_copy=" << perf_l1_copy_cycles
-           << " cb_route=" << perf_cb_route_cycles << " local_barr=" << perf_local_barrier_cycles
-           << " next_rd=" << perf_next_batch_read_cycles << " next_barr=" << perf_next_batch_barrier_cycles
-           << " n_local=" << perf_num_local << " n_remote=" << perf_num_remote << ENDL();
-#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -18,7 +18,16 @@
     DebugPrinter()
 #endif
 
-// Signal last element to writer to break out of loop
+#define ENABLE_PERF_TRACE 1
+#if ENABLE_PERF_TRACE
+inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
+#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
+#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
+#else
+#define PERF_BEGIN(var)
+#define PERF_END(var, accum)
+#endif
+
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -105,6 +114,21 @@ void kernel_main() {
     DPRINT_COMBINE << "Combine Reader: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
                    << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total_start = read_wall_clock();
+    uint32_t perf_init_cycles = 0;
+    uint32_t perf_dram_read_cycles = 0;
+    uint32_t perf_local_write_cycles = 0;
+    uint32_t perf_l1_copy_cycles = 0;
+    uint32_t perf_cb_route_cycles = 0;
+    uint32_t perf_local_barrier_cycles = 0;
+    uint32_t perf_next_batch_read_cycles = 0;
+    uint32_t perf_next_batch_barrier_cycles = 0;
+    uint32_t perf_num_local = 0;
+    uint32_t perf_num_remote = 0;
+    PERF_BEGIN(init);
+#endif
+
     const auto output_addr_gen = TensorAccessor(output_args, output_addr, aligned_output_page_size);
 
 #if INIT_ZEROS
@@ -139,6 +163,8 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_barrier_address);
     noc_semaphore_wait(barrier_sem_ptr, num_cores);
     noc_semaphore_set(barrier_sem_ptr, 0);
+
+    PERF_END(init, perf_init_cycles);
 
     // Read expert token counts
     const auto experts_tok_counter_addr_gen =
@@ -190,6 +216,7 @@ void kernel_main() {
         uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
         uint32_t first_batch_count = first_batch_end - start_page;
         if (first_batch_count > 0) {
+            PERF_BEGIN(dram_prefetch);
             for (uint32_t t = 0; t < first_batch_count; t++) {
                 noc_async_read_page(
                     start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
@@ -199,12 +226,16 @@ void kernel_main() {
                     metadata_base + t * aligned_dispatched_metadata_page_size);
             }
             noc_async_read_barrier();
+            PERF_END(dram_prefetch, perf_dram_read_cycles);
         }
 
         for (uint32_t batch_start = start_page; batch_start < end_page; batch_start += read_batch_size) {
             uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
             uint32_t batch_count = batch_end - batch_start;
             bool batch_did_local_write = false;
+
+            uint32_t remote_count = 0;
+            uint32_t remote_src_addrs[read_batch_size];
 
             for (uint32_t t = 0; t < batch_count; t++) {
                 uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
@@ -218,16 +249,21 @@ void kernel_main() {
                 uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
 
                 if (dst_chip == linearized_mesh_coord) {
+                    PERF_BEGIN(local_wr);
                     noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
                     noc_async_writes_flushed();
+                    PERF_END(local_wr, perf_local_write_cycles);
                     batch_did_local_write = true;
+#if ENABLE_PERF_TRACE
+                    perf_num_local++;
+#endif
                 } else {
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
 
-                        // Push route info to writer
+                        PERF_BEGIN(cb_route);
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -236,22 +272,48 @@ void kernel_main() {
                         route_info[2] = output_page_idx;
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
+                        PERF_END(cb_route, perf_cb_route_cycles);
 
-                        // Push output payload to writer
-                        cb_reserve_back(cb_output_for_writer_id, 1);
-                        uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
-                        noc_async_read(
-                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_output_for_writer_id, 1);
+                        remote_src_addrs[remote_count] = buffer_scratch_addr;
+                        remote_count++;
+#if ENABLE_PERF_TRACE
+                        perf_num_remote++;
+#endif
                     }
                 }
+            }
+
+            if (remote_count > 0) {
+                PERF_BEGIN(l1_copy);
+                uint32_t sent = 0;
+                while (sent < remote_count) {
+                    uint32_t fifo_lim = get_local_cb_interface(cb_output_for_writer_id).fifo_limit;
+                    uint32_t wr = get_write_ptr(cb_output_for_writer_id);
+                    uint32_t pages_to_end = (fifo_lim - wr) / aligned_dispatched_buffer_page_size;
+                    uint32_t chunk = remote_count - sent;
+                    if (chunk > pages_to_end) {
+                        chunk = pages_to_end;
+                    }
+                    cb_reserve_back(cb_output_for_writer_id, chunk);
+                    uint32_t base = get_write_ptr(cb_output_for_writer_id);
+                    for (uint32_t i = 0; i < chunk; i++) {
+                        noc_async_read(
+                            get_noc_addr(remote_src_addrs[sent + i]),
+                            base + i * aligned_dispatched_buffer_page_size,
+                            aligned_dispatched_buffer_page_size);
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_output_for_writer_id, chunk);
+                    sent += chunk;
+                }
+                PERF_END(l1_copy, perf_l1_copy_cycles);
             }
 
             // Issue next batch reads BEFORE write barrier
             uint32_t next_batch_start = batch_start + read_batch_size;
             bool has_next_batch = (next_batch_start < end_page);
             if (has_next_batch) {
+                PERF_BEGIN(next_batch_rd);
                 uint32_t next_batch_end =
                     (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
                 uint32_t next_batch_count = next_batch_end - next_batch_start;
@@ -265,14 +327,19 @@ void kernel_main() {
                         dispatched_metadata_addr_gen,
                         metadata_base + t * aligned_dispatched_metadata_page_size);
                 }
+                PERF_END(next_batch_rd, perf_next_batch_read_cycles);
             }
 
             if (batch_did_local_write) {
+                PERF_BEGIN(local_barr);
                 noc_async_write_barrier();
+                PERF_END(local_barr, perf_local_barrier_cycles);
             }
 
             if (has_next_batch) {
+                PERF_BEGIN(next_barr);
                 noc_async_read_barrier();
+                PERF_END(next_barr, perf_next_batch_barrier_cycles);
             }
         }
     }
@@ -286,4 +353,14 @@ void kernel_main() {
     route_info[2] = 0;
     route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
+
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total = read_wall_clock() - perf_total_start;
+    DPRINT << "PERF combine_reader chip=" << linearized_mesh_coord << " total=" << perf_total
+           << " init=" << perf_init_cycles << " dram_read=" << perf_dram_read_cycles
+           << " local_wr=" << perf_local_write_cycles << " l1_copy=" << perf_l1_copy_cycles
+           << " cb_route=" << perf_cb_route_cycles << " local_barr=" << perf_local_barrier_cycles
+           << " next_rd=" << perf_next_batch_read_cycles << " next_barr=" << perf_next_batch_barrier_cycles
+           << " n_local=" << perf_num_local << " n_remote=" << perf_num_remote << ENDL();
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -205,9 +205,6 @@ void kernel_main() {
             uint32_t batch_count = batch_end - batch_start;
             bool batch_did_local_write = false;
 
-            uint32_t remote_count = 0;
-            uint32_t remote_src_addrs[read_batch_size];
-
             for (uint32_t t = 0; t < batch_count; t++) {
                 uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
                 uint32_t metadata_scratch_addr = metadata_base + t * aligned_dispatched_metadata_page_size;
@@ -229,6 +226,7 @@ void kernel_main() {
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
 
+                        // Push route_info
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -238,33 +236,14 @@ void kernel_main() {
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
 
-                        remote_src_addrs[remote_count] = buffer_scratch_addr;
-                        remote_count++;
-                    }
-                }
-            }
-
-            if (remote_count > 0) {
-                uint32_t sent = 0;
-                while (sent < remote_count) {
-                    uint32_t fifo_lim = get_local_cb_interface(cb_output_for_writer_id).fifo_limit;
-                    uint32_t wr = get_write_ptr(cb_output_for_writer_id);
-                    uint32_t pages_to_end = (fifo_lim - wr) / aligned_dispatched_buffer_page_size;
-                    uint32_t chunk = remote_count - sent;
-                    if (chunk > pages_to_end) {
-                        chunk = pages_to_end;
-                    }
-                    cb_reserve_back(cb_output_for_writer_id, chunk);
-                    uint32_t base = get_write_ptr(cb_output_for_writer_id);
-                    for (uint32_t i = 0; i < chunk; i++) {
+                        // Copy output payload from scratch (L1) into output CB for writer
+                        cb_reserve_back(cb_output_for_writer_id, 1);
+                        uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
                         noc_async_read(
-                            get_noc_addr(remote_src_addrs[sent + i]),
-                            base + i * aligned_dispatched_buffer_page_size,
-                            aligned_dispatched_buffer_page_size);
+                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_output_for_writer_id, 1);
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_output_for_writer_id, chunk);
-                    sent += chunk;
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -164,7 +164,11 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
-    // Set up scratch buffers for batched reads
+    // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
+    // overwrites the same region at offsets [0, batch_count) without push/pop.
+    // DRAM reads are batched to saturate DRAM bandwidth, while the scratch-to-writer-CB
+    // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
+    // and measured faster in practice.
     cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -18,6 +18,7 @@
     DebugPrinter()
 #endif
 
+// Signal last element to writer to break out of loop
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -73,8 +74,11 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(31);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(32);
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 33)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<33>();
+    // Batch configuration (index 33)
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(33);
+
+    // TensorAccessorArgs for all 4 tensors (starting at index 34)
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<34>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =
@@ -161,7 +165,6 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
 
     // Set up scratch buffers for batched reads
-    constexpr uint32_t read_batch_size = 8;
     cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
     uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
     cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
@@ -226,7 +229,7 @@ void kernel_main() {
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
 
-                        // Push route_info
+                        // Push route info to writer
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -236,7 +239,7 @@ void kernel_main() {
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
 
-                        // Copy output payload from scratch (L1) into output CB for writer
+                        // Push output payload to writer
                         cb_reserve_back(cb_output_for_writer_id, 1);
                         uint32_t output_dst = get_write_ptr(cb_output_for_writer_id);
                         noc_async_read(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -74,8 +74,10 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(31);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(32);
 
-    // TensorAccessorArgs for all 4 tensors (starting at index 33)
-    constexpr auto dispatched_buffer_args = TensorAccessorArgs<33>();
+    // Batch configuration (index 33) — read_batch_size not used by writer
+
+    // TensorAccessorArgs for all 4 tensors (starting at index 34)
+    constexpr auto dispatched_buffer_args = TensorAccessorArgs<34>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
     constexpr auto experts_tok_counter_args =
@@ -100,9 +102,9 @@ void kernel_main() {
 
     // Read NOC coordinates for all cores (for inter-core barrier signaling).
     // num_cores = effective_num_links = min(num_links, 4).
-    constexpr uint32_t MAX_BARRIER_CORES = 4;
-    ASSERT(num_cores <= MAX_BARRIER_CORES);
-    uint64_t all_core_barrier_noc_addrs[MAX_BARRIER_CORES];
+    constexpr uint32_t MAX_WORKER_CORES = 4;
+    ASSERT(num_cores <= MAX_WORKER_CORES);
+    uint64_t all_core_barrier_noc_addrs[MAX_WORKER_CORES];
     for (uint32_t c = 0; c < num_cores; c++) {
         uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
@@ -201,6 +203,7 @@ void kernel_main() {
             output_page_idx,
             (int)aligned_output_page_size,
             l1_alignment);
+        noc_async_writes_flushed();  // Ensure output data departed L1 before freeing CB slot
 #endif
 
         cb_pop_front(cb_output_for_writer_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
 #include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
@@ -16,16 +17,6 @@
 #define DPRINT_COMBINE \
     if (0)             \
     DebugPrinter()
-#endif
-
-#define ENABLE_PERF_TRACE 1
-#if ENABLE_PERF_TRACE
-inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
-#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
-#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
-#else
-#define PERF_BEGIN(var)
-#define PERF_END(var, accum)
 #endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
@@ -107,8 +98,11 @@ void kernel_main() {
     uint32_t zero_init_semaphore_address = get_semaphore(zero_init_semaphore_id);
     uint32_t zero_init_barrier_l1_offset = get_semaphore(zero_init_barrier_semaphore_id);
 
-    // Read NOC coordinates for all cores (for inter-core barrier signaling)
-    uint64_t all_core_barrier_noc_addrs[2];
+    // Read NOC coordinates for all cores (for inter-core barrier signaling).
+    // Max 2 cores: one reader + one writer per link, capped by effective_num_links.
+    constexpr uint32_t MAX_BARRIER_CORES = 2;
+    ASSERT(num_cores <= MAX_BARRIER_CORES);
+    uint64_t all_core_barrier_noc_addrs[MAX_BARRIER_CORES];
     for (uint32_t c = 0; c < num_cores; c++) {
         uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
@@ -126,24 +120,11 @@ void kernel_main() {
     DPRINT_COMBINE << "Combine Writer: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
                    << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total_start = read_wall_clock();
-    uint32_t perf_zero_wait_cycles = 0;
-    uint32_t perf_fabric_setup_cycles = 0;
-    uint32_t perf_cb_wait_cycles = 0;
-    uint32_t perf_fabric_send_cycles = 0;
-    uint32_t perf_write_barrier_cycles = 0;
-    uint32_t perf_exit_barrier_cycles = 0;
-    uint32_t perf_num_sends = 0;
-#endif
-
     // Wait for reader to complete zero-init
-    PERF_BEGIN(zero_wait);
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_wait(zero_init_sem_ptr, 1);
     noc_semaphore_set(zero_init_sem_ptr, 0);
-    PERF_END(zero_wait, perf_zero_wait_cycles);
 
 #ifdef DEST_CHIP_ID
     constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;
@@ -151,7 +132,6 @@ void kernel_main() {
     constexpr uint8_t dest_mesh_ids[total_mesh_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
-    PERF_BEGIN(fab_setup);
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
 
@@ -177,7 +157,6 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, combine_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
-    PERF_END(fab_setup, perf_fabric_setup_cycles);
 
     DPRINT_COMBINE << "Fabric setup complete" << ENDL();
 #endif
@@ -194,14 +173,12 @@ void kernel_main() {
 
     // Sentinel-terminated fabric send loop
     while (true) {
-        PERF_BEGIN(cb_w);
         cb_wait_front(cb_route_info_id, 1);
         volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
         uint32_t route = route_info[0];
         if (route == ROUTE_INFO_SENTINEL) {
             cb_pop_front(cb_route_info_id, 1);
-            PERF_END(cb_w, perf_cb_wait_cycles);
             break;
         }
         uint32_t distance = route_info[1];
@@ -210,13 +187,11 @@ void kernel_main() {
 
         cb_wait_front(cb_output_for_writer_id, 1);
         uint32_t output_data_addr = get_read_ptr(cb_output_for_writer_id);
-        PERF_END(cb_w, perf_cb_wait_cycles);
 
         DPRINT_COMBINE << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << output_page_idx
                        << ENDL();
 
 #ifdef DEST_CHIP_ID
-        PERF_BEGIN(fab_send);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -226,23 +201,16 @@ void kernel_main() {
             output_page_idx,
             (int)aligned_output_page_size,
             l1_alignment);
-        PERF_END(fab_send, perf_fabric_send_cycles);
 #endif
 
         cb_pop_front(cb_output_for_writer_id, 1);
-#if ENABLE_PERF_TRACE
-        perf_num_sends++;
-#endif
     }
 
 #ifdef DEST_CHIP_ID
-    PERF_BEGIN(wr_barr);
     noc_async_write_barrier();
-    PERF_END(wr_barr, perf_write_barrier_cycles);
 
     // Exit semaphore exchange
     {
-        PERF_BEGIN(exit_barr);
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
@@ -258,18 +226,8 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
         noc_semaphore_wait(exit_sem_ptr, combine_devices - 1);
         noc_semaphore_set(exit_sem_ptr, 0);
-        PERF_END(exit_barr, perf_exit_barrier_cycles);
     }
 
     close_direction_connections(directions, fabric_connections);
-#endif
-
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total = read_wall_clock() - perf_total_start;
-    DPRINT << "PERF combine_writer chip=" << linearized_mesh_coord << " total=" << perf_total
-           << " zero_wait=" << perf_zero_wait_cycles << " fab_setup=" << perf_fabric_setup_cycles
-           << " cb_wait=" << perf_cb_wait_cycles << " fab_send=" << perf_fabric_send_cycles
-           << " wr_barr=" << perf_write_barrier_cycles << " exit_barr=" << perf_exit_barrier_cycles
-           << " n_sends=" << perf_num_sends << ENDL();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -18,6 +18,16 @@
     DebugPrinter()
 #endif
 
+#define ENABLE_PERF_TRACE 1
+#if ENABLE_PERF_TRACE
+inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
+#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
+#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
+#else
+#define PERF_BEGIN(var)
+#define PERF_END(var, accum)
+#endif
+
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -116,11 +126,24 @@ void kernel_main() {
     DPRINT_COMBINE << "Combine Writer: experts=[" << expert_start_idx << "," << expert_end_idx << ")"
                    << " linearized_mesh_coord=" << linearized_mesh_coord << ENDL();
 
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total_start = read_wall_clock();
+    uint32_t perf_zero_wait_cycles = 0;
+    uint32_t perf_fabric_setup_cycles = 0;
+    uint32_t perf_cb_wait_cycles = 0;
+    uint32_t perf_fabric_send_cycles = 0;
+    uint32_t perf_write_barrier_cycles = 0;
+    uint32_t perf_exit_barrier_cycles = 0;
+    uint32_t perf_num_sends = 0;
+#endif
+
     // Wait for reader to complete zero-init
+    PERF_BEGIN(zero_wait);
     volatile tt_l1_ptr uint32_t* zero_init_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(zero_init_semaphore_address);
     noc_semaphore_wait(zero_init_sem_ptr, 1);
     noc_semaphore_set(zero_init_sem_ptr, 0);
+    PERF_END(zero_wait, perf_zero_wait_cycles);
 
 #ifdef DEST_CHIP_ID
     constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;
@@ -128,6 +151,7 @@ void kernel_main() {
     constexpr uint8_t dest_mesh_ids[total_mesh_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
+    PERF_BEGIN(fab_setup);
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
 
@@ -153,6 +177,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, combine_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
+    PERF_END(fab_setup, perf_fabric_setup_cycles);
 
     DPRINT_COMBINE << "Fabric setup complete" << ENDL();
 #endif
@@ -169,12 +194,14 @@ void kernel_main() {
 
     // Sentinel-terminated fabric send loop
     while (true) {
+        PERF_BEGIN(cb_w);
         cb_wait_front(cb_route_info_id, 1);
         volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
         uint32_t route = route_info[0];
         if (route == ROUTE_INFO_SENTINEL) {
             cb_pop_front(cb_route_info_id, 1);
+            PERF_END(cb_w, perf_cb_wait_cycles);
             break;
         }
         uint32_t distance = route_info[1];
@@ -183,11 +210,13 @@ void kernel_main() {
 
         cb_wait_front(cb_output_for_writer_id, 1);
         uint32_t output_data_addr = get_read_ptr(cb_output_for_writer_id);
+        PERF_END(cb_w, perf_cb_wait_cycles);
 
         DPRINT_COMBINE << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << output_page_idx
                        << ENDL();
 
 #ifdef DEST_CHIP_ID
+        PERF_BEGIN(fab_send);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -197,16 +226,23 @@ void kernel_main() {
             output_page_idx,
             (int)aligned_output_page_size,
             l1_alignment);
-
-        noc_async_write_barrier();
+        PERF_END(fab_send, perf_fabric_send_cycles);
 #endif
 
         cb_pop_front(cb_output_for_writer_id, 1);
+#if ENABLE_PERF_TRACE
+        perf_num_sends++;
+#endif
     }
 
 #ifdef DEST_CHIP_ID
+    PERF_BEGIN(wr_barr);
+    noc_async_write_barrier();
+    PERF_END(wr_barr, perf_write_barrier_cycles);
+
     // Exit semaphore exchange
     {
+        PERF_BEGIN(exit_barr);
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
@@ -222,8 +258,18 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
         noc_semaphore_wait(exit_sem_ptr, combine_devices - 1);
         noc_semaphore_set(exit_sem_ptr, 0);
+        PERF_END(exit_barr, perf_exit_barrier_cycles);
     }
 
     close_direction_connections(directions, fabric_connections);
+#endif
+
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total = read_wall_clock() - perf_total_start;
+    DPRINT << "PERF combine_writer chip=" << linearized_mesh_coord << " total=" << perf_total
+           << " zero_wait=" << perf_zero_wait_cycles << " fab_setup=" << perf_fabric_setup_cycles
+           << " cb_wait=" << perf_cb_wait_cycles << " fab_send=" << perf_fabric_send_cycles
+           << " wr_barr=" << perf_write_barrier_cycles << " exit_barr=" << perf_exit_barrier_cycles
+           << " n_sends=" << perf_num_sends << ENDL();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -99,8 +99,8 @@ void kernel_main() {
     uint32_t zero_init_barrier_l1_offset = get_semaphore(zero_init_barrier_semaphore_id);
 
     // Read NOC coordinates for all cores (for inter-core barrier signaling).
-    // Max 2 cores: one reader + one writer per link, capped by effective_num_links.
-    constexpr uint32_t MAX_BARRIER_CORES = 2;
+    // num_cores = effective_num_links = min(num_links, 4).
+    constexpr uint32_t MAX_BARRIER_CORES = 4;
     ASSERT(num_cores <= MAX_BARRIER_CORES);
     uint64_t all_core_barrier_noc_addrs[MAX_BARRIER_CORES];
     for (uint32_t c = 0; c < num_cores; c++) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -179,7 +179,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         mesh_coordinate[1],
         sender_cores);
 
-    constexpr uint32_t read_batch_size = 8;
+    constexpr uint32_t read_batch_size = 8;  // matches BH DRAM bank count for full bandwidth utilization
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
     // c_0: input scratch (reader-only, batched DRAM reads)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -215,9 +215,13 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         "offsets_tensor");
 
     // c_4: route_info (reader->writer, 4 x uint32_t per entry)
+    // Must hold at least read_batch_size * num_experts_per_tok entries to avoid deadlock:
+    // the reader pushes all route_info entries for a batch before starting the L1 payload copy,
+    // so the CB must not fill up before the writer can consume (which requires payload data).
     {
         uint32_t route_info_page_size = l1_alignment;
-        constexpr uint32_t route_info_buffering = 16;
+        constexpr uint32_t read_batch_size = 8;  // must match kernel constant
+        uint32_t route_info_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         tt::tt_metal::CircularBufferConfig route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
                 route_info_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
@@ -226,21 +230,30 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     }
 
     // c_5: payload_for_writer (reader->writer, input pages for fabric sends)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        input_tensor,
-        /*buffering_factor=*/16,
-        /*cb_id=*/tt::CBIndex::c_5,
-        "payload_for_writer");
+    // Same buffering rationale as route_info: must hold a full batch of remote tokens.
+    {
+        constexpr uint32_t read_batch_size = 8;
+        uint32_t payload_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            input_tensor,
+            /*buffering_factor=*/payload_buffering,
+            /*cb_id=*/tt::CBIndex::c_5,
+            "payload_for_writer");
+    }
     // c_6: metadata_for_writer (reader->writer, metadata pages for fabric sends)
-    detail::create_tensor_cb(
-        program,
-        sender_core_grid,
-        metadata_tensor,
-        /*buffering_factor=*/16,
-        /*cb_id=*/tt::CBIndex::c_6,
-        "metadata_for_writer");
+    {
+        constexpr uint32_t read_batch_size = 8;
+        uint32_t metadata_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
+        detail::create_tensor_cb(
+            program,
+            sender_core_grid,
+            metadata_tensor,
+            /*buffering_factor=*/metadata_buffering,
+            /*cb_id=*/tt::CBIndex::c_6,
+            "metadata_for_writer");
+    }
 
     // c_7: metadata_temp (reader-only, for constructing metadata locally)
     detail::create_tensor_cb(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -216,41 +216,32 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         /*cb_id=*/tt::CBIndex::c_3,
         "offsets_tensor");
 
-    // c_4: route_info (reader->writer, 4 x uint32_t per entry)
-    // Must hold at least read_batch_size * num_experts_per_tok entries to avoid deadlock:
-    // the reader pushes all route_info entries for a batch before starting the L1 payload copy,
-    // so the CB must not fill up before the writer can consume (which requires payload data).
+    // c_4, c_5, c_6: reader→writer CBs for (route_info, payload, metadata) per remote entry.
+    // The reader pushes all three per entry in lockstep, so small buffering (2) suffices
+    // for the writer to drain concurrently. No large buffering needed.
     {
+        constexpr uint32_t rw_buffering = 2;
+
         uint32_t route_info_page_size = l1_alignment;
-        uint32_t route_info_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         tt::tt_metal::CircularBufferConfig route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
-                route_info_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
+                rw_buffering * route_info_page_size, {{tt::CBIndex::c_4, tt::DataFormat::UInt8}})
                 .set_page_size(tt::CBIndex::c_4, route_info_page_size);
         tt::tt_metal::CreateCircularBuffer(program, sender_core_grid, route_info_cb_config);
-    }
 
-    // c_5: payload_for_writer (reader->writer, input pages for fabric sends)
-    // Same buffering rationale as route_info (see c_4 comment for deadlock analysis).
-    {
-        uint32_t payload_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         detail::create_tensor_cb(
             program,
             sender_core_grid,
             input_tensor,
-            /*buffering_factor=*/payload_buffering,
+            /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_5,
             "payload_for_writer");
-    }
-    // c_6: metadata_for_writer (reader->writer, metadata pages for fabric sends)
-    // Same buffering rationale as route_info (see c_4 comment for deadlock analysis).
-    {
-        uint32_t metadata_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
+
         detail::create_tensor_cb(
             program,
             sender_core_grid,
             metadata_tensor,
-            /*buffering_factor=*/metadata_buffering,
+            /*buffering_factor=*/rw_buffering,
             /*cb_id=*/tt::CBIndex::c_6,
             "metadata_for_writer");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -149,7 +149,14 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    uint32_t effective_num_links = std::min(num_links, 4u);
+    // MAX_BARRIER_CORES: kernel writer_dispatch.cpp sizes its barrier address array to this limit.
+    constexpr uint32_t MAX_BARRIER_CORES = 4;
+    uint32_t effective_num_links = std::min(num_links, MAX_BARRIER_CORES);
+    TT_FATAL(
+        effective_num_links <= MAX_BARRIER_CORES,
+        "effective_num_links {} exceeds MAX_BARRIER_CORES {} (kernel barrier array limit)",
+        effective_num_links,
+        MAX_BARRIER_CORES);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",
@@ -178,6 +185,7 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         mesh_coordinate[1],
         sender_cores);
 
+    // Must match the read_batch_size constexpr in reader_dispatch.cpp kernel.
     constexpr uint32_t read_batch_size = 8;
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
@@ -220,7 +228,6 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     // so the CB must not fill up before the writer can consume (which requires payload data).
     {
         uint32_t route_info_page_size = l1_alignment;
-        constexpr uint32_t read_batch_size = 8;  // must match kernel constant
         uint32_t route_info_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         tt::tt_metal::CircularBufferConfig route_info_cb_config =
             tt::tt_metal::CircularBufferConfig(
@@ -230,9 +237,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     }
 
     // c_5: payload_for_writer (reader->writer, input pages for fabric sends)
-    // Same buffering rationale as route_info: must hold a full batch of remote tokens.
+    // Same buffering rationale as route_info (see c_4 comment for deadlock analysis).
     {
-        constexpr uint32_t read_batch_size = 8;
         uint32_t payload_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         detail::create_tensor_cb(
             program,
@@ -243,8 +249,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
             "payload_for_writer");
     }
     // c_6: metadata_for_writer (reader->writer, metadata pages for fabric sends)
+    // Same buffering rationale as route_info (see c_4 comment for deadlock analysis).
     {
-        constexpr uint32_t read_batch_size = 8;
         uint32_t metadata_buffering = read_batch_size * operation_attributes.num_experts_per_tok;
         detail::create_tensor_cb(
             program,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -149,14 +149,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    // MAX_BARRIER_CORES: kernel writer_dispatch.cpp sizes its barrier address array to this limit.
     constexpr uint32_t MAX_BARRIER_CORES = 4;
     uint32_t effective_num_links = std::min(num_links, MAX_BARRIER_CORES);
-    TT_FATAL(
-        effective_num_links <= MAX_BARRIER_CORES,
-        "effective_num_links {} exceeds MAX_BARRIER_CORES {} (kernel barrier array limit)",
-        effective_num_links,
-        MAX_BARRIER_CORES);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -149,8 +149,8 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
     auto worker_core_range_set = operation_attributes.worker_core_range_set;
 
     auto subdevice_cores = corerange_to_cores(worker_core_range_set);
-    constexpr uint32_t MAX_BARRIER_CORES = 4;
-    uint32_t effective_num_links = std::min(num_links, MAX_BARRIER_CORES);
+    constexpr uint32_t MAX_WORKER_CORES = 4;
+    uint32_t effective_num_links = std::min(num_links, MAX_WORKER_CORES);
     TT_FATAL(
         subdevice_cores.size() >= effective_num_links,
         "Not enough cores {} for {} links",
@@ -179,7 +179,6 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         mesh_coordinate[1],
         sender_cores);
 
-    // Must match the read_batch_size constexpr in reader_dispatch.cpp kernel.
     constexpr uint32_t read_batch_size = 8;
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
@@ -356,6 +355,9 @@ ttnn::device_operation::CachedProgram<DispatchSharedVariables> DispatchProgramFa
         l1_alignment,
         static_cast<uint32_t>(operation_attributes.num_links),
         static_cast<uint32_t>(topology),
+
+        // Batch configuration (1)
+        read_batch_size,
     };
 
     // Append TensorAccessorArgs for all 7 tensors

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -86,8 +86,11 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(46);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(47);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 48)
-    constexpr auto input_args = TensorAccessorArgs<48>();
+    // Batch configuration (index 48)
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(48);
+
+    // TensorAccessorArgs for all 7 tensors (starting at index 49)
+    constexpr auto input_args = TensorAccessorArgs<49>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
@@ -153,7 +156,6 @@ void kernel_main() {
     int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
 
     // Set up batched scratch buffers
-    constexpr uint32_t read_batch_size = 8;
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
     cb_reserve_back(cb_weights_id, read_batch_size);
@@ -238,7 +240,7 @@ void kernel_main() {
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
 
-                        // Push route_info
+                        // Push route info to writer
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -248,14 +250,14 @@ void kernel_main() {
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
 
-                        // Copy payload from input scratch (L1) into payload CB for writer
+                        // Push payload to writer
                         cb_reserve_back(cb_payload_for_writer_id, 1);
                         uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
                         noc_async_read(get_noc_addr(input_scratch_addr), payload_dst, aligned_input_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_payload_for_writer_id, 1);
 
-                        // Push metadata
+                        // Push metadata to writer
                         cb_reserve_back(cb_metadata_for_writer_id, 1);
                         volatile tt_l1_ptr int32_t* meta_dst =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(get_write_ptr(cb_metadata_for_writer_id));

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -18,6 +18,16 @@
     DebugPrinter()
 #endif
 
+#define ENABLE_PERF_TRACE 1
+#if ENABLE_PERF_TRACE
+inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
+#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
+#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
+#else
+#define PERF_BEGIN(var)
+#define PERF_END(var, accum)
+#endif
+
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -130,6 +140,22 @@ void kernel_main() {
     DPRINT_DISPATCH << "Reader kernel: tokens=[" << token_start_idx << "," << token_end_idx << ")"
                     << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores << ENDL();
 
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total_start = read_wall_clock();
+    uint32_t perf_init_cycles = 0;
+    uint32_t perf_dram_read_cycles = 0;
+    uint32_t perf_local_write_cycles = 0;
+    uint32_t perf_l1_payload_copy_cycles = 0;
+    uint32_t perf_l1_metadata_copy_cycles = 0;
+    uint32_t perf_cb_route_cycles = 0;
+    uint32_t perf_local_barrier_cycles = 0;
+    uint32_t perf_next_batch_read_cycles = 0;
+    uint32_t perf_next_batch_barrier_cycles = 0;
+    uint32_t perf_num_local = 0;
+    uint32_t perf_num_remote = 0;
+    PERF_BEGIN(init);
+#endif
+
     // Read offsets into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address, offsets_page_size);
     cb_reserve_back(cb_offsets_id, offsets_pages);
@@ -151,6 +177,8 @@ void kernel_main() {
     }
     noc_async_read_barrier();
     int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
+
+    PERF_END(init, perf_init_cycles);
 
     // Set up batched scratch buffers
     constexpr uint32_t read_batch_size = 8;
@@ -176,12 +204,14 @@ void kernel_main() {
         (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
     uint32_t first_batch_count = first_batch_end - token_start_idx;
     if (first_batch_count > 0) {
+        PERF_BEGIN(dram_prefetch);
         for (uint32_t t = 0; t < first_batch_count; t++) {
             noc_async_read_page(token_start_idx + t, input_addr_gen, input_base + t * aligned_input_page_size);
             noc_async_read_page(token_start_idx + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
             noc_async_read_page(token_start_idx + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
         }
         noc_async_read_barrier();
+        PERF_END(dram_prefetch, perf_dram_read_cycles);
     }
 
     // Main batch loop
@@ -190,6 +220,10 @@ void kernel_main() {
             (batch_start + read_batch_size < token_end_idx) ? batch_start + read_batch_size : token_end_idx;
         uint32_t batch_count = batch_end - batch_start;
         bool batch_did_local_write = false;
+
+        uint32_t remote_count = 0;
+        constexpr uint32_t max_remotes_per_batch = read_batch_size * num_experts_per_tok;
+        uint32_t remote_payload_src[max_remotes_per_batch];
 
         for (uint32_t t = 0; t < batch_count; t++) {
             uint32_t token_idx = batch_start + t;
@@ -219,27 +253,31 @@ void kernel_main() {
                 }
                 auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + offset;
 
-                // Construct metadata
-                volatile tt_l1_ptr int32_t* metadata =
-                    reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
-                metadata[0] = linearized_mesh_coord;
-                metadata[1] = token_idx;
-                metadata[2] = k;
-                metadata[3] = routed_expert;
-                metadata[4] = static_cast<int16_t>(weights[k]);
-
                 if (expert_chip == linearized_mesh_coord) {
+                    volatile tt_l1_ptr int32_t* metadata =
+                        reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
+                    metadata[0] = linearized_mesh_coord;
+                    metadata[1] = token_idx;
+                    metadata[2] = k;
+                    metadata[3] = routed_expert;
+                    metadata[4] = static_cast<int16_t>(weights[k]);
+
+                    PERF_BEGIN(local_wr);
                     noc_async_write_page(page_idx, output_addr_gen, input_scratch_addr);
                     noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
                     noc_async_writes_flushed();
+                    PERF_END(local_wr, perf_local_write_cycles);
                     batch_did_local_write = true;
+#if ENABLE_PERF_TRACE
+                    perf_num_local++;
+#endif
                 } else {
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
 
-                        // Push route info to writer
+                        PERF_BEGIN(cb_route);
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -248,20 +286,25 @@ void kernel_main() {
                         route_info[2] = page_idx;
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
+                        PERF_END(cb_route, perf_cb_route_cycles);
 
-                        // Push payload to writer
-                        cb_reserve_back(cb_payload_for_writer_id, 1);
-                        uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
-                        noc_async_read(get_noc_addr(input_scratch_addr), payload_dst, aligned_input_page_size);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_payload_for_writer_id, 1);
-
-                        // Push metadata to writer
+                        PERF_BEGIN(l1_meta);
                         cb_reserve_back(cb_metadata_for_writer_id, 1);
-                        uint32_t metadata_dst = get_write_ptr(cb_metadata_for_writer_id);
-                        noc_async_read(get_noc_addr(metadata_temp_addr), metadata_dst, aligned_metadata_page_size);
-                        noc_async_read_barrier();
+                        volatile tt_l1_ptr int32_t* meta_dst =
+                            reinterpret_cast<volatile tt_l1_ptr int32_t*>(get_write_ptr(cb_metadata_for_writer_id));
+                        meta_dst[0] = linearized_mesh_coord;
+                        meta_dst[1] = token_idx;
+                        meta_dst[2] = k;
+                        meta_dst[3] = routed_expert;
+                        meta_dst[4] = static_cast<int16_t>(weights[k]);
                         cb_push_back(cb_metadata_for_writer_id, 1);
+                        PERF_END(l1_meta, perf_l1_metadata_copy_cycles);
+
+                        remote_payload_src[remote_count] = input_scratch_addr;
+                        remote_count++;
+#if ENABLE_PERF_TRACE
+                        perf_num_remote++;
+#endif
                     }
                 }
 
@@ -269,10 +312,37 @@ void kernel_main() {
             }
         }
 
+        if (remote_count > 0) {
+            PERF_BEGIN(l1_payload);
+            uint32_t sent = 0;
+            while (sent < remote_count) {
+                uint32_t fifo_lim = get_local_cb_interface(cb_payload_for_writer_id).fifo_limit;
+                uint32_t wr = get_write_ptr(cb_payload_for_writer_id);
+                uint32_t pages_to_end = (fifo_lim - wr) / aligned_input_page_size;
+                uint32_t chunk = remote_count - sent;
+                if (chunk > pages_to_end) {
+                    chunk = pages_to_end;
+                }
+                cb_reserve_back(cb_payload_for_writer_id, chunk);
+                uint32_t base = get_write_ptr(cb_payload_for_writer_id);
+                for (uint32_t i = 0; i < chunk; i++) {
+                    noc_async_read(
+                        get_noc_addr(remote_payload_src[sent + i]),
+                        base + i * aligned_input_page_size,
+                        aligned_input_page_size);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_payload_for_writer_id, chunk);
+                sent += chunk;
+            }
+            PERF_END(l1_payload, perf_l1_payload_copy_cycles);
+        }
+
         // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
         uint32_t next_batch_start = batch_start + read_batch_size;
         bool has_next_batch = (next_batch_start < token_end_idx);
         if (has_next_batch) {
+            PERF_BEGIN(next_batch_rd);
             uint32_t next_batch_end = (next_batch_start + read_batch_size < token_end_idx)
                                           ? next_batch_start + read_batch_size
                                           : token_end_idx;
@@ -284,14 +354,19 @@ void kernel_main() {
                 noc_async_read_page(
                     next_batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
             }
+            PERF_END(next_batch_rd, perf_next_batch_read_cycles);
         }
 
         if (batch_did_local_write) {
+            PERF_BEGIN(local_barr);
             noc_async_write_barrier();
+            PERF_END(local_barr, perf_local_barrier_cycles);
         }
 
         if (has_next_batch) {
+            PERF_BEGIN(next_barr);
             noc_async_read_barrier();
+            PERF_END(next_barr, perf_next_batch_barrier_cycles);
         }
     }
 
@@ -304,4 +379,15 @@ void kernel_main() {
     route_info[2] = 0;
     route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
+
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total = read_wall_clock() - perf_total_start;
+    DPRINT << "PERF dispatch_reader chip=" << linearized_mesh_coord << " core=" << dispatch_core_idx
+           << " total=" << perf_total << " init=" << perf_init_cycles << " dram_read=" << perf_dram_read_cycles
+           << " local_wr=" << perf_local_write_cycles << " l1_payload=" << perf_l1_payload_copy_cycles
+           << " l1_meta=" << perf_l1_metadata_copy_cycles << " cb_route=" << perf_cb_route_cycles
+           << " local_barr=" << perf_local_barrier_cycles << " next_rd=" << perf_next_batch_read_cycles
+           << " next_barr=" << perf_next_batch_barrier_cycles << " n_local=" << perf_num_local
+           << " n_remote=" << perf_num_remote << ENDL();
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -18,16 +18,6 @@
     DebugPrinter()
 #endif
 
-#define ENABLE_PERF_TRACE 1
-#if ENABLE_PERF_TRACE
-inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
-#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
-#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
-#else
-#define PERF_BEGIN(var)
-#define PERF_END(var, accum)
-#endif
-
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -140,22 +130,6 @@ void kernel_main() {
     DPRINT_DISPATCH << "Reader kernel: tokens=[" << token_start_idx << "," << token_end_idx << ")"
                     << " dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores << ENDL();
 
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total_start = read_wall_clock();
-    uint32_t perf_init_cycles = 0;
-    uint32_t perf_dram_read_cycles = 0;
-    uint32_t perf_local_write_cycles = 0;
-    uint32_t perf_l1_payload_copy_cycles = 0;
-    uint32_t perf_l1_metadata_copy_cycles = 0;
-    uint32_t perf_cb_route_cycles = 0;
-    uint32_t perf_local_barrier_cycles = 0;
-    uint32_t perf_next_batch_read_cycles = 0;
-    uint32_t perf_next_batch_barrier_cycles = 0;
-    uint32_t perf_num_local = 0;
-    uint32_t perf_num_remote = 0;
-    PERF_BEGIN(init);
-#endif
-
     // Read offsets into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address, offsets_page_size);
     cb_reserve_back(cb_offsets_id, offsets_pages);
@@ -177,8 +151,6 @@ void kernel_main() {
     }
     noc_async_read_barrier();
     int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
-
-    PERF_END(init, perf_init_cycles);
 
     // Set up batched scratch buffers
     constexpr uint32_t read_batch_size = 8;
@@ -204,14 +176,12 @@ void kernel_main() {
         (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
     uint32_t first_batch_count = first_batch_end - token_start_idx;
     if (first_batch_count > 0) {
-        PERF_BEGIN(dram_prefetch);
         for (uint32_t t = 0; t < first_batch_count; t++) {
             noc_async_read_page(token_start_idx + t, input_addr_gen, input_base + t * aligned_input_page_size);
             noc_async_read_page(token_start_idx + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
             noc_async_read_page(token_start_idx + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
         }
         noc_async_read_barrier();
-        PERF_END(dram_prefetch, perf_dram_read_cycles);
     }
 
     // Main batch loop
@@ -262,22 +232,16 @@ void kernel_main() {
                     metadata[3] = routed_expert;
                     metadata[4] = static_cast<int16_t>(weights[k]);
 
-                    PERF_BEGIN(local_wr);
                     noc_async_write_page(page_idx, output_addr_gen, input_scratch_addr);
                     noc_async_write_page(page_idx, metadata_addr_gen, metadata_temp_addr);
                     noc_async_writes_flushed();
-                    PERF_END(local_wr, perf_local_write_cycles);
                     batch_did_local_write = true;
-#if ENABLE_PERF_TRACE
-                    perf_num_local++;
-#endif
                 } else {
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
 
-                        PERF_BEGIN(cb_route);
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -286,9 +250,7 @@ void kernel_main() {
                         route_info[2] = page_idx;
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
-                        PERF_END(cb_route, perf_cb_route_cycles);
 
-                        PERF_BEGIN(l1_meta);
                         cb_reserve_back(cb_metadata_for_writer_id, 1);
                         volatile tt_l1_ptr int32_t* meta_dst =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(get_write_ptr(cb_metadata_for_writer_id));
@@ -298,13 +260,9 @@ void kernel_main() {
                         meta_dst[3] = routed_expert;
                         meta_dst[4] = static_cast<int16_t>(weights[k]);
                         cb_push_back(cb_metadata_for_writer_id, 1);
-                        PERF_END(l1_meta, perf_l1_metadata_copy_cycles);
 
                         remote_payload_src[remote_count] = input_scratch_addr;
                         remote_count++;
-#if ENABLE_PERF_TRACE
-                        perf_num_remote++;
-#endif
                     }
                 }
 
@@ -313,7 +271,6 @@ void kernel_main() {
         }
 
         if (remote_count > 0) {
-            PERF_BEGIN(l1_payload);
             uint32_t sent = 0;
             while (sent < remote_count) {
                 uint32_t fifo_lim = get_local_cb_interface(cb_payload_for_writer_id).fifo_limit;
@@ -335,14 +292,12 @@ void kernel_main() {
                 cb_push_back(cb_payload_for_writer_id, chunk);
                 sent += chunk;
             }
-            PERF_END(l1_payload, perf_l1_payload_copy_cycles);
         }
 
         // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
         uint32_t next_batch_start = batch_start + read_batch_size;
         bool has_next_batch = (next_batch_start < token_end_idx);
         if (has_next_batch) {
-            PERF_BEGIN(next_batch_rd);
             uint32_t next_batch_end = (next_batch_start + read_batch_size < token_end_idx)
                                           ? next_batch_start + read_batch_size
                                           : token_end_idx;
@@ -354,19 +309,14 @@ void kernel_main() {
                 noc_async_read_page(
                     next_batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
             }
-            PERF_END(next_batch_rd, perf_next_batch_read_cycles);
         }
 
         if (batch_did_local_write) {
-            PERF_BEGIN(local_barr);
             noc_async_write_barrier();
-            PERF_END(local_barr, perf_local_barrier_cycles);
         }
 
         if (has_next_batch) {
-            PERF_BEGIN(next_barr);
             noc_async_read_barrier();
-            PERF_END(next_barr, perf_next_batch_barrier_cycles);
         }
     }
 
@@ -379,15 +329,4 @@ void kernel_main() {
     route_info[2] = 0;
     route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
-
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total = read_wall_clock() - perf_total_start;
-    DPRINT << "PERF dispatch_reader chip=" << linearized_mesh_coord << " core=" << dispatch_core_idx
-           << " total=" << perf_total << " init=" << perf_init_cycles << " dram_read=" << perf_dram_read_cycles
-           << " local_wr=" << perf_local_write_cycles << " l1_payload=" << perf_l1_payload_copy_cycles
-           << " l1_meta=" << perf_l1_metadata_copy_cycles << " cb_route=" << perf_cb_route_cycles
-           << " local_barr=" << perf_local_barrier_cycles << " next_rd=" << perf_next_batch_read_cycles
-           << " next_barr=" << perf_next_batch_barrier_cycles << " n_local=" << perf_num_local
-           << " n_remote=" << perf_num_remote << ENDL();
-#endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -155,7 +155,11 @@ void kernel_main() {
     noc_async_read_barrier();
     int32_t* expert_dispatch_table = (int32_t*)dispatch_table_base_addr;
 
-    // Set up batched scratch buffers
+    // Reserve scratch space once — these CBs are not used as FIFOs. Each batch
+    // overwrites the same region at offsets [0, batch_count) without push/pop.
+    // DRAM reads are batched to saturate DRAM bandwidth, while the L1-to-writer-CB
+    // copies below are done one page at a time — this avoids CB FIFO pointer wrapping
+    // and measured faster in practice.
     cb_reserve_back(cb_indices_id, read_batch_size);
     uint32_t indices_base = get_write_ptr(cb_indices_id);
     cb_reserve_back(cb_weights_id, read_batch_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -191,10 +191,6 @@ void kernel_main() {
         uint32_t batch_count = batch_end - batch_start;
         bool batch_did_local_write = false;
 
-        uint32_t remote_count = 0;
-        constexpr uint32_t max_remotes_per_batch = read_batch_size * num_experts_per_tok;
-        uint32_t remote_payload_src[max_remotes_per_batch];
-
         for (uint32_t t = 0; t < batch_count; t++) {
             uint32_t token_idx = batch_start + t;
             uint32_t input_scratch_addr = input_base + t * aligned_input_page_size;
@@ -242,6 +238,7 @@ void kernel_main() {
                         uint32_t distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
 
+                        // Push route_info
                         cb_reserve_back(cb_route_info_id, 1);
                         volatile tt_l1_ptr uint32_t* route_info =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
@@ -251,6 +248,14 @@ void kernel_main() {
                         route_info[3] = 0;
                         cb_push_back(cb_route_info_id, 1);
 
+                        // Copy payload from input scratch (L1) into payload CB for writer
+                        cb_reserve_back(cb_payload_for_writer_id, 1);
+                        uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
+                        noc_async_read(get_noc_addr(input_scratch_addr), payload_dst, aligned_input_page_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_payload_for_writer_id, 1);
+
+                        // Push metadata
                         cb_reserve_back(cb_metadata_for_writer_id, 1);
                         volatile tt_l1_ptr int32_t* meta_dst =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(get_write_ptr(cb_metadata_for_writer_id));
@@ -260,37 +265,10 @@ void kernel_main() {
                         meta_dst[3] = routed_expert;
                         meta_dst[4] = static_cast<int16_t>(weights[k]);
                         cb_push_back(cb_metadata_for_writer_id, 1);
-
-                        remote_payload_src[remote_count] = input_scratch_addr;
-                        remote_count++;
                     }
                 }
 
                 offset++;
-            }
-        }
-
-        if (remote_count > 0) {
-            uint32_t sent = 0;
-            while (sent < remote_count) {
-                uint32_t fifo_lim = get_local_cb_interface(cb_payload_for_writer_id).fifo_limit;
-                uint32_t wr = get_write_ptr(cb_payload_for_writer_id);
-                uint32_t pages_to_end = (fifo_lim - wr) / aligned_input_page_size;
-                uint32_t chunk = remote_count - sent;
-                if (chunk > pages_to_end) {
-                    chunk = pages_to_end;
-                }
-                cb_reserve_back(cb_payload_for_writer_id, chunk);
-                uint32_t base = get_write_ptr(cb_payload_for_writer_id);
-                for (uint32_t i = 0; i < chunk; i++) {
-                    noc_async_read(
-                        get_noc_addr(remote_payload_src[sent + i]),
-                        base + i * aligned_input_page_size,
-                        aligned_input_page_size);
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_payload_for_writer_id, chunk);
-                sent += chunk;
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -20,6 +20,16 @@
     DebugPrinter()
 #endif
 
+#define ENABLE_PERF_TRACE 1
+#if ENABLE_PERF_TRACE
+inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
+#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
+#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
+#else
+#define PERF_BEGIN(var)
+#define PERF_END(var, accum)
+#endif
+
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -124,11 +134,23 @@ void kernel_main() {
     DPRINT_DISPATCH << "Writer kernel: dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
                     << " dispatch_devices=" << dispatch_devices << ENDL();
 
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total_start = read_wall_clock();
+    uint32_t perf_fabric_setup_cycles = 0;
+    uint32_t perf_cb_wait_cycles = 0;
+    uint32_t perf_fabric_send_payload_cycles = 0;
+    uint32_t perf_fabric_send_metadata_cycles = 0;
+    uint32_t perf_write_barrier_cycles = 0;
+    uint32_t perf_exit_barrier_cycles = 0;
+    uint32_t perf_num_sends = 0;
+#endif
+
 #ifdef DEST_CHIP_ID
     constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
     constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
+    PERF_BEGIN(fab_setup);
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
 
@@ -153,6 +175,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
+    PERF_END(fab_setup, perf_fabric_setup_cycles);
 
     DPRINT_DISPATCH << "Fabric setup complete" << ENDL();
 #endif
@@ -162,12 +185,14 @@ void kernel_main() {
 
     // Sentinel-terminated fabric send loop
     while (true) {
+        PERF_BEGIN(cb_w);
         cb_wait_front(cb_route_info_id, 1);
         volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
         uint32_t route = route_info[0];
         if (route == ROUTE_INFO_SENTINEL) {
             cb_pop_front(cb_route_info_id, 1);
+            PERF_END(cb_w, perf_cb_wait_cycles);
             break;
         }
         uint32_t distance = route_info[1];
@@ -178,12 +203,13 @@ void kernel_main() {
         cb_wait_front(cb_metadata_for_writer_id, 1);
         uint32_t payload_addr = get_read_ptr(cb_payload_for_writer_id);
         uint32_t metadata_addr = get_read_ptr(cb_metadata_for_writer_id);
+        PERF_END(cb_w, perf_cb_wait_cycles);
 
         DPRINT_DISPATCH << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << page_idx
                         << ENDL();
 
 #ifdef DEST_CHIP_ID
-        // Send payload
+        PERF_BEGIN(fab_send_p);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -193,8 +219,9 @@ void kernel_main() {
             page_idx,
             (int)aligned_output_page_size,
             l1_alignment);
+        PERF_END(fab_send_p, perf_fabric_send_payload_cycles);
 
-        // Send metadata
+        PERF_BEGIN(fab_send_m);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             metadata_addr_gen,
@@ -204,17 +231,24 @@ void kernel_main() {
             page_idx,
             (int)aligned_metadata_page_size,
             l1_alignment);
-
-        noc_async_write_barrier();
+        PERF_END(fab_send_m, perf_fabric_send_metadata_cycles);
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);
         cb_pop_front(cb_metadata_for_writer_id, 1);
+#if ENABLE_PERF_TRACE
+        perf_num_sends++;
+#endif
     }
 
 #ifdef DEST_CHIP_ID
+    PERF_BEGIN(wr_barr);
+    noc_async_write_barrier();
+    PERF_END(wr_barr, perf_write_barrier_cycles);
+
     // Exit semaphore exchange
     {
+        PERF_BEGIN(exit_barr);
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
@@ -230,8 +264,18 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
         noc_semaphore_wait(exit_sem_ptr, dispatch_devices - 1);
         noc_semaphore_set(exit_sem_ptr, 0);
+        PERF_END(exit_barr, perf_exit_barrier_cycles);
     }
 
     close_direction_connections(directions, fabric_connections);
+#endif
+
+#if ENABLE_PERF_TRACE
+    uint32_t perf_total = read_wall_clock() - perf_total_start;
+    DPRINT << "PERF dispatch_writer chip=" << linearized_mesh_coord << " core=" << dispatch_core_idx
+           << " total=" << perf_total << " fab_setup=" << perf_fabric_setup_cycles << " cb_wait=" << perf_cb_wait_cycles
+           << " fab_send_p=" << perf_fabric_send_payload_cycles << " fab_send_m=" << perf_fabric_send_metadata_cycles
+           << " wr_barr=" << perf_write_barrier_cycles << " exit_barr=" << perf_exit_barrier_cycles
+           << " n_sends=" << perf_num_sends << ENDL();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -20,16 +20,6 @@
     DebugPrinter()
 #endif
 
-#define ENABLE_PERF_TRACE 1
-#if ENABLE_PERF_TRACE
-inline uint32_t read_wall_clock() { return *reinterpret_cast<volatile uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L); }
-#define PERF_BEGIN(var) uint32_t var##_start = read_wall_clock()
-#define PERF_END(var, accum) accum += (read_wall_clock() - var##_start)
-#else
-#define PERF_BEGIN(var)
-#define PERF_END(var, accum)
-#endif
-
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
@@ -134,23 +124,11 @@ void kernel_main() {
     DPRINT_DISPATCH << "Writer kernel: dispatch_core=" << dispatch_core_idx << "/" << num_dispatch_cores
                     << " dispatch_devices=" << dispatch_devices << ENDL();
 
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total_start = read_wall_clock();
-    uint32_t perf_fabric_setup_cycles = 0;
-    uint32_t perf_cb_wait_cycles = 0;
-    uint32_t perf_fabric_send_payload_cycles = 0;
-    uint32_t perf_fabric_send_metadata_cycles = 0;
-    uint32_t perf_write_barrier_cycles = 0;
-    uint32_t perf_exit_barrier_cycles = 0;
-    uint32_t perf_num_sends = 0;
-#endif
-
 #ifdef DEST_CHIP_ID
     constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
     constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
     constexpr std::array<bool, 4> directions = DIRECTIONS;
 
-    PERF_BEGIN(fab_setup);
     std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
 
@@ -175,7 +153,6 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
     noc_semaphore_wait(init_sem_ptr, dispatch_devices - 1);
     noc_semaphore_set(init_sem_ptr, 0);
-    PERF_END(fab_setup, perf_fabric_setup_cycles);
 
     DPRINT_DISPATCH << "Fabric setup complete" << ENDL();
 #endif
@@ -185,14 +162,12 @@ void kernel_main() {
 
     // Sentinel-terminated fabric send loop
     while (true) {
-        PERF_BEGIN(cb_w);
         cb_wait_front(cb_route_info_id, 1);
         volatile uint32_t* route_info = (volatile uint32_t*)(get_read_ptr(cb_route_info_id));
 
         uint32_t route = route_info[0];
         if (route == ROUTE_INFO_SENTINEL) {
             cb_pop_front(cb_route_info_id, 1);
-            PERF_END(cb_w, perf_cb_wait_cycles);
             break;
         }
         uint32_t distance = route_info[1];
@@ -203,13 +178,11 @@ void kernel_main() {
         cb_wait_front(cb_metadata_for_writer_id, 1);
         uint32_t payload_addr = get_read_ptr(cb_payload_for_writer_id);
         uint32_t metadata_addr = get_read_ptr(cb_metadata_for_writer_id);
-        PERF_END(cb_w, perf_cb_wait_cycles);
 
         DPRINT_DISPATCH << "Fabric send: route=" << route << " distance=" << distance << " page_idx=" << page_idx
                         << ENDL();
 
 #ifdef DEST_CHIP_ID
-        PERF_BEGIN(fab_send_p);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -219,9 +192,7 @@ void kernel_main() {
             page_idx,
             (int)aligned_output_page_size,
             l1_alignment);
-        PERF_END(fab_send_p, perf_fabric_send_payload_cycles);
 
-        PERF_BEGIN(fab_send_m);
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             metadata_addr_gen,
@@ -231,24 +202,17 @@ void kernel_main() {
             page_idx,
             (int)aligned_metadata_page_size,
             l1_alignment);
-        PERF_END(fab_send_m, perf_fabric_send_metadata_cycles);
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);
         cb_pop_front(cb_metadata_for_writer_id, 1);
-#if ENABLE_PERF_TRACE
-        perf_num_sends++;
-#endif
     }
 
 #ifdef DEST_CHIP_ID
-    PERF_BEGIN(wr_barr);
     noc_async_write_barrier();
-    PERF_END(wr_barr, perf_write_barrier_cycles);
 
     // Exit semaphore exchange
     {
-        PERF_BEGIN(exit_barr);
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
@@ -264,18 +228,8 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
         noc_semaphore_wait(exit_sem_ptr, dispatch_devices - 1);
         noc_semaphore_set(exit_sem_ptr, 0);
-        PERF_END(exit_barr, perf_exit_barrier_cycles);
     }
 
     close_direction_connections(directions, fabric_connections);
-#endif
-
-#if ENABLE_PERF_TRACE
-    uint32_t perf_total = read_wall_clock() - perf_total_start;
-    DPRINT << "PERF dispatch_writer chip=" << linearized_mesh_coord << " core=" << dispatch_core_idx
-           << " total=" << perf_total << " fab_setup=" << perf_fabric_setup_cycles << " cb_wait=" << perf_cb_wait_cycles
-           << " fab_send_p=" << perf_fabric_send_payload_cycles << " fab_send_m=" << perf_fabric_send_metadata_cycles
-           << " wr_barr=" << perf_write_barrier_cycles << " exit_barr=" << perf_exit_barrier_cycles
-           << " n_sends=" << perf_num_sends << ENDL();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -88,8 +88,10 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(46);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(47);
 
-    // TensorAccessorArgs for all 7 tensors (starting at index 48)
-    constexpr auto input_args = TensorAccessorArgs<48>();
+    // Batch configuration (index 48) — read_batch_size not used by writer
+
+    // TensorAccessorArgs for all 7 tensors (starting at index 49)
+    constexpr auto input_args = TensorAccessorArgs<49>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
@@ -183,6 +185,7 @@ void kernel_main() {
                         << ENDL();
 
 #ifdef DEST_CHIP_ID
+        // Send payload
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             output_addr_gen,
@@ -193,6 +196,7 @@ void kernel_main() {
             (int)aligned_output_page_size,
             l1_alignment);
 
+        // Send metadata
         fabric_set_unicast_route<false>((volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
         fabric_send_noc_unicast<fabric_max_packet_size>(
             metadata_addr_gen,
@@ -202,6 +206,7 @@ void kernel_main() {
             page_idx,
             (int)aligned_metadata_page_size,
             l1_alignment);
+        noc_async_writes_flushed();  // Ensure payload+metadata departed L1 before freeing CB slots
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/39620
https://github.com/tenstorrent/tt-metal/issues/40393

### Problem description
Dispatch and combine op read a single page from memory before issuing a read barrier. This is inefficient, so we increase the number of read requests before barrier to 8. This matches the number of DRAM banks, and due to interleaved DRAM tensor pages being distributed across DRAM banks round-robin, this results in an even NOC load.

During last optimization PR, this fix somehow disappeared during rebase and did not get merged.

Additionally, max NOC packet size was 7KB, because this was better when 1 Ethernet link is utilized. However, for 2 links and ring topology specifically, 14KB is better, which is supported on Blackhole. This configuration was added to PCC tests to make sure it works correctly.

This exposed an edge case hang when 14KB transfer size was used with a number of experts per token > 2. The CBs were too small, causing a deadlock. This was fixed with improved program factory logic. Measured advantage from ring topology is now 80% compared to linear on 2 links on dispatch, and 60% on combine (due to zero init overhead.)

### What's changed
- Reimplement DRAM fix
- Add 14KB transfer size
- Expand CBs based on number of experts per token.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/moe_dram_opt)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/moe_dram_opt)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=ianastasijevic/moe_dram_opt)
- [x] [![t3k-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ianastasijevic/moe_dram_opt)

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/moe_dram_opt) | [#1891](https://github.com/tenstorrent/tt-metal/actions/runs/23948176948) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/moe_dram_opt) | [#17037](https://github.com/tenstorrent/tt-metal/actions/runs/23948181388) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/moe_dram_opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/moe_dram_opt) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/moe_dram_opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/moe_dram_opt) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/moe_dram_opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/moe_dram_opt) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/moe_dram_opt) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/moe_dram_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/moe_dram_opt) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/moe_dram_opt) |