### PR TITLE
executor: don't teardown threadpool in parent fork

### DIFF
--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -7,7 +7,15 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <pthread.h>
 #endif
-#if __has_include(<sanitizer/lsan_interface.h>)
+// Include LSan interface only when a sanitizer that provides __lsan_ignore_object
+// is actually active.  __has_include is insufficient — the header ships with the
+// Clang toolchain and is present even in non-sanitizer builds, which causes
+// __lsan_ignore_object to be declared but not linked (undefined symbol at link time).
+// __has_feature(leak_sanitizer) / __has_feature(address_sanitizer) are Clang's
+// compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ cover GCC.
+#if (defined(__has_feature) && (__has_feature(leak_sanitizer) || __has_feature(address_sanitizer))) || \
+    defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_LEAK__)
+#define TT_LSAN_ACTIVE 1
 #include <sanitizer/lsan_interface.h>
 #endif
 #include <taskflow/taskflow.hpp>
@@ -78,7 +86,7 @@ inline Executor& GetExecutor() {
                 // internal state (mutexes, threads) is invalid post-fork and
                 // destroying it would deadlock or crash.  Suppress the leak in
                 // ASan/LSan builds so it is not reported as unintentional.
-#if __has_include(<sanitizer/lsan_interface.h>)
+#ifdef TT_LSAN_ACTIVE
                 __lsan_ignore_object(exec);
 #endif
                 exec = new Executor(EXECUTOR_NTHREADS);

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -8,12 +8,9 @@
 #include <pthread.h>
 #include <unistd.h>
 #endif
-// Include LSan interface only when a sanitizer that provides __lsan_ignore_object
-// is actually active.  __has_include is insufficient — the header ships with the
-// Clang toolchain and is present even in non-sanitizer builds, which causes
-// __lsan_ignore_object to be declared but not linked (undefined symbol at link time).
-// __has_feature(leak_sanitizer) / __has_feature(address_sanitizer) are Clang's
-// compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ cover GCC.
+// Include LSan interface only when present
+// __has_feature(leak_sanitizer) / __has_feature(address_sanitizer) for clang
+// compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ for gcc
 #if (defined(__has_feature) && (__has_feature(leak_sanitizer) || __has_feature(address_sanitizer))) || \
     defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_LEAK__)
 #define TT_LSAN_ACTIVE 1
@@ -52,6 +49,13 @@ inline Executor& GetExecutor() {
     // and synchronization primitives inherited from the parent are in an
     // indeterminate state post-fork, and calling the destructor would deadlock
     // or crash.  The same pattern is used by jemalloc and glibc malloc.
+    //
+    // The leak is bounded: it exists only in the child process for the
+    // child's lifetime.  The kernel reclaims all memory when the child
+    // exits.  The parent heap is unaffected -- the child's assignment to
+    // exec happens in the child's private copy-on-write address space.
+    // The Executor holds no OS resources (no FDs, no shared memory, no
+    // GPU handles), so no handles are stranded.
     static Executor* exec = [] {
         auto* e = new Executor(EXECUTOR_NTHREADS);
         std::atexit([] {
@@ -67,42 +71,24 @@ inline Executor& GetExecutor() {
                 // here rather than aborting because fork() is sometimes called
                 // from paths the application cannot control (e.g. Python's
                 // subprocess fallback from posix_spawn).
-                // Cache num_topologies() once — avoids calling it twice with internal
-                // synchronization in this constrained atfork context.
                 const auto num_topologies = exec ? exec->num_topologies() : 0;
                 if (num_topologies != 0) {
-                    // Use write(2) instead of fprintf: write() is async-signal-safe,
-                    // fprintf is not (it may acquire internal stdio locks).
+                    // Use write because it is async-signal-safe,
                     char buf[128];
-                    int n = snprintf(
+                    int n = std::snprintf(
                         buf,
                         sizeof(buf),
                         "WARNING: fork() called while executor has in-flight work "
                         "(num_topologies=%zu). This may cause hangs in the child process.\n",
                         num_topologies);
                     if (n > 0) {
-                        (void)write(STDERR_FILENO, buf, static_cast<size_t>(n));
+                        ::write(STDERR_FILENO, buf, static_cast<size_t>(n));
                     }
                 }
             },
             /*parent=*/nullptr,
             /*child=*/
             [] {
-                // The parent's threads are gone in the child; replace with a
-                // fresh Executor.  Intentionally leak the old one -- its
-                // internal state (mutexes, threads) is invalid post-fork and
-                // destroying it would deadlock or crash.  This is the canonical
-                // approach for fork-unsafe objects (same pattern used by jemalloc
-                // and glibc malloc): run a lightweight reinit in the child handler
-                // rather than invoking destructors on indeterminate state.
-                //
-                // The leak is bounded: it exists only in the child process for the
-                // child's lifetime.  The kernel reclaims all memory when the child
-                // exits.  The parent heap is unaffected -- the child's assignment to
-                // exec happens in the child's private copy-on-write address space.
-                // The Executor holds no OS resources (no FDs, no shared memory, no
-                // GPU handles), so no handles are stranded.
-                //
                 // Suppress the leak report in ASan/LSan builds so it is not
                 // flagged as unintentional.
 #ifdef TT_LSAN_ACTIVE

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -10,8 +10,13 @@
 #endif
 // Include LSan interface only when present
 // __has_feature(leak_sanitizer) / __has_feature(address_sanitizer) for clang
-// compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ for gcc
-#if (defined(__has_feature) && (__has_feature(leak_sanitizer) || __has_feature(address_sanitizer))) || \
+// compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ for gcc.
+// __has_feature is a Clang built-in; GCC does not define it.  Provide a
+// fallback so the #if below is well-formed on both compilers.
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+#if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer) || \
     defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_LEAK__)
 #define TT_LSAN_ACTIVE 1
 #include <sanitizer/lsan_interface.h>
@@ -82,7 +87,7 @@ inline Executor& GetExecutor() {
                         "(num_topologies=%zu). This may cause hangs in the child process.\n",
                         num_topologies);
                     if (n > 0) {
-                        ::write(STDERR_FILENO, buf, static_cast<size_t>(n));
+                        [[maybe_unused]] auto _ = ::write(STDERR_FILENO, buf, static_cast<size_t>(n));
                     }
                 }
             },

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -91,8 +91,20 @@ inline Executor& GetExecutor() {
                 // The parent's threads are gone in the child; replace with a
                 // fresh Executor.  Intentionally leak the old one -- its
                 // internal state (mutexes, threads) is invalid post-fork and
-                // destroying it would deadlock or crash.  Suppress the leak in
-                // ASan/LSan builds so it is not reported as unintentional.
+                // destroying it would deadlock or crash.  This is the canonical
+                // approach for fork-unsafe objects (same pattern used by jemalloc
+                // and glibc malloc): run a lightweight reinit in the child handler
+                // rather than invoking destructors on indeterminate state.
+                //
+                // The leak is bounded: it exists only in the child process for the
+                // child's lifetime.  The kernel reclaims all memory when the child
+                // exits.  The parent heap is unaffected -- the child's assignment to
+                // exec happens in the child's private copy-on-write address space.
+                // The Executor holds no OS resources (no FDs, no shared memory, no
+                // GPU handles), so no handles are stranded.
+                //
+                // Suppress the leak report in ASan/LSan builds so it is not
+                // flagged as unintentional.
 #ifdef TT_LSAN_ACTIVE
                 __lsan_ignore_object(exec);
 #undef TT_LSAN_ACTIVE

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -6,6 +6,7 @@
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <pthread.h>
+#include <unistd.h>
 #endif
 // Include LSan interface only when a sanitizer that provides __lsan_ignore_object
 // is actually active.  __has_include is insufficient — the header ships with the
@@ -19,8 +20,8 @@
 #include <sanitizer/lsan_interface.h>
 #endif
 #include <taskflow/taskflow.hpp>
-#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <thread>
 
 namespace tt::tt_metal::detail {
@@ -66,16 +67,22 @@ inline Executor& GetExecutor() {
                 // here rather than aborting because fork() is sometimes called
                 // from paths the application cannot control (e.g. Python's
                 // subprocess fallback from posix_spawn).
-                // Note: fprintf is used here instead of log_warning to avoid
-                // pulling tt-logger into this header and because this callback
-                // must remain lightweight (atfork handlers run in constrained
-                // process context).
-                if (exec && exec->num_topologies() != 0) {
-                    fprintf(
-                        stderr,
+                // Cache num_topologies() once — avoids calling it twice with internal
+                // synchronization in this constrained atfork context.
+                const auto num_topologies = exec ? exec->num_topologies() : 0;
+                if (num_topologies != 0) {
+                    // Use write(2) instead of fprintf: write() is async-signal-safe,
+                    // fprintf is not (it may acquire internal stdio locks).
+                    char buf[128];
+                    int n = snprintf(
+                        buf,
+                        sizeof(buf),
                         "WARNING: fork() called while executor has in-flight work "
                         "(num_topologies=%zu). This may cause hangs in the child process.\n",
-                        exec->num_topologies());
+                        num_topologies);
+                    if (n > 0) {
+                        (void)write(STDERR_FILENO, buf, static_cast<size_t>(n));
+                    }
                 }
             },
             /*parent=*/nullptr,
@@ -88,6 +95,7 @@ inline Executor& GetExecutor() {
                 // ASan/LSan builds so it is not reported as unintentional.
 #ifdef TT_LSAN_ACTIVE
                 __lsan_ignore_object(exec);
+#undef TT_LSAN_ACTIVE
 #endif
                 exec = new Executor(EXECUTOR_NTHREADS);
             });

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <pthread.h>
 #endif
 #if __has_include(<sanitizer/lsan_interface.h>)
@@ -24,15 +24,25 @@ using Executor = tf::Executor;
 using ExecTask = tf::Task;
 
 inline Executor& GetExecutor() {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     // After fork(), the child process must reinitialize the Executor because
     // the parent's worker threads do not survive across fork boundaries.
     // Without this, the child hangs trying to dispatch work to dead threads.
     //
     // Only the *child* handler recreates the Executor.  The parent's Executor
     // is left untouched -- destroying and recreating it in prepare/parent
-    // would needlessly tear down the thread pool on every fork() call
-    // (including those from posix_spawn fallback paths or Python subprocess).
+    // would needlessly tear down the thread pool on every fork() call.
+    // This matters because fork() is triggered in ways callers do not control:
+    //   - Python subprocess.Popen() may fall back from posix_spawn to fork()
+    //   - Python multiprocessing.Process() always uses fork() by default
+    //   - MPI launchers may fork internally
+    // In all these cases the parent's thread pool should remain undisturbed.
+    //
+    // In the child we intentionally leak the old Executor rather than delete
+    // it.  This is the canonical approach for fork-unsafe objects: the threads
+    // and synchronization primitives inherited from the parent are in an
+    // indeterminate state post-fork, and calling the destructor would deadlock
+    // or crash.  The same pattern is used by jemalloc and glibc malloc.
     static Executor* exec = [] {
         auto* e = new Executor(EXECUTOR_NTHREADS);
         std::atexit([] {
@@ -42,6 +52,16 @@ inline Executor& GetExecutor() {
         pthread_atfork(
             /*prepare=*/
             [] {
+                // fork() with in-flight Taskflow work is unsafe: the child will
+                // inherit a half-initialized executor state and may hang when it
+                // tries to dispatch tasks to the dead parent threads.  We warn
+                // here rather than aborting because fork() is sometimes called
+                // from paths the application cannot control (e.g. Python's
+                // subprocess fallback from posix_spawn).
+                // Note: fprintf is used here instead of log_warning to avoid
+                // pulling tt-logger into this header and because this callback
+                // must remain lightweight (atfork handlers run in constrained
+                // process context).
                 if (exec && exec->num_topologies() != 0) {
                     fprintf(
                         stderr,
@@ -53,11 +73,12 @@ inline Executor& GetExecutor() {
             /*parent=*/nullptr,
             /*child=*/
             [] {
-        // The parent's threads are gone in the child; replace with a
-        // fresh Executor.  Intentionally leak the old one -- its
-        // internal state (mutexes, threads) is invalid post-fork and
-        // destroying it would deadlock or crash.
-#ifdef __lsan_ignore_object
+                // The parent's threads are gone in the child; replace with a
+                // fresh Executor.  Intentionally leak the old one -- its
+                // internal state (mutexes, threads) is invalid post-fork and
+                // destroying it would deadlock or crash.  Suppress the leak in
+                // ASan/LSan builds so it is not reported as unintentional.
+#if __has_include(<sanitizer/lsan_interface.h>)
                 __lsan_ignore_object(exec);
 #endif
                 exec = new Executor(EXECUTOR_NTHREADS);

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -4,11 +4,16 @@
 
 #pragma once
 
+#ifdef __linux__
 #include <pthread.h>
+#endif
+#if __has_include(<sanitizer/lsan_interface.h>)
+#include <sanitizer/lsan_interface.h>
+#endif
 #include <taskflow/taskflow.hpp>
+#include <cstdio>
 #include <cstdlib>
 #include <thread>
-#include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal::detail {
 inline static const size_t EXECUTOR_NTHREADS = std::getenv("TT_METAL_THREADCOUNT")
@@ -19,10 +24,15 @@ using Executor = tf::Executor;
 using ExecTask = tf::Task;
 
 inline Executor& GetExecutor() {
-    // Child process needs to reinitialize the executor after fork()
-    // otherwise it will hang because it will try to reference stale thread state
-    // copied from the parent process.
-    // Also ensure that no work is in-flight on the main process before forking.
+#ifdef __linux__
+    // After fork(), the child process must reinitialize the Executor because
+    // the parent's worker threads do not survive across fork boundaries.
+    // Without this, the child hangs trying to dispatch work to dead threads.
+    //
+    // Only the *child* handler recreates the Executor.  The parent's Executor
+    // is left untouched -- destroying and recreating it in prepare/parent
+    // would needlessly tear down the thread pool on every fork() call
+    // (including those from posix_spawn fallback paths or Python subprocess).
     static Executor* exec = [] {
         auto* e = new Executor(EXECUTOR_NTHREADS);
         std::atexit([] {
@@ -32,19 +42,33 @@ inline Executor& GetExecutor() {
         pthread_atfork(
             /*prepare=*/
             [] {
-                TT_FATAL(
-                    exec->num_topologies() == 0,
-                    "fork() called while executor has in-flight work "
-                    "(num_topologies={}). All tasks must complete before forking.",
-                    exec->num_topologies());
-                delete exec;
-                exec = nullptr;
+                if (exec && exec->num_topologies() != 0) {
+                    fprintf(
+                        stderr,
+                        "WARNING: fork() called while executor has in-flight work "
+                        "(num_topologies=%zu). This may cause hangs in the child process.\n",
+                        exec->num_topologies());
+                }
             },
-            /*parent=*/[] { exec = new Executor(EXECUTOR_NTHREADS); },
-            /*child=*/[] { exec = new Executor(EXECUTOR_NTHREADS); });
+            /*parent=*/nullptr,
+            /*child=*/
+            [] {
+        // The parent's threads are gone in the child; replace with a
+        // fresh Executor.  Intentionally leak the old one -- its
+        // internal state (mutexes, threads) is invalid post-fork and
+        // destroying it would deadlock or crash.
+#ifdef __lsan_ignore_object
+                __lsan_ignore_object(exec);
+#endif
+                exec = new Executor(EXECUTOR_NTHREADS);
+            });
         return e;
     }();
     return *exec;
+#else
+    static Executor exec(EXECUTOR_NTHREADS);
+    return exec;
+#endif
 }
 
 inline std::mutex& GetExecutorMutex() {


### PR DESCRIPTION
### Ticket
Carveout of https://github.com/tenstorrent/tt-metal/pull/39174

### Problem description
Executor was tearing down the threadpool more aggressively than needed.

### What's changed
Executor preserves the thread pool in the parent and only spins up a new one in the fork. Why this is safe is explained in the adjacent code comments. TL;DR: There is a small but bounded resource leak around runtime state in fork children that is cleaned up when the child fork terminates. This is how glibc handles it. Fixes issue with an ND TT_FATAL I ran into when doing testing on quad galaxy.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-executor-nokill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-executor-nokill)
