### PR TITLE
[Feature]: Adding ability for kernels to use DFBs on WH/BH

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -527,14 +527,18 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
             core,
             DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = {cb_index}});
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = {cb_index, /*use_dfbs=*/false}});
 
         auto writer_kernel = CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
             core,
             DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {cb_index}});
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = {cb_index, /*use_dfbs=*/false}});
 
         SetRuntimeArgs(
             program_,

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -105,6 +105,21 @@ void run_single_dfb_program(
             (producer_type == DFBPorCType::DM && consumer_type == DFBPorCType::DM),
         "Multi-core DFB programs only support DM producer and consumer.");
 
+    const auto arch = mesh_device->get_devices()[0]->arch();
+    const bool is_quasar = (arch == ARCH::QUASAR);
+
+    if (!is_quasar) {
+        // WH/BH DM: one BRISC (RISCV_0) as producer and one NCRISC (RISCV_1) as consumer.
+        // Configs with num_producers > 1 or num_consumers > 1 require multi-threaded DM
+        // which is not available on WH/BH.
+        if (dfb_config.num_producers > 1 || dfb_config.num_consumers > 1) {
+            GTEST_SKIP() << "WH/BH DFB supports only 1 DM producer (BRISC) and 1 DM consumer (NCRISC)";
+        }
+        // read_in / write_out are Quasar-only; the device-side kernel would fail to compile
+        // if enable_implicit_sync=true is propagated as a compile-time arg.
+        dfb_config.enable_implicit_sync = false;
+    }
+
     Program program = CreateProgram();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
 
@@ -132,18 +147,34 @@ void run_single_dfb_program(
 
     KernelHandle producer_kernel;
     if (producer_type == DFBPorCType::DM) {
-        producer_kernel = experimental::quasar::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
-            core_range_set,
-            experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
+        const std::string dm_producer_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp";
+        if (is_quasar) {
+            producer_kernel = experimental::quasar::CreateKernel(
+                program,
+                dm_producer_kernel_path,
+                core_range_set,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
+        } else {
+            producer_kernel = CreateKernel(
+                program,
+                dm_producer_kernel_path,
+                core_range_set,
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .compile_args = producer_cta});
+        }
     } else {
-        producer_kernel = CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
-            core_range_set,
-            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
+        const std::string t6_producer_kernel_path = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp";
+        if (is_quasar) {
+            producer_kernel = CreateKernel(
+                program,
+                t6_producer_kernel_path,
+                core_range_set,
+                experimental::quasar::QuasarComputeConfig{
+                    .num_threads_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
+        } else {
+            producer_kernel = CreateKernel(
+                program, t6_producer_kernel_path, core_range_set, ComputeConfig{.compile_args = producer_cta});
+        }
     }
 
     uint32_t num_entries_per_consumer = is_blocked ? entries_per_core : entries_per_core / dfb_config.num_consumers;
@@ -156,18 +187,34 @@ void run_single_dfb_program(
 
     KernelHandle consumer_kernel;
     if (consumer_type == DFBPorCType::DM) {
-        consumer_kernel = experimental::quasar::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
-            core_range_set,
-            experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
+        const std::string dm_consumer_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp";
+        if (is_quasar) {
+            consumer_kernel = experimental::quasar::CreateKernel(
+                program,
+                dm_consumer_kernel_path,
+                core_range_set,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
+        } else {
+            consumer_kernel = CreateKernel(
+                program,
+                dm_consumer_kernel_path,
+                core_range_set,
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .compile_args = consumer_cta});
+        }
     } else {
-        consumer_kernel = CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
-            core_range_set,
-            experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
+        const std::string t6_consumer_kernel_path = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp";
+        if (is_quasar) {
+            consumer_kernel = CreateKernel(
+                program,
+                t6_consumer_kernel_path,
+                core_range_set,
+                experimental::quasar::QuasarComputeConfig{
+                    .num_threads_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
+        } else {
+            consumer_kernel = CreateKernel(
+                program, t6_consumer_kernel_path, core_range_set, ComputeConfig{.compile_args = consumer_cta});
+        }
     }
 
     auto logical_dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range_set, dfb_config);
@@ -346,8 +393,8 @@ void run_in_dfb_out_dfb_program(
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
+        GTEST_SKIP();
     }
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
@@ -363,8 +410,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB1Sx1S) {
 }
 
 TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
+        GTEST_SKIP();
     }
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,
@@ -379,8 +426,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB1Sx1S) {
 }
 
 TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
-        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    if (devices_.at(0)->arch() != ARCH::QUASAR and GetParam()) {
+        GTEST_SKIP();
     }
     experimental::dfb::DataflowBufferConfig config{
         .entry_size = 1024,

--- a/tests/tt_metal/tt_metal/api/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/api/test_banked.cpp
@@ -268,7 +268,8 @@ bool reader_datacopy_writer(const std::shared_ptr<distributed::MeshDevice>& mesh
             .compile_args = writer_compile_time_args_dc});
 
     vector<uint32_t> compute_kernel_args = {
-        uint(cfg.num_tiles)  // per_core_tile_cnt
+        uint(cfg.num_tiles),  // per_core_tile_cnt
+        false                 // use_dfbs
     };
     CreateKernel(
         program_,

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -195,7 +195,6 @@ struct ReaderWriterConfig {
 bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReaderWriterConfig& test_config) {
     bool pass = true;
 
-    const uint32_t cb_index = 0;
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -217,10 +216,16 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     auto output_dram_buffer = CreateBuffer(dram_config);
     uint32_t output_dram_byte_address = output_dram_buffer->address();
 
-    tt_metal::CircularBufferConfig l1_cb_config =
-        tt_metal::CircularBufferConfig(byte_size, {{cb_index, test_config.l1_data_format}})
-            .set_page_size(cb_index, test_config.tile_byte_size);
-    tt_metal::CreateCircularBuffer(program_, test_config.core, l1_cb_config);
+    tt_metal::experimental::dfb::DataflowBufferConfig l1_dfb_config = {
+        .entry_size = test_config.tile_byte_size,
+        .num_entries = test_config.num_tiles,
+        .num_producers = 1,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .data_format = test_config.l1_data_format};
+    uint32_t l1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_dfb_config);
 
     auto reader_kernel = tt_metal::CreateKernel(
         program_,
@@ -229,7 +234,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = {cb_index}});
+            .compile_args = {l1_dfb, /*use_dfbs=*/true}});
 
     auto writer_kernel = tt_metal::CreateKernel(
         program_,
@@ -238,7 +243,10 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = {cb_index}});
+            .compile_args = {l1_dfb, /*use_dfbs=*/true}});
+
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program_, l1_dfb, reader_kernel, writer_kernel);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation
@@ -321,49 +329,52 @@ bool reader_datacopy_writer(
     KernelHandle compute_kernel;
     uint32_t num_threads = 1;
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
+        num_threads = test_config.num_tiles == 1 ? 1 : 4;
+    }
+
+    tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
+        .entry_size = test_config.tile_byte_size,
+        .num_entries = test_config.num_tiles,
+        .num_producers = num_threads,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = num_threads,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,  // ignored on WH/BH
+        .data_format = test_config.l1_input_data_format};
+
+    tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
+        .entry_size = test_config.tile_byte_size,
+        .num_entries = test_config.num_tiles,
+        .num_producers = num_threads,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = num_threads,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = true,  // ignored on WH/BH
+        .data_format = test_config.l1_output_data_format};
+
+    uint32_t l1_input_dfb =
+        tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input_dfb_config);
+    uint32_t l1_output_dfb =
+        tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
+
+    if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
         if (test_config.num_tiles > 1) {
             TT_FATAL(test_config.num_tiles % 4 == 0, "Number of tiles must be divisible by 4");
         }
-        num_threads = test_config.num_tiles == 1 ? 1 : 4;
-
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_input_dfb_config = {
-            .entry_size = test_config.tile_byte_size,
-            .num_entries = test_config.num_tiles,
-            .num_producers = num_threads,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .num_consumers = num_threads,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = true,
-            .data_format = test_config.l1_input_data_format
-        };
-
-        tt_metal::experimental::dfb::DataflowBufferConfig l1_output_dfb_config = {
-            .entry_size = test_config.tile_byte_size,
-            .num_entries = test_config.num_tiles,
-            .num_producers = num_threads,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .num_consumers = num_threads,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = true,
-            .data_format = test_config.l1_output_data_format
-        };
-
-        uint32_t l1_input_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_input_dfb_config);
-        uint32_t l1_output_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program_, test_config.core, l1_output_dfb_config);
 
         reader_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = num_threads, .compile_args = {l1_input_dfb}});
+                .num_threads_per_cluster = num_threads, .compile_args = {l1_input_dfb, /*use_dfbs=*/true}});
 
         writer_kernel = tt_metal::experimental::quasar::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = num_threads, .compile_args = {l1_output_dfb}});
+                .num_threads_per_cluster = num_threads, .compile_args = {l1_output_dfb, /*use_dfbs=*/true}});
 
         uint32_t per_core_tile_cnt = test_config.num_tiles / num_threads;
         compute_kernel = tt_metal::experimental::quasar::CreateKernel(
@@ -371,24 +382,9 @@ bool reader_datacopy_writer(
             "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
             test_config.core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
-                .num_threads_per_cluster = num_threads, .compile_args = {uint(per_core_tile_cnt)}});
+                .num_threads_per_cluster = num_threads, .compile_args = {uint(per_core_tile_cnt), /*use_dfbs=*/true}});
 
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_input_dfb, reader_kernel, compute_kernel);
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program_, l1_output_dfb, compute_kernel, writer_kernel);
     } else {
-        const uint32_t input0_cb_index = 0;
-        const uint32_t output_cb_index = 16;
-
-        tt_metal::CircularBufferConfig l1_input_cb_config =
-            tt_metal::CircularBufferConfig(byte_size, {{input0_cb_index, test_config.l1_input_data_format}})
-                .set_page_size(input0_cb_index, test_config.tile_byte_size);
-        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_input_cb_config);
-
-        tt_metal::CircularBufferConfig l1_output_cb_config =
-            tt_metal::CircularBufferConfig(byte_size, {{output_cb_index, test_config.l1_output_data_format}})
-                .set_page_size(output_cb_index, test_config.tile_byte_size);
-        tt_metal::CreateCircularBuffer(program_, test_config.core, l1_output_cb_config);
-
         reader_kernel = tt_metal::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
@@ -396,7 +392,7 @@ bool reader_datacopy_writer(
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_1_default,
-                .compile_args = {input0_cb_index}});
+                .compile_args = {l1_input_dfb, /*use_dfbs=*/true}});
 
         writer_kernel = tt_metal::CreateKernel(
             program_,
@@ -405,14 +401,19 @@ bool reader_datacopy_writer(
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt_metal::NOC::RISCV_0_default,
-                .compile_args = {output_cb_index}});
+                .compile_args = {l1_output_dfb, /*use_dfbs=*/true}});
 
         compute_kernel = tt_metal::CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
             test_config.core,
-            tt_metal::ComputeConfig{.compile_args = {uint(test_config.num_tiles)}});
+            tt_metal::ComputeConfig{.compile_args = {uint(test_config.num_tiles), /*use_dfbs=*/true}});
     }
+
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program_, l1_input_dfb, reader_kernel, compute_kernel);
+    tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+        program_, l1_output_dfb, compute_kernel, writer_kernel);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Stimulus Generation

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -290,7 +290,7 @@ static DramBuffer prepare_reader(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt_metal::NOC::RISCV_1_default,
-            .compile_args = {DEFAULT_INPUT_CB_INDEX}});
+            .compile_args = {DEFAULT_INPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the reader kernel
     tt_metal::SetRuntimeArgs(
@@ -322,7 +322,7 @@ static DramBuffer prepare_writer(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = {DEFAULT_OUTPUT_CB_INDEX}});
+            .compile_args = {DEFAULT_OUTPUT_CB_INDEX, /*use_dfbs=*/false}});
 
     // Set runtime arguments for the writer kernel
     tt_metal::SetRuntimeArgs(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -22,6 +23,9 @@ using namespace tt::tt_metal;
 TEST_F(MeshDispatchFixture, DataflowCb) {
     auto mesh_device = devices_[0];
     IDevice* dev = mesh_device->get_devices()[0];
+    if (dev->arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "Quasar does not support CBs, skipping test";
+    }
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -69,8 +73,10 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     // Also test topmost
     create_cb(topmost_cb);
 
-    std::vector<uint32_t> reader_cb_compile_args = {start_cb, strided_cb_count, stride, topmost_cb, reader_ublock_size};
-    std::vector<uint32_t> writer_cb_compile_args = {start_cb, strided_cb_count, stride, topmost_cb, writer_ublock_size};
+    std::vector<uint32_t> reader_cb_compile_args = {
+        start_cb, strided_cb_count, stride, topmost_cb, reader_ublock_size, /*use_dfbs=*/false};
+    std::vector<uint32_t> writer_cb_compile_args = {
+        start_cb, strided_cb_count, stride, topmost_cb, writer_ublock_size, /*use_dfbs=*/false};
 
     auto reader_cb_kernel = CreateKernel(
         program,
@@ -96,6 +102,101 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_cb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_cb});
+
+    // Execute
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    this->RunProgram(mesh_device, workload);
+
+    std::vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+
+    // Validation
+    EXPECT_EQ(src_vec, result_vec);
+}
+
+TEST_F(MeshDispatchFixture, DataflowDfb) {
+    auto mesh_device = devices_[0];
+    IDevice* dev = mesh_device->get_devices()[0];
+    Program program = CreateProgram();
+
+    CoreCoord core = {0, 0};
+
+    // Tile configuration
+    constexpr uint32_t single_tile_size = 2 * 1024;
+    constexpr uint32_t cb_capacity_tiles = 8;
+    constexpr uint32_t tiles_to_transfer_per_dfb = 200;
+    constexpr uint32_t reader_ublock_size = 2;
+    constexpr uint32_t writer_ublock_size = 4;
+
+    static_assert(
+        tiles_to_transfer_per_dfb % writer_ublock_size == 0,
+        "tiles_to_transfer_per_dfb must be divisible by writer_ublock_size");
+
+    const uint32_t total_dfbs = max_cbs_;
+
+    const uint32_t num_tiles = tiles_to_transfer_per_dfb * total_dfbs;
+    const uint32_t dram_buffer_size = single_tile_size * num_tiles;
+
+    InterleavedBufferConfig dram_config{
+        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+
+    auto src_dram_buffer = CreateBuffer(dram_config);
+    uint32_t dram_buffer_src_addr = src_dram_buffer->address();
+    auto dst_dram_buffer = CreateBuffer(dram_config);
+    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+
+    tt_metal::experimental::dfb::DataflowBufferConfig dfb_config = {
+        .entry_size = single_tile_size,
+        .num_entries = cb_capacity_tiles,
+        .num_producers = 1,
+        .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .data_format = tt::DataFormat::Float16_b};
+
+    std::vector<uint32_t> dfb_ids(total_dfbs);
+    for (uint32_t idx = 0; idx < total_dfbs; idx++) {
+        dfb_ids[idx] = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dfb_config);
+    }
+
+    std::vector<uint32_t> reader_cb_compile_args = {
+        dfb_ids[0], total_dfbs - 1, 1, dfb_ids[total_dfbs - 1], reader_ublock_size, /*use_dfbs=*/true};
+    std::vector<uint32_t> writer_cb_compile_args = {
+        dfb_ids[0], total_dfbs - 1, 1, dfb_ids[total_dfbs - 1], writer_ublock_size, /*use_dfbs=*/true};
+
+    auto reader_cb_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_cb_test.cpp",
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_cb_compile_args});
+
+    auto writer_cb_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_cb_test.cpp",
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_cb_compile_args});
+
+    for (auto dfb_id : dfb_ids) {
+        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
+            program, dfb_id, reader_cb_kernel, writer_cb_kernel);
+    }
+
+    std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
+        dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    detail::WriteToBuffer(src_dram_buffer, src_vec);
+
+    SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_dfb});
+    SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_dfb});
 
     // Execute
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -147,7 +147,8 @@ bool flatten(
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
     vector<uint32_t> compute_kernel_args = {
-        num_tiles * 32  // per_core_tile_cnt
+        num_tiles * 32,  // per_core_tile_cnt
+        false            // use_dfbs
     };
 
     tt_metal::CreateKernel(
@@ -253,7 +254,7 @@ bool flatten_stress(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-    vector<uint32_t> compute_kernel_args = {num_tiles * 32};
+    vector<uint32_t> compute_kernel_args = {num_tiles * 32, /*use_dfbs=*/false};
 
     CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -136,7 +136,7 @@ Program create_program(IDevice* /*device*/, const ProgramAttributes& program_att
         core,
         DataMovementConfig{.processor = program_attributes.writer_processor, .noc = program_attributes.writer_noc});
 
-    vector<uint32_t> compute_kernel_args = {uint(program_attributes.num_tiles)};
+    vector<uint32_t> compute_kernel_args = {uint(program_attributes.num_tiles), /*use_dfbs=*/false};
 
     CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/test_flatten.cpp
@@ -139,7 +139,8 @@ int main(int argc, char** argv) {
                 .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
         vector<uint32_t> compute_kernel_args = {
-            num_tiles * 32  // per_core_tile_cnt
+            num_tiles * 32,  // per_core_tile_cnt
+            false            // use_dfbs
         };
 
         auto eltwise_unary_kernel = tt_metal::CreateKernel(

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -168,7 +168,7 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-        vector<uint32_t> compute_kernel_args = {uint(num_output_tiles)};
+        vector<uint32_t> compute_kernel_args = {uint(num_output_tiles), /*use_dfbs=*/false};
 
         tt_metal::CreateKernel(
             program,
@@ -314,7 +314,7 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = writer_compile_time_args});
 
-        vector<uint32_t> compute_kernel_args = {uint(num_output_tiles)};
+        vector<uint32_t> compute_kernel_args = {uint(num_output_tiles), /*use_dfbs=*/false};
 
         tt_metal::CreateKernel(
             program,
@@ -403,7 +403,7 @@ bool test_interleaved_l1_datacopy(
 
     // Buffers and host data
 
-    vector<uint32_t> compute_kernel_args = {num_pages};
+    vector<uint32_t> compute_kernel_args = {num_pages, /*use_dfbs=*/false};
     tt_metal::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
@@ -7,35 +7,23 @@
 #include "api/debug/dprint.h"
 
 void kernel_main() {
-    // CTA layout mirrors dfb_consumer.cpp: [dst_addr, num_entries_per_consumer, blocked_consumer, implicit_sync, ...]
-    // dst_addr (CTA[0]) and TensorAccessorArgs are unused by the Tensix consumer.
     const uint32_t num_entries_per_consumer = get_compile_time_arg_val(1);
     constexpr uint32_t blocked_consumer = get_compile_time_arg_val(2);
 
-    // RTA layout mirrors dfb_consumer.cpp: [consumer_mask, logical_dfb_id, chunk_offset]
-    // chunk_offset (RTA[2]) is unused since Tensix pops from DFB without writing to DRAM.
     uint32_t logical_dfb_id = get_arg_val<uint32_t>(1);
 
     experimental::DataflowBuffer dfb(logical_dfb_id);
-
-    // DPRINT << "t6 consumer trisc_id: " << trisc_id << " consumer_idx: " << consumer_idx
-    //        << " num_entries_per_consumer: " << num_entries_per_consumer << ENDL();
-    // DEVICE_PRINT("t6 consumer trisc_id: {} consumer_idx: {} num_entries_per_consumer: {}\n", trisc_id, consumer_idx,
-    // num_entries_per_consumer);
 
     // Each consumer pops exactly num_entries_per_consumer entries from its own TC(s).
     // No modulo-skip is needed: the DFB hardware delivers only this consumer's entries
     // to its TC, so every wait_front/pop_front here is for a tile this consumer owns.
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
         dfb.wait_front(1);
-        UNPACK(DPRINT << "unpack consumer tile id " << tile_id << ENDL());
         DEVICE_PRINT_UNPACK("unpack consumer tile id {}\n", tile_id);
         dfb.pop_front(1);
-        PACK(DPRINT << "pack consumer tile id " << tile_id << ENDL());
         DEVICE_PRINT_PACK("pack consumer tile id {}\n", tile_id);
     }
-    DPRINT << "CBWW" << ENDL();
+    DEVICE_PRINT("CBWW\n");
     dfb.finish();
-    DPRINT << "CBWD" << ENDL();
     DEVICE_PRINT("CBWD\n");
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp
@@ -13,30 +13,14 @@ void kernel_main() {
     // only posts credits so the DM consumer knows data is available.
     const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
 
-    // RTA layout mirrors dfb_producer.cpp: [producer_mask, chunk_offset]
-    // chunk_offset (RTA[1]) is unused since Tensix doesn't read from DRAM.
-    uint32_t producer_mask = get_arg_val<uint32_t>(0);
-
-    // Compute which logical producer slot this TRISC occupies within the mask.
-    uint32_t trisc_id = static_cast<uint32_t>(ckernel::csr_read<ckernel::CSR::TRISC_ID>());
-    uint32_t producer_idx = static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << trisc_id) - 1u)));
-
     experimental::DataflowBuffer dfb(0);
 
-    // DPRINT << "t6 producer trisc_id: " << trisc_id << " producer_idx: " << producer_idx
-    //        << " num_entries_per_producer: " << num_entries_per_producer << ENDL();
-    // DEVICE_PRINT("t6 producer trisc_id: {} producer_idx: {} num_entries_per_producer: {}\n",
-    //              trisc_id, producer_idx, num_entries_per_producer);
-
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
-        DPRINT << "producer tile id " << tile_id << ENDL();
         DEVICE_PRINT("producer tile id {}\n", tile_id);
         dfb.reserve_back(1);
         dfb.push_back(1);
     }
-    DPRINT << "PFW" << ENDL();
     DEVICE_PRINT("PFW\n");
     dfb.finish();
-    DPRINT << "PFD" << ENDL();
     DEVICE_PRINT("PFD\n");
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -8,24 +8,20 @@
 #include "api/compute/pack.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#ifdef ARCH_QUASAR
 #include "experimental/dataflow_buffer.h"
-#else
+#ifndef ARCH_QUASAR
 #include "experimental/circular_buffer.h"
 #endif
 
 void kernel_main() {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+    constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
 
-#ifdef ARCH_QUASAR
-    experimental::DataflowBuffer dfb_in(0);
-    experimental::DataflowBuffer dfb_out(1);
-    unary_op_init_common(dfb_in.get_id(), dfb_out.get_id());
-#else
-    experimental::CircularBuffer cb0(tt::CBIndex::c_0);
-    experimental::CircularBuffer cb16(tt::CBIndex::c_16);
-    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
-#endif
+    if constexpr (use_dfbs) {
+        unary_op_init_common(0, 1);
+    } else {
+        unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    }
 
 #ifdef PACK_RELU
 #ifdef ARCH_QUASAR
@@ -35,28 +31,35 @@ void kernel_main() {
 #endif
 #endif
 
-    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-        acquire_dst();
+    if constexpr (use_dfbs) {
+        experimental::DataflowBuffer dfb_in(0);
+        experimental::DataflowBuffer dfb_out(1);
+        for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+            acquire_dst();
 
-#ifdef ARCH_QUASAR
-        dfb_in.wait_front(1);
-        dfb_out.reserve_back(1);
-        copy_tile(dfb_in.get_id(), 0, 0);
-        pack_tile(0, dfb_out.get_id());
-        dfb_in.pop_front(1);
-        dfb_out.push_back(1);
-#else
-        // Pop tile after tile, copy to DST and pack
-        cb0.wait_front(1);
-        cb16.reserve_back(1);
-        copy_tile(tt::CBIndex::c_0, 0, 0);
+            dfb_in.wait_front(1);
+            dfb_out.reserve_back(1);
+            copy_tile(dfb_in.get_id(), 0, 0);
+            pack_tile(0, dfb_out.get_id());
+            dfb_in.pop_front(1);
+            dfb_out.push_back(1);
 
-        pack_tile(0, tt::CBIndex::c_16);
+            release_dst();
+        }
+    } else {
+        experimental::CircularBuffer cb0(tt::CBIndex::c_0);
+        experimental::CircularBuffer cb16(tt::CBIndex::c_16);
+        for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+            acquire_dst();
 
-        cb0.pop_front(1);
-        cb16.push_back(1);
-#endif
+            cb0.wait_front(1);
+            cb16.reserve_back(1);
+            copy_tile(tt::CBIndex::c_0, 0, 0);
+            pack_tile(0, tt::CBIndex::c_16);
+            cb0.pop_front(1);
+            cb16.push_back(1);
 
-        release_dst();
+            release_dst();
+        }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -45,7 +45,9 @@ void kernel_main() {
         DPRINT << "consumer tile id " << tile_id << " page id " << page_id << ENDL();
         DEVICE_PRINT("consumer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
             dfb.write_out(noc, tensor_accessor, {.page_id = page_id});
+#endif
         } else {
             dfb.wait_front(1);
             noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = page_id});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -48,7 +48,9 @@ void kernel_main() {
         DPRINT << "producer tile id " << tile_id << " page id " << page_id << ENDL();
         DEVICE_PRINT("producer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
+#ifdef ARCH_QUASAR
             dfb.read_in(noc, tensor_accessor, {.page_id = page_id});
+#endif
         } else {
             dfb.reserve_back(1);
             noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = page_id}, {});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_cb_test.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_cb_test.cpp
@@ -2,23 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc.h"
+#include "experimental/dataflow_buffer.h"
+#ifndef ARCH_QUASAR
+#include "experimental/circular_buffer.h"
+#endif
 
-inline __attribute__((always_inline))
-void read_and_push_to_cb(const uint32_t cb_id, uint32_t num_tiles_per_cb, uint32_t ublock_size_tiles, uint32_t ublock_size_bytes,
-                               uint32_t bank_id, uint32_t& dram_buffer_src_addr) {
-    // read a ublock of tiles at the time from DRAM to L1 buffer, and push a ublock at the time to unpacker
+template <bool use_dfbs, typename SyncBuffer>
+inline __attribute__((always_inline)) void read_and_push_to_cb(
+    SyncBuffer& sync_buffer,
+    uint32_t num_tiles_per_cb,
+    uint32_t ublock_size_tiles,
+    uint32_t ublock_size_bytes,
+    uint32_t bank_id,
+    uint32_t& dram_buffer_src_addr) {
+    experimental::Noc noc;
+    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
+    experimental::AllocatorBank<bank_type> src_dram;
+
     for (uint32_t i = 0; i < num_tiles_per_cb; i += ublock_size_tiles) {
-        // DRAM NOC src address
-        std::uint64_t dram_buffer_src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dram_buffer_src_addr);
-        cb_reserve_back(cb_id, ublock_size_tiles);
-        uint32_t l1_write_addr = get_write_ptr(cb_id);
-
-        noc_async_read(dram_buffer_src_noc_addr, l1_write_addr, ublock_size_bytes);
-        noc_async_read_barrier();
-
-        cb_push_back(cb_id, ublock_size_tiles);
+        sync_buffer.reserve_back(ublock_size_tiles);
+        noc.async_read(
+            src_dram, sync_buffer, ublock_size_bytes, {.bank_id = bank_id, .addr = dram_buffer_src_addr}, {});
+        noc.async_read_barrier();
+        sync_buffer.push_back(ublock_size_tiles);
         dram_buffer_src_addr += ublock_size_bytes;
     }
 }
@@ -33,16 +43,42 @@ void kernel_main() {
     constexpr uint32_t stride = get_compile_time_arg_val(2);
     constexpr uint32_t topmost_cb = get_compile_time_arg_val(3);
     constexpr uint32_t ublock_size_tiles = get_compile_time_arg_val(4);
+    constexpr bool use_dfbs = get_compile_time_arg_val(5) == 1;
+#ifdef ARCH_QUASAR
+    static_assert(use_dfbs, "DFBs must be used on Quasar");
+#endif
 
     // Process strided CBs: 0, 8, 16, ...
     for (uint32_t i = 0; i < num_cbs_stride; i++) {
         uint32_t cb_id = start_cb + i * stride;
-        uint32_t ublock_size_bytes = get_tile_size(cb_id) * ublock_size_tiles;
-        read_and_push_to_cb(
-            cb_id, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+#ifndef ARCH_QUASAR
+        experimental::CircularBuffer cb(cb_id);
+#endif
+        experimental::DataflowBuffer dfb(cb_id);
+        uint32_t ublock_size_bytes;
+        if constexpr (use_dfbs) {
+            ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+            read_and_push_to_cb<true, experimental::DataflowBuffer>(
+                dfb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+        } else {
+            ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+            read_and_push_to_cb<false, experimental::CircularBuffer>(
+                cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+        }
     }
     // Process topmost CB
-    uint32_t ublock_size_bytes = get_tile_size(topmost_cb) * ublock_size_tiles;
-    read_and_push_to_cb(
-        topmost_cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+#ifndef ARCH_QUASAR
+    experimental::CircularBuffer cb(topmost_cb);
+#endif
+    experimental::DataflowBuffer dfb(topmost_cb);
+    uint32_t ublock_size_bytes;
+    if constexpr (use_dfbs) {
+        ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+        read_and_push_to_cb<true, experimental::DataflowBuffer>(
+            dfb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+    } else {
+        ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+        read_and_push_to_cb<false, experimental::CircularBuffer>(
+            cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_src_addr);
+    }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -5,15 +5,17 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
-#ifdef ARCH_QUASAR
 #include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
+#ifndef ARCH_QUASAR
+#include "experimental/circular_buffer.h"
 #endif
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
+    constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
     uint32_t src_addr  = get_arg_val<uint32_t>(0); // global base address
     uint32_t src_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
@@ -22,37 +24,40 @@ void kernel_main() {
 
 #ifdef ARCH_QUASAR
     uint32_t producer_idx = get_my_thread_id();
+#else
+    uint32_t producer_idx = 0;
+#endif
 
-    experimental::DataflowBuffer dfb(cb_id);
     constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
     experimental::AllocatorBank<bank_type> src_dram;
     experimental::Noc noc;
+    if constexpr (use_dfbs) {
+        experimental::DataflowBuffer dfb(cb_id);
+        uint32_t ublock_size_bytes = dfb.get_entry_size();
+        uint32_t tlocal_src_addr = src_addr + (producer_idx * ublock_size_bytes);
 
-    uint32_t ublock_size_bytes = dfb.get_entry_size();
-
-    uint32_t tlocal_src_addr = src_addr + (producer_idx * ublock_size_bytes);
-
-    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        dfb.read_in(noc, src_dram, {.bank_id = src_bank_id, .addr = tlocal_src_addr});
-        tlocal_src_addr += dfb.get_stride_size();
-    }
-
+        for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#ifdef ARCH_QUASAR
+            dfb.read_in(noc, src_dram, {.bank_id = src_bank_id, .addr = tlocal_src_addr});
 #else
-    // ublocks size defined in tiles
-    uint32_t ublock_size_bytes = get_tile_size(cb_id) * ublock_size_tiles;
-
-    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
-    for (uint32_t i = 0; i<num_tiles; i += ublock_size_tiles) {
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(src_bank_id, src_addr);
-
-        cb_reserve_back(cb_id, ublock_size_tiles);
-        uint32_t l1_write_addr = get_write_ptr(cb_id);
-        noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes);
-
-        noc_async_read_barrier();
-
-        cb_push_back(cb_id, ublock_size_tiles);
-        src_addr += ublock_size_bytes;
-    }
+            dfb.reserve_back(ublock_size_tiles);
+            noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
+            noc.async_read_barrier();
+            dfb.push_back(ublock_size_tiles);
 #endif
+            tlocal_src_addr += dfb.get_stride_size();
+        }
+        dfb.finish();
+    } else {
+        experimental::CircularBuffer cb(cb_id);
+        uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+
+        for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+            cb.reserve_back(ublock_size_tiles);
+            noc.async_read(src_dram, cb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = src_addr}, {});
+            noc.async_read_barrier();
+            cb.push_back(ublock_size_tiles);
+            src_addr += ublock_size_bytes;
+        }
+    }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -3,15 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
-#ifdef ARCH_QUASAR
 #include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/endpoints.h"
 #include "experimental/noc.h"
+#ifndef ARCH_QUASAR
+#include "experimental/circular_buffer.h"
 #endif
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
+    constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
     uint32_t dst_addr  = get_arg_val<uint32_t>(0); // global base address
     uint32_t dst_bank_id = get_arg_val<uint32_t>(1); // data is in one bank
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
@@ -20,43 +22,51 @@ void kernel_main() {
 
 #ifdef ARCH_QUASAR
     uint32_t consumer_idx = get_my_thread_id();
+#else
+    uint32_t consumer_idx = 0;
+#endif
 
-    experimental::DataflowBuffer dfb(cb_id);
     constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
     experimental::AllocatorBank<bank_type> dst_dram;
     experimental::Noc noc;
 
-    uint32_t ublock_size_bytes = dfb.get_entry_size();
+    if constexpr (use_dfbs) {
+        experimental::DataflowBuffer dfb(cb_id);
+        uint32_t ublock_size_bytes = dfb.get_entry_size();
 
-    uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * ublock_size_bytes);
+        uint32_t tlocal_dst_addr = dst_addr + (consumer_idx * ublock_size_bytes);
 
-    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-        dfb.write_out(noc, dst_dram, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
-        tlocal_dst_addr += dfb.get_stride_size();
-    }
-
-    dfb.finish();
-
-    // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
-    LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
-    for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {
-        noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
-    }
+        for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#ifdef ARCH_QUASAR
+            dfb.write_out(noc, dst_dram, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
 #else
-    // single-tile ublocks
-    uint32_t ublock_size_bytes = get_tile_size(cb_id);
-
-    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-         uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_addr);
-
-        cb_wait_front(cb_id, ublock_size_tiles);
-        uint32_t l1_read_addr = get_read_ptr(cb_id);
-        noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
-
-        noc_async_write_barrier();
-
-        cb_pop_front(cb_id, ublock_size_tiles);
-        dst_addr += ublock_size_bytes;
-    }
+            dfb.wait_front(ublock_size_tiles);
+            noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+            noc.async_write_barrier();
+            dfb.pop_front(ublock_size_tiles);
 #endif
+            tlocal_dst_addr += dfb.get_stride_size();
+        }
+
+        dfb.finish();
+
+#ifdef ARCH_QUASAR
+        // TODO: This will be replaced with some dfb.commit or noc.async_write_barrier call
+        LocalDFBInterface& local_dfb_interface = g_dfb_interface[cb_id];
+        for (uint32_t i = 0; i < local_dfb_interface.num_txn_ids; i++) {
+            noc.async_write_barrier<experimental::Noc::BarrierMode::TXN_ID>(local_dfb_interface.txn_ids[i]);
+        }
+#endif
+    } else {
+        experimental::CircularBuffer cb(cb_id);
+        uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+
+        for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+            cb.wait_front(ublock_size_tiles);
+            noc.async_write(cb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = dst_addr});
+            noc.async_write_barrier();
+            cb.pop_front(ublock_size_tiles);
+            dst_addr += ublock_size_bytes;
+        }
+    }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_cb_test.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_cb_test.cpp
@@ -3,11 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
-#include "experimental/circular_buffer.h"
+#include "api/debug/dprint.h"
 #include "experimental/endpoints.h"
+#include "experimental/noc.h"
+#include "experimental/dataflow_buffer.h"
+#ifndef ARCH_QUASAR
+#include "experimental/circular_buffer.h"
+#endif
 
+template <bool use_dfbs, typename SyncBuffer>
 inline __attribute__((always_inline)) void pop_from_cb_and_write(
-    experimental::CircularBuffer& cb,
+    SyncBuffer& sync_buffer,
     uint32_t num_tiles_per_cb,
     uint32_t ublock_size_tiles,
     uint32_t ublock_size_bytes,
@@ -15,18 +21,15 @@ inline __attribute__((always_inline)) void pop_from_cb_and_write(
     uint32_t& dram_buffer_dst_addr) {
     experimental::Noc noc;
     for (uint32_t i = 0; i < num_tiles_per_cb; i += ublock_size_tiles) {
-        // DRAM NOC dst address
-        std::uint64_t dram_buffer_dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dram_buffer_dst_addr);
-
-        cb.wait_front(ublock_size_tiles);
+        sync_buffer.wait_front(ublock_size_tiles);
         noc.async_write(
-            cb,
+            sync_buffer,
             experimental::AllocatorBank<experimental::AllocatorBankType::DRAM>{},
             ublock_size_bytes,
             {},
             {.bank_id = bank_id, .addr = dram_buffer_dst_addr});
         noc.async_write_barrier();
-        cb.pop_front(ublock_size_tiles);
+        sync_buffer.pop_front(ublock_size_tiles);
         dram_buffer_dst_addr += ublock_size_bytes;
     }
 }
@@ -41,17 +44,42 @@ void kernel_main() {
     constexpr uint32_t stride = get_compile_time_arg_val(2);
     constexpr uint32_t topmost_cb = get_compile_time_arg_val(3);
     constexpr uint32_t ublock_size_tiles = get_compile_time_arg_val(4);
+    constexpr bool use_dfbs = get_compile_time_arg_val(5) == 1;
+#ifdef ARCH_QUASAR
+    static_assert(use_dfbs, "DFBs must be used on Quasar");
+#endif
 
     // Process strided CBs: 0, 8, 16, ...
     for (uint32_t i = 0; i < num_cbs_stride; i++) {
         uint32_t cb_id = start_cb + i * stride;
+#ifndef ARCH_QUASAR
         experimental::CircularBuffer cb(cb_id);
-        uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
-        pop_from_cb_and_write(
-            cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+#endif
+        experimental::DataflowBuffer dfb(cb_id);
+        uint32_t ublock_size_bytes;
+        if constexpr (use_dfbs) {
+            ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+            pop_from_cb_and_write<true, experimental::DataflowBuffer>(
+                dfb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+        } else {
+            ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+            pop_from_cb_and_write<false, experimental::CircularBuffer>(
+                cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+        }
     }
     // Process topmost CB
+#ifndef ARCH_QUASAR
     experimental::CircularBuffer cb(topmost_cb);
-    uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
-    pop_from_cb_and_write(cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+#endif
+    experimental::DataflowBuffer dfb(topmost_cb);
+    uint32_t ublock_size_bytes;
+    if constexpr (use_dfbs) {
+        ublock_size_bytes = dfb.get_entry_size() * ublock_size_tiles;
+        pop_from_cb_and_write<true, experimental::DataflowBuffer>(
+            dfb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+    } else {
+        ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+        pop_from_cb_and_write<false, experimental::CircularBuffer>(
+            cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+    }
 }

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -99,7 +99,7 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
     auto src_dram_buffer = CreateBuffer(dram_config);
     auto dst_dram_buffer = CreateBuffer(dram_config);
 
-    vector<uint32_t> compute_kernel_args = {uint(num_tiles)};
+    vector<uint32_t> compute_kernel_args = {uint(num_tiles), /*use_dfbs=*/false};
 
     auto [program, reader_kernel_id, writer_kernel_id] =
         create_program(dev, single_tile_size, all_cores, compute_kernel_args);

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -82,21 +82,23 @@ static void run_pack_relu_test(IDevice* dev, uint32_t relu_config, const std::fu
         "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp",
         core,
         tt_metal::experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1, .compile_args = {l1_input_dfb}});
+            .num_threads_per_cluster = 1, .compile_args = {l1_input_dfb, /*use_dfbs=*/true}});
 
     KernelHandle writer = tt_metal::experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp",
         core,
         tt_metal::experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1, .compile_args = {l1_output_dfb}});
+            .num_threads_per_cluster = 1, .compile_args = {l1_output_dfb, /*use_dfbs=*/true}});
 
     KernelHandle compute = CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp",
         core,
         tt_metal::experimental::quasar::QuasarComputeConfig{
-            .num_threads_per_cluster = 1, .compile_args = {num_tiles}, .defines = {{"PACK_RELU", "1"}}});
+            .num_threads_per_cluster = 1,
+            .compile_args = {num_tiles, /*use_dfbs=*/true},
+            .defines = {{"PACK_RELU", "1"}}});
 
     tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(
         program, l1_input_dfb, reader, compute);

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -109,7 +109,7 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
             .noc = NOC::RISCV_0_default,
             .compile_args = writer_compile_time_args});
 
-    std::vector<uint32_t> compute_kernel_args = {num_tensor_tiles};
+    std::vector<uint32_t> compute_kernel_args = {num_tensor_tiles, /*use_dfbs=*/false};
 
     CreateKernel(
         program,

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -4,317 +4,81 @@
 
 #pragma once
 
+// Arch-specific interface includes
+#ifdef ARCH_QUASAR
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"  // For g_dfb_interface extern declaration
-#include "api/debug/assert.h"
-#include "api/debug/waypoint.h"
-
-// TODO: make this the top level api header but then separate out 1xx and 2xx implementations
 
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
-#include "experimental/noc.h"
-#else
-#include "ckernel_trisc_common.h"
-#ifdef UCK_CHLKC_PACK
-#include "llk_io_pack.h"
 #endif
-#ifdef UCK_CHLKC_UNPACK
-#include "llk_io_unpack.h"
-#endif
+#else  // tt-1xx
+#include "internal/circular_buffer_interface.h"
 #endif
 
+#ifndef COMPILE_FOR_TRISC
+#include "experimental/noc.h"
+#include "tools/profiler/noc_debugging_metadata.hpp"
+#include "tools/profiler/noc_debugging_profiler.hpp"
+#endif
+
+#include "api/debug/assert.h"
+#include "api/debug/waypoint.h"
 #include "experimental/lock.h"
 
 namespace experimental {
 
 class DataflowBuffer {
 public:
-    DataflowBuffer(uint16_t logical_dfb_id) : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
+#ifdef ARCH_QUASAR
+    using DFBInterface = LocalDFBInterface;
+#else
+    using DFBInterface = LocalCBInterface;
+#endif
+
+    DataflowBuffer(uint16_t logical_dfb_id);
 
     uint16_t get_id() const { return logical_dfb_id_; }
 
-    uint32_t get_entry_size() const { return local_dfb_interface_.entry_size; }
-
-    uint32_t get_stride_size() const { return local_dfb_interface_.stride_size; }
+    uint32_t get_entry_size() const;
+    uint32_t get_stride_size() const;
 
     // Explicit sync APIs
-    void reserve_back(uint16_t num_entries) {
-        dfb::PackedTileCounter packed_tc =
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-        ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
-        llk_wait_for_free_tiles(logical_dfb_id_, num_entries);
-        // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " acked: " <<
-        // static_cast<uint32_t>(tile_counters[tc_id].f.acked) << ENDL(); DEVICE_PRINT("reserve_back: tc_id: {} acked:
-        // {}\n", static_cast<uint32_t>(tc_id), static_cast<uint32_t>(tile_counters[tc_id].f.acked));
-#elif !defined(COMPILE_FOR_TRISC)
-        if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
-            // DM-DM BLOCKED: wait until every consumer TC has free space (throttled by slowest consumer)
-            bool ready = false;
-            while (!ready) {
-                ready = true;
-                for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                    dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                    ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
-                    // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " <<
-                    // static_cast<uint32_t>(llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc))) <<
-                    // ENDL(); DEVICE_PRINT("reserve_back: tc_id: {} free space: {}\n", tc_id,
-                    // static_cast<uint32_t>(llk_intf_get_free_space(get_tensix_id(ptc), get_counter_id(ptc))));
-                    if (llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
-                        ready = false;
-                        break;
-                    }
-                }
-            }
-        } else {
-            uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-            ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-            while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
-            // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " <<
-            // static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL(); DEVICE_PRINT("reserve_back:
-            // tc_id: {} free space: {}\n", tc_id, static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)));
-        }
-#endif
-    }
-
-    void push_back(uint16_t num_entries) {
-        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-        ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
-        llk_push_tiles(logical_dfb_id_, num_entries);
-        // DPRINT << "push_bak: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " <<
-        // static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL(); DEVICE_PRINT("push_back: tc_id: {} posted:
-        // {}\n", tc_id, static_cast<uint32_t>(tile_counters[tc_id].f.posted));
-#elif !defined(COMPILE_FOR_TRISC)
-        if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
-            // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
-            for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
-                // DPRINT << "push_back: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " <<
-                // static_cast<uint32_t>(llk_intf_get_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc))) <<
-                // ENDL(); DEVICE_PRINT("push_back: tc_id: {} posted: {}\n", tc_id,
-                // static_cast<uint32_t>(llk_intf_get_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc))));
-                llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
-            }
-            local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-            if (local_dfb_interface_.tc_slots[0].wr_ptr == local_dfb_interface_.tc_slots[0].limit) {
-                local_dfb_interface_.tc_slots[0].wr_ptr = local_dfb_interface_.tc_slots[0].base_addr;
-            }
-            // tc_idx deliberately not advanced
-        } else {
-            uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-            ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-            llk_intf_inc_posted(tensix_id, tc_id, num_entries);
-            DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id)
-                   << " tc_id: " << static_cast<uint32_t>(tc_id)
-                   << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
-                   << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
-            DEVICE_PRINT(
-                "push_back: tensix_id: {} tc_id: {} capacity: {} posted: {}\n",
-                tensix_id,
-                tc_id,
-                static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id)),
-                static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)));
-
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-            if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-                local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-            }
-
-            local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-        }
-#endif
-    }
-
-    void wait_front(uint16_t num_entries) {
-        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
-        ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
-        if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
-            return;
-        }
-        DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id)
-               << " num_entries: " << static_cast<uint32_t>(num_entries) << ENDL();
-        DEVICE_PRINT("wait_front: tc_id: {} num_entries: {}\n", tc_id, num_entries);
-        llk_wait_tiles(logical_dfb_id_, num_entries);
-#elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id)
-        //        << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
-        //        << " tc_id: " << static_cast<uint32_t>(tc_id)
-        //        << " occupancy: " << static_cast<uint32_t>(llk_intf_get_occupancy(tensix_id, tc_id)) << ENDL();
-        // DEVICE_PRINT("wait_front: tensix_id: {} capacity: {} tc_id: {} occupancy: {}\n", tensix_id,
-        // static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id)), tc_id,
-        // static_cast<uint32_t>(llk_intf_get_occupancy(tensix_id, tc_id)));
-        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
-#endif
-    }
-
-    void pop_front(uint16_t num_entries) {
-        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
-        if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
-            return;
-        }
-        ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
-        llk_pop_tiles(logical_dfb_id_, num_entries);
-#elif !defined(COMPILE_FOR_TRISC)
-        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
-        llk_intf_inc_acked(tensix_id, tc_id, num_entries);
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-        }
-        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-        // DPRINT << "pop_front: free space: " << (uint32_t)llk_intf_get_free_space(tensix_id, tc_id) << ENDL();
-        // DEVICE_PRINT("pop_front: free space: {}\n", (uint32_t)llk_intf_get_free_space(tensix_id, tc_id));
-#endif
-    }
+    void reserve_back(uint16_t num_entries) { reserve_back_impl(num_entries); }
+    void push_back(uint16_t num_entries) { push_back_impl(num_entries); }
+    void wait_front(uint16_t num_entries) { wait_front_impl(num_entries); }
+    void pop_front(uint16_t num_entries) { pop_front_impl(num_entries); }
     // Explicit sync APIs end
 
-    // Implicit sync APIs
-    // one tile at a time right now
+#ifdef ARCH_QUASAR
 #ifndef COMPILE_FOR_TRISC
+    // Implicit sync APIs
     template <typename Src>
-    void read_in(const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args) {
-        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-
-        // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW doesn't track pending posts
-        // When this condition is met, we know previous reads were committed
-        DPRINT << "read_in: tensix_id: " << static_cast<uint32_t>(tensix_id)
-               << " tc_id: " << static_cast<uint32_t>(tc_id)
-               << " posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)) << ENDL();
-        DEVICE_PRINT(
-            "read_in: tensix_id: {} tc_id: {} posted: {}\n",
-            tensix_id,
-            tc_id,
-            static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)));
-        while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-
-        // Make sure there is space for the new tile
-        while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
-
-        // DPRINT << "issuing the read on " << static_cast<uint32_t>(local_dfb_interface_.txn_ids[ptxn_id_index_]) <<
-        // ENDL();
-        // DEVICE_PRINT("issuing the read on {}\n", local_dfb_interface_.txn_ids[ptxn_id_index_]);
-
-        noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
-
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-        }
-
-        ptiles_read_++;
-       // Move to next txn id when we have read in num tiles per DM producer.
-       // This is safe because we ensure previously read entries are posted before reading in more data
-        if (ptiles_read_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
-            ptxn_id_index_ = (ptxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
-            ptxn_id_loop_cnt_++;
-        }
-
-        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-    }
+    void read_in(const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args);
 
     template <typename Dst>
-    void write_out(const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
-        dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
-        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-        uint8_t tc_id = dfb::get_counter_id(packed_tc);
-
-
-        // Wait for entries that were previously written across all transaction ids to be acked. Need to do this because HW doesn't track pending acks
-        // When this condition is met, we know previous writes were issued
-        while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
-
-        while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
-
-        // DPRINT << "issuing the write on " << static_cast<uint32_t>(local_dfb_interface_.txn_ids[ctxn_id_index_]) <<
-        // ENDL();
-        // DEVICE_PRINT("issuing the write on {}\n", local_dfb_interface_.txn_ids[ctxn_id_index_]);
-
-        noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
-
-        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
-            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
-        }
-
-        ctiles_written_++;
-        // Move to next txn id when the DM has written its threshold per transaction id.
-        // This is safe because we ensure previous writes are acked before trying to write more data
-        if (ctiles_written_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
-            ctxn_id_index_ = (ctxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
-            ctxn_id_loop_cnt_++;
-        }
-
-        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
-    }
+    void write_out(const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args);
     // Implicit sync APIs end
 #endif
-
-    void finish() {
+#else  // tt-1xx
 #ifndef COMPILE_FOR_TRISC
-        // Handle case where outstanding transactions do not meet ISR threshold
-        // Each DM updates tile counters for the tiles it read/wrote by using its local counter
-        // DPRINT << "ptiles_read: " << static_cast<uint32_t>(ptiles_read_) << " ctiles_written: " <<
-        // static_cast<uint32_t>(ctiles_written_) << ENDL();
-        // DEVICE_PRINT("ptiles_read: {} ctiles_written: {}\n", ptiles_read_, ctiles_written_);
-        if (ptiles_read_ > 0) {
-            handle_final_credits<true>(ptiles_read_, ptxn_id_index_);
-        }
-        if (ctiles_written_ > 0) {
-            handle_final_credits<false>(ctiles_written_, ctxn_id_index_);
-        }
+    bool pages_reservable_at_back(int32_t num_pages) const;
+    bool pages_available_at_front(int32_t num_pages) const;
+#ifdef DATA_FORMATS_DEFINED
+    uint32_t get_tile_size() const;
+    uint32_t get_tile_hw() const;
+    DataFormat get_dataformat() const;
 #endif
-        bool all_acked = false;
-        WAYPOINT("AAW");
-        while (!all_acked) {
-            all_acked = true;
-            for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
-                dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
-                if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
-                    continue;
-                }
-                all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
-#elif !defined(COMPILE_FOR_TRISC)
-                uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-                DPRINT << "read acked: " << static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id))
-                       << " read posted: " << static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id))
-                       << ENDL();
-                DEVICE_PRINT(
-                    "read acked: {} read posted: {}\n",
-                    static_cast<uint32_t>(fast_llk_intf_read_acked(tensix_id, tc_id)),
-                    static_cast<uint32_t>(fast_llk_intf_read_posted(tensix_id, tc_id)));
-                all_acked &=
-                    (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
+#else  // trisc
+    uint32_t get_tile_address(uint32_t tile_index);
+    uint32_t read_tile_value(uint32_t tile_index, uint32_t element_offset);
 #endif
-            }
-        }
-        WAYPOINT("AAD");
-    }
+#endif
 
-    uint32_t get_write_ptr() const {
-        // return byte address (wr_ptr is 16B address on Gen1XX)
-        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
-    }
+    void finish() { finish_impl(); }
 
-    uint32_t get_read_ptr() const {
-        // return byte address (rd_ptr is 16B address on Gen1XX)
-        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
-    }
+    uint32_t get_write_ptr() const { return get_write_ptr_impl(); }
+    uint32_t get_read_ptr()  const { return get_read_ptr_impl(); }
 
     [[nodiscard]] auto scoped_lock() {
         // TODO: Register with the debugger to track the lock
@@ -322,130 +86,36 @@ public:
     }
 
 private:
-    // Handle case when final transactions issued by DMs do not meet ISR threshold by manually posting/acking credits.
-    // Each DM independently enters finish() so this needs to ensure all DMs have completed their final transactions
-    // to avoid manually posting/acking credits that would be handled by the ISR.
+    void reserve_back_impl(uint16_t num_entries);
+    void push_back_impl(uint16_t num_entries);
+    void wait_front_impl(uint16_t num_entries);
+    void pop_front_impl(uint16_t num_entries);
+    void finish_impl();
+    uint32_t get_write_ptr_impl() const;
+    uint32_t get_read_ptr_impl()  const;
+
+#ifdef ARCH_QUASAR
     template <bool is_producer>
-    void handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index) {
-#ifndef COMPILE_FOR_TRISC
-        // Determine the txn_id for the last batch. If transactions_issued lands exactly on
-        // a boundary, txn_id_index has already wrapped past it, so step back one slot.
-        uint8_t tail_txn_idx =
-            (transactions_issued % local_dfb_interface_.num_entries_per_txn_id == 0)
-                ? static_cast<uint8_t>(
-                      (txn_id_index + local_dfb_interface_.num_txn_ids - 1) % local_dfb_interface_.num_txn_ids)
-                : txn_id_index;
-        uint8_t tail_txn_id = local_dfb_interface_.txn_ids[tail_txn_idx];
-
-        uint8_t N = local_dfb_interface_.num_tcs_to_rr;
-        dfb::PackedTileCounter ptc0 = local_dfb_interface_.tc_slots[0].packed_tile_counter;
-        uint16_t expected_slot0 = transactions_issued / N + (0u < (transactions_issued % N) ? 1u : 0u);
-
-        auto read_actual_slot0 = [&]() -> uint16_t {
-            if constexpr (is_producer) {
-                return static_cast<uint16_t>(
-                    fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
-            } else {
-                return static_cast<uint16_t>(
-                    fast_llk_intf_read_acked(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
-            }
-        };
-
-        uint64_t threshold;
-        if constexpr (is_producer) {
-            threshold = GET_TILES_TO_PROCESS_THRES_TR_ACK(tail_txn_id);
-        } else {
-            threshold = GET_TILES_TO_PROCESS_THRES_WR_SENT(tail_txn_id);
-        }
-
-        // Wait until this DM's tail reads have completed.
-        // A transaction passes through three observable states:
-        //   not dispatched → tack == 0, tiles == 0
-        //   in-flight      → tack >  0
-        //   completed      → tack == 0, tiles >  0   ← break here
-        // Also exits early if the ISR fires (collective batch done).
-        WAYPOINT("WTP1");
-        while (read_actual_slot0() < expected_slot0) {
-            uint64_t tack, tiles;
-            if constexpr (is_producer) {
-                tack = CMDBUF_TR_ACK_TRID(OVERLAY_RD_CMD_BUF, tail_txn_id);
-                tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
-            } else {
-                tack = CMDBUF_WR_SENT_TRID(OVERLAY_WR_CMD_BUF, tail_txn_id);
-                tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
-            }
-            if (tack == 0 && tiles > 0) {
-                break;
-            }
-        }
-
-        // Transactions are completed. Spin giving the ISR a chance to fire
-        // Break when tiles < threshold which is a genuine partial tail the ISR can never handle.
-        WAYPOINT("WTP2");
-        while (read_actual_slot0() < expected_slot0) {
-            uint64_t tiles;
-            if constexpr (is_producer) {
-                tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
-            } else {
-                tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
-            }
-            if (tiles > 0 && tiles < threshold) {
-                break;
-            }
-        }
-
-        // Manually post missing credits if ISR did not fire.
-        uint16_t actual_slot0 = read_actual_slot0();
-        // DPRINT << "actual_slot0: " << static_cast<uint32_t>(actual_slot0)
-        //        << " expected_slot0: " << static_cast<uint32_t>(expected_slot0) << ENDL();
-        // DEVICE_PRINT("actual_slot0: {} expected_slot0: {}\n", actual_slot0, expected_slot0);
-
-        if (actual_slot0 < expected_slot0) {
-            for (uint8_t i = 0; i < N; i++) {
-                dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
-                uint8_t tensix_id = dfb::get_tensix_id(ptc);
-                uint8_t tc_id = dfb::get_counter_id(ptc);
-                uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
-                if constexpr (is_producer) {
-                    uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_posted(tensix_id, tc_id));
-                    if (actual < expected) {
-                        // DPRINT << "inc_posted tc(" << static_cast<uint32_t>(tensix_id) << "," <<
-                        // static_cast<uint32_t>(tc_id)
-                        //        << ") delta: " << static_cast<uint32_t>(expected - actual) << ENDL();
-                        // DEVICE_PRINT("inc_posted tc({}, {}) delta: {}\n", tensix_id, tc_id, expected - actual);
-                        fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
-                    }
-                } else {
-                    uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_acked(tensix_id, tc_id));
-                    if (actual < expected) {
-                        // DPRINT << "inc_acked tc(" << static_cast<uint32_t>(tensix_id) << "," <<
-                        // static_cast<uint32_t>(tc_id)
-                        //        << ") delta: " << static_cast<uint32_t>(expected - actual) << ENDL();
-                        // DEVICE_PRINT("inc_acked tc({}, {}) delta: {}\n", tensix_id, tc_id, expected - actual);
-                        fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
-                    }
-                }
-            }
-        }
+    void handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index);
 #endif
-    }
 
     void release_scoped_lock() {
         // TODO: Unregister with the debugger
     }
 
-    LocalDFBInterface& local_dfb_interface_;
-
+    DFBInterface& local_dfb_interface_;
     uint16_t logical_dfb_id_;
 
+#ifdef ARCH_QUASAR
     // Metadata for implicit sync
     uint16_t ptxn_id_loop_cnt_ = 0;
     uint8_t ptxn_id_index_ = 0;
-    uint16_t ptiles_read_ = 0; // isn't the same as reading the tile counter because we don't have a way of tracking pending posts from HW
+    uint16_t ptiles_read_ = 0;  // not the same as tile counter: HW has no way to track pending posts
 
     uint16_t ctxn_id_loop_cnt_ = 0;
     uint8_t ctxn_id_index_ = 0;
-    uint16_t ctiles_written_ = 0; // isn't the same as reading the tile counter because we don't have a way of tracking pending acks from HW
+    uint16_t ctiles_written_ = 0;  // not the same as tile counter: HW has no way to track pending acks
+#endif
 };
 
 #ifndef COMPILE_FOR_TRISC
@@ -476,13 +146,13 @@ struct noc_traits_t<DataflowBuffer> {
     static auto dst_addr(const DataflowBuffer& dst, const Noc& noc, const dst_args_type& args) {
         static_assert(
             address_type == Noc::AddressType::LOCAL_L1,
-            "DataflowBuffer without mcast range can only be used as L1 source");
+            "DataflowBuffer without mcast range can only be used as L1 destination");
         return dst.get_write_ptr() + args.offset_bytes;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr_mcast(const DataflowBuffer& dst, const Noc& noc, const dst_args_mcast_type& args) {
         static_assert(
-            address_type == Noc::AddressType::NOC, "DataflowBuffer with mcast range cannot be used as L1 source");
+            address_type == Noc::AddressType::NOC, "DataflowBuffer with mcast range cannot be used as L1 destination");
         auto local_addr = dst.get_write_ptr() + args.offset_bytes;
         return ::get_noc_multicast_addr(
             args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, local_addr, noc.get_noc_id());
@@ -492,3 +162,10 @@ struct noc_traits_t<DataflowBuffer> {
 #endif
 
 }  // namespace experimental
+
+// Arch-specific _impl bodies for DataflowBuffer member functions
+#ifdef ARCH_QUASAR
+#include "internal/tt-2xx/dataflow_buffer.inl"
+#else
+#include "internal/tt-1xx/dataflow_buffer.inl"
+#endif

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Defines the _impl bodies for DataflowBuffer on tt-1xx architectures
+
+#ifndef ARCH_QUASAR
+
+#include "stream_io_map.h"
+#ifdef COMPILE_FOR_TRISC
+#include "api/compute/common_globals.h"  // defines PACK/UNPACK/MATH macros
+#include "internal/circular_buffer_interface.h"
+#ifdef TRISC_PACK
+#include "llk_io_pack.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "llk_io_unpack.h"
+#endif
+#endif  // COMPILE_FOR_TRISC
+
+namespace experimental {
+
+inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
+    : local_dfb_interface_(get_local_cb_interface(logical_dfb_id)), logical_dfb_id_(logical_dfb_id) {}
+
+inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.fifo_page_size; }
+
+inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.fifo_page_size; }
+
+inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
+#ifdef COMPILE_FOR_TRISC
+    PACK((llk_wait_for_free_tiles<false, false, false>(logical_dfb_id_, num_entries)));
+#else
+    cb_reserve_back(logical_dfb_id_, num_entries);
+#endif
+}
+
+inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
+#ifdef COMPILE_FOR_TRISC
+    PACK((llk_push_tiles<false, false>(logical_dfb_id_, num_entries)));
+#else
+    cb_push_back(logical_dfb_id_, num_entries);
+#endif
+}
+
+inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
+#ifdef COMPILE_FOR_TRISC
+    UNPACK((llk_wait_tiles(logical_dfb_id_, num_entries)));
+#else
+    cb_wait_front(logical_dfb_id_, num_entries);
+#endif
+}
+
+inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
+#ifdef COMPILE_FOR_TRISC
+    UNPACK((llk_pop_tiles(logical_dfb_id_, num_entries)));
+#else
+    cb_pop_front(logical_dfb_id_, num_entries);
+#endif
+}
+
+#ifdef COMPILE_FOR_TRISC
+inline uint32_t DataflowBuffer::get_tile_address(uint32_t tile_index) {
+    uint32_t address = 0;
+
+    UNPACK({
+        uint32_t base_address = local_dfb_interface_.fifo_rd_ptr;
+        uint32_t offset_address = local_dfb_interface_.fifo_page_size * tile_index;
+        address = (base_address + offset_address) << 4;  // Convert to byte address
+
+        mailbox_write(ckernel::ThreadId::MathThreadId, address);
+        mailbox_write(ckernel::ThreadId::PackThreadId, address);
+    })
+
+    MATH(address = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    PACK(address = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+
+    return address;
+}
+
+inline uint32_t DataflowBuffer::read_tile_value(uint32_t tile_index, uint32_t element_offset) {
+    uint32_t value = 0;
+
+    UNPACK({
+        uint32_t base_address = local_dfb_interface_.fifo_rd_ptr;
+        uint32_t offset_address = local_dfb_interface_.fifo_page_size * tile_index;
+        uint32_t byte_address = (base_address + offset_address) << 4;  // Convert to byte address
+
+        value = reinterpret_cast<volatile uint32_t*>(byte_address)[element_offset];
+
+        mailbox_write(ckernel::ThreadId::MathThreadId, value);
+        mailbox_write(ckernel::ThreadId::PackThreadId, value);
+    })
+
+    MATH(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    PACK(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+
+    return value;
+}
+#else
+#ifdef DATA_FORMATS_DEFINED
+inline uint32_t DataflowBuffer::get_tile_size() const { return ::get_tile_size(logical_dfb_id_); }
+inline uint32_t DataflowBuffer::get_tile_hw() const { return ::get_tile_hw(logical_dfb_id_); }
+inline DataFormat DataflowBuffer::get_dataformat() const { return ::get_dataformat(logical_dfb_id_); }
+#endif
+
+inline bool DataflowBuffer::pages_reservable_at_back(int32_t num_pages) const { return cb_pages_reservable_at_back(logical_dfb_id_, num_pages); }
+
+inline bool DataflowBuffer::pages_available_at_front(int32_t num_pages) const { return cb_pages_available_at_front(logical_dfb_id_, num_pages); }
+
+#endif
+
+inline void DataflowBuffer::finish_impl() {}
+
+inline uint32_t DataflowBuffer::get_write_ptr_impl() const { return local_dfb_interface_.fifo_wr_ptr; }
+
+inline uint32_t DataflowBuffer::get_read_ptr_impl() const { return local_dfb_interface_.fifo_rd_ptr; }
+
+}  // namespace experimental
+
+#endif  // !ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Defines the _impl bodies for DataflowBuffer on tt-2xx architectures
+
+#ifdef ARCH_QUASAR
+
+#if defined(COMPILE_FOR_TRISC)
+#include "ckernel_trisc_common.h"
+#ifdef UCK_CHLKC_PACK
+#include "llk_io_pack.h"
+#endif
+#ifdef UCK_CHLKC_UNPACK
+#include "llk_io_unpack.h"
+#endif
+#endif
+
+namespace experimental {
+
+inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
+    : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
+
+inline uint32_t DataflowBuffer::get_entry_size() const { return local_dfb_interface_.entry_size; }
+
+inline uint32_t DataflowBuffer::get_stride_size() const { return local_dfb_interface_.stride_size; }
+
+inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
+    dfb::PackedTileCounter packed_tc =
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+    ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
+    llk_wait_for_free_tiles(logical_dfb_id_, num_entries);
+#elif !defined(COMPILE_FOR_TRISC)
+    if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
+        // DM-DM BLOCKED: wait until every consumer TC has free space (throttled by slowest consumer)
+        bool ready = false;
+        while (!ready) {
+            ready = true;
+            for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+                dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+                ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
+                if (llk_intf_get_free_space(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) < num_entries) {
+                    ready = false;
+                    break;
+                }
+            }
+        }
+    } else {
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+        while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
+    }
+#endif
+}
+
+inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+    ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
+    llk_push_tiles(logical_dfb_id_, num_entries);
+#elif !defined(COMPILE_FOR_TRISC)
+    if (__builtin_expect(local_dfb_interface_.broadcast_tc, 0)) {
+        // DM-DM BLOCKED: post to all N TCs; wr_ptr tracked on slot 0
+        for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+            dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+            ASSERT(llk_intf_get_capacity(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc)) >= num_entries);
+            llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
+        }
+        local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[0].wr_ptr == local_dfb_interface_.tc_slots[0].limit) {
+            local_dfb_interface_.tc_slots[0].wr_ptr = local_dfb_interface_.tc_slots[0].base_addr;
+        }
+        // tc_idx deliberately not advanced
+    } else {
+        uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+        ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+        llk_intf_inc_posted(tensix_id, tc_id, num_entries);
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+        }
+
+        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+    }
+#endif
+}
+
+inline void DataflowBuffer::wait_front_impl(uint16_t num_entries) {
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+    ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
+    if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+        return;
+    }
+    llk_wait_tiles(logical_dfb_id_, num_entries);
+#elif !defined(COMPILE_FOR_TRISC)
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+    while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
+#endif
+}
+
+inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+    if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+        return;
+    }
+    ASSERT(ckernel::trisc::tile_counters[tc_id].f.buf_capacity >= num_entries);
+    llk_pop_tiles(logical_dfb_id_, num_entries);
+#elif !defined(COMPILE_FOR_TRISC)
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
+    llk_intf_inc_acked(tensix_id, tc_id, num_entries);
+    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+    }
+    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+#endif
+}
+
+inline void DataflowBuffer::finish_impl() {
+#ifndef COMPILE_FOR_TRISC
+    if (ptiles_read_ > 0) {
+        handle_final_credits<true>(ptiles_read_, ptxn_id_index_);
+    }
+    if (ctiles_written_ > 0) {
+        handle_final_credits<false>(ctiles_written_, ctxn_id_index_);
+    }
+#endif
+    bool all_acked = false;
+    WAYPOINT("AAW");
+    while (!all_acked) {
+        all_acked = true;
+        for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+            dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+            uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+            if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
+                continue;
+            }
+            all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
+#elif !defined(COMPILE_FOR_TRISC)
+            uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+            all_acked &=
+                (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
+#endif
+        }
+    }
+    WAYPOINT("AAD");
+}
+
+inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
+    // return byte address (wr_ptr is 16B address on Gen1XX)
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
+}
+
+inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
+    // return byte address (rd_ptr is 16B address on Gen1XX)
+    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
+}
+
+#ifndef COMPILE_FOR_TRISC
+
+template <typename Src>
+inline void DataflowBuffer::read_in(
+    const Noc& noc, const Src& src, const typename noc_traits_t<Src>::src_args_type& src_args) {
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+
+    // Wait for entries that were previously read across all transaction ids to be posted. Need to do this because HW
+    // doesn't track pending posts. When this condition is met, we know previous reads were committed.
+    while (fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+
+    // Make sure there is space for the new tile
+    while (fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
+
+    noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
+
+    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (local_dfb_interface_.stride_size);
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+    }
+
+    ptiles_read_++;
+    // Move to next txn id when we have read in num tiles per DM producer.
+    // This is safe because we ensure previously read entries are posted before reading in more data
+    if (ptiles_read_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+        ptxn_id_index_ = (ptxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+        ptxn_id_loop_cnt_++;
+    }
+
+    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+}
+
+template <typename Dst>
+inline void DataflowBuffer::write_out(
+    const Noc& noc, const Dst& dst, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
+    dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    uint8_t tc_id = dfb::get_counter_id(packed_tc);
+
+    // Wait for entries that were previously written across all transaction ids to be acked. Need to do this because HW
+    // doesn't track pending acks. When this condition is met, we know previous writes were issued.
+    while (fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+
+    while (fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
+
+    noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
+
+    local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+    }
+
+    ctiles_written_++;
+    // Move to next txn id when the DM has written its threshold per transaction id.
+    // This is safe because we ensure previous writes are acked before trying to write more data
+    if (ctiles_written_ % local_dfb_interface_.num_entries_per_txn_id == 0) {
+        ctxn_id_index_ = (ctxn_id_index_ + 1) % local_dfb_interface_.num_txn_ids;
+        ctxn_id_loop_cnt_++;
+    }
+
+    local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+}
+
+template <bool is_producer>
+inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index) {
+    // Determine the txn_id for the last batch. If transactions_issued lands exactly on
+    // a boundary, txn_id_index has already wrapped past it, so step back one slot.
+    uint8_t tail_txn_idx = (transactions_issued % local_dfb_interface_.num_entries_per_txn_id == 0)
+                                ? static_cast<uint8_t>((txn_id_index + local_dfb_interface_.num_txn_ids - 1) % local_dfb_interface_.num_txn_ids)
+                                : txn_id_index;
+    uint8_t tail_txn_id = local_dfb_interface_.txn_ids[tail_txn_idx];
+
+    uint8_t N = local_dfb_interface_.num_tcs_to_rr;
+    dfb::PackedTileCounter ptc0 = local_dfb_interface_.tc_slots[0].packed_tile_counter;
+    uint16_t expected_slot0 = transactions_issued / N + (0u < (transactions_issued % N) ? 1u : 0u);
+
+    auto read_actual_slot0 = [&]() -> uint16_t {
+        if constexpr (is_producer) {
+            return static_cast<uint16_t>(
+                fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+        } else {
+            return static_cast<uint16_t>(
+                fast_llk_intf_read_acked(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+        }
+    };
+
+    uint64_t threshold;
+    if constexpr (is_producer) {
+        threshold = GET_TILES_TO_PROCESS_THRES_TR_ACK(tail_txn_id);
+    } else {
+        threshold = GET_TILES_TO_PROCESS_THRES_WR_SENT(tail_txn_id);
+    }
+
+    // Wait until this DM's tail reads have completed.
+    // A transaction passes through three observable states:
+    //   not dispatched → tack == 0, tiles == 0
+    //   in-flight      → tack >  0
+    //   completed      → tack == 0, tiles >  0   ← break here
+    // Also exits early if the ISR fires (collective batch done).
+    WAYPOINT("WTP1");
+    while (read_actual_slot0() < expected_slot0) {
+        uint64_t tack, tiles;
+        if constexpr (is_producer) {
+            tack  = CMDBUF_TR_ACK_TRID(OVERLAY_RD_CMD_BUF, tail_txn_id);
+            tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+        } else {
+            tack  = CMDBUF_WR_SENT_TRID(OVERLAY_WR_CMD_BUF, tail_txn_id);
+            tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
+        }
+        if (tack == 0 && tiles > 0) break;
+    }
+
+    // Transactions are completed. Spin giving the ISR a chance to fire.
+    // Break when tiles < threshold which is a genuine partial tail the ISR can never handle.
+    WAYPOINT("WTP2");
+    while (read_actual_slot0() < expected_slot0) {
+        uint64_t tiles;
+        if constexpr (is_producer) {
+            tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+        } else {
+            tiles = CMDBUF_READ_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, tail_txn_id);
+        }
+        if (tiles > 0 && tiles < threshold) break;
+    }
+
+    // Manually post missing credits if ISR did not fire.
+    uint16_t actual_slot0 = read_actual_slot0();
+    if (actual_slot0 < expected_slot0) {
+        for (uint8_t i = 0; i < N; i++) {
+            dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
+            uint8_t tensix_id = dfb::get_tensix_id(ptc);
+            uint8_t tc_id     = dfb::get_counter_id(ptc);
+            uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
+            if constexpr (is_producer) {
+                uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_posted(tensix_id, tc_id));
+                if (actual < expected) {
+                    fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
+                }
+            } else {
+                uint16_t actual = static_cast<uint16_t>(fast_llk_intf_read_acked(tensix_id, tc_id));
+                if (actual < expected) {
+                    fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
+                }
+            }
+        }
+    }
+}
+
+#endif  // !COMPILE_FOR_TRISC
+
+}  // namespace experimental
+
+#endif  // ARCH_QUASAR

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -182,6 +182,8 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-1xx/blackhole/tdma_xmov.h
     inc/internal/tt-1xx/blackhole/tensix.h
     inc/internal/tt-1xx/blackhole/tensix_types.h
+    inc/internal/tt-1xx/dataflow_buffer.inl
+    inc/internal/tt-2xx/dataflow_buffer.inl
     inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
     inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
     inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 
+#include "impl/context/metal_context.hpp"
 #include "jit_build/jit_build_options.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
@@ -42,6 +43,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     TT_FATAL(producer_kernel != nullptr, "Producer kernel not found");
     TT_FATAL(consumer_kernel != nullptr, "Consumer kernel not found");
 
+    // --- producer ---
     if (auto compute_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(producer_kernel)) {
         TT_FATAL(
             dfb->config.num_producers >= 1 && dfb->config.num_producers <= 4,
@@ -58,10 +60,18 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
         for (DataMovementProcessor dm : producer_dm_riscvs) {
             dfb->config.producer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
         }
+    } else if (auto gen1_dm_producer = std::dynamic_pointer_cast<DataMovementKernel>(producer_kernel)) {
+        // WH/BH DataMovementKernel: RISCV_0 = BRISC (bit 0), RISCV_1 = NCRISC (bit 1)
+        const DataMovementConfig dm_config = std::get<DataMovementConfig>(gen1_dm_producer->config());
+        dfb->config.producer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm_config.processor));
+    } else if (std::dynamic_pointer_cast<ComputeKernel>(producer_kernel)) {
+        // WH/BH ComputeKernel: bit 2 = Tensix
+        dfb->config.producer_risc_mask |= (1u << 2);
     } else {
-        TT_FATAL(false, "Unsupported kernel type");
+        TT_FATAL(false, "Unsupported kernel type for DFB producer");
     }
 
+    // --- consumer ---
     if (auto compute_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(consumer_kernel)) {
         TT_FATAL(
             dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 4,
@@ -78,10 +88,16 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
         for (DataMovementProcessor dm : consumer_dm_riscvs) {
             dfb->config.consumer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
         }
+    } else if (auto gen1_dm_consumer = std::dynamic_pointer_cast<DataMovementKernel>(consumer_kernel)) {
+        // WH/BH DataMovementKernel: RISCV_0 = BRISC (bit 0), RISCV_1 = NCRISC (bit 1)
+        const DataMovementConfig dm_config = std::get<DataMovementConfig>(gen1_dm_consumer->config());
+        dfb->config.consumer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm_config.processor));
+    } else if (std::dynamic_pointer_cast<ComputeKernel>(consumer_kernel)) {
+        // WH/BH ComputeKernel: bit 2 = Tensix
+        dfb->config.consumer_risc_mask |= (1u << 2);
     } else {
-        TT_FATAL(false, "Unsupported kernel type");
+        TT_FATAL(false, "Unsupported kernel type for DFB consumer");
     }
-
 }
 
 namespace detail {
@@ -275,7 +291,11 @@ struct TileCounterGroup {
 };
 
 uint32_t DataflowBufferImpl::serialized_size() const {
-    // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc.
+    // On WH/BH: one 4-word CB-format config entry per DFB (identical to a circular buffer config)
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return 4 * sizeof(uint32_t);
+    }
+    // On Quasar: one dfb_initializer_t + one dfb_initializer_per_risc_t per risc.
     // All groups have the same number of RISC configs
     TT_FATAL(!groups.empty(), "DFB {} has no groups (configs not finalized?)", id);
     return sizeof(dfb_initializer_t) +
@@ -284,6 +304,28 @@ uint32_t DataflowBufferImpl::serialized_size() const {
 
 std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
     TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
+
+    // On WH/BH: emit the same 4-word format used for circular buffers so the existing
+    // setup_local_cb_read_write_interfaces firmware path can initialise the DFB slot.
+    // Layout: [base_addr, total_size_bytes, num_pages, page_size_bytes]
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        auto it = this->core_lookup_.find(core);
+        TT_FATAL(
+            it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
+        const uint32_t alloc_addr = it->second.second;
+
+        std::vector<uint8_t> data;
+        data.reserve(4 * sizeof(uint32_t));
+        const uint32_t words[4] = {
+            alloc_addr,                                     // fifo_addr (base)
+            this->config.entry_size * this->config.num_entries,  // fifo_size
+            this->config.num_entries,                       // fifo_num_pages
+            this->config.entry_size,                        // fifo_page_size
+        };
+        const auto* bytes = reinterpret_cast<const uint8_t*>(words);
+        data.insert(data.end(), bytes, bytes + sizeof(words));
+        return data;
+    }
 
     auto it = this->core_lookup_.find(core);
     TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
@@ -469,29 +511,19 @@ uint32_t finalize_dfbs(
         auto kernel_config = kg->launch_msg.view().kernel_config();
         kernel_config.local_cb_offset() = base_offset;
 
-        // Calculate total DFB size for this kernel group
         uint32_t kg_dfb_size = 0;
         for (const auto& dfb : dataflow_buffers) {
             TT_ASSERT(dfb->configs_finalized, "DFB {} configs not finalized before serialization", dfb->id);
-            // Check if this DFB overlaps with any core in the kernel group
-            bool dfb_on_kg = false;
             for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
                 if (dfb->core_ranges.intersects(kg_range)) {
-                    dfb_on_kg = true;
+                    kg_dfb_size += dfb->serialized_size();
                     break;
                 }
             }
-            if (dfb_on_kg) {
-                kg_dfb_size += dfb->serialized_size();
-            }
         }
 
-        // Track max across all kernel groups
         dfb_size = std::max(dfb_size, kg_dfb_size);
     }
-
-    dfb_size = tt::align(
-        dfb_size, 64);  // workaround where non-64 byte aligned writes on sim seem to get zero padded to 64 bytes
 
     log_info(
         tt::LogMetal,
@@ -530,6 +562,17 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     auto dfb = std::make_shared<DataflowBufferImpl>();
 
     dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
+
+    // DFB IDs are auto-assigned contiguously from 0, so enforce the limit here.
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        uint32_t max_dfb_id = MetalContext::instance().hal().get_arch_num_circular_buffers();
+        TT_FATAL(
+            dfb->id < max_dfb_id,
+            "Cannot create DFB {}: WH/BH supports at most {} dataflow buffers",
+            dfb->id,
+            max_dfb_id);
+    }
+
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
 
@@ -599,6 +642,31 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 // Allocates TCs and remapper indices, per (dfb, core).
 void ProgramImpl::finalize_dataflow_buffer_configs() {
     if (this->dataflow_buffers_.empty()) {
+        return;
+    }
+
+    // On WH/BH there are no tile counters or remapper hardware.
+    // Mark configs finalized and create a single dummy group per DFB so allocate_dataflow_buffers() can fill in the L1
+    // address.
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        for (auto& dfb : this->dataflow_buffers_) {
+            if (dfb->configs_finalized) {
+                continue;
+            }
+            dfb->risc_mask = dfb->config.producer_risc_mask | dfb->config.consumer_risc_mask;
+
+            DfbGroup group;
+            for (const CoreRange& cr : dfb->core_ranges.ranges()) {
+                for (auto x = cr.start_coord.x; x <= cr.end_coord.x; x++) {
+                    for (auto y = cr.start_coord.y; y <= cr.end_coord.y; y++) {
+                        group.l1_by_core.emplace_back(CoreCoord(x, y), 0u);
+                    }
+                }
+            }
+            group.core_ranges = dfb->core_ranges;
+            dfb->groups.push_back(std::move(group));
+            dfb->configs_finalized = true;
+        }
         return;
     }
 
@@ -1205,6 +1273,59 @@ std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBuf
         }
     }
     return dfbs_on_core;
+}
+
+std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
+    std::vector<CoreRange> core_ranges;
+    for (const auto& dfb : dataflow_buffers_) {
+        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+            if (std::find(core_ranges.begin(), core_ranges.end(), core_range) == core_ranges.end()) {
+                core_ranges.push_back(core_range);
+            }
+        }
+    }
+
+    // Fast path: if no ranges overlap, return as-is.
+    bool has_overlap = false;
+    for (size_t i = 0; i < core_ranges.size() && !has_overlap; ++i) {
+        for (size_t j = i + 1; j < core_ranges.size(); ++j) {
+            if (core_ranges[i].intersects(core_ranges[j])) {
+                has_overlap = true;
+                break;
+            }
+        }
+    }
+    if (!has_overlap) {
+        return core_ranges;
+    }
+
+    // Make ranges non-overlapping so each core is targeted by exactly one multicast
+    // during DFB config dispatch.  Same A\B / A∩B / B\A splitting as CBs.
+    std::vector<CoreRange> result = std::move(core_ranges);
+    size_t i = 0;
+    while (i < result.size()) {
+        size_t j = i + 1;
+        for (; j < result.size(); ++j) {
+            if (result[i].intersects(result[j])) {
+                break;
+            }
+        }
+        if (j == result.size()) {
+            ++i;
+            continue;
+        }
+        CoreRangeSet a_set(result[i]), b_set(result[j]);
+        result.erase(result.begin() + j);
+        result.erase(result.begin() + i);
+        auto a_only = a_set.subtract(b_set);
+        auto b_only = b_set.subtract(a_set);
+        auto common = a_set.intersection(b_set);
+        result.insert(result.end(), a_only.ranges().begin(), a_only.ranges().end());
+        result.insert(result.end(), b_only.ranges().begin(), b_only.ranges().end());
+        result.insert(result.end(), common.ranges().begin(), common.ranges().end());
+        i = 0;
+    }
+    return result;
 }
 
 void ProgramImpl::set_dfb_data_fmt(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -11,6 +11,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <tt_stl/assert.hpp>
+
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
@@ -78,6 +80,13 @@ struct DataflowBufferImpl {
     uint32_t total_size() const { return config.entry_size * config.num_entries; }
     uint32_t serialized_size() const;
     std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;
+
+    // Returns the L1 data-buffer base address, which is identical for every core in the
+    // DFB's core range (guaranteed by finalize_dataflow_buffer_configs).
+    uint32_t uniform_alloc_addr() const {
+        TT_ASSERT(!core_lookup_.empty(), "DFB {} needs to be finalized before accessing the allocated address", id);
+        return core_lookup_.begin()->second.second;
+    }
 };
 
 class TileCounterAllocator {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -59,6 +59,7 @@
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
+#include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/types/core_coordinates.hpp>
@@ -330,6 +331,26 @@ uint32_t finalize_cbs(
     return tt::align(base_offset + total_cb_size, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 }
 
+void finalize_dfb_masks(
+    std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
+    const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& dataflow_buffers) {
+    for (auto& kg : kernel_groups) {
+        auto kernel_config = kg->launch_msg.view().kernel_config();
+        uint64_t kg_dfb_mask = 0;
+        for (const auto& dfb : dataflow_buffers) {
+            for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
+                if (dfb->core_ranges.intersects(kg_range)) {
+                    kg_dfb_mask |= (uint64_t(1) << dfb->id);
+                    break;
+                }
+            }
+        }
+        if (kg_dfb_mask != 0) {
+            kernel_config.local_cb_mask() = kg_dfb_mask;
+        }
+    }
+}
+
 uint32_t finalize_kernel_bins(
     IDevice* device,
     uint32_t programmable_core_type_index,
@@ -583,6 +604,8 @@ struct Transfer {
     // Keep track of what CBs contributed to this transfer, so we can update the data in
     // update_program_dispatch_commands.
     std::vector<std::shared_ptr<CircularBufferImpl>> cbs;
+    // Keep track of what DFBs contributed to this transfer for the same purpose.
+    std::vector<std::shared_ptr<experimental::dfb::detail::DataflowBufferImpl>> dfbs;
     // RTAs must be updated from data every time update_program_dispatch_commmands is called.
     RuntimeArgsData* rta_data = nullptr;
     size_t end() const { return start + data.size(); }
@@ -1103,6 +1126,90 @@ private:
     std::vector<std::vector<uint32_t>> cb_config_payloads;
 };
 
+class DataflowBufferCommandGenerator {
+public:
+    void construct_commands(
+        IDevice* device, const CommandConstants& constants, ProgramImpl& program, BatchedTransfers& batched_transfers) {
+        const auto& dataflow_buffers = program.dataflow_buffers();
+        if (dataflow_buffers.empty()) {
+            return;
+        }
+
+        const auto& hal = MetalContext::instance().hal();
+        uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+
+        const auto unique_coreranges = program.dataflow_buffers_unique_coreranges();
+        const uint32_t num_sub_cmds = unique_coreranges.size();
+
+        dfb_config_payloads = std::vector<std::vector<uint8_t>>(
+            num_sub_cmds, std::vector<uint8_t>(program.get_program_config(index).dfb_size, 0));
+
+        if (num_sub_cmds == 0) {
+            return;
+        }
+
+        uint32_t i = 0;
+        for (const CoreRange& core_range : unique_coreranges) {
+            const CoreCoord& virtual_start =
+                device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
+            const CoreCoord& virtual_end =
+                device->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
+
+            auto& payload = dfb_config_payloads[i];
+            const auto& dfbs_on_corerange = program.dataflow_buffers_on_corerange(core_range);
+
+            // core_lookup_ is keyed by logical coordinates, so pass a logical representative.
+            // All cores in a DFB's range have the same alloc_addr, so any core works.
+            const CoreCoord logical_representative = core_range.start_coord;
+
+            size_t max_byte_end = 0;
+            size_t sequential_byte_offset = 0;
+            for (const auto& dfb : dfbs_on_corerange) {
+                size_t dfb_byte_offset = 0;
+                if (!hal.has_tile_counter_registers()) {
+                    // WH/BH: DFBs reuse the CB slot format; slot N starts at N * 4 words.
+                    dfb_byte_offset =
+                        static_cast<size_t>(dfb->id) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+                } else {
+                    // Quasar: DFBs are laid out sequentially in the dfb config region.
+                    dfb_byte_offset = sequential_byte_offset;
+                    sequential_byte_offset += dfb->serialized_size();
+                }
+
+                auto serialized = dfb->serialize_for_core(logical_representative);
+                TT_ASSERT(serialized.size() == dfb->serialized_size());
+                TT_ASSERT(dfb_byte_offset + serialized.size() <= payload.size());
+                std::copy(serialized.begin(), serialized.end(), payload.begin() + dfb_byte_offset);
+                max_byte_end = std::max(max_byte_end, dfb_byte_offset + serialized.size());
+            }
+
+            CoreRange virtual_range(virtual_start, virtual_end);
+            auto noc_xy_addr = device->get_noc_multicast_encoding(constants.noc_index, virtual_range);
+            uint32_t start_addr = program.get_program_config(index).dfb_offset;
+
+            LOG_TRACE_LAZY(
+                tt::LogDispatch,
+                "Dataflow Buffers (MCAST): logical_range={}, virtual_range={}, "
+                "noc_xy=0x{:x}, num_dests={}, L1_addr=0x{:x}, config_size={} bytes",
+                core_range,
+                virtual_range,
+                noc_xy_addr,
+                core_range.size(),
+                start_addr,
+                max_byte_end);
+
+            batched_transfers[std::make_pair(noc_xy_addr, core_range.size())][start_addr] = std::vector<Transfer>{
+                {.start = start_addr,
+                 .data = tt::stl::Span<const uint8_t>(payload.data(), max_byte_end),
+                 .dfbs = dfbs_on_corerange}};
+            i++;
+        }
+    }
+
+private:
+    std::vector<std::vector<uint8_t>> dfb_config_payloads;
+};
+
 class ProgramBinaryCommandGenerator {
 public:
     // Generate kernel_bins_cmds (for multicast) and kernel_bins_unicast_cmds (for unicast) for the binaries in the
@@ -1541,6 +1648,10 @@ public:
                     program_command_sequence.cb_configs_payloads.push_back(
                         reinterpret_cast<uint32_t*>(data_collection_location[j]));
                 }
+                if (!transfer.dfbs.empty()) {
+                    program_command_sequence.dataflow_buffers_on_core_ranges.push_back(std::move(transfer.dfbs));
+                    program_command_sequence.dfb_configs_payloads.push_back(data_collection_location[j]);
+                }
                 if (transfer.rta_data) {
                     // When watcher enabled, transfer.data contains [count | args...]
                     // rt_args_data points to args location (data + offset)
@@ -1923,6 +2034,13 @@ void assemble_device_commands(
     CircularBufferCommandGenerator circular_buffer_command_generator;
     circular_buffer_command_generator.construct_commands(device, constants, program, batched_transfers);
 
+    TT_ASSERT(
+        program.dataflow_buffers().empty() || !MetalContext::instance().hal().has_tile_counter_registers(),
+        "Dataflow buffers on Quasar are not supported through Fast Dispatch yet. Use Slow Dispatch instead.");
+
+    DataflowBufferCommandGenerator dfb_command_generator;
+    dfb_command_generator.construct_commands(device, constants, program, batched_transfers);
+
     BatchedTransferGenerator batched_transfer_generator;
     batched_transfer_generator.construct_commands(batched_transfers, program_config_buffer_calculator);
 
@@ -2211,6 +2329,26 @@ void update_program_dispatch_commands(
         }
         i++;
     }
+
+    {
+        uint32_t dfb_i = 0;
+        for (const auto& dfbs_on_core_range : cached_program_command_sequence.dataflow_buffers_on_core_ranges) {
+            uint8_t* dfb_config_payload = cached_program_command_sequence.dfb_configs_payloads[dfb_i];
+            if (!hal.has_tile_counter_registers()) {
+                // WH/BH: overwrite the 4 uint32 words for each DFB slot in-place.
+                for (const auto& dfb : dfbs_on_core_range) {
+                    uint32_t base_index = dfb->id * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+                    uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload) + base_index;
+                    words[0] = dfb->uniform_alloc_addr();
+                    words[1] = dfb->config.entry_size * dfb->config.num_entries;
+                    words[2] = dfb->config.num_entries;
+                    words[3] = dfb->config.entry_size;
+                }
+            }
+            dfb_i++;
+        }
+    }
+
     // Update RTAs.
     for (auto& rta_update : cached_program_command_sequence.rta_updates) {
         memcpy(rta_update.dst, rta_update.src, rta_update.size);

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -97,6 +97,13 @@ uint32_t finalize_cbs(
     uint32_t& cb_size,
     uint32_t& local_cb_size);
 
+// On WH/BH, DFBs are initialised via setup_local_cb_read_write_interfaces and require
+// local_cb_mask to be a proper slot bitmask (one bit per DFB id).  Call this after
+// finalize_dfbs so the mask is set correctly for every kernel group.
+void finalize_dfb_masks(
+    std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
+    const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& dataflow_buffers);
+
 uint32_t finalize_kernel_bins(
     IDevice* device,
     uint32_t programmable_core_type_index,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -941,6 +941,8 @@ CBHandle detail::ProgramImpl::add_circular_buffer_(const std::shared_ptr<Circula
 CBHandle detail::ProgramImpl::add_circular_buffer(
     const CoreRangeSet& core_range_set, const CircularBufferConfig& config) {
     TT_FATAL(this->compiled_.empty(), "Cannot add circular buffer to an already compiled program {}", this->id);
+    TT_FATAL(
+        this->dataflow_buffers_.empty(), "Cannot add circular buffer to a program that already has dataflow buffers");
     // Merge ranges to reduce the number of multicasts needed to initialize CBs.
     std::shared_ptr<CircularBufferImpl> circular_buffer =
         std::make_shared<CircularBufferImpl>(core_range_set.merge_ranges(), config);
@@ -952,6 +954,8 @@ CBHandle detail::ProgramImpl::add_circular_buffer(
     const CircularBufferConfig& config,
     const experimental::GlobalCircularBuffer& global_circular_buffer) {
     TT_FATAL(this->compiled_.empty(), "Cannot add circular buffer to an already compiled program {}", this->id);
+    TT_FATAL(
+        this->dataflow_buffers_.empty(), "Cannot add circular buffer to a program that already has dataflow buffers");
     // Merge ranges to reduce the number of multicasts needed to initialize CBs.
     std::shared_ptr<CircularBufferImpl> circular_buffer =
         std::make_shared<CircularBufferImpl>(core_range_set.merge_ranges(), config, global_circular_buffer);
@@ -1977,6 +1981,12 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
             state.offset,
             state.dfb_offset,
             state.dfb_size);
+
+        // On WH/BH, DFBs reuse the CB firmware init path; set local_cb_mask to a proper DFB
+        // slot bitmask so setup_local_cb_read_write_interfaces initialises every DFB slot.
+        if (!hal.has_tile_counter_registers() && !dataflow_buffers.empty()) {
+            program_dispatch::finalize_dfb_masks(kernel_groups_getter(index), dataflow_buffers);
+        }
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -9,6 +9,7 @@
 
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include <numeric>
 
 struct CQDispatchWritePackedCmd;
@@ -47,6 +48,10 @@ struct ProgramCommandSequence {
     HostMemDeviceCommand go_msg_command_sequence;
     std::vector<uint32_t*> cb_configs_payloads;
     std::vector<std::vector<std::shared_ptr<CircularBufferImpl>>> circular_buffers_on_core_ranges;
+    // Parallel to cb_configs_payloads/circular_buffers_on_core_ranges but for Dataflow Buffers.
+    std::vector<uint8_t*> dfb_configs_payloads;
+    std::vector<std::vector<std::shared_ptr<experimental::dfb::detail::DataflowBufferImpl>>>
+        dataflow_buffers_on_core_ranges;
     // Note: some RTAs may be have their RuntimeArgsData modified so the source-of-truth of their data is the command
     // sequence. They won't be listed in rta_updates.
     std::vector<RtaUpdate> rta_updates;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -213,6 +213,7 @@ public:
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers_on_core(
         const CoreCoord& core) const;
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers_on_corerange(const CoreRange& cr) const;
+    std::vector<CoreRange> dataflow_buffers_unique_coreranges() const;
     std::vector<std::reference_wrapper<const Semaphore>> semaphores_on_core(
         const CoreCoord& core, CoreType core_type) const;
     void init_semaphores(

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -153,7 +153,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         true /*supports_cbs*/,
-        false /*supports_dfbs*/,
+        true /*supports_dfbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory(),
         tensix_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -152,7 +152,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         true /*supports_cbs*/,
-        false /*supports_dfbs*/,
+        true /*supports_dfbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory(),
         tensix_fabric_telemetry::create_factory()};


### PR DESCRIPTION
### Problem description
Part of ongoing DFB bring-up is to enable DFB usage on WH/BH through experimental APIs. Experimental APIs only allow "vanilla" DFBs. Features like aliasing, user specified backing memory, remote/global cb equivalent will be added incrementally alongside host apis. Goal of this PR is to allow the first Op writers on Quasar to not have to ifdef their kernels on CB/DFBs.

DFBs on WH/BH have the same features as CBs. The biggest difference is that users do not supplied CB ids, a logical DFB handle (uint32_t id for now) is returned from `CreateDataflowBuffer`. This handle should be passed into kernels to create the device side DataflowBuffer. 

### What's Changed
- Uplifted device `dataflow_buffer.h` to declare dfb apis. `tt-1xx/dataflow_buffer.inl` and `tt-2xx/dataflow_buffer.inl` hold arch specific implementation 
- Added ability to create FD commands for DFBs (this only works for WH/BH). No changes in FW to init DFBs because device side DataflowBuffer just pulls its metadata from `LocalCBInterface`
- Updated WH/BH tensix descriptors in HAL to allow DFBs
- Updated some slow dispatch tests to use DFBs + allowed 1Sx1S Quasar DFB tests to run on WH/BH
- Added DFB variant of `MeshDispatchFixture.DataflowCb` 


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-bport)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-bport)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-bport)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-bport)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-bport)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-bport)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

