### PR TITLE
[Test Only] Add DRAM write and DRAM multi-core worker range support to `test_bw_and_latency.cpp`

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
@@ -34,8 +34,13 @@ void kernel_main() {
                 get_noc_multicast_addr(NOC_ADDR_X, NOC_ADDR_Y, MCAST_NOC_END_ADDR_X, MCAST_NOC_END_ADDR_Y, write_ptr);
             noc_async_write_multicast(read_ptr, dst_noc_multicast_addr, page_size, NUM_MCAST_DESTS, LINKED);
 #elif WRITE
+#if WRITE_DRAM
+            uint64_t noc_write_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), NOC_MEM_ADDR);
+            noc_async_write(write_ptr, noc_write_addr, page_size);
+#else
             uint64_t noc_write_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), write_ptr);
             noc_async_write(NOC_MEM_ADDR, noc_write_addr, page_size);
+#endif
 #elif READ_ONE_PACKET
             noc_async_read_one_packet(noc_addr, read_ptr, page_size);
 #else

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_bw_and_latency.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_bw_and_latency.sh
@@ -69,6 +69,10 @@ echo "###" read dram
 bw_test "-m 1"
 latency_test "-m 1"
 
+echo "###" read dram all worker cores
+bw_test "-m 1 -rx 0 -ry 0 -rex $max_x -rey $max_y"
+latency_test "-m 1 -rx 0 -ry 0 -rex $max_x -rey $max_y"
+
 echo "###" read drams
 bw_test "-m 3"
 latency_test "-m 3"
@@ -84,6 +88,14 @@ latency_test "-m 2 -rx 0 -ry 0 -sx $hx -sy $hy"
 echo "###" read local
 bw_test "-m 2 -rx 0"
 latency_test "-m 2 -rx 0"
+
+echo "###" write dram
+bw_test "-m 1 -wr"
+latency_test "-m 1 -wr"
+
+echo "###" write dram all worker cores
+bw_test "-m 1 -wr -rx 0 -ry 0 -rex $max_x -rey $max_y"
+latency_test "-m 1 -wr -rx 0 -ry 0 -rex $max_x -rey $max_y"
 
 echo "###" write l1 far halfway away
 bw_test "-m 2 -rx 0 -ry 0 -sx $hx -sy $hy -wr"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_bw_and_latency.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_bw_and_latency.sh
@@ -69,10 +69,6 @@ echo "###" read dram
 bw_test "-m 1"
 latency_test "-m 1"
 
-echo "###" read dram all worker cores
-bw_test "-m 1 -rx 0 -ry 0 -rex $max_x -rey $max_y"
-latency_test "-m 1 -rx 0 -ry 0 -rex $max_x -rey $max_y"
-
 echo "###" read drams
 bw_test "-m 3"
 latency_test "-m 3"
@@ -88,14 +84,6 @@ latency_test "-m 2 -rx 0 -ry 0 -sx $hx -sy $hy"
 echo "###" read local
 bw_test "-m 2 -rx 0"
 latency_test "-m 2 -rx 0"
-
-echo "###" write dram
-bw_test "-m 1 -wr"
-latency_test "-m 1 -wr"
-
-echo "###" write dram all worker cores
-bw_test "-m 1 -wr -rx 0 -ry 0 -rex $max_x -rey $max_y"
-latency_test "-m 1 -wr -rx 0 -ry 0 -rex $max_x -rey $max_y"
 
 echo "###" write l1 far halfway away
 bw_test "-m 2 -rx 0 -ry 0 -sx $hx -sy $hy -wr"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -106,10 +106,10 @@ void init(int argc, char** argv) {
             0);
         log_info(LogTest, "  -tx: when issuing a multicast write, X of end core to write to (default {})", 0);
         log_info(LogTest, "  -ty: when issuing a multicast write, Y of end core to write to (default {})", 0);
-        log_info(LogTest, "  -rex: X of end core for worker range (default same as -rx)");
-        log_info(LogTest, "  -rey: Y of end core for worker range (default same as -ry)");
+        log_info(LogTest, "  -drx: when reading/writing dram, X of end core for worker range (default same as -rx)");
+        log_info(LogTest, "  -dry: when reading/writing dram, Y of end core for worker range (default same as -ry)");
         log_info(LogTest, "  -wr: issue unicast write instead of read (default false)");
-        log_info(LogTest, "  -c: when reading from dram, DRAM channel (default 0)");
+        log_info(LogTest, "  -c: when reading/writing dram, DRAM channel (default 0)");
         log_info(LogTest, "  -f: time just the finish call (default disabled)");
         log_info(LogTest, "  -o: use read_one_packet API.  restricts page size to 8K max (default {})", 0);
         log_info(LogTest, "-link: link mcast transactions");
@@ -124,8 +124,8 @@ void init(int argc, char** argv) {
 
     uint32_t core_x = test_args::get_command_option_uint32(input_args, "-rx", 1);
     uint32_t core_y = test_args::get_command_option_uint32(input_args, "-ry", 0);
-    uint32_t end_core_x = test_args::get_command_option_uint32(input_args, "-rex", core_x);
-    uint32_t end_core_y = test_args::get_command_option_uint32(input_args, "-rey", core_y);
+    uint32_t end_core_x = test_args::get_command_option_uint32(input_args, "-drx", core_x);
+    uint32_t end_core_y = test_args::get_command_option_uint32(input_args, "-dry", core_y);
     warmup_iterations_g = test_args::get_command_option_uint32(input_args, "-w", DEFAULT_WARMUP_ITERATIONS);
     iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
     hammer_write_reg_g = test_args::has_command_option(input_args, "-hr");
@@ -162,10 +162,14 @@ void init(int argc, char** argv) {
     read_profiler_results = test_args::has_command_option(input_args, "-profread");
 
     if (end_core_x < core_x || end_core_y < core_y) {
-        log_info(LogTest, "-rex must be >= -rx and -rey must be >= -ry");
+        log_info(LogTest, "-drx must be >= -rx and -dry must be >= -ry");
         exit(-1);
     }
     worker_g = CoreRange({core_x, core_y}, {end_core_x, end_core_y});
+    if (worker_g.size() > 1 && source_mem_g != 1) {
+        log_info(LogTest, "Multi-core worker range only supported with DRAM");
+        exit(-1);
+    }
     src_worker_g = {src_core_x, src_core_y};
 
     if (source_mem_g == 6) {
@@ -343,7 +347,7 @@ int main(int argc, char** argv) {
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .defines = defines});
         if (page_size_as_runtime_arg_g) {
-            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_coord, {page_size_g});
+            tt_metal::SetRuntimeArgs(program, dm0, worker_g, {page_size_g});
         }
         mesh_workload.add_program(
             tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -106,6 +106,8 @@ void init(int argc, char** argv) {
             0);
         log_info(LogTest, "  -tx: when issuing a multicast write, X of end core to write to (default {})", 0);
         log_info(LogTest, "  -ty: when issuing a multicast write, Y of end core to write to (default {})", 0);
+        log_info(LogTest, "  -rex: X of end core for worker range (default same as -rx)");
+        log_info(LogTest, "  -rey: Y of end core for worker range (default same as -ry)");
         log_info(LogTest, "  -wr: issue unicast write instead of read (default false)");
         log_info(LogTest, "  -c: when reading from dram, DRAM channel (default 0)");
         log_info(LogTest, "  -f: time just the finish call (default disabled)");
@@ -122,6 +124,8 @@ void init(int argc, char** argv) {
 
     uint32_t core_x = test_args::get_command_option_uint32(input_args, "-rx", 1);
     uint32_t core_y = test_args::get_command_option_uint32(input_args, "-ry", 0);
+    uint32_t end_core_x = test_args::get_command_option_uint32(input_args, "-rex", core_x);
+    uint32_t end_core_y = test_args::get_command_option_uint32(input_args, "-rey", core_y);
     warmup_iterations_g = test_args::get_command_option_uint32(input_args, "-w", DEFAULT_WARMUP_ITERATIONS);
     iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
     hammer_write_reg_g = test_args::has_command_option(input_args, "-hr");
@@ -148,8 +152,8 @@ void init(int argc, char** argv) {
     page_count_g = size_bytes / page_size_g;
 
     test_write = test_args::has_command_option(input_args, "-wr");
-    if (test_write && (source_mem_g != 2 && source_mem_g != 6)) {
-        log_info(LogTest, "Writing only tested w/ L1 destination\n");
+    if (test_write && (source_mem_g != 1 && source_mem_g != 2 && source_mem_g != 6)) {
+        log_info(LogTest, "Writing only tested w/ DRAM or L1 destination\n");
         exit(-1);
     }
 
@@ -157,7 +161,11 @@ void init(int argc, char** argv) {
 
     read_profiler_results = test_args::has_command_option(input_args, "-profread");
 
-    worker_g = CoreRange({core_x, core_y}, {core_x, core_y});
+    if (end_core_x < core_x || end_core_y < core_y) {
+        log_info(LogTest, "-rex must be >= -rx and -rey must be >= -ry");
+        exit(-1);
+    }
+    worker_g = CoreRange({core_x, core_y}, {end_core_x, end_core_y});
     src_worker_g = {src_core_x, src_core_y};
 
     if (source_mem_g == 6) {
@@ -218,6 +226,7 @@ int main(int argc, char** argv) {
         uint32_t noc_addr_x, noc_addr_y;
         uint64_t noc_mem_addr = 0;
         uint32_t dram_banked = 0;
+        uint32_t write_dram = 0;
         uint32_t issue_mcast = 0;
         uint32_t num_mcast_dests = mcast_src_workers_g.size();
         uint32_t mcast_noc_addr_end_x = 0;
@@ -245,7 +254,7 @@ int main(int argc, char** argv) {
                 noc_mem_addr = dev_pcie_base + pcie_offset;
             } break;
             case 1: {
-                src_mem = "FROM_DRAM";
+                src_mem = test_write ? "TO_DRAM" : "FROM_DRAM";
                 vector<tt::umd::CoreCoord> dram_cores = soc_d.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED);
                 TT_FATAL(
                     dram_cores.size() > dram_channel_g,
@@ -254,6 +263,7 @@ int main(int argc, char** argv) {
                     dram_cores.size());
                 noc_addr_x = dram_cores[dram_channel_g].x;
                 noc_addr_y = dram_cores[dram_channel_g].y;
+                write_dram = test_write;
             } break;
             case 2: {
                 src_mem = test_write ? "TO_L1" : "FROM_L1";
@@ -313,6 +323,7 @@ int main(int argc, char** argv) {
             {"MCAST_NOC_END_ADDR_X", std::to_string(mcast_noc_addr_end_x)},
             {"MCAST_NOC_END_ADDR_Y", std::to_string(mcast_noc_addr_end_y)},
             {"NOP_COUNT", std::to_string(nop_count_g)},
+            {"WRITE_DRAM", std::to_string(write_dram)},
         };
         if (!page_size_as_runtime_arg_g) {
             defines.insert(std::pair<std::string, std::string>("PAGE_SIZE", std::to_string(page_size_g)));
@@ -481,7 +492,7 @@ int main(int argc, char** argv) {
                 (float)std::chrono::duration_cast<std::chrono::microseconds>(elapsed_seconds).count() /
                     (page_count_g * iterations_g));
         } else {
-            float bw = (float)page_count_g * (float)page_size_g * (float)iterations_g /
+            float bw = (float)page_count_g * (float)page_size_g * (float)iterations_g * (float)worker_g.size() /
                        (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << bw;


### PR DESCRIPTION
Adds DRAM write support to `test_bw_and_latency.cpp`, which previously only supported writes to L1 and multicast destinations. Introduces `-drx`/`-dry` CLI options to specify a multi-core worker range for DRAM tests, allowing bandwidth and latency measurements across all worker cores rather than just a single core. The bandwidth calculation is updated to scale by the number of workers in the range.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/dram_write_latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/dram_write_latency)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/dram_write_latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/dram_write_latency)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/dram_write_latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/dram_write_latency)