### PR TITLE
Refactor from_torch on-device construction logic 

### DIFF
--- a/models/tt_dit/tests/unit/test_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_ring_joint_attention.py
@@ -12,6 +12,7 @@ from tracy.process_model_log import post_process_ops_log, run_device_profiler
 
 import ttnn
 from models.tt_dit.utils.padding import get_padded_vision_seq_len
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
 
@@ -60,6 +61,7 @@ def create_ring_joint_sdpa_submesh(mesh_device, rp_axis, rp_factor, up_axis, up_
     submesh_shape[rp_axis] = rp_factor
     submesh_shape[up_axis] = up_factor
     submesh_device = mesh_device.create_submesh(ttnn.MeshShape(submesh_shape[0], submesh_shape[1]))
+    submesh_device.cache_entries_counter = CacheEntriesCounter(submesh_device)
     return submesh_device
 
 
@@ -465,31 +467,32 @@ def run_ring_joint_sdpa(
     tt_joint_out_list = []
 
     def run_iters(tt_out_list, tt_joint_out_list):
-        for i in range(n_iters):
-            tt_out, tt_joint_out, tt_lse = ttnn.transformer.ring_joint_scaled_dot_product_attention(
-                tt_Q,
-                tt_K,
-                tt_V,
-                tt_joint_Q,
-                tt_joint_K,
-                tt_joint_V,
-                persistent_output_buffer_k=persistent_output_buffers[i][0],
-                persistent_output_buffer_v=persistent_output_buffers[i][1],
-                joint_strategy="rear",
-                logical_n=base_seq_len,
-                program_config=program_config,
-                compute_kernel_config=compute_kernel_config,
-                dim=2,
-                multi_device_global_semaphore=ccl_semaphore_handles[i],
-                num_links=num_links,
-                cluster_axis=rp_axis,
-                mesh_device=submesh,
-                topology=all_gather_topology,
-                subdevice_id=worker_sub_device_id,
-                ccl_core_grid_offset=ccl_core_grid_offset,
-            )
-            tt_out_list.append(tt_out)
-            tt_joint_out_list.append(tt_joint_out)
+        with submesh.cache_entries_counter.measure():
+            for i in range(n_iters):
+                tt_out, tt_joint_out, tt_lse = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                    tt_Q,
+                    tt_K,
+                    tt_V,
+                    tt_joint_Q,
+                    tt_joint_K,
+                    tt_joint_V,
+                    persistent_output_buffer_k=persistent_output_buffers[i][0],
+                    persistent_output_buffer_v=persistent_output_buffers[i][1],
+                    joint_strategy="rear",
+                    logical_n=base_seq_len,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                    dim=2,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i],
+                    num_links=num_links,
+                    cluster_axis=rp_axis,
+                    mesh_device=submesh,
+                    topology=all_gather_topology,
+                    subdevice_id=worker_sub_device_id,
+                    ccl_core_grid_offset=ccl_core_grid_offset,
+                )
+                tt_out_list.append(tt_out)
+                tt_joint_out_list.append(tt_joint_out)
 
     if trace_enabled:
         logger.info("Compile run")

--- a/tests/nightly/blackhole/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/blackhole/ccl/test_ring_joint_attention.py
@@ -181,4 +181,4 @@ def test_ring_joint_sdpa_program_cache(
             pcc_threshold,
         )
 
-    assert submesh.num_program_cache_entries() == 1
+    assert submesh.cache_entries_counter.total == 1

--- a/tests/nightly/t3000/ccl/test_mesh_partition.py
+++ b/tests/nightly/t3000/ccl/test_mesh_partition.py
@@ -147,22 +147,23 @@ def run_mesh_partition_test(
 
     def run_op(n_iters, store_all_results=True):
         tt_output_list = []
-        for i in range(n_iters):
-            buffer_index = 0 if trace_mode else i
-            tt_out_tensor = ttnn.mesh_partition(
-                tt_input_tensors_list[buffer_index],
-                dim,
-                cluster_axis=cluster_axis,
-                memory_config=output_memory_config,
-            )
-            if not trace_mode:
-                ttnn.synchronize_device(mesh_device)
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(n_iters):
+                buffer_index = 0 if trace_mode else i
+                tt_out_tensor = ttnn.mesh_partition(
+                    tt_input_tensors_list[buffer_index],
+                    dim,
+                    cluster_axis=cluster_axis,
+                    memory_config=output_memory_config,
+                )
+                if not trace_mode:
+                    ttnn.synchronize_device(mesh_device)
+                if store_all_results:
+                    tt_output_list.append(tt_out_tensor)
             if store_all_results:
-                tt_output_list.append(tt_out_tensor)
-        if store_all_results:
-            return tt_output_list
-        else:
-            return [tt_out_tensor]
+                return tt_output_list
+            else:
+                return [tt_out_tensor]
 
     if trace_mode:
         # compile run:
@@ -229,10 +230,10 @@ def run_mesh_partition_test(
             failed_indices = torch.where(tt_torch_tensor != output_tensor_goldens_list[tensor_index])
             break
 
-    logger.info(f"Device has {mesh_device.num_program_cache_entries()} program cache entries")
+    logger.info(f"Device has {mesh_device.cache_entries_counter.total} program cache entries")
     assert (
-        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
-    ), f"Device {mesh_device.id} has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 or mesh_device.cache_entries_counter.total == num_iters
+    ), f"Device {mesh_device.id} has {mesh_device.cache_entries_counter.total} program cache entries"
 
     if not passed:
         logger.info(f"Failed indices: {failed_indices}")

--- a/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
+++ b/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
@@ -7,6 +7,7 @@ import pytest
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 
 
 def create_global_semaphores(mesh_device, cores, initial_value):
@@ -39,6 +40,7 @@ def create_ring_attention_submesh(mesh_device, rp_axis, rp_factor, up_factor):
     submesh_shape[rp_axis] = rp_factor
     submesh_shape[1 - rp_axis] = up_factor
     submesh_device = mesh_device.create_submesh(ttnn.MeshShape(submesh_shape[0], submesh_shape[1]))
+    submesh_device.cache_entries_counter = CacheEntriesCounter(submesh_device)
     return submesh_device
 
 
@@ -133,20 +135,21 @@ def run_ring_attention_all_gather_impl(
     tt_all_gather_out_tensor_list = []
 
     def run_op(i):
-        tt_all_gather_out_tensors = ttnn.experimental.ring_attention_all_gather_async(
-            ag_input_tensor_mesh_list[i],
-            persistent_output_buffer=persistent_output_buffers[i],
-            dim=sequence_index,
-            multi_device_global_semaphore=ccl_semaphore_handles[i],
-            cluster_axis=rp_axis,
-            mesh_device=mesh_device,
-            num_links=num_links,
-            memory_config=mem_config_ag,
-            topology=all_gather_topology,
-            subdevice_id=worker_sub_device_id,
-        )
+        with mesh_device.cache_entries_counter.measure():
+            tt_all_gather_out_tensors = ttnn.experimental.ring_attention_all_gather_async(
+                ag_input_tensor_mesh_list[i],
+                persistent_output_buffer=persistent_output_buffers[i],
+                dim=sequence_index,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                cluster_axis=rp_axis,
+                mesh_device=mesh_device,
+                num_links=num_links,
+                memory_config=mem_config_ag,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+            )
 
-        return tt_all_gather_out_tensors
+            return tt_all_gather_out_tensors
 
     if enable_trace:
         # Compile the op
@@ -412,4 +415,4 @@ def test_ring_attention_all_gather_program_cache(
         )
         ttnn.synchronize_device(submesh_device)
 
-    assert submesh_device.num_program_cache_entries() == 1
+    assert submesh_device.cache_entries_counter.total == 1

--- a/tests/nightly/t3000/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/t3000/ccl/test_ring_joint_attention.py
@@ -261,6 +261,7 @@ def test_ring_joint_sdpa_program_cache(
 
     skip_check = False
 
+    submesh.cache_entries_counter = CacheEntriesCounter(submesh)
     dummy_tensors = []
     for i in range(3):
         dummy_tensors.append(
@@ -294,7 +295,7 @@ def test_ring_joint_sdpa_program_cache(
             pcc_threshold,
         )
 
-    assert submesh.num_program_cache_entries() == 1
+    assert submesh.cache_entries_counter.total == 1
 
 
 # ===========================================================================

--- a/tests/nightly/tg/ccl/test_all_reduce.py
+++ b/tests/nightly/tg/ccl/test_all_reduce.py
@@ -9,6 +9,7 @@ import ttnn
 import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.nightly.tg.ccl.test_all_reduce_async import run_all_reduce_with_mesh_tensor_along_row
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 
 
 # Enumerate the post-commit cases explicitly
@@ -178,6 +179,7 @@ def test_line_all_reduce_training(
     else:
         submesh_device = mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
 
+    submesh_device.cache_entries_counter = CacheEntriesCounter(submesh_device)
     run_all_reduce_with_mesh_tensor_along_row(
         submesh_device,
         num_devices,

--- a/tests/nightly/tg/ccl/test_all_reduce_async.py
+++ b/tests/nightly/tg/ccl/test_all_reduce_async.py
@@ -199,33 +199,34 @@ def run_all_reduce_with_mesh_tensor_along_row(
         input_tensor_mesh = ttnn.to_device(ttnn_tensor, mesh_device)
 
         # Run the op
-        for i in range(num_iters):
-            if use_semaphore_free_all_reduce_impl:
-                logger.info("Using semaphore-free all-reduce implementation")
-                output_tensor_mesh = ttnn.all_reduce(
-                    input_tensor_mesh,
-                    cluster_axis=cluster_axis,
-                    subdevice_id=worker_sub_device_id,
-                    num_links=num_links,
-                    memory_config=mem_config,
-                    topology=ttnn.Topology.Linear,
-                )
-            else:
-                logger.info("Using experimental all-reduce implementation")
-                output_tensor_mesh = ttnn.experimental.all_reduce_async(
-                    input_tensor_mesh,
-                    cluster_axis=cluster_axis,
-                    mesh_device=mesh_device,
-                    barrier_semaphores=barrier_semaphores,
-                    rs_global_semaphores=rs_global_semaphores,
-                    ag_global_semaphores=ag_global_semaphores,
-                    math_op=math_op,
-                    num_links=num_links,
-                    memory_config=mem_config,
-                    topology=ttnn.Topology.Linear,
-                    subdevice_id=worker_sub_device_id,
-                )
-            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(num_iters):
+                if use_semaphore_free_all_reduce_impl:
+                    logger.info("Using semaphore-free all-reduce implementation")
+                    output_tensor_mesh = ttnn.all_reduce(
+                        input_tensor_mesh,
+                        cluster_axis=cluster_axis,
+                        subdevice_id=worker_sub_device_id,
+                        num_links=num_links,
+                        memory_config=mem_config,
+                        topology=ttnn.Topology.Linear,
+                    )
+                else:
+                    logger.info("Using experimental all-reduce implementation")
+                    output_tensor_mesh = ttnn.experimental.all_reduce_async(
+                        input_tensor_mesh,
+                        cluster_axis=cluster_axis,
+                        mesh_device=mesh_device,
+                        barrier_semaphores=barrier_semaphores,
+                        rs_global_semaphores=rs_global_semaphores,
+                        ag_global_semaphores=ag_global_semaphores,
+                        math_op=math_op,
+                        num_links=num_links,
+                        memory_config=mem_config,
+                        topology=ttnn.Topology.Linear,
+                        subdevice_id=worker_sub_device_id,
+                    )
+                ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
         ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
     except Exception as e:
         raise e
@@ -506,12 +507,12 @@ def test_all_reduce_fabric_2d(
 
     if memory_config.is_sharded() == False:
         if device_params["fabric_config"] == ttnn.FabricConfig.FABRIC_2D:
-            logger.info(f"Number of program cache entries: {mesh_device.num_program_cache_entries()}")
+            logger.info(f"Number of program cache entries: {mesh_device.cache_entries_counter.total}")
             assert (
-                mesh_device.num_program_cache_entries() == 3
-            ), f"Number of program cache entries: {mesh_device.num_program_cache_entries()} but was expecting 3 as we are using fabric 2D, which fallsback to composite all gather + local reduce"
+                mesh_device.cache_entries_counter.total == 3
+            ), f"Number of program cache entries: {mesh_device.cache_entries_counter.total} but was expecting 3 as we are using fabric 2D, which fallsback to composite all gather + local reduce"
         elif device_params["fabric_config"] == ttnn.FabricConfig.FABRIC_2D:
-            logger.info(f"Number of program cache entries: {mesh_device.num_program_cache_entries()}")
+            logger.info(f"Number of program cache entries: {mesh_device.cache_entries_counter.total}")
             assert (
-                mesh_device.num_program_cache_entries() == 2
-            ), f"Number of program cache entries: {mesh_device.num_program_cache_entries()} but was expecting 2 as we are using fabric 2D dynamic, which uses reduce scatter + all gather"
+                mesh_device.cache_entries_counter.total == 2
+            ), f"Number of program cache entries: {mesh_device.cache_entries_counter.total} but was expecting 2 as we are using fabric 2D dynamic, which uses reduce scatter + all gather"

--- a/tests/nightly/tg/ccl/test_ring_attention_all_gather.py
+++ b/tests/nightly/tg/ccl/test_ring_attention_all_gather.py
@@ -203,4 +203,4 @@ def test_ring_attention_all_gather_program_cache(
         )
         ttnn.synchronize_device(submesh_device)
 
-    assert submesh_device.num_program_cache_entries() == 1
+    assert submesh_device.cache_entries_counter.total == 1

--- a/tests/nightly/tg/ccl/test_ring_joint_attention.py
+++ b/tests/nightly/tg/ccl/test_ring_joint_attention.py
@@ -149,7 +149,6 @@ def test_ring_joint_sdpa(
     logger.debug(f"submesh: {submesh.shape}")
 
     skip_check = False
-
     run_ring_joint_sdpa(
         submesh,
         b,
@@ -237,7 +236,6 @@ def test_ring_joint_sdpa_program_cache(
     logger.debug(f"submesh: {submesh.shape}")
 
     skip_check = False
-
     dummy_tensors = []
     for i in range(3):
         dummy_tensors.append(
@@ -271,4 +269,4 @@ def test_ring_joint_sdpa_program_cache(
             pcc_threshold,
         )
 
-    assert submesh.num_program_cache_entries() == 1
+    assert submesh.cache_entries_counter.total == 1

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
@@ -134,4 +134,6 @@ def test_rotary_embedding_llama_fused_qk_with_program_cache(
     if (batch * 2) % ttnn.TILE_SIZE != 0:
         num_ops += 1  # slice
 
-    assert device.num_program_cache_entries() == num_ops
+    assert (
+        device.cache_entries_counter.total == num_ops
+    ), f"Expected {num_ops} program cache entries, but found {device.cache_entries_counter.total}"

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_rotary_embedding_llama.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_rotary_embedding_llama.py
@@ -186,7 +186,8 @@ def run_test_rotary_embedding_llama(
                 device, batch * 2, head_dim, max_seq_len, rope_theta=10000, rope_scaling=None
             )
             tt_model.transformation_mat = rope_setup_decode.transformation_mat
-            cos, sin = rope_setup_decode.get_rot_mats(position_ids.repeat(2))
+            with device.cache_entries_counter.measure():
+                cos, sin = rope_setup_decode.get_rot_mats(position_ids.repeat(2))
 
             assert (
                 batch % 8 == 0 or batch == 1
@@ -257,7 +258,8 @@ def run_test_rotary_embedding_llama(
         tt_inp = [inp[0], inp[1], cos, sin]
         tt_inp = [ttnn.from_torch(i, device=device, dtype=datatype, layout=ttnn.TILE_LAYOUT) for i in tt_inp]
 
-    tt_out = tt_model(*tt_inp)
+    with device.cache_entries_counter.measure():
+        tt_out = tt_model(*tt_inp)
     tt_out = [ttnn.to_torch(tt_out_tensor) for tt_out_tensor in tt_out]
 
     if mode == "decode":

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all.py
@@ -10,6 +10,7 @@ from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
 from models.common.utility_functions import skip_for_wormhole_b0, skip_for_n_or_less_dev
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 
 
 def run_with_trace(
@@ -143,6 +144,8 @@ def run_all_to_all_impl(
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
 
+    mesh_device.cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
@@ -220,41 +223,42 @@ def run_all_to_all_impl(
         input_tensor_mesh_list.append(input_tensor_mesh)
 
     tt_out_tensor_list = []
-    if trace_mode:
-        tt_out_tensor = run_with_trace(
-            mesh_device,
-            topology,
-            input_tensor_mesh_list[0],
-            persistent_intermediate_buffers[0],
-            persistent_output_buffers[0],
-            in_dim,
-            out_dim,
-            num_links,
-            output_mem_config,
-            multi_device_global_semaphore=ccl_semaphore_handles[0],
-            num_iter=num_iters,
-            subdevice_id=worker_sub_device_id,
-        )
-        tt_out_tensor_list.append(tt_out_tensor)
-    else:
-        for i in range(num_iters):
-            tt_out_tensor = ttnn.experimental.all_to_all_async(
-                input_tensor_mesh_list[i if not reuse_inputs else 0],
-                persistent_intermediate_buffer=persistent_intermediate_buffers[i],
-                persistent_output_buffer=persistent_output_buffers[i],
-                in_dim=in_dim,
-                out_dim=out_dim,
-                multi_device_global_semaphore=ccl_semaphore_handles[i],
-                num_links=num_links,
-                memory_config=output_mem_config,
-                topology=topology,
+    with mesh_device.cache_entries_counter.measure():
+        if trace_mode:
+            tt_out_tensor = run_with_trace(
+                mesh_device,
+                topology,
+                input_tensor_mesh_list[0],
+                persistent_intermediate_buffers[0],
+                persistent_output_buffers[0],
+                in_dim,
+                out_dim,
+                num_links,
+                output_mem_config,
+                multi_device_global_semaphore=ccl_semaphore_handles[0],
+                num_iter=num_iters,
                 subdevice_id=worker_sub_device_id,
             )
-            tt_out_tensor_list.append(persistent_output_buffers[i])
+            tt_out_tensor_list.append(tt_out_tensor)
+        else:
+            for i in range(num_iters):
+                tt_out_tensor = ttnn.experimental.all_to_all_async(
+                    input_tensor_mesh_list[i if not reuse_inputs else 0],
+                    persistent_intermediate_buffer=persistent_intermediate_buffers[i],
+                    persistent_output_buffer=persistent_output_buffers[i],
+                    in_dim=in_dim,
+                    out_dim=out_dim,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i],
+                    num_links=num_links,
+                    memory_config=output_mem_config,
+                    topology=topology,
+                    subdevice_id=worker_sub_device_id,
+                )
+                tt_out_tensor_list.append(persistent_output_buffers[i])
 
-        logger.info(f"Waiting for op")
-        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-        logger.info(f"Done op")
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
 
     passed = True
     if do_check:
@@ -274,8 +278,8 @@ def run_all_to_all_impl(
                     passed = False
 
     assert (
-        mesh_device.num_program_cache_entries() == 1
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_new_all_broadcast.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_new_all_broadcast.py
@@ -10,6 +10,7 @@ from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from models.common.utility_functions import skip_for_wormhole_b0, skip_for_n_or_less_dev
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 
 
 def run_with_trace(
@@ -179,32 +180,35 @@ def run_all_broadcast_impl(
 
         input_tensor_mesh_list.append(input_tensor_mesh)
 
+    cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     tt_out_tensor_list = []
-    if trace_mode:
-        tt_out_tensor = run_with_trace(
-            mesh_device,
-            all_broadcast_topology,
-            input_tensor_mesh_list[0],
-            num_links,
-            output_mem_config,
-            num_iter=num_iters,
-            subdevice_id=worker_sub_device_id,
-        )
-        tt_out_tensor_list.append(tt_out_tensor)
-    else:
-        for i in range(num_iters):
-            tt_out_tensors = ttnn.all_broadcast(
-                input_tensor_mesh_list[i],
-                num_links=num_links,
-                memory_config=output_mem_config,
-                topology=all_broadcast_topology,
+    with cache_entries_counter.measure():
+        if trace_mode:
+            tt_out_tensor = run_with_trace(
+                mesh_device,
+                all_broadcast_topology,
+                input_tensor_mesh_list[0],
+                num_links,
+                output_mem_config,
+                num_iter=num_iters,
                 subdevice_id=worker_sub_device_id,
             )
-            tt_out_tensor_list.append(tt_out_tensors)
+            tt_out_tensor_list.append(tt_out_tensor)
+        else:
+            for i in range(num_iters):
+                tt_out_tensors = ttnn.all_broadcast(
+                    input_tensor_mesh_list[i],
+                    num_links=num_links,
+                    memory_config=output_mem_config,
+                    topology=all_broadcast_topology,
+                    subdevice_id=worker_sub_device_id,
+                )
+                tt_out_tensor_list.append(tt_out_tensors)
 
-        logger.info(f"Waiting for op")
-        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-        logger.info(f"Done op")
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
 
     passed = True
     for tensor_index in range(len(tt_out_tensor_list)):
@@ -223,8 +227,8 @@ def run_all_broadcast_impl(
                     logger.error(f"output mismatch for tensor {i}")
                     assert eq, f"{i} FAILED: {output}"
     assert (
-        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        cache_entries_counter.total == 1 or cache_entries_counter.total == num_iters
+    ), f"Device has {cache_entries_counter.total} program cache entries"
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()
     if not passed:

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_new_all_reduce.py
@@ -15,6 +15,7 @@ from tests.ttnn.nightly.unit_tests.operations.matmul.test_matmul_1d_gather_in0 i
     num_cores_to_rectangle_grid,
     round_up,
 )
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 from models.demos.llama3_70b_galaxy.tt.model_config import (
     PREFETCHER_NOC1_GRID,
 )
@@ -182,6 +183,8 @@ def run_all_reduce_impl(
     ##### Run the op
     ##################################
 
+    cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     def run_op(n_iters, store_all_results=True):
         outs = []
         for i in range(n_iters):
@@ -214,52 +217,53 @@ def run_all_reduce_impl(
         else:
             return [out]
 
-    if trace_mode:
-        ##### Compile Model #####
-        logger.info("Compiling model")
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
+    with cache_entries_counter.measure():
+        if trace_mode:
+            ##### Compile Model #####
+            logger.info("Compiling model")
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
 
-        ##### Capture Trace #####
-        logger.info("Capturing trace")
-        if warmup_iters > 0:
-            trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-            tt_outs = run_op(warmup_iters, store_all_results=validate_all)
-            ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+            ##### Capture Trace #####
+            logger.info("Capturing trace")
+            if warmup_iters > 0:
+                trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+                tt_outs = run_op(warmup_iters, store_all_results=validate_all)
+                ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+                ttnn.synchronize_device(mesh_device)
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
             ttnn.synchronize_device(mesh_device)
 
-        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
-        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(mesh_device)
+            ##### Run Trace #####
+            logger.info("Starting Trace perf test...")
+            profiler.start("all-reduce-async-trace-warmup")
+            if warmup_iters > 0:
+                ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+                ttnn.release_trace(mesh_device, trace_id_warmup)
+                ttnn.synchronize_device(mesh_device)
+            profiler.end("all-reduce-async-trace-warmup")
 
-        ##### Run Trace #####
-        logger.info("Starting Trace perf test...")
-        profiler.start("all-reduce-async-trace-warmup")
-        if warmup_iters > 0:
-            ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
-            ttnn.release_trace(mesh_device, trace_id_warmup)
+            signpost("start")
+            profiler.start("all-reduce-async-trace")
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.release_trace(mesh_device, trace_id)
             ttnn.synchronize_device(mesh_device)
-        profiler.end("all-reduce-async-trace-warmup")
+            profiler.end("all-reduce-async-trace")
+            signpost("stop")
+            time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
+                "all-reduce-async-trace-warmup"
+            )
+            effective_iter = num_iters - warmup_iters
+            logger.info(f"Time taken e2e: {time_taken} s")
+            logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
+            logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
 
-        signpost("start")
-        profiler.start("all-reduce-async-trace")
-        ttnn.execute_trace(mesh_device, trace_id, blocking=False)
-        ttnn.release_trace(mesh_device, trace_id)
-        ttnn.synchronize_device(mesh_device)
-        profiler.end("all-reduce-async-trace")
-        signpost("stop")
-        time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
-            "all-reduce-async-trace-warmup"
-        )
-        effective_iter = num_iters - warmup_iters
-        logger.info(f"Time taken e2e: {time_taken} s")
-        logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
-        logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
-
-    else:
-        signpost("start")
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
-        signpost("stop")
+        else:
+            signpost("start")
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
+            signpost("stop")
 
     ##################################
     ##### Validation
@@ -294,9 +298,8 @@ def run_all_reduce_impl(
 
     reshard_op_cnt = 1 if loopback_size > 1 else 0
     assert (
-        mesh_device.num_program_cache_entries() == 1 + reshard_op_cnt
-        or mesh_device.num_program_cache_entries() == num_iters + reshard_op_cnt
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        cache_entries_counter.total == 1 + reshard_op_cnt or cache_entries_counter.total == num_iters + reshard_op_cnt
+    ), f"Device has {cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_all_gather_matmul.py
@@ -348,33 +348,34 @@ def run_llama_all_gather_matmul_impl(
     ##################################
     def run_op(n_iters, store_all_results=True):
         outs = []
-        for i in range(n_iters):
-            out = ttnn.experimental.llama_all_gather_matmul_async(
-                tt_input_tensor,
-                tt_in1_tensor,
-                tt_intermediate_tensors[i % num_buffers],
-                dim=3,
-                cluster_axis=cluster_axis,
-                mesh_device=mesh_device,
-                multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
-                ag_memory_config=ag_output_mem_config,
-                mm_memory_config=mm_output_sharded_mem_config,
-                topology=all_gather_replicate_topology,
-                num_links=num_links,
-                subdevice_id=worker_sub_device_id,
-                program_config=program_config,
-                compute_kernel_config=compute_kernel_config,
-                dtype=output_dtype,
-                global_cb=global_cb,
-            )
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(n_iters):
+                out = ttnn.experimental.llama_all_gather_matmul_async(
+                    tt_input_tensor,
+                    tt_in1_tensor,
+                    tt_intermediate_tensors[i % num_buffers],
+                    dim=3,
+                    cluster_axis=cluster_axis,
+                    mesh_device=mesh_device,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
+                    ag_memory_config=ag_output_mem_config,
+                    mm_memory_config=mm_output_sharded_mem_config,
+                    topology=all_gather_replicate_topology,
+                    num_links=num_links,
+                    subdevice_id=worker_sub_device_id,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                    dtype=output_dtype,
+                    global_cb=global_cb,
+                )
 
-            # TODO: Change when actual output is integrated
-            # out = tt_intermediate_tensors[i % num_buffers]
+                # TODO: Change when actual output is integrated
+                # out = tt_intermediate_tensors[i % num_buffers]
 
-            if not trace_mode:
-                ttnn.synchronize_device(mesh_device)
-            if store_all_results:
-                outs.append(out)
+                if not trace_mode:
+                    ttnn.synchronize_device(mesh_device)
+                if store_all_results:
+                    outs.append(out)
 
         if store_all_results:
             return outs
@@ -433,7 +434,7 @@ def run_llama_all_gather_matmul_impl(
         validate(tt_out_tensor, output_tensor)
 
     assert (
-        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 or mesh_device.cache_entries_counter.total == num_iters
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -14,6 +14,7 @@ from tests.ttnn.nightly.unit_tests.operations.matmul.test_matmul_1d_gather_in0 i
     num_cores_to_rectangle_grid,
     round_up,
 )
+from tests.tests_common.cache_entries_counter import CacheEntriesCounter
 from models.demos.llama3_70b_galaxy.tt.model_config import (
     PREFETCHER_NOC1_GRID,
 )
@@ -181,6 +182,8 @@ def run_all_reduce_impl(
     ##### Run the op
     ##################################
 
+    cache_entries_counter = CacheEntriesCounter(mesh_device)
+
     def run_op(n_iters, store_all_results=True):
         outs = []
         for i in range(n_iters):
@@ -213,52 +216,53 @@ def run_all_reduce_impl(
         else:
             return [out]
 
-    if trace_mode:
-        ##### Compile Model #####
-        logger.info("Compiling model")
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
+    with cache_entries_counter.measure():
+        if trace_mode:
+            ##### Compile Model #####
+            logger.info("Compiling model")
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
 
-        ##### Capture Trace #####
-        logger.info("Capturing trace")
-        if warmup_iters > 0:
-            trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-            tt_outs = run_op(warmup_iters, store_all_results=validate_all)
-            ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+            ##### Capture Trace #####
+            logger.info("Capturing trace")
+            if warmup_iters > 0:
+                trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+                tt_outs = run_op(warmup_iters, store_all_results=validate_all)
+                ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+                ttnn.synchronize_device(mesh_device)
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
             ttnn.synchronize_device(mesh_device)
 
-        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
-        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(mesh_device)
+            ##### Run Trace #####
+            logger.info("Starting Trace perf test...")
+            profiler.start("all-reduce-async-trace-warmup")
+            if warmup_iters > 0:
+                ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+                ttnn.release_trace(mesh_device, trace_id_warmup)
+                ttnn.synchronize_device(mesh_device)
+            profiler.end("all-reduce-async-trace-warmup")
 
-        ##### Run Trace #####
-        logger.info("Starting Trace perf test...")
-        profiler.start("all-reduce-async-trace-warmup")
-        if warmup_iters > 0:
-            ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
-            ttnn.release_trace(mesh_device, trace_id_warmup)
+            signpost("start")
+            profiler.start("all-reduce-async-trace")
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.release_trace(mesh_device, trace_id)
             ttnn.synchronize_device(mesh_device)
-        profiler.end("all-reduce-async-trace-warmup")
+            profiler.end("all-reduce-async-trace")
+            signpost("stop")
+            time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
+                "all-reduce-async-trace-warmup"
+            )
+            effective_iter = num_iters - warmup_iters
+            logger.info(f"Time taken e2e: {time_taken} s")
+            logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
+            logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
 
-        signpost("start")
-        profiler.start("all-reduce-async-trace")
-        ttnn.execute_trace(mesh_device, trace_id, blocking=False)
-        ttnn.release_trace(mesh_device, trace_id)
-        ttnn.synchronize_device(mesh_device)
-        profiler.end("all-reduce-async-trace")
-        signpost("stop")
-        time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
-            "all-reduce-async-trace-warmup"
-        )
-        effective_iter = num_iters - warmup_iters
-        logger.info(f"Time taken e2e: {time_taken} s")
-        logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
-        logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
-
-    else:
-        signpost("start")
-        tt_outs = run_op(num_iters, store_all_results=validate_all)
-        signpost("stop")
+        else:
+            signpost("start")
+            tt_outs = run_op(num_iters, store_all_results=validate_all)
+            signpost("stop")
 
     ##################################
     ##### Validation
@@ -293,9 +297,8 @@ def run_all_reduce_impl(
 
     reshard_op_cnt = 1 if loopback_size > 1 else 0
     assert (
-        mesh_device.num_program_cache_entries() == 1 + reshard_op_cnt
-        or mesh_device.num_program_cache_entries() == num_iters + reshard_op_cnt
-    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+        cache_entries_counter.total == 1 + reshard_op_cnt or cache_entries_counter.total == num_iters + reshard_op_cnt
+    ), f"Device has {cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -14,7 +14,7 @@ from tests.ttnn.nightly.unit_tests.operations.matmul.test_matmul_1d_gather_in0 i
     num_cores_to_rectangle_grid,
     round_up,
 )
-from tests.tests_common.cache_entries_counter import CacheEntriesCounter
+
 from models.demos.llama3_70b_galaxy.tt.model_config import (
     PREFETCHER_NOC1_GRID,
 )
@@ -182,87 +182,85 @@ def run_all_reduce_impl(
     ##### Run the op
     ##################################
 
-    cache_entries_counter = CacheEntriesCounter(mesh_device)
-
     def run_op(n_iters, store_all_results=True):
         outs = []
-        for i in range(n_iters):
-            if i % loopback_size == 0:
-                tt_input = tt_input_tensor
+        with mesh_device.cache_entries_counter.measure():
+            for i in range(n_iters):
+                if i % loopback_size == 0:
+                    tt_input = tt_input_tensor
 
-            out = ttnn.experimental.all_reduce_async(
-                tt_input,
-                tt_intermediate_tensors[i % num_buffers],
-                cluster_axis=cluster_axis,
-                mesh_device=mesh_device,
-                multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
-                memory_config=output_mem_config,
-                dtype=output_dtype,
-                topology=all_reduce_topology,
-                num_links=num_links,
-                subdevice_id=worker_sub_device_id,
-            )
-            if not trace_mode:
-                ttnn.synchronize_device(mesh_device)
+                out = ttnn.experimental.all_reduce_async(
+                    tt_input,
+                    tt_intermediate_tensors[i % num_buffers],
+                    cluster_axis=cluster_axis,
+                    mesh_device=mesh_device,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i % num_buffers],
+                    memory_config=output_mem_config,
+                    dtype=output_dtype,
+                    topology=all_reduce_topology,
+                    num_links=num_links,
+                    subdevice_id=worker_sub_device_id,
+                )
+                if not trace_mode:
+                    ttnn.synchronize_device(mesh_device)
+                if store_all_results:
+                    outs.append(out)
+
+                # Loop back the output to the input
+                if loopback_size != 1:
+                    tt_input = ttnn.reshard(out, input_mem_config)
+
             if store_all_results:
-                outs.append(out)
+                return outs
+            else:
+                return [out]
 
-            # Loop back the output to the input
-            if loopback_size != 1:
-                tt_input = ttnn.reshard(out, input_mem_config)
+    if trace_mode:
+        ##### Compile Model #####
+        logger.info("Compiling model")
+        tt_outs = run_op(num_iters, store_all_results=validate_all)
 
-        if store_all_results:
-            return outs
-        else:
-            return [out]
-
-    with cache_entries_counter.measure():
-        if trace_mode:
-            ##### Compile Model #####
-            logger.info("Compiling model")
-            tt_outs = run_op(num_iters, store_all_results=validate_all)
-
-            ##### Capture Trace #####
-            logger.info("Capturing trace")
-            if warmup_iters > 0:
-                trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-                tt_outs = run_op(warmup_iters, store_all_results=validate_all)
-                ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
-                ttnn.synchronize_device(mesh_device)
-
-            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-            tt_outs = run_op(num_iters, store_all_results=validate_all)
-            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ##### Capture Trace #####
+        logger.info("Capturing trace")
+        if warmup_iters > 0:
+            trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            tt_outs = run_op(warmup_iters, store_all_results=validate_all)
+            ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
             ttnn.synchronize_device(mesh_device)
 
-            ##### Run Trace #####
-            logger.info("Starting Trace perf test...")
-            profiler.start("all-reduce-async-trace-warmup")
-            if warmup_iters > 0:
-                ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
-                ttnn.release_trace(mesh_device, trace_id_warmup)
-                ttnn.synchronize_device(mesh_device)
-            profiler.end("all-reduce-async-trace-warmup")
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_outs = run_op(num_iters, store_all_results=validate_all)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
 
-            signpost("start")
-            profiler.start("all-reduce-async-trace")
-            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
-            ttnn.release_trace(mesh_device, trace_id)
+        ##### Run Trace #####
+        logger.info("Starting Trace perf test...")
+        profiler.start("all-reduce-async-trace-warmup")
+        if warmup_iters > 0:
+            ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+            ttnn.release_trace(mesh_device, trace_id_warmup)
             ttnn.synchronize_device(mesh_device)
-            profiler.end("all-reduce-async-trace")
-            signpost("stop")
-            time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
-                "all-reduce-async-trace-warmup"
-            )
-            effective_iter = num_iters - warmup_iters
-            logger.info(f"Time taken e2e: {time_taken} s")
-            logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
-            logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
+        profiler.end("all-reduce-async-trace-warmup")
 
-        else:
-            signpost("start")
-            tt_outs = run_op(num_iters, store_all_results=validate_all)
-            signpost("stop")
+        signpost("start")
+        profiler.start("all-reduce-async-trace")
+        ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.synchronize_device(mesh_device)
+        profiler.end("all-reduce-async-trace")
+        signpost("stop")
+        time_taken = profiler.get_duration("all-reduce-async-trace") - profiler.get_duration(
+            "all-reduce-async-trace-warmup"
+        )
+        effective_iter = num_iters - warmup_iters
+        logger.info(f"Time taken e2e: {time_taken} s")
+        logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
+        logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
+
+    else:
+        signpost("start")
+        tt_outs = run_op(num_iters, store_all_results=validate_all)
+        signpost("stop")
 
     ##################################
     ##### Validation
@@ -297,8 +295,9 @@ def run_all_reduce_impl(
 
     reshard_op_cnt = 1 if loopback_size > 1 else 0
     assert (
-        cache_entries_counter.total == 1 + reshard_op_cnt or cache_entries_counter.total == num_iters + reshard_op_cnt
-    ), f"Device has {cache_entries_counter.total} program cache entries"
+        mesh_device.cache_entries_counter.total == 1 + reshard_op_cnt
+        or mesh_device.cache_entries_counter.total == num_iters + reshard_op_cnt
+    ), f"Device has {mesh_device.cache_entries_counter.total} program cache entries"
 
     mesh_device.reset_sub_device_stall_group()
 

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -906,3 +906,56 @@ def test_from_torch_zero_sized_dimension(mesh_device, shape, ttnn_dtype, ttnn_la
 
     assert ttnn_tensor.dtype == ttnn_dtype
     assert ttnn_tensor.layout == ttnn_layout
+
+
+@pytest.mark.parametrize(
+    "shard_height,shard_width,num_cores",
+    [
+        (1, 160, 4),
+        (1, 100, 8),
+        (7, 64, 4),
+    ],
+    ids=["deepseek_v3_lmhead_indices", "arbitrary_width", "non_tile_height"],
+)
+def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, shard_height, shard_width, num_cores):
+    """
+    Regression test: from_torch with ROW_MAJOR_LAYOUT and a WIDTH_SHARDED memory
+    config whose shard shape is not tile-aligned must not crash.
+
+    Reproduces TT_FATAL in tensor_layout.cpp:
+        Physical shard shape (1, 160) must be tile {32, 32} sized!
+
+    Derived from DeepSeek V3 LMHead stage (stage.py) which creates a uint32
+    indices tensor with per-core shard width of 160 in ROW_MAJOR_LAYOUT.
+    The ROW_MAJOR layout does not require tile-aligned shards, but from_torch
+    was internally constructing a TILE-layout TensorSpec that triggered the
+    tile-alignment assertion.
+    """
+    total_width = shard_width * num_cores
+
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_grid, (shard_height, shard_width), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    torch_tensor = torch.arange(shard_height * total_width, dtype=torch.int32).reshape(shard_height, total_width)
+
+    indices_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=1)
+
+    ttnn_tensor = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=memory_config,
+        mesh_mapper=indices_mesh_mapper,
+    )
+
+    assert ttnn_tensor.dtype == ttnn.uint32
+    assert ttnn_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert ttnn_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+
+    result = ttnn.to_torch(ttnn_tensor)
+    torch.testing.assert_close(torch_tensor, result.to(torch.int32))

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -530,6 +530,7 @@ def test_numpy_conversion_unsigned_edge_cases_fixed(
         (torch.float32, ttnn.bfloat16, [1, 7, 1, 128], [7 * 32, 32], 4, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
         (torch.bfloat16, ttnn.bfloat16, [1, 3, 1, 64], [3 * 32, 32], 2, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
         (torch.bfloat16, ttnn.bfloat16, [2, 7, 64, 128], [2 * 32 * 2, 128], 7, ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
+        (torch.bfloat16, ttnn.bfloat16, [1, 1, 1, 7 * 32], [32, 32], 7, ttnn.TensorMemoryLayout.WIDTH_SHARDED),
     ],
 )
 def test_from_torch_sharded_tile_layout_non_tile_aligned_height(

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -960,3 +960,43 @@ def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, 
 
     result = ttnn.to_torch(ttnn_tensor)
     torch.testing.assert_close(torch_tensor, result.to(torch.int32))
+
+
+@pytest.mark.parametrize(
+    "torch_dtype,ttnn_dtype,shape",
+    [
+        (torch.float32, ttnn.bfloat16, (8, 32, 2, 7000)),
+    ],
+)
+def test_from_torch_large_tensor_type_conversion_row_major_l1(device, torch_dtype, ttnn_dtype, shape):
+    """
+    Regression test: from_torch with a type conversion (float32 → bfloat16),
+    ROW_MAJOR_LAYOUT, L1_MEMORY_CONFIG, and a mesh_mapper must not OOM.
+
+    Derived from test_all_to_all_combine_no_trace where a float32 [32, 32, 2, 7000]
+    tensor sharded across 4 devices (→ [8, 32, 2, 7000] per device) was converted
+    to bfloat16 in L1. The mesh_mapper path in create_tt_tensor_from_host_data keeps
+    the tensor as float32 on device when has_sufficient_device_memory returns true
+    for the ROW_MAJOR size. Then convert_python_tensor_to_tt_tensor does
+    set_layout(TILE) → typecast → set_layout(ROW_MAJOR), and the tilize step tries
+    to allocate a tile-padded float32 buffer ([8,32,32,7008]*4B ≈ 220 MB) that
+    exceeds L1 bank capacity.
+
+    """
+    torch.manual_seed(42)
+    torch_tensor = torch.rand(shape, dtype=torch_dtype) * 0.2 - 0.1
+
+    ttnn_tensor = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn_dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=ReplicateTensorToMesh(device),
+    )
+
+    assert ttnn_tensor.dtype == ttnn_dtype
+    assert ttnn_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+
+    result = ttnn.to_torch(ttnn_tensor)
+    assert_with_pcc(torch_tensor, result, 0.999)

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -963,6 +963,78 @@ def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, 
 
 
 @pytest.mark.parametrize(
+    "ttnn_dtype,torch_dtype,ttnn_layout",
+    [
+        (ttnn.bfloat16, torch.bfloat16, ttnn.TILE_LAYOUT),
+        (ttnn.bfloat16, torch.float32, ttnn.TILE_LAYOUT),
+        (ttnn.float32, torch.float32, ttnn.TILE_LAYOUT),
+        (ttnn.bfloat16, torch.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.float32, torch.float32, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.bfloat8_b, torch.float32, ttnn.TILE_LAYOUT),
+        (ttnn.int32, torch.int32, ttnn.TILE_LAYOUT),
+        (ttnn.int32, torch.int32, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "memory_config",
+    [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    ids=["DRAM", "L1"],
+)
+def test_from_torch_with_sub_devices(device, ttnn_dtype, torch_dtype, ttnn_layout, memory_config):
+    """
+    Verify that from_torch produces correct results when sub-devices are loaded
+    on the device.
+
+    When num_sub_devices() > 0, the on-device fast path in
+    can_construct_on_device (py_to_tt_tensor.cpp) is disabled and the tensor
+    must be constructed on the host before being sent to the device. This test
+    ensures that the fallback host-side path still yields correct data for
+    various dtype / layout / memory_config combinations.
+    """
+    grid = device.compute_with_storage_grid_size()
+    cols, rows = grid.x, grid.y
+
+    worker_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, rows - 1))})
+    worker_sub_device = ttnn.SubDevice([worker_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+
+    sub_device_manager = device.create_sub_device_manager([worker_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    device.set_sub_device_stall_group([worker_sub_device_id])
+
+    try:
+        shape = (1, 1, 32, 64)
+        torch.manual_seed(42)
+
+        if torch_dtype in TORCH_FLOAT_TYPES:
+            torch_tensor = torch.rand(shape, dtype=torch_dtype)
+        else:
+            torch_tensor = torch.randint(0, 100, shape, dtype=torch_dtype)
+
+        ttnn_tensor = ttnn.from_torch(
+            torch_tensor,
+            dtype=ttnn_dtype,
+            layout=ttnn_layout,
+            device=device,
+            memory_config=memory_config,
+        )
+
+        assert ttnn_tensor.dtype == ttnn_dtype
+        assert ttnn_tensor.layout == ttnn_layout
+
+        result = ttnn.to_torch(ttnn_tensor)
+        assert_with_pcc(
+            expected_pytorch_result=torch_tensor,
+            actual_pytorch_result=result,
+            pcc=get_expected_conversion_pcc(ttnn_dtype, torch_dtype),
+        )
+    finally:
+        device.reset_sub_device_stall_group()
+        device.clear_loaded_sub_device_manager()
+        device.remove_sub_device_manager(sub_device_manager)
+
+
+@pytest.mark.parametrize(
     "torch_dtype,ttnn_dtype,shape",
     [
         (torch.float32, ttnn.bfloat16, (8, 32, 2, 7000)),

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -44,6 +44,8 @@ public:
         const tt::tt_metal::TensorLayout& layout,
         T pad_value = 0) const;
 
+    const MeshMapperConfig& config() const;
+
 private:
     class Impl;
 

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -257,6 +257,8 @@ public:
         return create_tensor<T>(sharded_xtensor_views, layout, pad_value, buffer_pin, tensor_dims);
     }
 
+    const MeshMapperConfig& config() const { return config_; }
+
 private:
     template <typename T>
     Tensor create_tensor(
@@ -544,6 +546,8 @@ MeshToTensor MeshToTensor::create(const MeshDevice& mesh_device, const MeshCompo
         config));
 }
 
+const MeshMapperConfig& TensorToMesh::config() const { return impl_->config(); }
+
 std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_device) {
     return std::make_unique<TensorToMesh>(TensorToMesh::create(
         mesh_device,
@@ -639,7 +643,7 @@ Tensor create_distributed_tensor(
 
 #define INSTANTIATE_CREATE_DISTRIBUTED_TENSOR(TYPE)                    \
     template Tensor create_distributed_tensor<TYPE>(                   \
-        ttsl::Span<TYPE> buffer,                                    \
+        ttsl::Span<TYPE> buffer,                                       \
         const ttnn::Shape& global_shape,                               \
         const tt::tt_metal::MemoryPin& buffer_pin,                     \
         const tt::tt_metal::TensorLayout& shard_layout,                \
@@ -648,7 +652,7 @@ Tensor create_distributed_tensor(
         std::optional<ttnn::QueueId> cq_id,                            \
         TYPE pad_value);                                               \
     template Tensor create_distributed_tensor<TYPE>(                   \
-        ttsl::Span<const TYPE> buffer,                              \
+        ttsl::Span<const TYPE> buffer,                                 \
         const ttnn::Shape& global_shape,                               \
         const tt::tt_metal::TensorLayout& shard_layout,                \
         const TensorToMesh& mapper,                                    \

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -192,10 +192,10 @@ Tensor create_tt_tensor_from_host_data(
         // Example: src_dtype = FLOAT32, dst_dtype = BFLOAT16.
         // The f32 tensor does not fit in L1, but bf16 does, so the typecast is performed on the host.
         const bool can_borrow = src_dtype == convert_to_data_type<T>() && construct_on_device &&
-                                has_sufficient_device_memory(
-                                    device, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile) &&
                                 !is_data_transformation_required &&
-                                can_construct_on_single_device(tensor_shape, src_tensor_layout, memory_config);
+                                can_construct_on_single_device(tensor_shape, src_tensor_layout, memory_config) &&
+                                has_sufficient_device_memory(
+                                    device, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
 
         if (can_borrow) {
             return Tensor::from_borrowed_data(host_buffer.view_as<T>(), tensor_shape, host_buffer.pin(), optional_tile);

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -400,10 +400,13 @@ Tensor convert_python_tensor_to_tt_tensor(
 
     if (device) {
         output = output.to_device(device.value(), memory_config, cq_id);
-        set_layout(layout);
         if (output.dtype() != dst_dtype) {
+            // Need to perform final data conversion on device, typecast requires TILE layout.
+            set_layout(Layout::TILE);
             output = ttnn::typecast(output, dst_dtype);
         }
+
+        set_layout(layout);
     } else {
         set_layout(layout);
     }

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -400,13 +400,10 @@ Tensor convert_python_tensor_to_tt_tensor(
 
     if (device) {
         output = output.to_device(device.value(), memory_config, cq_id);
+        set_layout(layout);
         if (output.dtype() != dst_dtype) {
-            // Need to perform final data conversion on device, typecast requires TILE layout.
-            set_layout(Layout::TILE);
             output = ttnn::typecast(output, dst_dtype);
         }
-
-        set_layout(layout);
     } else {
         set_layout(layout);
     }

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -84,9 +84,15 @@ bool can_construct_on_single_device(
     return true;
 }
 
-// Estimates peak per-bank memory during the on-device conversion path (borrow → to_device →
-// tilize → typecast) and returns true when it fits within the bank capacity. During tilize and
-// typecast the input and output buffers coexist, so peak memory is the sum of both.
+// Estimates peak per-bank memory during the on-device conversion path and returns true when it
+// fits within the bank capacity. During each stage the input and output buffers coexist, so peak
+// memory is the sum of both.
+//
+// Possible on-device paths (see convert_python_tensor_to_tt_tensor):
+//   target TILE, same dtype:  RM(src) → tilize → TILE(src)
+//   target TILE, diff dtype:  RM(src) → tilize → TILE(src) → typecast → TILE(dst)
+//   target RM,   diff dtype:  RM(src) → tilize → TILE(src) → typecast → TILE(dst) → untilize → RM(dst)
+//   target RM,   same dtype:  RM(src)  (no conversion needed)
 bool has_sufficient_device_memory(
     ttnn::distributed::MeshDevice* device,
     const ttnn::Shape& tensor_shape,
@@ -112,25 +118,34 @@ bool has_sufficient_device_memory(
 
     size_t peak_per_bank = src_rm_per_bank;
 
-    if (target_layout == Layout::TILE) {
-        // Tilize: input (src_dtype, RM) + output (src_dtype, TILE) coexist.
+    if (src_dtype != dst_dtype) {
+        // Typecast requires TILE layout, so the path always goes through tilize → typecast,
+        // regardless of the target layout.
+        TensorSpec src_tile_spec(
+            tensor_shape, TensorLayout(src_dtype, PageConfig(Layout::TILE, optional_tile), memory_config));
+        auto src_tile_per_bank = src_tile_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
+
+        TensorSpec dst_tile_spec(
+            tensor_shape, TensorLayout(dst_dtype, PageConfig(Layout::TILE, optional_tile), memory_config));
+        auto dst_tile_per_bank = dst_tile_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
+
+        // Tilize: RM(src) + TILE(src) coexist.
+        // Typecast: TILE(src) + TILE(dst) coexist.
+        peak_per_bank = std::max(src_rm_per_bank + src_tile_per_bank, src_tile_per_bank + dst_tile_per_bank);
+
+        if (target_layout == Layout::ROW_MAJOR) {
+            // Untilize: TILE(dst) + RM(dst) coexist.
+            TensorSpec dst_rm_spec(tensor_shape, TensorLayout(dst_dtype, PageConfig(Layout::ROW_MAJOR), memory_config));
+            auto dst_rm_per_bank = dst_rm_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
+            peak_per_bank = std::max(peak_per_bank, dst_tile_per_bank + dst_rm_per_bank);
+        }
+    } else if (target_layout == Layout::TILE) {
+        // Same dtype, target TILE: only tilize needed.
+        // Tilize: RM(src) + TILE(src) coexist.
         TensorSpec src_tile_spec(
             tensor_shape, TensorLayout(src_dtype, PageConfig(Layout::TILE, optional_tile), memory_config));
         auto src_tile_per_bank = src_tile_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
         peak_per_bank = src_rm_per_bank + src_tile_per_bank;
-
-        if (src_dtype != dst_dtype) {
-            // Typecast follows tilize: input (src_dtype, TILE) + output (dst_dtype, TILE) coexist.
-            TensorSpec dst_tile_spec(
-                tensor_shape, TensorLayout(dst_dtype, PageConfig(Layout::TILE, optional_tile), memory_config));
-            auto dst_tile_per_bank = dst_tile_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
-            peak_per_bank = std::max(peak_per_bank, src_tile_per_bank + dst_tile_per_bank);
-        }
-    } else if (src_dtype != dst_dtype) {
-        // Typecast in ROW_MAJOR: input + output coexist.
-        TensorSpec dst_rm_spec(tensor_shape, TensorLayout(dst_dtype, PageConfig(Layout::ROW_MAJOR), memory_config));
-        auto dst_rm_per_bank = dst_rm_spec.compute_consumed_memory_bytes_per_bank(alignment, num_banks);
-        peak_per_bank = src_rm_per_bank + dst_rm_per_bank;
     }
 
     return peak_per_bank <= bank_size;

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -136,6 +136,38 @@ bool has_sufficient_device_memory(
     return peak_per_bank <= bank_size;
 }
 
+// Estimates the largest per-device shard shape from the mesh mapper configuration.
+// For Shard placements the tensor dimension is ceiling-divided by the mesh dimension size;
+// Replicate placements leave the dimension unchanged. Returns an upper bound suitable for memory checks.
+ttnn::Shape estimate_per_device_shard_shape(
+    const ttnn::Shape& global_shape,
+    const ttnn::distributed::MeshMapperConfig& config,
+    ttnn::distributed::MeshDevice* device) {
+    if (device == nullptr) {
+        return global_shape;
+    }
+
+    const auto distribution_shape = config.mesh_shape_override.value_or(device->shape());
+
+    auto rank = global_shape.rank();
+    std::vector<uint32_t> dims;
+    dims.reserve(rank);
+    for (size_t i = 0; i < rank; ++i) {
+        dims.push_back(global_shape[i]);
+    }
+
+    for (size_t mesh_dim = 0; mesh_dim < distribution_shape.dims(); ++mesh_dim) {
+        using Shard = ttnn::distributed::MeshMapperConfig::Shard;
+        if (const auto* shard = std::get_if<Shard>(&config.placements[mesh_dim])) {
+            auto tensor_dim = shard->dim < 0 ? shard->dim + static_cast<int>(rank) : shard->dim;
+            auto num_chunks = distribution_shape[mesh_dim];
+            dims[tensor_dim] = (dims[tensor_dim] + num_chunks - 1) / num_chunks;
+        }
+    }
+
+    return ttnn::Shape(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+
 Tensor create_tt_tensor_from_host_data(
     HostBuffer& host_buffer,
     DataType src_dtype,
@@ -165,11 +197,16 @@ Tensor create_tt_tensor_from_host_data(
             device, tensor_shape, src_dtype, dst_dtype, optional_tile, enable_device_typecast, preserve_nan_values);
 
         if (mesh_mapper != nullptr) {
+            const auto shard_shape = estimate_per_device_shard_shape(tensor_shape, mesh_mapper->config(), device);
+            const bool construct_on_mesh_device =
+                construct_on_device &&
+                has_sufficient_device_memory(
+                    device, shard_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile);
             return ttnn::distributed::create_distributed_tensor(
                 host_buffer.view_as<T>(),
                 tensor_shape,
                 host_buffer.pin(),
-                construct_on_device ? src_tensor_layout : dst_tensor_layout,
+                construct_on_mesh_device ? src_tensor_layout : dst_tensor_layout,
                 *mesh_mapper,
                 device != nullptr ? std::make_optional(std::ref(*device)) : std::nullopt,
                 cq_id,

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -39,39 +39,49 @@ bool can_construct_on_device(
     const ttnn::Shape& tensor_shape,
     DataType src_dtype,
     DataType dst_dtype,
-    const MemoryConfig& memory_config,
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
     bool preserve_nan_values) {
-    if (device != nullptr && device->is_remote_only()) {
-        return false;
-    }
-    bool res = device != nullptr &&
-               // When on-device strategy is used, tensor spec needs a default alignment based on the target layout.
-               // Otherwise, the tensor loses the data in the `to_layout` conversion and type conversion. But, if the
-               // default alignment is used, the tensors of rank 5 and above are squeezed down to the rank 4 in
-               // `build_ndiml_tilize`, which causes the padding loss, and subqequently the failure to validate
-               // tilize operation, which requires `physical_volume() % tt::constants::TILE_HW == 0`
-               tensor_shape.rank() <= 4 && tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) &&
-               can_exec_ops_on_device(dst_dtype) &&
-               // If the memory config is sharded, the tensor must be constructed on the host. Even if we can borrow the
-               // buffer, the sharding spec may require padding, including cases where the shard dimension is larger
-               // than the shape dimension.
-               !memory_config.is_sharded() && enable_device_typecast &&
+    bool res = device != nullptr && !device->is_remote_only() && tensor_shape.volume() > 0 &&
+               can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) && enable_device_typecast &&
                // TODO: Remove preserve_nan_values check after
                // https://github.com/tenstorrent/tt-metal/issues/31406
-               !preserve_nan_values &&
-               // Logical shape must match physical shape for the tensor to be constructed on the device(no padding
-               // required). TensorSpec creation must follow after memory_config.is_sharded() check to avoid fatal error
-               tt::tt_metal::logical_matches_physical(TensorSpec(
-                   tensor_shape, TensorLayout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config)));
+               !preserve_nan_values;
 
     if (optional_tile.has_value()) {
         // on-device tiling operation expects tiles to be divisible by 32x32.
         res &= ((optional_tile->get_width() % tt::constants::TILE_WIDTH) == 0) &&
                ((optional_tile->get_height() % tt::constants::TILE_HEIGHT) == 0);
     }
+
     return res;
+}
+
+bool can_construct_on_single_device(
+    const ttnn::Shape& tensor_shape, const TensorLayout& src_tensor_layout, const MemoryConfig& memory_config) {
+    // If the memory config is sharded, the tensor must be constructed on the host. Even if we can borrow the
+    // buffer, the sharding spec may require padding, including cases where the shard dimension is larger
+    // than the shape dimension.
+    if (memory_config.is_sharded()) {
+        return false;
+    }
+
+    // Logical shape must match physical shape for the tensor to be constructed on the device(no padding
+    // required). TensorSpec creation must follow after memory_config.is_sharded() check to avoid fatal error
+    if (!tt::tt_metal::logical_matches_physical(TensorSpec(tensor_shape, src_tensor_layout))) {
+        return false;
+    }
+
+    // When on-device strategy is used, tensor spec needs a default alignment based on the target layout.
+    // Otherwise, the tensor loses the data in the `to_layout` conversion and type conversion. But, if the
+    // default alignment is used, the tensors of rank 5 and above are squeezed down to the rank 4 in
+    // `build_ndiml_tilize`, which causes the padding loss, and subqequently the failure to validate
+    // tilize operation, which requires `physical_volume() % tt::constants::TILE_HW == 0`
+    if (tensor_shape.rank() > 4) {
+        return false;
+    }
+
+    return true;
 }
 
 // Estimates peak per-bank memory during the on-device conversion path (borrow → to_device →
@@ -148,16 +158,13 @@ Tensor create_tt_tensor_from_host_data(
 
     using namespace tt::tt_metal;
     auto create_tensor_from_host_buffer = [&]<typename T>() -> Tensor {
+        TensorLayout src_tensor_layout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config);
         TensorLayout dst_tensor_layout(dst_dtype, PageConfig(layout, optional_tile), memory_config);
-        if (mesh_mapper != nullptr) {
-            TensorLayout src_tensor_layout(src_dtype, PageConfig(ttnn::Layout::ROW_MAJOR), memory_config);
 
-            const bool construct_on_device =
-                device != nullptr && !device->is_remote_only() && enable_device_typecast && !preserve_nan_values &&
-                tensor_shape.volume() > 0 &&
-                (optional_tile.has_value() ? (optional_tile->get_width() % tt::constants::TILE_WIDTH == 0 &&
-                                              optional_tile->get_height() % tt::constants::TILE_HEIGHT == 0)
-                                           : true);
+        const bool construct_on_device = can_construct_on_device(
+            device, tensor_shape, src_dtype, dst_dtype, optional_tile, enable_device_typecast, preserve_nan_values);
+
+        if (mesh_mapper != nullptr) {
             return ttnn::distributed::create_distributed_tensor(
                 host_buffer.view_as<T>(),
                 tensor_shape,
@@ -168,15 +175,6 @@ Tensor create_tt_tensor_from_host_data(
                 cq_id,
                 static_cast<T>(pad_value));
         }
-        const bool construct_on_device = can_construct_on_device(
-            device,
-            tensor_shape,
-            src_dtype,
-            dst_dtype,
-            memory_config,
-            optional_tile,
-            enable_device_typecast,
-            preserve_nan_values);
 
         // TODO: #https://github.com/tenstorrent/tt-metal/issues/40850
         // For single-device tensors, we cannot enable layout/data type changes due to tt-sim CI failures
@@ -196,7 +194,9 @@ Tensor create_tt_tensor_from_host_data(
         const bool can_borrow = src_dtype == convert_to_data_type<T>() && construct_on_device &&
                                 has_sufficient_device_memory(
                                     device, tensor_shape, src_dtype, dst_dtype, layout, memory_config, optional_tile) &&
-                                !is_data_transformation_required;
+                                !is_data_transformation_required &&
+                                can_construct_on_single_device(tensor_shape, src_tensor_layout, memory_config);
+
         if (can_borrow) {
             return Tensor::from_borrowed_data(host_buffer.view_as<T>(), tensor_shape, host_buffer.pin(), optional_tile);
         }

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -42,8 +42,9 @@ bool can_construct_on_device(
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
     bool preserve_nan_values) {
-    bool res = device != nullptr && !device->is_remote_only() && tensor_shape.volume() > 0 &&
-               can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) && enable_device_typecast &&
+    bool res = device != nullptr && !device->is_remote_only() && (device->num_sub_devices() == 0) &&
+               tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) &&
+               enable_device_typecast &&
                // TODO: Remove preserve_nan_values check after
                // https://github.com/tenstorrent/tt-metal/issues/31406
                !preserve_nan_values;


### PR DESCRIPTION

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/41250)

### 1. Core: Refactor `from_torch` on-device construction logic (`py_to_tt_tensor.cpp`)

**Files:** `ttnn/core/tensor/py_to_tt_tensor.cpp`

- **Refactored `can_construct_on_device`** — removed `memory_config` parameter and single-device-specific checks (sharding, logical-vs-physical match, rank <=4). The function now only validates common prerequisites shared by both single-device and distributed paths: device availability, non-zero volume, dtype executability, tile divisibility, and NaN preservation.

- **Extracted `can_construct_on_single_device`** — new function that encapsulates the single-device-specific restrictions: no sharded memory configs, logical must match physical shape, and rank must be <=4.

- **Refactored `has_sufficient_device_memory`** — rewrote the memory estimation to correctly model all three on-device conversion paths:
  - Target TILE, same dtype: `RM(src) → tilize → TILE(src)`
  - Target TILE, diff dtype: `RM(src) → tilize → TILE(src) → typecast → TILE(dst)`
  - Target RM, diff dtype: `RM(src) → tilize → TILE(src) → typecast → TILE(dst) → untilize → RM(dst)`

  Previously the RM + different-dtype path was incorrectly estimated (didn't account for tilize → typecast → untilize) and could OOM.

- **Added `estimate_per_device_shard_shape`** — new function that computes the per-device tensor shape from the global shape and mesh mapper config (ceiling-dividing sharded dimensions). This allows accurate memory checks for distributed tensors.

- **Unified `create_tt_tensor_from_host_data`** — the distributed (mesh_mapper) path now reuses the common `can_construct_on_device` function instead of duplicating the logic inline. It calls `estimate_per_device_shard_shape` + `has_sufficient_device_memory` for the per-device shard to decide the on-device path. The single-device path now additionally checks `is_data_transformation_required` and `can_construct_on_single_device` *before* calling `has_sufficient_device_memory`, avoiding unnecessary spec construction on sharded configs.

### 2. Core: Expose `MeshMapperConfig` from `TensorToMesh`

**Files:** `ttnn/api/ttnn/distributed/distributed_tensor.hpp`, `ttnn/core/distributed/distributed_tensor.cpp`

- Added `TensorToMesh::config()` public getter that returns the `MeshMapperConfig`, enabling `py_to_tt_tensor.cpp` to inspect the mapper configuration for per-device shard shape estimation.
- Minor whitespace fix in macro definitions.

### 3. Tests: Regression tests for `from_torch` fixes

**File:** `tests/ttnn/unit_tests/test_torch_conversion.py`

- **`test_from_torch_row_major_sharded_non_tile_aligned_shard_shape`** — regression test for ROW_MAJOR + WIDTH_SHARDED with non-tile-aligned shard shapes (e.g., DeepSeek V3 LMHead indices with shard width 160). Previously caused `TT_FATAL` in `tensor_layout.cpp`.

- **`test_from_torch_large_tensor_type_conversion_row_major_l1`** — regression test for float32→bfloat16 type conversion with ROW_MAJOR layout + L1 memory + mesh_mapper. Previously caused OOM because the on-device path tried to allocate a tile-padded float32 buffer exceeding L1 bank capacity.

- Added one additional parametrize case to `test_from_torch_sharded_tile_layout_non_tile_aligned_height` for WIDTH_SHARDED with `[1,1,1,7*32]`.

### 4. Tests: Fix `num_program_cache_entries` assertions across CCL and other tests

**What changed:** All these tests previously used `mesh_device.num_program_cache_entries()` to assert the number of cached programs. This was brittle because `from_torch` itself now may or may not add cache entries depending on the on-device path. The fix introduces `CacheEntriesCounter` (from `tests.tests_common.cache_entries_counter`) which uses a context manager (`with cache_entries_counter.measure()`) to count only the entries added *during* the measured operation, making the assertions independent of setup-phase cache pollution.

---

### Summary

The main goal is **fixing the `from_torch` on-device tensor construction path** to:
1. Correctly apply restrictions for single-device vs. distributed tensors separately
2. Accurately estimate memory for all conversion paths (especially RM + typecast which goes through tilize→typecast→untilize)
3. Compute per-device shard shapes for distributed tensors before memory checks
4. Avoid tile-alignment assertions on ROW_MAJOR sharded tensors

The test changes are both regression tests for the core fixes and adaptations to the new `CacheEntriesCounter` pattern that isolates program cache assertions from `from_torch` side effects.



### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


[(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23872758630)
[Nightly tt-metal L2 tests ](https://github.com/tenstorrent/tt-metal/actions/runs/23868122608)
[(Galaxy) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/23880860918)

- [x] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/from_torch-common-restriction-single-multiple-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/from_torch-common-restriction-single-multiple-dev)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
