### PR TITLE
Fix cb overlap in attention_block

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -1929,7 +1929,6 @@ class AttentionBlock:
         # CB descriptor creation (device-invariant, using reference tensors)
         # ========================================================================
         sdpa_out_interm_running_offset = 0
-        sdpa_out_interm_running_offset_kv_cache_update_offset = 0
         # CBs overlapped with sdpa_kv_cache L1 buffer (consumed before SDPA runs)
         sdpa_kv_cache_running_offset = 0
         # CBs overlapped with sdpa_kv_cache L1 buffer permanently allocated on the mcast core
@@ -1937,7 +1936,9 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset_mcast_core = 0
 
         sdpa_forwarder_scratch_running_offset = 0
+        sdpa_intermediate_recv_running_offset = 0
         input_running_offset = 0
+        attn_block_output_running_offset = 0
 
         # Create circular buffer descriptors
         # CB: Input (created from sharded tensor)
@@ -2017,8 +2018,8 @@ class AttentionBlock:
         matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             matmul_input_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset,  # 0 B
+            ref_input_tensor,
+            address_offset=input_running_offset,  # 0 B
             total_size=matmul_input_total_size,
             core_ranges=full_device_grid,
         )
@@ -2030,9 +2031,7 @@ class AttentionBlock:
                 tile=matmul_input_tile_descriptor,
             )
         ]
-        sdpa_out_interm_running_offset += matmul_input_cb_descriptor.total_size  # +14336 B
-
-        sdpa_out_interm_running_offset_kv_cache_update_offset = sdpa_out_interm_running_offset
+        # input_running_offset += matmul_input_cb_descriptor.total_size  # +14336 B
 
         # CB: Matmul output buffer (single tile) — overlap with sdpa_out_interm L1 buffer
         # at offset 0 B. This CB is consumed before SDPA runs.
@@ -2140,11 +2139,6 @@ class AttentionBlock:
             )
         ]
         sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size  # +3072 B
-
-        # Make sure mcast does not trample kv cache update data
-        sdpa_out_interm_running_offset_kv_cache_update_offset = max(
-            sdpa_out_interm_running_offset_kv_cache_update_offset, sdpa_out_interm_running_offset
-        )
 
         # CB 12: Matmul2 output buffer — overlap with sdpa_out_interm L1 buffer
         # at offset 12352 B. This CB is consumed before SDPA runs.
@@ -2329,8 +2323,8 @@ class AttentionBlock:
         dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
         dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             dkv_matmul_output_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_running_offset,
             total_size=dkv_matmul_output_page_size,
             core_ranges=dkv_matmul_weights_core_grid,
         )
@@ -2342,14 +2336,10 @@ class AttentionBlock:
                 tile=dkv_matmul_output_tile_descriptor,
             )
         ]
-        sdpa_out_interm_running_offset_kv_cache_update_offset += dkv_matmul_output_cb_descriptor.total_size
+        attn_block_output_running_offset += dkv_matmul_output_cb_descriptor.total_size
 
-        sdpa_out_interm_running_offset_kv_cache_update_rope_offset = (
-            sdpa_out_interm_running_offset_kv_cache_update_offset
-        )
-        sdpa_out_interm_running_offset_kv_cache_update_nope_offset = (
-            sdpa_out_interm_running_offset_kv_cache_update_offset
-        )
+        attn_block_output_kv_cache_update_rope_running_offset = attn_block_output_running_offset
+        attn_block_output_kv_cache_update_nope_running_offset = attn_block_output_running_offset
 
         # CB 25: KV RMSNorm input buffer — overlap with sdpa_kv_cache L1 buffer
         # at offset 37888 B. This CB is consumed before SDPA runs.
@@ -2362,8 +2352,8 @@ class AttentionBlock:
         kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
         kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_input_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_kv_cache_update_rope_running_offset,
             total_size=1 * kv_rmsnorm_page_size,
             core_ranges=dkv_gather_sender_grid.merge(dkv_gather_receiver_core_grid),
         )
@@ -2375,15 +2365,16 @@ class AttentionBlock:
                 tile=kv_rmsnorm_tile_descriptor,
             )
         ]
-        sdpa_out_interm_running_offset_kv_cache_update_nope_offset += kv_rmsnorm_input_cb_descriptor.total_size
+        # In-place the rmsnorm output, so it uses the same offset as the input
+        # attn_block_output_offset_kv_cache_update_nope_offset += kv_rmsnorm_input_cb_descriptor.total_size
 
         # CB 27: KV RMSNorm output buffer — overlap with sdpa_kv_cache L1 buffer
         # at offset 38912 B. This CB is consumed before SDPA runs.
         # Shares CB ID with rmsnorm2_output_cb (disjoint grids: rows 0-7 vs rows 8-9)
         kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_output_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_kv_cache_update_nope_running_offset,
             total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
             core_ranges=dkv_gather_receiver_core_grid,  # Only the nope core (BRISC) reads kv_rmsnorm_output_cb
         )
@@ -2395,7 +2386,7 @@ class AttentionBlock:
                 tile=kv_rmsnorm_tile_descriptor,
             )
         ]
-        sdpa_out_interm_running_offset_kv_cache_update_nope_offset += kv_rmsnorm_output_cb_descriptor.total_size
+        attn_block_output_kv_cache_update_nope_running_offset += kv_rmsnorm_output_cb_descriptor.total_size
         # CB 29: Cos (DRAM, read by NCRISC)
         krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         krope_cos_sin_cb_format = ttnn.CBFormatDescriptor(
@@ -2406,13 +2397,13 @@ class AttentionBlock:
         )
         krope_cos_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             qkv_rope_cos_sin_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_kv_cache_update_rope_running_offset,
             total_size=krope_Wt * krope_rope_tile_size * 2,
             core_ranges=krope_grid,
         )
         krope_cos_sin_cb_descriptor.format_descriptors = [krope_cos_sin_cb_format]
-        sdpa_out_interm_running_offset_kv_cache_update_rope_offset += krope_cos_sin_cb_descriptor.total_size
+        attn_block_output_kv_cache_update_rope_running_offset += krope_cos_sin_cb_descriptor.total_size
 
         # CB 28: KRoPE output — overlap with sdpa_kv_cache L1 buffer
         # at offset 39936 B. This CB is consumed before SDPA runs.
@@ -2420,8 +2411,8 @@ class AttentionBlock:
         krope_tile_size = TILE_1x32.get_tile_size(data_format)
         krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             krope_output_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_kv_cache_update_rope_running_offset,
             total_size=1 * krope_tile_size,
             core_ranges=krope_grid,
         )
@@ -2433,11 +2424,11 @@ class AttentionBlock:
                 tile=ttnn.TileDescriptor(TILE_1x32),
             )
         ]
-        sdpa_out_interm_running_offset_kv_cache_update_rope_offset += krope_output_cb_descriptor.total_size
+        attn_block_output_kv_cache_update_rope_running_offset += krope_output_cb_descriptor.total_size
 
-        sdpa_out_interm_running_offset_kv_cache_update_offset = max(
-            sdpa_out_interm_running_offset_kv_cache_update_nope_offset,
-            sdpa_out_interm_running_offset_kv_cache_update_rope_offset,
+        attn_block_output_running_offset = max(
+            attn_block_output_kv_cache_update_rope_running_offset,
+            attn_block_output_kv_cache_update_nope_running_offset,
         )
 
         TILE_32x32 = ttnn.Tile((32, 32))
@@ -2457,14 +2448,14 @@ class AttentionBlock:
         )
         kv_cache_input_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_cache_input_cb,
-            ref_sdpa_out_interm_buffer,
-            address_offset=sdpa_out_interm_running_offset_kv_cache_update_offset,
+            ref_sdpa_intermediate_recv,
+            address_offset=sdpa_intermediate_recv_running_offset,
             total_size=kv_cache_num_tiles * kv_cache_page_size,
             core_ranges=full_device_grid,
         )
         # Overlap the input and output CBs
         kv_cache_input_output_cb_descriptor.format_descriptors = [kv_cache_input_cb_format, kv_cache_output_cb_format]
-        sdpa_out_interm_running_offset_kv_cache_update_offset += kv_cache_input_output_cb_descriptor.total_size
+        sdpa_intermediate_recv_running_offset += kv_cache_input_output_cb_descriptor.total_size
         kv_cache_intermed_cb_format = ttnn.CBFormatDescriptor(
             buffer_index=kv_cache_intermed_cb,
             data_format=untilize_df,
@@ -2555,8 +2546,8 @@ class AttentionBlock:
         # cb_mask: Mask input
         mla_mask_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             mla_mask_cb,
-            ref_input_tensor,
-            address_offset=input_running_offset,
+            ref_sdpa_forwarder_scratch,
+            address_offset=sdpa_forwarder_scratch_running_offset,
             total_size=q_tile_size,
             core_ranges=full_device_grid,
         )
@@ -2568,7 +2559,7 @@ class AttentionBlock:
                 tile=q_tile_descriptor,
             )
         ]
-        input_running_offset += mla_mask_cb_descriptor.total_size
+        sdpa_forwarder_scratch_running_offset += mla_mask_cb_descriptor.total_size
         mla_cb_descriptors.append(mla_mask_cb_descriptor)
 
         # mla_out_o_cb/mla_interm_out_cb: output O (tiny tile)
@@ -2626,13 +2617,13 @@ class AttentionBlock:
         )
         matmul4_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             matmul4_in0_cb,
-            ref_input_tensor,
-            address_offset=input_running_offset,
+            ref_attention_block_output_tensor,
+            address_offset=attn_block_output_running_offset,
             total_size=matmul4_k_num_tiles * tile_1x32_size,
             core_ranges=full_device_grid,
         )
         matmul4_in0_cb_descriptor.format_descriptors = [matmul4_in0_cb_format]
-        input_running_offset += matmul4_in0_cb_descriptor.total_size
+        attn_block_output_running_offset += matmul4_in0_cb_descriptor.total_size
         scatter_dest_l1_addr = ttnn.get_cb_address(matmul4_in0_cb_descriptor)
 
         # CB 2: Matmul4 output (4 tiles of 1x32 per core, kv_b2 grid)

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -2353,7 +2353,7 @@ class AttentionBlock:
         kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
             kv_rmsnorm_input_cb,
             ref_attention_block_output_tensor,
-            address_offset=attn_block_output_kv_cache_update_rope_running_offset,
+            address_offset=attn_block_output_kv_cache_update_nope_running_offset,
             total_size=1 * kv_rmsnorm_page_size,
             core_ranges=dkv_gather_sender_grid.merge(dkv_gather_receiver_core_grid),
         )
@@ -2366,7 +2366,7 @@ class AttentionBlock:
             )
         ]
         # In-place the rmsnorm output, so it uses the same offset as the input
-        # attn_block_output_offset_kv_cache_update_nope_offset += kv_rmsnorm_input_cb_descriptor.total_size
+        # attn_block_output_kv_cache_update_nope_running_offset += kv_rmsnorm_input_cb_descriptor.total_size
 
         # CB 27: KV RMSNorm output buffer — overlap with sdpa_kv_cache L1 buffer
         # at offset 38912 B. This CB is consumed before SDPA runs.


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There are risks of a potential race, especially if we have core skew from SD, etc with some of the address reuse in attention. Specifically the kv cache buffers for the nope path could get corrupted by the sdpa tail reductions, since it was overlapped with the sdpa intermediate buffer.

### What's changed
Move kv cache path cbs to overlap with other tensors such as ccl tensors that are on different cores in order to prevent corruption.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/cb-overlap)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/cb-overlap)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/cb-overlap)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/cb-overlap)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/cb-overlap)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/cb-overlap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/cb-overlap)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
