### PR TITLE
Add local mode to ttnn.dump_tensor

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_dump_and_load.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dump_and_load.py
@@ -29,6 +29,21 @@ def test_dump_and_load(tmp_path, height, width, layout):
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_dump_and_load_local_mode(tmp_path, height, width, layout):
+    file_name = tmp_path / pathlib.Path("tensor.tensorbin")
+
+    torch_tensor = torch.rand((height, width), dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(torch_tensor, layout=layout)
+    ttnn.dump_tensor(file_name, tensor, mode=ttnn.DumpTensorMode.LOCAL)
+
+    loaded_tensor = ttnn.load_tensor(file_name)
+    loaded_torch_tensor = ttnn.to_torch(loaded_tensor)
+    assert torch.allclose(torch_tensor, loaded_torch_tensor)
+
+
+@pytest.mark.parametrize("height", [1024])
+@pytest.mark.parametrize("width", [1024])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [None, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_dump_from_device_and_load_to_device(tmp_path, device, height, width, layout, memory_config):
     file_name = tmp_path / pathlib.Path("tensor.tensorbin")

--- a/ttnn/api/ttnn/tensor/serialization.hpp
+++ b/ttnn/api/ttnn/tensor/serialization.hpp
@@ -6,17 +6,24 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 
 namespace tt::tt_metal {
+
+enum class DumpTensorMode : std::uint8_t {
+    DISTRIBUTED_GATHER = 0,
+    LOCAL = 1,
+};
 
 // Functions to load and dump tensor to file using FlatBuffer format with inline file storage.
 // Only inline file storage (data stored in same file) is currently supported:
 // 1. Tensor metadata is serialized and stored as file "header", while the rest of the file is used as a data region for
 //    tensor data.
 // 2. Metadata includes data offsets and sizes for tensor / tensor shards (multi device context).
-void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor);
+void dump_tensor_flatbuffer(
+    const std::string& file_name, const Tensor& tensor, DumpTensorMode mode = DumpTensorMode::DISTRIBUTED_GATHER);
 Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device = nullptr);
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/serialization.cpp
+++ b/ttnn/core/tensor/serialization.cpp
@@ -50,54 +50,62 @@ void safe_fwrite_bytes(
 
 constexpr std::uint32_t kFlatbufferAlignment = alignof(std::uint64_t);
 
-}  // namespace
-
-void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor) {
+void dump_tensor_flatbuffer_impl(const std::string& file_name, const Tensor& tensor, DumpTensorMode mode) {
     Tensor cpu_tensor = tensor.cpu();
 
-    // Dump tensor to disk from (global) rank 0 host.
-    // Note we use global context as opposed to context embedded to the host-side tensor, since the tensor may already
-    // be fully host-local. In this latter case, host buffer context will consist of a single (local) host rank, and
-    // each host will attempt to flush the serialized tensor file to disk.
-    cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
-    const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
-    if (ctx->rank() == tt::tt_metal::distributed::multihost::Rank(0)) {
-        FILE* output_file = fopen(file_name.c_str(), "wb");
-        TT_FATAL(
-            output_file != nullptr,
-            "Cannot open \"{}\" for writing: errno={} \"{}\"",
-            file_name,
-            errno,
-            strerror(errno));
-        auto cleanup = ttsl::make_cleanup([f = output_file, &file_name]() {
-            if (f && fclose(f) != 0) {
-                log_warning(tt::LogAlways, "Failed to close \"{}\"", file_name);
-            }
-        });
-
-        std::vector<HostBuffer> buffers;
-        flatbuffers::FlatBufferBuilder builder;
-        auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
-        // To be able to read flatbuffer data with `mmap` safely, make sure the serialized flatbuffer is aligned to at
-        // least 8 bytes, just like `header_size`. Individual `buffers` are aligned according to their element size,
-        // which is already what we need for `mmap` to work.
-        builder.Align(kFlatbufferAlignment);
-        builder.Finish(tensor_offset);
-
-        const uint64_t header_size = builder.GetSize();
-        safe_fwrite_bytes(&header_size, sizeof(header_size), output_file, file_name, "tensor header size");
-        safe_fwrite_bytes(builder.GetBufferPointer(), header_size, output_file, file_name, "tensor header");
-
-        for (const auto& buffer : buffers) {
-            auto buffer_view = buffer.view_bytes();
-            TT_FATAL(!buffer_view.empty(), "Unexpected empty buffer during tensor serialization");
-            safe_fwrite_bytes(buffer_view.data(), buffer_view.size(), output_file, file_name, "tensor data");
+    if (mode == DumpTensorMode::DISTRIBUTED_GATHER) {
+        // Dump tensor to disk from (global) rank 0 host.
+        // Note we use global context as opposed to context embedded to the host-side tensor, since the tensor may
+        // already be fully host-local. In this latter case, host buffer context will consist of a single (local) host
+        // rank, and each host will attempt to flush the serialized tensor file to disk.
+        cpu_tensor = ttnn::distributed::host_ccl::all_gather(cpu_tensor);
+        const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
+        if (ctx->rank() != tt::tt_metal::distributed::multihost::Rank(0)) {
+            ctx->barrier();
+            return;
         }
-
-        TT_FATAL(
-            fflush(output_file) == 0, "Failed to flush \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
     }
-    ctx->barrier();
+
+    FILE* output_file = fopen(file_name.c_str(), "wb");
+    TT_FATAL(
+        output_file != nullptr, "Cannot open \"{}\" for writing: errno={} \"{}\"", file_name, errno, strerror(errno));
+    auto cleanup = ttsl::make_cleanup([f = output_file, &file_name]() {
+        if (f && fclose(f) != 0) {
+            log_warning(tt::LogAlways, "Failed to close \"{}\"", file_name);
+        }
+    });
+
+    std::vector<HostBuffer> buffers;
+    flatbuffers::FlatBufferBuilder builder;
+    auto tensor_offset = ttnn::to_flatbuffer(cpu_tensor, builder, buffers);
+    // To be able to read flatbuffer data with `mmap` safely, make sure the serialized flatbuffer is aligned to at
+    // least 8 bytes, just like `header_size`. Individual `buffers` are aligned according to their element size,
+    // which is already what we need for `mmap` to work.
+    builder.Align(kFlatbufferAlignment);
+    builder.Finish(tensor_offset);
+
+    const uint64_t header_size = builder.GetSize();
+    safe_fwrite_bytes(&header_size, sizeof(header_size), output_file, file_name, "tensor header size");
+    safe_fwrite_bytes(builder.GetBufferPointer(), header_size, output_file, file_name, "tensor header");
+
+    for (const auto& buffer : buffers) {
+        auto buffer_view = buffer.view_bytes();
+        TT_FATAL(!buffer_view.empty(), "Unexpected empty buffer during tensor serialization");
+        safe_fwrite_bytes(buffer_view.data(), buffer_view.size(), output_file, file_name, "tensor data");
+    }
+
+    TT_FATAL(fflush(output_file) == 0, "Failed to flush \"{}\": errno={} \"{}\"", file_name, errno, strerror(errno));
+
+    if (mode == DumpTensorMode::DISTRIBUTED_GATHER) {
+        const auto& ctx = distributed::multihost::DistributedContext::get_current_world();
+        ctx->barrier();
+    }
+}
+
+}  // namespace
+
+void dump_tensor_flatbuffer(const std::string& file_name, const Tensor& tensor, DumpTensorMode mode) {
+    dump_tensor_flatbuffer_impl(file_name, tensor, mode);
 }
 
 Tensor load_tensor_flatbuffer(const std::string& file_name, distributed::MeshDevice* device) {

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -165,6 +165,10 @@ void tensor_mem_config_module_types(nb::module_& m_tensor) {
 }
 
 void tensor_mem_config_module(nb::module_& m_tensor) {
+    nb::enum_<DumpTensorMode>(m_tensor, "DumpTensorMode")
+        .value("DISTRIBUTED_GATHER", DumpTensorMode::DISTRIBUTED_GATHER)
+        .value("LOCAL", DumpTensorMode::LOCAL);
+
     auto py_core_coord = static_cast<nb::class_<CoreCoord>>(m_tensor.attr("CoreCoord"));
     py_core_coord.def(nb::init<std::size_t, std::size_t>())
         .def(
@@ -599,6 +603,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             &dump_tensor_flatbuffer,
             nb::arg("filename"),
             nb::arg("tensor"),
+            nb::arg("mode") = DumpTensorMode::DISTRIBUTED_GATHER,
             R"doc(
                 Dump tensor to file using FlatBuffer format with inline file storage.
             )doc")

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -197,6 +197,7 @@ from ttnn._ttnn.hd_socket import (
 from ttnn.types import (
     TILE_SIZE,
     DataType,
+    DumpTensorMode,
     uint8,
     uint16,
     int32,

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -5,7 +5,7 @@
 import math
 import os
 import pathlib
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import ttnn.decorators
 from loguru import logger
@@ -550,7 +550,7 @@ def dump_tensor(
     file_name: Union[str, pathlib.Path],
     tensor: ttnn.Tensor,
     *,
-    mode: Any = ttnn._ttnn.tensor.DumpTensorMode.DISTRIBUTED_GATHER,
+    mode: ttnn.DumpTensorMode = ttnn.DumpTensorMode.DISTRIBUTED_GATHER,
 ) -> None:
     """
     Dump tensor to a file.
@@ -558,6 +558,15 @@ def dump_tensor(
     Args:
         file_name (str | pathlib.Path): The file name.
         tensor (ttnn.Tensor): the tensor to be dumped.
+
+    Keyword Args:
+        mode (ttnn.DumpTensorMode, optional): How host-side distributed tensors are written. Defaults to
+            ``DISTRIBUTED_GATHER``.
+
+            * ``DISTRIBUTED_GATHER``: perform a host all-gather, write the full tensor from global rank 0 only,
+              and synchronize with barriers. Use this for a single canonical file from a distributed tensor.
+            * ``LOCAL``: skip collectives and write the caller's local shard only. In multi-host runs, each process
+              must use a distinct ``file_name`` (for example a per-host cache path).
 
     Returns:
         `None`: tensor saved to a specified file.

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -546,7 +546,12 @@ def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.MeshDevice 
 
 
 @ttnn.register_python_operation(name="ttnn.dump_tensor")
-def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor) -> None:
+def dump_tensor(
+    file_name: Union[str, pathlib.Path],
+    tensor: ttnn.Tensor,
+    *,
+    mode: Any = ttnn._ttnn.tensor.DumpTensorMode.DISTRIBUTED_GATHER,
+) -> None:
     """
     Dump tensor to a file.
 
@@ -559,7 +564,7 @@ def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor) -> Non
     """
     file_name = pathlib.Path(file_name)
     _validate_file_extension(file_name)
-    ttnn._ttnn.tensor.dump_tensor_flatbuffer(str(file_name), tensor)
+    ttnn._ttnn.tensor.dump_tensor_flatbuffer(str(file_name), tensor, mode)
 
 
 @ttnn.register_python_operation(name="ttnn.as_tensor")

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -16,6 +16,7 @@ float32 = DataType.FLOAT32
 bfloat16 = DataType.BFLOAT16
 bfloat8_b = DataType.BFLOAT8_B
 bfloat4_b = DataType.BFLOAT4_B
+DumpTensorMode = ttnn._ttnn.tensor.DumpTensorMode
 
 BufferType = ttnn._ttnn.tensor.BufferType
 TensorMemoryLayout = ttnn._ttnn.tensor.TensorMemoryLayout


### PR DESCRIPTION
### Summary

Currently, `ttnn.dump_tensor` unconditionally performs a host all-gather and writes the result only from global rank 0. This is correct when the goal is to produce a single canonical file from a distributed tensor, but it breaks the DeepSeek V3 B1 per-host cache write path, where each host can/should independently write its own local shard to its own cache directory. 

### What's changed

Adds a DumpTensorMode enum (DISTRIBUTED_GATHER | LOCAL) and threads it through the full dump_tensor stack:

- serialization.hpp / .cpp -- New DumpTensorMode enum. The write logic is refactored so that DISTRIBUTED_GATHER (the default) preserves the existing all-gather + rank-0-write + barrier behavior, while LOCAL skips all collective communication and lets the caller write directly.
- ttnn-nanobind/tensor.cpp -- Binds the enum and adds mode as an optional keyword argument (default DISTRIBUTED_GATHER) to the C++ dump_tensor_flatbuffer binding.
- ttnn/operations/core.py -- Forwards the new mode kwarg from the Python ttnn.dump_tensor wrapper.
ttnn/types.py / ttnn/__init__.py -- Exports DumpTensorMode so users can write ttnn.DumpTensorMode.LOCAL.
- test_dump_and_load.py -- Adds test_dump_and_load_local_mode covering both tile and row-major layouts.
Existing callers are unaffected -- the default mode is DISTRIBUTED_GATHER, which is identical to the previous behavior.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/local-dump-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/local-dump-tensor)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/local-dump-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/local-dump-tensor)
- [x] Multi-host test: https://github.com/tenstorrent/tt-metal/actions/runs/23870811592

