### PR TITLE
MeshTensor as backing storage for ttnn::Tensor

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -70,6 +70,19 @@ TEST(MeshTensorTest, MoveAssignment) {
     (void)other;
 }
 
+TEST(MeshTensorTest, DefaultConstructedIsNotInitialized) {
+    MeshTensor tensor;
+    EXPECT_FALSE(tensor.is_initialized());
+}
+
+TEST(MeshTensorTest, MovedFromIsNotInitialized) {
+    MeshTensor source;
+    MeshTensor dest;
+    dest = std::move(source);
+    EXPECT_FALSE(source.is_initialized());
+    EXPECT_FALSE(dest.is_initialized());
+}
+
 TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
     auto page_config = PageConfig(Layout::ROW_MAJOR);
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
@@ -134,6 +147,42 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
     EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(tensor.logical_shape(), Shape({1, 32}));
+}
+
+TEST_F(MeshTensorDeviceTest, ConstructedWithMeshBufferIsInitialized) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    ASSERT_NE(mesh_buffer, nullptr);
+    ASSERT_TRUE(mesh_buffer->is_allocated());
+
+    auto topology = TensorTopology();
+
+    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
+
+    EXPECT_TRUE(tensor.is_initialized());
+}
+
+TEST_F(MeshTensorDeviceTest, IsNotInitializedAfterMoveFrom) {
+    auto page_config = PageConfig(Layout::ROW_MAJOR);
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
+    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
+
+    auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
+    auto topology = TensorTopology();
+
+    MeshTensor original(mesh_buffer, std::move(spec), std::move(topology));
+
+    EXPECT_TRUE(original.is_initialized());
+
+    MeshTensor moved(std::move(original));
+
+    EXPECT_FALSE(original.is_initialized());
+    EXPECT_TRUE(moved.is_initialized());
 }
 
 TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -79,7 +79,7 @@ TEST(MeshTensorTest, MovedFromIsNotInitialized) {
     MeshTensor source;
     MeshTensor dest;
     dest = std::move(source);
-    EXPECT_FALSE(source.is_initialized());
+    EXPECT_FALSE(source.is_initialized());  // NOLINT(bugprone-use-after-move)
     EXPECT_FALSE(dest.is_initialized());
 }
 
@@ -181,7 +181,7 @@ TEST_F(MeshTensorDeviceTest, IsNotInitializedAfterMoveFrom) {
 
     MeshTensor moved(std::move(original));
 
-    EXPECT_FALSE(original.is_initialized());
+    EXPECT_FALSE(original.is_initialized());  // NOLINT(bugprone-use-after-move)
     EXPECT_TRUE(moved.is_initialized());
 }
 

--- a/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
@@ -27,4 +27,4 @@ def test_deallocate(device, h, w):
     with pytest.raises(RuntimeError) as exception:
         output_tensor_reference + output_tensor_reference
 
-    assert "Buffer is not allocated" in str(exception.value)
+    assert "Device Memory is not allocated" in str(exception.value)

--- a/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
@@ -26,5 +26,3 @@ def test_deallocate(device, h, w):
     ttnn.deallocate(output_tensor)
     with pytest.raises(RuntimeError) as exception:
         output_tensor_reference + output_tensor_reference
-
-    assert "Device Memory is not allocated" in str(exception.value)

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -65,6 +65,7 @@ set(UNIT_TESTS_TTNN_TENSOR_SOURCES
     tensor/test_create_tensor_multi_device.cpp
     tensor/test_create_tensor_with_layout.cpp
     tensor/test_device_storage_ownership.cpp
+    tensor/test_tensor_deallocation.cpp
     tensor/test_distributed_tensor.cpp
     tensor/test_tensor_topology.cpp
     tensor/test_mesh_tensor.cpp

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -76,6 +76,7 @@ set(UNIT_TESTS_TTNN_TENSOR_SOURCES
     tensor/test_unit_mesh_utils.cpp
     tensor/test_vector_conversion.cpp
     tensor/test_xtensor_adapter.cpp
+    tensor/test_unchecked_reinterpret_layout.cpp
     tensor/test_xtensor_conversion.cpp
 )
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -268,7 +268,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     // Step 2: Copy the DeviceStorage (simulating what view() does internally)
     // This creates a separate DeviceStorage with a copy of the shared_ptr<MeshBuffer>
     auto storage_copy = tensor_a.device_storage();  // Makes a copy, not a reference
-    Tensor tensor_b = Tensor(storage_copy, tensor_spec, TensorTopology{});
+    Tensor tensor_b = Tensor(storage_copy);
 
     ASSERT_NE(tensor_b.device(), nullptr) << "Tensor B should have valid device";
     ASSERT_TRUE(tensor_b.is_allocated()) << "Tensor B should be allocated";
@@ -288,7 +288,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     // Step 4: Create tensor C from B's storage (simulating another view() call)
     // This is where the bug manifests - if Tensor constructor uses is_allocated(),
     // mesh_device_ won't be set because is_allocated() returns false
-    Tensor tensor_c = Tensor(storage_b, tensor_spec, TensorTopology{});
+    Tensor tensor_c = Tensor(storage_b);
 
     // THE KEY ASSERTION: tensor C must have valid device pointer
     // This is the workaround - without it, device() returns nullptr and causes segfaults

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -17,6 +17,7 @@
 
 #include <tt-metalium/buffer_types.hpp>
 #include "common_tensor_test_utils.hpp"
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/shape.hpp>
 #include "ttnn/async_runtime.hpp"
@@ -58,9 +59,7 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
     ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_device_buffer(device, tensor_spec);
 
-    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
-
-    Tensor input_tensor = Tensor(input_storage, tensor_spec, TensorTopology{});
+    Tensor input_tensor(tt::tt_metal::MeshTensor(input_buffer, tensor_spec, TensorTopology{}));
 
     ttnn::write_buffer(io_cq, input_tensor, {host_data});
 
@@ -261,9 +260,7 @@ TEST_F(TensorFromDeallocatedStorageTest, ConstructingTensorFromDeallocatedStorag
     TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
 
     // Step 1: Create initial tensor on device
-    auto input_buffer = tt::tt_metal::tensor_impl::allocate_device_buffer(device_, tensor_spec);
-    auto input_storage = tt::tt_metal::DeviceStorage{input_buffer, {tt::tt_metal::distributed::MeshCoordinate{0, 0}}};
-    Tensor tensor_a = Tensor(input_storage, tensor_spec, TensorTopology{});
+    Tensor tensor_a = create_device_tensor(tensor_spec, device_);
 
     ASSERT_NE(tensor_a.device(), nullptr) << "Tensor A should have valid device";
     ASSERT_TRUE(tensor_a.is_allocated()) << "Tensor A should be allocated";

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -125,35 +125,6 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_OwnerDeallocateAffectsView) {
     EXPECT_FALSE(view_storage.is_allocated());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_DefaultConstructedThrowsForSpecTopologyAndMeshTensor) {
-    DeviceStorage storage;
-
-    EXPECT_THROW(storage.get_tensor_spec(), std::exception);
-    EXPECT_THROW(storage.get_tensor_topology(), std::exception);
-    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
-}
-
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SpecAndTopologyAccessibleAfterDeallocate) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    DeviceStorage storage = tensor.device_storage();
-
-    storage.deallocate();
-    ASSERT_FALSE(storage.is_allocated());
-
-    EXPECT_NO_THROW(storage.get_tensor_spec());
-    EXPECT_NO_THROW(storage.get_tensor_topology());
-}
-
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MeshTensorGetterThrowsWhenDeallocated) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    DeviceStorage storage = tensor.device_storage();
-
-    storage.deallocate();
-    ASSERT_FALSE(storage.is_allocated());
-
-    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
-}
-
 TEST_F(DeviceStorageOwnershipTest, DeviceStorage_BufferGettersThrowWhenDeallocated) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     tensor.deallocate(/*force=*/true);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -125,13 +125,41 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_OwnerDeallocateAffectsView) {
     EXPECT_FALSE(view_storage.is_allocated());
 }
 
-TEST_F(DeviceStorageOwnershipTest, DeviceStorage_GettersThrowWhenDeallocated) {
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_DefaultConstructedThrowsForSpecTopologyAndMeshTensor) {
+    DeviceStorage storage;
+
+    EXPECT_THROW(storage.get_tensor_spec(), std::exception);
+    EXPECT_THROW(storage.get_tensor_topology(), std::exception);
+    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_SpecAndTopologyAccessibleAfterDeallocate) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_NO_THROW(storage.get_tensor_spec());
+    EXPECT_NO_THROW(storage.get_tensor_topology());
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_MeshTensorGetterThrowsWhenDeallocated) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_BufferGettersThrowWhenDeallocated) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     tensor.deallocate(/*force=*/true);
 
     EXPECT_THROW(tensor.device_storage().get_buffer(), std::exception);
     EXPECT_THROW(tensor.device_storage().get_mesh_buffer(), std::exception);
-    EXPECT_THROW(tensor.device_storage().get_device(), std::exception);
 }
 
 // ======================================================================================

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -261,7 +261,7 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
             combine_device_tensors(shards_to_aggregate);
         }),
-        ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
+        ThrowsMessage<std::runtime_error>(HasSubstr("All DeviceStorages must point to the same device memory")));
 
     // Try to aggregate the same shard twice
     EXPECT_THAT(

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -27,6 +27,7 @@ using ::testing::SizeIs;
 using ::testing::ThrowsMessage;
 
 using MeshTensorTest = GenericMeshDeviceFixture;
+using MeshTensorTest1x2 = MeshDevice1x2Fixture;
 using MeshTensorTest2x4 = MeshDevice2x4Fixture;
 
 TEST(MeshTensorHostTest, ToHostAlreadyOnHost) {
@@ -290,6 +291,59 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     EXPECT_EQ(partial_device_storage.get_coords()[1], (distributed::MeshCoordinate{0, 2}));
     EXPECT_EQ(partial_device_storage.get_coords()[2], (distributed::MeshCoordinate{1, 0}));
     EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
+}
+
+TEST_F(MeshTensorTest1x2, CombineDeviceTensors) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+
+    Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
+
+    Tensor device_tensor1 = to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor2 = to_device(input_host_tensor, mesh_device_.get());
+
+    auto device_tensors1 = get_device_tensors(device_tensor1);
+    auto device_tensors2 = get_device_tensors(device_tensor2);
+
+    EXPECT_THAT(device_tensors1, SizeIs(mesh_device_->num_devices()));
+    EXPECT_THAT(device_tensors2, SizeIs(mesh_device_->num_devices()));
+
+    // Try to aggregate shards from different mesh buffers.
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
+            combine_device_tensors(shards_to_aggregate);
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
+
+    // Try to aggregate the same shard twice.
+    EXPECT_THAT(
+        ([&]() {
+            std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors1[0]};
+            combine_device_tensors(shards_to_aggregate);
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordinate")));
+
+    // Aggregate both shards in reverse order; verify coords come out sorted.
+    int shard_dim = 2;
+    auto partial_tensor =
+        combine_device_tensors(std::vector<Tensor>{device_tensors1[1], device_tensors1[0]}, shard_dim);
+
+    const auto& partial_device_storage = partial_tensor.device_storage();
+    EXPECT_NO_THROW({ partial_device_storage.get_mesh_buffer(); });
+
+    EXPECT_EQ(partial_tensor.tensor_topology().distribution_shape(), MeshShape(2));
+    EXPECT_EQ(
+        std::get<distributed::MeshMapperConfig::Shard>(partial_tensor.tensor_topology().placements()[0]).dim,
+        shard_dim);
+
+    ASSERT_THAT(partial_device_storage.get_coords(), SizeIs(2));
+    EXPECT_EQ(partial_device_storage.get_coords()[0], (distributed::MeshCoordinate{0, 0}));
+    EXPECT_EQ(partial_device_storage.get_coords()[1], (distributed::MeshCoordinate{0, 1}));
 }
 
 TEST_F(MeshTensorTest2x4, CombineDeviceTensorsWithDifferentShardDims) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -293,7 +293,8 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
 }
 
-TEST_F(MeshTensorTest1x2, CombineDeviceTensors) {
+// This is the mini version of MeshTensorTest2x4.CombineDeviceTensors above.
+TEST_F(MeshTensorTest1x2, CombineDeviceTensorsMini) {
     const ttnn::Shape shape{1, 1, 32, 32};
     const TensorSpec tensor_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
@@ -329,17 +330,10 @@ TEST_F(MeshTensorTest1x2, CombineDeviceTensors) {
         ThrowsMessage<std::runtime_error>(HasSubstr("Found a tensor shard at duplicate coordinate")));
 
     // Aggregate both shards in reverse order; verify coords come out sorted.
-    int shard_dim = 2;
-    auto partial_tensor =
-        combine_device_tensors(std::vector<Tensor>{device_tensors1[1], device_tensors1[0]}, shard_dim);
+    auto partial_tensor = combine_device_tensors(std::vector<Tensor>{device_tensors1[1], device_tensors1[0]});
 
     const auto& partial_device_storage = partial_tensor.device_storage();
     EXPECT_NO_THROW({ partial_device_storage.get_mesh_buffer(); });
-
-    EXPECT_EQ(partial_tensor.tensor_topology().distribution_shape(), MeshShape(2));
-    EXPECT_EQ(
-        std::get<distributed::MeshMapperConfig::Shard>(partial_tensor.tensor_topology().placements()[0]).dim,
-        shard_dim);
 
     ASSERT_THAT(partial_device_storage.get_coords(), SizeIs(2));
     EXPECT_EQ(partial_device_storage.get_coords()[0], (distributed::MeshCoordinate{0, 0}));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -261,7 +261,7 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
             std::vector<Tensor> shards_to_aggregate = {device_tensors1[0], device_tensors2[1]};
             combine_device_tensors(shards_to_aggregate);
         }),
-        ThrowsMessage<std::runtime_error>(HasSubstr("All DeviceStorages must point to the same device memory")));
+        ThrowsMessage<std::runtime_error>(HasSubstr("tensor shards must be allocated on the same mesh buffer.")));
 
     // Try to aggregate the same shard twice
     EXPECT_THAT(

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -292,6 +292,71 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
     EXPECT_EQ(partial_device_storage.get_coords()[3], (distributed::MeshCoordinate{1, 2}));
 }
 
+TEST_F(MeshTensorTest2x4, CombineDeviceTensorsWithDifferentShardDims) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    std::vector<float> host_data(shape.volume());
+    std::iota(host_data.begin(), host_data.end(), 0);
+
+    Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
+    Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get());
+    auto device_tensors = get_device_tensors(device_tensor);
+    ASSERT_THAT(device_tensors, SizeIs(mesh_device_->num_devices()));
+
+    const int num_shards = static_cast<int>(device_tensors.size());
+    const MeshShape expected_distribution_shape(num_shards);
+
+    for (int shard_dim : {0, 3}) {
+        auto combined = combine_device_tensors(device_tensors, shard_dim);
+        EXPECT_EQ(combined.tensor_topology().distribution_shape(), expected_distribution_shape);
+        EXPECT_EQ(
+            std::get<distributed::MeshMapperConfig::Shard>(combined.tensor_topology().placements()[0]).dim, shard_dim);
+    }
+}
+
+TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
+    tt::tt_metal::DeviceStorage storage;
+
+    EXPECT_THAT(([&]() { storage.get_buffer(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(([&]() { storage.get_mesh_buffer(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(([&]() { storage.get_mesh_tensor(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(([&]() { storage.get_tensor_spec(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(
+        ([&]() { storage.get_tensor_topology(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(
+        ([&]() { storage.get_mesh_buffer_leak_ownership(); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(
+        ([&]() { storage.get_device_bypass_deallocate_check(); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+
+    EXPECT_FALSE(storage.is_allocated());
+    EXPECT_TRUE(storage.is_uniform_storage());
+}
+
+TEST_F(MeshTensorTest2x4, CombineDeviceTensorsShardDimValidation) {
+    const ttnn::Shape shape{1, 1, 32, 32};
+    const TensorSpec tensor_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+
+    Tensor input_host_tensor = Tensor::from_vector(std::vector<float>(shape.volume()), tensor_spec);
+    Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get());
+    auto device_tensors = get_device_tensors(device_tensor);
+    ASSERT_THAT(device_tensors, SizeIs(mesh_device_->num_devices()));
+
+    EXPECT_THAT(
+        ([&]() {
+            const int invalid_shard_dim = static_cast<int>(shape.rank());
+            combine_device_tensors(std::vector<Tensor>{device_tensors[0]}, invalid_shard_dim);
+        }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("shard_dim")));
+    EXPECT_THAT(
+        ([&]() { combine_device_tensors(std::vector<Tensor>{device_tensors[0]}, /*shard_dim=*/-1); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("shard_dim")));
+}
+
 struct MeshTensorWriteTestParams {
     ttnn::Shape shape;
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+namespace ttnn::distributed::test {
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace tt::tt_metal;
+
+TensorSpec make_test_tensor_spec() {
+    return TensorSpec(ttnn::Shape{1, 1, 32, 32}, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+}
+
+using DeallocateTest = GenericMeshDeviceFixture;
+
+TEST_F(DeallocateTest, HostTensorDeallocate) {
+    Tensor tensor = allocate_tensor_on_host(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force = */ true);
+    EXPECT_TRUE(tensor.is_allocated()) << "Host tensor should not be able to be deallocated";
+}
+
+TEST_F(DeallocateTest, SingleTensorDeallocate) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    // This tensor is the only instance, so deallocate will succeed.
+    tensor.deallocate(/*force = */ false);
+    EXPECT_FALSE(tensor.is_allocated()) << "Single tensor should be able to be deallocated";
+}
+
+TEST_F(DeallocateTest, SharedTensorDeallocate) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    Tensor tensor2 = tensor1;
+    Tensor tensor3(tensor1.device_storage());
+    tensor1.deallocate(/*force = */ false);
+    EXPECT_TRUE(tensor1.is_allocated() && tensor2.is_allocated() && tensor3.is_allocated())
+        << "Shared tensor should not be able to be deallocated when deallocated with force=false";
+    tensor2.deallocate(/*force = */ true);
+    EXPECT_FALSE(tensor1.is_allocated() || tensor2.is_allocated() || tensor3.is_allocated())
+        << "Shared tensor should be able to be deallocated when deallocated with force=true";
+}
+
+TEST_F(DeallocateTest, SharedTensorDeallocateForce) {
+    Tensor tensor1 = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    Tensor tensor2 = tensor1;
+    Tensor tensor3(tensor1.device_storage());
+    tensor1.deallocate(/*force = */ true);
+    EXPECT_FALSE(tensor1.is_allocated() || tensor2.is_allocated() || tensor3.is_allocated())
+        << "Shared tensor should be able to be deallocated when deallocated with force=true";
+}
+
+TEST_F(DeallocateTest, DeallocatedTensorHasDevice) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force = */ true);
+    EXPECT_FALSE(tensor.is_allocated());
+
+    EXPECT_NE(tensor.device(), nullptr) << "Deallocated tensor should have valid device";
+
+    Tensor tensor2 = tensor;
+    EXPECT_NE(tensor2.device(), nullptr) << "Copy of deallocated tensor should have valid device";
+
+    Tensor tensor3(tensor.device_storage());
+    EXPECT_NE(tensor3.device(), nullptr) << "Tensor constructed from deallocated storage should have valid device";
+}
+
+TEST_F(DeallocateTest, DeallocatedTensorDoesNOTHaveMeshTensor) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force = */ true);
+    EXPECT_FALSE(tensor.is_allocated());
+
+    EXPECT_ANY_THROW({ tensor.mesh_tensor(); }) << "Deallocated tensor should not have mesh tensor";
+
+    Tensor tensor1 = tensor;
+    EXPECT_ANY_THROW({ tensor1.mesh_tensor(); }) << "Copy of deallocated tensor should not have mesh tensor";
+
+    Tensor tensor2(tensor.device_storage());
+    EXPECT_ANY_THROW({ tensor2.mesh_tensor(); })
+        << "Tensor constructed from deallocated storage should not have mesh tensor";
+}
+
+TEST_F(DeallocateTest, DeallocatedTensorTensorSpec) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    tensor.deallocate(/*force = */ true);
+    EXPECT_FALSE(tensor.is_allocated());
+
+    EXPECT_EQ(tensor.tensor_spec(), make_test_tensor_spec()) << "Deallocated tensor should have valid tensor spec";
+
+    Tensor tensor2 = tensor;
+    EXPECT_EQ(tensor2.tensor_spec(), make_test_tensor_spec())
+        << "Copy of deallocated tensor should have valid tensor spec";
+    EXPECT_EQ(tensor2.tensor_spec(), tensor.tensor_spec())
+        << "Copy of deallocated tensor should have same tensor spec as original";
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -101,6 +101,35 @@ TEST_F(DeallocateTest, DeallocatedTensorTensorSpec) {
         << "Copy of deallocated tensor should have same tensor spec as original";
 }
 
+TEST_F(DeallocateTest, DefaultConstructedThrowsForSpecTopologyAndMeshTensor) {
+    DeviceStorage storage;
+
+    EXPECT_THROW(storage.get_tensor_spec(), std::exception);
+    EXPECT_THROW(storage.get_tensor_topology(), std::exception);
+    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
+}
+
+TEST_F(DeallocateTest, SpecAndTopologyAccessibleAfterDeallocate) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_NO_THROW(storage.get_tensor_spec());
+    EXPECT_NO_THROW(storage.get_tensor_topology());
+}
+
+TEST_F(DeallocateTest, MeshTensorGetterThrowsWhenDeallocated) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -130,6 +130,44 @@ TEST_F(DeallocateTest, MeshTensorGetterThrowsWhenDeallocated) {
     EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
 }
 
+// Tombstone state (DeallocatedTombStone): MeshTensor is gone but spec/topology and a shared MeshBuffer are kept
+// so device-facing workarounds still work (https://github.com/tenstorrent/tt-metal/issues/40716).
+
+TEST_F(DeallocateTest, DeallocatedTombStoneMeshBufferLeakOwnershipNonNull) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    auto mesh_buffer = storage.get_mesh_buffer_leak_ownership();
+    EXPECT_NE(mesh_buffer, nullptr) << "Tombstone should preserve MeshBuffer shared_ptr for leak-ownership access";
+}
+
+TEST_F(DeallocateTest, DeallocatedTombStoneDeviceBypassDeallocateCheckNonNull) {
+    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
+    DeviceStorage storage = tensor.device_storage();
+
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    distributed::MeshDevice* device = storage.get_device_bypass_deallocate_check();
+    EXPECT_NE(device, nullptr) << "Tombstone should expose MeshDevice via preserved MeshBuffer";
+    EXPECT_EQ(device, mesh_device_.get()) << "Device pointer should match the tensor's mesh device";
+}
+
+TEST_F(DeallocateTest, DefaultConstructedThrowsForDeviceBypassDeallocateCheck) {
+    DeviceStorage storage;
+
+    EXPECT_THROW(storage.get_device_bypass_deallocate_check(), std::exception);
+}
+
+TEST_F(DeallocateTest, DefaultConstructedThrowsForMeshBufferLeakOwnership) {
+    DeviceStorage storage;
+
+    EXPECT_THROW(storage.get_mesh_buffer_leak_ownership(), std::exception);
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
@@ -37,6 +37,7 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, TileToRowMajorPreservesShapeAndDtyp
     EXPECT_EQ(rm_tensor.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(rm_tensor.logical_shape(), tile_tensor.logical_shape());
     EXPECT_EQ(rm_tensor.dtype(), tile_tensor.dtype());
+    EXPECT_EQ(rm_tensor.tensor_spec().tile(), tile_tensor.tensor_spec().tile());
 }
 
 TEST_F(UncheckedReinterpretLayoutDeviceTest, RowMajorToTilePreservesShapeAndDtype) {
@@ -52,6 +53,22 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, RowMajorToTilePreservesShapeAndDtyp
     EXPECT_EQ(tile_tensor.layout(), Layout::TILE);
     EXPECT_EQ(tile_tensor.logical_shape(), rm_tensor.logical_shape());
     EXPECT_EQ(tile_tensor.dtype(), rm_tensor.dtype());
+    EXPECT_EQ(tile_tensor.tensor_spec().tile(), rm_tensor.tensor_spec().tile());
+}
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, PreservesNonDefaultTile) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    Tile custom_tile({16, 32});
+    ttnn::Shape shape({1, 1, 16, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, custom_tile), mem_cfg));
+
+    Tensor original = create_device_tensor(spec, device_);
+    ASSERT_EQ(original.tensor_spec().tile(), custom_tile);
+
+    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
 }
 
 TEST_F(UncheckedReinterpretLayoutDeviceTest, AliasesTheSameDeviceAddress) {
@@ -115,6 +132,23 @@ TEST_F(UncheckedReinterpretLayoutHostTest, TileToRowMajorOnHost) {
     EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
     EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());
     EXPECT_EQ(reinterpreted.dtype(), host_tensor.dtype());
+    EXPECT_EQ(reinterpreted.tensor_spec().tile(), host_tensor.tensor_spec().tile());
+}
+
+TEST_F(UncheckedReinterpretLayoutHostTest, PreservesNonDefaultTileOnHost) {
+    Tile custom_tile({16, 32});
+    ttnn::Shape shape({1, 1, 16, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, custom_tile), MemoryConfig{}));
+
+    auto num_elements = shape.volume();
+    std::vector<bfloat16> data(num_elements, bfloat16(1.0f));
+    Tensor host_tensor(HostBuffer(data), spec);
+    ASSERT_EQ(host_tensor.tensor_spec().tile(), custom_tile);
+
+    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
 }
 
 TEST_F(UncheckedReinterpretLayoutHostTest, RowMajorToTileOnHost) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+using namespace tt::tt_metal;
+
+// ---------------------------------------------------------------------------
+// Device tests
+// ---------------------------------------------------------------------------
+
+class UncheckedReinterpretLayoutDeviceTest
+    : public ttnn::TTNNFixtureWithSuiteDevice<UncheckedReinterpretLayoutDeviceTest> {};
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, TileToRowMajorPreservesShapeAndDtype) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
+
+    Tensor tile_tensor = create_device_tensor(spec, device_);
+    ASSERT_EQ(tile_tensor.layout(), Layout::TILE);
+
+    Tensor rm_tensor = unchecked_reinterpret_layout(tile_tensor, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(rm_tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(rm_tensor.logical_shape(), tile_tensor.logical_shape());
+    EXPECT_EQ(rm_tensor.dtype(), tile_tensor.dtype());
+}
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, RowMajorToTilePreservesShapeAndDtype) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), mem_cfg));
+
+    Tensor rm_tensor = create_device_tensor(spec, device_);
+    ASSERT_EQ(rm_tensor.layout(), Layout::ROW_MAJOR);
+
+    Tensor tile_tensor = unchecked_reinterpret_layout(rm_tensor, Layout::TILE);
+
+    EXPECT_EQ(tile_tensor.layout(), Layout::TILE);
+    EXPECT_EQ(tile_tensor.logical_shape(), rm_tensor.logical_shape());
+    EXPECT_EQ(tile_tensor.dtype(), rm_tensor.dtype());
+}
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, AliasesTheSameDeviceAddress) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
+
+    Tensor original = create_device_tensor(spec, device_);
+    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(
+        original.device_storage().get_mesh_buffer().address(),
+        reinterpreted.device_storage().get_mesh_buffer().address());
+}
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, SameLayoutIsIdentity) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
+
+    Tensor original = create_device_tensor(spec, device_);
+    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::TILE);
+
+    EXPECT_EQ(reinterpreted.layout(), Layout::TILE);
+    EXPECT_EQ(reinterpreted.tensor_spec(), original.tensor_spec());
+    EXPECT_EQ(
+        original.device_storage().get_mesh_buffer().address(),
+        reinterpreted.device_storage().get_mesh_buffer().address());
+}
+
+TEST_F(UncheckedReinterpretLayoutDeviceTest, OriginalTensorStaysAliveAfterReinterpretedDeallocated) {
+    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
+
+    Tensor original = create_device_tensor(spec, device_);
+    {
+        Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
+        ASSERT_TRUE(reinterpreted.is_allocated());
+    }
+    EXPECT_TRUE(original.is_allocated());
+}
+
+// ---------------------------------------------------------------------------
+// Host tests
+// ---------------------------------------------------------------------------
+
+class UncheckedReinterpretLayoutHostTest : public ::testing::Test {};
+
+TEST_F(UncheckedReinterpretLayoutHostTest, TileToRowMajorOnHost) {
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
+
+    auto num_elements = shape.volume();
+    std::vector<bfloat16> data(num_elements, bfloat16(1.0f));
+    Tensor host_tensor(HostBuffer(data), spec);
+    ASSERT_EQ(host_tensor.layout(), Layout::TILE);
+
+    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());
+    EXPECT_EQ(reinterpreted.dtype(), host_tensor.dtype());
+}
+
+TEST_F(UncheckedReinterpretLayoutHostTest, RowMajorToTileOnHost) {
+    ttnn::Shape shape({1, 1, 32, 32});
+    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
+
+    auto num_elements = shape.volume();
+    std::vector<bfloat16> data(num_elements, bfloat16(2.0f));
+    Tensor host_tensor(HostBuffer(data), spec);
+    ASSERT_EQ(host_tensor.layout(), Layout::ROW_MAJOR);
+
+    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::TILE);
+
+    EXPECT_EQ(reinterpreted.layout(), Layout::TILE);
+    EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());
+    EXPECT_EQ(reinterpreted.dtype(), host_tensor.dtype());
+}

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -132,6 +132,12 @@ public:
 
     // Getters:
 
+    /**
+     * If MeshTensor is in a default constructed state.
+     * This will be true for a default constructed MeshTensor or a MeshTensor in a move-from state.
+     */
+    bool has_value() const;
+
     const TensorSpec& tensor_spec() const;
 
     /**

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -121,7 +121,7 @@ public:
      *
      * See: #38691, #38375
      */
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_invariant_breaking() const;
 
     /**
      * Get the device the allocated device memory is on.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -121,7 +121,7 @@ public:
      *
      * See: #38691, #38375
      */
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_invariant_breaking() const;
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
 
     /**
      * Get the device the allocated device memory is on.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -133,10 +133,9 @@ public:
     // Getters:
 
     /**
-     * If MeshTensor is in a default constructed state.
-     * This will be true for a default constructed MeshTensor or a MeshTensor in a move-from state.
+     * Returns true if MeshTensor owns device memory (not default-constructed or moved-from).
      */
-    bool has_value() const;
+    bool is_initialized() const;
 
     const TensorSpec& tensor_spec() const;
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -72,7 +72,7 @@ MeshTensor::~MeshTensor() = default;
 
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
-std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
+const std::shared_ptr<distributed::MeshBuffer>& MeshTensor::mesh_buffer_invariant_breaking() const {
     TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
     return impl->mesh_buffer();
 }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -72,7 +72,7 @@ MeshTensor::~MeshTensor() = default;
 
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
-const std::shared_ptr<distributed::MeshBuffer>& MeshTensor::mesh_buffer_invariant_breaking() const {
+std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
     TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
     return impl->mesh_buffer();
 }

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -64,7 +64,7 @@ MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, Ten
     impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
 MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) {
-    TT_FATAL(other.impl != nullptr, "Cannot move from a default-constructed or moved-from MeshTensor.");
+    TT_FATAL(other.has_value(), "Cannot move from a default-constructed or moved-from MeshTensor.");
     impl = std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
 }
 
@@ -73,19 +73,21 @@ MeshTensor::~MeshTensor() = default;
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
 std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
-    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
     return impl->mesh_buffer();
 }
 
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
 
+bool MeshTensor::has_value() const { return impl != nullptr; }
+
 const TensorSpec& MeshTensor::tensor_spec() const {
-    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
     return impl->spec();
 }
 
 const TensorTopology& MeshTensor::tensor_topology() const {
-    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
     return impl->topology();
 }
 
@@ -128,7 +130,7 @@ std::size_t MeshTensor::element_size() const {
 Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
 
 void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_ASSERT(impl != nullptr, "MeshTensor is in default constructed state.");
+    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
     impl->update_topology(std::move(tensor_topology));
 }
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -64,7 +64,7 @@ MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, Ten
     impl(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
 
 MeshTensor::MeshTensor(MeshTensor&& other, TensorSpec spec, TensorTopology topology) {
-    TT_FATAL(other.has_value(), "Cannot move from a default-constructed or moved-from MeshTensor.");
+    TT_FATAL(other.is_initialized(), "Cannot move from a default-constructed or moved-from MeshTensor.");
     impl = std::make_unique<MeshTensorImpl>(std::move(*other.impl), std::move(spec), std::move(topology));
 }
 
@@ -73,21 +73,21 @@ MeshTensor::~MeshTensor() = default;
 distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return *mesh_buffer_invariant_breaking(); }
 
 std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
-    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
+    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
     return impl->mesh_buffer();
 }
 
 distributed::MeshDevice& MeshTensor::device() const { return *mesh_buffer().device(); }
 
-bool MeshTensor::has_value() const { return impl != nullptr; }
+bool MeshTensor::is_initialized() const { return impl != nullptr; }
 
 const TensorSpec& MeshTensor::tensor_spec() const {
-    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
+    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
     return impl->spec();
 }
 
 const TensorTopology& MeshTensor::tensor_topology() const {
-    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
+    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
     return impl->topology();
 }
 
@@ -130,7 +130,7 @@ std::size_t MeshTensor::element_size() const {
 Strides MeshTensor::strides() const { return tensor_spec().tensor_layout().compute_strides(logical_shape()); }
 
 void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
-    TT_FATAL(has_value(), "MeshTensor is in default constructed state.");
+    TT_FATAL(is_initialized(), "MeshTensor is in default constructed state.");
     impl->update_topology(std::move(tensor_topology));
 }
 

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -58,11 +58,8 @@ TensorReturnValue filter_tensor_shards(
                 }
             }
 
-            // Create new storage with filtered coords, sharing the mesh_buffer
-            tt::tt_metal::DeviceStorage new_storage(old_storage, std::move(filtered_coords));
-
-            // Return new tensor with new storage
-            return Tensor(std::move(new_storage), tensor.tensor_spec(), tensor.tensor_topology());
+            // Create new storage with filtered coords, sharing the device memory
+            return Tensor(tt::tt_metal::DeviceStorage(old_storage, std::move(filtered_coords)));
         },
         tensor_return_value);
 }

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -117,6 +117,7 @@ struct DeviceStorage {
     const distributed::MeshBuffer& get_mesh_buffer() const;
 
     const MeshTensor& get_mesh_tensor() const;
+    MeshTensor& get_mesh_tensor();
 
     // Get the device the device memory is allocated on
     // Throws if the DeviceStorage is not allocated.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -164,11 +164,15 @@ struct DeviceStorage {
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
     //
     // Creates a DeviceStorage representing a view of existing device memory.
-    // `surface_buffer` could provide a different buffer configuration (e.g., sharding parameters) from the
-    // configuration of the owning_storage. Ownership of the underlying device memory is shared amongs the new
-    // DeviceStorage and the owning_storage. Deallocation will affect both the new DeviceStorage and the owning_storage.
+    // `surface_mesh_tensor` could provide a different tensor configuration (TensorSpec, e.g. different layout) from the
+    // configuration of the owning_storage. This can be achived by creating the surface_mesh_tensor using an externally
+    // owned MeshBuffer.
     //
-    // These are considered internal functions and are not part of the public API.
+    // Ownership of the underlying device memory is shared amongs the new DeviceStorage and the owning_storage.
+    // Deallocation will affect both the new DeviceStorage and the owning_storage.
+    //
+    // This is the recommended way to reinterpret an existing Tensor.
+    // However this is considered internal function and is not part of the public API.
     // They will be replaced with a new initiative as described in: #38093
     DeviceStorage(const DeviceStorage& owning_storage, MeshTensor surface_mesh_tensor);
     // End internal functions.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -75,8 +75,15 @@ private:
 //   - get_coords/ is_uniform_storage will be undefined (for transition, ideally they should all throw).
 //   - Calls to deallocate will have no effect.
 //
-// Right now the deallocated state is only restircted to have a nullptr to the mesh_buffer,
-// in the future we should restrict it to also cover have a non-null mesh_buffer that has a deallocated state.
+// Right now the deallocated state is only restircted to have a nullptr to the MeshTensor,
+// However, the MeshTensor could still be in a deallocated state when other owners of DeviceStorage calls deallocate.
+// This is problematic in two ways:
+// 1. This breaks the invariant that the MeshTensor is always allocated.
+// 2. The definition of deallocated state is not conforming to `DeviceStorage::is_allocated()`.
+//
+// Long term, "deallocated" and `!is_allocated()` should be synonymous. Migration is difficult: some
+// operations (e.g. move) still rely on accessing tensors in a deallocated state, and asserts do not
+// cover every intentional or accidental use of deallocated tensors.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
     DeviceStorage() = default;
@@ -123,8 +130,9 @@ struct DeviceStorage {
     // Throws if the DeviceStorage is not allocated.
     distributed::MeshDevice& get_device() const;
 
-    // Returns the MeshDevice pointer if mesh_buffer exists, or nullptr otherwise.
-    // Unlike get_device(), this does NOT throw when the buffer is deallocated.
+    // Returns the MeshDevice pointer if mesh_tensor exists, or nullptr otherwise.
+    // Unlike get_device(), this does NOT throw when the mesh_tensor exist but it's mesh_buffer being in a deallocated
+    // state.
     //
     // Workaround for https://github.com/tenstorrent/tt-metal/issues/40716:
     // When a tensor's DeviceStorage is copied (e.g., by view/reshape) and the original
@@ -164,18 +172,21 @@ struct DeviceStorage {
     // Begin internal functions:
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
     //
-    // Creates a DeviceStorage representing a view of existing device memory.
-    // `surface_mesh_tensor` could provide a different tensor configuration (TensorSpec, e.g. different layout) from the
-    // configuration of the owning_storage. This can be achived by creating the surface_mesh_tensor using an externally
-    // owned MeshBuffer.
+    // There are situations where we want to "reinterpret" an existing Tensor without modifying its underlying memory.
+    // For example, select slice ops can be done in-place, as can select reshapes. This DeviceStorage constructor
+    // addresses such cases.
+    //  - owning_storage is the original DeviceStorage object that owns the device memory
+    //  - reinterpreted_mesh_tensor is the new interpretation of the device memory
     //
-    // Ownership of the underlying device memory is shared amongs the new DeviceStorage and the owning_storage.
-    // Deallocation will affect both the new DeviceStorage and the owning_storage.
+    // Upon construction, ownership of the underlying device memory is SHARED by the new DeviceStorage and the original
+    // owning_storage.
     //
-    // This is the recommended way to reinterpret an existing Tensor.
-    // However this is considered internal function and is not part of the public API.
-    // They will be replaced with a new initiative as described in: #38093
-    DeviceStorage(const DeviceStorage& owning_storage, MeshTensor surface_mesh_tensor);
+    // Note that deallocation will affect BOTH the new DeviceStorage and the original owning_storage.
+
+    // This is currently the recommended method to reinterpret an existing Tensor.
+    // This is  internal functionality: it is not part of the public API.
+    // TODO: implement a more robust mechanism for Tensor reinterpretation (#38093)
+    DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor);
     // End internal functions.
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -200,7 +200,6 @@ private:
 
     std::shared_ptr<MeshTensor> mesh_tensor_;
     std::vector<distributed::MeshCoordinate> coords_;
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
 
     // Experimental features for viewing an existing DeviceStorage
     const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -60,33 +60,25 @@ private:
     HostTensor tensor;
 };
 
-// DeviceStorage manages a piece of device memory and that is valid for a vector of MeshCoordinates.
+// DeviceStorage is a wrapper around the MeshTensor to fit the semantics of ttnn::Tensor.
 //
-// DeviceStorage owns the lifetime of the underlying device memory.
-// Copying the DeviceStorage will share the ownership of the underlying device memory.
+// Different from MeshTensor, DeviceStorage has the following additional features:
+// - It can be in a deallocated state.
+// - It is copyable, copying a DeviceStorage shares the underlying device memory.
+// - It represents a MeshTensor at specific coordinates of the MeshDevice.
 //
-// DeviceStorage has two possible states:
-// - Allocated: the underlying device memory is allocated.
-//   - Can query device memory state/ coordinates/ device.
-//   - The MeshCoordinates obtained from get_coords will be within the boundaries of the underlying device memory.
-//   - Can be switched to the deallocated state by calling deallocate.
-// - Deallocated: the underlying device memory is released.
-//   - Query of device memory state/ device will throw.
-//   - get_coords/ is_uniform_storage will be undefined (for transition, ideally they should all throw).
-//   - Calls to deallocate will have no effect.
-//
-// Right now the deallocated state is only restircted to have a nullptr to the MeshTensor,
-// However, the MeshTensor could still be in a deallocated state when other owners of DeviceStorage calls deallocate.
-// This is problematic in two ways:
-// 1. This breaks the invariant that the MeshTensor is always allocated.
-// 2. The definition of deallocated state is not conforming to `DeviceStorage::is_allocated()`.
-//
-// Long term, "deallocated" and `!is_allocated()` should be synonymous. Migration is difficult: some
-// operations (e.g. move) still rely on accessing tensors in a deallocated state, and asserts do not
-// cover every intentional or accidental use of deallocated tensors.
+// Invariant:
+// - A default-constructed DeviceStorage acts like a deallocated DeviceStorage. However it is not associated with
+// TensorSpec and TensorTopology.
+// - An allocated DeviceStorage always holds a non-default constructed MeshTensor. Do not move the MeshTensor out of
+//   DeviceStorage.
+// - TensorSpec and TensorTopology are always accessible for a DeviceStorage constructed from a MeshTensor. This stays
+// true even after deallocate() is called.
+// - deallocate() releases the underlying device memory.
+// - MeshTensor getters will always throw if the DeviceStorage is deallocated.
 struct DeviceStorage {
     // Construct a DeviceStorage that is deallocated
-    DeviceStorage() = default;
+    DeviceStorage();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructs a DeviceStorage from a device memory
@@ -120,25 +112,23 @@ struct DeviceStorage {
     Buffer* get_buffer() const;
 
     // Get mesh buffer that represents the device memory
-    // Throws if the DeviceStorage is not allocated.
+    // Throws if the DeviceStorage is deallocated.
     const distributed::MeshBuffer& get_mesh_buffer() const;
 
+    // Get the underlying MeshTensor, throws if the DeviceStorage is deallocated.
     const MeshTensor& get_mesh_tensor() const;
+
+    // Get the underlying MeshTensor, throws if the DeviceStorage is deallocated.
+    // Please do not move the MeshTensor out of the DeviceStorage using this function.
     MeshTensor& get_mesh_tensor();
 
-    // Get the device the device memory is allocated on
-    // Throws if the DeviceStorage is not allocated.
-    distributed::MeshDevice& get_device() const;
-
-    // Returns the MeshDevice pointer if mesh_tensor exists, or nullptr otherwise.
-    // Unlike get_device(), this does NOT throw when the mesh_tensor exist but it's mesh_buffer being in a deallocated
-    // state.
+    // Returns the MeshDevice associated with the underlying device memory.
+    // Throws if the DeviceStorage is not constructed from a MeshTensor.
     //
     // Workaround for https://github.com/tenstorrent/tt-metal/issues/40716:
-    // When a tensor's DeviceStorage is copied (e.g., by view/reshape) and the original
-    // is deallocated, the copy's MeshBuffer is in DeallocatedState but still exists.
-    // This function allows retrieving the device even in that state, preventing nullptr
-    // device propagation when constructing new tensors from such storage.
+    // When DeviceStorage is copied (e.g. view/reshape) and the original is deallocated, the copy's
+    // holder becomes DeallocatedTombStone while the MeshBuffer reference is still present.
+    // This path preserves a valid device pointer when constructing new tensors from such storage.
     //
     // TODO: Remove this workaround once models properly manage tensor lifetimes and
     // don't operate on deallocated tensors.
@@ -162,7 +152,7 @@ struct DeviceStorage {
     // Deallocate will deallocate the device memory of among all shared instances.
     void deallocate();
 
-    // Returns true if no other DeviceStorage shares this storage's MeshTensor handle(s) (surface and optional root).
+    // Returns true when DeviceStorage is allocated and is the sole owner of the underlying MeshTensor.
     bool is_sole_owner_of_device_memory() const;
 
     // Returns true if the underlying device memory is allocated.
@@ -170,8 +160,14 @@ struct DeviceStorage {
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Begin internal functions:
+
+    // Returns the MeshBuffer associated with the underlying device memory.
+    // This function should be removed in-favor of `get_mesh_tensor()`.
+    // The function also leaks the ownership of the underlying device memory out.
+    // This is meant to be transitional and is to be removed.
+    // Throws if the DeviceStorage is not constructed from a MeshTensor.
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
-    //
+
     // There are situations where we want to "reinterpret" an existing Tensor without modifying its underlying memory.
     // For example, select slice ops can be done in-place, as can select reshapes. This DeviceStorage constructor
     // addresses such cases.
@@ -194,14 +190,25 @@ struct DeviceStorage {
     //
     // Combines a vector of DeviceStorages that shares the same device storage but spread across difference coordinates
     // into a single DeviceStorage.
+    //
+    // Throws if:
+    // - The vector of DeviceStorages is empty.
+    // - The vector of DeviceStorages does not share the same device storage.
+    // - Any DeviceStorage is deallocated.
     static DeviceStorage combine_device_storages(
         const std::vector<std::reference_wrapper<const DeviceStorage>>& storages, int shard_dim);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Update tensor topology
+    // Throws if the device storage is deallocated.
     void update_tensor_topology(const TensorTopology& tensor_topology);
 
+    // Returns the tensor spec associated with the MeshTensor.
+    // Throws if the DeviceStorage is not constructed from a MeshTensor.
     const TensorSpec& get_tensor_spec() const;
+    // Returns the tensor topology associated with the MeshTensor.
+    // Throws if the DeviceStorage is not constructed from a MeshTensor.
+    const TensorTopology& get_tensor_topology() const;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Serialization
@@ -210,69 +217,20 @@ struct DeviceStorage {
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
-    struct LocallyAllocatedState {
-        // Engaged and actively sharing a MeshTensor.
-        // This does not necessarily mean the associated MeshTensor is allocated.
-        // This means that deallocate is not called on *this instance of DeviceStorage,
-        // other DeviceStorage that shares the same MeshTensor may have deallocated the DeviceMemory.
-
-        explicit LocallyAllocatedState(MeshTensor mesh_tensor) :
-            mesh_tensor_(std::make_shared<MeshTensor>(std::move(mesh_tensor))) {}
-        std::shared_ptr<MeshTensor> mesh_tensor_;
-
-        const TensorSpec& get_tensor_spec() const { return mesh_tensor_->tensor_spec(); }
-        const TensorTopology& get_tensor_topology() const { return mesh_tensor_->tensor_topology(); }
-    };
-    struct DeallocatedState {
-        // Represents the deallocated state.
-        DeallocatedState() : state_(DefaultConstructed{}) {}
-
-        // Preserve the tensor spec and topology after deallocation for backwards compatibility.
-        explicit DeallocatedState(const MeshTensor& mesh_tensor) :
-            state_(TombStone{
-                mesh_tensor.tensor_spec(),
-                mesh_tensor.tensor_topology(),
-                mesh_tensor.mesh_buffer_invariant_breaking()}) {}
-
-        struct DefaultConstructed {};
-        struct TombStone {
-            TensorSpec tensor_spec_;
-            TensorTopology tensor_topology_;
-            // This mesh_buffer_ must have been deallocated
-            // This is to allow access to the mesh_device_ without pointing to a freed-device.
-            // This should be removed once we kick mesh_device access after deallocation out.
-            std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
-        };
-        std::variant<DefaultConstructed, TombStone> state_;
-
-        const TensorSpec& get_tensor_spec() const {
-            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
-            return std::get<TombStone>(state_).tensor_spec_;
-        }
-        const TensorTopology& get_tensor_topology() const {
-            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
-            return std::get<TombStone>(state_).tensor_topology_;
-        }
-        distributed::MeshDevice* get_device() const {
-            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
-            return std::get<TombStone>(state_).mesh_buffer_->device();
-        }
-    };
-
-    using States = std::variant<DeallocatedState, LocallyAllocatedState>;
+    struct MeshTensorHolder;
 
     // Main internal constructor, performs all validation
     DeviceStorage(
-        States state, std::vector<distributed::MeshCoordinate> coords, std::shared_ptr<MeshTensor> root_mesh_tensor);
+        std::shared_ptr<MeshTensorHolder> mesh_tensor_holder,
+        std::vector<distributed::MeshCoordinate> coords,
+        std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder);
 
-    const std::shared_ptr<MeshTensor>& get_mesh_tensor_bypass_deallocate_check() const;
-
-    States state_;
+    std::shared_ptr<MeshTensorHolder> mesh_tensor_holder_;
     std::vector<distributed::MeshCoordinate> coords_;
 
     // Experimental features for viewing an existing DeviceStorage
-    const std::shared_ptr<MeshTensor>& get_root_mesh_tensor() const;
-    std::shared_ptr<MeshTensor> root_mesh_tensor_;
+    const std::shared_ptr<MeshTensorHolder>& get_root_mesh_tensor() const;
+    std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder_;
     // End experimental features
 };
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -153,7 +153,7 @@ struct DeviceStorage {
     // Deallocate will deallocate the device memory of among all shared instances.
     void deallocate();
 
-    // Returns true if no other DeviceStorage or third party has a shared reference to the device memory (MeshBuffer).
+    // Returns true if no other DeviceStorage shares this storage's MeshTensor handle(s) (surface and optional root).
     bool is_sole_owner_of_device_memory() const;
 
     // Returns true if the underlying device memory is allocated.

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <vector>
 
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include "tt-metalium/distributed_host_buffer.hpp"
 #include "tt-metalium/experimental/tensor/host_tensor.hpp"
 #include <ttnn/tensor/tensor_spec.hpp>
@@ -84,12 +85,11 @@ struct DeviceStorage {
     // Constructs a DeviceStorage from a device memory
 
     // Constructs DeviceStorage with coords covering the full mesh device shape.
-    explicit DeviceStorage(const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_);
+    explicit DeviceStorage(MeshTensor mesh_tensor);
 
     // Constructs DeviceStorage that is a view of the mesh_buffer_ at the given coords_.
     // Throws if the coords_ are out of bounds for the mesh_buffer_ device shape.
-    DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
+    DeviceStorage(MeshTensor mesh_tensor, std::vector<distributed::MeshCoordinate> coords);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Copys an existing DeviceStorage and share it's underlying device memory.
@@ -115,6 +115,8 @@ struct DeviceStorage {
     // Get mesh buffer that represents the device memory
     // Throws if the DeviceStorage is not allocated.
     const distributed::MeshBuffer& get_mesh_buffer() const;
+
+    const MeshTensor& get_mesh_tensor() const;
 
     // Get the device the device memory is allocated on
     // Throws if the DeviceStorage is not allocated.
@@ -177,7 +179,11 @@ struct DeviceStorage {
     // Combines a vector of DeviceStorages that shares the same device storage but spread across difference coordinates
     // into a single DeviceStorage.
     static DeviceStorage combine_device_storages(
-        const std::vector<std::reference_wrapper<const DeviceStorage>>& storages);
+        const std::vector<std::reference_wrapper<const DeviceStorage>>& storages, int shard_dim);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Update tensor topology
+    void update_tensor_topology(const TensorTopology& tensor_topology);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Serialization
@@ -188,10 +194,11 @@ struct DeviceStorage {
 private:
     // Main internal constructor, performs all validation
     DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+        std::shared_ptr<MeshTensor> mesh_tensor,
         std::vector<distributed::MeshCoordinate> coords,
         std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer);
 
+    std::shared_ptr<MeshTensor> mesh_tensor_;
     std::vector<distributed::MeshCoordinate> coords_;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -170,7 +170,7 @@ struct DeviceStorage {
     //
     // These are considered internal functions and are not part of the public API.
     // They will be replaced with a new initiative as described in: #38093
-    DeviceStorage(const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer);
+    DeviceStorage(const DeviceStorage& owning_storage, MeshTensor surface_mesh_tensor);
     // End internal functions.
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -196,14 +196,14 @@ private:
     DeviceStorage(
         std::shared_ptr<MeshTensor> mesh_tensor,
         std::vector<distributed::MeshCoordinate> coords,
-        std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer);
+        std::shared_ptr<MeshTensor> root_mesh_tensor);
 
     std::shared_ptr<MeshTensor> mesh_tensor_;
     std::vector<distributed::MeshCoordinate> coords_;
 
     // Experimental features for viewing an existing DeviceStorage
-    const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
+    const std::shared_ptr<MeshTensor>& get_root_mesh_tensor() const;
+    std::shared_ptr<MeshTensor> root_mesh_tensor_;
     // End experimental features
 };
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -182,7 +182,7 @@ struct DeviceStorage {
     // owning_storage.
     //
     // Note that deallocation will affect BOTH the new DeviceStorage and the original owning_storage.
-
+    //
     // This is currently the recommended method to reinterpret an existing Tensor.
     // This is  internal functionality: it is not part of the public API.
     // TODO: implement a more robust mechanism for Tensor reinterpretation (#38093)
@@ -211,8 +211,11 @@ struct DeviceStorage {
 
 private:
     struct LocallyAllocatedState {
-        // Engaged and actively sharing an allocated MeshTensor.
-        LocallyAllocatedState() = default;
+        // Engaged and actively sharing a MeshTensor.
+        // This does not necessarily mean the associated MeshTensor is allocated.
+        // This means that deallocate is not called on *this instance of DeviceStorage,
+        // other DeviceStorage that shares the same MeshTensor may have deallocated the DeviceMemory.
+
         explicit LocallyAllocatedState(MeshTensor mesh_tensor) :
             mesh_tensor_(std::make_shared<MeshTensor>(std::move(mesh_tensor))) {}
         std::shared_ptr<MeshTensor> mesh_tensor_;
@@ -221,18 +224,42 @@ private:
         const TensorTopology& get_tensor_topology() const { return mesh_tensor_->tensor_topology(); }
     };
     struct DeallocatedState {
-        // Tombstone of a deallocated MeshTensor.
-        // Transitionally preserve the tensor spec for backwards compatibility.
-        explicit DeallocatedState(const MeshTensor& mesh_tensor) :
-            tensor_spec_(mesh_tensor.tensor_spec()), tensor_topology_(mesh_tensor.tensor_topology()) {}
-        TensorSpec tensor_spec_;
-        TensorTopology tensor_topology_;
+        // Represents the deallocated state.
+        DeallocatedState() : state_(DefaultConstructed{}) {}
 
-        const TensorSpec& get_tensor_spec() const { return tensor_spec_; }
-        const TensorTopology& get_tensor_topology() const { return tensor_topology_; }
+        // Preserve the tensor spec and topology after deallocation for backwards compatibility.
+        explicit DeallocatedState(const MeshTensor& mesh_tensor) :
+            state_(TombStone{
+                mesh_tensor.tensor_spec(),
+                mesh_tensor.tensor_topology(),
+                mesh_tensor.mesh_buffer_invariant_breaking()}) {}
+
+        struct DefaultConstructed {};
+        struct TombStone {
+            TensorSpec tensor_spec_;
+            TensorTopology tensor_topology_;
+            // This mesh_buffer_ must have been deallocated
+            // This is to allow access to the mesh_device_ without pointing to a freed-device.
+            // This should be removed once we kick mesh_device access after deallocation out.
+            std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
+        };
+        std::variant<DefaultConstructed, TombStone> state_;
+
+        const TensorSpec& get_tensor_spec() const {
+            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
+            return std::get<TombStone>(state_).tensor_spec_;
+        }
+        const TensorTopology& get_tensor_topology() const {
+            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
+            return std::get<TombStone>(state_).tensor_topology_;
+        }
+        distributed::MeshDevice* get_device() const {
+            TT_FATAL(std::holds_alternative<TombStone>(state_), "Tensor is not allocated");
+            return std::get<TombStone>(state_).mesh_buffer_->device();
+        }
     };
 
-    using States = std::variant<LocallyAllocatedState, DeallocatedState>;
+    using States = std::variant<DeallocatedState, LocallyAllocatedState>;
 
     // Main internal constructor, performs all validation
     DeviceStorage(

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -201,6 +201,8 @@ struct DeviceStorage {
     // Update tensor topology
     void update_tensor_topology(const TensorTopology& tensor_topology);
 
+    const TensorSpec& get_tensor_spec() const;
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Serialization
 
@@ -208,13 +210,37 @@ struct DeviceStorage {
     auto attribute_values() const { return std::forward_as_tuple(); }
 
 private:
+    struct LocallyAllocatedState {
+        // Engaged and actively sharing an allocated MeshTensor.
+        LocallyAllocatedState() = default;
+        explicit LocallyAllocatedState(MeshTensor mesh_tensor) :
+            mesh_tensor_(std::make_shared<MeshTensor>(std::move(mesh_tensor))) {}
+        std::shared_ptr<MeshTensor> mesh_tensor_;
+
+        const TensorSpec& get_tensor_spec() const { return mesh_tensor_->tensor_spec(); }
+        const TensorTopology& get_tensor_topology() const { return mesh_tensor_->tensor_topology(); }
+    };
+    struct DeallocatedState {
+        // Tombstone of a deallocated MeshTensor.
+        // Transitionally preserve the tensor spec for backwards compatibility.
+        explicit DeallocatedState(const MeshTensor& mesh_tensor) :
+            tensor_spec_(mesh_tensor.tensor_spec()), tensor_topology_(mesh_tensor.tensor_topology()) {}
+        TensorSpec tensor_spec_;
+        TensorTopology tensor_topology_;
+
+        const TensorSpec& get_tensor_spec() const { return tensor_spec_; }
+        const TensorTopology& get_tensor_topology() const { return tensor_topology_; }
+    };
+
+    using States = std::variant<LocallyAllocatedState, DeallocatedState>;
+
     // Main internal constructor, performs all validation
     DeviceStorage(
-        std::shared_ptr<MeshTensor> mesh_tensor,
-        std::vector<distributed::MeshCoordinate> coords,
-        std::shared_ptr<MeshTensor> root_mesh_tensor);
+        States state, std::vector<distributed::MeshCoordinate> coords, std::shared_ptr<MeshTensor> root_mesh_tensor);
 
-    std::shared_ptr<MeshTensor> mesh_tensor_;
+    const std::shared_ptr<MeshTensor>& get_mesh_tensor_bypass_deallocate_check() const;
+
+    States state_;
     std::vector<distributed::MeshCoordinate> coords_;
 
     // Experimental features for viewing an existing DeviceStorage

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -181,7 +181,7 @@ struct DeviceStorage {
     //
     // This is currently the recommended method to reinterpret an existing Tensor.
     // This is  internal functionality: it is not part of the public API.
-    // TODO: implement a more robust mechanism for Tensor reinterpretation (#38093)
+    // TODO(#38093): implement a more robust mechanism for Tensor reinterpretation
     DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor);
     // End internal functions.
 
@@ -199,10 +199,6 @@ struct DeviceStorage {
         const std::vector<std::reference_wrapper<const DeviceStorage>>& storages, int shard_dim);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Update tensor topology
-    // Throws if the device storage is deallocated.
-    void update_tensor_topology(const TensorTopology& tensor_topology);
-
     // Returns the tensor spec associated with the MeshTensor.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
     const TensorSpec& get_tensor_spec() const;

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -12,6 +12,8 @@
 #include <tuple>
 #include <vector>
 
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/distributed/tensor_topology.hpp"
 #include "ttnn/tensor/storage.hpp"
@@ -57,10 +59,12 @@ public:
     //
     // TODO(#40348): Remove this.
     [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
-
     [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
+    [[nodiscard]] explicit Tensor(DeviceStorage storage);
+
     [[nodiscard]] explicit Tensor(HostTensor tensor);
+    [[nodiscard]] explicit Tensor(MeshTensor tensor);
 
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -59,7 +59,6 @@ public:
     //
     // TODO(#40348): Remove this.
     [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
-    [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
     [[nodiscard]] explicit Tensor(DeviceStorage storage);
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -199,14 +199,6 @@ public:
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
-private:
-    // TODO(river):
-    // This will be removed as part of Metal Tensor split lowering (#37692).
-    // The function is removed publicly as the underlying storage of Tensor will be changed as part of the refactoring
-    // effort.
-    const Storage& storage() const;
-
-public:
     DataType dtype() const;
     Layout layout() const;
     const tt::tt_metal::Shape& logical_shape() const;
@@ -249,7 +241,13 @@ public:
 
     // Returns the associated HostTensor.
     const HostTensor& host_tensor() const&;
+    HostTensor& host_tensor() &;
     const HostTensor& host_tensor() const&& = delete;  // prevents dangling reference to temporaries.
+
+    // Returns the associated MeshTensor.
+    const MeshTensor& mesh_tensor() const&;
+    MeshTensor& mesh_tensor() &;
+    const MeshTensor& mesh_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns device `MeshBuffer`.
     // Throws if the tensor is not allocated on a device.
@@ -265,7 +263,7 @@ public:
     uint32_t element_size() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("storage", "tensor_spec");
-    auto attribute_values() const { return std::forward_as_tuple(storage(), tensor_spec()); }
+    auto attribute_values() const { return std::forward_as_tuple(tensor_attributes->get_storage(), tensor_spec()); }
 
     static std::uint64_t get_tensor_id_counter();
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -232,21 +232,21 @@ public:
     // Returns device `Storage`.
     // Throws if the tensor is not on device.
     const DeviceStorage& device_storage() const&;
+    DeviceStorage& device_storage() &;
     const DeviceStorage& device_storage() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns host `Storage`.
     // Throws if the tensor is not on host.
     const HostStorage& host_storage() const&;
+    HostStorage& host_storage() &;
     const HostStorage& host_storage() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns the associated HostTensor.
     const HostTensor& host_tensor() const&;
-    HostTensor& host_tensor() &;
     const HostTensor& host_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns the associated MeshTensor.
     const MeshTensor& mesh_tensor() const&;
-    MeshTensor& mesh_tensor() &;
     const MeshTensor& mesh_tensor() const&& = delete;  // prevents dangling reference to temporaries.
 
     // Returns device `MeshBuffer`.

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -15,6 +15,7 @@ namespace tt::tt_metal {
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
     TensorAttributes(HostStorage storage);
+    TensorAttributes(DeviceStorage storage);
 
     // Transitional constructor: use TensorAttributes(HostStorage) instead.
     //
@@ -33,7 +34,11 @@ public:
     // TODO(#40348): Remove this.
     TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
+    // Transitional constructor: use TensorAttributes(DeviceStorage) instead.
+    // Same reason as above.
+    // TODO(#40348): Remove this.
     TensorAttributes(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;
     TensorAttributes& operator=(const TensorAttributes&) = default;

--- a/ttnn/api/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_attributes.hpp
@@ -34,11 +34,6 @@ public:
     // TODO(#40348): Remove this.
     TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
-    // Transitional constructor: use TensorAttributes(DeviceStorage) instead.
-    // Same reason as above.
-    // TODO(#40348): Remove this.
-    TensorAttributes(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
-
     TensorAttributes(const TensorAttributes&) = default;
     TensorAttributes(TensorAttributes&&) = default;
     TensorAttributes& operator=(const TensorAttributes&) = default;
@@ -54,12 +49,6 @@ public:
 
 private:
     Storage storage_;
-
-    // These will be removed after Runtime Tensor refactoring,
-    // as they will be part of the Host and MeshTensor,
-    // Thus a part of Storage.
-    TensorSpec tensor_spec_;
-    TensorTopology tensor_topology_;
 };
 
 }  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -87,6 +87,9 @@ std::shared_ptr<distributed::MeshBuffer> allocate_device_buffer(
 
 HostBuffer allocate_host_buffer(const TensorSpec& tensor_spec);
 
+MeshTensor allocate_mesh_tensor(
+    const TensorSpec& tensor_spec, distributed::MeshDevice& device, TensorTopology topology);
+
 // ======================================================================================
 //                                         .to_host() and .to_device()
 // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -156,6 +156,16 @@ HostTensor view(
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
+HostTensor unchecked_force_reinterpret(
+    const HostTensor& tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology);
+
+MeshTensor unchecked_force_reinterpret(
+    const MeshTensor& tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology);
+
 // ======================================================================================
 //                                         Print
 // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -156,16 +156,6 @@ HostTensor view(
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
-HostTensor unchecked_force_reinterpret(
-    const HostTensor& tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology);
-
-MeshTensor unchecked_force_reinterpret(
-    const MeshTensor& tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology);
-
 // ======================================================================================
 //                                         Print
 // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -83,6 +83,21 @@ Tensor view(
     const tt::tt_metal::Shape& new_logical_shape,
     const tt::tt_metal::Shape& new_padded_shape);
 
+/**
+ * Forcefully reinterpret the device memory of input_tensor with new_spec and new_topology.
+ *
+ * This function provides minimal checks and is extremely error prone. Thus should be used with extreme caution.
+ * Reading the content of the Tensor after reinterpretation should be considered as undefined behavior.
+ *
+ * A proposal for a safer alternative is described in #38093.
+ *
+ * This function should not be considered as part of the general public API and will be unstable.
+ */
+Tensor unchecked_force_reinterpret(
+    const Tensor& input_tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology);
+
 Tensor to_dtype(const Tensor& input_tensor, DataType dtype);
 
 std::string to_string(const Tensor& tensor);

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -84,19 +84,15 @@ Tensor view(
     const tt::tt_metal::Shape& new_padded_shape);
 
 /**
- * Forcefully reinterpret the device memory of input_tensor with new_spec and new_topology.
+ * Reinterpret the underlying memory of input_tensor with target_layout without moving or converting data.
  *
- * This function provides minimal checks and is extremely error prone. Thus should be used with extreme caution.
- * Reading the content of the Tensor after reinterpretation should be considered as undefined behavior.
+ * The result and input_tensor will point to the same memory (whether on host or device),
+ * this is a pure metadata change.
  *
- * A proposal for a safer alternative is described in #38093.
- *
- * This function should not be considered as part of the general public API and will be unstable.
+ * This function is error prone, and the caller is responsible for ensuring that the reinterpretation is semantically
+ * valid.
  */
-Tensor unchecked_force_reinterpret(
-    const Tensor& input_tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology);
+Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_layout);
 
 Tensor to_dtype(const Tensor& input_tensor, DataType dtype);
 

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -78,8 +78,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
         std::vector<ttnn::Tensor> tensors;
         tensors.reserve(device_storage.get_coords().size());
         for (const auto& coord : device_storage.get_coords()) {
-            DeviceStorage shard_storage(device_storage, {coord});
-            tensors.push_back(Tensor(std::move(shard_storage), tensor.tensor_spec(), tensor.tensor_topology()));
+            tensors.push_back(Tensor(DeviceStorage(device_storage, {coord})));
         }
         return tensors;
     }
@@ -132,10 +131,7 @@ Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shar
         device_storages.push_back(std::cref(shard.device_storage()));
     }
 
-    auto combined_storage = DeviceStorage::combine_device_storages(device_storages);
-    TensorTopology topology =
-        TensorTopology::create_sharded_tensor_topology(MeshShape(tensor_shards.size()), shard_dim);
-    return Tensor(std::move(combined_storage), reference_shard.tensor_spec(), std::move(topology));
+    return Tensor(DeviceStorage::combine_device_storages(device_storages, shard_dim));
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <numeric>
 #include <functional>
+#include <tt-logger/tt-logger.hpp>
 #include <unordered_set>
 #include <vector>
 
@@ -74,64 +75,128 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
     return HostStorage(tensor.transform(callable));
 }
 
+// MeshTensor lifetime holder:
+// Conceptually MeshTensor has two states:
+// - Allocated: actively holding a MeshTensor.
+// - Deallocated: the MeshTensor was deallocated by any of the DeviceStorage instances.
+//
+// To ease transition, we keep a tombstone of the MeshTensor's spec, topology, and buffer when the MeshTensor is
+// deallocated.
+struct DeviceStorage::MeshTensorHolder {
+    struct DeallocatedDefaultConstructed {};
+
+    struct Allocated {
+        MeshTensor mesh_tensor_;
+    };
+
+    struct DeallocatedTombStone {
+        TensorSpec tensor_spec_;
+        TensorTopology tensor_topology_;
+        // Deallocated buffer kept so device() stays valid without dangling MeshDevice.
+        // Remove once post-deallocation mesh_device access is no longer needed.
+        // See: get_device_bypass_deallocate_check
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_;
+    };
+
+    using States = std::variant<DeallocatedDefaultConstructed, Allocated, DeallocatedTombStone>;
+    States state_;
+
+    MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
+    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {}
+
+    bool is_allocated() const { return std::holds_alternative<Allocated>(state_); }
+
+    void deallocate() {
+        if (auto* allocated = std::get_if<Allocated>(&state_)) {
+            allocated->mesh_tensor_.mesh_buffer().deallocate();
+            state_ = DeallocatedTombStone{
+                allocated->mesh_tensor_.tensor_spec(),
+                allocated->mesh_tensor_.tensor_topology(),
+                allocated->mesh_tensor_.mesh_buffer_invariant_breaking()};
+        }
+    }
+};
+
+DeviceStorage::DeviceStorage() : mesh_tensor_holder_(std::make_shared<MeshTensorHolder>()) {}
+
 DeviceStorage::DeviceStorage(MeshTensor mesh_tensor) :
-    state_(LocallyAllocatedState(std::move(mesh_tensor))),
-    coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(get_device())) {}
+    mesh_tensor_holder_(std::make_shared<MeshTensorHolder>(std::move(mesh_tensor))),
+    coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(get_mesh_tensor().device())) {}
 
 DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(LocallyAllocatedState(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
+    DeviceStorage(std::make_shared<MeshTensorHolder>(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(other.state_, std::move(coords), other.root_mesh_tensor_) {}
+    DeviceStorage(other.mesh_tensor_holder_, std::move(coords), other.root_mesh_tensor_holder_) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor) :
     DeviceStorage(
-        LocallyAllocatedState(std::move(reinterpreted_mesh_tensor)),
+        std::make_shared<MeshTensorHolder>(std::move(reinterpreted_mesh_tensor)),
         owning_storage.coords_,
         owning_storage.get_root_mesh_tensor()) {}
 
 DeviceStorage::DeviceStorage(
-    States state, std::vector<distributed::MeshCoordinate> coords, std::shared_ptr<MeshTensor> root_mesh_tensor) :
-    state_(std::move(state)), coords_(std::move(coords)), root_mesh_tensor_(std::move(root_mesh_tensor)) {
+    std::shared_ptr<MeshTensorHolder> mesh_tensor_holder,
+    std::vector<distributed::MeshCoordinate> coords,
+    std::shared_ptr<MeshTensorHolder> root_mesh_tensor_holder) :
+    mesh_tensor_holder_(std::move(mesh_tensor_holder)),
+    coords_(std::move(coords)),
+    root_mesh_tensor_holder_(std::move(root_mesh_tensor_holder)) {
     if (is_allocated()) {
-        CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
+        CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_mesh_tensor().device());
     }
 }
 
 Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
 
-const std::shared_ptr<MeshTensor>& DeviceStorage::get_mesh_tensor_bypass_deallocate_check() const {
-    TT_FATAL(std::holds_alternative<LocallyAllocatedState>(state_), "Device Memory is not allocated");
-    return std::get<LocallyAllocatedState>(state_).mesh_tensor_;
-}
-
 const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    return get_mesh_tensor_bypass_deallocate_check()->mesh_buffer();
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) -> const distributed::MeshBuffer& {
+                return allocated.mesh_tensor_.mesh_buffer();
+            },
+            [](const auto&) -> const distributed::MeshBuffer& { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
 bool DeviceStorage::is_sole_owner_of_device_memory() const {
     if (!is_allocated()) {
         return false;
     }
-    return get_mesh_tensor_bypass_deallocate_check().use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
+    return mesh_tensor_holder_.use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
 }
 
 const MeshTensor& DeviceStorage::get_mesh_tensor() const {
-    TT_FATAL(is_allocated(), "MeshTensor is not allocated");
-    return *get_mesh_tensor_bypass_deallocate_check();
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) -> const MeshTensor& { return allocated.mesh_tensor_; },
+            [](const auto&) -> const MeshTensor& { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
 MeshTensor& DeviceStorage::get_mesh_tensor() {
-    TT_FATAL(is_allocated(), "MeshTensor is not allocated");
-    return *get_mesh_tensor_bypass_deallocate_check();
+    return std::visit(
+        ttsl::overloaded{
+            [](MeshTensorHolder::Allocated& allocated) -> MeshTensor& { return allocated.mesh_tensor_; },
+            [](const auto&) -> MeshTensor& { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    return get_mesh_tensor_bypass_deallocate_check()->mesh_buffer_invariant_breaking();
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) -> std::shared_ptr<distributed::MeshBuffer> {
+                return allocated.mesh_tensor_.mesh_buffer_invariant_breaking();
+            },
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> std::shared_ptr<distributed::MeshBuffer> {
+                return tombstone.mesh_buffer_;
+            },
+            [](const auto&) -> std::shared_ptr<distributed::MeshBuffer> { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
-const std::shared_ptr<MeshTensor>& DeviceStorage::get_root_mesh_tensor() const {
-    return root_mesh_tensor_ ? root_mesh_tensor_ : std::get<LocallyAllocatedState>(state_).mesh_tensor_;
+const std::shared_ptr<DeviceStorage::MeshTensorHolder>& DeviceStorage::get_root_mesh_tensor() const {
+    return root_mesh_tensor_holder_ ? root_mesh_tensor_holder_ : mesh_tensor_holder_;
 }
 
 void DeviceStorage::deallocate() {
@@ -139,29 +204,23 @@ void DeviceStorage::deallocate() {
         return;
     }
 
-    get_root_mesh_tensor()->mesh_buffer().deallocate();
-    DeallocatedState new_state(*get_mesh_tensor_bypass_deallocate_check());
-    state_ = std::move(new_state);
+    get_root_mesh_tensor()->deallocate();
+    mesh_tensor_holder_->deallocate();
 }
 
-bool DeviceStorage::is_allocated() const {
-    if (const auto* allocated = std::get_if<LocallyAllocatedState>(&state_)) {
-        return allocated->mesh_tensor_->mesh_buffer().is_allocated();
-    }
-    return false;
-}
+bool DeviceStorage::is_allocated() const { return mesh_tensor_holder_->is_allocated(); }
 
 distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
-    if (const auto* allocated = std::get_if<LocallyAllocatedState>(&state_)) {
-        return allocated->mesh_tensor_->mesh_buffer().device();
-    }
-    return std::get<DeallocatedState>(state_).get_device();
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) { return &allocated.mesh_tensor_.device(); },
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) { return tombstone.mesh_buffer_->device(); },
+            [](const auto&) -> distributed::MeshDevice* { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
-distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
-
 bool DeviceStorage::is_uniform_storage() const {
-    if (std::holds_alternative<DeallocatedState>(state_)) {
+    if (!is_allocated()) {
         return true;
     }
     return coords_.size() == get_device_bypass_deallocate_check()->num_devices();
@@ -180,17 +239,15 @@ DeviceStorage DeviceStorage::combine_device_storages(
     const auto& model_storage = storages.front().get();
     TT_FATAL(
         std::all_of(
-            storages.begin(),
-            storages.end(),
-            [&](const auto& storage) { return std::holds_alternative<LocallyAllocatedState>(storage.get().state_); }),
+            storages.begin(), storages.end(), [&](const auto& storage) { return storage.get().is_allocated(); }),
         "All DeviceStorages must be allocated");
     TT_FATAL(
         std::all_of(
             storages.begin(),
             storages.end(),
             [&](const auto& storage) {
-                return storage.get().get_mesh_tensor_bypass_deallocate_check() ==
-                       model_storage.get_mesh_tensor_bypass_deallocate_check();
+                return std::addressof(storage.get().get_mesh_tensor()) ==
+                       std::addressof(model_storage.get_mesh_tensor());
             }),
         "All DeviceStorages must point to the same device memory");
 
@@ -215,12 +272,33 @@ DeviceStorage DeviceStorage::combine_device_storages(
 }
 
 void DeviceStorage::update_tensor_topology(const TensorTopology& tensor_topology) {
-    TT_FATAL(is_allocated(), "Device memory is not allocated");
     get_mesh_tensor().update_tensor_topology(tensor_topology);
 }
 
 const TensorSpec& DeviceStorage::get_tensor_spec() const {
-    return std::visit([](const auto& state) -> const TensorSpec& { return state.get_tensor_spec(); }, state_);
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) -> const TensorSpec& {
+                return allocated.mesh_tensor_.tensor_spec();
+            },
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const TensorSpec& {
+                return tombstone.tensor_spec_;
+            },
+            [](const auto&) -> const TensorSpec& { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
+}
+
+const TensorTopology& DeviceStorage::get_tensor_topology() const {
+    return std::visit(
+        ttsl::overloaded{
+            [](const MeshTensorHolder::Allocated& allocated) -> const TensorTopology& {
+                return allocated.mesh_tensor_.tensor_topology();
+            },
+            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> const TensorTopology& {
+                return tombstone.tensor_topology_;
+            },
+            [](const auto&) -> const TensorTopology& { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -122,6 +122,11 @@ const MeshTensor& DeviceStorage::get_mesh_tensor() const {
     return *mesh_tensor_;
 }
 
+MeshTensor& DeviceStorage::get_mesh_tensor() {
+    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
+    return *mesh_tensor_;
+}
+
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
     TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
     return mesh_tensor_->mesh_buffer_invariant_breaking();

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -104,7 +104,7 @@ struct DeviceStorage::MeshTensorHolder {
     MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
     MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {
         TT_FATAL(
-            std::get<Allocated>(state_).mesh_tensor_.has_value(),
+            std::get<Allocated>(state_).mesh_tensor_.is_initialized(),
             "MeshTensor must not be in default constructed state.");
     }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <ttnn/tensor/layout/layout.hpp>
+#include <ttnn/distributed/types.hpp>
 #include "tt-metalium/mesh_coord.hpp"
 
 #include "ttnn/tensor/storage.hpp"
@@ -73,27 +74,27 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
     return HostStorage(tensor.transform(callable));
 }
 
-DeviceStorage::DeviceStorage(const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer_) :
-    DeviceStorage(mesh_buffer_, CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(*mesh_buffer_->device())) {}
+DeviceStorage::DeviceStorage(MeshTensor mesh_tensor) :
+    mesh_tensor_(std::make_shared<MeshTensor>(std::move(mesh_tensor))),
+    coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(mesh_tensor_->device())) {}
 
-DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(std::move(mesh_buffer_), std::move(coords), nullptr) {}
+DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::MeshCoordinate> coords) :
+    DeviceStorage(std::make_shared<MeshTensor>(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(other.mesh_buffer, std::move(coords), other.root_mesh_buffer) {}
+    DeviceStorage(other.mesh_tensor_, std::move(coords), other.root_mesh_buffer) {}
+
+// TODO: what do we do with this?
+// DeviceStorage::DeviceStorage(
+//     const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
+//     DeviceStorage(std::move(surface_buffer), owning_storage.coords_, owning_storage.get_root_mesh_buffer()) {}
 
 DeviceStorage::DeviceStorage(
-    const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
-    DeviceStorage(std::move(surface_buffer), owning_storage.coords_, owning_storage.get_root_mesh_buffer()) {}
-
-DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer,
+    std::shared_ptr<MeshTensor> mesh_tensor,
     std::vector<distributed::MeshCoordinate> coords,
     std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
-    coords_(std::move(coords)), mesh_buffer(std::move(mesh_buffer)), root_mesh_buffer(std::move(root_mesh_buffer)) {
+    mesh_tensor_(std::move(mesh_tensor)), coords_(std::move(coords)), root_mesh_buffer(std::move(root_mesh_buffer)) {
     if (!is_allocated()) {
-        this->mesh_buffer = nullptr;
         this->root_mesh_buffer = nullptr;
         return;
     }
@@ -116,14 +117,20 @@ bool DeviceStorage::is_sole_owner_of_device_memory() const {
     return mesh_buffer.use_count() == 1 && get_root_mesh_buffer().use_count() == 1;
 }
 
-std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
-    return mesh_buffer;
+const MeshTensor& DeviceStorage::get_mesh_tensor() const {
+    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
+    return *mesh_tensor_;
 }
 
-const std::shared_ptr<distributed::MeshBuffer>& DeviceStorage::get_root_mesh_buffer() const {
-    return root_mesh_buffer ? root_mesh_buffer : mesh_buffer;
+std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
+    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
+    return mesh_tensor_->mesh_buffer_invariant_breaking();
 }
+
+// TODO: what do we do with this?
+// const std::shared_ptr<distributed::MeshBuffer>& DeviceStorage::get_root_mesh_buffer() const {
+//     return root_mesh_buffer ? root_mesh_buffer : mesh_buffer;
+// }
 
 void DeviceStorage::deallocate() {
     if (!is_allocated()) {
@@ -157,16 +164,16 @@ std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
 }
 
 DeviceStorage DeviceStorage::combine_device_storages(
-    const std::vector<std::reference_wrapper<const DeviceStorage>>& storages) {
+    const std::vector<std::reference_wrapper<const DeviceStorage>>& storages, int shard_dim) {
     TT_FATAL(!storages.empty(), "Cannot aggregate empty vector of DeviceStorages");
 
     const auto& model_storage = storages.front().get();
-    TT_FATAL(
-        std::all_of(
-            storages.begin(),
-            storages.end(),
-            [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
-        "All DeviceStorages must point to the same device memory");
+    // TT_FATAL(
+    //     std::all_of(
+    //         storages.begin(),
+    //         storages.end(),
+    //         [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
+    //     "All DeviceStorages must point to the same device memory");
 
     auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
         return sum + storage.get().get_coords().size();
@@ -179,8 +186,13 @@ DeviceStorage DeviceStorage::combine_device_storages(
         joint_coords.insert(other_coords.begin(), other_coords.end());
     }
 
-    return DeviceStorage(
+    TensorTopology topology =
+        TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(joint_coords.size()), shard_dim);
+
+    DeviceStorage res(
         model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
+    res.update_tensor_topology(topology);
+    return res;
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -76,7 +76,7 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
 }
 
 // MeshTensor lifetime holder:
-// Conceptually MeshTensor has two states:
+// This holder type has two states:
 // - Allocated: actively holding a MeshTensor.
 // - Deallocated: the MeshTensor was deallocated by any of the DeviceStorage instances.
 //
@@ -108,7 +108,11 @@ struct DeviceStorage::MeshTensorHolder {
 
     void deallocate() {
         if (auto* allocated = std::get_if<Allocated>(&state_)) {
+            // We should favor letting MeshTensor go out of scope instead of explicitly calling the underlying
+            // MeshBuffer. Calling deallocate is currently needed as we keep the MeshBuffer object alive in the
+            // DeallocatedTombStone state.
             allocated->mesh_tensor_.mesh_buffer().deallocate();
+            // MeshTensor goes out of scope at this assignment:
             state_ = DeallocatedTombStone{
                 allocated->mesh_tensor_.tensor_spec(),
                 allocated->mesh_tensor_.tensor_topology(),

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -75,65 +75,63 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
 }
 
 DeviceStorage::DeviceStorage(MeshTensor mesh_tensor) :
-    mesh_tensor_(std::make_shared<MeshTensor>(std::move(mesh_tensor))),
-    coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(mesh_tensor_->device())) {}
+    state_(LocallyAllocatedState(std::move(mesh_tensor))),
+    coords_(CMAKE_UNIQUE_NAMESPACE::get_all_mesh_coordinates(get_device())) {}
 
 DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(std::make_shared<MeshTensor>(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
+    DeviceStorage(LocallyAllocatedState(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(other.mesh_tensor_, std::move(coords), other.root_mesh_tensor_) {}
+    DeviceStorage(other.state_, std::move(coords), other.root_mesh_tensor_) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor) :
     DeviceStorage(
-        std::make_shared<MeshTensor>(std::move(reinterpreted_mesh_tensor)),
+        LocallyAllocatedState(std::move(reinterpreted_mesh_tensor)),
         owning_storage.coords_,
         owning_storage.get_root_mesh_tensor()) {}
 
 DeviceStorage::DeviceStorage(
-    std::shared_ptr<MeshTensor> mesh_tensor,
-    std::vector<distributed::MeshCoordinate> coords,
-    std::shared_ptr<MeshTensor> root_mesh_tensor) :
-    mesh_tensor_(std::move(mesh_tensor)), coords_(std::move(coords)), root_mesh_tensor_(std::move(root_mesh_tensor)) {
-    if (!is_allocated()) {
-        this->mesh_tensor_ = nullptr;
-        this->root_mesh_tensor_ = nullptr;
-        return;
+    States state, std::vector<distributed::MeshCoordinate> coords, std::shared_ptr<MeshTensor> root_mesh_tensor) :
+    state_(std::move(state)), coords_(std::move(coords)), root_mesh_tensor_(std::move(root_mesh_tensor)) {
+    if (is_allocated()) {
+        CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
     }
-    CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
 }
 
 Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
 
+const std::shared_ptr<MeshTensor>& DeviceStorage::get_mesh_tensor_bypass_deallocate_check() const {
+    TT_FATAL(std::holds_alternative<LocallyAllocatedState>(state_), "Device Memory is not allocated");
+    return std::get<LocallyAllocatedState>(state_).mesh_tensor_;
+}
+
 const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    TT_FATAL(mesh_tensor_ != nullptr, "Device Memory is not allocated");
-    return mesh_tensor_->mesh_buffer();
+    return get_mesh_tensor_bypass_deallocate_check()->mesh_buffer();
 }
 
 bool DeviceStorage::is_sole_owner_of_device_memory() const {
     if (!is_allocated()) {
         return false;
     }
-    return mesh_tensor_.use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
+    return get_mesh_tensor_bypass_deallocate_check().use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
 }
 
 const MeshTensor& DeviceStorage::get_mesh_tensor() const {
-    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
-    return *mesh_tensor_;
+    TT_FATAL(is_allocated(), "MeshTensor is not allocated");
+    return *get_mesh_tensor_bypass_deallocate_check();
 }
 
 MeshTensor& DeviceStorage::get_mesh_tensor() {
-    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
-    return *mesh_tensor_;
+    TT_FATAL(is_allocated(), "MeshTensor is not allocated");
+    return *get_mesh_tensor_bypass_deallocate_check();
 }
 
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    TT_FATAL(mesh_tensor_ != nullptr, "MeshTensor is not allocated");
-    return mesh_tensor_->mesh_buffer_invariant_breaking();
+    return get_mesh_tensor_bypass_deallocate_check()->mesh_buffer_invariant_breaking();
 }
 
 const std::shared_ptr<MeshTensor>& DeviceStorage::get_root_mesh_tensor() const {
-    return root_mesh_tensor_ ? root_mesh_tensor_ : mesh_tensor_;
+    return root_mesh_tensor_ ? root_mesh_tensor_ : std::get<LocallyAllocatedState>(state_).mesh_tensor_;
 }
 
 void DeviceStorage::deallocate() {
@@ -142,25 +140,31 @@ void DeviceStorage::deallocate() {
     }
 
     get_root_mesh_tensor()->mesh_buffer().deallocate();
-    root_mesh_tensor_ = nullptr;
-    mesh_tensor_ = nullptr;
+    DeallocatedState new_state(*get_mesh_tensor_bypass_deallocate_check());
+    state_ = std::move(new_state);
 }
 
 bool DeviceStorage::is_allocated() const {
-    return this->mesh_tensor_ != nullptr && this->mesh_tensor_->mesh_buffer().is_allocated();
+    if (const auto* allocated = std::get_if<LocallyAllocatedState>(&state_)) {
+        return allocated->mesh_tensor_->mesh_buffer().is_allocated();
+    }
+    return false;
 }
 
 distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
-    return this->mesh_tensor_ ? this->mesh_tensor_->mesh_buffer().device() : nullptr;
+    if (const auto* allocated = std::get_if<LocallyAllocatedState>(&state_)) {
+        return allocated->mesh_tensor_->mesh_buffer().device();
+    }
+    return nullptr;
 }
 
 distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
 
 bool DeviceStorage::is_uniform_storage() const {
-    if (mesh_tensor_ == nullptr) {
+    if (std::holds_alternative<DeallocatedState>(state_)) {
         return true;
     }
-    return coords_.size() == mesh_tensor_->device().num_devices();
+    return coords_.size() == get_device_bypass_deallocate_check()->num_devices();
 }
 
 std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
@@ -178,7 +182,16 @@ DeviceStorage DeviceStorage::combine_device_storages(
         std::all_of(
             storages.begin(),
             storages.end(),
-            [&](const auto& storage) { return storage.get().mesh_tensor_ == model_storage.mesh_tensor_; }),
+            [&](const auto& storage) { return std::holds_alternative<LocallyAllocatedState>(storage.get().state_); }),
+        "All DeviceStorages must be allocated");
+    TT_FATAL(
+        std::all_of(
+            storages.begin(),
+            storages.end(),
+            [&](const auto& storage) {
+                return storage.get().get_mesh_tensor_bypass_deallocate_check() ==
+                       model_storage.get_mesh_tensor_bypass_deallocate_check();
+            }),
         "All DeviceStorages must point to the same device memory");
 
     auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
@@ -202,8 +215,12 @@ DeviceStorage DeviceStorage::combine_device_storages(
 }
 
 void DeviceStorage::update_tensor_topology(const TensorTopology& tensor_topology) {
-    TT_FATAL(mesh_tensor_ != nullptr, "Device memory is not allocated");
-    mesh_tensor_->update_tensor_topology(tensor_topology);
+    TT_FATAL(is_allocated(), "Device memory is not allocated");
+    get_mesh_tensor().update_tensor_topology(tensor_topology);
+}
+
+const TensorSpec& DeviceStorage::get_tensor_spec() const {
+    return std::visit([](const auto& state) -> const TensorSpec& { return state.get_tensor_spec(); }, state_);
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -155,7 +155,7 @@ distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() con
     if (const auto* allocated = std::get_if<LocallyAllocatedState>(&state_)) {
         return allocated->mesh_tensor_->mesh_buffer().device();
     }
-    return nullptr;
+    return std::get<DeallocatedState>(state_).get_device();
 }
 
 distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -111,7 +111,10 @@ struct DeviceStorage::MeshTensorHolder {
             // We should favor letting MeshTensor go out of scope instead of explicitly calling the underlying
             // MeshBuffer. Calling deallocate is currently needed as we keep the MeshBuffer object alive in the
             // DeallocatedTombStone state.
-            allocated->mesh_tensor_.mesh_buffer().deallocate();
+            // Calling mesh_buffer_invariant_breaking() as we wish to get a mutable pointer to the MeshBuffer,
+            // and this is breaking the invariant of MeshTensor (Device memory is allocated when the MeshTensor object
+            // is alive).
+            allocated->mesh_tensor_.mesh_buffer_invariant_breaking()->deallocate();
             // MeshTensor goes out of scope at this assignment:
             state_ = DeallocatedTombStone{
                 allocated->mesh_tensor_.tensor_spec(),

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -102,7 +102,11 @@ struct DeviceStorage::MeshTensorHolder {
     States state_;
 
     MeshTensorHolder() : state_(DeallocatedDefaultConstructed{}) {}
-    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {}
+    MeshTensorHolder(MeshTensor mesh_tensor) : state_(Allocated{std::move(mesh_tensor)}) {
+        TT_FATAL(
+            std::get<Allocated>(state_).mesh_tensor_.has_value(),
+            "MeshTensor must not be in default constructed state.");
+    }
 
     bool is_allocated() const { return std::holds_alternative<Allocated>(state_); }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -111,9 +111,10 @@ const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
 }
 
 bool DeviceStorage::is_sole_owner_of_device_memory() const {
-    const auto& surface_mesh_buffer = mesh_tensor_->mesh_buffer_invariant_breaking();
-    const auto& root_mesh_buffer = get_root_mesh_tensor()->mesh_buffer_invariant_breaking();
-    return surface_mesh_buffer.use_count() == 1 && root_mesh_buffer.use_count() == 1;
+    if (!is_allocated()) {
+        return false;
+    }
+    return mesh_tensor_.use_count() == 1 && get_root_mesh_tensor().use_count() == 1;
 }
 
 const MeshTensor& DeviceStorage::get_mesh_tensor() const {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -84,9 +84,9 @@ DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::M
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
     DeviceStorage(other.mesh_tensor_, std::move(coords), other.root_mesh_tensor_) {}
 
-DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor surface_mesh_tensor) :
+DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor reinterpreted_mesh_tensor) :
     DeviceStorage(
-        std::make_shared<MeshTensor>(std::move(surface_mesh_tensor)),
+        std::make_shared<MeshTensor>(std::move(reinterpreted_mesh_tensor)),
         owning_storage.coords_,
         owning_storage.get_root_mesh_tensor()) {}
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -82,20 +82,22 @@ DeviceStorage::DeviceStorage(MeshTensor mesh_tensor_, std::vector<distributed::M
     DeviceStorage(std::make_shared<MeshTensor>(std::move(mesh_tensor_)), std::move(coords), nullptr) {}
 
 DeviceStorage::DeviceStorage(const DeviceStorage& other, std::vector<distributed::MeshCoordinate> coords) :
-    DeviceStorage(other.mesh_tensor_, std::move(coords), other.root_mesh_buffer) {}
+    DeviceStorage(other.mesh_tensor_, std::move(coords), other.root_mesh_tensor_) {}
 
-// TODO: what do we do with this?
-// DeviceStorage::DeviceStorage(
-//     const DeviceStorage& owning_storage, std::shared_ptr<distributed::MeshBuffer> surface_buffer) :
-//     DeviceStorage(std::move(surface_buffer), owning_storage.coords_, owning_storage.get_root_mesh_buffer()) {}
+DeviceStorage::DeviceStorage(const DeviceStorage& owning_storage, MeshTensor surface_mesh_tensor) :
+    DeviceStorage(
+        std::make_shared<MeshTensor>(std::move(surface_mesh_tensor)),
+        owning_storage.coords_,
+        owning_storage.get_root_mesh_tensor()) {}
 
 DeviceStorage::DeviceStorage(
     std::shared_ptr<MeshTensor> mesh_tensor,
     std::vector<distributed::MeshCoordinate> coords,
-    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer) :
-    mesh_tensor_(std::move(mesh_tensor)), coords_(std::move(coords)), root_mesh_buffer(std::move(root_mesh_buffer)) {
+    std::shared_ptr<MeshTensor> root_mesh_tensor) :
+    mesh_tensor_(std::move(mesh_tensor)), coords_(std::move(coords)), root_mesh_tensor_(std::move(root_mesh_tensor)) {
     if (!is_allocated()) {
-        this->root_mesh_buffer = nullptr;
+        this->mesh_tensor_ = nullptr;
+        this->root_mesh_tensor_ = nullptr;
         return;
     }
     CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
@@ -109,7 +111,9 @@ const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
 }
 
 bool DeviceStorage::is_sole_owner_of_device_memory() const {
-    return mesh_tensor_.use_count() == 1 && get_root_mesh_buffer().use_count() == 1;
+    const auto& surface_mesh_buffer = mesh_tensor_->mesh_buffer_invariant_breaking();
+    const auto& root_mesh_buffer = get_root_mesh_tensor()->mesh_buffer_invariant_breaking();
+    return surface_mesh_buffer.use_count() == 1 && root_mesh_buffer.use_count() == 1;
 }
 
 const MeshTensor& DeviceStorage::get_mesh_tensor() const {
@@ -122,18 +126,17 @@ std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_own
     return mesh_tensor_->mesh_buffer_invariant_breaking();
 }
 
-// TODO: what do we do with this?
-// const std::shared_ptr<distributed::MeshBuffer>& DeviceStorage::get_root_mesh_buffer() const {
-//     return root_mesh_buffer ? root_mesh_buffer : mesh_buffer;
-// }
+const std::shared_ptr<MeshTensor>& DeviceStorage::get_root_mesh_tensor() const {
+    return root_mesh_tensor_ ? root_mesh_tensor_ : mesh_tensor_;
+}
 
 void DeviceStorage::deallocate() {
     if (!is_allocated()) {
         return;
     }
 
-    get_root_mesh_buffer()->deallocate();
-    root_mesh_buffer = nullptr;
+    get_root_mesh_tensor()->mesh_buffer().deallocate();
+    root_mesh_tensor_ = nullptr;
     mesh_tensor_ = nullptr;
 }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -101,20 +101,15 @@ DeviceStorage::DeviceStorage(
     CMAKE_UNIQUE_NAMESPACE::validate_mesh_coordinates(coords_, get_device());
 }
 
-Buffer* DeviceStorage::get_buffer() const {
-    if (this->mesh_buffer != nullptr) {
-        return this->mesh_buffer->get_reference_buffer();
-    }
-    TT_THROW("Buffer is not allocated");
-}
+Buffer* DeviceStorage::get_buffer() const { return get_mesh_buffer().get_reference_buffer(); }
 
 const distributed::MeshBuffer& DeviceStorage::get_mesh_buffer() const {
-    TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
-    return *mesh_buffer;
+    TT_FATAL(mesh_tensor_ != nullptr, "Device Memory is not allocated");
+    return mesh_tensor_->mesh_buffer();
 }
 
 bool DeviceStorage::is_sole_owner_of_device_memory() const {
-    return mesh_buffer.use_count() == 1 && get_root_mesh_buffer().use_count() == 1;
+    return mesh_tensor_.use_count() == 1 && get_root_mesh_buffer().use_count() == 1;
 }
 
 const MeshTensor& DeviceStorage::get_mesh_tensor() const {
@@ -139,22 +134,24 @@ void DeviceStorage::deallocate() {
 
     get_root_mesh_buffer()->deallocate();
     root_mesh_buffer = nullptr;
-    mesh_buffer = nullptr;
+    mesh_tensor_ = nullptr;
 }
 
-bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }
+bool DeviceStorage::is_allocated() const {
+    return this->mesh_tensor_ != nullptr && this->mesh_tensor_->mesh_buffer().is_allocated();
+}
 
 distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() const {
-    return this->mesh_buffer ? this->mesh_buffer->device() : nullptr;
+    return this->mesh_tensor_ ? this->mesh_tensor_->mesh_buffer().device() : nullptr;
 }
 
 distributed::MeshDevice& DeviceStorage::get_device() const { return *get_mesh_buffer().device(); }
 
 bool DeviceStorage::is_uniform_storage() const {
-    if (mesh_buffer == nullptr) {
+    if (mesh_tensor_ == nullptr) {
         return true;
     }
-    return coords_.size() == mesh_buffer->device()->num_devices();
+    return coords_.size() == mesh_tensor_->device().num_devices();
 }
 
 std::span<const distributed::MeshCoordinate> DeviceStorage::get_coords() const {
@@ -168,12 +165,12 @@ DeviceStorage DeviceStorage::combine_device_storages(
     TT_FATAL(!storages.empty(), "Cannot aggregate empty vector of DeviceStorages");
 
     const auto& model_storage = storages.front().get();
-    // TT_FATAL(
-    //     std::all_of(
-    //         storages.begin(),
-    //         storages.end(),
-    //         [&](const auto& storage) { return storage.get().mesh_buffer == model_storage.mesh_buffer; }),
-    //     "All DeviceStorages must point to the same device memory");
+    TT_FATAL(
+        std::all_of(
+            storages.begin(),
+            storages.end(),
+            [&](const auto& storage) { return storage.get().mesh_tensor_ == model_storage.mesh_tensor_; }),
+        "All DeviceStorages must point to the same device memory");
 
     auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
         return sum + storage.get().get_coords().size();
@@ -193,6 +190,11 @@ DeviceStorage DeviceStorage::combine_device_storages(
         model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
     res.update_tensor_topology(topology);
     return res;
+}
+
+void DeviceStorage::update_tensor_topology(const TensorTopology& tensor_topology) {
+    TT_FATAL(mesh_tensor_ != nullptr, "Device memory is not allocated");
+    mesh_tensor_->update_tensor_topology(tensor_topology);
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -278,12 +278,8 @@ DeviceStorage DeviceStorage::combine_device_storages(
 
     DeviceStorage res(
         model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
-    res.update_tensor_topology(topology);
+    res.get_mesh_tensor().update_tensor_topology(topology);
     return res;
-}
-
-void DeviceStorage::update_tensor_topology(const TensorTopology& tensor_topology) {
-    get_mesh_tensor().update_tensor_topology(tensor_topology);
 }
 
 const TensorSpec& DeviceStorage::get_tensor_spec() const {

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -6,7 +6,7 @@
 #include <numeric>
 #include <functional>
 #include <tt-logger/tt-logger.hpp>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 #include <ttnn/tensor/layout/layout.hpp>
@@ -262,16 +262,18 @@ DeviceStorage DeviceStorage::combine_device_storages(
             }),
         "All DeviceStorages must point to the same device memory");
 
-    auto num_coords = std::accumulate(storages.begin(), storages.end(), 0, [](size_t sum, const auto& storage) {
-        return sum + storage.get().get_coords().size();
-    });
-
-    std::unordered_set<distributed::MeshCoordinate> joint_coords;
-    joint_coords.reserve(num_coords);
+    std::set<distributed::MeshCoordinate> seen_coords;
+    std::vector<distributed::MeshCoordinate> joint_coords;
     for (const auto& storage : storages) {
-        auto other_coords = storage.get().get_coords();
-        joint_coords.insert(other_coords.begin(), other_coords.end());
+        for (const auto& coord : storage.get().get_coords()) {
+            TT_FATAL(
+                seen_coords.insert(coord).second,
+                "Found a tensor shard at duplicate coordinate {}",
+                coord);
+            joint_coords.push_back(coord);
+        }
     }
+    std::sort(joint_coords.begin(), joint_coords.end());
 
     const int tensor_rank = static_cast<int>(model_storage.get_tensor_spec().logical_shape().rank());
     TT_FATAL(
@@ -284,8 +286,7 @@ DeviceStorage DeviceStorage::combine_device_storages(
     TensorTopology topology =
         TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(joint_coords.size()), shard_dim);
 
-    DeviceStorage res(
-        model_storage, std::vector<distributed::MeshCoordinate>(joint_coords.begin(), joint_coords.end()));
+    DeviceStorage res(model_storage, std::move(joint_coords));
     res.get_mesh_tensor().update_tensor_topology(topology);
     return res;
 }

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -273,6 +273,14 @@ DeviceStorage DeviceStorage::combine_device_storages(
         joint_coords.insert(other_coords.begin(), other_coords.end());
     }
 
+    const int tensor_rank = static_cast<int>(model_storage.get_tensor_spec().logical_shape().rank());
+    TT_FATAL(
+        shard_dim >= 0 && shard_dim < tensor_rank,
+        "shard_dim ({}) is out of range for tensor logical rank {} (expected range [0, {}))",
+        shard_dim,
+        tensor_rank,
+        tensor_rank);
+
     TensorTopology topology =
         TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(joint_coords.size()), shard_dim);
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -260,20 +260,16 @@ DeviceStorage DeviceStorage::combine_device_storages(
                 return std::addressof(storage.get().get_mesh_tensor()) ==
                        std::addressof(model_storage.get_mesh_tensor());
             }),
-        "All DeviceStorages must point to the same device memory");
+        "tensor shards must be allocated on the same mesh buffer.");
 
     std::set<distributed::MeshCoordinate> seen_coords;
-    std::vector<distributed::MeshCoordinate> joint_coords;
     for (const auto& storage : storages) {
         for (const auto& coord : storage.get().get_coords()) {
-            TT_FATAL(
-                seen_coords.insert(coord).second,
-                "Found a tensor shard at duplicate coordinate {}",
-                coord);
-            joint_coords.push_back(coord);
+            auto [_, coord_is_new] = seen_coords.insert(coord);
+            TT_FATAL(coord_is_new, "Found a tensor shard at duplicate coordinate {}", coord);
         }
     }
-    std::sort(joint_coords.begin(), joint_coords.end());
+    std::vector<distributed::MeshCoordinate> vec_coords(seen_coords.begin(), seen_coords.end());
 
     const int tensor_rank = static_cast<int>(model_storage.get_tensor_spec().logical_shape().rank());
     TT_FATAL(
@@ -284,9 +280,9 @@ DeviceStorage DeviceStorage::combine_device_storages(
         tensor_rank);
 
     TensorTopology topology =
-        TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(joint_coords.size()), shard_dim);
+        TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(vec_coords.size()), shard_dim);
 
-    DeviceStorage res(model_storage, std::move(joint_coords));
+    DeviceStorage res(model_storage, std::move(vec_coords));
     res.get_mesh_tensor().update_tensor_topology(topology);
     return res;
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -116,6 +116,9 @@ Tensor::Tensor(MeshTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(std::make_shared<TensorAttributes>(DeviceStorage(std::move(tensor)))) {}
 
+Tensor::Tensor(DeviceStorage storage) :
+    tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {}
+
 Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -114,10 +114,18 @@ Tensor::Tensor(HostTensor tensor) :
 
 Tensor::Tensor(MeshTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
-    tensor_attributes(std::make_shared<TensorAttributes>(DeviceStorage(std::move(tensor)))) {}
+    tensor_attributes(std::make_shared<TensorAttributes>(DeviceStorage(std::move(tensor)))) {
+    if (auto* device = device_storage().get_device_bypass_deallocate_check()) {
+        mesh_device_ = device;
+    }
+}
 
 Tensor::Tensor(DeviceStorage storage) :
-    tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {}
+    tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {
+    if (auto* device = device_storage().get_device_bypass_deallocate_check()) {
+        mesh_device_ = device;
+    }
+}
 
 Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -494,7 +494,7 @@ bool Tensor::is_allocated() const {
             [](const DeviceStorage& storage) { return storage.is_allocated(); },
             [](const HostStorage&) { return true; },
         },
-        this->storage());
+        tensor_attributes->get_storage());
     return output;
 }
 
@@ -504,7 +504,7 @@ StorageType Tensor::storage_type() const {
             [](const HostStorage&) { return StorageType::HOST; },
             [](const DeviceStorage&) { return StorageType::DEVICE; },
         },
-        this->storage());
+        tensor_attributes->get_storage());
 }
 
 tt::tt_metal::Shape Tensor::strides() const {
@@ -603,8 +603,6 @@ Tensor set_tensor_id(const Tensor& tensor) {
     return output;
 };
 
-const Storage& Tensor::storage() const { return this->tensor_attributes->get_storage(); }
-
 const tt::tt_metal::Shape& Tensor::logical_shape() const {
     return this->tensor_attributes->get_tensor_spec().logical_shape();
 }
@@ -622,21 +620,39 @@ const TensorSpec& Tensor::tensor_spec() const { return this->tensor_attributes->
 Buffer* Tensor::buffer() const { return device_storage().get_buffer(); }
 
 const DeviceStorage& Tensor::device_storage() const& {
-    const auto* device_storage = std::get_if<DeviceStorage>(&this->storage());
+    const auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
     TT_FATAL(device_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
     return *device_storage;
 }
 
 const HostStorage& Tensor::host_storage() const& {
-    const auto* host_storage = std::get_if<HostStorage>(&this->storage());
+    const auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return *host_storage;
 }
 
 const HostTensor& Tensor::host_tensor() const& {
-    const auto* host_storage = std::get_if<HostStorage>(&this->storage());
+    const auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return host_storage->host_tensor();
+}
+
+HostTensor& Tensor::host_tensor() & {
+    auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
+    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return host_storage->host_tensor();
+}
+
+const MeshTensor& Tensor::mesh_tensor() const& {
+    const auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
+    TT_FATAL(mesh_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
+    return mesh_storage->get_mesh_tensor();
+}
+
+MeshTensor& Tensor::mesh_tensor() & {
+    auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
+    TT_FATAL(mesh_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return mesh_storage->get_mesh_tensor();
 }
 
 distributed::MeshDevice* Tensor::device() const {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -112,25 +112,10 @@ Tensor::Tensor(HostTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(std::make_shared<TensorAttributes>(HostStorage(std::move(tensor)))) {}
 
-Tensor::Tensor(MeshTensor tensor) :
-    tensor_id(Tensor::next_tensor_id()),
-    tensor_attributes(std::make_shared<TensorAttributes>(DeviceStorage(std::move(tensor)))) {
-    if (auto* device = device_storage().get_device_bypass_deallocate_check()) {
-        mesh_device_ = device;
-    }
-}
+Tensor::Tensor(MeshTensor tensor) : Tensor::Tensor(DeviceStorage(std::move(tensor))) {}
 
 Tensor::Tensor(DeviceStorage storage) :
     tensor_id(Tensor::next_tensor_id()), tensor_attributes(std::make_shared<TensorAttributes>(std::move(storage))) {
-    if (auto* device = device_storage().get_device_bypass_deallocate_check()) {
-        mesh_device_ = device;
-    }
-}
-
-Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    tensor_id(Tensor::next_tensor_id()),
-    tensor_attributes(
-        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
     // Workaround for https://github.com/tenstorrent/tt-metal/issues/40716:
     // Use get_device_bypass_deallocate_check() to preserve mesh_device_ even when the
     // buffer is deallocated. This prevents nullptr device propagation when operations

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -651,7 +651,7 @@ const MeshTensor& Tensor::mesh_tensor() const& {
 
 MeshTensor& Tensor::mesh_tensor() & {
     auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
-    TT_FATAL(mesh_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    TT_FATAL(mesh_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
     return mesh_storage->get_mesh_tensor();
 }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -112,6 +112,10 @@ Tensor::Tensor(HostTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(std::make_shared<TensorAttributes>(HostStorage(std::move(tensor)))) {}
 
+Tensor::Tensor(MeshTensor tensor) :
+    tensor_id(Tensor::next_tensor_id()),
+    tensor_attributes(std::make_shared<TensorAttributes>(DeviceStorage(std::move(tensor)))) {}
+
 Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -625,8 +625,20 @@ const DeviceStorage& Tensor::device_storage() const& {
     return *device_storage;
 }
 
+DeviceStorage& Tensor::device_storage() & {
+    auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
+    TT_FATAL(device_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
+    return *device_storage;
+}
+
 const HostStorage& Tensor::host_storage() const& {
     const auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
+    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
+    return *host_storage;
+}
+
+HostStorage& Tensor::host_storage() & {
+    auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
     TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
     return *host_storage;
 }
@@ -637,20 +649,8 @@ const HostTensor& Tensor::host_tensor() const& {
     return host_storage->host_tensor();
 }
 
-HostTensor& Tensor::host_tensor() & {
-    auto* host_storage = std::get_if<HostStorage>(&tensor_attributes->get_storage());
-    TT_FATAL(host_storage != nullptr, "Expected Tensor with HostStorage, got {}", this->storage_type());
-    return host_storage->host_tensor();
-}
-
 const MeshTensor& Tensor::mesh_tensor() const& {
     const auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
-    TT_FATAL(mesh_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
-    return mesh_storage->get_mesh_tensor();
-}
-
-MeshTensor& Tensor::mesh_tensor() & {
-    auto* mesh_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
     TT_FATAL(mesh_storage != nullptr, "Expected Tensor with DeviceStorage, got {}", this->storage_type());
     return mesh_storage->get_mesh_tensor();
 }

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -9,16 +9,22 @@
 namespace tt::tt_metal {
 
 static const HostTensor& get_host_tensor(const Storage& storage) {
-    if (const auto* host_storage = std::get_if<HostStorage>(&storage)) {
-        return host_storage->host_tensor();
-    }
     return std::get<HostStorage>(storage).host_tensor();
+}
+
+static const MeshTensor& get_mesh_tensor(const Storage& storage) {
+    return std::get<DeviceStorage>(storage).get_mesh_tensor();
 }
 
 TensorAttributes::TensorAttributes(HostStorage storage) :
     storage_(std::move(storage)),
     tensor_spec_(get_host_tensor(storage_).tensor_spec()),
     tensor_topology_(get_host_tensor(storage_).tensor_topology()) {}
+
+TensorAttributes::TensorAttributes(DeviceStorage storage) :
+    storage_(std::move(storage)),
+    tensor_spec_(get_mesh_tensor(storage_).tensor_spec()),
+    tensor_topology_(get_mesh_tensor(storage_).tensor_topology()) {}
 
 // Transitional: assumes a HostStorage constructed without proper TensorSpec and TensorTopology.
 // Overrides the existing spec and topology in the HostStorage.

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -38,7 +38,7 @@ const TensorTopology& TensorAttributes::get_tensor_topology() const {
                 return host_storage.host_tensor().tensor_topology();
             },
             [](const DeviceStorage& device_storage) -> const TensorTopology& {
-                return device_storage.get_mesh_tensor().tensor_topology();
+                return device_storage.get_tensor_topology();
             },
         },
         storage_);

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -26,9 +26,7 @@ const TensorSpec& TensorAttributes::get_tensor_spec() const {
             [](const HostStorage& host_storage) -> const TensorSpec& {
                 return host_storage.host_tensor().tensor_spec();
             },
-            [](const DeviceStorage& device_storage) -> const TensorSpec& {
-                return device_storage.get_mesh_tensor().tensor_spec();
-            },
+            [](const DeviceStorage& device_storage) -> const TensorSpec& { return device_storage.get_tensor_spec(); },
         },
         storage_);
 }

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -8,57 +8,51 @@
 
 namespace tt::tt_metal {
 
-static const HostTensor& get_host_tensor(const Storage& storage) {
-    return std::get<HostStorage>(storage).host_tensor();
-}
+TensorAttributes::TensorAttributes(HostStorage storage) : storage_(std::move(storage)) {}
 
-static const MeshTensor& get_mesh_tensor(const Storage& storage) {
-    return std::get<DeviceStorage>(storage).get_mesh_tensor();
-}
-
-TensorAttributes::TensorAttributes(HostStorage storage) :
-    storage_(std::move(storage)),
-    tensor_spec_(get_host_tensor(storage_).tensor_spec()),
-    tensor_topology_(get_host_tensor(storage_).tensor_topology()) {}
-
-TensorAttributes::TensorAttributes(DeviceStorage storage) :
-    storage_(std::move(storage)),
-    tensor_spec_(get_mesh_tensor(storage_).tensor_spec()),
-    tensor_topology_(get_mesh_tensor(storage_).tensor_topology()) {}
+TensorAttributes::TensorAttributes(DeviceStorage storage) : storage_(std::move(storage)) {}
 
 // Transitional: assumes a HostStorage constructed without proper TensorSpec and TensorTopology.
 // Overrides the existing spec and topology in the HostStorage.
 TensorAttributes::TensorAttributes(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    storage_(HostStorage(std::move(storage), tensor_spec, tensor_topology)),
-    tensor_spec_(std::move(tensor_spec)),
-    tensor_topology_(std::move(tensor_topology)) {}
-
-TensorAttributes::TensorAttributes(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)), tensor_topology_(std::move(tensor_topology)) {}
+    storage_(HostStorage(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
 Storage& TensorAttributes::get_storage() { return storage_; }
 
 const TensorSpec& TensorAttributes::get_tensor_spec() const {
-    // Prefer spec from HostStorage
-    // TODO(#40348): TensorAttributes should not store spec and topology.
-    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        return host_storage->host_tensor().tensor_spec();
-    }
-    return tensor_spec_;
+    return std::visit(
+        ttsl::overloaded{
+            [](const HostStorage& host_storage) -> const TensorSpec& {
+                return host_storage.host_tensor().tensor_spec();
+            },
+            [](const DeviceStorage& device_storage) -> const TensorSpec& {
+                return device_storage.get_mesh_tensor().tensor_spec();
+            },
+        },
+        storage_);
 }
 
 const TensorTopology& TensorAttributes::get_tensor_topology() const {
-    // Prefer spec from HostStorage
-    // TODO(#40348): TensorAttributes should not store spec and topology.
-    if (const auto* host_storage = std::get_if<HostStorage>(&storage_)) {
-        return host_storage->host_tensor().tensor_topology();
-    }
-    return tensor_topology_;
+    return std::visit(
+        ttsl::overloaded{
+            [](const HostStorage& host_storage) -> const TensorTopology& {
+                return host_storage.host_tensor().tensor_topology();
+            },
+            [](const DeviceStorage& device_storage) -> const TensorTopology& {
+                return device_storage.get_mesh_tensor().tensor_topology();
+            },
+        },
+        storage_);
 }
 
 void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topology) {
-    tensor_topology_ = tensor_topology;
+    std::visit(
+        ttsl::overloaded{
+            [&](HostStorage& host_storage) { host_storage.host_tensor().update_tensor_topology(tensor_topology); },
+            [&](DeviceStorage& device_storage) { device_storage.update_tensor_topology(tensor_topology); },
+        },
+        storage_);
 }
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -48,7 +48,9 @@ void TensorAttributes::update_tensor_topology(const TensorTopology& tensor_topol
     std::visit(
         ttsl::overloaded{
             [&](HostStorage& host_storage) { host_storage.host_tensor().update_tensor_topology(tensor_topology); },
-            [&](DeviceStorage& device_storage) { device_storage.update_tensor_topology(tensor_topology); },
+            [&](DeviceStorage& device_storage) {
+                device_storage.get_mesh_tensor().update_tensor_topology(tensor_topology);
+            },
         },
         storage_);
 }

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -485,7 +485,7 @@ std::string to_string_impl(const Tensor& tensor) {
         return to_string_impl<T>(cpu_tensor);
     }
 
-    auto& mesh_device = storage.get_device();
+    auto& mesh_device = storage.get_mesh_tensor().device();
     // TODO: Uncomment after the distributed tensors migration to tt-metal is complete.
     // if (mesh_device->num_devices() == 1) {
     //     return to_string<T>(ttnn::distributed::get_device_tensors(cpu_tensor).at(0));

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -75,6 +75,13 @@ std::shared_ptr<distributed::MeshBuffer> allocate_device_buffer(
     return distributed::MeshBuffer::create(replicated_buffer_config, device_local_buffer_config, mesh_device);
 }
 
+MeshTensor allocate_mesh_tensor(
+    const TensorSpec& tensor_spec, distributed::MeshDevice& device, TensorTopology topology) {
+    using namespace tt::tt_metal;
+    auto mesh_buffer = tensor_impl::allocate_device_buffer(&device, tensor_spec);
+    return MeshTensor(mesh_buffer, tensor_spec, std::move(topology));
+}
+
 HostTensor pad_bfloat8_b(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
@@ -584,9 +591,7 @@ Tensor to_device(
                                   ? &tensor_spec_overriden_memory_config.value()
                                   : &tensor.tensor_spec();
 
-    auto mesh_buffer = allocate_device_buffer(mesh_device, *tensor_spec);
-    // Tensor topology will be overwritten in copy_to_device, an empty constructed one is sufficient.
-    auto result = Tensor(DeviceStorage(mesh_buffer), *tensor_spec, TensorTopology{});
+    auto result = Tensor(allocate_mesh_tensor(*tensor_spec, *mesh_device, tensor.tensor_topology()));
     tt::tt_metal::tensor_impl::copy_to_device(tensor, result, cq_id);
     return result;
 }
@@ -681,27 +686,29 @@ Tensor copy_as_replicate_tensor_on_1x1_mesh(
 
     const auto& mesh_device_shape = mesh_buffer->device()->shape();
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape);
-    return Tensor(
-        DeviceStorage(mesh_buffer),
-        host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
-        topology);
+    MeshTensor mesh_tensor(
+        mesh_buffer, host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()), topology);
+    return Tensor(std::move(mesh_tensor));
 }
 
 Tensor copy_as_distributed_tensor(
     const Tensor& host_tensor, const Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
     auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
     command_queue.enqueue_write(mesh_buffer, host_tensor.host_storage().buffer(), /*blocking=*/false);
+
     // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.
+    // Coordinates here represents the shards that are local to this instance, there maybe other shards that are on
+    // another host.
     std::vector<distributed::MeshCoordinate> coords;
-    coords.reserve(host_tensor.host_storage().buffer().shard_coords().size());
-    std::copy(
-        host_tensor.host_storage().buffer().shard_coords().begin(),
-        host_tensor.host_storage().buffer().shard_coords().end(),
-        std::back_inserter(coords));
-    return Tensor(
-        DeviceStorage(mesh_buffer, std::move(coords)),
+    const auto& shard_coords = host_tensor.host_storage().buffer().shard_coords();
+    coords.reserve(shard_coords.size());
+    std::copy(shard_coords.begin(), shard_coords.end(), std::back_inserter(coords));
+
+    MeshTensor mesh_tensor(
+        mesh_buffer,
         host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
         host_tensor.tensor_topology());
+    return Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -669,8 +669,8 @@ void copy_to_host(
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
-Tensor copy_as_replicate_tensor_on_1x1_mesh(
-    const Tensor& host_tensor, const Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
+void copy_as_replicate_tensor_on_1x1_mesh(
+    const Tensor& host_tensor, Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
     const auto host_buffer = host_tensor.host_storage().buffer().get_shard(distributed::MeshCoordinate(0, 0));
     auto data_to_write = host_buffer->view_bytes();
     const auto expected_packed_buffer_size_bytes = device_tensor.tensor_spec().compute_packed_buffer_size_bytes();
@@ -688,11 +688,11 @@ Tensor copy_as_replicate_tensor_on_1x1_mesh(
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape);
     MeshTensor mesh_tensor(
         mesh_buffer, host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()), topology);
-    return Tensor(std::move(mesh_tensor));
+    device_tensor = Tensor(std::move(mesh_tensor));
 }
 
-Tensor copy_as_distributed_tensor(
-    const Tensor& host_tensor, const Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
+void copy_as_distributed_tensor(
+    const Tensor& host_tensor, Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
     auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
     command_queue.enqueue_write(mesh_buffer, host_tensor.host_storage().buffer(), /*blocking=*/false);
 
@@ -708,7 +708,7 @@ Tensor copy_as_distributed_tensor(
         mesh_buffer,
         host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
         host_tensor.tensor_topology());
-    return Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+    device_tensor = Tensor(DeviceStorage(std::move(mesh_tensor), std::move(coords)));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -734,8 +734,7 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
     // Special case of replicating tensors on 1x1 mesh across the entire mesh device.
     if (host_storage_shape.mesh_size() < mesh_device_shape.mesh_size() &&
         host_storage_shape == distributed::MeshShape(1, 1)) {
-        device_tensor =
-            CMAKE_UNIQUE_NAMESPACE::copy_as_replicate_tensor_on_1x1_mesh(host_tensor, device_tensor, command_queue);
+        CMAKE_UNIQUE_NAMESPACE::copy_as_replicate_tensor_on_1x1_mesh(host_tensor, device_tensor, command_queue);
         return;
     }
 
@@ -745,7 +744,7 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
         host_storage_shape,
         mesh_device_shape);
 
-    device_tensor = CMAKE_UNIQUE_NAMESPACE::copy_as_distributed_tensor(host_tensor, device_tensor, command_queue);
+    CMAKE_UNIQUE_NAMESPACE::copy_as_distributed_tensor(host_tensor, device_tensor, command_queue);
 }
 
 void copy_to_device(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -564,73 +564,6 @@ Tensor to_host(const Tensor& tensor, bool blocking, std::optional<tt::tt_metal::
 //                               .to_device() details
 // ======================================================================================
 
-namespace {
-
-DeviceStorage replicate_to_mesh_buffer(
-    const HostBuffer& buffer,
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
-    const TensorSpec& tensor_spec,
-    std::optional<tt::tt_metal::QueueId> cq_id) {
-    auto* mesh_device = mesh_buffer->device();
-    auto data_to_write = buffer.view_bytes();
-    const auto expected_packed_buffer_size_bytes = tensor_spec.compute_packed_buffer_size_bytes();
-    const auto input_size_bytes = data_to_write.size();
-    TT_FATAL(
-        input_size_bytes == expected_packed_buffer_size_bytes,
-        "Host data with total size {}B does not match expected size {}B of device buffer!",
-        input_size_bytes,
-        expected_packed_buffer_size_bytes);
-
-    std::optional<uint8_t> cq_id_int = cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
-    mesh_device->mesh_command_queue(cq_id_int).enqueue_write_mesh_buffer(
-        mesh_buffer, data_to_write.data(), /*blocking=*/false);
-
-    return DeviceStorage(mesh_buffer);
-}
-
-DeviceStorage write_to_mesh_buffer(
-    const DistributedHostBuffer& distributed_host_buffer,
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
-    std::optional<tt::tt_metal::QueueId> cq_id) {
-    std::optional<uint8_t> cq_id_int = cq_id.has_value() ? std::make_optional(cq_id.value().get()) : std::nullopt;
-    mesh_buffer->device()->mesh_command_queue(cq_id_int).enqueue_write(
-        mesh_buffer, distributed_host_buffer, /*blocking=*/false);
-    // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.
-    std::vector<distributed::MeshCoordinate> coords;
-    coords.reserve(distributed_host_buffer.shard_coords().size());
-    std::copy(
-        distributed_host_buffer.shard_coords().begin(),
-        distributed_host_buffer.shard_coords().end(),
-        std::back_inserter(coords));
-    return DeviceStorage(mesh_buffer, std::move(coords));
-}
-
-}  // namespace
-
-std::pair<DeviceStorage, TensorTopology> to_device_mesh_buffer(
-    const HostStorage& host_storage,
-    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
-    const TensorSpec& tensor_spec,
-    const TensorTopology& tensor_topology,
-    std::optional<tt::tt_metal::QueueId> cq_id) {
-    const auto& host_storage_shape = host_storage.buffer().shape();
-    const auto& mesh_device_shape = mesh_buffer->device()->shape();
-    if (host_storage_shape.mesh_size() < mesh_device_shape.mesh_size() &&
-        host_storage_shape == distributed::MeshShape(1, 1)) {
-        // Special case of replicating tensors on 1x1 mesh across the entire mesh device.
-        const auto device_buffer = host_storage.buffer().get_shard(distributed::MeshCoordinate(0, 0));
-        return {
-            replicate_to_mesh_buffer(*device_buffer, mesh_buffer, tensor_spec, cq_id),
-            TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape)};
-    }
-    TT_FATAL(
-        host_storage_shape == mesh_device_shape,
-        "Distributed host buffer has different shape {} than the mesh device {}",
-        host_storage_shape,
-        mesh_device_shape);
-    return {write_to_mesh_buffer(host_storage.buffer(), mesh_buffer, cq_id), tensor_topology};
-}
-
 Tensor to_device(
     const Tensor& tensor,
     distributed::MeshDevice* mesh_device,
@@ -650,10 +583,12 @@ Tensor to_device(
     const auto* tensor_spec = tensor_spec_overriden_memory_config.has_value()
                                   ? &tensor_spec_overriden_memory_config.value()
                                   : &tensor.tensor_spec();
+
     auto mesh_buffer = allocate_device_buffer(mesh_device, *tensor_spec);
-    auto [mesh_storage, topology] =
-        to_device_mesh_buffer(tensor.host_storage(), mesh_buffer, *tensor_spec, tensor.tensor_topology(), cq_id);
-    return Tensor(std::move(mesh_storage), *tensor_spec, topology);
+    // Tensor topology will be overwritten in copy_to_device, an empty constructed one is sufficient.
+    auto result = Tensor(DeviceStorage(mesh_buffer), *tensor_spec, TensorTopology{});
+    tt::tt_metal::tensor_impl::copy_to_device(tensor, result, cq_id);
+    return result;
 }
 
 void copy_to_host(
@@ -726,6 +661,52 @@ void copy_to_host(
         shard_data_transfers, device_tensor.device_storage().get_mesh_buffer_leak_ownership(), blocking);
 }
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+Tensor copy_as_replicate_tensor_on_1x1_mesh(
+    const Tensor& host_tensor, const Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
+    const auto host_buffer = host_tensor.host_storage().buffer().get_shard(distributed::MeshCoordinate(0, 0));
+    auto data_to_write = host_buffer->view_bytes();
+    const auto expected_packed_buffer_size_bytes = device_tensor.tensor_spec().compute_packed_buffer_size_bytes();
+    const auto input_size_bytes = data_to_write.size();
+    TT_FATAL(
+        input_size_bytes == expected_packed_buffer_size_bytes,
+        "Host data with total size {}B does not match expected size {}B of device buffer!",
+        input_size_bytes,
+        expected_packed_buffer_size_bytes);
+
+    auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
+    command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+
+    const auto& mesh_device_shape = mesh_buffer->device()->shape();
+    auto topology = TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape);
+    return Tensor(
+        DeviceStorage(mesh_buffer),
+        host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
+        topology);
+}
+
+Tensor copy_as_distributed_tensor(
+    const Tensor& host_tensor, const Tensor& device_tensor, distributed::MeshCommandQueue& command_queue) {
+    auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
+    command_queue.enqueue_write(mesh_buffer, host_tensor.host_storage().buffer(), /*blocking=*/false);
+    // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.
+    std::vector<distributed::MeshCoordinate> coords;
+    coords.reserve(host_tensor.host_storage().buffer().shard_coords().size());
+    std::copy(
+        host_tensor.host_storage().buffer().shard_coords().begin(),
+        host_tensor.host_storage().buffer().shard_coords().end(),
+        std::back_inserter(coords));
+    return Tensor(
+        DeviceStorage(mesh_buffer, std::move(coords)),
+        host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()),
+        host_tensor.tensor_topology());
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optional<tt::tt_metal::QueueId> cq_id) {
     TT_FATAL(host_tensor.storage_type() == StorageType::HOST, "Source tensor is not on host.");
     TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Destination tensor is not on device.");
@@ -738,11 +719,26 @@ void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optio
         "Host tensor has different page config");
 
     auto mesh_buffer = device_tensor.device_storage().get_mesh_buffer_leak_ownership();
+    const auto& host_storage_shape = host_tensor.host_storage().buffer().shape();
+    const auto& mesh_device_shape = mesh_buffer->device()->shape();
 
-    auto [mesh_storage, topology] = to_device_mesh_buffer(
-        host_tensor.host_storage(), mesh_buffer, device_tensor.tensor_spec(), host_tensor.tensor_topology(), cq_id);
-    device_tensor = Tensor(
-        std::move(mesh_storage), host_tensor.tensor_spec().with_memory_config(device_tensor.memory_config()), topology);
+    auto& command_queue = mesh_buffer->device()->mesh_command_queue(raw_optional(cq_id));
+
+    // Special case of replicating tensors on 1x1 mesh across the entire mesh device.
+    if (host_storage_shape.mesh_size() < mesh_device_shape.mesh_size() &&
+        host_storage_shape == distributed::MeshShape(1, 1)) {
+        device_tensor =
+            CMAKE_UNIQUE_NAMESPACE::copy_as_replicate_tensor_on_1x1_mesh(host_tensor, device_tensor, command_queue);
+        return;
+    }
+
+    TT_FATAL(
+        host_storage_shape == mesh_device_shape,
+        "Distributed host buffer has different shape {} than the mesh device {}",
+        host_storage_shape,
+        mesh_device_shape);
+
+    device_tensor = CMAKE_UNIQUE_NAMESPACE::copy_as_distributed_tensor(host_tensor, device_tensor, command_queue);
 }
 
 void copy_to_device(

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1419,26 +1419,6 @@ HostTensor view(
     return HostTensor(buffer, new_spec, tensor.tensor_topology());
 }
 
-HostTensor unchecked_force_reinterpret(
-    const HostTensor& tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology) {
-    return HostTensor(tensor.buffer(), new_spec, new_topology);
-}
-
-MeshTensor unchecked_force_reinterpret(
-    const MeshTensor& tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology) {
-    auto original_buffer = tensor.mesh_buffer_invariant_breaking();
-    auto new_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-        original_buffer->global_config(),
-        original_buffer->device_local_config(),
-        original_buffer->device(),
-        original_buffer->address());
-    return MeshTensor(new_buffer, new_spec, new_topology);
-}
-
 // ======================================================================================
 //                                  .extract_shard()
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1419,6 +1419,26 @@ HostTensor view(
     return HostTensor(buffer, new_spec, tensor.tensor_topology());
 }
 
+HostTensor unchecked_force_reinterpret(
+    const HostTensor& tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology) {
+    return HostTensor(tensor.buffer(), new_spec, new_topology);
+}
+
+MeshTensor unchecked_force_reinterpret(
+    const MeshTensor& tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology) {
+    auto original_buffer = tensor.mesh_buffer_invariant_breaking();
+    auto new_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        original_buffer->global_config(),
+        original_buffer->device_local_config(),
+        original_buffer->device(),
+        original_buffer->address());
+    return MeshTensor(new_buffer, new_spec, new_topology);
+}
+
 // ======================================================================================
 //                                  .extract_shard()
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -276,7 +276,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
             input_buffer.address());
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
-        DeviceStorage view_storage(std::move(view_mesh_tensor));
+        DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return Tensor(std::move(view_storage));
     }
     if (!input_tensor.memory_config().is_sharded()) {
@@ -289,7 +289,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
             input_buffer.global_config(), new_device_config, input_buffer.device(), input_buffer.address());
 
         MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
-        DeviceStorage view_storage(std::move(view_mesh_tensor));
+        DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return Tensor(std::move(view_storage));
     }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -306,9 +306,10 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
         new_device_config,
         input_tensor.device(),
         input_tensor.mesh_buffer().address());
-    tt::tt_metal::DeviceStorage view_storage(input_tensor.device_storage(), view_mesh_buffer);
 
-    return Tensor(view_storage, new_spec, input_tensor.tensor_topology());
+    tt::tt_metal::DeviceStorage view_storage(
+        input_tensor.device_storage(), MeshTensor(view_mesh_buffer, new_spec, input_tensor.tensor_topology()));
+    return Tensor(std::move(view_storage));
 }
 
 Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -267,14 +267,30 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
     // TODO (#25340): Review tensor topology logic for reshape
     if (input_tensor.layout() != Layout::ROW_MAJOR || !changing_last_dim) {
-        return Tensor(input_tensor.device_storage(), new_spec, input_tensor.tensor_topology());
+        const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
+
+        auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+            input_buffer.global_config(),
+            input_buffer.device_local_config(),
+            input_buffer.device(),
+            input_buffer.address());
+
+        MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
+        DeviceStorage view_storage(std::move(view_mesh_tensor));
+        return Tensor(std::move(view_storage));
     }
     if (!input_tensor.memory_config().is_sharded()) {
-        auto device_storage = input_tensor.device_storage();
-        auto* device_buffer = device_storage.get_buffer();
-        auto page_size_bytes = new_spec.compute_page_size_bytes();
-        device_buffer->set_page_size(page_size_bytes);
-        return Tensor(std::move(device_storage), new_spec, input_tensor.tensor_topology());
+        const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
+
+        auto new_device_config = input_buffer.device_local_config();
+        new_device_config.page_size = new_spec.compute_page_size_bytes();
+
+        auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+            input_buffer.global_config(), new_device_config, input_buffer.device(), input_buffer.address());
+
+        MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
+        DeviceStorage view_storage(std::move(view_mesh_tensor));
+        return Tensor(std::move(view_storage));
     }
 
     tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -20,35 +20,6 @@
 #include <tracy/Tracy.hpp>
 #include "ttnn/graph/graph_serialization.hpp"
 
-namespace {
-
-tt::tt_metal::Tensor allocate_tensor_on_device(
-    const tt::tt_metal::TensorSpec& tensor_spec,
-    tt::tt_metal::distributed::MeshDevice* device,
-    std::optional<tt::tt_metal::TensorTopology> topology) {
-    using namespace tt::tt_metal;
-    auto mesh_buffer = tensor_impl::allocate_device_buffer(device, tensor_spec);
-    DeviceStorage device_storage(mesh_buffer);
-
-    TensorTopology tensor_topology;
-    if (topology.has_value()) {
-        tensor_topology = std::move(*topology);
-    } else {
-        // Use Replicate as default value for placements in MeshMapperConfig
-        ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(device->shape().dims());
-        for (size_t i = 0; i < device->shape().dims(); i++) {
-            placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
-        }
-        tensor_topology = TensorTopology{
-            device->shape(),
-            placements,
-            std::vector<distributed::MeshCoordinate>(
-                device_storage.get_coords().begin(), device_storage.get_coords().end())};
-    }
-    return Tensor(std::move(device_storage), tensor_spec, tensor_topology);
-}
-}  // namespace
-
 namespace tt::tt_metal {
 
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* device) {
@@ -81,7 +52,30 @@ Tensor create_device_tensor(
 
     Tensor output;
     distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
-    output = allocate_tensor_on_device(tensor_spec, mesh_device, std::move(tensor_topology));
+
+    auto topology = std::invoke([&]() {
+        if (tensor_topology.has_value()) {
+            return std::move(*tensor_topology);
+        }
+        // TODO (#25340): Implement correct logic and add test for this
+        // River: why are we constructing the topology here like this instead of using the
+        // TensorTopology::create_fully_replicated_tensor_topology function?
+        //
+        // Use Replicate as default value for placements in MeshMapperConfig
+        const auto& mesh_shape = mesh_device->shape();
+        ttsl::SmallVector<distributed::MeshMapperConfig::Placement> placements(
+            mesh_shape.dims(), tt::tt_metal::distributed::MeshMapperConfig::Replicate{});
+
+        std::vector<distributed::MeshCoordinate> coordinates;
+        coordinates.reserve(mesh_shape.mesh_size());
+        for (const auto& coord : distributed::MeshCoordinateRange(mesh_shape)) {
+            coordinates.push_back(coord);
+        }
+
+        return TensorTopology{mesh_shape, placements, std::move(coordinates)};
+    });
+
+    output = Tensor(tensor_impl::allocate_mesh_tensor(tensor_spec, *mesh_device, std::move(topology)));
     output = tt::tt_metal::set_tensor_id(output);
 
     GraphTracker::instance().track_function_end(output);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -346,23 +346,29 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
 
 Tensor view(const Tensor& input_tensor, const Shape& new_shape) { return view(input_tensor, new_shape, new_shape); }
 
-Tensor unchecked_force_reinterpret(
-    const Tensor& input_tensor,
-    const tt::tt_metal::TensorSpec& new_spec,
-    const tt::tt_metal::TensorTopology& new_topology) {
-    Tensor output;
+Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_layout) {
+    const auto& old_spec = input_tensor.tensor_spec();
+    const auto& old_layout = old_spec.tensor_layout();
+
+    TensorLayout new_tensor_layout(
+        old_layout.get_data_type(), PageConfig(target_layout), old_layout.get_memory_config());
+    TensorSpec new_spec(old_spec.logical_shape(), new_tensor_layout);
+    const auto& topology = input_tensor.tensor_topology();
+
     if (is_cpu_tensor(input_tensor)) {
-        output = Tensor(tensor_impl::unchecked_force_reinterpret(input_tensor.host_tensor(), new_spec, new_topology));
-    } else {
-        // Here reinterpreted_mesh_tensor does not own the device memory, and the ownership of the device memory is
-        // managed by the input_tensor. Thus we need to use the special constructor of DeviceStorage to keep the
-        // reinterpreted_mesh_tensor alive.
-        auto reinterpreted_mesh_tensor =
-            tensor_impl::unchecked_force_reinterpret(input_tensor.mesh_tensor(), new_spec, new_topology);
-        DeviceStorage reinterpreted_device_storage(input_tensor.device_storage(), std::move(reinterpreted_mesh_tensor));
-        output = Tensor(std::move(reinterpreted_device_storage));
+        return Tensor(HostTensor(input_tensor.host_tensor().buffer(), new_spec, topology));
     }
-    return output;
+
+    const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
+    auto new_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        input_buffer.global_config(),
+        input_buffer.device_local_config(),
+        input_buffer.device(),
+        input_buffer.address());
+
+    MeshTensor reinterpreted(std::move(new_mesh_buffer), new_spec, topology);
+    DeviceStorage reinterpreted_storage(input_tensor.device_storage(), std::move(reinterpreted));
+    return Tensor(std::move(reinterpreted_storage));
 }
 
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -346,6 +346,25 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
 
 Tensor view(const Tensor& input_tensor, const Shape& new_shape) { return view(input_tensor, new_shape, new_shape); }
 
+Tensor unchecked_force_reinterpret(
+    const Tensor& input_tensor,
+    const tt::tt_metal::TensorSpec& new_spec,
+    const tt::tt_metal::TensorTopology& new_topology) {
+    Tensor output;
+    if (is_cpu_tensor(input_tensor)) {
+        output = Tensor(tensor_impl::unchecked_force_reinterpret(input_tensor.host_tensor(), new_spec, new_topology));
+    } else {
+        // Here reinterpreted_mesh_tensor does not own the device memory, and the ownership of the device memory is
+        // managed by the input_tensor. Thus we need to use the special constructor of DeviceStorage to keep the
+        // reinterpreted_mesh_tensor alive.
+        auto reinterpreted_mesh_tensor =
+            tensor_impl::unchecked_force_reinterpret(input_tensor.mesh_tensor(), new_spec, new_topology);
+        DeviceStorage reinterpreted_device_storage(input_tensor.device_storage(), std::move(reinterpreted_mesh_tensor));
+        output = Tensor(std::move(reinterpreted_device_storage));
+    }
+    return output;
+}
+
 // ======================================================================================
 //                                  .tensor_reshape()
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -351,7 +351,7 @@ Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_la
     const auto& old_layout = old_spec.tensor_layout();
 
     TensorLayout new_tensor_layout(
-        old_layout.get_data_type(), PageConfig(target_layout), old_layout.get_memory_config());
+        old_layout.get_data_type(), PageConfig(target_layout, old_layout.get_tile()), old_layout.get_memory_config());
     TensorSpec new_spec(old_spec.logical_shape(), new_tensor_layout);
     const auto& topology = input_tensor.tensor_topology();
 

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -91,13 +91,14 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     for (const auto& coord : tt::tt_metal::distributed::MeshCoordinateRange(parent_mesh->shape())) {
         coords.push_back(coord);
     }
-    tt::tt_metal::DeviceStorage device_storage(std::move(mesh_buffer), std::move(coords));
 
-    return Tensor(
-        std::move(device_storage),
-        reference_spec,
-        tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
-            tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0));
+    auto topology = tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+        tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0);
+
+    MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
+
+    auto result = Tensor(tt::tt_metal::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
+    return result;
 }
 
 std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tensor) {
@@ -137,13 +138,13 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
 
-        DeviceStorage device_storage(mesh_buffer);
+        Tensor unit_tensor(tt::tt_metal::MeshTensor(mesh_buffer, reference_spec, TensorTopology{}));
         TT_FATAL(
-            device_storage.get_coords().size() == 1 &&
-                device_storage.get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),
+            unit_tensor.device_storage().get_coords().size() == 1 &&
+                unit_tensor.device_storage().get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),
             "mesh_buffer is not on a unit submesh");
 
-        result.push_back(Tensor(std::move(device_storage), reference_spec, TensorTopology{}));
+        result.push_back(std::move(unit_tensor));
     }
 
     return result;

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1549,12 +1549,12 @@ void pytensor_module(nb::module_& mod) {
 
             mesh_device->mesh_command_queue().enqueue_write_shards(mesh_buffer, {transfer}, /*blocking=*/true);
 
-            DeviceStorage device_storage(std::move(mesh_buffer), {coord});
             TensorTopology topology(
                 tt::tt_metal::distributed::MeshShape(1, 1),
                 {tt::tt_metal::distributed::MeshMapperConfig::Replicate{}},
                 {coord});
-            return Tensor(std::move(device_storage), tensor_spec, std::move(topology));
+            DeviceStorage device_storage(MeshTensor(std::move(mesh_buffer), tensor_spec, std::move(topology)), {coord});
+            return Tensor(std::move(device_storage));
         },
         nb::arg("host_tensor"),
         nb::arg("mesh_device"),

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -126,7 +126,6 @@ ttnn::Tensor narrow(
             storage.get_mesh_buffer().device(),
             storage.get_mesh_buffer().address() + offset_bytes);
 
-        tt::tt_metal::DeviceStorage subtensor_storage(storage, subtensor_mesh);
         TensorSpec subtensor_spec = TensorSpec(
             output_tensor_shape,
             tt::tt_metal::TensorLayout(
@@ -134,7 +133,9 @@ ttnn::Tensor narrow(
                 input_tensor.tensor_spec().page_config(),
                 input_tensor.tensor_spec().memory_config()));
 
-        return Tensor(subtensor_storage, subtensor_spec, input_tensor.tensor_topology());
+        tt::tt_metal::DeviceStorage subtensor_storage(
+            storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
+        return Tensor(std::move(subtensor_storage));
     }
 
     // Handle sharded L1 buffers
@@ -282,8 +283,6 @@ ttnn::Tensor narrow(
             storage.get_mesh_buffer().device(),
             storage.get_mesh_buffer().address() + (page_offset * buffer->aligned_page_size()));
 
-        tt::tt_metal::DeviceStorage subtensor_storage(storage, subtensor_mesh);
-
         auto narrowed_memory_config =
             MemoryConfig(input_tensor.memory_config().memory_layout(), BufferType::L1, narrowed_shard_spec);
 
@@ -292,7 +291,9 @@ ttnn::Tensor narrow(
             tt::tt_metal::TensorLayout(
                 input_tensor.dtype(), input_tensor.tensor_spec().page_config(), narrowed_memory_config));
 
-        return Tensor(subtensor_storage, subtensor_spec, input_tensor.tensor_topology());
+        tt::tt_metal::DeviceStorage subtensor_storage(
+            storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
+        return Tensor(std::move(subtensor_storage));
     }
 
     // Unsupported tensor configuration

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -165,11 +165,17 @@ MoEComputeDeviceOperation::tensor_return_value_t MoEComputeDeviceOperation::crea
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], tensor_args.tilize_input_tensor.device());
 
     // re-percieve tilize output tensor as RM for output
-    const auto& output_storage = tilize_output_tensor.device_storage();
-    const auto& output_spec = output_specs[4];
-    const auto& output_topology = tilize_output_tensor.tensor_attributes->get_tensor_topology();
-    const ttnn::Tensor matmul_output_tensor(output_storage, output_spec, output_topology);
+    const auto& original_mesh_buffer = tilize_output_tensor.mesh_buffer();
+    auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        original_mesh_buffer.global_config(),
+        original_mesh_buffer.device_local_config(),
+        original_mesh_buffer.device(),
+        original_mesh_buffer.address());
 
+    tt::tt_metal::MeshTensor view_mesh_tensor(
+        std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
+    tt::tt_metal::DeviceStorage view_storage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor));
+    const ttnn::Tensor matmul_output_tensor(view_storage);
     const auto& combine_output_tensor = tensor_args.optional_output_tensor.value_or(
         create_device_tensor(output_specs[5], tensor_args.tilize_input_tensor.device()));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -164,7 +164,7 @@ MoEComputeDeviceOperation::tensor_return_value_t MoEComputeDeviceOperation::crea
 
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], tensor_args.tilize_input_tensor.device());
 
-    // re-percieve tilize output tensor as RM for output
+    // re-perceive tilize output tensor as RM for output
     const auto& original_mesh_buffer = tilize_output_tensor.mesh_buffer();
     auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         original_mesh_buffer.global_config(),
@@ -174,8 +174,8 @@ MoEComputeDeviceOperation::tensor_return_value_t MoEComputeDeviceOperation::crea
 
     tt::tt_metal::MeshTensor view_mesh_tensor(
         std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
-    tt::tt_metal::DeviceStorage view_storage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor));
-    const ttnn::Tensor matmul_output_tensor(view_storage);
+    const ttnn::Tensor matmul_output_tensor(
+        tt::tt_metal::DeviceStorage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor)));
     const auto& combine_output_tensor = tensor_args.optional_output_tensor.value_or(
         create_device_tensor(output_specs[5], tensor_args.tilize_input_tensor.device()));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -165,8 +165,11 @@ MoEComputeDeviceOperation::tensor_return_value_t MoEComputeDeviceOperation::crea
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], tensor_args.tilize_input_tensor.device());
 
     // re-percieve tilize output tensor as RM for output
-    const auto matmul_output_tensor = tt::tt_metal::unchecked_force_reinterpret(
-        tilize_output_tensor, output_specs[4], tilize_output_tensor.tensor_topology());
+    const auto matmul_output_tensor =
+        tt::tt_metal::unchecked_reinterpret_layout(tilize_output_tensor, tt::tt_metal::Layout::ROW_MAJOR);
+    TT_FATAL(
+        matmul_output_tensor.tensor_spec() == output_specs[4],
+        "Reinterpreted tensor spec does not match expected output_specs[4]");
     const auto& combine_output_tensor = tensor_args.optional_output_tensor.value_or(
         create_device_tensor(output_specs[5], tensor_args.tilize_input_tensor.device()));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -164,18 +164,9 @@ MoEComputeDeviceOperation::tensor_return_value_t MoEComputeDeviceOperation::crea
 
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], tensor_args.tilize_input_tensor.device());
 
-    // re-perceive tilize output tensor as RM for output
-    const auto& original_mesh_buffer = tilize_output_tensor.mesh_buffer();
-    auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-        original_mesh_buffer.global_config(),
-        original_mesh_buffer.device_local_config(),
-        original_mesh_buffer.device(),
-        original_mesh_buffer.address());
-
-    tt::tt_metal::MeshTensor view_mesh_tensor(
-        std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
-    const ttnn::Tensor matmul_output_tensor(
-        tt::tt_metal::DeviceStorage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor)));
+    // re-percieve tilize output tensor as RM for output
+    const auto matmul_output_tensor = tt::tt_metal::unchecked_force_reinterpret(
+        tilize_output_tensor, output_specs[4], tilize_output_tensor.tensor_topology());
     const auto& combine_output_tensor = tensor_args.optional_output_tensor.value_or(
         create_device_tensor(output_specs[5], tensor_args.tilize_input_tensor.device()));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
@@ -197,8 +197,8 @@ MoEGPTDeviceOperation::tensor_return_value_t MoEGPTDeviceOperation::create_outpu
 
     tt::tt_metal::MeshTensor view_mesh_tensor(
         std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
-    tt::tt_metal::DeviceStorage view_storage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor));
-    const ttnn::Tensor output_tensor(view_storage);
+    const ttnn::Tensor output_tensor(
+        tt::tt_metal::DeviceStorage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor)));
 
     return {
         create_device_tensor(output_specs[0], device),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
@@ -188,10 +188,17 @@ MoEGPTDeviceOperation::tensor_return_value_t MoEGPTDeviceOperation::create_outpu
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], device);
 
     // Re-perceive tilize output tensor as RM for output[4] (same buffer, different layout view)
-    const auto& output_storage = tilize_output_tensor.device_storage();
-    const auto& output_spec = output_specs[4];
-    const auto& output_topology = tilize_output_tensor.tensor_attributes->get_tensor_topology();
-    const ttnn::Tensor output_tensor(output_storage, output_spec, output_topology);
+    const auto& original_mesh_buffer = tilize_output_tensor.mesh_buffer();
+    auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+        original_mesh_buffer.global_config(),
+        original_mesh_buffer.device_local_config(),
+        original_mesh_buffer.device(),
+        original_mesh_buffer.address());
+
+    tt::tt_metal::MeshTensor view_mesh_tensor(
+        std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
+    tt::tt_metal::DeviceStorage view_storage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor));
+    const ttnn::Tensor output_tensor(view_storage);
 
     return {
         create_device_tensor(output_specs[0], device),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
@@ -188,17 +188,8 @@ MoEGPTDeviceOperation::tensor_return_value_t MoEGPTDeviceOperation::create_outpu
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], device);
 
     // Re-perceive tilize output tensor as RM for output[4] (same buffer, different layout view)
-    const auto& original_mesh_buffer = tilize_output_tensor.mesh_buffer();
-    auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
-        original_mesh_buffer.global_config(),
-        original_mesh_buffer.device_local_config(),
-        original_mesh_buffer.device(),
-        original_mesh_buffer.address());
-
-    tt::tt_metal::MeshTensor view_mesh_tensor(
-        std::move(view_mesh_buffer), output_specs[4], tilize_output_tensor.tensor_topology());
-    const ttnn::Tensor output_tensor(
-        tt::tt_metal::DeviceStorage(tilize_output_tensor.device_storage(), std::move(view_mesh_tensor)));
+    const auto output_tensor = tt::tt_metal::unchecked_force_reinterpret(
+        tilize_output_tensor, output_specs[4], tilize_output_tensor.tensor_topology());
 
     return {
         create_device_tensor(output_specs[0], device),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_device_operation.cpp
@@ -188,8 +188,11 @@ MoEGPTDeviceOperation::tensor_return_value_t MoEGPTDeviceOperation::create_outpu
     const auto tilize_output_tensor = create_device_tensor(output_specs[3], device);
 
     // Re-perceive tilize output tensor as RM for output[4] (same buffer, different layout view)
-    const auto output_tensor = tt::tt_metal::unchecked_force_reinterpret(
-        tilize_output_tensor, output_specs[4], tilize_output_tensor.tensor_topology());
+    const auto output_tensor =
+        tt::tt_metal::unchecked_reinterpret_layout(tilize_output_tensor, tt::tt_metal::Layout::ROW_MAJOR);
+    TT_FATAL(
+        output_tensor.tensor_spec() == output_specs[4],
+        "Reinterpreted tensor spec does not match expected output_specs[4]");
 
     return {
         create_device_tensor(output_specs[0], device),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36373

### PR Type
Refactoring

### Problem description
Runtime is lowering Tensor into tt_metal as Host and MeshTensor.
Host and MeshTensor will become a first class data type like MeshBuffer.

TTNN::Tensor is currently built upon `MeshBuffer`, and needs porting to the new MeshTensor.

### What's changed

Swapped the underlying storage within `ttnn::Tensor` from `MeshBuffer` to `MeshTensor`.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mesh-tensor-in-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mesh-tensor-in-tensor)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mesh-tensor-in-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mesh-tensor-in-tensor)
  - Failure not related to current branch.
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mesh-tensor-in-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mesh-tensor-in-tensor)
- [ ] [T3K Unit test](https://github.com/tenstorrent/tt-metal/actions/runs/24230177002)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

- [ ] [Models mandatory single device](https://github.com/tenstorrent/tt-metal/actions/runs/24224877061)
- [ ] [T3K Models Mandtory](https://github.com/tenstorrent/tt-metal/actions/runs/24229470319)
