### PR TITLE
Reduce to all b1 op

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unified Reduce-to-All Kernel for 4x2 mesh hypercube all-reduce.
+ *
+ * Uses the unified ReduceToAllB1 op from unified_kernels/reduce_to_all_b1.hpp
+ */
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/reduce_to_all_b1.hpp"
+
+void kernel_main() {
+    using ReduceToAll = deepseek_b1_ops::ReduceToAllB1;
+
+#if defined(COMPILE_FOR_NCRISC)
+    using CTArgs = ReduceToAll::ReaderCTArgs<
+        get_named_compile_time_arg_val("num_tiles"),
+        get_named_compile_time_arg_val("local_cb"),
+        get_named_compile_time_arg_val("received_cb"),
+        get_named_compile_time_arg_val("is_fabric_core"),
+        get_named_compile_time_arg_val("defer_r3_send"),
+        get_named_compile_time_arg_val("num_workers"),
+        get_named_compile_time_arg_val("slot_size_bytes"),
+        get_named_compile_time_arg_val("packet_cb"),
+        get_named_compile_time_arg_val("payload_size_bytes"),
+        get_named_compile_time_arg_val("is_r3_forwarder"),
+        get_named_compile_time_arg_val("num_r3_workers")>;
+
+    ReduceToAll::ReaderArgs rt_args{};
+    if constexpr (CTArgs::is_fabric_core == 0) {
+        rt_args = {
+            get_common_arg_val<uint32_t>(0),  // recv_sem_round1
+            get_common_arg_val<uint32_t>(1),  // recv_sem_round2
+            get_common_arg_val<uint32_t>(2),  // recv_sem_round3
+            get_common_arg_val<uint32_t>(3),  // r3_gate_addr
+        };
+    }
+
+#elif defined(COMPILE_FOR_BRISC)
+    using CTArgs = ReduceToAll::WriterCTArgs<
+        get_named_compile_time_arg_val("num_tiles"),
+        get_named_compile_time_arg_val("payload_size_bytes"),
+        get_named_compile_time_arg_val("local_cb"),
+        get_named_compile_time_arg_val("scratch_cb"),
+        get_named_compile_time_arg_val("packet_cb"),
+        get_named_compile_time_arg_val("num_workers"),
+        get_named_compile_time_arg_val("slot_size_bytes"),
+        get_named_compile_time_arg_val("is_fabric_core"),
+        get_named_compile_time_arg_val("r1_dst_chip_id"),
+        get_named_compile_time_arg_val("r1_dst_mesh_id"),
+        get_named_compile_time_arg_val("r2_dst_chip_id"),
+        get_named_compile_time_arg_val("r2_dst_mesh_id"),
+        get_named_compile_time_arg_val("r3_dst_chip_id"),
+        get_named_compile_time_arg_val("r3_dst_mesh_id"),
+        get_named_compile_time_arg_val("defer_r3_send")>;
+
+    ReduceToAll::WorkerWriterArgs rt_args{};
+    if constexpr (CTArgs::is_fabric_core == 0) {
+        rt_args = {
+            get_arg_val<uint32_t>(0),   // fabric_core_noc_x
+            get_arg_val<uint32_t>(1),   // fabric_core_noc_y
+            get_arg_val<uint32_t>(2),   // my_slot_idx
+            get_arg_val<uint32_t>(3),   // worker_sem_addr
+            get_arg_val<uint32_t>(4),   // r1_dst_l1_addr
+            get_arg_val<uint32_t>(5),   // r1_dst_sem_addr
+            get_arg_val<uint32_t>(6),   // r2_dst_l1_addr
+            get_arg_val<uint32_t>(7),   // r2_dst_sem_addr
+            get_arg_val<uint32_t>(8),   // r3_dst_l1_addr
+            get_arg_val<uint32_t>(9),   // r3_dst_sem_addr
+            get_arg_val<uint32_t>(10),  // output_base_addr
+            get_arg_val<uint32_t>(11),  // r3_gate_addr
+            get_arg_val<uint32_t>(12),  // r3_fabric_core_noc_x
+            get_arg_val<uint32_t>(13),  // r3_fabric_core_noc_y
+            get_arg_val<uint32_t>(14),  // r3_slot_idx
+            get_arg_val<uint32_t>(15),  // r3_ncrisc_sem_addr
+        };
+    }
+
+#elif defined(COMPILE_FOR_TRISC)
+    using CTArgs = ReduceToAll::ComputeCTArgs<
+        get_named_compile_time_arg_val("num_tiles"),
+        get_named_compile_time_arg_val("local_cb"),
+        get_named_compile_time_arg_val("received_cb"),
+        get_named_compile_time_arg_val("scratch_cb"),
+        get_named_compile_time_arg_val("is_fabric_core")>;
+
+    ReduceToAll::ComputeArgs rt_args{};
+    deepseek_compute_kernel_init();
+#endif
+
+    constexpr uint32_t num_loop_iters = get_named_compile_time_arg_val("num_loop_iters");
+    ReduceToAll::Op<CTArgs, true> op;
+    for (uint32_t iter = 0; iter < num_loop_iters; ++iter) {
+        op(rt_args);
+    }
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+#endif
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Unified Reduce-to-All Kernel for 4x2 mesh hypercube all-reduce.
- *
- * Uses the unified ReduceToAllB1 op from unified_kernels/reduce_to_all_b1.hpp
+ * Unified Reduce-to-All Kernel — Ring + Cross-Column algorithm.
+ * Phase 1: FC BRISC=FWD, FC NCRISC=BWD (matching sdpa_reduce_to_all).
+ * Phase 2: FC BRISC closes FWD, opens cross-column conn, forwards R3.
  */
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
@@ -21,13 +21,12 @@ void kernel_main() {
         get_named_compile_time_arg_val("local_cb"),
         get_named_compile_time_arg_val("received_cb"),
         get_named_compile_time_arg_val("is_fabric_core"),
-        get_named_compile_time_arg_val("defer_r3_send"),
-        get_named_compile_time_arg_val("num_workers"),
+        get_named_compile_time_arg_val("slots_per_direction"),
         get_named_compile_time_arg_val("slot_size_bytes"),
         get_named_compile_time_arg_val("packet_cb"),
         get_named_compile_time_arg_val("payload_size_bytes"),
-        get_named_compile_time_arg_val("is_r3_forwarder"),
-        get_named_compile_time_arg_val("num_r3_workers")>;
+        get_named_compile_time_arg_val("r2_buffer_offset"),
+        get_named_compile_time_arg_val("ncrisc_buffer_offset")>;
 
     ReduceToAll::ReaderArgs rt_args{};
     if constexpr (CTArgs::is_fabric_core == 0) {
@@ -35,7 +34,6 @@ void kernel_main() {
             get_common_arg_val<uint32_t>(0),  // recv_sem_round1
             get_common_arg_val<uint32_t>(1),  // recv_sem_round2
             get_common_arg_val<uint32_t>(2),  // recv_sem_round3
-            get_common_arg_val<uint32_t>(3),  // r3_gate_addr
         };
     }
 
@@ -46,36 +44,43 @@ void kernel_main() {
         get_named_compile_time_arg_val("local_cb"),
         get_named_compile_time_arg_val("scratch_cb"),
         get_named_compile_time_arg_val("packet_cb"),
-        get_named_compile_time_arg_val("num_workers"),
         get_named_compile_time_arg_val("slot_size_bytes"),
         get_named_compile_time_arg_val("is_fabric_core"),
-        get_named_compile_time_arg_val("r1_dst_chip_id"),
-        get_named_compile_time_arg_val("r1_dst_mesh_id"),
-        get_named_compile_time_arg_val("r2_dst_chip_id"),
-        get_named_compile_time_arg_val("r2_dst_mesh_id"),
+        get_named_compile_time_arg_val("fwd_dst_chip_id"),
+        get_named_compile_time_arg_val("fwd_dst_mesh_id"),
+        get_named_compile_time_arg_val("bwd_dst_chip_id"),
+        get_named_compile_time_arg_val("bwd_dst_mesh_id"),
         get_named_compile_time_arg_val("r3_dst_chip_id"),
         get_named_compile_time_arg_val("r3_dst_mesh_id"),
-        get_named_compile_time_arg_val("defer_r3_send")>;
+        get_named_compile_time_arg_val("reload_cb"),
+        get_named_compile_time_arg_val("compute_tile_size"),
+        get_named_compile_time_arg_val("slots_per_direction"),
+        get_named_compile_time_arg_val("r2_buffer_offset"),
+        get_named_compile_time_arg_val("ncrisc_buffer_offset"),
+        get_named_compile_time_arg_val("r3_buffer_offset")>;
 
     ReduceToAll::WorkerWriterArgs rt_args{};
     if constexpr (CTArgs::is_fabric_core == 0) {
         rt_args = {
-            get_arg_val<uint32_t>(0),   // fabric_core_noc_x
-            get_arg_val<uint32_t>(1),   // fabric_core_noc_y
-            get_arg_val<uint32_t>(2),   // my_slot_idx
-            get_arg_val<uint32_t>(3),   // worker_sem_addr
-            get_arg_val<uint32_t>(4),   // r1_dst_l1_addr
-            get_arg_val<uint32_t>(5),   // r1_dst_sem_addr
-            get_arg_val<uint32_t>(6),   // r2_dst_l1_addr
-            get_arg_val<uint32_t>(7),   // r2_dst_sem_addr
-            get_arg_val<uint32_t>(8),   // r3_dst_l1_addr
-            get_arg_val<uint32_t>(9),   // r3_dst_sem_addr
-            get_arg_val<uint32_t>(10),  // output_base_addr
-            get_arg_val<uint32_t>(11),  // r3_gate_addr
-            get_arg_val<uint32_t>(12),  // r3_fabric_core_noc_x
-            get_arg_val<uint32_t>(13),  // r3_fabric_core_noc_y
-            get_arg_val<uint32_t>(14),  // r3_slot_idx
-            get_arg_val<uint32_t>(15),  // r3_ncrisc_sem_addr
+            get_arg_val<uint32_t>(0),   // fc_noc_x
+            get_arg_val<uint32_t>(1),   // fc_noc_y
+            get_arg_val<uint32_t>(2),   // is_type_a
+            get_arg_val<uint32_t>(3),   // r1_slot_offset
+            get_arg_val<uint32_t>(4),   // r1_slot_bit
+            get_arg_val<uint32_t>(5),   // r1_sem_addr
+            get_arg_val<uint32_t>(6),   // r2_slot_offset
+            get_arg_val<uint32_t>(7),   // r2_slot_bit
+            get_arg_val<uint32_t>(8),   // r2_sem_addr
+            get_arg_val<uint32_t>(9),   // r1_dst_l1_addr
+            get_arg_val<uint32_t>(10),  // r1_dst_sem_addr
+            get_arg_val<uint32_t>(11),  // r2_dst_l1_addr
+            get_arg_val<uint32_t>(12),  // r2_dst_sem_addr
+            get_arg_val<uint32_t>(13),  // r3_dst_l1_addr
+            get_arg_val<uint32_t>(14),  // r3_dst_sem_addr
+            get_arg_val<uint32_t>(15),  // output_base_addr
+            get_arg_val<uint32_t>(16),  // r3_slot_offset
+            get_arg_val<uint32_t>(17),  // r3_slot_bit
+            get_arg_val<uint32_t>(18),  // r3_sem_addr
         };
     }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
@@ -85,6 +85,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("local_cb"),
         get_named_compile_time_arg_val("received_cb"),
         get_named_compile_time_arg_val("scratch_cb"),
+        get_named_compile_time_arg_val("reload_cb"),
         get_named_compile_time_arg_val("is_fabric_core")>;
 
     ReduceToAll::ComputeArgs rt_args{};

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Unified Reduce-to-All Kernel — Ring + Cross-Column algorithm.
- * Phase 1: FC BRISC=FWD, FC NCRISC=BWD (matching sdpa_reduce_to_all).
- * Phase 2: FC BRISC closes FWD, opens cross-column conn, forwards R3.
+ * Unified Reduce-to-All Kernel — Ring + Cross-Column algorithm: similar to reduce to one b1 kernel but all 8 devices
+ * have the final output. Phase 1: FC BRISC=FWD, FC NCRISC=BWD (matching sdpa_reduce_to_all). Phase 2: FC BRISC closes
+ * FWD, opens cross-column conn, forwards R3.
  */
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
@@ -62,25 +62,25 @@ void kernel_main() {
     ReduceToAll::WorkerWriterArgs rt_args{};
     if constexpr (CTArgs::is_fabric_core == 0) {
         rt_args = {
-            get_arg_val<uint32_t>(0),   // fc_noc_x
-            get_arg_val<uint32_t>(1),   // fc_noc_y
-            get_arg_val<uint32_t>(2),   // is_type_a
-            get_arg_val<uint32_t>(3),   // r1_slot_offset
-            get_arg_val<uint32_t>(4),   // r1_slot_bit
-            get_arg_val<uint32_t>(5),   // r1_sem_addr
-            get_arg_val<uint32_t>(6),   // r2_slot_offset
-            get_arg_val<uint32_t>(7),   // r2_slot_bit
-            get_arg_val<uint32_t>(8),   // r2_sem_addr
-            get_arg_val<uint32_t>(9),   // r1_dst_l1_addr
-            get_arg_val<uint32_t>(10),  // r1_dst_sem_addr
-            get_arg_val<uint32_t>(11),  // r2_dst_l1_addr
-            get_arg_val<uint32_t>(12),  // r2_dst_sem_addr
-            get_arg_val<uint32_t>(13),  // r3_dst_l1_addr
-            get_arg_val<uint32_t>(14),  // r3_dst_sem_addr
-            get_arg_val<uint32_t>(15),  // output_base_addr
-            get_arg_val<uint32_t>(16),  // r3_slot_offset
-            get_arg_val<uint32_t>(17),  // r3_slot_bit
-            get_arg_val<uint32_t>(18),  // r3_sem_addr
+            get_arg_val<uint32_t>(0),                  // fc_noc_x
+            get_arg_val<uint32_t>(1),                  // fc_noc_y
+            get_arg_val<uint32_t>(2),                  // is_type_a
+            get_arg_val<uint32_t>(3),                  // r1_slot_offset
+            get_arg_val<uint32_t>(4),                  // r1_slot_bit
+            get_semaphore(get_arg_val<uint32_t>(5)),   // r1_sem_addr (from sem ID)
+            get_arg_val<uint32_t>(6),                  // r2_slot_offset
+            get_arg_val<uint32_t>(7),                  // r2_slot_bit
+            get_semaphore(get_arg_val<uint32_t>(8)),   // r2_sem_addr (from sem ID)
+            get_arg_val<uint32_t>(9),                  // r1_dst_l1_addr
+            get_arg_val<uint32_t>(10),                 // r1_dst_sem_addr
+            get_arg_val<uint32_t>(11),                 // r2_dst_l1_addr
+            get_arg_val<uint32_t>(12),                 // r2_dst_sem_addr
+            get_arg_val<uint32_t>(13),                 // r3_dst_l1_addr
+            get_arg_val<uint32_t>(14),                 // r3_dst_sem_addr
+            get_arg_val<uint32_t>(15),                 // output_base_addr
+            get_arg_val<uint32_t>(16),                 // r3_slot_offset
+            get_arg_val<uint32_t>(17),                 // r3_slot_bit
+            get_semaphore(get_arg_val<uint32_t>(18)),  // r3_sem_addr (from sem ID)
         };
     }
 

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -3,28 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Reduce-to-All B1 Operation using ttnn.generic_op
+Reduce-to-All B1 — Ring + Cross-Column (modelled on sdpa_reduce_to_all).
 
-This module implements a multi-device all-reduce operation for a 4x2 mesh
-where all 8 devices end up with the sum of every device's input, using a
-3-round hypercube bidirectional exchange.
+Requires FABRIC_2D_TORUS_X (or TORUS_XY) for 1-hop ring wrap-around.
+
+Phase 1 — Column all-reduce (2-round ring, A/B split, all 1-hop):
+    Type A workers: R1 → FWD (row+1), R2 → BWD (row-1).
+    Type B workers: R1 → BWD (row-1), R2 → FWD (row+1).
+    FC BRISC (conn → FWD neighbor): forwards R1(A) + R2(B).
+    FC NCRISC (conn → BWD neighbor): forwards R1(B) + R2(A).
+    Every packet travels exactly 1 hop (ring/torus topology).
+
+Phase 2 — Cross-column exchange (FC-forwarded):
+    Workers write R3 to FC's R3 buffer area and signal r3_fwd_sem.
+    FC BRISC closes FWD conn, opens cross-column conn, forwards R3.
+
+After both phases every device holds sum(all 8 inputs).
 
 Mesh layout (coord = [row, col]):
     [0,0] a0  |  b0 [0,1]
     [1,0] a1  |  b1 [1,1]
     [2,0] a2  |  b2 [2,1]
     [3,0] a3  |  b3 [3,1]
-
-Hypercube all-reduce (device_index = row * 2 + col):
-    Round 1 (adjacent rows):  (row, col) <-> (row^1, col)
-    Round 2 (2-apart rows):   (row, col) <-> (row^2, col)
-    Round 3 (cross-column):   (row, col) <-> (row, col^1)
-
-After 3 rounds every device holds sum(all 8 inputs).
-
-R1/R2 are forwarded by each fabric core's BRISC via the same-column EDM
-connection. R3 is forwarded by FC1's NCRISC via a separate cross-column
-EDM connection (link_idx=1), avoiding circular deadlock.
 """
 
 import torch
@@ -37,24 +37,8 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
 )
 
 
-def get_hypercube_partner(row: int, col: int, round_num: int):
-    """Return (partner_row, partner_col) for the given hypercube round."""
-    if round_num == 1:
-        return (row ^ 1, col)
-    elif round_num == 2:
-        return (row ^ 2, col)
-    elif round_num == 3:
-        return (row, col ^ 1)
-    raise ValueError(f"Invalid round number: {round_num}")
-
-
 class ReduceToAllB1:
-    """
-    Multi-device all-reduce (sum) across a 4x2 mesh.
-
-    Uses 3-round hypercube bidirectional exchange so that every device
-    accumulates the full reduction result.
-    """
+    """Multi-device all-reduce (sum) across a 4x2 mesh."""
 
     @staticmethod
     def golden(input_tensors: list) -> torch.Tensor:
@@ -67,14 +51,17 @@ class ReduceToAllB1:
         intermediate_tensor: ttnn.Tensor,
         output_tensor: ttnn.Tensor,
         semaphores: list,
+        fwd_r1_sem_addr: int,
+        fwd_r2_sem_addr: int,
+        bwd_r1_sem_addr: int,
+        bwd_r2_sem_addr: int,
+        r3_fwd_sem_addr: int,
         num_iterations: int = 1,
     ) -> ttnn.Tensor:
         mesh_device = input_tensor_mesh.device()
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
-
-        print(f"[ReduceToAllB1] mesh_shape={mesh_rows}x{mesh_cols}, num_iterations={num_iterations}")
 
         if mesh_rows != 4 or mesh_cols != 2:
             raise ValueError(f"Mesh shape must be 4x2, got {mesh_rows}x{mesh_cols}")
@@ -86,7 +73,6 @@ class ReduceToAllB1:
         sem_round1_addr = ttnn.get_global_semaphore_address(semaphores[0])
         sem_round2_addr = ttnn.get_global_semaphore_address(semaphores[1])
         sem_round3_addr = ttnn.get_global_semaphore_address(semaphores[2])
-        print(f"[ReduceToAllB1] sem addrs: R1={sem_round1_addr:#x} R2={sem_round2_addr:#x} R3={sem_round3_addr:#x}")
 
         # Tensor geometry
         input_sample = input_tensors_per_device[0]
@@ -113,11 +99,6 @@ class ReduceToAllB1:
         packet_header_size_bytes = 96
         slot_size_bytes = packet_header_size_bytes + payload_size_bytes
 
-        print(f"[ReduceToAllB1] shard_shape={shard_shape} num_pages={num_pages} num_compute_tiles={num_compute_tiles}")
-        print(
-            f"[ReduceToAllB1] page_size_bytes={page_size_bytes} payload_size_bytes={payload_size_bytes} slot_size_bytes={slot_size_bytes}"
-        )
-
         # CB indices
         local_cb = 0
         received_cb = 1
@@ -126,35 +107,20 @@ class ReduceToAllB1:
         reload_cb = 4
         scratch_cb = 5
 
-        # Worker-fabric semaphores for BRISC forwarding (R1/R2, reused across rounds)
         shard_grid = input_sample.memory_config().shard_spec.grid
         shard_cores = ttnn.corerange_to_cores(shard_grid, row_wise=True)
 
         sample_columns = {}
         for c in shard_cores:
             sample_columns.setdefault(c.x, []).append(c)
-        num_workers_per_column = len(sample_columns[sorted(sample_columns.keys())[0]])
-        device_grid_size = mesh_device.compute_with_storage_grid_size()
-        worker_fabric_sem_cores = ttnn.CoreRangeSet(
-            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
-        )
-        worker_fabric_global_sems = [
-            ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0) for _ in range(num_workers_per_column)
-        ]
-        worker_fabric_sem_addrs = [ttnn.get_global_semaphore_address(s) for s in worker_fabric_global_sems]
-
-        # R3 gate semaphore (for column-1 defer)
-        r3_gate_sem = ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0)
-        r3_gate_addr = ttnn.get_global_semaphore_address(r3_gate_sem)
-
-        # R3 NCRISC semaphores: 8 per device (all workers signal FC1 NCRISC)
-        num_total_workers = len(shard_cores)
-        r3_ncrisc_global_sems = [
-            ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0) for _ in range(num_total_workers)
-        ]
-        r3_ncrisc_sem_addrs = [ttnn.get_global_semaphore_address(s) for s in r3_ncrisc_global_sems]
+        sorted_column_keys = sorted(sample_columns.keys())
+        num_columns = len(sorted_column_keys)
+        num_workers_per_link = len(shard_cores) // num_columns
 
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp"
+
+        print(f"[ReduceToAllB1] num_compute_tiles={num_compute_tiles} payload={payload_size_bytes}")
+        print(f"[ReduceToAllB1] num_workers_per_link={num_workers_per_link} total={len(shard_cores)}")
 
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
 
@@ -179,9 +145,6 @@ class ReduceToAllB1:
                 for x in sorted_columns:
                     column_to_cores[x].sort(key=lambda c: c.y)
 
-                num_columns = len(sorted_columns)
-                num_workers_per_column = len(column_to_cores[sorted_columns[0]])
-
                 all_y_coords = set(core.y for core in input_cores_list)
                 is_horizontal_layout = len(all_y_coords) <= 2
 
@@ -190,61 +153,80 @@ class ReduceToAllB1:
                 for x in sorted_columns:
                     bottom_core = max(column_to_cores[x], key=lambda c: c.y)
                     if is_horizontal_layout:
-                        fabric_core = ttnn.CoreCoord(bottom_core.x, bottom_core.y + 1)
+                        fc = ttnn.CoreCoord(bottom_core.x, bottom_core.y + 1)
                     else:
-                        fabric_core = ttnn.CoreCoord(bottom_core.x + 1, bottom_core.y)
-                    fabric_cores.append(fabric_core)
-                    column_to_fabric_core[x] = fabric_core
-
-                core_to_slot_idx = {}
-                for x in sorted_columns:
-                    for slot_idx, core in enumerate(column_to_cores[x]):
-                        core_to_slot_idx[(core.x, core.y)] = slot_idx
-
-                # FC1 is the second fabric core (link_idx=1, cross-column)
-                fc1 = fabric_cores[1]
-                fc1_phys = device.worker_core_from_logical_core(fc1)
+                        fc = ttnn.CoreCoord(bottom_core.x + 1, bottom_core.y)
+                    fabric_cores.append(fc)
+                    column_to_fabric_core[x] = fc
 
                 fabric_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in fabric_cores])
-                fc1_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(fc1, fc1)])
                 all_cores_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in input_cores_list + fabric_cores])
 
-                # Hypercube partners for the 3 rounds
-                intermediate_base = intermediate_device.buffer_address()
-                partners = {}
-                for rnd in (1, 2, 3):
-                    pr, pc = get_hypercube_partner(row, col, rnd)
-                    dest_coord = ttnn.MeshCoordinate(pr, pc)
-                    dest_fabric_node_id = mesh_device.get_fabric_node_id(dest_coord)
-                    page_offset = (rnd - 1) * payload_size_bytes
-                    dst_l1_addr = intermediate_base + page_offset
-                    dst_sem_addr = [sem_round1_addr, sem_round2_addr, sem_round3_addr][rnd - 1]
-                    partners[rnd] = {
-                        "coord": dest_coord,
-                        "fabric_node_id": dest_fabric_node_id,
-                        "dst_l1_addr": dst_l1_addr,
-                        "dst_sem_addr": dst_sem_addr,
-                    }
-                    print(
-                        f"[ReduceToAllB1] dev({row},{col}) R{rnd}: partner=({pr},{pc}) chip_id={dest_fabric_node_id.chip_id} mesh_id={int(dest_fabric_node_id.mesh_id)} dst_l1={dst_l1_addr:#x} dst_sem={dst_sem_addr:#x}"
-                    )
+                # Ring neighbors (1-hop each, ring/torus topology)
+                fwd_row = (row + 1) % mesh_rows
+                bwd_row = (row - 1 + mesh_rows) % mesh_rows
+                r3_col = col ^ 1
+
+                fwd_coord = ttnn.MeshCoordinate(fwd_row, col)
+                bwd_coord = ttnn.MeshCoordinate(bwd_row, col)
+                r3_coord = ttnn.MeshCoordinate(row, r3_col)
 
                 fabric_node_id = mesh_device.get_fabric_node_id(coord)
+                fwd_fabric_node_id = mesh_device.get_fabric_node_id(fwd_coord)
+                bwd_fabric_node_id = mesh_device.get_fabric_node_id(bwd_coord)
+                r3_fabric_node_id = mesh_device.get_fabric_node_id(r3_coord)
+
+                intermediate_base = intermediate_device.buffer_address()
+                r1_recv_l1 = intermediate_base
+                r2_recv_l1 = intermediate_base + payload_size_bytes
+                r3_recv_l1 = intermediate_base + 2 * payload_size_bytes
+
+                # A/B split: half workers per link in each type
+                slots_per_direction = num_workers_per_link // 2
+
+                # FC buffer layout:
+                #   BRISC area [FWD]: [R1: slots_per_dir slots][R2: slots_per_dir slots]
+                #   NCRISC area [BWD]: [R1: slots_per_dir slots][R2: slots_per_dir slots]
+                #   R3 area: [num_workers_per_link slots] (forwarded by FC BRISC after Phase 1)
+                r2_buf_offset = slots_per_direction * slot_size_bytes
+                brisc_buf_size = 2 * slots_per_direction * slot_size_bytes
+                ncrisc_buf_offset = brisc_buf_size
+                r3_buf_offset = 4 * slots_per_direction * slot_size_bytes
+                packet_cb_slots = 4 * slots_per_direction + num_workers_per_link
+
                 print(
-                    f"[ReduceToAllB1] dev({row},{col}) intermediate_base={intermediate_base:#x} fabric_node_id=chip{fabric_node_id.chip_id},mesh{int(fabric_node_id.mesh_id)}"
+                    f"[ReduceToAllB1] dev({row},{col}) fwd=({fwd_row},{col}) bwd=({bwd_row},{col}) r3=({row},{r3_col})"
                 )
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) slots_per_dir={slots_per_direction} packet_cb_slots={packet_cb_slots}"
+                )
+
+                # Gather per-link info
+                links = []
+                for link_idx, x in enumerate(sorted_columns):
+                    cores_for_link = column_to_cores[x]
+                    fc = column_to_fabric_core[x]
+                    fc_phys = device.worker_core_from_logical_core(fc)
+                    links.append(
+                        {
+                            "link_idx": link_idx,
+                            "cores": cores_for_link,
+                            "fc": fc,
+                            "fc_phys": fc_phys,
+                        }
+                    )
 
                 # === Compile-time args ===
                 reader_ct_args = [
                     ("num_tiles", num_compute_tiles),
                     ("local_cb", local_cb),
                     ("received_cb", received_cb),
-                    ("defer_r3_send", col),
-                    ("num_workers", num_workers_per_column),
+                    ("slots_per_direction", slots_per_direction),
                     ("slot_size_bytes", slot_size_bytes),
                     ("packet_cb", packet_cb),
                     ("payload_size_bytes", payload_size_bytes),
-                    ("num_r3_workers", num_total_workers),
+                    ("r2_buffer_offset", r2_buf_offset),
+                    ("ncrisc_buffer_offset", ncrisc_buf_offset),
                     ("num_loop_iters", num_iterations),
                 ]
 
@@ -254,15 +236,19 @@ class ReduceToAllB1:
                     ("local_cb", local_cb),
                     ("scratch_cb", scratch_cb),
                     ("packet_cb", packet_cb),
-                    ("num_workers", num_workers_per_column),
                     ("slot_size_bytes", slot_size_bytes),
-                    ("r1_dst_chip_id", partners[1]["fabric_node_id"].chip_id),
-                    ("r1_dst_mesh_id", int(partners[1]["fabric_node_id"].mesh_id)),
-                    ("r2_dst_chip_id", partners[2]["fabric_node_id"].chip_id),
-                    ("r2_dst_mesh_id", int(partners[2]["fabric_node_id"].mesh_id)),
-                    ("r3_dst_chip_id", partners[3]["fabric_node_id"].chip_id),
-                    ("r3_dst_mesh_id", int(partners[3]["fabric_node_id"].mesh_id)),
-                    ("defer_r3_send", col),
+                    ("fwd_dst_chip_id", fwd_fabric_node_id.chip_id),
+                    ("fwd_dst_mesh_id", int(fwd_fabric_node_id.mesh_id)),
+                    ("bwd_dst_chip_id", bwd_fabric_node_id.chip_id),
+                    ("bwd_dst_mesh_id", int(bwd_fabric_node_id.mesh_id)),
+                    ("r3_dst_chip_id", r3_fabric_node_id.chip_id),
+                    ("r3_dst_mesh_id", int(r3_fabric_node_id.mesh_id)),
+                    ("reload_cb", reload_cb),
+                    ("compute_tile_size", compute_tile_size_bytes),
+                    ("slots_per_direction", slots_per_direction),
+                    ("r2_buffer_offset", r2_buf_offset),
+                    ("ncrisc_buffer_offset", ncrisc_buf_offset),
+                    ("r3_buffer_offset", r3_buf_offset),
                     ("num_loop_iters", num_iterations),
                 ]
 
@@ -276,49 +262,85 @@ class ReduceToAllB1:
                 ]
 
                 # === Common Runtime Args ===
-                reader_common_rt_args = [sem_round1_addr, sem_round2_addr, sem_round3_addr, r3_gate_addr]
-
-                print(f"[ReduceToAllB1] dev({row},{col}) worker_cores={[(c.x,c.y) for c in input_cores_list]}")
-                print(f"[ReduceToAllB1] dev({row},{col}) fabric_cores={[(c.x,c.y) for c in fabric_cores]}")
-                print(f"[ReduceToAllB1] dev({row},{col}) fc1_phys=({fc1_phys.x},{fc1_phys.y})")
+                reader_common_rt_args = [sem_round1_addr, sem_round2_addr, sem_round3_addr]
 
                 # === Per-Core Runtime Args ===
-                # BRISC: worker cores get per-core args; fabric cores get BRISC sem addrs
                 brisc_per_core_args = []
-                for global_idx, core in enumerate(input_cores_list):
-                    fabric_core = column_to_fabric_core[core.x]
-                    fabric_core_phys = device.worker_core_from_logical_core(fabric_core)
-                    slot_idx = core_to_slot_idx[(core.x, core.y)]
+                ncrisc_per_core_args = []
 
-                    worker_args = [
-                        fabric_core_phys.x,
-                        fabric_core_phys.y,
-                        slot_idx,
-                        worker_fabric_sem_addrs[slot_idx],
-                        partners[1]["dst_l1_addr"],
-                        partners[1]["dst_sem_addr"],
-                        partners[2]["dst_l1_addr"],
-                        partners[2]["dst_sem_addr"],
-                        partners[3]["dst_l1_addr"],
-                        partners[3]["dst_sem_addr"],
-                        output_tensor_device.buffer_address(),
-                        r3_gate_addr,
-                        fc1_phys.x,
-                        fc1_phys.y,
-                        global_idx,
-                        r3_ncrisc_sem_addrs[global_idx],
-                    ]
-                    brisc_per_core_args.append((core, worker_args))
-                    print(
-                        f"[ReduceToAllB1] dev({row},{col}) worker core({core.x},{core.y}) slot={slot_idx} r3_slot={global_idx} fab_phys=({fabric_core_phys.x},{fabric_core_phys.y}) r3_fab=({fc1_phys.x},{fc1_phys.y})"
-                    )
+                for link_info in links:
+                    fc_phys = link_info["fc_phys"]
+                    fc = link_info["fc"]
+                    link_idx = link_info["link_idx"]
 
-                # Fabric core BRISC: worker semaphore addresses for R1/R2
-                for fc in fabric_cores:
-                    brisc_per_core_args.append((fc, list(worker_fabric_sem_addrs)))
+                    # Direction configs — mirrors sdpa_reduce_to_all DirectionConfig
+                    # FWD: buffer starts at packet_cb base (offset 0)
+                    # BWD: buffer starts at ncrisc_buf_offset
+                    class DirCfg:
+                        def __init__(self, r1_sem, r2_sem, buf_base_offset):
+                            self.r1_sem = r1_sem
+                            self.r2_sem = r2_sem
+                            self.buf_base_offset = buf_base_offset
+                            self.r1_count = 0
+                            self.r2_count = 0
 
-                # NCRISC: FC1 gets R3 NCRISC per-core args (sems); FC0 gets nothing
-                ncrisc_per_core_args = [(fc1, list(r3_ncrisc_sem_addrs))]
+                    fwd_cfg = DirCfg(fwd_r1_sem_addr, fwd_r2_sem_addr, 0)
+                    bwd_cfg = DirCfg(bwd_r1_sem_addr, bwd_r2_sem_addr, ncrisc_buf_offset)
+
+                    for worker_idx, core in enumerate(link_info["cores"]):
+                        is_type_a = ((row + worker_idx) % 2) == 0
+
+                        # Type A: R1→FWD, R2→BWD;  Type B: R1→BWD, R2→FWD
+                        r1_cfg = fwd_cfg if is_type_a else bwd_cfg
+                        r2_cfg = bwd_cfg if is_type_a else fwd_cfg
+
+                        r1_slot_idx = r1_cfg.r1_count
+                        r1_cfg.r1_count += 1
+                        r2_slot_idx = r2_cfg.r2_count
+                        r2_cfg.r2_count += 1
+
+                        r1_slot_offset = r1_cfg.buf_base_offset + r1_slot_idx * slot_size_bytes
+                        r1_slot_bit = 1 << r1_slot_idx
+                        r1_sem = r1_cfg.r1_sem
+
+                        r2_slot_offset = r2_cfg.buf_base_offset + r2_buf_offset + r2_slot_idx * slot_size_bytes
+                        r2_slot_bit = 1 << r2_slot_idx
+                        r2_sem = r2_cfg.r2_sem
+
+                        # R3: worker writes to FC's R3 area (after BRISC+NCRISC areas)
+                        r3_slot_off = r3_buf_offset + worker_idx * slot_size_bytes
+                        r3_slot_b = 1 << worker_idx
+
+                        worker_args = [
+                            fc_phys.x,  # 0
+                            fc_phys.y,  # 1
+                            1 if is_type_a else 0,  # 2
+                            r1_slot_offset,  # 3
+                            r1_slot_bit,  # 4
+                            r1_sem,  # 5
+                            r2_slot_offset,  # 6
+                            r2_slot_bit,  # 7
+                            r2_sem,  # 8
+                            r1_recv_l1,  # 9
+                            sem_round1_addr,  # 10
+                            r2_recv_l1,  # 11
+                            sem_round2_addr,  # 12
+                            r3_recv_l1,  # 13
+                            sem_round3_addr,  # 14
+                            output_tensor_device.buffer_address(),  # 15
+                            r3_slot_off,  # 16
+                            r3_slot_b,  # 17
+                            r3_fwd_sem_addr,  # 18
+                        ]
+                        brisc_per_core_args.append((core, worker_args))
+
+                    # FC BRISC: FWD forwarding + R3 cross-column forwarding
+                    # [0] fwd_r1_sem, [1] fwd_r2_sem, [2] r3_fwd_sem,
+                    # then FWD conn args, then cross-column conn args (appended later)
+                    brisc_per_core_args.append((fc, [fwd_r1_sem_addr, fwd_r2_sem_addr, r3_fwd_sem_addr]))
+
+                    # FC NCRISC: BWD forwarding (2 sem addrs + conn appended later)
+                    ncrisc_per_core_args.append((fc, [bwd_r1_sem_addr, bwd_r2_sem_addr]))
 
                 # === CB Descriptors ===
                 compute_tile_desc = ttnn.TileDescriptor(compute_tile_height, compute_tile_width)
@@ -359,8 +381,6 @@ class ReduceToAllB1:
                     )
                 ]
 
-                # packet_cb: 2 rounds × num_workers (BRISC R1/R2) + num_total_workers (NCRISC R3)
-                packet_cb_slots = 2 * num_workers_per_column + num_total_workers
                 cb3_desc = ttnn.CBDescriptor(
                     total_size=packet_cb_slots * slot_size_bytes,
                     core_ranges=all_cores_set,
@@ -369,24 +389,6 @@ class ReduceToAllB1:
                             buffer_index=packet_cb,
                             data_format=dtype,
                             page_size=slot_size_bytes,
-                        )
-                    ],
-                )
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) packet_cb slots={packet_cb_slots} total={packet_cb_slots * slot_size_bytes}"
-                )
-
-                scratch_num_pages = 4
-                cb_size_bytes = scratch_num_pages * num_compute_tiles * compute_tile_size_bytes
-                cb5_desc = ttnn.CBDescriptor(
-                    total_size=cb_size_bytes,
-                    core_ranges=all_cores_set,
-                    format_descriptors=[
-                        ttnn.CBFormatDescriptor(
-                            buffer_index=scratch_cb,
-                            data_format=dtype,
-                            page_size=compute_tile_size_bytes,
-                            tile=compute_tile_desc,
                         )
                     ],
                 )
@@ -404,24 +406,23 @@ class ReduceToAllB1:
                     ],
                 )
 
+                scratch_num_pages = 4
+                cb5_desc = ttnn.CBDescriptor(
+                    total_size=scratch_num_pages * num_compute_tiles * compute_tile_size_bytes,
+                    core_ranges=all_cores_set,
+                    format_descriptors=[
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=scratch_cb,
+                            data_format=dtype,
+                            page_size=compute_tile_size_bytes,
+                            tile=compute_tile_desc,
+                        )
+                    ],
+                )
+
                 cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb4_desc, cb5_desc]
 
                 # === Unified kernel descriptor ===
-                unified_ct_core_descriptors = [
-                    UnifiedCompileTimeCoreDescriptor(
-                        named_compile_time_arg="is_fabric_core",
-                        core_range=fabric_core_set,
-                        value=1,
-                        other_value=0,
-                    ),
-                    UnifiedCompileTimeCoreDescriptor(
-                        named_compile_time_arg="is_r3_forwarder",
-                        core_range=fc1_core_set,
-                        value=1,
-                        other_value=0,
-                    ),
-                ]
-
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
                     core_ranges=all_cores_set,
@@ -434,27 +435,25 @@ class ReduceToAllB1:
                         fp32_dest_acc_en=False,
                         math_approx_mode=False,
                     ),
-                    unified_compile_time_core_descriptors=unified_ct_core_descriptors,
+                    unified_compile_time_core_descriptors=[
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_fabric_core",
+                            core_range=fabric_core_set,
+                            value=1,
+                            other_value=0,
+                        ),
+                    ],
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
                         brisc_args=brisc_per_core_args,
                         ncrisc_args=ncrisc_per_core_args,
                     ),
+                    noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
                 )
 
                 kernel_result = unified_kernel.get_kernel_descriptors()
 
-                # With two UnifiedCompileTimeCoreDescriptors we get 3 groups:
-                #   workers:  is_fabric_core=0, is_r3_forwarder=0
-                #   FC0:      is_fabric_core=1, is_r3_forwarder=0
-                #   FC1:      is_fabric_core=1, is_r3_forwarder=1
-                fc0_group = None
-                fc1_group = None
-                for g in kernel_result.groups:
-                    v = g.compile_time_arg_values
-                    if v.get("is_fabric_core") == 1 and v.get("is_r3_forwarder") == 0:
-                        fc0_group = g
-                    elif v.get("is_fabric_core") == 1 and v.get("is_r3_forwarder") == 1:
-                        fc1_group = g
+                fabric_group = kernel_result.get_group_by_arg("is_fabric_core", 1)
+                worker_group = kernel_result.get_group_by_arg("is_fabric_core", 0)
 
                 program = ttnn.ProgramDescriptor(
                     kernels=kernel_result.kernels,
@@ -462,81 +461,45 @@ class ReduceToAllB1:
                     cbs=cb_list,
                 )
 
-                fc0 = fabric_cores[0]
-                # FC0 BRISC: connection 1 — R1 partner (same-column, link_idx=0)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC R1 link_idx=0 -> chip {partners[1]['fabric_node_id'].chip_id}"
-                )
-                conn_args_fc0_r1 = ttnn.setup_fabric_connection(
-                    fabric_node_id,
-                    partners[1]["fabric_node_id"],
-                    0,
-                    program,
-                    fc0,
-                )
-                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0_r1)
+                # Append FC fabric connections:
+                #   BRISC: FWD conn (Phase 1) + cross-column conn (Phase 2)
+                #   NCRISC: BWD conn (Phase 1)
+                brisc_idx = fabric_group.brisc_kernel_index
+                ncrisc_idx = fabric_group.ncrisc_kernel_index
+                for link_info in links:
+                    fc = link_info["fc"]
+                    link_idx = link_info["link_idx"]
 
-                # FC0 BRISC: connection 2 — R2 partner (same-column, link_idx=0)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC R2 link_idx=0 -> chip {partners[2]['fabric_node_id'].chip_id}"
-                )
-                conn_args_fc0_r2 = ttnn.setup_fabric_connection(
-                    fabric_node_id,
-                    partners[2]["fabric_node_id"],
-                    0,
-                    program,
-                    fc0,
-                )
-                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0_r2)
+                    fwd_conn_args = ttnn.setup_fabric_connection(
+                        fabric_node_id,
+                        fwd_fabric_node_id,
+                        link_idx,
+                        program,
+                        fc,
+                    )
+                    program.kernels[brisc_idx].runtime_args[fc.x][fc.y].extend(fwd_conn_args)
 
-                # FC1 BRISC: connection 1 — R1 partner (same-column, link_idx=1)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC R1 link_idx=1 -> chip {partners[1]['fabric_node_id'].chip_id}"
-                )
-                conn_args_fc1_r1 = ttnn.setup_fabric_connection(
-                    fabric_node_id,
-                    partners[1]["fabric_node_id"],
-                    1,
-                    program,
-                    fc1,
-                )
-                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1_r1)
+                    r3_conn_args = ttnn.setup_fabric_connection(
+                        fabric_node_id,
+                        r3_fabric_node_id,
+                        link_idx,
+                        program,
+                        fc,
+                    )
+                    program.kernels[brisc_idx].runtime_args[fc.x][fc.y].extend(r3_conn_args)
 
-                # FC1 BRISC: connection 2 — R2 partner (same-column, link_idx=1)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC R2 link_idx=1 -> chip {partners[2]['fabric_node_id'].chip_id}"
-                )
-                conn_args_fc1_r2 = ttnn.setup_fabric_connection(
-                    fabric_node_id,
-                    partners[2]["fabric_node_id"],
-                    1,
-                    program,
-                    fc1,
-                )
-                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1_r2)
-
-                # FC1 NCRISC: connection to R3 partner (cross-column, link_idx=1)
-                r3_conn_args = ttnn.setup_fabric_connection(
-                    fabric_node_id,
-                    partners[3]["fabric_node_id"],
-                    1,
-                    program,
-                    fc1,
-                )
-                program.kernels[fc1_group.ncrisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(r3_conn_args)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) NCRISC R3 conn_args count={len(r3_conn_args)}"
-                )
+                    bwd_conn_args = ttnn.setup_fabric_connection(
+                        fabric_node_id,
+                        bwd_fabric_node_id,
+                        link_idx,
+                        program,
+                        fc,
+                    )
+                    program.kernels[ncrisc_idx].runtime_args[fc.x][fc.y].extend(bwd_conn_args)
 
                 mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
 
-        input_list = [
-            input_tensor_mesh,
-            output_tensor,
-            intermediate_tensor,
-        ]
-        print(f"[ReduceToAllB1] calling generic_op...")
+        input_list = [input_tensor_mesh, output_tensor, intermediate_tensor]
         ttnn.generic_op(input_list, mesh_program_descriptor)
-        print(f"[ReduceToAllB1] generic_op returned")
 
         return output_tensor

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -5,8 +5,6 @@
 """
 Reduce-to-All B1 — Ring + Cross-Column
 
-Requires FABRIC_2D_TORUS_X (or TORUS_XY) for 1-hop ring wrap-around.
-
 Phase 1 — Column all-reduce (2-round ring, A/B split, all 1-hop):
     Type A workers: R1 → FWD (row+1), R2 → BWD (row-1).
     Type B workers: R1 → BWD (row-1), R2 → FWD (row+1).

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -123,6 +123,7 @@ class ReduceToAllB1:
         received_cb = 1
         output_cb = 2
         packet_cb = 3
+        reload_cb = 4
         scratch_cb = 5
 
         # Worker-fabric semaphores for BRISC forwarding (R1/R2, reused across rounds)
@@ -270,6 +271,7 @@ class ReduceToAllB1:
                     ("local_cb", local_cb),
                     ("received_cb", received_cb),
                     ("scratch_cb", scratch_cb),
+                    ("reload_cb", reload_cb),
                     ("num_loop_iters", num_iterations),
                 ]
 
@@ -389,7 +391,20 @@ class ReduceToAllB1:
                     ],
                 )
 
-                cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb5_desc]
+                cb4_desc = ttnn.CBDescriptor(
+                    total_size=num_compute_tiles * compute_tile_size_bytes,
+                    core_ranges=all_cores_set,
+                    format_descriptors=[
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=reload_cb,
+                            data_format=dtype,
+                            page_size=compute_tile_size_bytes,
+                            tile=compute_tile_desc,
+                        )
+                    ],
+                )
+
+                cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb4_desc, cb5_desc]
 
                 # === Unified kernel descriptor ===
                 unified_ct_core_descriptors = [
@@ -448,33 +463,57 @@ class ReduceToAllB1:
                 )
 
                 fc0 = fabric_cores[0]
-                # FC0 BRISC: connection to R1 partner (same-column, link_idx=0)
-                print(f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC link_idx=0")
-                conn_args_fc0 = ttnn.setup_fabric_connection(
+                # FC0 BRISC: connection 1 — R1 partner (same-column, link_idx=0)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC R1 link_idx=0 -> chip {partners[1]['fabric_node_id'].chip_id}"
+                )
+                conn_args_fc0_r1 = ttnn.setup_fabric_connection(
                     fabric_node_id,
                     partners[1]["fabric_node_id"],
                     0,
                     program,
                     fc0,
                 )
-                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0)
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC conn_args count={len(conn_args_fc0)}"
-                )
+                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0_r1)
 
-                # FC1 BRISC: connection to R1 partner (same-column, link_idx=1)
-                print(f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC link_idx=1")
-                conn_args_fc1 = ttnn.setup_fabric_connection(
+                # FC0 BRISC: connection 2 — R2 partner (same-column, link_idx=0)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC R2 link_idx=0 -> chip {partners[2]['fabric_node_id'].chip_id}"
+                )
+                conn_args_fc0_r2 = ttnn.setup_fabric_connection(
+                    fabric_node_id,
+                    partners[2]["fabric_node_id"],
+                    0,
+                    program,
+                    fc0,
+                )
+                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0_r2)
+
+                # FC1 BRISC: connection 1 — R1 partner (same-column, link_idx=1)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC R1 link_idx=1 -> chip {partners[1]['fabric_node_id'].chip_id}"
+                )
+                conn_args_fc1_r1 = ttnn.setup_fabric_connection(
                     fabric_node_id,
                     partners[1]["fabric_node_id"],
                     1,
                     program,
                     fc1,
                 )
-                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1)
+                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1_r1)
+
+                # FC1 BRISC: connection 2 — R2 partner (same-column, link_idx=1)
                 print(
-                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC conn_args count={len(conn_args_fc1)}"
+                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC R2 link_idx=1 -> chip {partners[2]['fabric_node_id'].chip_id}"
                 )
+                conn_args_fc1_r2 = ttnn.setup_fabric_connection(
+                    fabric_node_id,
+                    partners[2]["fabric_node_id"],
+                    1,
+                    program,
+                    fc1,
+                )
+                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1_r2)
 
                 # FC1 NCRISC: connection to R3 partner (cross-column, link_idx=1)
                 r3_conn_args = ttnn.setup_fabric_connection(

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Reduce-to-All B1 — Ring + Cross-Column (modelled on sdpa_reduce_to_all).
+Reduce-to-All B1 — Ring + Cross-Column
 
 Requires FABRIC_2D_TORUS_X (or TORUS_XY) for 1-hop ring wrap-around.
 
@@ -51,11 +51,6 @@ class ReduceToAllB1:
         intermediate_tensor: ttnn.Tensor,
         output_tensor: ttnn.Tensor,
         semaphores: list,
-        fwd_r1_sem_addr: int,
-        fwd_r2_sem_addr: int,
-        bwd_r1_sem_addr: int,
-        bwd_r2_sem_addr: int,
-        r3_fwd_sem_addr: int,
         num_iterations: int = 1,
     ) -> ttnn.Tensor:
         mesh_device = input_tensor_mesh.device()
@@ -121,6 +116,13 @@ class ReduceToAllB1:
 
         print(f"[ReduceToAllB1] num_compute_tiles={num_compute_tiles} payload={payload_size_bytes}")
         print(f"[ReduceToAllB1] num_workers_per_link={num_workers_per_link} total={len(shard_cores)}")
+
+        # Forwarder bitmask semaphore IDs (program-local, matching sdpa_reduce_to_all)
+        fwd_r1_sem_id = 0
+        fwd_r2_sem_id = 1
+        bwd_r1_sem_id = 2
+        bwd_r2_sem_id = 3
+        r3_fwd_sem_id = 4
 
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()
 
@@ -284,8 +286,8 @@ class ReduceToAllB1:
                             self.r1_count = 0
                             self.r2_count = 0
 
-                    fwd_cfg = DirCfg(fwd_r1_sem_addr, fwd_r2_sem_addr, 0)
-                    bwd_cfg = DirCfg(bwd_r1_sem_addr, bwd_r2_sem_addr, ncrisc_buf_offset)
+                    fwd_cfg = DirCfg(fwd_r1_sem_id, fwd_r2_sem_id, 0)
+                    bwd_cfg = DirCfg(bwd_r1_sem_id, bwd_r2_sem_id, ncrisc_buf_offset)
 
                     for worker_idx, core in enumerate(link_info["cores"]):
                         is_type_a = ((row + worker_idx) % 2) == 0
@@ -330,17 +332,17 @@ class ReduceToAllB1:
                             output_tensor_device.buffer_address(),  # 15
                             r3_slot_off,  # 16
                             r3_slot_b,  # 17
-                            r3_fwd_sem_addr,  # 18
+                            r3_fwd_sem_id,  # 18 (sem ID, resolved via get_semaphore)
                         ]
                         brisc_per_core_args.append((core, worker_args))
 
                     # FC BRISC: FWD forwarding + R3 cross-column forwarding
-                    # [0] fwd_r1_sem, [1] fwd_r2_sem, [2] r3_fwd_sem,
+                    # [0] fwd_r1_sem_id, [1] fwd_r2_sem_id, [2] r3_fwd_sem_id,
                     # then FWD conn args, then cross-column conn args (appended later)
-                    brisc_per_core_args.append((fc, [fwd_r1_sem_addr, fwd_r2_sem_addr, r3_fwd_sem_addr]))
+                    brisc_per_core_args.append((fc, [fwd_r1_sem_id, fwd_r2_sem_id, r3_fwd_sem_id]))
 
-                    # FC NCRISC: BWD forwarding (2 sem addrs + conn appended later)
-                    ncrisc_per_core_args.append((fc, [bwd_r1_sem_addr, bwd_r2_sem_addr]))
+                    # FC NCRISC: BWD forwarding (2 sem IDs + conn appended later)
+                    ncrisc_per_core_args.append((fc, [bwd_r1_sem_id, bwd_r2_sem_id]))
 
                 # === CB Descriptors ===
                 compute_tile_desc = ttnn.TileDescriptor(compute_tile_height, compute_tile_width)
@@ -422,6 +424,15 @@ class ReduceToAllB1:
 
                 cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb4_desc, cb5_desc]
 
+                # Forwarder bitmask semaphores (program-local, on FC cores only)
+                forwarder_semaphores = [
+                    ttnn.SemaphoreDescriptor(id=fwd_r1_sem_id, core_ranges=fabric_core_set, initial_value=0),
+                    ttnn.SemaphoreDescriptor(id=fwd_r2_sem_id, core_ranges=fabric_core_set, initial_value=0),
+                    ttnn.SemaphoreDescriptor(id=bwd_r1_sem_id, core_ranges=fabric_core_set, initial_value=0),
+                    ttnn.SemaphoreDescriptor(id=bwd_r2_sem_id, core_ranges=fabric_core_set, initial_value=0),
+                    ttnn.SemaphoreDescriptor(id=r3_fwd_sem_id, core_ranges=fabric_core_set, initial_value=0),
+                ]
+
                 # === Unified kernel descriptor ===
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=kernel_path,
@@ -457,7 +468,7 @@ class ReduceToAllB1:
 
                 program = ttnn.ProgramDescriptor(
                     kernels=kernel_result.kernels,
-                    semaphores=[],
+                    semaphores=forwarder_semaphores,
                     cbs=cb_list,
                 )
 

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -114,9 +114,6 @@ class ReduceToAllB1:
 
         kernel_path = "models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp"
 
-        print(f"[ReduceToAllB1] num_compute_tiles={num_compute_tiles} payload={payload_size_bytes}")
-        print(f"[ReduceToAllB1] num_workers_per_link={num_workers_per_link} total={len(shard_cores)}")
-
         # Forwarder bitmask semaphore IDs (program-local, matching sdpa_reduce_to_all)
         fwd_r1_sem_id = 0
         fwd_r2_sem_id = 1
@@ -195,13 +192,6 @@ class ReduceToAllB1:
                 ncrisc_buf_offset = brisc_buf_size
                 r3_buf_offset = 4 * slots_per_direction * slot_size_bytes
                 packet_cb_slots = 4 * slots_per_direction + num_workers_per_link
-
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) fwd=({fwd_row},{col}) bwd=({bwd_row},{col}) r3=({row},{r3_col})"
-                )
-                print(
-                    f"[ReduceToAllB1] dev({row},{col}) slots_per_dir={slots_per_direction} packet_cb_slots={packet_cb_slots}"
-                )
 
                 # Gather per-link info
                 links = []

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -263,7 +263,6 @@ class ReduceToAllB1:
                 for link_info in links:
                     fc_phys = link_info["fc_phys"]
                     fc = link_info["fc"]
-                    link_idx = link_info["link_idx"]
 
                     # Direction configs — mirrors sdpa_reduce_to_all DirectionConfig
                     # FWD: buffer starts at packet_cb base (offset 0)
@@ -454,7 +453,6 @@ class ReduceToAllB1:
                 kernel_result = unified_kernel.get_kernel_descriptors()
 
                 fabric_group = kernel_result.get_group_by_arg("is_fabric_core", 1)
-                worker_group = kernel_result.get_group_by_arg("is_fabric_core", 0)
 
                 program = ttnn.ProgramDescriptor(
                     kernels=kernel_result.kernels,

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -1,0 +1,503 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Reduce-to-All B1 Operation using ttnn.generic_op
+
+This module implements a multi-device all-reduce operation for a 4x2 mesh
+where all 8 devices end up with the sum of every device's input, using a
+3-round hypercube bidirectional exchange.
+
+Mesh layout (coord = [row, col]):
+    [0,0] a0  |  b0 [0,1]
+    [1,0] a1  |  b1 [1,1]
+    [2,0] a2  |  b2 [2,1]
+    [3,0] a3  |  b3 [3,1]
+
+Hypercube all-reduce (device_index = row * 2 + col):
+    Round 1 (adjacent rows):  (row, col) <-> (row^1, col)
+    Round 2 (2-apart rows):   (row, col) <-> (row^2, col)
+    Round 3 (cross-column):   (row, col) <-> (row, col^1)
+
+After 3 rounds every device holds sum(all 8 inputs).
+
+R1/R2 are forwarded by each fabric core's BRISC via the same-column EDM
+connection. R3 is forwarded by FC1's NCRISC via a separate cross-column
+EDM connection (link_idx=1), avoiding circular deadlock.
+"""
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreRuntimeArgsDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+def get_hypercube_partner(row: int, col: int, round_num: int):
+    """Return (partner_row, partner_col) for the given hypercube round."""
+    if round_num == 1:
+        return (row ^ 1, col)
+    elif round_num == 2:
+        return (row ^ 2, col)
+    elif round_num == 3:
+        return (row, col ^ 1)
+    raise ValueError(f"Invalid round number: {round_num}")
+
+
+class ReduceToAllB1:
+    """
+    Multi-device all-reduce (sum) across a 4x2 mesh.
+
+    Uses 3-round hypercube bidirectional exchange so that every device
+    accumulates the full reduction result.
+    """
+
+    @staticmethod
+    def golden(input_tensors: list) -> torch.Tensor:
+        """PyTorch reference: sum of all input tensors."""
+        return torch.sum(torch.stack(input_tensors), dim=0)
+
+    @staticmethod
+    def op(
+        input_tensor_mesh: ttnn.Tensor,
+        intermediate_tensor: ttnn.Tensor,
+        output_tensor: ttnn.Tensor,
+        semaphores: list,
+        num_iterations: int = 1,
+    ) -> ttnn.Tensor:
+        mesh_device = input_tensor_mesh.device()
+        mesh_shape = mesh_device.shape
+        mesh_rows = mesh_shape[0]
+        mesh_cols = mesh_shape[1]
+
+        print(f"[ReduceToAllB1] mesh_shape={mesh_rows}x{mesh_cols}, num_iterations={num_iterations}")
+
+        if mesh_rows != 4 or mesh_cols != 2:
+            raise ValueError(f"Mesh shape must be 4x2, got {mesh_rows}x{mesh_cols}")
+
+        input_tensors_per_device = ttnn.get_device_tensors(input_tensor_mesh)
+        output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
+        intermediate_per_device = ttnn.get_device_tensors(intermediate_tensor)
+
+        sem_round1_addr = ttnn.get_global_semaphore_address(semaphores[0])
+        sem_round2_addr = ttnn.get_global_semaphore_address(semaphores[1])
+        sem_round3_addr = ttnn.get_global_semaphore_address(semaphores[2])
+        print(f"[ReduceToAllB1] sem addrs: R1={sem_round1_addr:#x} R2={sem_round2_addr:#x} R3={sem_round3_addr:#x}")
+
+        # Tensor geometry
+        input_sample = input_tensors_per_device[0]
+        tile = input_sample.tile
+        tile_height, tile_width = tile.tile_shape
+        dtype = input_sample.dtype
+        element_size = 2  # bfloat16
+
+        page_size_bytes = tile_height * tile_width * element_size
+        shard_spec = input_sample.memory_config().shard_spec
+        shard_shape = shard_spec.shape
+        shard_width = shard_shape[1]
+        num_pages = shard_width // tile_width
+        payload_size_bytes = num_pages * page_size_bytes
+
+        compute_tile_height = 32
+        compute_tile_width = 32
+        compute_tile_size_bytes = compute_tile_height * compute_tile_width * element_size
+        shard_elements = shard_shape[0] * shard_shape[1]
+        num_compute_tiles = (shard_elements + compute_tile_height * compute_tile_width - 1) // (
+            compute_tile_height * compute_tile_width
+        )
+
+        packet_header_size_bytes = 96
+        slot_size_bytes = packet_header_size_bytes + payload_size_bytes
+
+        print(f"[ReduceToAllB1] shard_shape={shard_shape} num_pages={num_pages} num_compute_tiles={num_compute_tiles}")
+        print(
+            f"[ReduceToAllB1] page_size_bytes={page_size_bytes} payload_size_bytes={payload_size_bytes} slot_size_bytes={slot_size_bytes}"
+        )
+
+        # CB indices
+        local_cb = 0
+        received_cb = 1
+        output_cb = 2
+        packet_cb = 3
+        scratch_cb = 5
+
+        # Worker-fabric semaphores for BRISC forwarding (R1/R2, reused across rounds)
+        shard_grid = input_sample.memory_config().shard_spec.grid
+        shard_cores = ttnn.corerange_to_cores(shard_grid, row_wise=True)
+
+        sample_columns = {}
+        for c in shard_cores:
+            sample_columns.setdefault(c.x, []).append(c)
+        num_workers_per_column = len(sample_columns[sorted(sample_columns.keys())[0]])
+        device_grid_size = mesh_device.compute_with_storage_grid_size()
+        worker_fabric_sem_cores = ttnn.CoreRangeSet(
+            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+        )
+        worker_fabric_global_sems = [
+            ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0) for _ in range(num_workers_per_column)
+        ]
+        worker_fabric_sem_addrs = [ttnn.get_global_semaphore_address(s) for s in worker_fabric_global_sems]
+
+        # R3 gate semaphore (for column-1 defer)
+        r3_gate_sem = ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0)
+        r3_gate_addr = ttnn.get_global_semaphore_address(r3_gate_sem)
+
+        # R3 NCRISC semaphores: 8 per device (all workers signal FC1 NCRISC)
+        num_total_workers = len(shard_cores)
+        r3_ncrisc_global_sems = [
+            ttnn.create_global_semaphore(mesh_device, worker_fabric_sem_cores, 0) for _ in range(num_total_workers)
+        ]
+        r3_ncrisc_sem_addrs = [ttnn.get_global_semaphore_address(s) for s in r3_ncrisc_global_sems]
+
+        kernel_path = "models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/kernels/reduce_to_all_kernel.cpp"
+
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                coord = ttnn.MeshCoordinate(row, col)
+                device_idx = row * mesh_cols + col
+
+                input_tensor_device = input_tensors_per_device[device_idx]
+                output_tensor_device = output_tensors_per_device[device_idx]
+                intermediate_device = intermediate_per_device[device_idx]
+                device = input_tensor_device.device()
+
+                # Worker / fabric core topology
+                input_shard_grid = input_tensor_device.memory_config().shard_spec.grid
+                input_cores_list = ttnn.corerange_to_cores(input_shard_grid, row_wise=True)
+
+                column_to_cores = {}
+                for core in input_cores_list:
+                    column_to_cores.setdefault(core.x, []).append(core)
+                sorted_columns = sorted(column_to_cores.keys())
+                for x in sorted_columns:
+                    column_to_cores[x].sort(key=lambda c: c.y)
+
+                num_columns = len(sorted_columns)
+                num_workers_per_column = len(column_to_cores[sorted_columns[0]])
+
+                all_y_coords = set(core.y for core in input_cores_list)
+                is_horizontal_layout = len(all_y_coords) <= 2
+
+                fabric_cores = []
+                column_to_fabric_core = {}
+                for x in sorted_columns:
+                    bottom_core = max(column_to_cores[x], key=lambda c: c.y)
+                    if is_horizontal_layout:
+                        fabric_core = ttnn.CoreCoord(bottom_core.x, bottom_core.y + 1)
+                    else:
+                        fabric_core = ttnn.CoreCoord(bottom_core.x + 1, bottom_core.y)
+                    fabric_cores.append(fabric_core)
+                    column_to_fabric_core[x] = fabric_core
+
+                core_to_slot_idx = {}
+                for x in sorted_columns:
+                    for slot_idx, core in enumerate(column_to_cores[x]):
+                        core_to_slot_idx[(core.x, core.y)] = slot_idx
+
+                # FC1 is the second fabric core (link_idx=1, cross-column)
+                fc1 = fabric_cores[1]
+                fc1_phys = device.worker_core_from_logical_core(fc1)
+
+                fabric_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in fabric_cores])
+                fc1_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(fc1, fc1)])
+                all_cores_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in input_cores_list + fabric_cores])
+
+                # Hypercube partners for the 3 rounds
+                intermediate_base = intermediate_device.buffer_address()
+                partners = {}
+                for rnd in (1, 2, 3):
+                    pr, pc = get_hypercube_partner(row, col, rnd)
+                    dest_coord = ttnn.MeshCoordinate(pr, pc)
+                    dest_fabric_node_id = mesh_device.get_fabric_node_id(dest_coord)
+                    page_offset = (rnd - 1) * payload_size_bytes
+                    dst_l1_addr = intermediate_base + page_offset
+                    dst_sem_addr = [sem_round1_addr, sem_round2_addr, sem_round3_addr][rnd - 1]
+                    partners[rnd] = {
+                        "coord": dest_coord,
+                        "fabric_node_id": dest_fabric_node_id,
+                        "dst_l1_addr": dst_l1_addr,
+                        "dst_sem_addr": dst_sem_addr,
+                    }
+                    print(
+                        f"[ReduceToAllB1] dev({row},{col}) R{rnd}: partner=({pr},{pc}) chip_id={dest_fabric_node_id.chip_id} mesh_id={int(dest_fabric_node_id.mesh_id)} dst_l1={dst_l1_addr:#x} dst_sem={dst_sem_addr:#x}"
+                    )
+
+                fabric_node_id = mesh_device.get_fabric_node_id(coord)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) intermediate_base={intermediate_base:#x} fabric_node_id=chip{fabric_node_id.chip_id},mesh{int(fabric_node_id.mesh_id)}"
+                )
+
+                # === Compile-time args ===
+                reader_ct_args = [
+                    ("num_tiles", num_compute_tiles),
+                    ("local_cb", local_cb),
+                    ("received_cb", received_cb),
+                    ("defer_r3_send", col),
+                    ("num_workers", num_workers_per_column),
+                    ("slot_size_bytes", slot_size_bytes),
+                    ("packet_cb", packet_cb),
+                    ("payload_size_bytes", payload_size_bytes),
+                    ("num_r3_workers", num_total_workers),
+                    ("num_loop_iters", num_iterations),
+                ]
+
+                writer_ct_args = [
+                    ("num_tiles", num_compute_tiles),
+                    ("payload_size_bytes", payload_size_bytes),
+                    ("local_cb", local_cb),
+                    ("scratch_cb", scratch_cb),
+                    ("packet_cb", packet_cb),
+                    ("num_workers", num_workers_per_column),
+                    ("slot_size_bytes", slot_size_bytes),
+                    ("r1_dst_chip_id", partners[1]["fabric_node_id"].chip_id),
+                    ("r1_dst_mesh_id", int(partners[1]["fabric_node_id"].mesh_id)),
+                    ("r2_dst_chip_id", partners[2]["fabric_node_id"].chip_id),
+                    ("r2_dst_mesh_id", int(partners[2]["fabric_node_id"].mesh_id)),
+                    ("r3_dst_chip_id", partners[3]["fabric_node_id"].chip_id),
+                    ("r3_dst_mesh_id", int(partners[3]["fabric_node_id"].mesh_id)),
+                    ("defer_r3_send", col),
+                    ("num_loop_iters", num_iterations),
+                ]
+
+                compute_ct_args = [
+                    ("num_tiles", num_compute_tiles),
+                    ("local_cb", local_cb),
+                    ("received_cb", received_cb),
+                    ("scratch_cb", scratch_cb),
+                    ("num_loop_iters", num_iterations),
+                ]
+
+                # === Common Runtime Args ===
+                reader_common_rt_args = [sem_round1_addr, sem_round2_addr, sem_round3_addr, r3_gate_addr]
+
+                print(f"[ReduceToAllB1] dev({row},{col}) worker_cores={[(c.x,c.y) for c in input_cores_list]}")
+                print(f"[ReduceToAllB1] dev({row},{col}) fabric_cores={[(c.x,c.y) for c in fabric_cores]}")
+                print(f"[ReduceToAllB1] dev({row},{col}) fc1_phys=({fc1_phys.x},{fc1_phys.y})")
+
+                # === Per-Core Runtime Args ===
+                # BRISC: worker cores get per-core args; fabric cores get BRISC sem addrs
+                brisc_per_core_args = []
+                for global_idx, core in enumerate(input_cores_list):
+                    fabric_core = column_to_fabric_core[core.x]
+                    fabric_core_phys = device.worker_core_from_logical_core(fabric_core)
+                    slot_idx = core_to_slot_idx[(core.x, core.y)]
+
+                    worker_args = [
+                        fabric_core_phys.x,
+                        fabric_core_phys.y,
+                        slot_idx,
+                        worker_fabric_sem_addrs[slot_idx],
+                        partners[1]["dst_l1_addr"],
+                        partners[1]["dst_sem_addr"],
+                        partners[2]["dst_l1_addr"],
+                        partners[2]["dst_sem_addr"],
+                        partners[3]["dst_l1_addr"],
+                        partners[3]["dst_sem_addr"],
+                        output_tensor_device.buffer_address(),
+                        r3_gate_addr,
+                        fc1_phys.x,
+                        fc1_phys.y,
+                        global_idx,
+                        r3_ncrisc_sem_addrs[global_idx],
+                    ]
+                    brisc_per_core_args.append((core, worker_args))
+                    print(
+                        f"[ReduceToAllB1] dev({row},{col}) worker core({core.x},{core.y}) slot={slot_idx} r3_slot={global_idx} fab_phys=({fabric_core_phys.x},{fabric_core_phys.y}) r3_fab=({fc1_phys.x},{fc1_phys.y})"
+                    )
+
+                # Fabric core BRISC: worker semaphore addresses for R1/R2
+                for fc in fabric_cores:
+                    brisc_per_core_args.append((fc, list(worker_fabric_sem_addrs)))
+
+                # NCRISC: FC1 gets R3 NCRISC per-core args (sems); FC0 gets nothing
+                ncrisc_per_core_args = [(fc1, list(r3_ncrisc_sem_addrs))]
+
+                # === CB Descriptors ===
+                compute_tile_desc = ttnn.TileDescriptor(compute_tile_height, compute_tile_width)
+
+                cb0_desc = ttnn.cb_descriptor_from_sharded_tensor(local_cb, input_tensor_device)
+                cb0_desc.core_ranges = all_cores_set
+                cb0_desc.total_size = payload_size_bytes
+                cb0_desc.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=local_cb,
+                        data_format=dtype,
+                        page_size=payload_size_bytes,
+                        tile=compute_tile_desc,
+                    )
+                ]
+
+                cb1_desc = ttnn.cb_descriptor_from_sharded_tensor(received_cb, intermediate_device)
+                cb1_desc.core_ranges = all_cores_set
+                cb1_desc.total_size = 3 * payload_size_bytes
+                cb1_desc.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=received_cb,
+                        data_format=dtype,
+                        page_size=payload_size_bytes,
+                        tile=compute_tile_desc,
+                    )
+                ]
+
+                cb2_desc = ttnn.cb_descriptor_from_sharded_tensor(output_cb, output_tensor_device)
+                cb2_desc.core_ranges = all_cores_set
+                cb2_desc.total_size = payload_size_bytes
+                cb2_desc.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=output_cb,
+                        data_format=dtype,
+                        page_size=payload_size_bytes,
+                        tile=compute_tile_desc,
+                    )
+                ]
+
+                # packet_cb: 2 rounds × num_workers (BRISC R1/R2) + num_total_workers (NCRISC R3)
+                packet_cb_slots = 2 * num_workers_per_column + num_total_workers
+                cb3_desc = ttnn.CBDescriptor(
+                    total_size=packet_cb_slots * slot_size_bytes,
+                    core_ranges=all_cores_set,
+                    format_descriptors=[
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=packet_cb,
+                            data_format=dtype,
+                            page_size=slot_size_bytes,
+                        )
+                    ],
+                )
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) packet_cb slots={packet_cb_slots} total={packet_cb_slots * slot_size_bytes}"
+                )
+
+                scratch_num_pages = 4
+                cb_size_bytes = scratch_num_pages * num_compute_tiles * compute_tile_size_bytes
+                cb5_desc = ttnn.CBDescriptor(
+                    total_size=cb_size_bytes,
+                    core_ranges=all_cores_set,
+                    format_descriptors=[
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=scratch_cb,
+                            data_format=dtype,
+                            page_size=compute_tile_size_bytes,
+                            tile=compute_tile_desc,
+                        )
+                    ],
+                )
+
+                cb_list = [cb0_desc, cb1_desc, cb2_desc, cb3_desc, cb5_desc]
+
+                # === Unified kernel descriptor ===
+                unified_ct_core_descriptors = [
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_fabric_core",
+                        core_range=fabric_core_set,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_r3_forwarder",
+                        core_range=fc1_core_set,
+                        value=1,
+                        other_value=0,
+                    ),
+                ]
+
+                unified_kernel = UnifiedKernelDescriptor(
+                    kernel_source=kernel_path,
+                    core_ranges=all_cores_set,
+                    ncrisc_named_compile_time_args=reader_ct_args,
+                    brisc_named_compile_time_args=writer_ct_args,
+                    trisc_named_compile_time_args=compute_ct_args,
+                    ncrisc_common_runtime_args=reader_common_rt_args,
+                    trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                        math_fidelity=ttnn.MathFidelity.HiFi4,
+                        fp32_dest_acc_en=False,
+                        math_approx_mode=False,
+                    ),
+                    unified_compile_time_core_descriptors=unified_ct_core_descriptors,
+                    per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
+                        brisc_args=brisc_per_core_args,
+                        ncrisc_args=ncrisc_per_core_args,
+                    ),
+                )
+
+                kernel_result = unified_kernel.get_kernel_descriptors()
+
+                # With two UnifiedCompileTimeCoreDescriptors we get 3 groups:
+                #   workers:  is_fabric_core=0, is_r3_forwarder=0
+                #   FC0:      is_fabric_core=1, is_r3_forwarder=0
+                #   FC1:      is_fabric_core=1, is_r3_forwarder=1
+                fc0_group = None
+                fc1_group = None
+                for g in kernel_result.groups:
+                    v = g.compile_time_arg_values
+                    if v.get("is_fabric_core") == 1 and v.get("is_r3_forwarder") == 0:
+                        fc0_group = g
+                    elif v.get("is_fabric_core") == 1 and v.get("is_r3_forwarder") == 1:
+                        fc1_group = g
+
+                program = ttnn.ProgramDescriptor(
+                    kernels=kernel_result.kernels,
+                    semaphores=[],
+                    cbs=cb_list,
+                )
+
+                fc0 = fabric_cores[0]
+                # FC0 BRISC: connection to R1 partner (same-column, link_idx=0)
+                print(f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC link_idx=0")
+                conn_args_fc0 = ttnn.setup_fabric_connection(
+                    fabric_node_id,
+                    partners[1]["fabric_node_id"],
+                    0,
+                    program,
+                    fc0,
+                )
+                program.kernels[fc0_group.brisc_kernel_index].runtime_args[fc0.x][fc0.y].extend(conn_args_fc0)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC0({fc0.x},{fc0.y}) BRISC conn_args count={len(conn_args_fc0)}"
+                )
+
+                # FC1 BRISC: connection to R1 partner (same-column, link_idx=1)
+                print(f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC link_idx=1")
+                conn_args_fc1 = ttnn.setup_fabric_connection(
+                    fabric_node_id,
+                    partners[1]["fabric_node_id"],
+                    1,
+                    program,
+                    fc1,
+                )
+                program.kernels[fc1_group.brisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(conn_args_fc1)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) BRISC conn_args count={len(conn_args_fc1)}"
+                )
+
+                # FC1 NCRISC: connection to R3 partner (cross-column, link_idx=1)
+                r3_conn_args = ttnn.setup_fabric_connection(
+                    fabric_node_id,
+                    partners[3]["fabric_node_id"],
+                    1,
+                    program,
+                    fc1,
+                )
+                program.kernels[fc1_group.ncrisc_kernel_index].runtime_args[fc1.x][fc1.y].extend(r3_conn_args)
+                print(
+                    f"[ReduceToAllB1] dev({row},{col}) FC1({fc1.x},{fc1.y}) NCRISC R3 conn_args count={len(r3_conn_args)}"
+                )
+
+                mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+        input_list = [
+            input_tensor_mesh,
+            output_tensor,
+            intermediate_tensor,
+        ]
+        print(f"[ReduceToAllB1] calling generic_op...")
+        ttnn.generic_op(input_list, mesh_program_descriptor)
+        print(f"[ReduceToAllB1] generic_op returned")
+
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_all_b1/op.py
@@ -89,7 +89,7 @@ class ReduceToAllB1:
             compute_tile_height * compute_tile_width
         )
 
-        packet_header_size_bytes = 96
+        packet_header_size_bytes = ttnn.get_tt_fabric_packet_header_size_bytes()
         slot_size_bytes = packet_header_size_bytes + payload_size_bytes
 
         # CB indices

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for ReduceToAllB1 operation.
+
+This test validates the 3-round hypercube all-reduce for a 4x2 mesh,
+checking that every device holds the correct sum of all 8 inputs.
+"""
+
+import pytest
+import torch
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.common.utility_functions import skip_for_wormhole_b0
+from models.demos.deepseek_v3_b1.micro_ops.reduce_to_all_b1.op import ReduceToAllB1
+from models.perf.benchmarking_utils import BenchmarkProfiler
+
+
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
+def setup_reduce_to_all_test(mesh_device):
+    """Common setup for reduce_to_all tests. Returns test configuration."""
+    logger.info(f"mesh_device shape: {mesh_device.shape}")
+    logger.info(f"mesh_device num_devices: {mesh_device.get_num_devices()}")
+
+    mesh_rows, mesh_cols = mesh_device.shape
+    if mesh_rows * mesh_cols < 8:
+        pytest.skip(f"Need at least 8 devices, got {mesh_rows * mesh_cols}")
+    logger.info(f"Mesh is {mesh_rows}x{mesh_cols} = {mesh_rows * mesh_cols} devices")
+
+    num_devices = 8
+    submesh_device = mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    logger.info(f"Created submesh with shape: {submesh_device.shape}")
+    assert submesh_device.shape == ttnn.MeshShape((4, 2)), f"Expected 4x2 mesh, got {submesh_device.shape}"
+
+    # Same tensor shape/sharding as reduce_to_one_b1
+    tensor_shape = [1, 7168]
+    dtype = ttnn.bfloat16
+    layout = ttnn.TILE_LAYOUT
+    tile = ttnn.Tile((1, 32))
+
+    compute_cores = submesh_device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+    num_cores = len(compute_cores)
+    logger.info(f"Using {num_cores} optimal DRAM cores: {compute_cores[:8]}")
+
+    num_shard_cores = 8
+    shard_cores_list = compute_cores[:num_shard_cores]
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in shard_cores_list})
+
+    shard_shape = [1, 896]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec)
+
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh_device.shape)
+    mesh_mapper = ttnn.create_mesh_mapper(submesh_device, mesh_mapper_config)
+
+    # Intermediate tensor: 3× shard width (3-page CB for received data)
+    intermediate_shard_shape = [1, shard_shape[1] * 3]
+    intermediate_tensor_shape = [1, tensor_shape[1] * 3]
+    intermediate_shard_spec = ttnn.ShardSpec(shard_grid, intermediate_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    intermediate_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, intermediate_shard_spec
+    )
+    intermediate_data = torch.zeros([4, 2] + intermediate_tensor_shape, dtype=torch.bfloat16)
+    intermediate_tensor = ttnn.from_torch(
+        intermediate_data,
+        device=submesh_device,
+        layout=layout,
+        tile=tile,
+        dtype=dtype,
+        memory_config=intermediate_mem_config,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # Output tensor: SAME sharding as input (all devices get the result)
+    output_data = torch.zeros([4, 2] + tensor_shape, dtype=torch.bfloat16)
+    output_tensor = ttnn.from_torch(
+        output_data,
+        device=submesh_device,
+        layout=layout,
+        tile=tile,
+        dtype=dtype,
+        memory_config=mem_config,
+        mesh_mapper=mesh_mapper,
+    )
+    logger.info("Created output tensor with same sharding as input (all devices)")
+
+    # Random input data
+    data_per_device = []
+    torch.manual_seed(42)
+    for _ in range(num_devices):
+        data = torch.randn(tensor_shape, dtype=torch.bfloat16)
+        data_per_device.append(data)
+
+    data_all = torch.stack(data_per_device, dim=0).reshape(4, 2, *tensor_shape)
+
+    input_tensor = ttnn.from_torch(
+        data_all,
+        device=submesh_device,
+        layout=layout,
+        tile=tile,
+        dtype=dtype,
+        memory_config=mem_config,
+        mesh_mapper=mesh_mapper,
+    )
+
+    ref_output = ReduceToAllB1.golden(data_per_device)
+
+    # 3 semaphores (one per reduction round)
+    compute_grid = submesh_device.compute_with_storage_grid_size()
+    available_cores = ttnn.num_cores_to_corerangeset(compute_grid.x * compute_grid.y, compute_grid, row_wise=True)
+    ttnn.synchronize_device(submesh_device)
+    semaphores = [ttnn.create_global_semaphore(submesh_device, available_cores, 0) for _ in range(3)]
+    ttnn.synchronize_device(submesh_device)
+
+    return {
+        "submesh_device": submesh_device,
+        "input_tensor": input_tensor,
+        "intermediate_tensor": intermediate_tensor,
+        "output_tensor": output_tensor,
+        "ref_output": ref_output,
+        "semaphores": semaphores,
+    }
+
+
+def verify_output(output_tensor, submesh_device, ref_output):
+    """Verify output matches reference on ALL devices."""
+    output_torch = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh_device, dim=0))
+
+    num_devices = submesh_device.shape[0] * submesh_device.shape[1]
+    rtol = 0.01
+    atol = 0.05
+    ref_flat = ref_output.flatten()
+
+    all_match = True
+    for device_idx in range(num_devices):
+        output_device = output_torch[device_idx].flatten()
+        match = torch.allclose(output_device, ref_flat, rtol=rtol, atol=atol)
+
+        row = device_idx // submesh_device.shape[1]
+        col = device_idx % submesh_device.shape[1]
+        if not match:
+            diff = torch.abs(output_device - ref_flat)
+            print(
+                f"Device ({row},{col}) idx={device_idx}: MISMATCH  max_diff={diff.max():.6f}  mean_diff={diff.mean():.6f}"
+            )
+            print(f"  ref[:8]   = {ref_flat[:8]}")
+            print(f"  got[:8]   = {output_device[:8]}")
+            all_match = False
+        else:
+            print(f"Device ({row},{col}) idx={device_idx}: OK")
+
+    return all_match
+
+
+def run_reduce_to_all(mesh_device, num_iterations=1):
+    """Run reduce_to_all test."""
+    print(f"\n=== Testing reduce_to_all (num_iterations={num_iterations}) ===")
+
+    config = setup_reduce_to_all_test(mesh_device)
+
+    print(f"Running reduce_to_all with {num_iterations} iterations...")
+    output_tensor = ReduceToAllB1.op(
+        config["input_tensor"],
+        config["intermediate_tensor"],
+        config["output_tensor"],
+        config["semaphores"],
+        num_iterations=num_iterations,
+    )
+    ttnn.synchronize_device(config["submesh_device"])
+
+    print("\nVerifying output on all devices...")
+    match = verify_output(
+        output_tensor,
+        config["submesh_device"],
+        config["ref_output"],
+    )
+
+    assert match, "Output tensor does not match reference on one or more devices"
+    print("Test passed — all 8 devices hold the correct sum!")
+
+
+def run_reduce_to_all_with_trace(mesh_device):
+    """Run reduce_to_all test with trace capture and replay."""
+    print(f"\n=== Testing reduce_to_all with trace ===")
+
+    config = setup_reduce_to_all_test(mesh_device)
+    submesh_device = config["submesh_device"]
+    input_tensor = config["input_tensor"]
+    intermediate_tensor = config["intermediate_tensor"]
+    output_tensor = config["output_tensor"]
+    ref_output = config["ref_output"]
+    semaphores = config["semaphores"]
+
+    # Compile run
+    print("Running reduce_to_all (compiling)...")
+    output_tensor = ReduceToAllB1.op(input_tensor, intermediate_tensor, output_tensor, semaphores)
+    ttnn.synchronize_device(submesh_device)
+
+    profiler = BenchmarkProfiler()
+
+    def run_iterations(num_iters):
+        for _ in range(num_iters):
+            ReduceToAllB1.op(input_tensor, intermediate_tensor, output_tensor, semaphores)
+
+    # Capture warmup trace
+    logger.info("Capturing warmup trace")
+    trace_id_warmup = ttnn.begin_trace_capture(submesh_device, cq_id=0)
+    run_iterations(15)
+    ttnn.end_trace_capture(submesh_device, trace_id_warmup, cq_id=0)
+    ttnn.synchronize_device(submesh_device)
+
+    # Capture main trace
+    logger.info("Capturing main trace")
+    trace_id = ttnn.begin_trace_capture(submesh_device, cq_id=0)
+    run_iterations(30)
+    ttnn.end_trace_capture(submesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(submesh_device)
+
+    # Execute warmup
+    logger.info("Execute warmup trace")
+    profiler.start("warmup-trace")
+    ttnn.execute_trace(submesh_device, trace_id_warmup, blocking=False)
+    ttnn.release_trace(submesh_device, trace_id_warmup)
+    ttnn.synchronize_device(submesh_device)
+    profiler.end("warmup-trace")
+
+    # Execute main
+    logger.info("Execute main trace")
+    signpost("start")
+    profiler.start("main-trace")
+    ttnn.execute_trace(submesh_device, trace_id, blocking=False)
+    ttnn.release_trace(submesh_device, trace_id)
+    ttnn.synchronize_device(submesh_device)
+    profiler.end("main-trace")
+    signpost("stop")
+
+    # Verify
+    print("\nVerifying trace output on all devices...")
+    match = verify_output(output_tensor, submesh_device, ref_output)
+
+    assert match, "Output tensor does not match reference after trace execution"
+    print("Trace test passed!")
+
+
+# === Tests ===
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize(
+    "device_params",
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
+    indirect=["device_params"],
+    ids=["fabric_2d"],
+)
+def test_reduce_to_all_2d(bh_2d_mesh_device):
+    """Test reduce_to_all with 2D fabric."""
+    run_reduce_to_all(bh_2d_mesh_device)
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize(
+    "device_params",
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
+    indirect=["device_params"],
+    ids=["fabric_2d"],
+)
+def test_reduce_to_all_2d_multi_iter(bh_2d_mesh_device):
+    """Test reduce_to_all with 2D fabric and multiple iterations."""
+    run_reduce_to_all(bh_2d_mesh_device, num_iterations=100)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
@@ -3,10 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Unit tests for ReduceToAllB1 operation.
-
-This test validates the 3-round hypercube all-reduce for a 4x2 mesh,
-checking that every device holds the correct sum of all 8 inputs.
+Unit tests for ReduceToAllB1 operation (Ring + Cross-Column algorithm).
 """
 
 import pytest
@@ -21,7 +18,6 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 
 
 def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
     config = ttnn._ttnn.fabric.FabricRouterConfig()
     config.max_packet_payload_size_bytes = max_payload_size
     return config
@@ -40,18 +36,14 @@ def setup_reduce_to_all_test(mesh_device):
     num_devices = 8
     submesh_device = mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     logger.info(f"Created submesh with shape: {submesh_device.shape}")
-    assert submesh_device.shape == ttnn.MeshShape((4, 2)), f"Expected 4x2 mesh, got {submesh_device.shape}"
+    assert submesh_device.shape == ttnn.MeshShape((4, 2))
 
-    # Same tensor shape/sharding as reduce_to_one_b1
     tensor_shape = [1, 7168]
     dtype = ttnn.bfloat16
     layout = ttnn.TILE_LAYOUT
     tile = ttnn.Tile((1, 32))
 
     compute_cores = submesh_device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
-    num_cores = len(compute_cores)
-    logger.info(f"Using {num_cores} optimal DRAM cores: {compute_cores[:8]}")
-
     num_shard_cores = 8
     shard_cores_list = compute_cores[:num_shard_cores]
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in shard_cores_list})
@@ -63,7 +55,7 @@ def setup_reduce_to_all_test(mesh_device):
     mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], submesh_device.shape)
     mesh_mapper = ttnn.create_mesh_mapper(submesh_device, mesh_mapper_config)
 
-    # Intermediate tensor: 3× shard width (3-page CB for received data)
+    # Intermediate tensor: 3x shard width (R1/R2/R3 receive buffers)
     intermediate_shard_shape = [1, shard_shape[1] * 3]
     intermediate_tensor_shape = [1, tensor_shape[1] * 3]
     intermediate_shard_spec = ttnn.ShardSpec(shard_grid, intermediate_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
@@ -81,7 +73,6 @@ def setup_reduce_to_all_test(mesh_device):
         mesh_mapper=mesh_mapper,
     )
 
-    # Output tensor: SAME sharding as input (all devices get the result)
     output_data = torch.zeros([4, 2] + tensor_shape, dtype=torch.bfloat16)
     output_tensor = ttnn.from_torch(
         output_data,
@@ -92,7 +83,6 @@ def setup_reduce_to_all_test(mesh_device):
         memory_config=mem_config,
         mesh_mapper=mesh_mapper,
     )
-    logger.info("Created output tensor with same sharding as input (all devices)")
 
     # Random input data
     data_per_device = []
@@ -102,7 +92,6 @@ def setup_reduce_to_all_test(mesh_device):
         data_per_device.append(data)
 
     data_all = torch.stack(data_per_device, dim=0).reshape(4, 2, *tensor_shape)
-
     input_tensor = ttnn.from_torch(
         data_all,
         device=submesh_device,
@@ -115,11 +104,29 @@ def setup_reduce_to_all_test(mesh_device):
 
     ref_output = ReduceToAllB1.golden(data_per_device)
 
-    # 3 semaphores (one per reduction round)
+    # Create semaphores (all trace-safe — created before trace capture)
     compute_grid = submesh_device.compute_with_storage_grid_size()
-    available_cores = ttnn.num_cores_to_corerangeset(compute_grid.x * compute_grid.y, compute_grid, row_wise=True)
+    available_cores = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid.x - 1, compute_grid.y - 1))]
+    )
     ttnn.synchronize_device(submesh_device)
+
+    # 3 round receive semaphores
     semaphores = [ttnn.create_global_semaphore(submesh_device, available_cores, 0) for _ in range(3)]
+
+    # 4 bitmask forwarding semaphores (matching sdpa_reduce_to_all pattern)
+    fwd_r1_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+    fwd_r2_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+    bwd_r1_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+    bwd_r2_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+    r3_fwd_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
+
+    fwd_r1_sem_addr = ttnn.get_global_semaphore_address(fwd_r1_gs)
+    fwd_r2_sem_addr = ttnn.get_global_semaphore_address(fwd_r2_gs)
+    bwd_r1_sem_addr = ttnn.get_global_semaphore_address(bwd_r1_gs)
+    bwd_r2_sem_addr = ttnn.get_global_semaphore_address(bwd_r2_gs)
+    r3_fwd_sem_addr = ttnn.get_global_semaphore_address(r3_fwd_gs)
+
     ttnn.synchronize_device(submesh_device)
 
     return {
@@ -129,6 +136,11 @@ def setup_reduce_to_all_test(mesh_device):
         "output_tensor": output_tensor,
         "ref_output": ref_output,
         "semaphores": semaphores,
+        "fwd_r1_sem_addr": fwd_r1_sem_addr,
+        "fwd_r2_sem_addr": fwd_r2_sem_addr,
+        "bwd_r1_sem_addr": bwd_r1_sem_addr,
+        "bwd_r2_sem_addr": bwd_r2_sem_addr,
+        "r3_fwd_sem_addr": r3_fwd_sem_addr,
     }
 
 
@@ -150,76 +162,84 @@ def verify_output(output_tensor, submesh_device, ref_output):
         col = device_idx % submesh_device.shape[1]
         if not match:
             diff = torch.abs(output_device - ref_flat)
-            print(
+            logger.warning(
                 f"Device ({row},{col}) idx={device_idx}: MISMATCH  max_diff={diff.max():.6f}  mean_diff={diff.mean():.6f}"
             )
-            print(f"  ref[:8]   = {ref_flat[:8]}")
-            print(f"  got[:8]   = {output_device[:8]}")
+            logger.warning(f"  ref[:8]   = {ref_flat[:8]}")
+            logger.warning(f"  got[:8]   = {output_device[:8]}")
             all_match = False
         else:
-            print(f"Device ({row},{col}) idx={device_idx}: OK")
+            logger.info(f"Device ({row},{col}) idx={device_idx}: OK")
 
     return all_match
 
 
+def _call_op(config):
+    """Helper to call ReduceToAllB1.op with the config dict."""
+    return ReduceToAllB1.op(
+        config["input_tensor"],
+        config["intermediate_tensor"],
+        config["output_tensor"],
+        config["semaphores"],
+        config["fwd_r1_sem_addr"],
+        config["fwd_r2_sem_addr"],
+        config["bwd_r1_sem_addr"],
+        config["bwd_r2_sem_addr"],
+        config["r3_fwd_sem_addr"],
+    )
+
+
 def run_reduce_to_all(mesh_device, num_iterations=1):
     """Run reduce_to_all test."""
-    print(f"\n=== Testing reduce_to_all (num_iterations={num_iterations}) ===")
-
+    logger.info(f"Testing reduce_to_all (num_iterations={num_iterations})")
     config = setup_reduce_to_all_test(mesh_device)
 
-    print(f"Running reduce_to_all with {num_iterations} iterations...")
+    logger.info(f"Running reduce_to_all with {num_iterations} iterations...")
     output_tensor = ReduceToAllB1.op(
         config["input_tensor"],
         config["intermediate_tensor"],
         config["output_tensor"],
         config["semaphores"],
+        config["fwd_r1_sem_addr"],
+        config["fwd_r2_sem_addr"],
+        config["bwd_r1_sem_addr"],
+        config["bwd_r2_sem_addr"],
+        config["r3_fwd_sem_addr"],
         num_iterations=num_iterations,
     )
     ttnn.synchronize_device(config["submesh_device"])
 
-    print("\nVerifying output on all devices...")
-    match = verify_output(
-        output_tensor,
-        config["submesh_device"],
-        config["ref_output"],
-    )
-
+    logger.info("Verifying output on all devices...")
+    match = verify_output(output_tensor, config["submesh_device"], config["ref_output"])
     assert match, "Output tensor does not match reference on one or more devices"
-    print("Test passed — all 8 devices hold the correct sum!")
+    logger.info("Test passed — all 8 devices hold the correct sum!")
 
 
 def run_reduce_to_all_with_trace(mesh_device):
     """Run reduce_to_all test with trace capture and replay."""
-    print(f"\n=== Testing reduce_to_all with trace ===")
-
+    logger.info("Testing reduce_to_all with trace")
     config = setup_reduce_to_all_test(mesh_device)
     submesh_device = config["submesh_device"]
-    input_tensor = config["input_tensor"]
-    intermediate_tensor = config["intermediate_tensor"]
-    output_tensor = config["output_tensor"]
-    ref_output = config["ref_output"]
-    semaphores = config["semaphores"]
 
-    # Compile run
-    print("Running reduce_to_all (compiling)...")
-    output_tensor = ReduceToAllB1.op(input_tensor, intermediate_tensor, output_tensor, semaphores)
+    # Compile run (outside trace)
+    logger.info("Running reduce_to_all (compiling)...")
+    _call_op(config)
     ttnn.synchronize_device(submesh_device)
 
     profiler = BenchmarkProfiler()
 
-    def run_iterations(num_iters):
-        for _ in range(num_iters):
-            ReduceToAllB1.op(input_tensor, intermediate_tensor, output_tensor, semaphores)
+    def run_iterations(n):
+        for _ in range(n):
+            _call_op(config)
 
-    # Capture warmup trace
+    # Warmup trace
     logger.info("Capturing warmup trace")
     trace_id_warmup = ttnn.begin_trace_capture(submesh_device, cq_id=0)
     run_iterations(15)
     ttnn.end_trace_capture(submesh_device, trace_id_warmup, cq_id=0)
     ttnn.synchronize_device(submesh_device)
 
-    # Capture main trace
+    # Main trace
     logger.info("Capturing main trace")
     trace_id = ttnn.begin_trace_capture(submesh_device, cq_id=0)
     run_iterations(30)
@@ -245,33 +265,65 @@ def run_reduce_to_all_with_trace(mesh_device):
     signpost("stop")
 
     # Verify
-    print("\nVerifying trace output on all devices...")
-    match = verify_output(output_tensor, submesh_device, ref_output)
-
+    logger.info("Verifying trace output on all devices...")
+    match = verify_output(config["output_tensor"], submesh_device, config["ref_output"])
     assert match, "Output tensor does not match reference after trace execution"
-    print("Trace test passed!")
+    logger.info("Trace test passed!")
 
 
 # === Tests ===
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+                "fabric_router_config": create_fabric_router_config(15232),
+            }
+        )
+    ],
     indirect=["device_params"],
-    ids=["fabric_2d"],
+    ids=["fabric_2d_torus_x"],
 )
 def test_reduce_to_all_2d(bh_2d_mesh_device):
-    """Test reduce_to_all with 2D fabric."""
+    """Test reduce_to_all with 2D torus-X fabric (ring wrap-around in column direction)."""
     run_reduce_to_all(bh_2d_mesh_device)
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+                "fabric_router_config": create_fabric_router_config(15232),
+            }
+        )
+    ],
     indirect=["device_params"],
-    ids=["fabric_2d"],
+    ids=["fabric_2d_torus_x"],
 )
 def test_reduce_to_all_2d_multi_iter(bh_2d_mesh_device):
-    """Test reduce_to_all with 2D fabric and multiple iterations."""
+    """Test reduce_to_all with 2D torus-X fabric and multiple iterations."""
     run_reduce_to_all(bh_2d_mesh_device, num_iterations=100)
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+                "fabric_router_config": create_fabric_router_config(15232),
+            }
+        )
+    ],
+    indirect=["device_params"],
+    ids=["fabric_2d_torus_x"],
+)
+def test_reduce_to_all_2d_trace(bh_2d_mesh_device):
+    """Test reduce_to_all with 2D torus-X fabric using trace capture and replay."""
+    run_reduce_to_all_with_trace(bh_2d_mesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
@@ -9,12 +9,10 @@ Unit tests for ReduceToAllB1 operation (Ring + Cross-Column algorithm).
 import pytest
 import torch
 from loguru import logger
-from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.micro_ops.reduce_to_all_b1.op import ReduceToAllB1
-from models.perf.benchmarking_utils import BenchmarkProfiler
 
 
 def create_fabric_router_config(max_payload_size):
@@ -187,62 +185,6 @@ def run_reduce_to_all(mesh_device, num_iterations=1):
     logger.info("Test passed — all 8 devices hold the correct sum!")
 
 
-def run_reduce_to_all_with_trace(mesh_device):
-    """Run reduce_to_all test with trace capture and replay."""
-    logger.info("Testing reduce_to_all with trace")
-    config = setup_reduce_to_all_test(mesh_device)
-    submesh_device = config["submesh_device"]
-
-    # Compile run (outside trace)
-    logger.info("Running reduce_to_all (compiling)...")
-    _call_op(config)
-    ttnn.synchronize_device(submesh_device)
-
-    profiler = BenchmarkProfiler()
-
-    def run_iterations(n):
-        for _ in range(n):
-            _call_op(config)
-
-    # Warmup trace
-    logger.info("Capturing warmup trace")
-    trace_id_warmup = ttnn.begin_trace_capture(submesh_device, cq_id=0)
-    run_iterations(15)
-    ttnn.end_trace_capture(submesh_device, trace_id_warmup, cq_id=0)
-    ttnn.synchronize_device(submesh_device)
-
-    # Main trace
-    logger.info("Capturing main trace")
-    trace_id = ttnn.begin_trace_capture(submesh_device, cq_id=0)
-    run_iterations(30)
-    ttnn.end_trace_capture(submesh_device, trace_id, cq_id=0)
-    ttnn.synchronize_device(submesh_device)
-
-    # Execute warmup
-    logger.info("Execute warmup trace")
-    profiler.start("warmup-trace")
-    ttnn.execute_trace(submesh_device, trace_id_warmup, blocking=False)
-    ttnn.release_trace(submesh_device, trace_id_warmup)
-    ttnn.synchronize_device(submesh_device)
-    profiler.end("warmup-trace")
-
-    # Execute main
-    logger.info("Execute main trace")
-    signpost("start")
-    profiler.start("main-trace")
-    ttnn.execute_trace(submesh_device, trace_id, blocking=False)
-    ttnn.release_trace(submesh_device, trace_id)
-    ttnn.synchronize_device(submesh_device)
-    profiler.end("main-trace")
-    signpost("stop")
-
-    # Verify
-    logger.info("Verifying trace output on all devices...")
-    match = verify_output(config["output_tensor"], submesh_device, config["ref_output"])
-    assert match, "Output tensor does not match reference after trace execution"
-    logger.info("Trace test passed!")
-
-
 # === Tests ===
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
@@ -280,22 +222,3 @@ def test_reduce_to_all_2d(bh_2d_mesh_device):
 def test_reduce_to_all_2d_multi_iter(bh_2d_mesh_device):
     """Test reduce_to_all with 2D torus-X fabric and multiple iterations."""
     run_reduce_to_all(bh_2d_mesh_device, num_iterations=100)
-
-
-@skip_for_wormhole_b0("This test is for blackhole")
-@pytest.mark.parametrize(
-    "device_params",
-    [
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-                "fabric_router_config": create_fabric_router_config(15232),
-            }
-        )
-    ],
-    indirect=["device_params"],
-    ids=["fabric_2d_torus_x"],
-)
-def test_reduce_to_all_2d_trace(bh_2d_mesh_device):
-    """Test reduce_to_all with 2D torus-X fabric using trace capture and replay."""
-    run_reduce_to_all_with_trace(bh_2d_mesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
@@ -104,28 +104,15 @@ def setup_reduce_to_all_test(mesh_device):
 
     ref_output = ReduceToAllB1.golden(data_per_device)
 
-    # Create semaphores (all trace-safe — created before trace capture)
+    # Create global semaphores for round receive (trace-safe — created before trace capture)
     compute_grid = submesh_device.compute_with_storage_grid_size()
     available_cores = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid.x - 1, compute_grid.y - 1))]
     )
     ttnn.synchronize_device(submesh_device)
 
-    # 3 round receive semaphores
+    # 3 round receive semaphores (global — incremented by remote fabric packets)
     semaphores = [ttnn.create_global_semaphore(submesh_device, available_cores, 0) for _ in range(3)]
-
-    # 4 bitmask forwarding semaphores (matching sdpa_reduce_to_all pattern)
-    fwd_r1_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
-    fwd_r2_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
-    bwd_r1_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
-    bwd_r2_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
-    r3_fwd_gs = ttnn.create_global_semaphore(submesh_device, available_cores, 0)
-
-    fwd_r1_sem_addr = ttnn.get_global_semaphore_address(fwd_r1_gs)
-    fwd_r2_sem_addr = ttnn.get_global_semaphore_address(fwd_r2_gs)
-    bwd_r1_sem_addr = ttnn.get_global_semaphore_address(bwd_r1_gs)
-    bwd_r2_sem_addr = ttnn.get_global_semaphore_address(bwd_r2_gs)
-    r3_fwd_sem_addr = ttnn.get_global_semaphore_address(r3_fwd_gs)
 
     ttnn.synchronize_device(submesh_device)
 
@@ -136,11 +123,6 @@ def setup_reduce_to_all_test(mesh_device):
         "output_tensor": output_tensor,
         "ref_output": ref_output,
         "semaphores": semaphores,
-        "fwd_r1_sem_addr": fwd_r1_sem_addr,
-        "fwd_r2_sem_addr": fwd_r2_sem_addr,
-        "bwd_r1_sem_addr": bwd_r1_sem_addr,
-        "bwd_r2_sem_addr": bwd_r2_sem_addr,
-        "r3_fwd_sem_addr": r3_fwd_sem_addr,
     }
 
 
@@ -181,11 +163,6 @@ def _call_op(config):
         config["intermediate_tensor"],
         config["output_tensor"],
         config["semaphores"],
-        config["fwd_r1_sem_addr"],
-        config["fwd_r2_sem_addr"],
-        config["bwd_r1_sem_addr"],
-        config["bwd_r2_sem_addr"],
-        config["r3_fwd_sem_addr"],
     )
 
 
@@ -200,11 +177,6 @@ def run_reduce_to_all(mesh_device, num_iterations=1):
         config["intermediate_tensor"],
         config["output_tensor"],
         config["semaphores"],
-        config["fwd_r1_sem_addr"],
-        config["fwd_r2_sem_addr"],
-        config["bwd_r1_sem_addr"],
-        config["bwd_r2_sem_addr"],
-        config["r3_fwd_sem_addr"],
         num_iterations=num_iterations,
     )
     ttnn.synchronize_device(config["submesh_device"])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_all_b1.py
@@ -125,7 +125,7 @@ def setup_reduce_to_all_test(mesh_device):
 
 
 def verify_output(output_tensor, submesh_device, ref_output):
-    """Verify output matches reference on ALL devices."""
+    """Verify output matches reference on ALL devices AND all devices are identical."""
     output_torch = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ConcatMeshToTensor(submesh_device, dim=0))
 
     num_devices = submesh_device.shape[0] * submesh_device.shape[1]
@@ -134,6 +134,8 @@ def verify_output(output_tensor, submesh_device, ref_output):
     ref_flat = ref_output.flatten()
 
     all_match = True
+
+    # 1) Check each device against the golden reference
     for device_idx in range(num_devices):
         output_device = output_torch[device_idx].flatten()
         match = torch.allclose(output_device, ref_flat, rtol=rtol, atol=atol)
@@ -149,7 +151,27 @@ def verify_output(output_tensor, submesh_device, ref_output):
             logger.warning(f"  got[:8]   = {output_device[:8]}")
             all_match = False
         else:
-            logger.info(f"Device ({row},{col}) idx={device_idx}: OK")
+            logger.info(f"Device ({row},{col}) idx={device_idx}: OK vs golden")
+
+    # 2) Cross-device consistency: all devices must produce identical results.
+    device0_output = output_torch[0].flatten()
+    for device_idx in range(1, num_devices):
+        output_device = output_torch[device_idx].flatten()
+        if not torch.equal(device0_output, output_device):
+            diff = torch.abs(device0_output - output_device)
+            nonzero_mask = diff > 0
+            num_mismatched = nonzero_mask.sum().item()
+            row = device_idx // submesh_device.shape[1]
+            col = device_idx % submesh_device.shape[1]
+            logger.warning(
+                f"Device (0,0) vs ({row},{col}): NOT identical — "
+                f"{num_mismatched} elements differ, max_diff={diff.max():.6f}"
+            )
+            all_match = False
+        else:
+            row = device_idx // submesh_device.shape[1]
+            col = device_idx % submesh_device.shape[1]
+            logger.info(f"Device (0,0) vs ({row},{col}): identical")
 
     return all_match
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -4,28 +4,21 @@
 #pragma once
 
 /**
- * Unified Reduce-to-All B1 Operation
+ * Unified Reduce-to-All B1 — Ring + Cross-Column (modelled on sdpa_reduce_to_all)
  *
- * Performs 3-round hypercube all-reduce across a 4x2 mesh so that every
- * device ends up with the sum of all 8 inputs.
+ * Phase 1 — Column all-reduce (2-round ring, A/B split, all 1-hop):
+ *   Type A workers: R1 → FWD (row+1), R2 → BWD (row-1)
+ *   Type B workers: R1 → BWD (row-1), R2 → FWD (row+1)
+ *   FC BRISC: single connection to FWD neighbor, forwards R1(A) + R2(B)
+ *   FC NCRISC: single connection to BWD neighbor, forwards R1(B) + R2(A)
  *
- * Each round, every device simultaneously sends to and receives from a
- * partner determined by XOR-ing one dimension of the device index:
+ * Phase 2 — Cross-column exchange (FC-forwarded):
+ *   Workers write R3 to FC's R3 buffer area, signal r3_fwd_sem bitmask.
+ *   FC BRISC closes FWD conn, opens cross-column conn, forwards R3.
  *
- *   Round 1 (adjacent rows):  (row, col) <-> (row^1, col)
- *   Round 2 (2-apart rows):   (row, col) <-> (row^2, col)
- *   Round 3 (cross-column):   (row, col) <-> (row, col^1)
- *
- * TRISC uses add_tiles (CB-to-CB add) each round with a reload_cb to
- * carry the accumulated partial sum across rounds.  tile_regs_commit/
- * wait/release provide explicit MATH↔PACK sync; the release zeros the
- * current dest half, so reload_cb stores the intermediate result for
- * the next round's add_tiles to re-read.
- *
- * R1/R2 are forwarded by BRISC on each fabric core via its same-column
- * EDM connection.  R3 is forwarded by NCRISC on FC1 (link_idx=1) via a
- * separate cross-column EDM connection, avoiding the circular deadlock
- * that occurs when R3 shares the same-column link.
+ * After both phases every device holds sum(all 8 inputs).
+ * All Phase 1 traffic is exactly 1 hop (ring/torus topology).
+ * Requires FABRIC_2D_TORUS_X for the wrap-around link.
  */
 
 #include "kernel_op_api.hpp"
@@ -34,22 +27,22 @@
 #if defined(COMPILE_FOR_BRISC)
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "api/socket_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
-#include "api/debug/dprint.h"
 
 #elif defined(COMPILE_FOR_NCRISC)
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "api/socket_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
-#include "api/debug/dprint.h"
 
 #elif defined(COMPILE_FOR_TRISC)
 #include "api/compute/compute_kernel_api.h"
@@ -61,34 +54,35 @@
 namespace deepseek_b1_ops {
 
 struct ReduceToAllB1 {
-    // ========================================================================
-    // Compile-time args structs
-    // ========================================================================
+    // ================================================================
+    // Compile-time args
+    // ================================================================
 
     template <
         uint32_t numTiles,
         uint32_t localCb,
         uint32_t receivedCb,
         uint32_t isFabricCore,
-        uint32_t deferR3Send,
-        uint32_t numWorkers,
+        uint32_t slotsPerDirection,
         uint32_t slotSizeBytes,
         uint32_t packetCb,
         uint32_t payloadSizeBytes,
-        uint32_t isR3Forwarder,
-        uint32_t numR3Workers>
+        uint32_t r2BufferOffset,
+        uint32_t ncriscBufferOffset>
     struct ReaderCTArgs {
         static constexpr uint32_t num_tiles = numTiles;
         static constexpr uint32_t local_cb = localCb;
         static constexpr uint32_t received_cb = receivedCb;
         static constexpr uint32_t is_fabric_core = isFabricCore;
-        static constexpr uint32_t defer_r3_send = deferR3Send;
-        static constexpr uint32_t num_workers = numWorkers;
+        static constexpr uint32_t slots_per_direction = slotsPerDirection;
         static constexpr uint32_t slot_size_bytes = slotSizeBytes;
         static constexpr uint32_t packet_cb = packetCb;
         static constexpr uint32_t payload_size_bytes = payloadSizeBytes;
-        static constexpr uint32_t is_r3_forwarder = isR3Forwarder;
-        static constexpr uint32_t num_r3_workers = numR3Workers;
+        static constexpr uint32_t r2_buffer_offset = r2BufferOffset;
+        static constexpr uint32_t ncrisc_buffer_offset = ncriscBufferOffset;
+
+        static constexpr uint32_t all_sent_mask =
+            (slotsPerDirection == 32) ? 0xFFFF'FFFFu : ((1u << slotsPerDirection) - 1u);
     };
 
     template <
@@ -97,32 +91,45 @@ struct ReduceToAllB1 {
         uint32_t localCb,
         uint32_t scratchCb,
         uint32_t packetCb,
-        uint32_t numWorkers,
         uint32_t slotSizeBytes,
         uint32_t isFabricCore,
-        uint32_t r1DstChipId,
-        uint32_t r1DstMeshId,
-        uint32_t r2DstChipId,
-        uint32_t r2DstMeshId,
+        uint32_t fwdDstChipId,
+        uint32_t fwdDstMeshId,
+        uint32_t bwdDstChipId,
+        uint32_t bwdDstMeshId,
         uint32_t r3DstChipId,
         uint32_t r3DstMeshId,
-        uint32_t deferR3Send>
+        uint32_t reloadCb,
+        uint32_t computeTileSize,
+        uint32_t slotsPerDirection,
+        uint32_t r2BufferOffset,
+        uint32_t ncriscBufferOffset,
+        uint32_t r3BufferOffset>
     struct WriterCTArgs {
         static constexpr uint32_t num_tiles = numTiles;
         static constexpr uint32_t payload_size_bytes = payloadSizeBytes;
         static constexpr uint32_t local_cb = localCb;
         static constexpr uint32_t scratch_cb = scratchCb;
         static constexpr uint32_t packet_cb = packetCb;
-        static constexpr uint32_t num_workers = numWorkers;
         static constexpr uint32_t slot_size_bytes = slotSizeBytes;
         static constexpr uint32_t is_fabric_core = isFabricCore;
-        static constexpr uint32_t r1_dst_chip_id = r1DstChipId;
-        static constexpr uint32_t r1_dst_mesh_id = r1DstMeshId;
-        static constexpr uint32_t r2_dst_chip_id = r2DstChipId;
-        static constexpr uint32_t r2_dst_mesh_id = r2DstMeshId;
+        static constexpr uint32_t fwd_dst_chip_id = fwdDstChipId;
+        static constexpr uint32_t fwd_dst_mesh_id = fwdDstMeshId;
+        static constexpr uint32_t bwd_dst_chip_id = bwdDstChipId;
+        static constexpr uint32_t bwd_dst_mesh_id = bwdDstMeshId;
         static constexpr uint32_t r3_dst_chip_id = r3DstChipId;
         static constexpr uint32_t r3_dst_mesh_id = r3DstMeshId;
-        static constexpr uint32_t defer_r3_send = deferR3Send;
+        static constexpr uint32_t reload_cb = reloadCb;
+        static constexpr uint32_t compute_tile_size = computeTileSize;
+        static constexpr uint32_t slots_per_direction = slotsPerDirection;
+        static constexpr uint32_t r2_buffer_offset = r2BufferOffset;
+        static constexpr uint32_t ncrisc_buffer_offset = ncriscBufferOffset;
+        static constexpr uint32_t r3_buffer_offset = r3BufferOffset;
+
+        static constexpr uint32_t all_sent_mask =
+            (slotsPerDirection == 32) ? 0xFFFF'FFFFu : ((1u << slotsPerDirection) - 1u);
+        static constexpr uint32_t r3_all_sent_mask =
+            ((2 * slotsPerDirection) == 32) ? 0xFFFF'FFFFu : ((1u << (2 * slotsPerDirection)) - 1u);
     };
 
     template <
@@ -141,22 +148,32 @@ struct ReduceToAllB1 {
         static constexpr uint32_t is_fabric_core = isFabricCore;
     };
 
-    // ========================================================================
-    // Runtime args structs
-    // ========================================================================
+    // ================================================================
+    // Runtime args
+    // ================================================================
 
     struct ReaderArgs {
         uint32_t recv_sem_round1;
         uint32_t recv_sem_round2;
         uint32_t recv_sem_round3;
-        uint32_t r3_gate_addr;
+    };
+
+    // FC forwarder runtime args (both BRISC and NCRISC)
+    struct ForwarderArgs {
+        uint32_t r1_sem_addr;
+        uint32_t r2_sem_addr;
     };
 
     struct WorkerWriterArgs {
-        uint32_t fabric_core_noc_x;
-        uint32_t fabric_core_noc_y;
-        uint32_t my_slot_idx;
-        uint32_t worker_sem_addr;
+        uint32_t fc_noc_x;
+        uint32_t fc_noc_y;
+        uint32_t is_type_a;
+        uint32_t r1_slot_offset;  // byte offset from packet_cb base
+        uint32_t r1_slot_bit;     // bitmask bit to signal
+        uint32_t r1_sem_addr;     // forwarder bitmask sem
+        uint32_t r2_slot_offset;
+        uint32_t r2_slot_bit;
+        uint32_t r2_sem_addr;
         uint32_t r1_dst_l1_addr;
         uint32_t r1_dst_sem_addr;
         uint32_t r2_dst_l1_addr;
@@ -164,26 +181,44 @@ struct ReduceToAllB1 {
         uint32_t r3_dst_l1_addr;
         uint32_t r3_dst_sem_addr;
         uint32_t output_base_addr;
-        uint32_t r3_gate_addr;
-        uint32_t r3_fabric_core_noc_x;
-        uint32_t r3_fabric_core_noc_y;
-        uint32_t r3_slot_idx;
-        uint32_t r3_ncrisc_sem_addr;
+        uint32_t r3_slot_offset;  // byte offset from packet_cb base for R3 FC slot
+        uint32_t r3_slot_bit;     // bitmask bit to signal on r3_fwd_sem
+        uint32_t r3_sem_addr;     // FC's r3 bitmask sem address
     };
 
     struct ComputeArgs {};
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WorkerWriterArgs, ComputeArgs>;
 
-    // ========================================================================
+    // ================================================================
     // Op implementation
-    // ========================================================================
+    // ================================================================
     template <typename CTArgs, bool IsWorkerCore, bool SkipLocalCbPush = false>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
 
     private:
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+        template <typename FabricConnection>
+        static FORCE_INLINE uint32_t process_ready_slots(
+            volatile tt_l1_ptr uint32_t* sem_ptr, uint32_t sent_mask, uint32_t buffer_base, FabricConnection& conn) {
+            uint32_t sem_value = *sem_ptr;
+            uint32_t pending = sem_value & ~sent_mask;
+            while (pending != 0) {
+                uint32_t slot = __builtin_ctz(pending);
+                uint32_t slot_addr = buffer_base + slot * CTArgs::slot_size_bytes;
+                auto* hdr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(slot_addr);
+                uint32_t pkt_bytes = hdr->get_payload_size_including_header();
+                conn.wait_for_empty_write_slot();
+                conn.send_payload_flush_non_blocking_from_address(slot_addr, pkt_bytes);
+                sent_mask |= (1u << slot);
+                pending &= ~(1u << slot);
+            }
+            return sent_mask;
+        }
+#endif
+
 #if defined(COMPILE_FOR_BRISC)
         template <typename packet_header_t>
         static FORCE_INLINE void set_unicast_route(
@@ -195,7 +230,7 @@ struct ReduceToAllB1 {
             }
         }
 
-        static FORCE_INLINE void send_via_fabric(
+        static FORCE_INLINE void send_to_forwarder(
             volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
             uint16_t dst_chip_id,
             uint16_t dst_mesh_id,
@@ -204,9 +239,13 @@ struct ReduceToAllB1 {
             uint32_t dst_l1_addr,
             uint32_t dst_sem_addr,
             uint32_t data_addr,
-            uint64_t header_noc_addr,
-            uint64_t payload_noc_addr,
-            uint64_t arrival_sem_noc_addr) {
+            uint32_t fc_noc_x,
+            uint32_t fc_noc_y,
+            uint32_t fc_slot_offset,
+            uint32_t fc_sem_addr,
+            uint32_t fc_slot_bit) {
+            constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
+
             set_unicast_route(packet_header, dst_chip_id, dst_mesh_id, static_cast<uint16_t>(1));
 
             uint64_t dst_noc_addr = get_noc_addr(my_noc_x, my_noc_y, dst_l1_addr);
@@ -215,10 +254,17 @@ struct ReduceToAllB1 {
                 tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{dst_noc_addr, dst_sem_noc_addr, 1, false},
                 CTArgs::payload_size_bytes);
 
-            constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
-            noc_async_write(reinterpret_cast<uint32_t>(packet_header), header_noc_addr, pkt_hdr_bytes);
-            noc_async_write(data_addr, payload_noc_addr, CTArgs::payload_size_bytes);
-            noc_semaphore_inc(arrival_sem_noc_addr, 1);
+            uint32_t packet_base = get_write_ptr(CTArgs::packet_cb);
+            uint32_t slot_l1 = packet_base + fc_slot_offset;
+            uint64_t slot_hdr_noc = get_noc_addr(fc_noc_x, fc_noc_y, slot_l1);
+            uint64_t slot_pay_noc = get_noc_addr(fc_noc_x, fc_noc_y, slot_l1 + pkt_hdr_bytes);
+
+            noc_async_write(reinterpret_cast<uint32_t>(packet_header), slot_hdr_noc, pkt_hdr_bytes);
+            noc_async_write(data_addr, slot_pay_noc, CTArgs::payload_size_bytes);
+            noc_async_writes_flushed();
+
+            uint64_t sem_noc = get_noc_addr(fc_noc_x, fc_noc_y, fc_sem_addr);
+            noc_semaphore_inc(sem_noc, fc_slot_bit);
             noc_async_write_barrier();
             noc_async_atomic_barrier();
         }
@@ -231,353 +277,209 @@ struct ReduceToAllB1 {
 
 #if defined(COMPILE_FOR_NCRISC)
             // ================================================================
-            // NCRISC — Reader / R3 fabric forwarder
+            // NCRISC — FC: BWD forwarding; Worker: receive R1/R2/R3
             // ================================================================
             if constexpr (CTArgs::is_fabric_core) {
-                if constexpr (CTArgs::is_r3_forwarder) {
-                    DPRINT << "NCRISC FABRIC R3: start, num_r3_workers=" << (uint32_t)CTArgs::num_r3_workers << ENDL();
-                    size_t arg_idx = 0;
-                    uint32_t r3_worker_sems[CTArgs::num_r3_workers];
-                    for (uint32_t i = 0; i < CTArgs::num_r3_workers; i++) {
-                        r3_worker_sems[i] = get_arg_val<uint32_t>(arg_idx++);
-                        DPRINT << "NCRISC FABRIC R3: sem[" << i << "]=" << r3_worker_sems[i] << ENDL();
-                    }
+                // FC NCRISC: forward R1(B) + R2(A) to BWD neighbor
+                // Identical pattern to sdpa_reduce_forwarder.hpp
+                DPRINT << "NCRISC FC BWD start" << ENDL();
 
-                    const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
-                    constexpr uint32_t r3_region_offset = 2 * CTArgs::num_workers * CTArgs::slot_size_bytes;
-                    uint32_t r3_slot_base = packet_buffer_addr + r3_region_offset;
-                    DPRINT << "NCRISC FABRIC R3: pkt_buf=" << packet_buffer_addr << " r3_base=" << r3_slot_base
-                           << ENDL();
+                const uint32_t buf_base = get_write_ptr(CTArgs::packet_cb) + CTArgs::ncrisc_buffer_offset;
+                const uint32_t r1_base = buf_base;
+                const uint32_t r2_base = buf_base + CTArgs::r2_buffer_offset;
 
-                    DPRINT << "NCRISC FABRIC R3: build_from_args, arg_idx=" << (uint32_t)arg_idx << ENDL();
-                    auto fabric_sender =
-                        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
-                    DPRINT << "NCRISC FABRIC R3: opening" << ENDL();
-                    fabric_sender.open();
-                    DPRINT << "NCRISC FABRIC R3: opened" << ENDL();
+                size_t arg_idx = 0;
+                const uint32_t r1_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+                const uint32_t r2_sem_addr = get_arg_val<uint32_t>(arg_idx++);
 
-                    constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
-                    for (uint32_t w = 0; w < CTArgs::num_r3_workers; w++) {
-                        DPRINT << "NCRISC FABRIC R3: waiting worker " << w << " sem @" << r3_worker_sems[w] << ENDL();
-                        volatile tt_l1_ptr uint32_t* sem =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_worker_sems[w]);
-                        noc_semaphore_wait_min(sem, 1);
-                        unified_kernels::semaphore_dec(sem);
-                        DPRINT << "NCRISC FABRIC R3: worker " << w << " sem acquired" << ENDL();
+                auto bwd_sender =
+                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
 
-                        uint32_t hdr_addr = r3_slot_base;
-                        uint32_t payload_addr = r3_slot_base + pkt_hdr_bytes;
+                volatile tt_l1_ptr uint32_t* r1_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r1_sem_addr);
+                volatile tt_l1_ptr uint32_t* r2_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_sem_addr);
 
-                        fabric_sender.wait_for_empty_write_slot();
-                        fabric_sender.send_payload_without_header_non_blocking_from_address(
-                            payload_addr, CTArgs::payload_size_bytes);
-                        fabric_sender.send_payload_flush_blocking_from_address(hdr_addr, pkt_hdr_bytes);
-                        DPRINT << "NCRISC FABRIC R3: worker " << w << " forwarded" << ENDL();
-
-                        r3_slot_base += CTArgs::slot_size_bytes;
-                    }
-
-                    DPRINT << "NCRISC FABRIC R3: closing" << ENDL();
-                    fabric_sender.close();
-                    noc_async_write_barrier();
-                    DPRINT << "NCRISC FABRIC R3: done" << ENDL();
+                bwd_sender.open();
+                DPRINT << "NCRISC FC BWD conn open" << ENDL();
+                {
+                    uint32_t r1_sent = 0;
+                    uint32_t r2_sent = 0;
+                    do {
+                        invalidate_l1_cache();
+                        r1_sent = process_ready_slots(r1_sem, r1_sent, r1_base, bwd_sender);
+                        r2_sent = process_ready_slots(r2_sem, r2_sent, r2_base, bwd_sender);
+                    } while (r1_sent != CTArgs::all_sent_mask || r2_sent != CTArgs::all_sent_mask);
+                    noc_semaphore_set(r1_sem, 0);
+                    noc_semaphore_set(r2_sem, 0);
                 }
+                bwd_sender.close();
+                noc_async_full_barrier();
+                DPRINT << "NCRISC FC BWD done" << ENDL();
                 return;
             }
 
-            DPRINT << "NCRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
-            {
-                volatile tt_l1_ptr uint32_t* r2_sem =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
-                DPRINT << "NCRISC: INIT r2_sem=" << *r2_sem << ENDL();
-            }
-
+            // Worker NCRISC — receive data for 3 rounds
+            DPRINT << "NCRISC worker start" << ENDL();
             if constexpr (!SkipLocalCbPush) {
-                DPRINT << "NCRISC: local_cb reserve_back" << ENDL();
                 cb_reserve_back(CTArgs::local_cb, CTArgs::num_tiles);
                 cb_push_back(CTArgs::local_cb, CTArgs::num_tiles);
-                DPRINT << "NCRISC: local_cb pushed" << ENDL();
             }
 
-            // Round 1
-            DPRINT << "NCRISC: R1 reserve received_cb" << ENDL();
-            cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC: R1 waiting on sem @" << (uint32_t)args.recv_sem_round1 << ENDL();
-            {
-                volatile tt_l1_ptr uint32_t* sem_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round1);
+            auto wait_round = [](uint32_t sem_addr) {
+                volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
                 noc_semaphore_wait_min(sem_ptr, 1);
                 unified_kernels::semaphore_dec(sem_ptr);
-            }
-            {
-                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
-                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
-                DPRINT << "NCRISC: R1 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-            }
-            cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC: R1 received_cb pushed" << ENDL();
+            };
 
-            // Round 2
-            DPRINT << "NCRISC: R2 reserve received_cb" << ENDL();
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
-            {
-                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
-                volatile uint16_t* d_pre = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
-                DPRINT << "NCRISC: R2 PRE-SEM addr=" << recv_addr << " val[0]=0x" << HEX() << (uint32_t)d_pre[0]
-                       << ENDL();
-            }
-            DPRINT << "NCRISC: R2 waiting on sem @" << (uint32_t)args.recv_sem_round2 << ENDL();
-            {
-                volatile tt_l1_ptr uint32_t* sem_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
-                noc_semaphore_wait_min(sem_ptr, 1);
-                unified_kernels::semaphore_dec(sem_ptr);
-            }
-            {
-                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
-                DPRINT << "NCRISC: R2 recv_addr=" << recv_addr << ENDL();
-                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
-                DPRINT << "NCRISC: R2 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-            }
+            wait_round(args.recv_sem_round1);
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC: R2 received_cb pushed" << ENDL();
+            DPRINT << "NCRISC R1 done" << ENDL();
 
-            // Round 3
-            DPRINT << "NCRISC: R3 reserve received_cb" << ENDL();
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC: R3 waiting on sem @" << (uint32_t)args.recv_sem_round3 << ENDL();
-            {
-                volatile tt_l1_ptr uint32_t* sem_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round3);
-                noc_semaphore_wait_min(sem_ptr, 1);
-                unified_kernels::semaphore_dec(sem_ptr);
-            }
-            {
-                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
-                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
-                DPRINT << "NCRISC: R3 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-            }
+            wait_round(args.recv_sem_round2);
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC: R3 received_cb pushed" << ENDL();
+            DPRINT << "NCRISC R2 done" << ENDL();
 
-            if constexpr (CTArgs::defer_r3_send) {
-                volatile tt_l1_ptr uint32_t* gate = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r3_gate_addr);
-                *gate = 1;
-                DPRINT << "NCRISC: R3 gate set" << ENDL();
-            }
-            DPRINT << "NCRISC: done" << ENDL();
+            cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
+            wait_round(args.recv_sem_round3);
+            cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC R3 done" << ENDL();
 
 #elif defined(COMPILE_FOR_BRISC)
             // ================================================================
-            // BRISC — Writer: fabric core forwards R1+R2; worker sends + output
+            // BRISC — FC: FWD + R3 forwarding; Worker: R1/R2/R3 via FC
             // ================================================================
-            constexpr uint32_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
+            constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
 
             if constexpr (CTArgs::is_fabric_core) {
-                // Fabric core BRISC: forward R1 and R2 only (R3 handled by NCRISC on FC1)
-                DPRINT << "BRISC FABRIC: start, num_workers=" << (uint32_t)CTArgs::num_workers << ENDL();
+                DPRINT << "BRISC FC start" << ENDL();
+
+                const uint32_t buf_base = get_write_ptr(CTArgs::packet_cb);
+                const uint32_t r1_base = buf_base;
+                const uint32_t r2_base = buf_base + CTArgs::r2_buffer_offset;
+                const uint32_t r3_base = buf_base + CTArgs::r3_buffer_offset;
+
                 size_t arg_idx = 0;
-                uint32_t worker_sem_addr[CTArgs::num_workers];
-                for (uint32_t i = 0; i < CTArgs::num_workers; i++) {
-                    worker_sem_addr[i] = get_arg_val<uint32_t>(arg_idx++);
-                    DPRINT << "BRISC FABRIC: worker_sem_addr[" << i << "]=" << worker_sem_addr[i] << ENDL();
-                }
-                const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
-                DPRINT << "BRISC FABRIC: packet_buffer_addr=" << packet_buffer_addr << ENDL();
+                const uint32_t r1_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+                const uint32_t r2_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+                const uint32_t r3_sem_addr_val = get_arg_val<uint32_t>(arg_idx++);
 
-                DPRINT << "BRISC FABRIC: build sender_r1, arg_idx=" << (uint32_t)arg_idx << ENDL();
-                auto sender_r1 =
-                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
-                DPRINT << "BRISC FABRIC: build sender_r2, arg_idx=" << (uint32_t)arg_idx << ENDL();
-                auto sender_r2 =
+                auto fwd_sender =
                     tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
 
-                constexpr uint32_t round_stride = CTArgs::num_workers * CTArgs::slot_size_bytes;
+                volatile tt_l1_ptr uint32_t* r1_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r1_sem_addr);
+                volatile tt_l1_ptr uint32_t* r2_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_sem_addr);
+                volatile tt_l1_ptr uint32_t* r3_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_sem_addr_val);
 
-                // R1: use sender_r1 (connection to R1 partner)
-                DPRINT << "BRISC FABRIC: R1 opening sender_r1" << ENDL();
-                sender_r1.open();
+                // Phase 1: forward R1(A)+R2(B) to FWD neighbor
+                fwd_sender.open();
+                DPRINT << "BRISC FC FWD open" << ENDL();
                 {
-                    uint32_t slot_base = packet_buffer_addr;
-                    for (uint32_t worker = 0; worker < CTArgs::num_workers; worker++) {
-                        DPRINT << "BRISC FABRIC: R1 waiting worker " << worker << " sem @" << worker_sem_addr[worker]
-                               << ENDL();
-                        volatile tt_l1_ptr uint32_t* worker_sem_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
-                        noc_semaphore_wait_min(worker_sem_ptr, 1);
-                        unified_kernels::semaphore_dec(worker_sem_ptr);
-                        DPRINT << "BRISC FABRIC: R1 worker " << worker << " sem acquired" << ENDL();
-
-                        uint32_t worker_header_addr = slot_base;
-                        uint32_t worker_payload_addr = slot_base + packet_header_size_bytes;
-
-                        sender_r1.wait_for_empty_write_slot();
-                        sender_r1.send_payload_without_header_non_blocking_from_address(
-                            worker_payload_addr, CTArgs::payload_size_bytes);
-                        sender_r1.send_payload_flush_blocking_from_address(
-                            worker_header_addr, packet_header_size_bytes);
-                        DPRINT << "BRISC FABRIC: R1 worker " << worker << " forwarded" << ENDL();
-
-                        slot_base += CTArgs::slot_size_bytes;
-                    }
+                    uint32_t r1_sent = 0;
+                    uint32_t r2_sent = 0;
+                    do {
+                        invalidate_l1_cache();
+                        r1_sent = process_ready_slots(r1_sem, r1_sent, r1_base, fwd_sender);
+                        r2_sent = process_ready_slots(r2_sem, r2_sent, r2_base, fwd_sender);
+                    } while (r1_sent != CTArgs::all_sent_mask || r2_sent != CTArgs::all_sent_mask);
+                    noc_semaphore_set(r1_sem, 0);
+                    noc_semaphore_set(r2_sem, 0);
                 }
-                DPRINT << "BRISC FABRIC: R1 closing sender_r1" << ENDL();
-                sender_r1.close();
-                noc_async_write_barrier();
+                fwd_sender.close();
+                noc_async_full_barrier();
+                DPRINT << "BRISC FC FWD done" << ENDL();
 
-                // R2: use sender_r2 (connection to R2 partner)
-                DPRINT << "BRISC FABRIC: R2 opening sender_r2" << ENDL();
-                sender_r2.open();
+                // Phase 2: forward R3 to cross-column partner
+                auto r3_sender =
+                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+                r3_sender.open();
+                DPRINT << "BRISC FC R3 open" << ENDL();
                 {
-                    uint32_t slot_base = packet_buffer_addr + round_stride;
-                    for (uint32_t worker = 0; worker < CTArgs::num_workers; worker++) {
-                        DPRINT << "BRISC FABRIC: R2 waiting worker " << worker << " sem @" << worker_sem_addr[worker]
-                               << ENDL();
-                        volatile tt_l1_ptr uint32_t* worker_sem_ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
-                        noc_semaphore_wait_min(worker_sem_ptr, 1);
-                        unified_kernels::semaphore_dec(worker_sem_ptr);
-                        DPRINT << "BRISC FABRIC: R2 worker " << worker << " sem acquired" << ENDL();
-
-                        uint32_t worker_header_addr = slot_base;
-                        uint32_t worker_payload_addr = slot_base + packet_header_size_bytes;
-
-                        sender_r2.wait_for_empty_write_slot();
-                        sender_r2.send_payload_without_header_non_blocking_from_address(
-                            worker_payload_addr, CTArgs::payload_size_bytes);
-                        sender_r2.send_payload_flush_blocking_from_address(
-                            worker_header_addr, packet_header_size_bytes);
-                        DPRINT << "BRISC FABRIC: R2 worker " << worker << " forwarded" << ENDL();
-
-                        slot_base += CTArgs::slot_size_bytes;
-                    }
+                    uint32_t r3_sent = 0;
+                    do {
+                        invalidate_l1_cache();
+                        r3_sent = process_ready_slots(r3_sem, r3_sent, r3_base, r3_sender);
+                    } while (r3_sent != CTArgs::r3_all_sent_mask);
+                    noc_semaphore_set(r3_sem, 0);
                 }
-                DPRINT << "BRISC FABRIC: R2 closing sender_r2" << ENDL();
-                sender_r2.close();
-                noc_async_write_barrier();
-                DPRINT << "BRISC FABRIC: done" << ENDL();
+                r3_sender.close();
+                noc_async_full_barrier();
+                DPRINT << "BRISC FC R3 done" << ENDL();
                 return;
             }
 
             // ----------------------------------------------------------
-            // Worker core: 3 rounds of sending + output write
+            // Worker BRISC: R1 + R2 + R3 via FC forwarders
             // ----------------------------------------------------------
-            DPRINT << "BRISC WORKER: start" << ENDL();
             const uint32_t my_noc_x = my_x[0];
             const uint32_t my_noc_y = my_y[0];
-            const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
-            const uint32_t arrival_sem_addr = args.worker_sem_addr;
-
-            DPRINT << "BRISC WORKER: noc=(" << my_noc_x << "," << my_noc_y << ") slot=" << (uint32_t)args.my_slot_idx
-                   << " fab_core=(" << (uint32_t)args.fabric_core_noc_x << "," << (uint32_t)args.fabric_core_noc_y
-                   << ")" << ENDL();
-            DPRINT << "BRISC WORKER: r3_fab=(" << (uint32_t)args.r3_fabric_core_noc_x << ","
-                   << (uint32_t)args.r3_fabric_core_noc_y << ") r3_slot=" << (uint32_t)args.r3_slot_idx << ENDL();
-            DPRINT << "BRISC WORKER: r1_dst_chip=" << (uint32_t)CTArgs::r1_dst_chip_id
-                   << " r2_dst_chip=" << (uint32_t)CTArgs::r2_dst_chip_id
-                   << " r3_dst_chip=" << (uint32_t)CTArgs::r3_dst_chip_id << ENDL();
-            DPRINT << "BRISC WORKER: reload_cb_wptr=" << get_write_ptr(4) << " recv_cb_wptr=" << get_write_ptr(1)
-                   << ENDL();
 
             PacketHeaderPool::reset();
             auto* packet_header = PacketHeaderPool::allocate_header(1);
 
-            // R1/R2 slots: on assigned fabric core (BRISC forwarding)
-            constexpr uint32_t round_stride = CTArgs::num_workers * CTArgs::slot_size_bytes;
-            uint32_t r1_hdr_dest = packet_buffer_addr + args.my_slot_idx * CTArgs::slot_size_bytes;
-            uint32_t r2_hdr_dest = r1_hdr_dest + round_stride;
+            DPRINT << "BRISC W start typeA=" << args.is_type_a << ENDL();
 
-            uint64_t r1_header_noc = get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r1_hdr_dest);
-            uint64_t r1_payload_noc =
-                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r1_hdr_dest + packet_header_size_bytes);
-            uint64_t r2_header_noc = get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r2_hdr_dest);
-            uint64_t r2_payload_noc =
-                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r2_hdr_dest + packet_header_size_bytes);
-            uint64_t arrival_sem_noc_addr =
-                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, arrival_sem_addr);
-
-            // R3 slot: on FC1 (NCRISC forwarding via cross-column link)
-            constexpr uint32_t r3_region_offset = 2 * CTArgs::num_workers * CTArgs::slot_size_bytes;
-            uint32_t r3_hdr_dest = packet_buffer_addr + r3_region_offset + args.r3_slot_idx * CTArgs::slot_size_bytes;
-            uint64_t r3_header_noc = get_noc_addr(args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, r3_hdr_dest);
-            uint64_t r3_payload_noc = get_noc_addr(
-                args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, r3_hdr_dest + packet_header_size_bytes);
-            uint64_t r3_arrival_sem_noc_addr =
-                get_noc_addr(args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, args.r3_ncrisc_sem_addr);
-
-            // Round 1: send local data
-            DPRINT << "BRISC WORKER: R1 sending local data" << ENDL();
+            // R1: Type A → FWD (fwd_dst), Type B → BWD (bwd_dst)
             {
                 if constexpr (SkipLocalCbPush) {
                     cb_wait_front(CTArgs::local_cb, CTArgs::num_tiles);
                 }
                 uint32_t data_addr = get_read_ptr(CTArgs::local_cb);
-                DPRINT << "BRISC WORKER: R1 data_addr=" << data_addr << ENDL();
-                {
-                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
-                    DPRINT << "BRISC WORKER: R1 local_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-                }
-                send_via_fabric(
+                uint16_t r1_chip = args.is_type_a ? CTArgs::fwd_dst_chip_id : CTArgs::bwd_dst_chip_id;
+                uint16_t r1_mesh = args.is_type_a ? CTArgs::fwd_dst_mesh_id : CTArgs::bwd_dst_mesh_id;
+                send_to_forwarder(
                     packet_header,
-                    static_cast<uint16_t>(CTArgs::r1_dst_chip_id),
-                    static_cast<uint16_t>(CTArgs::r1_dst_mesh_id),
+                    r1_chip,
+                    r1_mesh,
                     my_noc_x,
                     my_noc_y,
                     args.r1_dst_l1_addr,
                     args.r1_dst_sem_addr,
                     data_addr,
-                    r1_header_noc,
-                    r1_payload_noc,
-                    arrival_sem_noc_addr);
+                    args.fc_noc_x,
+                    args.fc_noc_y,
+                    args.r1_slot_offset,
+                    args.r1_sem_addr,
+                    args.r1_slot_bit);
             }
-            DPRINT << "BRISC WORKER: R1 sent" << ENDL();
+            DPRINT << "BRISC W R1 done" << ENDL();
 
-            // Round 2: send round-1 partial sum
-            DPRINT << "BRISC WORKER: R2 waiting scratch_cb" << ENDL();
+            // R2: Type A → BWD (bwd_dst), Type B → FWD (fwd_dst)
             {
                 cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
-                DPRINT << "BRISC WORKER: R2 scratch_cb ready" << ENDL();
                 uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
-                DPRINT << "BRISC WORKER: R2 data_addr=" << data_addr << ENDL();
-                {
-                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
-                    DPRINT << "BRISC WORKER: R2 scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-                }
-                send_via_fabric(
+                uint16_t r2_chip = args.is_type_a ? CTArgs::bwd_dst_chip_id : CTArgs::fwd_dst_chip_id;
+                uint16_t r2_mesh = args.is_type_a ? CTArgs::bwd_dst_mesh_id : CTArgs::fwd_dst_mesh_id;
+                send_to_forwarder(
                     packet_header,
-                    static_cast<uint16_t>(CTArgs::r2_dst_chip_id),
-                    static_cast<uint16_t>(CTArgs::r2_dst_mesh_id),
+                    r2_chip,
+                    r2_mesh,
                     my_noc_x,
                     my_noc_y,
                     args.r2_dst_l1_addr,
                     args.r2_dst_sem_addr,
                     data_addr,
-                    r2_header_noc,
-                    r2_payload_noc,
-                    arrival_sem_noc_addr);
+                    args.fc_noc_x,
+                    args.fc_noc_y,
+                    args.r2_slot_offset,
+                    args.r2_sem_addr,
+                    args.r2_slot_bit);
+
+                cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
+                uint32_t reload_wr = get_write_ptr(CTArgs::reload_cb);
+                uint64_t reload_noc = get_noc_addr(my_noc_x, my_noc_y, reload_wr);
+                noc_async_write(data_addr, reload_noc, CTArgs::num_tiles * CTArgs::compute_tile_size);
+                noc_async_write_barrier();
+                cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC WORKER: R2 sent" << ENDL();
+            DPRINT << "BRISC W R2 done" << ENDL();
 
-            // Round 3: send round-2 partial sum via FC1 NCRISC (cross-column link)
-            if constexpr (CTArgs::defer_r3_send) {
-                DPRINT << "BRISC WORKER: R3 waiting for gate" << ENDL();
-                volatile tt_l1_ptr uint32_t* gate = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r3_gate_addr);
-                while (*gate == 0) {
-                }
-                DPRINT << "BRISC WORKER: R3 gate passed" << ENDL();
-            }
-            DPRINT << "BRISC WORKER: R3 waiting scratch_cb" << ENDL();
+            // R3: send column sum to FC for cross-column forwarding
             {
                 cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
-                DPRINT << "BRISC WORKER: R3 scratch_cb ready" << ENDL();
                 uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
-                DPRINT << "BRISC WORKER: R3 data_addr=" << data_addr << ENDL();
-                {
-                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
-                    DPRINT << "BRISC WORKER: R3 scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-                }
-                send_via_fabric(
+                send_to_forwarder(
                     packet_header,
                     static_cast<uint16_t>(CTArgs::r3_dst_chip_id),
                     static_cast<uint16_t>(CTArgs::r3_dst_mesh_id),
@@ -586,149 +488,113 @@ struct ReduceToAllB1 {
                     args.r3_dst_l1_addr,
                     args.r3_dst_sem_addr,
                     data_addr,
-                    r3_header_noc,
-                    r3_payload_noc,
-                    r3_arrival_sem_noc_addr);
+                    args.fc_noc_x,
+                    args.fc_noc_y,
+                    args.r3_slot_offset,
+                    args.r3_sem_addr,
+                    args.r3_slot_bit);
+
+                cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
+                uint32_t reload_wr = get_write_ptr(CTArgs::reload_cb);
+                uint64_t reload_noc = get_noc_addr(my_noc_x, my_noc_y, reload_wr);
+                noc_async_write(data_addr, reload_noc, CTArgs::num_tiles * CTArgs::compute_tile_size);
+                noc_async_write_barrier();
+                cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC WORKER: R3 sent" << ENDL();
+            DPRINT << "BRISC W R3 done" << ENDL();
 
-            // Output: write final result to this core's output shard
-            DPRINT << "BRISC WORKER: OUTPUT waiting scratch_cb" << ENDL();
+            // Output: write final result
             {
                 cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
-                DPRINT << "BRISC WORKER: OUTPUT scratch_cb ready" << ENDL();
                 uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
-                {
-                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(src_addr + 32);
-                    DPRINT << "BRISC WORKER: OUTPUT scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
-                }
-                uint64_t output_noc_addr = get_noc_addr(my_noc_x, my_noc_y, args.output_base_addr);
-                noc_async_write(src_addr, output_noc_addr, CTArgs::payload_size_bytes);
+                uint64_t output_noc = get_noc_addr(my_noc_x, my_noc_y, args.output_base_addr);
+                noc_async_write(src_addr, output_noc, CTArgs::payload_size_bytes);
                 noc_async_write_barrier();
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC WORKER: done" << ENDL();
 
             if constexpr (SkipLocalCbPush) {
                 cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
             }
+            DPRINT << "BRISC W done" << ENDL();
 
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================
-            // TRISC — Compute: add_tiles + reload_cb for cross-round accumulation
-            //
-            // tile_regs_commit/release zero the current dest half (SyncHalf),
-            // so we use add_tiles(cbA, cbB) to read both operands from CBs
-            // each round.  reload_cb stores the intermediate accumulated value
-            // for the next round.
+            // TRISC — 3-round add_tiles (same as reduce_to_one_b1)
             // ================================================================
             if constexpr (CTArgs::is_fabric_core) {
                 return;
             }
 
-            DPRINT << "TRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
-
-            // --- Round 1: local_cb + received_cb ---
-            DPRINT << "TRISC: R1 add_tiles_init" << ENDL();
-            add_tiles_init(CTArgs::local_cb, CTArgs::received_cb);
+            reconfig_data_format<false, true>(CTArgs::local_cb, CTArgs::received_cb);
             pack_reconfig_data_format<true>(CTArgs::scratch_cb);
 
-            DPRINT << "TRISC: R1 tile_regs_acquire" << ENDL();
-            tile_regs_acquire();
-            DPRINT << "TRISC: R1 waiting local_cb + received_cb" << ENDL();
+            // R1: local + received_R1
+            add_tiles_init(CTArgs::local_cb, CTArgs::received_cb, true);
             cb_wait_front(CTArgs::local_cb, CTArgs::num_tiles);
             cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 add_tiles" << ENDL();
+
+            tile_regs_acquire();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 add_tiles(CTArgs::local_cb, CTArgs::received_cb, i, i, i);
             }
             cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 commit" << ENDL();
-            tile_regs_commit();
 
-            DPRINT << "TRISC: R1 wait+pack scratch" << ENDL();
-            tile_regs_wait();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            tile_regs_commit();
+            tile_regs_wait();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 pack reload" << ENDL();
-            cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
-            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                pack_tile(i, CTArgs::reload_cb, i);
-            }
-            cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 release" << ENDL();
             tile_regs_release();
-            DPRINT << "TRISC: R1 done" << ENDL();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
 
-            // --- Round 2: reload_cb (R1 result) + received_cb ---
-            DPRINT << "TRISC: R2 add_tiles_init" << ENDL();
-            add_tiles_init(CTArgs::reload_cb, CTArgs::received_cb);
-
-            DPRINT << "TRISC: R2 tile_regs_acquire" << ENDL();
-            tile_regs_acquire();
-            DPRINT << "TRISC: R2 waiting reload_cb + received_cb" << ENDL();
+            // R2: reload(R1 sum) + received_R2
+            add_tiles_init(CTArgs::reload_cb, CTArgs::received_cb, true);
             cb_wait_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 add_tiles" << ENDL();
+
+            tile_regs_acquire();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 add_tiles(CTArgs::reload_cb, CTArgs::received_cb, i, i, i);
             }
             cb_pop_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 commit" << ENDL();
-            tile_regs_commit();
 
-            DPRINT << "TRISC: R2 wait+pack scratch" << ENDL();
-            tile_regs_wait();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            tile_regs_commit();
+            tile_regs_wait();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 pack reload" << ENDL();
-            cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
-            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                pack_tile(i, CTArgs::reload_cb, i);
-            }
-            cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 release" << ENDL();
             tile_regs_release();
-            DPRINT << "TRISC: R2 done" << ENDL();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
 
-            // --- Round 3: reload_cb (R2 result) + received_cb ---
-            DPRINT << "TRISC: R3 tile_regs_acquire" << ENDL();
-            tile_regs_acquire();
-            DPRINT << "TRISC: R3 waiting reload_cb + received_cb" << ENDL();
+            // R3: reload(column sum) + received_R3
+            add_tiles_init(CTArgs::reload_cb, CTArgs::received_cb, true);
             cb_wait_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R3 add_tiles" << ENDL();
+
+            tile_regs_acquire();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 add_tiles(CTArgs::reload_cb, CTArgs::received_cb, i, i, i);
             }
             cb_pop_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R3 commit" << ENDL();
-            tile_regs_commit();
 
-            DPRINT << "TRISC: R3 wait+pack scratch" << ENDL();
-            tile_regs_wait();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            tile_regs_commit();
+            tile_regs_wait();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R3 release" << ENDL();
             tile_regs_release();
-            DPRINT << "TRISC: R3 done" << ENDL();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
 #endif
         }
-    };  // class Op
-
-};  // struct ReduceToAllB1
+    };
+};
 
 }  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -281,7 +281,6 @@ struct ReduceToAllB1 {
             if constexpr (CTArgs::is_fabric_core) {
                 // FC NCRISC: forward R1(B) + R2(A) to BWD neighbor
                 // Identical pattern to sdpa_reduce_forwarder.hpp
-                DPRINT << "NCRISC FC BWD start" << ENDL();
 
                 const uint32_t buf_base = get_write_ptr(CTArgs::packet_cb) + CTArgs::ncrisc_buffer_offset;
                 const uint32_t r1_base = buf_base;
@@ -298,7 +297,6 @@ struct ReduceToAllB1 {
                 volatile tt_l1_ptr uint32_t* r2_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r2_sem_addr);
 
                 bwd_sender.open();
-                DPRINT << "NCRISC FC BWD conn open" << ENDL();
                 {
                     uint32_t r1_sent = 0;
                     uint32_t r2_sent = 0;
@@ -312,12 +310,10 @@ struct ReduceToAllB1 {
                 }
                 bwd_sender.close();
                 noc_async_full_barrier();
-                DPRINT << "NCRISC FC BWD done" << ENDL();
                 return;
             }
 
             // Worker NCRISC — receive data for 3 rounds
-            DPRINT << "NCRISC worker start" << ENDL();
             if constexpr (!SkipLocalCbPush) {
                 cb_reserve_back(CTArgs::local_cb, CTArgs::num_tiles);
                 cb_push_back(CTArgs::local_cb, CTArgs::num_tiles);
@@ -332,17 +328,14 @@ struct ReduceToAllB1 {
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
             wait_round(args.recv_sem_round1);
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC R1 done" << ENDL();
 
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
             wait_round(args.recv_sem_round2);
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC R2 done" << ENDL();
 
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
             wait_round(args.recv_sem_round3);
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "NCRISC R3 done" << ENDL();
 
 #elif defined(COMPILE_FOR_BRISC)
             // ================================================================
@@ -351,8 +344,6 @@ struct ReduceToAllB1 {
             constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
 
             if constexpr (CTArgs::is_fabric_core) {
-                DPRINT << "BRISC FC start" << ENDL();
-
                 const uint32_t buf_base = get_write_ptr(CTArgs::packet_cb);
                 const uint32_t r1_base = buf_base;
                 const uint32_t r2_base = buf_base + CTArgs::r2_buffer_offset;
@@ -372,7 +363,6 @@ struct ReduceToAllB1 {
 
                 // Phase 1: forward R1(A)+R2(B) to FWD neighbor
                 fwd_sender.open();
-                DPRINT << "BRISC FC FWD open" << ENDL();
                 {
                     uint32_t r1_sent = 0;
                     uint32_t r2_sent = 0;
@@ -386,13 +376,11 @@ struct ReduceToAllB1 {
                 }
                 fwd_sender.close();
                 noc_async_full_barrier();
-                DPRINT << "BRISC FC FWD done" << ENDL();
 
                 // Phase 2: forward R3 to cross-column partner
                 auto r3_sender =
                     tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
                 r3_sender.open();
-                DPRINT << "BRISC FC R3 open" << ENDL();
                 {
                     uint32_t r3_sent = 0;
                     do {
@@ -403,7 +391,6 @@ struct ReduceToAllB1 {
                 }
                 r3_sender.close();
                 noc_async_full_barrier();
-                DPRINT << "BRISC FC R3 done" << ENDL();
                 return;
             }
 
@@ -415,8 +402,6 @@ struct ReduceToAllB1 {
 
             PacketHeaderPool::reset();
             auto* packet_header = PacketHeaderPool::allocate_header(1);
-
-            DPRINT << "BRISC W start typeA=" << args.is_type_a << ENDL();
 
             // R1: Type A → FWD (fwd_dst), Type B → BWD (bwd_dst)
             {
@@ -441,7 +426,6 @@ struct ReduceToAllB1 {
                     args.r1_sem_addr,
                     args.r1_slot_bit);
             }
-            DPRINT << "BRISC W R1 done" << ENDL();
 
             // R2: Type A → BWD (bwd_dst), Type B → FWD (fwd_dst)
             {
@@ -472,7 +456,6 @@ struct ReduceToAllB1 {
                 cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC W R2 done" << ENDL();
 
             // R3: send column sum to FC for cross-column forwarding
             {
@@ -501,7 +484,6 @@ struct ReduceToAllB1 {
                 cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
                 cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC W R3 done" << ENDL();
 
             // Output: write final result
             {
@@ -516,7 +498,6 @@ struct ReduceToAllB1 {
             if constexpr (SkipLocalCbPush) {
                 cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
             }
-            DPRINT << "BRISC W done" << ENDL();
 
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -18,7 +18,6 @@
  *
  * After both phases every device holds sum(all 8 inputs).
  * All Phase 1 traffic is exactly 1 hop (ring/torus topology).
- * Requires FABRIC_2D_TORUS_X for the wrap-around link.
  */
 
 #include "kernel_op_api.hpp"
@@ -27,7 +26,6 @@
 #if defined(COMPILE_FOR_BRISC)
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
 #include "api/socket_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -37,7 +35,6 @@
 #elif defined(COMPILE_FOR_NCRISC)
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
 #include "api/socket_api.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -48,7 +45,6 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
-#include "api/debug/dprint.h"
 #endif
 
 namespace deepseek_b1_ops {

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -16,9 +16,11 @@
  *   Round 2 (2-apart rows):   (row, col) <-> (row^2, col)
  *   Round 3 (cross-column):   (row, col) <-> (row, col^1)
  *
- * TRISC keeps the running accumulation in dest registers across all
- * three rounds (pack_tile copies dest to CB without clearing it) and
- * packs intermediate results to scratch_cb for BRISC to forward.
+ * TRISC uses add_tiles (CB-to-CB add) each round with a reload_cb to
+ * carry the accumulated partial sum across rounds.  tile_regs_commit/
+ * wait/release provide explicit MATH↔PACK sync; the release zeros the
+ * current dest half, so reload_cb stores the intermediate result for
+ * the next round's add_tiles to re-read.
  *
  * R1/R2 are forwarded by BRISC on each fabric core via its same-column
  * EDM connection.  R3 is forwarded by NCRISC on FC1 (link_idx=1) via a
@@ -123,12 +125,19 @@ struct ReduceToAllB1 {
         static constexpr uint32_t defer_r3_send = deferR3Send;
     };
 
-    template <uint32_t numTiles, uint32_t localCb, uint32_t receivedCb, uint32_t scratchCb, uint32_t isFabricCore>
+    template <
+        uint32_t numTiles,
+        uint32_t localCb,
+        uint32_t receivedCb,
+        uint32_t scratchCb,
+        uint32_t reloadCb,
+        uint32_t isFabricCore>
     struct ComputeCTArgs {
         static constexpr uint32_t num_tiles = numTiles;
         static constexpr uint32_t local_cb = localCb;
         static constexpr uint32_t received_cb = receivedCb;
         static constexpr uint32_t scratch_cb = scratchCb;
+        static constexpr uint32_t reload_cb = reloadCb;
         static constexpr uint32_t is_fabric_core = isFabricCore;
     };
 
@@ -277,6 +286,11 @@ struct ReduceToAllB1 {
             }
 
             DPRINT << "NCRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
+            {
+                volatile tt_l1_ptr uint32_t* r2_sem =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
+                DPRINT << "NCRISC: INIT r2_sem=" << *r2_sem << ENDL();
+            }
 
             if constexpr (!SkipLocalCbPush) {
                 DPRINT << "NCRISC: local_cb reserve_back" << ENDL();
@@ -295,18 +309,35 @@ struct ReduceToAllB1 {
                 noc_semaphore_wait_min(sem_ptr, 1);
                 unified_kernels::semaphore_dec(sem_ptr);
             }
+            {
+                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
+                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
+                DPRINT << "NCRISC: R1 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
+            }
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
             DPRINT << "NCRISC: R1 received_cb pushed" << ENDL();
 
             // Round 2
             DPRINT << "NCRISC: R2 reserve received_cb" << ENDL();
             cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
+            {
+                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
+                volatile uint16_t* d_pre = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
+                DPRINT << "NCRISC: R2 PRE-SEM addr=" << recv_addr << " val[0]=0x" << HEX() << (uint32_t)d_pre[0]
+                       << ENDL();
+            }
             DPRINT << "NCRISC: R2 waiting on sem @" << (uint32_t)args.recv_sem_round2 << ENDL();
             {
                 volatile tt_l1_ptr uint32_t* sem_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
                 noc_semaphore_wait_min(sem_ptr, 1);
                 unified_kernels::semaphore_dec(sem_ptr);
+            }
+            {
+                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
+                DPRINT << "NCRISC: R2 recv_addr=" << recv_addr << ENDL();
+                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
+                DPRINT << "NCRISC: R2 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
             }
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
             DPRINT << "NCRISC: R2 received_cb pushed" << ENDL();
@@ -320,6 +351,11 @@ struct ReduceToAllB1 {
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round3);
                 noc_semaphore_wait_min(sem_ptr, 1);
                 unified_kernels::semaphore_dec(sem_ptr);
+            }
+            {
+                uint32_t recv_addr = get_write_ptr(CTArgs::received_cb);
+                volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(recv_addr + 32);
+                DPRINT << "NCRISC: R3 recv_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
             }
             cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
             DPRINT << "NCRISC: R3 received_cb pushed" << ENDL();
@@ -349,42 +385,75 @@ struct ReduceToAllB1 {
                 const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
                 DPRINT << "BRISC FABRIC: packet_buffer_addr=" << packet_buffer_addr << ENDL();
 
-                DPRINT << "BRISC FABRIC: build_from_args, arg_idx=" << (uint32_t)arg_idx << ENDL();
-                auto fabric_sender =
+                DPRINT << "BRISC FABRIC: build sender_r1, arg_idx=" << (uint32_t)arg_idx << ENDL();
+                auto sender_r1 =
                     tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
-                DPRINT << "BRISC FABRIC: opening" << ENDL();
-                fabric_sender.open();
-                DPRINT << "BRISC FABRIC: opened" << ENDL();
+                DPRINT << "BRISC FABRIC: build sender_r2, arg_idx=" << (uint32_t)arg_idx << ENDL();
+                auto sender_r2 =
+                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
 
                 constexpr uint32_t round_stride = CTArgs::num_workers * CTArgs::slot_size_bytes;
-                for (uint32_t round = 0; round < 2; round++) {
-                    uint32_t slot_base = packet_buffer_addr + round * round_stride;
+
+                // R1: use sender_r1 (connection to R1 partner)
+                DPRINT << "BRISC FABRIC: R1 opening sender_r1" << ENDL();
+                sender_r1.open();
+                {
+                    uint32_t slot_base = packet_buffer_addr;
                     for (uint32_t worker = 0; worker < CTArgs::num_workers; worker++) {
-                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " waiting worker " << worker << " sem @"
-                               << worker_sem_addr[worker] << ENDL();
+                        DPRINT << "BRISC FABRIC: R1 waiting worker " << worker << " sem @" << worker_sem_addr[worker]
+                               << ENDL();
                         volatile tt_l1_ptr uint32_t* worker_sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
                         noc_semaphore_wait_min(worker_sem_ptr, 1);
                         unified_kernels::semaphore_dec(worker_sem_ptr);
-                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " worker " << worker << " sem acquired" << ENDL();
+                        DPRINT << "BRISC FABRIC: R1 worker " << worker << " sem acquired" << ENDL();
 
                         uint32_t worker_header_addr = slot_base;
                         uint32_t worker_payload_addr = slot_base + packet_header_size_bytes;
 
-                        fabric_sender.wait_for_empty_write_slot();
-                        fabric_sender.send_payload_without_header_non_blocking_from_address(
+                        sender_r1.wait_for_empty_write_slot();
+                        sender_r1.send_payload_without_header_non_blocking_from_address(
                             worker_payload_addr, CTArgs::payload_size_bytes);
-                        fabric_sender.send_payload_flush_blocking_from_address(
+                        sender_r1.send_payload_flush_blocking_from_address(
                             worker_header_addr, packet_header_size_bytes);
-                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " worker " << worker << " forwarded" << ENDL();
+                        DPRINT << "BRISC FABRIC: R1 worker " << worker << " forwarded" << ENDL();
 
                         slot_base += CTArgs::slot_size_bytes;
                     }
-                    DPRINT << "BRISC FABRIC: R" << (round + 1) << " all workers forwarded" << ENDL();
                 }
+                DPRINT << "BRISC FABRIC: R1 closing sender_r1" << ENDL();
+                sender_r1.close();
+                noc_async_write_barrier();
 
-                DPRINT << "BRISC FABRIC: closing" << ENDL();
-                fabric_sender.close();
+                // R2: use sender_r2 (connection to R2 partner)
+                DPRINT << "BRISC FABRIC: R2 opening sender_r2" << ENDL();
+                sender_r2.open();
+                {
+                    uint32_t slot_base = packet_buffer_addr + round_stride;
+                    for (uint32_t worker = 0; worker < CTArgs::num_workers; worker++) {
+                        DPRINT << "BRISC FABRIC: R2 waiting worker " << worker << " sem @" << worker_sem_addr[worker]
+                               << ENDL();
+                        volatile tt_l1_ptr uint32_t* worker_sem_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
+                        noc_semaphore_wait_min(worker_sem_ptr, 1);
+                        unified_kernels::semaphore_dec(worker_sem_ptr);
+                        DPRINT << "BRISC FABRIC: R2 worker " << worker << " sem acquired" << ENDL();
+
+                        uint32_t worker_header_addr = slot_base;
+                        uint32_t worker_payload_addr = slot_base + packet_header_size_bytes;
+
+                        sender_r2.wait_for_empty_write_slot();
+                        sender_r2.send_payload_without_header_non_blocking_from_address(
+                            worker_payload_addr, CTArgs::payload_size_bytes);
+                        sender_r2.send_payload_flush_blocking_from_address(
+                            worker_header_addr, packet_header_size_bytes);
+                        DPRINT << "BRISC FABRIC: R2 worker " << worker << " forwarded" << ENDL();
+
+                        slot_base += CTArgs::slot_size_bytes;
+                    }
+                }
+                DPRINT << "BRISC FABRIC: R2 closing sender_r2" << ENDL();
+                sender_r2.close();
                 noc_async_write_barrier();
                 DPRINT << "BRISC FABRIC: done" << ENDL();
                 return;
@@ -407,6 +476,8 @@ struct ReduceToAllB1 {
             DPRINT << "BRISC WORKER: r1_dst_chip=" << (uint32_t)CTArgs::r1_dst_chip_id
                    << " r2_dst_chip=" << (uint32_t)CTArgs::r2_dst_chip_id
                    << " r3_dst_chip=" << (uint32_t)CTArgs::r3_dst_chip_id << ENDL();
+            DPRINT << "BRISC WORKER: reload_cb_wptr=" << get_write_ptr(4) << " recv_cb_wptr=" << get_write_ptr(1)
+                   << ENDL();
 
             PacketHeaderPool::reset();
             auto* packet_header = PacketHeaderPool::allocate_header(1);
@@ -442,6 +513,10 @@ struct ReduceToAllB1 {
                 }
                 uint32_t data_addr = get_read_ptr(CTArgs::local_cb);
                 DPRINT << "BRISC WORKER: R1 data_addr=" << data_addr << ENDL();
+                {
+                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
+                    DPRINT << "BRISC WORKER: R1 local_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
+                }
                 send_via_fabric(
                     packet_header,
                     static_cast<uint16_t>(CTArgs::r1_dst_chip_id),
@@ -464,6 +539,10 @@ struct ReduceToAllB1 {
                 DPRINT << "BRISC WORKER: R2 scratch_cb ready" << ENDL();
                 uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
                 DPRINT << "BRISC WORKER: R2 data_addr=" << data_addr << ENDL();
+                {
+                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
+                    DPRINT << "BRISC WORKER: R2 scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
+                }
                 send_via_fabric(
                     packet_header,
                     static_cast<uint16_t>(CTArgs::r2_dst_chip_id),
@@ -494,6 +573,10 @@ struct ReduceToAllB1 {
                 DPRINT << "BRISC WORKER: R3 scratch_cb ready" << ENDL();
                 uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
                 DPRINT << "BRISC WORKER: R3 data_addr=" << data_addr << ENDL();
+                {
+                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(data_addr + 32);
+                    DPRINT << "BRISC WORKER: R3 scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
+                }
                 send_via_fabric(
                     packet_header,
                     static_cast<uint16_t>(CTArgs::r3_dst_chip_id),
@@ -516,6 +599,10 @@ struct ReduceToAllB1 {
                 cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
                 DPRINT << "BRISC WORKER: OUTPUT scratch_cb ready" << ENDL();
                 uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
+                {
+                    volatile uint16_t* d = reinterpret_cast<volatile uint16_t*>(src_addr + 32);
+                    DPRINT << "BRISC WORKER: OUTPUT scratch_val[0]=0x" << HEX() << (uint32_t)d[0] << ENDL();
+                }
                 uint64_t output_noc_addr = get_noc_addr(my_noc_x, my_noc_y, args.output_base_addr);
                 noc_async_write(src_addr, output_noc_addr, CTArgs::payload_size_bytes);
                 noc_async_write_barrier();
@@ -529,7 +616,12 @@ struct ReduceToAllB1 {
 
 #elif defined(COMPILE_FOR_TRISC)
             // ================================================================
-            // TRISC — Compute: accumulate 3 rounds in dest registers
+            // TRISC — Compute: add_tiles + reload_cb for cross-round accumulation
+            //
+            // tile_regs_commit/release zero the current dest half (SyncHalf),
+            // so we use add_tiles(cbA, cbB) to read both operands from CBs
+            // each round.  reload_cb stores the intermediate accumulated value
+            // for the next round.
             // ================================================================
             if constexpr (CTArgs::is_fabric_core) {
                 return;
@@ -537,88 +629,102 @@ struct ReduceToAllB1 {
 
             DPRINT << "TRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
 
-            reconfig_data_format<false, true>(CTArgs::local_cb, CTArgs::received_cb);
+            // --- Round 1: local_cb + received_cb ---
+            DPRINT << "TRISC: R1 add_tiles_init" << ENDL();
+            add_tiles_init(CTArgs::local_cb, CTArgs::received_cb);
             pack_reconfig_data_format<true>(CTArgs::scratch_cb);
 
-            copy_tile_to_dst_init_short(CTArgs::local_cb);
             DPRINT << "TRISC: R1 tile_regs_acquire" << ENDL();
             tile_regs_acquire();
-            DPRINT << "TRISC: R1 waiting local_cb" << ENDL();
+            DPRINT << "TRISC: R1 waiting local_cb + received_cb" << ENDL();
             cb_wait_front(CTArgs::local_cb, CTArgs::num_tiles);
+            cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R1 add_tiles" << ENDL();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                copy_tile(CTArgs::local_cb, i, i);
+                add_tiles(CTArgs::local_cb, CTArgs::received_cb, i, i, i);
             }
             cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 local copied to dest" << ENDL();
-
-            binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb);
-
-            DPRINT << "TRISC: R1 waiting received_cb" << ENDL();
-            cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
-            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
-            }
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 ELWADD done, committing" << ENDL();
+            DPRINT << "TRISC: R1 commit" << ENDL();
             tile_regs_commit();
 
-            DPRINT << "TRISC: R1 tile_regs_wait (pack)" << ENDL();
+            DPRINT << "TRISC: R1 wait+pack scratch" << ENDL();
             tile_regs_wait();
-            DPRINT << "TRISC: R1 reserve scratch_cb" << ENDL();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            tile_regs_release();
             cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R1 packed to scratch_cb" << ENDL();
+            DPRINT << "TRISC: R1 pack reload" << ENDL();
+            cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                pack_tile(i, CTArgs::reload_cb, i);
+            }
+            cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R1 release" << ENDL();
+            tile_regs_release();
+            DPRINT << "TRISC: R1 done" << ENDL();
 
-            // Round 2
+            // --- Round 2: reload_cb (R1 result) + received_cb ---
+            DPRINT << "TRISC: R2 add_tiles_init" << ENDL();
+            add_tiles_init(CTArgs::reload_cb, CTArgs::received_cb);
+
             DPRINT << "TRISC: R2 tile_regs_acquire" << ENDL();
             tile_regs_acquire();
-            DPRINT << "TRISC: R2 waiting received_cb" << ENDL();
+            DPRINT << "TRISC: R2 waiting reload_cb + received_cb" << ENDL();
+            cb_wait_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R2 add_tiles" << ENDL();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
+                add_tiles(CTArgs::reload_cb, CTArgs::received_cb, i, i, i);
             }
+            cb_pop_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 ELWADD done, committing" << ENDL();
+            DPRINT << "TRISC: R2 commit" << ENDL();
             tile_regs_commit();
 
-            DPRINT << "TRISC: R2 tile_regs_wait (pack)" << ENDL();
+            DPRINT << "TRISC: R2 wait+pack scratch" << ENDL();
             tile_regs_wait();
-            DPRINT << "TRISC: R2 reserve scratch_cb" << ENDL();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            tile_regs_release();
             cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R2 packed to scratch_cb" << ENDL();
+            DPRINT << "TRISC: R2 pack reload" << ENDL();
+            cb_reserve_back(CTArgs::reload_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                pack_tile(i, CTArgs::reload_cb, i);
+            }
+            cb_push_back(CTArgs::reload_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R2 release" << ENDL();
+            tile_regs_release();
+            DPRINT << "TRISC: R2 done" << ENDL();
 
-            // Round 3
+            // --- Round 3: reload_cb (R2 result) + received_cb ---
             DPRINT << "TRISC: R3 tile_regs_acquire" << ENDL();
             tile_regs_acquire();
-            DPRINT << "TRISC: R3 waiting received_cb" << ENDL();
+            DPRINT << "TRISC: R3 waiting reload_cb + received_cb" << ENDL();
+            cb_wait_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R3 add_tiles" << ENDL();
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
-                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
+                add_tiles(CTArgs::reload_cb, CTArgs::received_cb, i, i, i);
             }
+            cb_pop_front(CTArgs::reload_cb, CTArgs::num_tiles);
             cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R3 ELWADD done, committing" << ENDL();
+            DPRINT << "TRISC: R3 commit" << ENDL();
             tile_regs_commit();
 
-            DPRINT << "TRISC: R3 tile_regs_wait (pack)" << ENDL();
+            DPRINT << "TRISC: R3 wait+pack scratch" << ENDL();
             tile_regs_wait();
-            DPRINT << "TRISC: R3 reserve scratch_cb" << ENDL();
             cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
             for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
                 pack_tile(i, CTArgs::scratch_cb, i);
             }
-            tile_regs_release();
             cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
-            DPRINT << "TRISC: R3 packed to scratch_cb" << ENDL();
-            DPRINT << "TRISC: done" << ENDL();
+            DPRINT << "TRISC: R3 release" << ENDL();
+            tile_regs_release();
+            DPRINT << "TRISC: R3 done" << ENDL();
 #endif
         }
     };  // class Op

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -1,0 +1,628 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * Unified Reduce-to-All B1 Operation
+ *
+ * Performs 3-round hypercube all-reduce across a 4x2 mesh so that every
+ * device ends up with the sum of all 8 inputs.
+ *
+ * Each round, every device simultaneously sends to and receives from a
+ * partner determined by XOR-ing one dimension of the device index:
+ *
+ *   Round 1 (adjacent rows):  (row, col) <-> (row^1, col)
+ *   Round 2 (2-apart rows):   (row, col) <-> (row^2, col)
+ *   Round 3 (cross-column):   (row, col) <-> (row, col^1)
+ *
+ * TRISC keeps the running accumulation in dest registers across all
+ * three rounds (pack_tile copies dest to CB without clearing it) and
+ * packs intermediate results to scratch_cb for BRISC to forward.
+ *
+ * R1/R2 are forwarded by BRISC on each fabric core via its same-column
+ * EDM connection.  R3 is forwarded by NCRISC on FC1 (link_idx=1) via a
+ * separate cross-column EDM connection, avoiding the circular deadlock
+ * that occurs when R3 shares the same-column link.
+ */
+
+#include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include <type_traits>
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "api/debug/dprint.h"
+
+#elif defined(COMPILE_FOR_NCRISC)
+#include <type_traits>
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "api/debug/dprint.h"
+
+#elif defined(COMPILE_FOR_TRISC)
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/debug/dprint.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+struct ReduceToAllB1 {
+    // ========================================================================
+    // Compile-time args structs
+    // ========================================================================
+
+    template <
+        uint32_t numTiles,
+        uint32_t localCb,
+        uint32_t receivedCb,
+        uint32_t isFabricCore,
+        uint32_t deferR3Send,
+        uint32_t numWorkers,
+        uint32_t slotSizeBytes,
+        uint32_t packetCb,
+        uint32_t payloadSizeBytes,
+        uint32_t isR3Forwarder,
+        uint32_t numR3Workers>
+    struct ReaderCTArgs {
+        static constexpr uint32_t num_tiles = numTiles;
+        static constexpr uint32_t local_cb = localCb;
+        static constexpr uint32_t received_cb = receivedCb;
+        static constexpr uint32_t is_fabric_core = isFabricCore;
+        static constexpr uint32_t defer_r3_send = deferR3Send;
+        static constexpr uint32_t num_workers = numWorkers;
+        static constexpr uint32_t slot_size_bytes = slotSizeBytes;
+        static constexpr uint32_t packet_cb = packetCb;
+        static constexpr uint32_t payload_size_bytes = payloadSizeBytes;
+        static constexpr uint32_t is_r3_forwarder = isR3Forwarder;
+        static constexpr uint32_t num_r3_workers = numR3Workers;
+    };
+
+    template <
+        uint32_t numTiles,
+        uint32_t payloadSizeBytes,
+        uint32_t localCb,
+        uint32_t scratchCb,
+        uint32_t packetCb,
+        uint32_t numWorkers,
+        uint32_t slotSizeBytes,
+        uint32_t isFabricCore,
+        uint32_t r1DstChipId,
+        uint32_t r1DstMeshId,
+        uint32_t r2DstChipId,
+        uint32_t r2DstMeshId,
+        uint32_t r3DstChipId,
+        uint32_t r3DstMeshId,
+        uint32_t deferR3Send>
+    struct WriterCTArgs {
+        static constexpr uint32_t num_tiles = numTiles;
+        static constexpr uint32_t payload_size_bytes = payloadSizeBytes;
+        static constexpr uint32_t local_cb = localCb;
+        static constexpr uint32_t scratch_cb = scratchCb;
+        static constexpr uint32_t packet_cb = packetCb;
+        static constexpr uint32_t num_workers = numWorkers;
+        static constexpr uint32_t slot_size_bytes = slotSizeBytes;
+        static constexpr uint32_t is_fabric_core = isFabricCore;
+        static constexpr uint32_t r1_dst_chip_id = r1DstChipId;
+        static constexpr uint32_t r1_dst_mesh_id = r1DstMeshId;
+        static constexpr uint32_t r2_dst_chip_id = r2DstChipId;
+        static constexpr uint32_t r2_dst_mesh_id = r2DstMeshId;
+        static constexpr uint32_t r3_dst_chip_id = r3DstChipId;
+        static constexpr uint32_t r3_dst_mesh_id = r3DstMeshId;
+        static constexpr uint32_t defer_r3_send = deferR3Send;
+    };
+
+    template <uint32_t numTiles, uint32_t localCb, uint32_t receivedCb, uint32_t scratchCb, uint32_t isFabricCore>
+    struct ComputeCTArgs {
+        static constexpr uint32_t num_tiles = numTiles;
+        static constexpr uint32_t local_cb = localCb;
+        static constexpr uint32_t received_cb = receivedCb;
+        static constexpr uint32_t scratch_cb = scratchCb;
+        static constexpr uint32_t is_fabric_core = isFabricCore;
+    };
+
+    // ========================================================================
+    // Runtime args structs
+    // ========================================================================
+
+    struct ReaderArgs {
+        uint32_t recv_sem_round1;
+        uint32_t recv_sem_round2;
+        uint32_t recv_sem_round3;
+        uint32_t r3_gate_addr;
+    };
+
+    struct WorkerWriterArgs {
+        uint32_t fabric_core_noc_x;
+        uint32_t fabric_core_noc_y;
+        uint32_t my_slot_idx;
+        uint32_t worker_sem_addr;
+        uint32_t r1_dst_l1_addr;
+        uint32_t r1_dst_sem_addr;
+        uint32_t r2_dst_l1_addr;
+        uint32_t r2_dst_sem_addr;
+        uint32_t r3_dst_l1_addr;
+        uint32_t r3_dst_sem_addr;
+        uint32_t output_base_addr;
+        uint32_t r3_gate_addr;
+        uint32_t r3_fabric_core_noc_x;
+        uint32_t r3_fabric_core_noc_y;
+        uint32_t r3_slot_idx;
+        uint32_t r3_ncrisc_sem_addr;
+    };
+
+    struct ComputeArgs {};
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WorkerWriterArgs, ComputeArgs>;
+
+    // ========================================================================
+    // Op implementation
+    // ========================================================================
+    template <typename CTArgs, bool IsWorkerCore, bool SkipLocalCbPush = false>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) { impl(args); }
+
+    private:
+#if defined(COMPILE_FOR_BRISC)
+        template <typename packet_header_t>
+        static FORCE_INLINE void set_unicast_route(
+            volatile tt_l1_ptr packet_header_t* header, uint16_t dst_dev_id, uint16_t dst_mesh_id, uint16_t num_hops) {
+            if constexpr (std::is_same_v<packet_header_t, tt::tt_fabric::HybridMeshPacketHeader>) {
+                fabric_set_unicast_route(header, dst_dev_id, dst_mesh_id);
+            } else {
+                fabric_set_unicast_route<false>(header, num_hops);
+            }
+        }
+
+        static FORCE_INLINE void send_via_fabric(
+            volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
+            uint16_t dst_chip_id,
+            uint16_t dst_mesh_id,
+            uint32_t my_noc_x,
+            uint32_t my_noc_y,
+            uint32_t dst_l1_addr,
+            uint32_t dst_sem_addr,
+            uint32_t data_addr,
+            uint64_t header_noc_addr,
+            uint64_t payload_noc_addr,
+            uint64_t arrival_sem_noc_addr) {
+            set_unicast_route(packet_header, dst_chip_id, dst_mesh_id, static_cast<uint16_t>(1));
+
+            uint64_t dst_noc_addr = get_noc_addr(my_noc_x, my_noc_y, dst_l1_addr);
+            uint64_t dst_sem_noc_addr = get_noc_addr(my_noc_x, my_noc_y, dst_sem_addr);
+            packet_header->to_noc_fused_unicast_write_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{dst_noc_addr, dst_sem_noc_addr, 1, false},
+                CTArgs::payload_size_bytes);
+
+            constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
+            noc_async_write(reinterpret_cast<uint32_t>(packet_header), header_noc_addr, pkt_hdr_bytes);
+            noc_async_write(data_addr, payload_noc_addr, CTArgs::payload_size_bytes);
+            noc_semaphore_inc(arrival_sem_noc_addr, 1);
+            noc_async_write_barrier();
+            noc_async_atomic_barrier();
+        }
+#endif
+
+        void impl([[maybe_unused]] const RTArgs& args) {
+            if constexpr (!IsWorkerCore) {
+                return;
+            }
+
+#if defined(COMPILE_FOR_NCRISC)
+            // ================================================================
+            // NCRISC — Reader / R3 fabric forwarder
+            // ================================================================
+            if constexpr (CTArgs::is_fabric_core) {
+                if constexpr (CTArgs::is_r3_forwarder) {
+                    DPRINT << "NCRISC FABRIC R3: start, num_r3_workers=" << (uint32_t)CTArgs::num_r3_workers << ENDL();
+                    size_t arg_idx = 0;
+                    uint32_t r3_worker_sems[CTArgs::num_r3_workers];
+                    for (uint32_t i = 0; i < CTArgs::num_r3_workers; i++) {
+                        r3_worker_sems[i] = get_arg_val<uint32_t>(arg_idx++);
+                        DPRINT << "NCRISC FABRIC R3: sem[" << i << "]=" << r3_worker_sems[i] << ENDL();
+                    }
+
+                    const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
+                    constexpr uint32_t r3_region_offset = 2 * CTArgs::num_workers * CTArgs::slot_size_bytes;
+                    uint32_t r3_slot_base = packet_buffer_addr + r3_region_offset;
+                    DPRINT << "NCRISC FABRIC R3: pkt_buf=" << packet_buffer_addr << " r3_base=" << r3_slot_base
+                           << ENDL();
+
+                    DPRINT << "NCRISC FABRIC R3: build_from_args, arg_idx=" << (uint32_t)arg_idx << ENDL();
+                    auto fabric_sender =
+                        tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+                    DPRINT << "NCRISC FABRIC R3: opening" << ENDL();
+                    fabric_sender.open();
+                    DPRINT << "NCRISC FABRIC R3: opened" << ENDL();
+
+                    constexpr uint32_t pkt_hdr_bytes = sizeof(PACKET_HEADER_TYPE);
+                    for (uint32_t w = 0; w < CTArgs::num_r3_workers; w++) {
+                        DPRINT << "NCRISC FABRIC R3: waiting worker " << w << " sem @" << r3_worker_sems[w] << ENDL();
+                        volatile tt_l1_ptr uint32_t* sem =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(r3_worker_sems[w]);
+                        noc_semaphore_wait_min(sem, 1);
+                        unified_kernels::semaphore_dec(sem);
+                        DPRINT << "NCRISC FABRIC R3: worker " << w << " sem acquired" << ENDL();
+
+                        uint32_t hdr_addr = r3_slot_base;
+                        uint32_t payload_addr = r3_slot_base + pkt_hdr_bytes;
+
+                        fabric_sender.wait_for_empty_write_slot();
+                        fabric_sender.send_payload_without_header_non_blocking_from_address(
+                            payload_addr, CTArgs::payload_size_bytes);
+                        fabric_sender.send_payload_flush_blocking_from_address(hdr_addr, pkt_hdr_bytes);
+                        DPRINT << "NCRISC FABRIC R3: worker " << w << " forwarded" << ENDL();
+
+                        r3_slot_base += CTArgs::slot_size_bytes;
+                    }
+
+                    DPRINT << "NCRISC FABRIC R3: closing" << ENDL();
+                    fabric_sender.close();
+                    noc_async_write_barrier();
+                    DPRINT << "NCRISC FABRIC R3: done" << ENDL();
+                }
+                return;
+            }
+
+            DPRINT << "NCRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
+
+            if constexpr (!SkipLocalCbPush) {
+                DPRINT << "NCRISC: local_cb reserve_back" << ENDL();
+                cb_reserve_back(CTArgs::local_cb, CTArgs::num_tiles);
+                cb_push_back(CTArgs::local_cb, CTArgs::num_tiles);
+                DPRINT << "NCRISC: local_cb pushed" << ENDL();
+            }
+
+            // Round 1
+            DPRINT << "NCRISC: R1 reserve received_cb" << ENDL();
+            cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R1 waiting on sem @" << (uint32_t)args.recv_sem_round1 << ENDL();
+            {
+                volatile tt_l1_ptr uint32_t* sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round1);
+                noc_semaphore_wait_min(sem_ptr, 1);
+                unified_kernels::semaphore_dec(sem_ptr);
+            }
+            cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R1 received_cb pushed" << ENDL();
+
+            // Round 2
+            DPRINT << "NCRISC: R2 reserve received_cb" << ENDL();
+            cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R2 waiting on sem @" << (uint32_t)args.recv_sem_round2 << ENDL();
+            {
+                volatile tt_l1_ptr uint32_t* sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
+                noc_semaphore_wait_min(sem_ptr, 1);
+                unified_kernels::semaphore_dec(sem_ptr);
+            }
+            cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R2 received_cb pushed" << ENDL();
+
+            // Round 3
+            DPRINT << "NCRISC: R3 reserve received_cb" << ENDL();
+            cb_reserve_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R3 waiting on sem @" << (uint32_t)args.recv_sem_round3 << ENDL();
+            {
+                volatile tt_l1_ptr uint32_t* sem_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round3);
+                noc_semaphore_wait_min(sem_ptr, 1);
+                unified_kernels::semaphore_dec(sem_ptr);
+            }
+            cb_push_back(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "NCRISC: R3 received_cb pushed" << ENDL();
+
+            if constexpr (CTArgs::defer_r3_send) {
+                volatile tt_l1_ptr uint32_t* gate = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r3_gate_addr);
+                *gate = 1;
+                DPRINT << "NCRISC: R3 gate set" << ENDL();
+            }
+            DPRINT << "NCRISC: done" << ENDL();
+
+#elif defined(COMPILE_FOR_BRISC)
+            // ================================================================
+            // BRISC — Writer: fabric core forwards R1+R2; worker sends + output
+            // ================================================================
+            constexpr uint32_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
+
+            if constexpr (CTArgs::is_fabric_core) {
+                // Fabric core BRISC: forward R1 and R2 only (R3 handled by NCRISC on FC1)
+                DPRINT << "BRISC FABRIC: start, num_workers=" << (uint32_t)CTArgs::num_workers << ENDL();
+                size_t arg_idx = 0;
+                uint32_t worker_sem_addr[CTArgs::num_workers];
+                for (uint32_t i = 0; i < CTArgs::num_workers; i++) {
+                    worker_sem_addr[i] = get_arg_val<uint32_t>(arg_idx++);
+                    DPRINT << "BRISC FABRIC: worker_sem_addr[" << i << "]=" << worker_sem_addr[i] << ENDL();
+                }
+                const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
+                DPRINT << "BRISC FABRIC: packet_buffer_addr=" << packet_buffer_addr << ENDL();
+
+                DPRINT << "BRISC FABRIC: build_from_args, arg_idx=" << (uint32_t)arg_idx << ENDL();
+                auto fabric_sender =
+                    tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+                DPRINT << "BRISC FABRIC: opening" << ENDL();
+                fabric_sender.open();
+                DPRINT << "BRISC FABRIC: opened" << ENDL();
+
+                constexpr uint32_t round_stride = CTArgs::num_workers * CTArgs::slot_size_bytes;
+                for (uint32_t round = 0; round < 2; round++) {
+                    uint32_t slot_base = packet_buffer_addr + round * round_stride;
+                    for (uint32_t worker = 0; worker < CTArgs::num_workers; worker++) {
+                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " waiting worker " << worker << " sem @"
+                               << worker_sem_addr[worker] << ENDL();
+                        volatile tt_l1_ptr uint32_t* worker_sem_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
+                        noc_semaphore_wait_min(worker_sem_ptr, 1);
+                        unified_kernels::semaphore_dec(worker_sem_ptr);
+                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " worker " << worker << " sem acquired" << ENDL();
+
+                        uint32_t worker_header_addr = slot_base;
+                        uint32_t worker_payload_addr = slot_base + packet_header_size_bytes;
+
+                        fabric_sender.wait_for_empty_write_slot();
+                        fabric_sender.send_payload_without_header_non_blocking_from_address(
+                            worker_payload_addr, CTArgs::payload_size_bytes);
+                        fabric_sender.send_payload_flush_blocking_from_address(
+                            worker_header_addr, packet_header_size_bytes);
+                        DPRINT << "BRISC FABRIC: R" << (round + 1) << " worker " << worker << " forwarded" << ENDL();
+
+                        slot_base += CTArgs::slot_size_bytes;
+                    }
+                    DPRINT << "BRISC FABRIC: R" << (round + 1) << " all workers forwarded" << ENDL();
+                }
+
+                DPRINT << "BRISC FABRIC: closing" << ENDL();
+                fabric_sender.close();
+                noc_async_write_barrier();
+                DPRINT << "BRISC FABRIC: done" << ENDL();
+                return;
+            }
+
+            // ----------------------------------------------------------
+            // Worker core: 3 rounds of sending + output write
+            // ----------------------------------------------------------
+            DPRINT << "BRISC WORKER: start" << ENDL();
+            const uint32_t my_noc_x = my_x[0];
+            const uint32_t my_noc_y = my_y[0];
+            const uint32_t packet_buffer_addr = get_write_ptr(CTArgs::packet_cb);
+            const uint32_t arrival_sem_addr = args.worker_sem_addr;
+
+            DPRINT << "BRISC WORKER: noc=(" << my_noc_x << "," << my_noc_y << ") slot=" << (uint32_t)args.my_slot_idx
+                   << " fab_core=(" << (uint32_t)args.fabric_core_noc_x << "," << (uint32_t)args.fabric_core_noc_y
+                   << ")" << ENDL();
+            DPRINT << "BRISC WORKER: r3_fab=(" << (uint32_t)args.r3_fabric_core_noc_x << ","
+                   << (uint32_t)args.r3_fabric_core_noc_y << ") r3_slot=" << (uint32_t)args.r3_slot_idx << ENDL();
+            DPRINT << "BRISC WORKER: r1_dst_chip=" << (uint32_t)CTArgs::r1_dst_chip_id
+                   << " r2_dst_chip=" << (uint32_t)CTArgs::r2_dst_chip_id
+                   << " r3_dst_chip=" << (uint32_t)CTArgs::r3_dst_chip_id << ENDL();
+
+            PacketHeaderPool::reset();
+            auto* packet_header = PacketHeaderPool::allocate_header(1);
+
+            // R1/R2 slots: on assigned fabric core (BRISC forwarding)
+            constexpr uint32_t round_stride = CTArgs::num_workers * CTArgs::slot_size_bytes;
+            uint32_t r1_hdr_dest = packet_buffer_addr + args.my_slot_idx * CTArgs::slot_size_bytes;
+            uint32_t r2_hdr_dest = r1_hdr_dest + round_stride;
+
+            uint64_t r1_header_noc = get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r1_hdr_dest);
+            uint64_t r1_payload_noc =
+                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r1_hdr_dest + packet_header_size_bytes);
+            uint64_t r2_header_noc = get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r2_hdr_dest);
+            uint64_t r2_payload_noc =
+                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, r2_hdr_dest + packet_header_size_bytes);
+            uint64_t arrival_sem_noc_addr =
+                get_noc_addr(args.fabric_core_noc_x, args.fabric_core_noc_y, arrival_sem_addr);
+
+            // R3 slot: on FC1 (NCRISC forwarding via cross-column link)
+            constexpr uint32_t r3_region_offset = 2 * CTArgs::num_workers * CTArgs::slot_size_bytes;
+            uint32_t r3_hdr_dest = packet_buffer_addr + r3_region_offset + args.r3_slot_idx * CTArgs::slot_size_bytes;
+            uint64_t r3_header_noc = get_noc_addr(args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, r3_hdr_dest);
+            uint64_t r3_payload_noc = get_noc_addr(
+                args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, r3_hdr_dest + packet_header_size_bytes);
+            uint64_t r3_arrival_sem_noc_addr =
+                get_noc_addr(args.r3_fabric_core_noc_x, args.r3_fabric_core_noc_y, args.r3_ncrisc_sem_addr);
+
+            // Round 1: send local data
+            DPRINT << "BRISC WORKER: R1 sending local data" << ENDL();
+            {
+                if constexpr (SkipLocalCbPush) {
+                    cb_wait_front(CTArgs::local_cb, CTArgs::num_tiles);
+                }
+                uint32_t data_addr = get_read_ptr(CTArgs::local_cb);
+                DPRINT << "BRISC WORKER: R1 data_addr=" << data_addr << ENDL();
+                send_via_fabric(
+                    packet_header,
+                    static_cast<uint16_t>(CTArgs::r1_dst_chip_id),
+                    static_cast<uint16_t>(CTArgs::r1_dst_mesh_id),
+                    my_noc_x,
+                    my_noc_y,
+                    args.r1_dst_l1_addr,
+                    args.r1_dst_sem_addr,
+                    data_addr,
+                    r1_header_noc,
+                    r1_payload_noc,
+                    arrival_sem_noc_addr);
+            }
+            DPRINT << "BRISC WORKER: R1 sent" << ENDL();
+
+            // Round 2: send round-1 partial sum
+            DPRINT << "BRISC WORKER: R2 waiting scratch_cb" << ENDL();
+            {
+                cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                DPRINT << "BRISC WORKER: R2 scratch_cb ready" << ENDL();
+                uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
+                DPRINT << "BRISC WORKER: R2 data_addr=" << data_addr << ENDL();
+                send_via_fabric(
+                    packet_header,
+                    static_cast<uint16_t>(CTArgs::r2_dst_chip_id),
+                    static_cast<uint16_t>(CTArgs::r2_dst_mesh_id),
+                    my_noc_x,
+                    my_noc_y,
+                    args.r2_dst_l1_addr,
+                    args.r2_dst_sem_addr,
+                    data_addr,
+                    r2_header_noc,
+                    r2_payload_noc,
+                    arrival_sem_noc_addr);
+                cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+            }
+            DPRINT << "BRISC WORKER: R2 sent" << ENDL();
+
+            // Round 3: send round-2 partial sum via FC1 NCRISC (cross-column link)
+            if constexpr (CTArgs::defer_r3_send) {
+                DPRINT << "BRISC WORKER: R3 waiting for gate" << ENDL();
+                volatile tt_l1_ptr uint32_t* gate = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.r3_gate_addr);
+                while (*gate == 0) {
+                }
+                DPRINT << "BRISC WORKER: R3 gate passed" << ENDL();
+            }
+            DPRINT << "BRISC WORKER: R3 waiting scratch_cb" << ENDL();
+            {
+                cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                DPRINT << "BRISC WORKER: R3 scratch_cb ready" << ENDL();
+                uint32_t data_addr = get_read_ptr(CTArgs::scratch_cb);
+                DPRINT << "BRISC WORKER: R3 data_addr=" << data_addr << ENDL();
+                send_via_fabric(
+                    packet_header,
+                    static_cast<uint16_t>(CTArgs::r3_dst_chip_id),
+                    static_cast<uint16_t>(CTArgs::r3_dst_mesh_id),
+                    my_noc_x,
+                    my_noc_y,
+                    args.r3_dst_l1_addr,
+                    args.r3_dst_sem_addr,
+                    data_addr,
+                    r3_header_noc,
+                    r3_payload_noc,
+                    r3_arrival_sem_noc_addr);
+                cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+            }
+            DPRINT << "BRISC WORKER: R3 sent" << ENDL();
+
+            // Output: write final result to this core's output shard
+            DPRINT << "BRISC WORKER: OUTPUT waiting scratch_cb" << ENDL();
+            {
+                cb_wait_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+                DPRINT << "BRISC WORKER: OUTPUT scratch_cb ready" << ENDL();
+                uint32_t src_addr = get_read_ptr(CTArgs::scratch_cb);
+                uint64_t output_noc_addr = get_noc_addr(my_noc_x, my_noc_y, args.output_base_addr);
+                noc_async_write(src_addr, output_noc_addr, CTArgs::payload_size_bytes);
+                noc_async_write_barrier();
+                cb_pop_front(CTArgs::scratch_cb, CTArgs::num_tiles);
+            }
+            DPRINT << "BRISC WORKER: done" << ENDL();
+
+            if constexpr (SkipLocalCbPush) {
+                cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
+            }
+
+#elif defined(COMPILE_FOR_TRISC)
+            // ================================================================
+            // TRISC — Compute: accumulate 3 rounds in dest registers
+            // ================================================================
+            if constexpr (CTArgs::is_fabric_core) {
+                return;
+            }
+
+            DPRINT << "TRISC: start, num_tiles=" << (uint32_t)CTArgs::num_tiles << ENDL();
+
+            reconfig_data_format<false, true>(CTArgs::local_cb, CTArgs::received_cb);
+            pack_reconfig_data_format<true>(CTArgs::scratch_cb);
+
+            copy_tile_to_dst_init_short(CTArgs::local_cb);
+            DPRINT << "TRISC: R1 tile_regs_acquire" << ENDL();
+            tile_regs_acquire();
+            DPRINT << "TRISC: R1 waiting local_cb" << ENDL();
+            cb_wait_front(CTArgs::local_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                copy_tile(CTArgs::local_cb, i, i);
+            }
+            cb_pop_front(CTArgs::local_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R1 local copied to dest" << ENDL();
+
+            binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb);
+
+            DPRINT << "TRISC: R1 waiting received_cb" << ENDL();
+            cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
+            }
+            cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R1 ELWADD done, committing" << ENDL();
+            tile_regs_commit();
+
+            DPRINT << "TRISC: R1 tile_regs_wait (pack)" << ENDL();
+            tile_regs_wait();
+            DPRINT << "TRISC: R1 reserve scratch_cb" << ENDL();
+            cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                pack_tile(i, CTArgs::scratch_cb, i);
+            }
+            tile_regs_release();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R1 packed to scratch_cb" << ENDL();
+
+            // Round 2
+            DPRINT << "TRISC: R2 tile_regs_acquire" << ENDL();
+            tile_regs_acquire();
+            DPRINT << "TRISC: R2 waiting received_cb" << ENDL();
+            cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
+            }
+            cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R2 ELWADD done, committing" << ENDL();
+            tile_regs_commit();
+
+            DPRINT << "TRISC: R2 tile_regs_wait (pack)" << ENDL();
+            tile_regs_wait();
+            DPRINT << "TRISC: R2 reserve scratch_cb" << ENDL();
+            cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                pack_tile(i, CTArgs::scratch_cb, i);
+            }
+            tile_regs_release();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R2 packed to scratch_cb" << ENDL();
+
+            // Round 3
+            DPRINT << "TRISC: R3 tile_regs_acquire" << ENDL();
+            tile_regs_acquire();
+            DPRINT << "TRISC: R3 waiting received_cb" << ENDL();
+            cb_wait_front(CTArgs::received_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(CTArgs::received_cb, i, i);
+            }
+            cb_pop_front(CTArgs::received_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R3 ELWADD done, committing" << ENDL();
+            tile_regs_commit();
+
+            DPRINT << "TRISC: R3 tile_regs_wait (pack)" << ENDL();
+            tile_regs_wait();
+            DPRINT << "TRISC: R3 reserve scratch_cb" << ENDL();
+            cb_reserve_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            for (uint32_t i = 0; i < CTArgs::num_tiles; i++) {
+                pack_tile(i, CTArgs::scratch_cb, i);
+            }
+            tile_regs_release();
+            cb_push_back(CTArgs::scratch_cb, CTArgs::num_tiles);
+            DPRINT << "TRISC: R3 packed to scratch_cb" << ENDL();
+            DPRINT << "TRISC: done" << ENDL();
+#endif
+        }
+    };  // class Op
+
+};  // struct ReduceToAllB1
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_all_b1.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 /**
- * Unified Reduce-to-All B1 — Ring + Cross-Column (modelled on sdpa_reduce_to_all)
+ * Unified Reduce-to-All B1 — Ring + Cross-Column
  *
  * Phase 1 — Column all-reduce (2-round ring, A/B split, all 1-hop):
  *   Type A workers: R1 → FWD (row+1), R2 → BWD (row-1)
@@ -168,9 +168,9 @@ struct ReduceToAllB1 {
         uint32_t fc_noc_x;
         uint32_t fc_noc_y;
         uint32_t is_type_a;
-        uint32_t r1_slot_offset;  // byte offset from packet_cb base
-        uint32_t r1_slot_bit;     // bitmask bit to signal
-        uint32_t r1_sem_addr;     // forwarder bitmask sem
+        uint32_t r1_slot_offset;
+        uint32_t r1_slot_bit;
+        uint32_t r1_sem_addr;
         uint32_t r2_slot_offset;
         uint32_t r2_slot_bit;
         uint32_t r2_sem_addr;
@@ -181,9 +181,9 @@ struct ReduceToAllB1 {
         uint32_t r3_dst_l1_addr;
         uint32_t r3_dst_sem_addr;
         uint32_t output_base_addr;
-        uint32_t r3_slot_offset;  // byte offset from packet_cb base for R3 FC slot
-        uint32_t r3_slot_bit;     // bitmask bit to signal on r3_fwd_sem
-        uint32_t r3_sem_addr;     // FC's r3 bitmask sem address
+        uint32_t r3_slot_offset;
+        uint32_t r3_slot_bit;
+        uint32_t r3_sem_addr;
     };
 
     struct ComputeArgs {};
@@ -265,8 +265,7 @@ struct ReduceToAllB1 {
 
             uint64_t sem_noc = get_noc_addr(fc_noc_x, fc_noc_y, fc_sem_addr);
             noc_semaphore_inc(sem_noc, fc_slot_bit);
-            noc_async_write_barrier();
-            noc_async_atomic_barrier();
+            noc_async_full_barrier();
         }
 #endif
 
@@ -289,8 +288,8 @@ struct ReduceToAllB1 {
                 const uint32_t r2_base = buf_base + CTArgs::r2_buffer_offset;
 
                 size_t arg_idx = 0;
-                const uint32_t r1_sem_addr = get_arg_val<uint32_t>(arg_idx++);
-                const uint32_t r2_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+                const uint32_t r1_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+                const uint32_t r2_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
                 auto bwd_sender =
                     tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
@@ -360,9 +359,9 @@ struct ReduceToAllB1 {
                 const uint32_t r3_base = buf_base + CTArgs::r3_buffer_offset;
 
                 size_t arg_idx = 0;
-                const uint32_t r1_sem_addr = get_arg_val<uint32_t>(arg_idx++);
-                const uint32_t r2_sem_addr = get_arg_val<uint32_t>(arg_idx++);
-                const uint32_t r3_sem_addr_val = get_arg_val<uint32_t>(arg_idx++);
+                const uint32_t r1_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+                const uint32_t r2_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+                const uint32_t r3_sem_addr_val = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
                 auto fwd_sender =
                     tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/41202

### Problem description
Provide context for the problem.

### What's changed
- Implement reduce to all op for blitz decoder. It is the same as reduce to one op but the final output is available on all 8 devices: it uses bidirectional fabric transactions between devices instead of unidirectional ones and all devices do the local reduction
- This op will replace reduce to one op in blitz moe: this would allow us to have 4 to 8 exit nodes per pipeline stage, which will remove later the need for broadcast op at the start of the decoder and improve perf
- Next step is to add support for multi exit node for the pipeline op

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nardo/reduce_to_all_b1)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/reduce_to_all_b1)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/reduce_to_all_b1)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/reduce_to_all_b1)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/reduce_to_all_b1)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/reduce_to_all_b1)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nardo/reduce_to_all_b1) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/reduce_to_all_b1) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/reduce_to_all_b1) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/reduce_to_all_b1) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/reduce_to_all_b1) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/reduce_to_all_b1) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nardo/reduce_to_all_b1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/reduce_to_all_b1) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/reduce_to_all_b1) |