### PR TITLE
tools/triage: restrict tt-exalens to x86_64 (no aarch64 wheels)

### DIFF
--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,2 +1,2 @@
 pycapnp==2.0.0
-tt-exalens==0.3.13
+tt-exalens==0.3.13; platform_machine == "x86_64"


### PR DESCRIPTION
## Summary

- `tt-exalens==0.3.13` depends on `tt-umd` which only has `manylinux_2_28_x86_64` wheels — no `aarch64` support.
- `create_venv` fails on Linux/aarch64 because the dependency is unsatisfiable.
- Fix: add a `platform_machine == "x86_64"` marker so `tt-exalens` is only pulled in on x86_64.

## Test plan

- [ ] Verify `create_venv` succeeds on Linux/aarch64
- [ ] Verify triage tooling still works on x86_64 (tt-exalens still installed there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)