### PR TITLE
[skip ci] Update WH galaxy sku config strings

### DIFF
--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -1,18 +1,14 @@
 import yaml
+import argparse
 import sys
-import os
 from collections import defaultdict
 
 
-def verify_timeouts(tests_file, time_budget_file, workflow_name):
+def verify_timeouts(tests_file, time_budget_file, workflow_name, *, skip_budget_check=False):
     """
     Verifies that the SUM of all test timeouts for each (Team, SKU) pair in tests_file
     is within the total time budget defined in time_budget_file for the given workflow.
     """
-    print(f"Loading time budgets from: {time_budget_file}")
-    with open(time_budget_file, "r") as f:
-        budgets = yaml.safe_load(f)
-
     print(f"Loading tests from: {tests_file}")
     with open(tests_file, "r") as f:
         tests = yaml.safe_load(f)
@@ -67,6 +63,14 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
         print(f"\nMissing keys in {tests_file}. Please fix the entries above.")
         sys.exit(1)
 
+    if skip_budget_check:
+        print(f"\n--skip-budget-check: skipping total time budget checks against {time_budget_file}.")
+        sys.exit(0)
+
+    print(f"Loading time budgets from: {time_budget_file}")
+    with open(time_budget_file, "r") as f:
+        budgets = yaml.safe_load(f)
+
     # --- Part 2: Verify Total Time Budget for each (Team, SKU) pair ---
     print("\n--- Verifying Total Time Budgets ---")
 
@@ -104,9 +108,26 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
         sys.exit(0)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python verify_time_budget.py <path_to_tests.yaml> <path_to_time_budget.yaml> <workflow_name>")
-        sys.exit(1)
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify summed test timeouts per (team, SKU) against time_budget.yaml."
+    )
+    parser.add_argument("tests_file", help="Path to tests YAML (e.g. tests/pipeline_reorg/.../*.yaml)")
+    parser.add_argument("time_budget_file", help="Path to time budget YAML (e.g. .github/time_budget.yaml)")
+    parser.add_argument("workflow_name", help="Workflow key inside time budget config (e.g. integration)")
+    parser.add_argument(
+        "--skip-budget-check",
+        action="store_true",
+        help="Validate tests YAML and sum timeouts only; do not compare to time_budget_file.",
+    )
+    args = parser.parse_args()
+    verify_timeouts(
+        args.tests_file,
+        args.time_budget_file,
+        args.workflow_name,
+        skip_budget_check=args.skip_budget_check,
+    )
 
-    verify_timeouts(sys.argv[1], sys.argv[2], sys.argv[3])
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -118,7 +118,7 @@ def main() -> None:
     parser.add_argument(
         "--skip-budget-check",
         action="store_true",
-        help="Validate tests YAML and sum timeouts only; do not compare to time_budget_file.",
+        help="Validate tests YAML and sum timeouts only; do not fail on comparison to time_budget_file. This switch should be used for TESTING ON BRANCH ONLY. All CI pipelines should be subject to time budget checks.",
     )
     args = parser.parse_args()
     verify_timeouts(

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -59,6 +59,11 @@ skus:
       - topology-6u
       - in-release
 
+  wh_galaxy_uf_test:
+    runs_on:
+      - UF-EV-A12-GWH01
+      - in-service
+
   bh_galaxy:
     runs_on:
       - arch-blackhole

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -59,11 +59,6 @@ skus:
       - topology-6u
       - in-release
 
-  wh_galaxy_uf_test:
-    runs_on:
-      - UF-EV-A12-GWH01
-      - in-service
-
   bh_galaxy:
     runs_on:
       - arch-blackhole

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -80,6 +80,7 @@ ttnn:
   integration:
     wh_llmbox: 30
     wh_galaxy: 350
+    wh_galaxy_perf: 110
 
 shield:
   e2e:

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -42,7 +42,8 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "integration"
+            "integration" \
+            --skip-budget-check
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -45,7 +45,8 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "integration"
+            "integration" \
+            --skip-budget-check
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -12,9 +12,6 @@ on:
       build-artifact-name:
         required: true
         type: string
-      enabled-skus:
-        required: true
-        type: string
       model:
         required: false
         type: string
@@ -51,7 +48,7 @@ jobs:
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
+            ALL_SKUS_IN_TESTS
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -45,8 +45,7 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "integration" \
-            --skip-budget-check
+            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/galaxy-integration-tests-impl.yaml
+++ b/.github/workflows/galaxy-integration-tests-impl.yaml
@@ -42,14 +42,13 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "integration" \
-            --skip-budget-check
+            "integration"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            ALL_SKUS_IN_TESTS
+            ALL_SKUS_IN_TESTS \
             ./.github/sku_config.yaml
       - name: Apply model filter
         id: apply-model-filter

--- a/.github/workflows/galaxy-integration-tests.yaml
+++ b/.github/workflows/galaxy-integration-tests.yaml
@@ -65,5 +65,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy
       model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -234,7 +234,6 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy
       model: ${{ inputs.trigger_type == 'manual' && inputs.galaxy-integration || 'all' }}
   galaxy-demo-tests:
     if: ${{ needs.determine-tests.outputs.run-demo == 'true' }}

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -41,7 +41,7 @@
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model sd35
   model: sd35
   skus:
-    wh_galaxy:
+    wh_galaxy_perf:
       timeout: 50
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: ttnn

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -19,21 +19,66 @@
 #   owner_id: U053W15B6JF # Djordje Ivanovic
 #   team: ttnn
 
+- name: Galaxy resnet50 integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model resnet50
+  model: resnet50
+  skus:
+    wh_galaxy:
+      timeout: 50
+  owner_id: U052J2QDDKQ # Pavle Josipovic
+  team: ttnn
+
+- name: Galaxy unit/distributed integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model unit
+  model: unit
+  skus:
+    wh_galaxy:
+      timeout: 50
+  owner_id: UBHPP2NDP # Joseph Chu
+  team: ttnn
+
+- name: Galaxy SD3.5 integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model sd35
+  model: sd35
+  skus:
+    wh_galaxy_perf:
+      timeout: 50
+  owner_id: U03FJB5TM5Y # Colman Glagovich
+  team: ttnn
+
 - name: Galaxy Wan2.2 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
   model: wan22
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy:
       timeout: 40
   owner_id: U03FJB5TM5Y # Colman Glagovich
+  team: ttnn
+
+- name: Galaxy mochi integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model mochi
+  model: mochi
+  skus:
+    wh_galaxy:
+      timeout: 80
+  owner_id: U09ELB03XRU # Stephen Osborne
   team: ttnn
 
 - name: Galaxy Flux.1 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model flux1
   model: flux1
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy:
       timeout: 50
+  owner_id: U08TED0JM9D # Samuel Adesoye
+  team: ttnn
+
+- name: Galaxy Motif integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model motif
+  model: motif
+  skus:
+    wh_galaxy:
+      timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn
 
@@ -41,7 +86,7 @@
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model qwenimage
   model: qwenimage
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy:
       timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -19,66 +19,21 @@
 #   owner_id: U053W15B6JF # Djordje Ivanovic
 #   team: ttnn
 
-- name: Galaxy resnet50 integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model resnet50
-  model: resnet50
-  skus:
-    wh_galaxy:
-      timeout: 50
-  owner_id: U052J2QDDKQ # Pavle Josipovic
-  team: ttnn
-
-- name: Galaxy unit/distributed integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model unit
-  model: unit
-  skus:
-    wh_galaxy:
-      timeout: 50
-  owner_id: UBHPP2NDP # Joseph Chu
-  team: ttnn
-
-- name: Galaxy SD3.5 integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model sd35
-  model: sd35
-  skus:
-    wh_galaxy_perf:
-      timeout: 50
-  owner_id: U03FJB5TM5Y # Colman Glagovich
-  team: ttnn
-
 - name: Galaxy Wan2.2 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
   model: wan22
   skus:
-    wh_galaxy:
+    wh_galaxy_uf_test:
       timeout: 40
   owner_id: U03FJB5TM5Y # Colman Glagovich
-  team: ttnn
-
-- name: Galaxy mochi integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model mochi
-  model: mochi
-  skus:
-    wh_galaxy:
-      timeout: 80
-  owner_id: U09ELB03XRU # Stephen Osborne
   team: ttnn
 
 - name: Galaxy Flux.1 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model flux1
   model: flux1
   skus:
-    wh_galaxy:
+    wh_galaxy_uf_test:
       timeout: 50
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: ttnn
-
-- name: Galaxy Motif integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model motif
-  model: motif
-  skus:
-    wh_galaxy:
-      timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn
 
@@ -86,7 +41,7 @@
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model qwenimage
   model: qwenimage
   skus:
-    wh_galaxy:
+    wh_galaxy_uf_test:
       timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -19,21 +19,66 @@
 #   owner_id: U053W15B6JF # Djordje Ivanovic
 #   team: ttnn
 
+- name: Galaxy resnet50 integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model resnet50
+  model: resnet50
+  skus:
+    wh_galaxy:
+      timeout: 50
+  owner_id: U052J2QDDKQ # Pavle Josipovic
+  team: ttnn
+
+- name: Galaxy unit/distributed integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model unit
+  model: unit
+  skus:
+    wh_galaxy:
+      timeout: 50
+  owner_id: UBHPP2NDP # Joseph Chu
+  team: ttnn
+
+- name: Galaxy SD3.5 integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model sd35
+  model: sd35
+  skus:
+    wh_galaxy_perf:
+      timeout: 50
+  owner_id: U03FJB5TM5Y # Colman Glagovich
+  team: ttnn
+
 - name: Galaxy Wan2.2 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
   model: wan22
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy:
       timeout: 40
   owner_id: U03FJB5TM5Y # Colman Glagovich
+  team: ttnn
+
+- name: Galaxy mochi integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model mochi
+  model: mochi
+  skus:
+    wh_galaxy:
+      timeout: 80
+  owner_id: U09ELB03XRU # Stephen Osborne
   team: ttnn
 
 - name: Galaxy Flux.1 integration tests
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model flux1
   model: flux1
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy_perf:
       timeout: 50
+  owner_id: U08TED0JM9D # Samuel Adesoye
+  team: ttnn
+
+- name: Galaxy Motif integration tests
+  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model motif
+  model: motif
+  skus:
+    wh_galaxy_perf:
+      timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn
 
@@ -41,7 +86,7 @@
   cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model qwenimage
   model: qwenimage
   skus:
-    wh_galaxy_uf_test:
+    wh_galaxy:
       timeout: 10
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: ttnn


### PR DESCRIPTION
Recently there was an effort to reduce demand on WH galaxies in AUS colo with weka mounts (model weights) by moving tests that do not need model weights to machines in Unsung Fields. The sku config file was updated along with machine tags to differentiate the two pools of machines. https://github.com/tenstorrent/tt-metal/commit/100b241106aee88762204b238c549e2d20b37785

`wh_galaxy` sku should be used for tests that **do not** need model weights
`wh_galaxy_perf` sku should be used for tests that need model weights

This PR changes some tests to run on specific skus based on what the test requires.
Only the following tests require `wh_galaxy_perf`. All other tests only need `wh_galaxy`.
Galaxy integration pipeline:
SD3.5
pending... https://github.com/tenstorrent/tt-metal/actions/runs/23882128496

This PR also adds a `--skip-budget-check` switch as input to `verify_time_budget.py` for testing pipelines