### PR TITLE
Update metal SFPU wrappers for dst_index_in/dst_index_out (LLK #30298)

### DIFF
--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -178,7 +178,7 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
     #ifdef TRISC_MATH
 
     // Low-level function operating on a tile face
-    void my_smoothstep_tile_face(float edge0, float edge1, float inv_delta) {
+    void my_smoothstep_tile_face(uint32_t dst_index_in, uint32_t dst_index_out, float edge0, float edge1, float inv_delta) {
         constexpr size_t vectors_per_face = 8;
         for (size_t i = 0; i < vectors_per_face; i++) {
             vFloat x = dst_reg[i];
@@ -197,6 +197,7 @@ The ``my_smoothstep_tiles`` function uses the layered abstraction pattern shown 
     inline void my_smoothstep_tile(uint32_t idx_dst0, float edge0, float edge1, float inv_delta) {
         MATH(_llk_math_eltwise_unary_sfpu_params_<false>(
             smoothstep_tile_face,
+            idx_dst0,
             idx_dst0,
             VectorMode::RC, // Apply on all 4 faces of the tile
             edge0,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -325,7 +325,8 @@ void reverse_sort_order() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_sum_top2() {
+inline void _deepseek_moe_gate_sum_top2(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     constexpr bool idir = false;  // Sort descending order
     constexpr int load_store_replay_count = 8;
     constexpr int load_replay_offset = 0;
@@ -365,7 +366,8 @@ inline void _deepseek_moe_gate_sum_top2() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_sort_top4_groups() {
+inline void _deepseek_moe_gate_sort_top4_groups(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     // Sort top4
     // Load the top2 sums and concat indices
@@ -392,7 +394,8 @@ inline void _deepseek_moe_gate_sort_top4_groups() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+inline void _deepseek_moe_gate_top8(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t eps, uint32_t scale) {
     constexpr bool idir = false;  // Sort descending order
 
     // Combine and sort 4 groups of 8 values to 2 groups of 8 values

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -325,7 +325,8 @@ void reverse_sort_order() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_sum_top2() {
+inline void _deepseek_moe_gate_sum_top2(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     constexpr bool idir = false;  // Sort descending order
     constexpr int load_store_replay_count = 8;
     constexpr int load_replay_offset = 0;
@@ -365,7 +366,8 @@ inline void _deepseek_moe_gate_sum_top2() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_sort_top4_groups() {
+inline void _deepseek_moe_gate_sort_top4_groups(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     // Sort top4
     // Load the top2 sums and concat indices
@@ -392,7 +394,8 @@ inline void _deepseek_moe_gate_sort_top4_groups() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+inline void _deepseek_moe_gate_top8(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t eps, uint32_t scale) {
     constexpr bool idir = false;  // Sort descending order
 
     // Combine and sort 4 groups of 8 values to 2 groups of 8 values

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
@@ -14,7 +14,8 @@ namespace ckernel::sfpu {
 // param0 is the bit representation of a float
 // This is useful for operations like RMSNorm: rsqrt(variance + epsilon)
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool fp32_dest_acc_en, bool FAST_APPROX>
-inline void calculate_add_rsqrt(uint32_t param0) {
+inline void calculate_add_rsqrt(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t param0) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -14,18 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sum_top2() {
-    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+inline void deepseek_moe_gate_sum_top2(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sort_top4_groups() {
-    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+inline void deepseek_moe_gate_sort_top4_groups(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
-    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
+inline void deepseek_moe_gate_top8(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t eps, uint32_t scale) {
+    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, eps, scale);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -20,21 +20,29 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
     uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
+        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        eps,
+        scale);
 }
 
 }  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add_rsqrt.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_add_rsqrt(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_add_rsqrt<APPROXIMATE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>,
         dst_index,
+        dst_index,
         vector_mode,
         param0);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -14,18 +14,18 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sum_top2() {
-    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+inline void deepseek_moe_gate_sum_top2(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_sort_top4_groups() {
-    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+inline void deepseek_moe_gate_sort_top4_groups(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
-inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
-    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
+inline void deepseek_moe_gate_top8(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t eps, uint32_t scale) {
+    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(dst_index_in, dst_index_out, eps, scale);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -20,21 +20,29 @@ inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
     uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_sfpu_deepseek_moe_gate_top8(
     uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
+        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        eps,
+        scale);
 }
 
 }  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -360,7 +360,8 @@ void compute_sdpa_recip(uint32_t cb_q, uint32_t sum_dst_offset, uint32_t recip_d
  * fused_max_sub_exp_add_tile
  */
 template <bool SDPA_EXP_APPROX_MODE, bool final_norm = false>
-void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
+void calculate_fused_max_sub_exp_add_tile(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, int scale_bf16) {
     // Non-Approx mode for exp initializes recip for final normalization
     static_assert(!(final_norm && SDPA_EXP_APPROX_MODE), "Approx mode must be disabled when final_norm is true");
 
@@ -420,7 +421,7 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
 template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C, bool final_norm = false>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
     _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
-        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE, final_norm>, idst, vector_mode, scale_bf16);
+        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE, final_norm>, idst, idst, vector_mode, scale_bf16);
 }
 #endif
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs() {
+inline void calculate_abs(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
@@ -23,7 +23,7 @@ inline void calculate_abs() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs_int32() {
+inline void calculate_abs_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(1, 12, ADDR_MOD_7, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_add1() {
+inline void calculate_add1(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         dst_reg[0] = 1.0f + val;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -10,9 +10,14 @@
 namespace ckernel::sfpu {
 
 template <DataFormat format>
-inline void calculate_add_top_row(const uint tile_idx_0, const uint tile_idx_1, const uint tile_idx_dst) {
+inline void calculate_add_top_row(
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    const uint tile_idx_0,
+    const uint tile_idx_1,
+    const uint tile_idx_dst) {
     // Use the specified format and tile indices for the add_top_row operation
-    _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
+    _calculate_add_top_row_<format>(dst_index_in, dst_index_out, tile_idx_0, tile_idx_1, tile_idx_dst);
 }
 
 inline void init_add_top_row() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -20,7 +20,8 @@ inline void calculate_addcdiv(
     const uint value) {        // scalar value to multiply with input_b
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
-        "Unsupported data format for calculate_addcdiv(). Supported data formats are: Float32, Float16_b");
+        "Unsupported data format for calculate_addcdiv(dst_index_in, dst_index_out). Supported data formats are: "
+        "Float32, Float16_b");
 
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
@@ -18,7 +18,8 @@ inline void calculate_addcmul(
     const uint value) {        // scalar value to multiply with input_b
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Bfp8_b,
-        "Unsupported data format for calculate_addcmul(). Only Float32, Float16_b (BFloat16), and Bfp8_b (BFloat8B) "
+        "Unsupported data format for calculate_addcmul(dst_index_in, dst_index_out). Only Float32, Float16_b "
+        "(BFloat16), and Bfp8_b (BFloat8B) "
         "are allowed.");
 
     constexpr InstrModLoadStore mod0 =

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
-inline void calculate_alt_complex_rotate90() {
+inline void calculate_alt_complex_rotate90(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         dst_reg[0] = -dst_reg[1];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -22,7 +22,7 @@ enum {
 };  // BINOP_MODE
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
-void calculate_binop_with_scalar(uint32_t param) {
+void calculate_binop_with_scalar(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
     const sfpi::vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -48,33 +48,33 @@ void calculate_binop_with_scalar(uint32_t param) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_add(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+void calculate_add(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_sub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+void calculate_sub(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_mul(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+void calculate_mul(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_div(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+void calculate_div(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_rsub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+void calculate_rsub(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
+void calculate_add_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
 
     // Load value scalar to lreg2
@@ -89,7 +89,7 @@ void calculate_add_int32(uint32_t scalar) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_sub_int32(uint32_t scalar) {
+void calculate_sub_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
 
     // Load value scalar to lreg2

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_and(const uint value) {
+inline void calculate_bitwise_and(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not() {
+inline void calculate_bitwise_not(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_7, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -9,7 +9,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_or(const uint value) {
+inline void calculate_bitwise_or(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_xor(const uint value) {
+inline void calculate_bitwise_xor(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -14,7 +14,7 @@ namespace ckernel::sfpu {
 // Moroz et al. <https://doi.org/10.3390/en14041058>
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cube_root() {
+inline void calculate_cube_root(uint32_t dst_index_in, uint32_t dst_index_out) {
     sfpi::vFloat negative_third_256 = -0x1.555556p-10f;
 
     // Magic constant 0x548c2b4b / 256 + 2^23

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -11,7 +11,7 @@ namespace ckernel::sfpu {
 
 // CELU: alpha * (exp(x / alpha) - 1)
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_celu(uint32_t param0, uint32_t param1) {
+inline void calculate_celu(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param0, uint32_t param1) {
     // All params are in FP16_B format
     // param0 = alpha
     // param1 = alpha_recip

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -14,24 +14,24 @@ enum { Max = true, Min = false };  // Clamp Mode
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint min_val, uint max_val) {
+inline void calculate_clamp(uint32_t dst_index_in, uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_float(min_val);
-        calculate_unary_max_min_float_body<Max>();
+        calculate_unary_max_min_float_body<Max>(dst_index_in, dst_index_out);
         load_value_param_float(max_val);
-        calculate_unary_max_min_float_body<Min>();
+        calculate_unary_max_min_float_body<Min>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp_int32(uint min_val, uint max_val) {
+inline void calculate_clamp_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint min_val, uint max_val) {
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_int(min_val);
-        calculate_unary_max_min_int32_body<Max>(min_val);
+        calculate_unary_max_min_int32_body<Max>(dst_index_in, dst_index_out, min_val);
         load_value_param_int(max_val);
-        calculate_unary_max_min_int32_body<Min>(max_val);
+        calculate_unary_max_min_int32_body<Min>(dst_index_in, dst_index_out, max_val);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp(uint exponent_size_8) {
+inline void calculate_comp(uint32_t dst_index_in, uint32_t dst_index_out, uint exponent_size_8) {
     const vFloat zero = 0.0f;
     const vFloat one = 1.0f;
     for (int d = 0; d < ITERATIONS; d++) {
@@ -67,7 +67,7 @@ inline void calculate_comp(uint exponent_size_8) {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_int() {
+inline void calculate_comp_int(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
         vInt zero = 0;
@@ -120,7 +120,7 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
+inline void calculate_comp_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
     constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -141,7 +141,7 @@ inline void calculate_comp_uint16() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_eqz_uint32() {
+inline void calculate_eqz_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
     int scalar = -5;  // used for shift operation
     _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -154,7 +154,7 @@ inline void calculate_eqz_uint32() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_nez_uint32() {
+inline void calculate_nez_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         // initially put 0 into output
@@ -172,7 +172,7 @@ inline void calculate_nez_uint32() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_unary_int(int scalar) {
+inline void calculate_comp_unary_int(uint32_t dst_index_in, uint32_t dst_index_out, int scalar) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first) {
-    _calculate_cumsum_<false, 1>(first);  // There is only non APPROXIMATE implementation and one iteration
+inline void calculate_cumsum(uint32_t dst_index_in, uint32_t dst_index_out, bool first) {
+    _calculate_cumsum_<false, 1>(
+        dst_index_in, dst_index_out, first);  // There is only non APPROXIMATE implementation and one iteration
 }
 
 template <bool APPROXIMATION_MODE /*unused*/>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -12,8 +12,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_dropout(uint probability, uint scale) {
-    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, probability, scale);
+inline void calculate_dropout(uint32_t dst_index_in, uint32_t dst_index_out, uint probability, uint scale) {
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, probability, scale);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -10,8 +10,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(slope);
+inline void calculate_elu(uint32_t dst_index_in, uint32_t dst_index_out, uint slope) {
+    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf_erfc.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erf_erfc.h
@@ -34,7 +34,7 @@ sfpi_inline vFloat calculate_erf_body(vFloat x) {
 
 // TODO: Fix assertion error for accurate mode
 template <bool APPROXIMATION_MODE>
-inline void calculate_erf() {
+inline void calculate_erf(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < 8; d++) {
         // SFPU microcode:
         vFloat x = dst_reg[0];
@@ -51,7 +51,7 @@ inline void calculate_erf() {
 
 // TODO: Fix assertion error for accurate mode
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfc() {
+inline void calculate_erfc(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode:
     for (int d = 0; d < 8; d++) {
         vFloat x = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -50,7 +50,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfinv() {
+inline void calculate_erfinv(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     constexpr int ITERATIONS = 8;
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -20,7 +20,8 @@ template <
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false,
     bool CLAMP_NEGATIVE = true>
-void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
+void calculate_exponential(
+    uint32_t dst_index_in, uint32_t dst_index_out, const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (APPROXIMATION_MODE) {
         _calculate_exponential_<
             APPROXIMATION_MODE,
@@ -28,7 +29,7 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
             ITERATIONS,
             FAST_APPROX,
             SKIP_POSITIVE_CHECK,
-            CLAMP_NEGATIVE>(exp_base_scale_factor);
+            CLAMP_NEGATIVE>(dst_index_in, dst_index_out, exp_base_scale_factor);
     } else {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+inline void calculate_exp2(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -114,7 +114,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_expm1() {
+inline void calculate_expm1(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // Use original approximation mode
         for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -21,7 +21,7 @@ inline void init_fmod(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_fmod(const uint value, const uint recip) {
+inline void calculate_fmod(uint32_t dst_index_in, uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int max_input_bits = 31>
-inline void calculate_sfpu_gcd_body() {
+inline void calculate_sfpu_gcd_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // c = a
     TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // c |= b
 
@@ -60,7 +60,7 @@ inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
         TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
-        calculate_sfpu_gcd_body<31>();
+        calculate_sfpu_gcd_body<31>(0, 0);
 
         TT_SFPSTORE(p_sfpu::LREG1, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -155,9 +155,9 @@ void gelu_derivative_init() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu() {
+inline void calculate_gelu(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>();
+        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
     } else {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -173,8 +173,8 @@ inline void calculate_gelu() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu_derivative() {
-    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_gelu_derivative(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // =============================================================================
@@ -324,7 +324,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_gelu_derivative_polynomial() {
+inline void calculate_gelu_derivative_polynomial(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardtanh(uint param0, uint param1) {
+inline void calculate_hardtanh(uint32_t dst_index_in, uint32_t dst_index_out, uint param0, uint param1) {
     // Load both params outside the loop for better performance
     // param0 = min_val -> LREG2, param1 = max_val -> LREG3
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_heaviside(uint value) {
+inline void calculate_heaviside(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat s = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -23,7 +23,7 @@ namespace sfpu {
           t4) *                                                                                                   \
      t4)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i0() {
+inline void calculate_i0(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -25,7 +25,7 @@ namespace sfpu {
      t2)
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i1() {
+inline void calculate_i1(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
@@ -17,7 +17,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity() {
+inline void calculate_identity(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
@@ -27,7 +27,7 @@ inline void calculate_identity() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity_uint() {
+inline void calculate_identity_uint(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_col() {
+inline void calculate_sum_int_col(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (size_t i = 0; i < 2; ++i) {
         vInt a = dst_reg[i];
 
@@ -34,7 +34,7 @@ inline void calculate_sum_int_col() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_row() {
+inline void calculate_sum_int_row(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (size_t i = 0; i < 8; i += 2) {
         vInt a = dst_reg[i];
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 // inputs are lreg0, lreg1. output is lreg4
-inline void calculate_sfpu_mul_u16_to_u32_body() {
+inline void calculate_sfpu_mul_u16_to_u32_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     TTI_SFPMUL24(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG4, sfpi::SFPMUL24_MOD1_UPPER);
     TTI_SFPMUL24(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG5, sfpi::SFPMUL24_MOD1_LOWER);
     TTI_SFPSHFT(23, 0, p_sfpu::LREG4, 1); // SFPSHFT_MOD1_ARG_IMM
@@ -32,7 +32,7 @@ inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in
         TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
-        calculate_sfpu_gcd_body<15>();
+        calculate_sfpu_gcd_body<15>(0, 0);
 
         // Two iterations of Newton's method to find reciprocal of gcd(a, b)
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
@@ -69,7 +69,7 @@ inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
 
 	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
-        calculate_sfpu_mul_u16_to_u32_body();
+        calculate_sfpu_mul_u16_to_u32_body(0, 0);
 
         TT_SFPSTORE(p_sfpu::LREG4, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_left_shift(const uint shift_amt) {
+inline void calculate_left_shift(uint32_t dst_index_in, uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(0,12,ADDR_MOD_7,0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -18,7 +18,8 @@ inline void calculate_lerp(
     const uint dst_index_out) {
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
-        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+        "Unsupported data format for calculate_lerp(dst_index_in, dst_index_out). Supported data formats are: Float32, "
+        "Float16_b.");
 
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -13,7 +13,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_lgamma_stirling() {
+inline void calculate_lgamma_stirling(uint32_t dst_index_in, uint32_t dst_index_out) {
     constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
 
     // Minimal coefficients for 0-3 ULP

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -180,7 +180,7 @@ template <
     bool HAS_BASE_SCALING,
     bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
-inline void calculate_log(uint log_base_scale_factor) {
+inline void calculate_log(uint32_t dst_index_in, uint32_t dst_index_out, uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -190,7 +190,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
  * @tparam ITERATIONS Number of iterations for given face
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_log1p() {
+inline void calculate_log1p(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -11,7 +11,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void calculate_logical_not() {
+inline void calculate_logical_not(uint32_t dst_index_in, uint32_t dst_index_out) {
     static_assert(
         INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
             INSTRUCTION_MODE == InstrModLoadStore::INT32,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask() {
+inline void calculate_mask(uint32_t dst_index_in, uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
@@ -27,7 +27,7 @@ inline void calculate_mask() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_int_mask() {
+inline void calculate_int_mask(uint32_t dst_index_in, uint32_t dst_index_out) {
     const int mask_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -39,7 +39,7 @@ inline void calculate_int_mask() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask_posinf() {
+inline void calculate_mask_posinf(uint32_t dst_index_in, uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -21,16 +21,21 @@ template <
     DataLayout layout = DataLayout::TILE,
     bool accumulate = false>
 inline void calculate_max_pool_with_indices(
-    uint values_tile_idx, uint indices_tile_idx, uint unused_tile_idx, uint chunk) {
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    uint values_tile_idx,
+    uint indices_tile_idx,
+    uint unused_tile_idx,
+    uint chunk) {
     if constexpr (num_rows <= 9) {
         _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout, accumulate>(
-            values_tile_idx, indices_tile_idx, chunk);
+            dst_index_in, dst_index_out, values_tile_idx, indices_tile_idx, chunk);
     } else {
         static_assert(num_rows <= 32, "num_rows must be <= 32");
         static_assert(
             layout == DataLayout::ROW_MAJOR, "generic max pool with indices is only implemented for ROW_MAJOR layout");
         _calculate_max_pool_with_indices_generic_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, accumulate>(
-            values_tile_idx, indices_tile_idx, chunk);
+            dst_index_in, dst_index_out, values_tile_idx, indices_tile_idx, chunk);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_prelu(const uint value) {
+inline void calculate_prelu(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
     // SFPU microcode
     vFloat init = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -16,7 +16,8 @@ inline void rand_init(uint32_t seed) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void rand(uint32_t from, uint32_t scale) {
+inline void rand(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -11,7 +11,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS>
-inline void calculate_rdiv(const uint value) {
+inline void calculate_rdiv(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
     sfpi::vFloat val = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -23,8 +23,9 @@ sfpi_inline void sfpu_reciprocal_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8, bool legacy_compat = false>
-inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+inline void calculate_reciprocal(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -12,8 +12,8 @@
 namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t ct_dim, uint32_t rt_dim) {
-    _calculate_reduce_<pool_type, reduce_dim, format>(ct_dim, rt_dim);
+inline void calculate_reduce(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim) {
+    _calculate_reduce_<pool_type, reduce_dim, format>(dst_index_in, dst_index_out, ct_dim, rt_dim);
 }
 
 template <PoolType pool_type, DataFormat format>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -40,8 +40,8 @@ inline void relu_max(uint uint_threshold) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_lrelu(uint slope) {
-    _calculate_lrelu_<APPROXIMATION_MODE>(ITERATIONS, slope);
+inline void calculate_lrelu(uint32_t dst_index_in, uint32_t dst_index_out, uint slope) {
+    _calculate_lrelu_<APPROXIMATION_MODE>(dst_index_in, dst_index_out, ITERATIONS, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -21,7 +21,7 @@ inline void init_remainder(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_remainder(const uint value, const uint recip) {
+inline void calculate_remainder(uint32_t dst_index_in, uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -11,8 +11,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_reshuffle_rows(uint idx_addr) {
-    _calculate_reshuffle_rows_(idx_addr);
+inline void calculate_reshuffle_rows(uint32_t dst_index_in, uint32_t dst_index_out, uint idx_addr) {
+    _calculate_reshuffle_rows_(dst_index_in, dst_index_out, idx_addr);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_right_shift(const uint shift_amt) {
+inline void calculate_right_shift(uint32_t dst_index_in, uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
@@ -11,7 +11,7 @@
 namespace ckernel::sfpu {
 // ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void calculate_rpow(const uint32_t base_val) {
+inline void calculate_rpow(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t base_val) {
     sfpi::vFloat base_val_v = Converter::as_float(base_val);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -13,8 +13,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
+inline void calculate_rsqrt(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -42,7 +42,7 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_rsub_scalar_int32(uint32_t scalar) {
+void calculate_rsub_scalar_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load scalar value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG1, int_scalar);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -39,7 +39,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_sigmoid() {
+inline void calculate_sigmoid(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (!APPROXIMATION_MODE) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -53,7 +53,7 @@ inline void calculate_sigmoid() {
             sfpi::dst_reg++;
         }
     } else {
-        calculate_sigmoid_appx<ITERATIONS>();
+        calculate_sigmoid_appx<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
-inline void calculate_sigmoid_appx() {
+inline void calculate_sigmoid_appx(uint32_t dst_index_in, uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -13,8 +13,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign(const uint exponent_size_8) {
-    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
+inline void calculate_sign(uint32_t dst_index_in, uint32_t dst_index_out, const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 
 // TODO: Implement using bitwise comparison
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit() {
+inline void calculate_signbit(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         v_if(val < 0.0f) { val = 1.0f; }
@@ -25,7 +25,7 @@ inline void calculate_signbit() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit_int32() {
+inline void calculate_signbit_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_7, 0);
         TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -9,7 +9,7 @@
 namespace ckernel::sfpu {
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_silu() {
+inline void calculate_silu(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -97,19 +97,24 @@ inline vFloat softplus(vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
+inline void calculate_softplus_body(
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    const float beta,
+    const float beta_reciprocal,
+    const float threshold) {
     vFloat x = beta * dst_reg[0];
     v_if(x < threshold) { dst_reg[0] = beta_reciprocal * softplus(x); }
     v_endif;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_softplus(uint param0, uint param1, uint param2) {
+inline void calculate_softplus(uint32_t dst_index_in, uint32_t dst_index_out, uint param0, uint param1, uint param2) {
     const float beta = Converter::as_float(param0);
     const float beta_reciprocal = Converter::as_float(param1);
     const float threshold = Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_softplus_body<APPROXIMATION_MODE>(beta, beta_reciprocal, threshold);
+        calculate_softplus_body<APPROXIMATION_MODE>(dst_index_in, dst_index_out, beta, beta_reciprocal, threshold);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softshrink(uint32_t param0) {
+inline void calculate_softshrink(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param0) {
     // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
     // SFPU microcode
     sfpi::vFloat lambda = Converter::as_float(param0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softsign() {
+inline void calculate_softsign(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -13,8 +13,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX>
-inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(ITERATIONS);
+inline void calculate_sqrt(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -11,8 +11,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_square() {
-    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_square(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -116,7 +116,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tanh() {
+inline void calculate_tanh(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
         sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
-inline void calculate_tanh_derivative() {
+inline void calculate_tanh_derivative(uint32_t dst_index_in, uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tiled_prod() {
+inline void calculate_tiled_prod(uint32_t dst_index_in, uint32_t dst_index_out) {
     vFloat result = 1.0f;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -15,19 +15,28 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
-    uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    uint idir,
+    uint i_end_phase,
+    uint i_start_phase,
+    uint i_end_step,
+    uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
-        idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
+        dst_index_in, dst_index_out, idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
+inline void calculate_bitonic_topk_merge(uint32_t dst_index_in, uint32_t dst_index_out, uint m_iter, uint k) {
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(
+        dst_index_in, dst_index_out, m_iter, k);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
+inline void calculate_bitonic_topk_rebuild(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
+        dst_index_in, dst_index_out, idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -91,7 +91,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tangent() {
+inline void calculate_tangent(uint32_t dst_index_in, uint32_t dst_index_out) {
     // Constants for four-stage Cody-Waite reduction with -PI/2 = P0 + P1 + P2 + P3
     const float P0 = -0x1.92p+0f;       // representable as bf16
     const float P1 = -0x1.fbp-12f;      // representable as fp16
@@ -137,7 +137,7 @@ inline void calculate_tangent() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sine() {
+inline void calculate_sine(uint32_t dst_index_in, uint32_t dst_index_out) {
     // 1. Reduce argument using a four-stage Cody-Waite reduction to the interval [-PI/2, PI/2].
     // 2. Use odd symmetry (sin(-x) = -sin(x)) via quadrant/sign tracking.
     // 3. Evaluate sin(a) = a + a^3 (C0 + a^2 (C1 + a^2 (C2 + a^2 C3))) on [0, PI/2].
@@ -210,7 +210,7 @@ inline void calculate_sine() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosine() {
+inline void calculate_cosine(uint32_t dst_index_in, uint32_t dst_index_out) {
     // 1. Build an odd quadrant index j for PI/2-based reduction.
     // 2. Reduce to a in [-PI/2, PI/2] and fold sign from the quadrant parity.
     // 3. Evaluate sin(a) polynomial and use identity cos(x) = sin(x + PI/2).
@@ -350,7 +350,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_atan() {
+inline void calculate_atan(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
@@ -419,7 +419,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
-inline void calculate_asin_acos_impl() {
+inline void calculate_asin_acos_impl(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -444,18 +444,18 @@ inline void calculate_asin_acos_impl() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_asin() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+inline void calculate_asin(uint32_t dst_index_in, uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_acos() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
+inline void calculate_acos(uint32_t dst_index_in, uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // cosh = (exp(x) + exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosh() {
+inline void calculate_cosh(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -468,7 +468,7 @@ inline void calculate_cosh() {
 
 // sinh = (exp(x) - exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sinh() {
+inline void calculate_sinh(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -16,11 +16,11 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint16() {
-    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint8() {
+inline void calculate_typecast_fp32_to_uint8(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -48,7 +48,7 @@ inline void calculate_typecast_fp32_to_uint8() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool u16 = false>
-inline void calculate_typecast_uint_to_uint8() {
+inline void calculate_typecast_uint_to_uint8(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
@@ -63,63 +63,63 @@ inline void calculate_typecast_uint_to_uint8() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp16b() {
-    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp16b() {
-    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_int32() {
-    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_fp16b() {
-    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp32() {
-    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp32() {
-    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint32() {
-    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp16b() {
-    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp32() {
-    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_uint32() {
-    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_uint16() {
-    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_uint16() {
-    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
+inline void calculate_unary_ne(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -31,7 +31,7 @@ inline void calculate_unary_ne(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
+inline void calculate_unary_eq(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -49,7 +49,7 @@ inline void calculate_unary_eq(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
+inline void calculate_unary_gt(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -67,7 +67,7 @@ inline void calculate_unary_gt(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
+inline void calculate_unary_lt(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -85,7 +85,7 @@ inline void calculate_unary_lt(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
+inline void calculate_unary_ge(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -103,7 +103,7 @@ inline void calculate_unary_ge(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
+inline void calculate_unary_le(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu {
 sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = value; }
 
 template <bool IS_MAX_OP>
-sfpi_inline void calculate_unary_max_min_float_body() {
+sfpi_inline void calculate_unary_max_min_float_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
 
     if constexpr (IS_MAX_OP) {
@@ -27,7 +27,7 @@ sfpi_inline void calculate_unary_max_min_float_body() {
 }
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min(uint value) {
+inline void calculate_unary_max_min(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -43,7 +43,7 @@ inline void calculate_unary_max_min(uint value) {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        calculate_unary_max_min_float_body<IS_MAX_OP>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 #else
@@ -67,7 +67,7 @@ sfpi_inline void load_value_param_int(uint value) {
 }
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
-sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+sfpi_inline void calculate_unary_max_min_int32_body(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
@@ -91,13 +91,13 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min_int32(uint value) {
+inline void calculate_unary_max_min_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(dst_index_in, dst_index_out, value);
         sfpi::dst_reg++;
     }
 #else

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -316,7 +316,7 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
  * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_unary_power(const uint32_t exponent) {
+inline void calculate_unary_power(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t exponent) {
     if constexpr (is_fp32_dest_acc_en) {
         _sfpu_unary_power_fp32_<ITERATIONS>(exponent);
     } else {
@@ -330,7 +330,7 @@ inline void calculate_unary_power(const uint32_t exponent) {
  * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_power_iterative(const uint32_t exponent) {
+inline void calculate_unary_power_iterative(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t exponent) {
     // iterative approach for positive integer exponents
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
@@ -14,7 +14,7 @@ namespace sfpu {
 
 // SELU(x) = scale ∗ ( max(0, x) + min(0, α ∗ (exp(x)−1) ) )
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS>
-inline void calculate_selu(uint scale, uint alpha) {
+inline void calculate_selu(uint32_t dst_index_in, uint32_t dst_index_out, uint scale, uint alpha) {
     sfpi::vFloat scale_value = Converter::as_float(scale);
     sfpi::vFloat alpha_value = Converter::as_float(alpha);
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -116,7 +116,8 @@ sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloa
  *        --> alpha_n * (expm1(minimum(x, eps)) - x) + beta * x
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
+inline void calculate_xielu(
+    uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t param0, const uint32_t param1) {
     sfpi::vFloat alpha_p = Converter::as_float(param0);
     sfpi::vFloat alpha_n = Converter::as_float(param1);
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -18,13 +18,13 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -22,7 +22,9 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        dst_index,
         dst_index,
         vector_mode);
 }
@@ -36,7 +38,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 // celu
@@ -49,9 +51,11 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
+        [](uint32_t dst_index_in, uint32_t dst_index_out, uint32_t alpha, uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
         },
+        dst_index,
         dst_index,
         vector_mode,
         alpha,
@@ -67,7 +71,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -14,7 +14,7 @@ template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
+        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE>
@@ -26,14 +26,14 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -19,14 +19,19 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        min_val,
+        max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
     _llk_math_eltwise_unary_sfpu_params_<false>(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
+        dst_index,                               // There is only non APPROXIMATE implementation
         dst_index,
         VectorMode::RC_custom,  // Can only work in RC_custom mode
         first);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -19,7 +19,11 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -33,6 +37,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index,
         dst_index,
         vector_mode,
         base_scale);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -36,25 +36,33 @@
     llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, FAST_APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
-#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
-        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                  \
+        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, \
+        DST_IDX,                                                                        \
+        DST_IDX,                                                                        \
+        (int)VectorMode::MODE,                                                          \
+        PARAM0);
 
 // For the int32 comparison variants with underscore in callback
 #define SFPU_COMP_INT32_KERNEL_UNDERSCORE(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                            \
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>,     \
+        DST_IDX,                                                                              \
+        DST_IDX,                                                                              \
+        (int)VectorMode::MODE,                                                                \
+        PARAM0);
 
 // For ops where the compute functor is not "calculate_<OP>", but an arbitrary function name (e.g., relu_min, relu_max,
 // etc.),and which take one extra runtime uint parameter
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND an additional template param (ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(FN, MODE, APPROXIMATE, EXTRA_PARAM, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
+        ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(                                                        \
@@ -65,40 +73,46 @@
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
-        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>,                                             \
+        DST_IDX,                                                                                                    \
+        DST_IDX,                                                                                                    \
+        (int)VectorMode::MODE,                                                                                      \
+        PARAM0)
 
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly two extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_TWO_PARAM_KERNEL_WITH_DST_ACCUM(FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
-        ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+        ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly three extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_THREE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1, PARAM2) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                           \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops without extra uint parameter
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                \
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameter with ITERATIONS
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN_ITERATIONS(FN, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                       \
+        ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameters with type and iteration
 #define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(FN, TYPE, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
-        ckernel::sfpu::FN<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
 #define SFPU_TEMPLATE_PARAMS_KERNEL_FN(                \
@@ -123,58 +137,63 @@
             SKIP_POSITIVE_CHECK,                       \
             CLAMP_NEGATIVE>,                           \
         DST_IDX,                                       \
+        DST_IDX,                                       \
         VECTOR_MODE,                                   \
         SCALE)
 
 // For kernels with one template parameter and one extra runtime argument.
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                               \
-        ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
-        ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For kernels whose functor takes one template parameter (e.g., <APPROXIMATE>)
 #define SFPU_ONE_PARAM_KERNEL(FN, APPROXIMATE, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER/USE_FP32>)
 #define SFPU_TWO_PARAM_KERNEL(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER>) and one extra runtime param.
 #define SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                       \
+        ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, DST_IDX, VECTOR_MODE, PARAM0)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, ITER, USE_FP32>)
 #define SFPU_THREE_PARAM_KERNEL_ITER_FIRST(FN, APPROXIMATE, ITER, FP32, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                            \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For functors with <APPROXIMATE, USE_FP32, ITER>
 #define SFPU_THREE_PARAM_KERNEL_FP32_FIRST(FN, APPROXIMATE, FP32, ITER, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, fp32_dest_acc_en, FP32_FIRST, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
+        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, DST_IDX, MODE)
 
 // For unary ops with five template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, FAST_APPROX, legacy_compat)
 #define SFPU_FIVE_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                               \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>,                                      \
+        DST_IDX,                                                                                                     \
+        DST_IDX,                                                                                                     \
+        (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
 #define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
@@ -193,19 +212,19 @@
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
-        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
+        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)
 #define SFPU_ZERO_KERNEL(OP, MODE, APPROXIMATE, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(   \
-        ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE, 8);
+        ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, DST_IDX, (int)VectorMode::MODE, 8);
 
 // Generalized macro for compare-with-zero ops for any type (e.g., int, uint16)
 #define SFPU_ZERO_KERNEL_TYPE(TYPE, OP, MODE, APPROXIMATE, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(              \
-        ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE);
+        ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, DST_IDX, (int)VectorMode::MODE);
 
 // For log1p op that needs three template parameters
 #define SFPU_UNARY_NO_PARAM_KERNEL_LOG1P_FN(FN, MODE, APPROXIMATE, FAST_APPROX, FP32, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                         \
-        ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, DST_IDX, (int)VectorMode::MODE)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -26,10 +26,10 @@ inline void llk_math_eltwise_unary_sfpu_mask(
     uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 template <bool APPROXIMATE>
@@ -32,7 +32,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 template <bool APPROXIMATE>
@@ -45,7 +49,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary minimum
@@ -57,7 +65,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 template <bool APPROXIMATE>
@@ -70,7 +78,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 template <bool APPROXIMATE>
@@ -83,7 +95,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -19,7 +19,11 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
+        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        exponent);
 }
 
 template <bool APPROXIMATE>
@@ -31,7 +35,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
+        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, dst_index, vector_mode, exponent);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,
+        dst_index,
         vector_mode,
         value);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, dst_index, vector_mode, ct_dim, rt_dim);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -48,7 +48,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
+        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, dst_index, vector_mode, idx_addr);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
+        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode, base_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -20,6 +20,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = 
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,
+        dst_index,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_selu(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,
+        dst_index,
         vector_mode,
         scale,
         alpha);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -17,7 +17,8 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_sigmoid_appx, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, dst_index, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -18,13 +18,13 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -18,7 +18,9 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        dst_index,
         dst_index,
         vector_mode,
         param0,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -28,6 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
+        dst_index,
         vector_mode,
         idir,
         i_end_phase,
@@ -41,6 +42,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
+        dst_index,
         dst_index,
         vector_mode,
         m_iter,
@@ -58,6 +60,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -17,76 +17,76 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
 
     if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
@@ -97,22 +97,22 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
@@ -130,28 +130,29 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
             dst_index,
+            dst_index,
             vector_mode);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
         // No SFPU kernel needed.
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs() {
+inline void calculate_abs(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
@@ -23,7 +23,7 @@ inline void calculate_abs() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_abs_int32() {
+inline void calculate_abs_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         TT_SFPLOAD(1, 4, 3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_add1() {
+inline void calculate_add1(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         dst_reg[0] = 1.0f + val;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_top_row.h
@@ -10,9 +10,14 @@
 namespace ckernel::sfpu {
 
 template <DataFormat format>
-inline void calculate_add_top_row(const uint tile_idx_0, const uint tile_idx_1, const uint tile_idx_dst) {
+inline void calculate_add_top_row(
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    const uint tile_idx_0,
+    const uint tile_idx_1,
+    const uint tile_idx_dst) {
     // Use the specified format and tile indices for the add_top_row operation
-    _calculate_add_top_row_<format>(tile_idx_0, tile_idx_1, tile_idx_dst);
+    _calculate_add_top_row_<format>(dst_index_in, dst_index_out, tile_idx_0, tile_idx_1, tile_idx_dst);
 }
 
 inline void init_add_top_row() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -20,7 +20,8 @@ inline void calculate_addcdiv(
     const uint value) {        // scalar value to multiply with input_b
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
-        "Unsupported data format for calculate_addcdiv(). Supported data formats are: Float32, Float16_b.");
+        "Unsupported data format for calculate_addcdiv(dst_index_in, dst_index_out). Supported data formats are: "
+        "Float32, Float16_b.");
 
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
@@ -18,7 +18,8 @@ inline void calculate_addcmul(
     const uint value) {        // scalar value to multiply with input_b
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Bfp8_b,
-        "Unsupported data format for calculate_addcmul(). Only Float32, Float16_b (BFloat16), and Bfp8_b (BFloat8B) "
+        "Unsupported data format for calculate_addcmul(dst_index_in, dst_index_out). Only Float32, Float16_b "
+        "(BFloat16), and Bfp8_b (BFloat8B) "
         "are allowed.");
 
     constexpr InstrModLoadStore mod0 =

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
-inline void calculate_alt_complex_rotate90() {
+inline void calculate_alt_complex_rotate90(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         dst_reg[0] = -dst_reg[1];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -23,7 +23,7 @@ enum {
 };  // BINOP_MODE
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
-void calculate_binop_with_scalar(uint32_t param) {
+void calculate_binop_with_scalar(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
     const sfpi::vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -49,33 +49,33 @@ void calculate_binop_with_scalar(uint32_t param) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_add(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+void calculate_add(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_sub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+void calculate_sub(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_mul(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+void calculate_mul(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_div(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+void calculate_div(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_rsub(uint32_t param) {
-    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+void calculate_rsub(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(dst_index_in, dst_index_out, param);
     return;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
+void calculate_add_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
@@ -89,7 +89,7 @@ void calculate_add_int32(uint32_t scalar) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_sub_int32(uint32_t scalar) {
+void calculate_sub_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load value scalar to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_and(const uint value) {
+inline void calculate_bitwise_and(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not() {
+inline void calculate_bitwise_not(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::LREG4, ADDR_MOD_3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -9,7 +9,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_or(const uint value) {
+inline void calculate_bitwise_or(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_xor(const uint value) {
+inline void calculate_bitwise_xor(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -14,7 +14,7 @@ namespace ckernel::sfpu {
 // Moroz et al. <https://doi.org/10.3390/en14041058>
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cube_root() {
+inline void calculate_cube_root(uint32_t dst_index_in, uint32_t dst_index_out) {
     sfpi::vFloat negative_third_256 = -0x1.555556p-10f;
 
     // Magic constant 0x548c2b4b / 256 + 2^23

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -11,7 +11,7 @@ namespace ckernel::sfpu {
 
 // CELU: alpha * (exp(x / alpha) - 1)
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_celu(uint32_t param0, uint32_t param1) {
+inline void calculate_celu(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param0, uint32_t param1) {
     // All params are in FP16_B format
     // param0 = alpha
     // param1 = alpha_recip

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -13,25 +13,25 @@ enum { Max = true, Min = false };  // Clamp Mode
 
 // out = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp(uint min_val, uint max_val) {
+inline void calculate_clamp(uint32_t dst_index_in, uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_float(min_val);
-        calculate_unary_max_min_float_body<Max>();
+        calculate_unary_max_min_float_body<Max>(dst_index_in, dst_index_out);
         load_value_param_float(max_val);
-        calculate_unary_max_min_float_body<Min>();
+        calculate_unary_max_min_float_body<Min>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_clamp_int32(uint min_val, uint max_val) {
+inline void calculate_clamp_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint min_val, uint max_val) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         load_value_param_int(min_val);
-        calculate_unary_max_min_int32_body<Max>(min_val);
+        calculate_unary_max_min_int32_body<Max>(dst_index_in, dst_index_out, min_val);
         load_value_param_int(max_val);
-        calculate_unary_max_min_int32_body<Min>(max_val);
+        calculate_unary_max_min_int32_body<Min>(dst_index_in, dst_index_out, max_val);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -34,7 +34,7 @@ sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
 #endif  // SFPU_SIGN_MAG_TO_TWOS_COMP_DEFINED
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp(uint exponent_size_8) {
+inline void calculate_comp(uint32_t dst_index_in, uint32_t dst_index_out, uint exponent_size_8) {
     const vFloat zero = 0.0f;
     const vFloat one = 1.0f;
     for (int d = 0; d < ITERATIONS; d++) {
@@ -88,7 +88,7 @@ inline void calculate_comp(uint exponent_size_8) {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_int() {
+inline void calculate_comp_int(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt v = dst_reg[0];
         vInt zero = 0;
@@ -141,7 +141,7 @@ inline void calculate_comp_int() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_uint16() {
+inline void calculate_comp_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
     constexpr int check = ((COMP_MODE == SfpuType::equal_zero) ? SFPSETCC_MOD1_LREG_EQ0 : SFPSETCC_MOD1_LREG_NE0);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -162,7 +162,7 @@ inline void calculate_comp_uint16() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_eqz_uint32() {
+inline void calculate_eqz_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
     int scalar = -5;  // used for shift operation
     _sfpu_load_imm32_(p_sfpu::LREG2, scalar);
     for (int d = 0; d < ITERATIONS; d++) {
@@ -175,7 +175,7 @@ inline void calculate_eqz_uint32() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_nez_uint32() {
+inline void calculate_nez_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         // initially put 0 into output
@@ -193,7 +193,7 @@ inline void calculate_nez_uint32() {
 }
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
-inline void calculate_comp_unary_int(int scalar) {
+inline void calculate_comp_unary_int(uint32_t dst_index_in, uint32_t dst_index_out, int scalar) {
     // Convert both operands to two's complement format
     //
     // LOGIC:

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -14,8 +14,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first) {
-    _calculate_cumsum_<false, 1>(first);  // There is only non APPROXIMATE implementation and one iteration
+inline void calculate_cumsum(uint32_t dst_index_in, uint32_t dst_index_out, bool first) {
+    _calculate_cumsum_<false, 1>(
+        dst_index_in, dst_index_out, first);  // There is only non APPROXIMATE implementation and one iteration
 }
 
 template <bool APPROXIMATION_MODE /*unused*/>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -14,8 +14,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_dropout(uint probability, uint scale) {
-    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, probability, scale);
+inline void calculate_dropout(uint32_t dst_index_in, uint32_t dst_index_out, uint probability, uint scale) {
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, probability, scale);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -10,8 +10,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_elu(uint slope) {
-    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(slope);
+inline void calculate_elu(uint32_t dst_index_in, uint32_t dst_index_out, uint slope) {
+    _calculate_elu_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf_erfc.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erf_erfc.h
@@ -32,7 +32,7 @@ sfpi_inline vFloat calculate_erf_body(vFloat x) {
 
 // TODO: Fix assertion error for accurate mode
 template <bool APPROXIMATION_MODE>
-inline void calculate_erf() {
+inline void calculate_erf(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < 8; d++) {
         // SFPU microcode:
         vFloat x = dst_reg[0];
@@ -49,7 +49,7 @@ inline void calculate_erf() {
 
 // TODO: Fix assertion error for accurate mode
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfc() {
+inline void calculate_erfc(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode:
     for (int d = 0; d < 8; d++) {
         vFloat x = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -50,7 +50,7 @@ sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat in) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_erfinv() {
+inline void calculate_erfinv(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     constexpr int ITERATIONS = 8;
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -19,7 +19,8 @@ template <
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false,
     bool CLAMP_NEGATIVE = true>
-void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
+void calculate_exponential(
+    uint32_t dst_index_in, uint32_t dst_index_out, const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (APPROXIMATION_MODE) {
         _calculate_exponential_<
             APPROXIMATION_MODE,
@@ -27,7 +28,7 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
             ITERATIONS,
             FAST_APPROX,
             SKIP_POSITIVE_CHECK,
-            CLAMP_NEGATIVE>(exp_base_scale_factor);
+            CLAMP_NEGATIVE>(dst_index_in, dst_index_out, exp_base_scale_factor);
     } else {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -9,8 +9,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_exp2() {
-    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+inline void calculate_exp2(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_exp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -114,7 +114,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_expm1() {
+inline void calculate_expm1(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // Use original approximation mode
         for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -21,7 +21,7 @@ inline void init_fmod(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_fmod(const uint value, const uint recip) {
+inline void calculate_fmod(uint32_t dst_index_in, uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int max_input_bits = 31>
-inline void calculate_sfpu_gcd_body() {
+inline void calculate_sfpu_gcd_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // c = a
     TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // c |= b
 
@@ -60,7 +60,7 @@ inline void calculate_sfpu_gcd(const uint dst_index_in0, const uint dst_index_in
         TT_SFPLOAD(p_sfpu::LREG0, 4, 3, dst_index_in0 * dst_tile_size);  // a
         TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
-        calculate_sfpu_gcd_body<31>();
+        calculate_sfpu_gcd_body<31>(0, 0);
 
         TT_SFPSTORE(p_sfpu::LREG1, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -155,9 +155,9 @@ void gelu_derivative_init() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu() {
+inline void calculate_gelu(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>();
+        _calculate_gelu_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
     } else {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -173,8 +173,8 @@ inline void calculate_gelu() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_gelu_derivative() {
-    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_gelu_derivative(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_gelu_derivative_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // =============================================================================
@@ -324,7 +324,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_derivative_simple(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
-inline void calculate_gelu_derivative_polynomial() {
+inline void calculate_gelu_derivative_polynomial(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hardtanh.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 // Hardtanh(x) = max_val if x > max_val, min_val if x < min_val, else x
 // Equivalent to: clamp(x, min_val, max_val) = min(max(x, min_val), max_val)
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_hardtanh(uint param0, uint param1) {
+inline void calculate_hardtanh(uint32_t dst_index_in, uint32_t dst_index_out, uint param0, uint param1) {
     // Load both params outside the loop for better performance
     // param0 = min_val -> LREG2, param1 = max_val -> LREG3
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, param0 & 0xFFFF);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_heaviside.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_heaviside(uint value) {
+inline void calculate_heaviside(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat s = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -23,7 +23,7 @@ namespace sfpu {
           t4) *                                                                                                   \
      t4)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i0() {
+inline void calculate_i0(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i1.h
@@ -25,7 +25,7 @@ namespace sfpu {
      t2)
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_i1() {
+inline void calculate_i1(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
@@ -17,7 +17,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity() {
+inline void calculate_identity(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
@@ -27,7 +27,7 @@ inline void calculate_identity() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_identity_uint() {
+inline void calculate_identity_uint(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -42,7 +42,7 @@ sfpi_inline vInt sfpu_twos_comp_to_sign_mag(vInt value) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_col() {
+inline void calculate_sum_int_col(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (unsigned i = 0; i < 2; ++i) {
         vInt a = dst_reg[i];
         a = sfpu_twos_comp_to_sign_mag(a);
@@ -65,7 +65,7 @@ inline void calculate_sum_int_col() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_sum_int_row() {
+inline void calculate_sum_int_row(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (unsigned i = 0; i < 8; i += 2) {
         vInt a = dst_reg[i];
         a = sfpu_twos_comp_to_sign_mag(a);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 // inputs are lreg0, lreg1. output is lreg4
-inline void calculate_sfpu_mul_u16_to_u32_body() {
+inline void calculate_sfpu_mul_u16_to_u32_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     // mask
     TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xff);
     // copy
@@ -61,7 +61,7 @@ inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in
         TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_index_in1 * dst_tile_size);  // b
 
         // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
-        calculate_sfpu_gcd_body<15>();
+        calculate_sfpu_gcd_body<15>(0, 0);
 
         // Two iterations of Newton's method to find reciprocal of gcd(a, b)
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
@@ -98,7 +98,7 @@ inline void calculate_sfpu_lcm(const uint dst_index_in0, const uint dst_index_in
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
 
 	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
-        calculate_sfpu_mul_u16_to_u32_body();
+        calculate_sfpu_mul_u16_to_u32_body(0, 0);
 
         TT_SFPSTORE(p_sfpu::LREG4, 4, 3, dst_index_out * dst_tile_size);
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_left_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_left_shift(const uint shift_amt) {
+inline void calculate_left_shift(uint32_t dst_index_in, uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(0,4,3,0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -18,7 +18,8 @@ inline void calculate_lerp(
     const uint dst_index_out) {
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
-        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+        "Unsupported data format for calculate_lerp(dst_index_in, dst_index_out). Supported data formats are: Float32, "
+        "Float16_b.");
 
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -13,7 +13,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_lgamma_stirling() {
+inline void calculate_lgamma_stirling(uint32_t dst_index_in, uint32_t dst_index_out) {
     constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
 
     // Minimal coefficients for 0-3 ULP

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -183,7 +183,7 @@ template <
     bool HAS_BASE_SCALING,
     bool is_fp32_dest_acc_en,
     int ITERATIONS = 8>
-inline void calculate_log(uint log_base_scale_factor) {
+inline void calculate_log(uint32_t dst_index_in, uint32_t dst_index_out, uint log_base_scale_factor) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h
@@ -193,7 +193,7 @@ sfpi_inline sfpi::vFloat calculate_log1p_fp32(sfpi::vFloat val) {
  * @tparam ITERATIONS Number of iterations for given face
  */
 template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_log1p() {
+inline void calculate_log1p(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -11,7 +11,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
-inline void calculate_logical_not() {
+inline void calculate_logical_not(uint32_t dst_index_in, uint32_t dst_index_out) {
     static_assert(
         INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
             INSTRUCTION_MODE == InstrModLoadStore::INT32,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask() {
+inline void calculate_mask(uint32_t dst_index_in, uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8
@@ -27,7 +27,7 @@ inline void calculate_mask() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_int_mask() {
+inline void calculate_int_mask(uint32_t dst_index_in, uint32_t dst_index_out) {
     const int mask_idx = 32;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -39,7 +39,7 @@ inline void calculate_int_mask() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_mask_posinf() {
+inline void calculate_mask_posinf(uint32_t dst_index_in, uint32_t dst_index_out) {
     const bool exponent_size_8 = true;
     const int mask_val_idx = 32;
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -21,16 +21,21 @@ template <
     DataLayout layout = DataLayout::TILE,
     bool accumulate = false>
 inline void calculate_max_pool_with_indices(
-    uint values_tile_idx, uint indices_tile_idx, uint unused_tile_idx, uint chunk) {
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    uint values_tile_idx,
+    uint indices_tile_idx,
+    uint unused_tile_idx,
+    uint chunk) {
     if constexpr (num_rows <= 9) {
         _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout, accumulate>(
-            values_tile_idx, indices_tile_idx, chunk);
+            dst_index_in, dst_index_out, values_tile_idx, indices_tile_idx, chunk);
     } else {
         static_assert(num_rows <= 32, "num_rows must be <= 32");
         static_assert(
             layout == DataLayout::ROW_MAJOR, "generic max pool with indices is only implemented for ROW_MAJOR layout");
         _calculate_max_pool_with_indices_generic_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, accumulate>(
-            values_tile_idx, indices_tile_idx, chunk);
+            dst_index_in, dst_index_out, values_tile_idx, indices_tile_idx, chunk);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -14,7 +14,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_prelu(uint value) {
+inline void calculate_prelu(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     vFloat init = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rand.h
@@ -16,7 +16,8 @@ inline void rand_init(uint32_t seed) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void rand(uint32_t from, uint32_t scale) {
+inline void rand(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t from, uint32_t scale) {
     // Load scale param to lreg1
     TT_SFPLOADI(p_sfpu::LREG1, 10, scale & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG1, 8, scale >> 16);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -11,7 +11,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS>
-inline void calculate_rdiv(const uint value) {
+inline void calculate_rdiv(uint32_t dst_index_in, uint32_t dst_index_out, const uint value) {
     sfpi::vFloat val = Converter::as_float(value);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -25,8 +25,9 @@ sfpi_inline void sfpu_reciprocal_init() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8, bool legacy_compat = false>
-inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(ITERATIONS);
+inline void calculate_reciprocal(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -12,8 +12,8 @@
 namespace ckernel::sfpu {
 
 template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t ct_dim, uint32_t rt_dim) {
-    _calculate_reduce_<pool_type, reduce_dim, format>(ct_dim, rt_dim);
+inline void calculate_reduce(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t ct_dim, uint32_t rt_dim) {
+    _calculate_reduce_<pool_type, reduce_dim, format>(dst_index_in, dst_index_out, ct_dim, rt_dim);
 }
 
 template <PoolType pool_type, DataFormat format>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -40,8 +40,8 @@ inline void relu_max(uint uint_threshold) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_lrelu(const uint slope) {
-    _calculate_lrelu_<APPROXIMATION_MODE>(ITERATIONS, slope);
+inline void calculate_lrelu(uint32_t dst_index_in, uint32_t dst_index_out, const uint slope) {
+    _calculate_lrelu_<APPROXIMATION_MODE>(dst_index_in, dst_index_out, ITERATIONS, slope);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -21,7 +21,7 @@ inline void init_remainder(const uint value, const uint recip) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_remainder(const uint value, const uint recip) {
+inline void calculate_remainder(uint32_t dst_index_in, uint32_t dst_index_out, const uint value, const uint recip) {
     // SFPU microcode
     vFloat s = vConstFloatPrgm0;
     vFloat recip_val = vConstFloatPrgm1;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -11,8 +11,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_reshuffle_rows(uint idx_addr) {
-    _calculate_reshuffle_rows_(idx_addr);
+inline void calculate_reshuffle_rows(uint32_t dst_index_in, uint32_t dst_index_out, uint idx_addr) {
+    _calculate_reshuffle_rows_(dst_index_in, dst_index_out, idx_addr);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_right_shift.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_right_shift(const uint shift_amt) {
+inline void calculate_right_shift(uint32_t dst_index_in, uint32_t dst_index_out, const uint shift_amt) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
@@ -11,7 +11,7 @@
 namespace ckernel::sfpu {
 // ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
-inline void calculate_rpow(const uint32_t base_val) {
+inline void calculate_rpow(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t base_val) {
     sfpi::vFloat base_val_v = Converter::as_float(base_val);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -13,8 +13,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX, bool legacy_compat>
-inline void calculate_rsqrt() {
-    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(ITERATIONS);
+inline void calculate_rsqrt(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_rsqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX, legacy_compat>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE, bool legacy_compat>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -40,7 +40,7 @@ inline void calculate_rsub_int(const uint dst_index_in0, const uint dst_index_in
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_rsub_scalar_int32(uint32_t scalar) {
+void calculate_rsub_scalar_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t scalar) {
     int int_scalar = scalar;
     // Load scalar value param to lreg2
     _sfpu_load_imm32_(p_sfpu::LREG1, int_scalar);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -39,7 +39,7 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_sigmoid() {
+inline void calculate_sigmoid(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (!APPROXIMATION_MODE) {
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -55,7 +55,7 @@ inline void calculate_sigmoid() {
             sfpi::dst_reg++;
         }
     } else {
-        calculate_sigmoid_appx<ITERATIONS>();
+        calculate_sigmoid_appx<ITERATIONS>(dst_index_in, dst_index_out);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS = 8>
-inline void calculate_sigmoid_appx() {
+inline void calculate_sigmoid_appx(uint32_t dst_index_in, uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sign.h
@@ -13,8 +13,8 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_sign(const uint exponent_size_8) {
-    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, exponent_size_8);
+inline void calculate_sign(uint32_t dst_index_in, uint32_t dst_index_out, const uint exponent_size_8) {
+    _calculate_sign_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out, ITERATIONS, exponent_size_8);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_signbit.h
@@ -12,7 +12,7 @@ namespace ckernel::sfpu {
 
 // TODO: Implement using bitwise comparison
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit() {
+inline void calculate_signbit(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat val = dst_reg[0];
         v_if(val < 0.0f) { val = 1.0f; }
@@ -25,7 +25,7 @@ inline void calculate_signbit() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_signbit_int32() {
+inline void calculate_signbit_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, INT32, ADDR_MOD_3, 0);
         TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG0, p_sfpu::LREG0, 1);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -9,7 +9,7 @@
 namespace ckernel::sfpu {
 
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_silu() {
+inline void calculate_silu(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -97,19 +97,24 @@ inline vFloat softplus(vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void calculate_softplus_body(const float beta, const float beta_reciprocal, const float threshold) {
+inline void calculate_softplus_body(
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    const float beta,
+    const float beta_reciprocal,
+    const float threshold) {
     vFloat x = beta * dst_reg[0];
     v_if(x < threshold) { dst_reg[0] = beta_reciprocal * softplus(x); }
     v_endif;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_softplus(uint param0, uint param1, uint param2) {
+inline void calculate_softplus(uint32_t dst_index_in, uint32_t dst_index_out, uint param0, uint param1, uint param2) {
     const float beta = Converter::as_float(param0);
     const float beta_reciprocal = Converter::as_float(param1);
     const float threshold = Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_softplus_body<APPROXIMATION_MODE>(beta, beta_reciprocal, threshold);
+        calculate_softplus_body<APPROXIMATION_MODE>(dst_index_in, dst_index_out, beta, beta_reciprocal, threshold);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softshrink(uint32_t param0) {
+inline void calculate_softshrink(uint32_t dst_index_in, uint32_t dst_index_out, uint32_t param0) {
     // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
     // SFPU microcode
     sfpi::vFloat lambda = Converter::as_float(param0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -10,7 +10,7 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_softsign() {
+inline void calculate_softsign(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -13,8 +13,9 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool fp32_dest_acc_en, bool FAST_APPROX>
-inline void calculate_sqrt() {
-    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(ITERATIONS);
+inline void calculate_sqrt(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, fp32_dest_acc_en, FAST_APPROX>(
+        dst_index_in, dst_index_out, ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -11,8 +11,8 @@
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_square() {
-    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_square(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_square_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -114,7 +114,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tanh() {
+inline void calculate_tanh(uint32_t dst_index_in, uint32_t dst_index_out) {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
         sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh_derivative.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int WITH_PRECOMPUTED_TANH = 0, int ITERATIONS = 8>
-inline void calculate_tanh_derivative() {
+inline void calculate_tanh_derivative(uint32_t dst_index_in, uint32_t dst_index_out) {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
     vUInt l2 = l_reg[LRegs::LReg2];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tiled_prod.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_tiled_prod() {
+inline void calculate_tiled_prod(uint32_t dst_index_in, uint32_t dst_index_out) {
     vFloat result = 1.0f;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -15,19 +15,28 @@ namespace sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
 inline void calculate_bitonic_topk_phases_steps(
-    uint idir, uint i_end_phase, uint i_start_phase, uint i_end_step, uint i_start_step) {
+    uint32_t dst_index_in,
+    uint32_t dst_index_out,
+    uint idir,
+    uint i_end_phase,
+    uint i_start_phase,
+    uint i_end_step,
+    uint i_start_step) {
     _bitonic_topk_phases_steps<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
-        idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
+        dst_index_in, dst_index_out, idir, i_end_phase, i_start_phase, i_end_step, i_start_step);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir = false, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_merge(uint m_iter, uint k) {
-    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(m_iter, k);
+inline void calculate_bitonic_topk_merge(uint32_t dst_index_in, uint32_t dst_index_out, uint m_iter, uint k) {
+    _bitonic_topk_merge<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir, STABLE_SORT>(
+        dst_index_in, dst_index_out, m_iter, k);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool STABLE_SORT = false>
-inline void calculate_bitonic_topk_rebuild(uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
-    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(idir, m_iter, k, logk, skip_second);
+inline void calculate_bitonic_topk_rebuild(
+    uint32_t dst_index_in, uint32_t dst_index_out, uint idir, uint m_iter, uint k, uint logk, uint skip_second) {
+    _bitonic_topk_rebuild<APPROXIMATION_MODE, is_fp32_dest_acc_en, STABLE_SORT>(
+        dst_index_in, dst_index_out, idir, m_iter, k, logk, skip_second);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -111,7 +111,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_tangent() {
+inline void calculate_tangent(uint32_t dst_index_in, uint32_t dst_index_out) {
     // Constants for four-stage Cody-Waite reduction with -PI/2 = P0 + P1 + P2 + P3
     const float P0 = -0x1.92p+0f;   // representable as bf16
     const float P1 = -0x1.fbp-12f;  // representable as fp16
@@ -157,7 +157,7 @@ inline void calculate_tangent() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sine() {
+inline void calculate_sine(uint32_t dst_index_in, uint32_t dst_index_out) {
     // 1. Reduce argument using a four-stage Cody-Waite reduction to the interval [-PI/2, PI/2].
     // 2. Use odd symmetry (sin(-x) = -sin(x)) via quadrant/sign tracking.
     // 3. Evaluate sin(a) = a + a^3 (C0 + a^2 (C1 + a^2 (C2 + a^2 C3))) on [0, PI/2].
@@ -230,7 +230,7 @@ inline void calculate_sine() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosine() {
+inline void calculate_cosine(uint32_t dst_index_in, uint32_t dst_index_out) {
     // 1. Build an odd quadrant index j for PI/2-based reduction.
     // 2. Reduce to a in [-PI/2, PI/2] and fold sign from the quadrant parity.
     // 3. Evaluate sin(a) polynomial and use identity cos(x) = sin(x + PI/2).
@@ -370,7 +370,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_atan() {
+inline void calculate_atan(uint32_t dst_index_in, uint32_t dst_index_out) {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
@@ -439,7 +439,7 @@ sfpi_inline sfpi::vFloat sfpu_asin_range_reduced(sfpi::vFloat val) {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool IS_ACOS, int ITERATIONS = 8>
-inline void calculate_asin_acos_impl() {
+inline void calculate_asin_acos_impl(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -464,18 +464,18 @@ inline void calculate_asin_acos_impl() {
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_asin() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>();
+inline void calculate_asin(uint32_t dst_index_in, uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, false, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void calculate_acos() {
-    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>();
+inline void calculate_acos(uint32_t dst_index_in, uint32_t dst_index_out) {
+    calculate_asin_acos_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, true, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 // cosh = (exp(x) + exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_cosh() {
+inline void calculate_cosh(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
@@ -488,7 +488,7 @@ inline void calculate_cosh() {
 
 // sinh = (exp(x) - exp(-x)) / 2
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_sinh() {
+inline void calculate_sinh(uint32_t dst_index_in, uint32_t dst_index_out) {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -16,12 +16,12 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint16() {
-    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint8() {
+inline void calculate_typecast_fp32_to_uint8(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -49,7 +49,7 @@ inline void calculate_typecast_fp32_to_uint8() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool u16 = false>
-inline void calculate_typecast_uint_to_uint8() {
+inline void calculate_typecast_uint_to_uint8(uint32_t dst_index_in, uint32_t dst_index_out) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
@@ -64,63 +64,63 @@ inline void calculate_typecast_uint_to_uint8() {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp16b() {
-    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp16b() {
-    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_int32() {
-    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_int32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_int32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_fp16b() {
-    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_fp32() {
-    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_fp32() {
-    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_fp32_to_uint32() {
-    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_fp32_to_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_fp32_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp16b() {
-    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp16b(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp16b_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_fp32() {
-    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_fp32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_fp32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint16_to_uint32() {
-    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint16_to_uint32(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint16_to_uint32_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_uint32_to_uint16() {
-    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_uint32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_uint32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_typecast_int32_to_uint16() {
-    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>();
+inline void calculate_typecast_int32_to_uint16(uint32_t dst_index_in, uint32_t dst_index_out) {
+    _calculate_typecast_int32_to_uint16_<APPROXIMATION_MODE, ITERATIONS>(dst_index_in, dst_index_out);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -13,7 +13,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ne(uint value) {
+inline void calculate_unary_ne(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -31,7 +31,7 @@ inline void calculate_unary_ne(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_eq(uint value) {
+inline void calculate_unary_eq(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -49,7 +49,7 @@ inline void calculate_unary_eq(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_gt(uint value) {
+inline void calculate_unary_gt(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -67,7 +67,7 @@ inline void calculate_unary_gt(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_lt(uint value) {
+inline void calculate_unary_lt(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -85,7 +85,7 @@ inline void calculate_unary_lt(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_ge(uint value) {
+inline void calculate_unary_ge(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 
@@ -103,7 +103,7 @@ inline void calculate_unary_ge(uint value) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_le(uint value) {
+inline void calculate_unary_le(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // SFPU microcode
     sfpi::vFloat s = Converter::as_float(value);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -13,7 +13,7 @@ namespace ckernel::sfpu {
 sfpi_inline void load_value_param_float(uint value) { sfpi::vConstIntPrgm0 = value; }
 
 template <bool IS_MAX_OP>
-sfpi_inline void calculate_unary_max_min_float_body() {
+sfpi_inline void calculate_unary_max_min_float_body(uint32_t dst_index_in, uint32_t dst_index_out) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
 
     if constexpr (IS_MAX_OP) {
@@ -27,7 +27,7 @@ sfpi_inline void calculate_unary_max_min_float_body() {
 }
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min(uint value) {
+inline void calculate_unary_max_min(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
     //
     // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
@@ -43,7 +43,7 @@ inline void calculate_unary_max_min(uint value) {
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_float_body<IS_MAX_OP>();
+        calculate_unary_max_min_float_body<IS_MAX_OP>(dst_index_in, dst_index_out);
         sfpi::dst_reg++;
     }
 #else
@@ -67,7 +67,7 @@ sfpi_inline void load_value_param_int(uint value) {
 }
 
 template <bool IS_MAX_OP, bool IS_UNSIGNED = false>
-sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
+sfpi_inline void calculate_unary_max_min_int32_body(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
 
     if (IS_UNSIGNED ^ ((int)value >= 0)) {
@@ -91,13 +91,13 @@ sfpi_inline void calculate_unary_max_min_int32_body(uint value) {
 }
 
 template <bool IS_MAX_OP = true, bool IS_UNSIGNED = false, bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max_min_int32(uint value) {
+inline void calculate_unary_max_min_int32(uint32_t dst_index_in, uint32_t dst_index_out, uint value) {
     load_value_param_int<IS_UNSIGNED>(value);
 
 #ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(value);
+        calculate_unary_max_min_int32_body<IS_MAX_OP, IS_UNSIGNED>(dst_index_in, dst_index_out, value);
         sfpi::dst_reg++;
     }
 #else

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -318,7 +318,7 @@ inline void _sfpu_unary_power_fp32_(const uint32_t exponent) {
  * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_unary_power(const uint32_t exponent) {
+inline void calculate_unary_power(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t exponent) {
     if constexpr (is_fp32_dest_acc_en) {
         _sfpu_unary_power_fp32_<ITERATIONS>(exponent);
     } else {
@@ -332,7 +332,7 @@ inline void calculate_unary_power(const uint32_t exponent) {
  * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_unary_power_iterative(const uint32_t exponent) {
+inline void calculate_unary_power_iterative(uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t exponent) {
     // iterative approach for positive integer exponents
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_selu.h
@@ -14,7 +14,7 @@ namespace sfpu {
 
 // SELU(x) = scale ∗ ( max(0, x) + min(0, α ∗ (exp(x)−1) ) )
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_selu(uint scale, uint alpha) {
+inline void calculate_selu(uint32_t dst_index_in, uint32_t dst_index_out, uint scale, uint alpha) {
     sfpi::vFloat scale_value = Converter::as_float(scale);
     sfpi::vFloat alpha_value = Converter::as_float(alpha);
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -113,7 +113,8 @@ sfpi_inline void _xielu_mad_(sfpi::vFloat mul_a, sfpi::vFloat mul_b, sfpi::vFloa
  *        --> alpha_n * (expm1(minimum(x, eps)) - x) + beta * x
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
-inline void calculate_xielu(const uint32_t param0, const uint32_t param1) {
+inline void calculate_xielu(
+    uint32_t dst_index_in, uint32_t dst_index_out, const uint32_t param0, const uint32_t param1) {
     sfpi::vFloat alpha_p = Converter::as_float(param0);
     sfpi::vFloat alpha_n = Converter::as_float(param1);
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_sfpu_lgamma.h
@@ -22,7 +22,7 @@ inline void llk_math_eltwise_unary_sfpu_lgamma_stirling_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_lgamma_stirling(uint32_t dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_lgamma_stirling<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -18,13 +18,13 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_activations.h
@@ -21,7 +21,9 @@ inline void llk_math_eltwise_unary_sfpu_hardsigmoid_init() {
 template <bool APPROXIMATE, ckernel::ActivationType ACTIVATION, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardsigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        static_cast<void (*)()>(ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_activation_<APPROXIMATE, ACTIVATION, ITERATIONS>),
+        dst_index,
         dst_index,
         vector_mode);
 }
@@ -35,7 +37,7 @@ inline void llk_math_eltwise_unary_sfpu_softsign_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softsign(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_softsign<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 // celu
@@ -48,9 +50,11 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8
 inline void llk_math_eltwise_unary_sfpu_celu(
     uint dst_index, uint32_t alpha, uint32_t alpha_recip, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        [](uint32_t alpha, uint32_t alpha_recip) {
-            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(alpha, alpha_recip);
+        [](uint32_t dst_index_in, uint32_t dst_index_out, uint32_t alpha, uint32_t alpha_recip) {
+            ckernel::sfpu::calculate_celu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>(
+                dst_index_in, dst_index_out, alpha, alpha_recip);
         },
+        dst_index,
         dst_index,
         vector_mode,
         alpha,
@@ -66,7 +70,7 @@ inline void llk_math_eltwise_unary_sfpu_softshrink_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_softshrink(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_softshrink<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_add1.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_add1_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_add1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_add1<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_alt_complex_rotate90.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_alt_complex_rotate90(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_alt_complex_rotate90<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -14,7 +14,7 @@ template <bool APPROXIMATE, int binop_mode>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, vector_mode, scalar);
+        sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>, dst_index, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE>
@@ -26,14 +26,14 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_add_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_add_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_sub_int32(
     uint dst_index, uint32_t scalar, int vector_mode = VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_sub_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_cast_fp32_to_fp16a(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_cast_fp32_to_fp16a<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cbrt.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_cbrt_init() {
 template <bool APPROXIMATE, bool fp32_dest_acc_en, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_cbrt(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+        sfpu::calculate_cube_root<APPROXIMATE, fp32_dest_acc_en, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_clamp.h
@@ -19,14 +19,19 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+        ckernel::sfpu::calculate_clamp<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, min_val, max_val);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_clamp_int32(
     uint dst_index, uint min_val, uint max_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, min_val, max_val);
+        ckernel::sfpu::calculate_clamp_int32<APPROXIMATE, ITERATIONS>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        min_val,
+        max_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_cumsum(
     uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
     _llk_math_eltwise_unary_sfpu_params_<false>(
         ckernel::sfpu::calculate_cumsum<false>,  // There is only non APPROXIMATE implementation
+        dst_index,                               // There is only non APPROXIMATE implementation
         dst_index,
         VectorMode::RC_custom,  // Can only work in RC_custom mode
         first);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_exp2.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_exp2_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_exp2(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_exp2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_expm1_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardmish.h
@@ -17,7 +17,8 @@ inline void llk_math_eltwise_unary_sfpu_hardmish_init() {
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardmish(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        sfpu::hardmish<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_hardtanh.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_hardtanh(
     uint dst_index, uint param0, uint param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, param0, param1);
+        ckernel::sfpu::calculate_hardtanh<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, param0, param1);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_heaviside.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_heaviside_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_heaviside(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_heaviside<APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_log.h
@@ -19,7 +19,11 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>, dst_index, vector_mode, 0);
+        ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, false, is_fp32_dest_acc_en>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        0);
 }
 
 template <bool APPROXIMATE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
@@ -33,6 +37,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base(
     uint dst_index, uint base_scale, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_log<APPROXIMATE, FAST_APPROX, true, is_fp32_dest_acc_en>,
+        dst_index,
         dst_index,
         vector_mode,
         base_scale);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -36,25 +36,33 @@
     llk_math_eltwise_unary_sfpu_init<SfpuType::OP, APPROX>(INIT_CB<APPROX, FAST_APPROX, SCALE, CLAMP_NEGATIVE>)
 
 // For the int32 comparison variants
-#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                 \
-        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+#define SFPU_COMP_INT32_KERNEL(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0)      \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                  \
+        ckernel::sfpu::calculate_comp_unary_int<APPROXIMATE, SfpuType::OP, ITERATIONS>, \
+        DST_IDX,                                                                        \
+        DST_IDX,                                                                        \
+        (int)VectorMode::MODE,                                                          \
+        PARAM0);
 
 // For the int32 comparison variants with underscore in callback
 #define SFPU_COMP_INT32_KERNEL_UNDERSCORE(OP, MODE, APPROXIMATE, ITERATIONS, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                            \
-        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>, DST_IDX, (int)VectorMode::MODE, PARAM0);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::_calculate_comp_unary_int_<APPROXIMATE, SfpuType::OP, ITERATIONS>,     \
+        DST_IDX,                                                                              \
+        DST_IDX,                                                                              \
+        (int)VectorMode::MODE,                                                                \
+        PARAM0);
 
 // For ops where the compute functor is not "calculate_<OP>", but an arbitrary function name (e.g., relu_min, relu_max,
 // etc.),and which take one extra runtime uint parameter
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND an additional template param (ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(FN, MODE, APPROXIMATE, EXTRA_PARAM, DST_IDX, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
+        ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
 #define SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(                                                        \
@@ -65,40 +73,46 @@
     constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
-        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>,                                             \
+        DST_IDX,                                                                                                    \
+        DST_IDX,                                                                                                    \
+        (int)VectorMode::MODE,                                                                                      \
+        PARAM0)
 
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly two extra uint parameters AND DST_ACCUM_MODE as template param
 #define SFPU_UNARY_TWO_PARAM_KERNEL_WITH_DST_ACCUM(FN, MODE, APPROXIMATE, DST_ACCUM, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
-        ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
+        ckernel::sfpu::FN<APPROXIMATE, DST_ACCUM>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1)
 
 // For ops with exactly three extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_THREE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1, PARAM2) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                           \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1, PARAM2)
 
 // For ops without extra uint parameter
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                \
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameter with ITERATIONS
 #define SFPU_UNARY_NO_PARAM_KERNEL_FN_ITERATIONS(FN, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                       \
+        ckernel::sfpu::FN<APPROXIMATE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops without extra uint parameters with type and iteration
 #define SFPU_UNARY_NO_PARAM_KERNEL_WITH_TYPE_AND_ITERATIONS(OP, TYPE, MODE, APPROXIMATE, DST_IDX, ITERATIONS) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
-        ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                        \
+        ckernel::sfpu::OP<SfpuType::TYPE, APPROXIMATE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For ops where compute takes extra args
 #define SFPU_UNARY_PARAMS_KERNEL_EXTRA_ARGS(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                      \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
 #define SFPU_TEMPLATE_PARAMS_KERNEL_FN(                \
@@ -123,58 +137,63 @@
             SKIP_POSITIVE_CHECK,                       \
             CLAMP_NEGATIVE>,                           \
         DST_IDX,                                       \
+        DST_IDX,                                       \
         VECTOR_MODE,                                   \
         SCALE)
 
 // For kernels with one template parameter and one extra runtime argument.
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                         \
-        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_FLOAT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                               \
-        ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<sfpi::vFloat, APPROXIMATE, 8, uint32_t>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 #define SFPU_UNARY_ONE_PARAM_KERNEL_FN_INT(FN, MODE, APPROXIMATE, DST_IDX, PARAM0) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                             \
-        ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+        ckernel::sfpu::FN<sfpi::vInt, APPROXIMATE, 8, uint32_t>, DST_IDX, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
 // For kernels whose functor takes one template parameter (e.g., <APPROXIMATE>)
 #define SFPU_ONE_PARAM_KERNEL(FN, APPROXIMATE, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER/USE_FP32>)
 #define SFPU_TWO_PARAM_KERNEL(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For kernels whose functor takes two template parameters (e.g., <APPROXIMATE, ITER>) and one extra runtime param.
 #define SFPU_TWO_PARAM_KERNEL_ONE_RUNTIME(FN, APPROXIMATE, T2, DST_IDX, VECTOR_MODE, PARAM0) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, VECTOR_MODE, PARAM0)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                       \
+        ckernel::sfpu::FN<APPROXIMATE, T2>, DST_IDX, DST_IDX, VECTOR_MODE, PARAM0)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, ITER, USE_FP32>)
 #define SFPU_THREE_PARAM_KERNEL_ITER_FIRST(FN, APPROXIMATE, ITER, FP32, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                            \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For functors with <APPROXIMATE, USE_FP32, ITER>
 #define SFPU_THREE_PARAM_KERNEL_FP32_FIRST(FN, APPROXIMATE, FP32, ITER, DST_IDX, VECTOR_MODE) \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                               \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, VECTOR_MODE)
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                        \
+        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER>, DST_IDX, DST_IDX, VECTOR_MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, LEGACY_COMPAT>, DST_IDX, DST_IDX, (int)VectorMode::MODE)
 
 // For unary ops with four template parameters (APPROXIMATE, fp32_dest_acc_en, FP32_FIRST, legacy_compat)
 #define SFPU_FOUR_PARAM_KERNEL_FP32_FIRST_FN(FN, APPROXIMATE, FP32, ITER, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                  \
-        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, MODE)
+        ckernel::sfpu::FN<APPROXIMATE, FP32, ITER, LEGACY_COMPAT>, DST_IDX, DST_IDX, MODE)
 
 // For unary ops with five template parameters (APPROXIMATE, ITER, fp32_dest_acc_en, FAST_APPROX, legacy_compat)
 #define SFPU_FIVE_PARAM_KERNEL_ITER_FIRST_FN(FN, APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT, DST_IDX, MODE) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                               \
-        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>,                                      \
+        DST_IDX,                                                                                                     \
+        DST_IDX,                                                                                                     \
+        (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
 #define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
@@ -193,19 +212,19 @@
         : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
                                                                                   : InstrModLoadStore::DEFAULT;    \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
-        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
+        ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)
 #define SFPU_ZERO_KERNEL(OP, MODE, APPROXIMATE, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(   \
-        ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE, 8);
+        ckernel::sfpu::calculate_comp<APPROXIMATE, SfpuType::OP>, DST_IDX, DST_IDX, (int)VectorMode::MODE, 8);
 
 // Generalized macro for compare-with-zero ops for any type (e.g., int, uint16)
 #define SFPU_ZERO_KERNEL_TYPE(TYPE, OP, MODE, APPROXIMATE, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(              \
-        ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, (int)VectorMode::MODE);
+        ckernel::sfpu::TYPE<APPROXIMATE, SfpuType::OP>, DST_IDX, DST_IDX, (int)VectorMode::MODE);
 
 // For log1p op that needs three template parameters
 #define SFPU_UNARY_NO_PARAM_KERNEL_LOG1P_FN(FN, MODE, APPROXIMATE, FAST_APPROX, FP32, DST_IDX) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                         \
-        ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, (int)VectorMode::MODE)
+        ckernel::sfpu::FN<APPROXIMATE, FAST_APPROX, FP32>, DST_IDX, DST_IDX, (int)VectorMode::MODE)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_mask_posinf(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_mask_posinf<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -26,10 +26,10 @@ inline void llk_math_eltwise_unary_sfpu_mask(
     uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
     if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, dst_index, vector_mode);
     } else if (data_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_max_min.h
@@ -19,7 +19,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 template <bool APPROXIMATE>
@@ -32,7 +32,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, false, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 template <bool APPROXIMATE>
@@ -45,7 +49,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<true, true, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 // Unary minimum
@@ -57,7 +65,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, dst_index, vector_mode, param0);
 }
 
 template <bool APPROXIMATE>
@@ -70,7 +78,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_int32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<false, false, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 template <bool APPROXIMATE>
@@ -83,7 +95,11 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min_uint32(
     uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min_int32<false, true, APPROXIMATE>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_power.h
@@ -19,7 +19,11 @@ template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_power(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode, exponent);
+        ckernel::sfpu::calculate_unary_power<APPROXIMATE, is_fp32_dest_acc_en, 8>,
+        dst_index,
+        dst_index,
+        vector_mode,
+        exponent);
 }
 
 template <bool APPROXIMATE>
@@ -31,6 +35,6 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_power_iterative(
     uint dst_index, uint32_t exponent = 0, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, vector_mode, exponent);
+        ckernel::sfpu::calculate_unary_power_iterative<APPROXIMATE, 8>, dst_index, dst_index, vector_mode, exponent);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rdiv.h
@@ -21,6 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_rdiv(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_rdiv<APPROXIMATE, fp32_dest_acc_en, rounding_mode, ITERATIONS>,
         dst_index,
+        dst_index,
         vector_mode,
         value);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reduce.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE, PoolType pool_type, ReduceDim reduce_dim, DataFormat
 inline void llk_math_eltwise_unary_sfpu_reduce(
     uint32_t dst_index, uint32_t ct_dim, uint32_t rt_dim, VectorMode vector_mode) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, vector_mode, ct_dim, rt_dim);
+        sfpu::calculate_reduce<pool_type, reduce_dim, format>, dst_index, dst_index, vector_mode, ct_dim, rt_dim);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -48,7 +48,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(
     uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, vector_mode, idx_addr);
+        sfpu::calculate_reshuffle_rows<APPROXIMATE>, dst_index, dst_index, vector_mode, idx_addr);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rpow.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rpow_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_rpow(uint dst_index, uint32_t base_val, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode, base_val);
+        sfpu::calculate_rpow<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, dst_index, vector_mode, base_val);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -20,6 +20,7 @@ inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index, int vector_mode = 
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_rsqrt<APPROXIMATE, 8, fp32_dest_acc_en, FAST_APPROX, legacy_compat>,
         dst_index,
+        dst_index,
         vector_mode);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsub_int32.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_rsub_int32_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_rsub_int32(uint dst_index, uint scalar, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode, scalar);
+        sfpu::calculate_rsub_scalar_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode, scalar);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_selu.h
@@ -20,6 +20,7 @@ inline void llk_math_eltwise_unary_sfpu_selu(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_selu<APPROXIMATE, is_fp32_dest_acc_en, ITERATIONS>,
         dst_index,
+        dst_index,
         vector_mode,
         scale,
         alpha);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_sigmoid(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        sfpu::calculate_sigmoid<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -17,7 +17,8 @@ inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_sigmoid_appx, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sign.h
@@ -19,7 +19,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sign(
     uint dst_index, int vector_mode = (int)VectorMode::RC, uint exponent_size_8 = 1) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, vector_mode, exponent_size_8);
+        ckernel::sfpu::calculate_sign<APPROXIMATE>, dst_index, dst_index, vector_mode, exponent_size_8);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_signbit.h
@@ -18,13 +18,13 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_signbit<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_signbit_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_signbit_int32<APPROXIMATE, ITERATIONS>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_silu_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_square.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_square_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_square<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh_derivative.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_derivative_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_derivative(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh_derivative<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_threshold.h
@@ -18,7 +18,9 @@ template <bool APPROXIMATE, int ITERATIONS = 8>
 inline void llk_math_eltwise_unary_sfpu_threshold(
     uint dst_index, uint32_t param0, uint32_t param1, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        static_cast<void (*)(uint32_t, uint32_t)>(ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        static_cast<void (*)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+            ckernel::sfpu::_calculate_threshold_<APPROXIMATE, ITERATIONS>),
+        dst_index,
         dst_index,
         vector_mode,
         param0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tiled_prod.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tiled_prod_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tiled_prod(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tiled_prod<APPROXIMATE>, dst_index, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_topk.h
@@ -28,6 +28,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_local_sort(
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_phases_steps<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
         dst_index,
+        dst_index,
         vector_mode,
         idir,
         i_end_phase,
@@ -41,6 +42,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_merge(
     uint dst_index, int m_iter, int k, int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_merge<APPROXIMATE, is_fp32_dest_acc_en, idir, STABLE_SORT>,
+        dst_index,
         dst_index,
         vector_mode,
         m_iter,
@@ -58,6 +60,7 @@ inline void llk_math_eltwise_unary_sfpu_topk_rebuild(
     int vector_mode = (int)VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_bitonic_topk_rebuild<APPROXIMATE, is_fp32_dest_acc_en, STABLE_SORT>,
+        dst_index,
         dst_index,
         vector_mode,
         idir,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -17,76 +17,76 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
 
     if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Float32) {
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float16_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Float32 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp8_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Int32) {
         // Calls same kernel as UInt32 case
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp8_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp8_b) {
@@ -97,22 +97,22 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
         // no SFPU kernel needed, handled by packer
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Int32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_int32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Int32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_int32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::UInt32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::UInt32 && out_format == DataFormat::Bfp4_b) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (in_format == DataFormat::Bfp4_b && out_format == DataFormat::Float16_b) {
         // no SFPU kernel needed, handled by unpacker
     } else if constexpr (in_format == DataFormat::Float16_b && out_format == DataFormat::Bfp4_b) {
@@ -130,28 +130,29 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
          in_format == DataFormat::Bfp4_b) &&
         out_format == DataFormat::UInt8) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_fp32_to_uint8<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         (in_format == DataFormat::Int32 || in_format == DataFormat::UInt32 || in_format == DataFormat::UInt16) &&
         out_format == DataFormat::UInt8) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_uint_to_uint8<APPROXIMATE, 8, (in_format == DataFormat::UInt16)>,
             dst_index,
+            dst_index,
             vector_mode);
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::Float32) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp32<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 &&
         (out_format == DataFormat::Float16_b || out_format == DataFormat::Bfp8_b || out_format == DataFormat::Bfp4_b)) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_fp16b<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     } else if constexpr (
         in_format == DataFormat::UInt8 && (out_format == DataFormat::Int32 || out_format == DataFormat::UInt32)) {
         // No SFPU kernel needed.
     } else if constexpr (in_format == DataFormat::UInt8 && out_format == DataFormat::UInt16) {
         _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, vector_mode);
+            ckernel::sfpu::calculate_typecast_uint32_to_uint16<APPROXIMATE, 8>, dst_index, dst_index, vector_mode);
     }
 }
 

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp
@@ -27,7 +27,12 @@
  *
  * This function only processes ONE FACE of a tile. The wrapper will call it for each face.
  */
-inline void smoothstep_tile_face(float edge0, float edge1, float inv_delta) {
+inline void smoothstep_tile_face(
+    [[maybe_unused]] uint32_t dst_index_in,
+    [[maybe_unused]] uint32_t dst_index_out,
+    float edge0,
+    float edge1,
+    float inv_delta) {
     constexpr size_t vectors_per_face = 8;
     for (size_t i = 0; i < vectors_per_face; i++) {
         vFloat x = dst_reg[i];
@@ -57,7 +62,7 @@ inline void smoothstep_tile_face(float edge0, float edge1, float inv_delta) {
  */
 inline void my_smoothstep_tiles(uint32_t idx_dst0, float edge0, float edge1, float inv_delta) {
     MATH(_llk_math_eltwise_unary_sfpu_params_<false>(
-        smoothstep_tile_face, idx_dst0, VectorMode::RC, edge0, edge1, inv_delta));
+        smoothstep_tile_face, idx_dst0, idx_dst0, VectorMode::RC, edge0, edge1, inv_delta));
 }
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -61,7 +61,7 @@ inline void _add_bias_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _add_bias_() {
+inline void _add_bias_([[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Let us load in the bias values
@@ -140,7 +140,7 @@ inline void _llk_math_add_bias_init_() {
 
 inline void _llk_math_add_bias_(uint32_t input_index) {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom);
+        ckernel::sfpu::_add_bias_, input_index, input_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
@@ -60,7 +60,7 @@ inline void _top2_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _top2_calculate_top2_() {
+inline void _top2_calculate_top2_([[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     constexpr uint16_t NEG_INF_BF16 = 0xFF80;
 
     // Reset Dst RWC to 0
@@ -157,7 +157,7 @@ inline void _llk_math_sum_top2_tile_init_() {
 
 inline void _llk_math_sum_top2_tile_(uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_top2_calculate_top2_, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_top2_calculate_top2_, dst_index, dst_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
@@ -60,7 +60,7 @@ inline void _top4_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _calculate_top4_() {
+inline void _calculate_top4_([[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     // Reset Dst RWC to 0
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
@@ -170,7 +170,7 @@ inline void _llk_math_top4_tile_init_() {
 
 inline void _llk_math_top4_tile_(uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_calculate_top4_, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_calculate_top4_, dst_index, dst_index, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
@@ -268,7 +268,7 @@ inline void _top8_merge_two_sorted_8_() {
 
 // Main entry point for cross-core merge
 template <uint32_t column_idx>
-inline void _top8_merge_() {
+inline void _top8_merge_([[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Sequentially merge core 0 data with that in cores 1-7
@@ -438,7 +438,7 @@ inline void _llk_math_top8_merge_init_() {
 template <uint32_t column_idx>
 inline void _llk_math_top8_merge_() {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_top8_merge_<column_idx>, 0, VectorMode::RC_custom);
+        ckernel::sfpu::_top8_merge_<column_idx>, 0, 0, VectorMode::RC_custom);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -457,7 +457,8 @@ inline void _top8_merge_sorted_8_() {
     }
 }
 
-inline void _calculate_top8_tile_(uint32_t tile_index) {
+inline void _calculate_top8_tile_(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, uint32_t tile_index) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     //-------------------------------------------------------------------------
@@ -615,7 +616,7 @@ inline void _llk_math_top8_tile_init_() {
 
 inline void _llk_math_top8_tile_(uint32_t tile_index, uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_calculate_top8_tile_, dst_index, VectorMode::RC_custom, tile_index);
+        ckernel::sfpu::_calculate_top8_tile_, dst_index, dst_index, VectorMode::RC_custom, tile_index);
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -220,7 +220,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
  * recip_tile on only the columns 0:8 of a face
  */
 template <bool legacy_compat = true>
-void calculate_recip_first_column() {
+void calculate_recip_first_column([[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     if constexpr (legacy_compat) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
@@ -262,7 +262,7 @@ void calculate_recip_first_column() {
 template <bool legacy_compat = true>
 void recip_tile_first_column(uint32_t idst) {
     _llk_math_eltwise_unary_sfpu_params_<APPROX /*APPROXIMATE*/>(
-        calculate_recip_first_column<legacy_compat>, idst, (int)VectorMode::C);
+        calculate_recip_first_column<legacy_compat>, idst, idst, (int)VectorMode::C);
 }
 #endif
 
@@ -827,7 +827,8 @@ void calculate_exponential_polynomial() {
  * exp_tile on only the columns 0:8 of a face
  */
 template <bool SDPA_EXP_APPROX_MODE, uint16_t scale_bf16>
-void calculate_exponential_first_column() {
+void calculate_exponential_first_column(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     if constexpr (SDPA_EXP_APPROX_MODE) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
@@ -855,7 +856,7 @@ void calculate_exponential_first_column() {
 template <bool SDPA_EXP_APPROX_MODE, uint16_t scale_bf16>
 void exp_tile_first_column(uint32_t idst) {
     _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
-        calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, (int)VectorMode::C);
+        calculate_exponential_first_column<SDPA_EXP_APPROX_MODE, scale_bf16>, idst, idst, (int)VectorMode::C);
 }
 #endif  // defined(TRISC_MATH) || defined(TRISC_PACK)
 
@@ -901,7 +902,8 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
  * fused_max_sub_exp_add_tile
  */
 template <bool SDPA_EXP_APPROX_MODE>
-void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
+void calculate_fused_max_sub_exp_add_tile(
+    [[maybe_unused]] uint32_t dst_index_in, [[maybe_unused]] uint32_t dst_index_out, int scale_bf16) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     constexpr uint32_t prev_max_base_idx = 0;      // dst_reg_0 (Tile 0)
     constexpr uint32_t worker_max_base_idx = 32;   // dst_reg_1 (Tile 1)
@@ -950,7 +952,7 @@ void calculate_fused_max_sub_exp_add_tile(int scale_bf16) {
 template <bool SDPA_EXP_APPROX_MODE, int vector_mode = (int)VectorMode::C>
 void fused_max_sub_exp_add_tile(uint32_t idst, int scale_bf16) {
     _llk_math_eltwise_unary_sfpu_params_<false /*APPROXIMATE*/>(
-        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, vector_mode, scale_bf16);
+        calculate_fused_max_sub_exp_add_tile<SDPA_EXP_APPROX_MODE>, idst, idst, vector_mode, scale_bf16);
 }
 #endif
 
@@ -1105,20 +1107,25 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
  * softplus_tile on only the columns 0:8 of a face
  */
 template <bool SDPA_EXP_APPROX_MODE>
-void calculate_softplus_first_column(uint param0, uint param1, uint param2) {
+void calculate_softplus_first_column(
+    [[maybe_unused]] uint32_t dst_index_in,
+    [[maybe_unused]] uint32_t dst_index_out,
+    uint param0,
+    uint param1,
+    uint param2) {
     constexpr int ITERATIONS_HALF_FACE = 4;
     float beta = ckernel::sfpu::Converter::as_float(param0);
     float beta_reciprocal = ckernel::sfpu::Converter::as_float(param1);
     float threshold = ckernel::sfpu::Converter::as_float(param2);
     for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
-        ckernel::sfpu::calculate_softplus_body<APPROX>(beta, beta_reciprocal, threshold);
+        ckernel::sfpu::calculate_softplus_body<APPROX>(0, 0, beta, beta_reciprocal, threshold);
         sfpi::dst_reg += 2;
     }
 }
 
 void softplus_tile_first_column(uint32_t idst, uint beta, uint beta_reciprocal, uint threshold) {
     _llk_math_eltwise_unary_sfpu_params_<APPROX /*APPROXIMATE*/>(
-        calculate_softplus_first_column<APPROX>, idst, (int)VectorMode::C, beta, beta_reciprocal, threshold);
+        calculate_softplus_first_column<APPROX>, idst, idst, (int)VectorMode::C, beta, beta_reciprocal, threshold);
 }
 #endif
 


### PR DESCRIPTION
Update all metal-side references to match the tt-llk signature change where _llk_math_eltwise_unary_sfpu_params_ now takes separate dst_index_in and dst_index_out parameters, and forwards them to the SFPU callback as the first two arguments.

Changes:
- Bump tt_llk submodule to include the dst_index_in/out fix
- Duplicate dst_index in all _llk_math_eltwise_unary_sfpu_params_ call sites (backward-compatible same-tile behavior)
- Update all macros in llk_math_eltwise_unary_sfpu_macros.h
- Add dst_index_in/out params to all void calculate_* callback definitions in ckernel_sfpu_*.h and forward to _calculate_*_ calls
- Update TTNN deepseek MOE, SDPA, and custom SFPI kernel callbacks
- Update models/demos deepseek_v3_b1 kernel includes
- Update documentation code examples

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/30298_llk_issue)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/30298_llk_issue)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/30298_llk_issue)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/30298_llk_issue)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/30298_llk_issue)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/30298_llk_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/30298_llk_issue)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
