### PR TITLE
#25549: move implicit padding to device for generic reduce

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -845,3 +845,86 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op):
     assert torch.allclose(
         torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True
     ), f"torch: {torch_result}, ttnn: {ttnn_result}"
+
+
+@pytest.mark.parametrize("input_value", [2.0])
+@pytest.mark.parametrize(
+    "input_shape,input_reshape",
+    [
+        ((32, 64), (32, 64)),  # No padding - tile aligned
+        ((32, 64), (32, 50)),  # Padding in W dimension only
+        ((32, 64), (20, 64)),  # Padding in H dimension only
+        ((32, 64), (20, 50)),  # Padding in both H and W dimensions
+        ((64, 96), (33, 65)),  # Padding with multiple tiles, 1 extra element
+        ((64, 96), (48, 80)),  # Partial tile padding
+    ],
+)
+@pytest.mark.parametrize(
+    "reduce_op,dim",
+    [
+        ("sum", -1),  # W reduction
+        ("sum", -2),  # H reduction
+        ("sum", None),  # HW reduction (full reduce)
+        ("max", -1),  # W reduction
+        ("max", -2),  # H reduction
+        ("max", None),  # HW reduction
+        ("min", -1),  # W reduction
+        ("min", -2),  # H reduction
+        ("min", None),  # HW reduction
+        ("mean", -1),  # W reduction
+        ("mean", -2),  # H reduction
+        ("mean", None),  # HW reduction
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True])
+def test_reduce_with_padding(device, input_shape, input_reshape, input_value, reduce_op, dim, keepdim):
+    """
+    Test that reduction operations work correctly when the logical shape differs
+    from the padded shape. This verifies that native tile padding in reduction
+    kernels produces correct results.
+
+    The test creates a tensor with a padded shape, reshapes it to a smaller logical
+    shape (introducing tile padding), and verifies that the reduction produces the
+    same result as PyTorch operating on the logical shape.
+    """
+    torch.manual_seed(0)
+
+    # Create input tensor with the padded shape, filled with a specific value
+    input_tensor_padded = torch.full(input_shape, input_value, dtype=torch.float32)
+
+    # Create the "logical" tensor for golden reference
+    input_tensor_logical = torch.full(input_reshape, input_value, dtype=torch.float32)
+
+    # Compute golden output using PyTorch on the logical tensor
+    torch_op = getattr(torch, reduce_op)
+    if dim is not None:
+        golden_output = torch_op(input_tensor_logical, dim=dim, keepdim=keepdim)
+    else:
+        golden_output = torch_op(input_tensor_logical)
+        if keepdim:
+            golden_output = golden_output.reshape([1] * len(input_reshape))
+
+    # For min/max, extract values if it returns a named tuple
+    if isinstance(golden_output, (torch.return_types.min, torch.return_types.max)):
+        golden_output = golden_output.values
+
+    # Convert to ttnn tensor with padded shape
+    input_ttnn = ttnn.from_torch(input_tensor_padded, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Reshape to logical shape (this creates the padding scenario)
+    input_reshaped_ttnn = ttnn.reshape(input_ttnn, input_reshape, padded_shape=input_shape)
+
+    # Perform reduction
+    ttnn_op = getattr(ttnn, reduce_op)
+    if dim is not None:
+        output_ttnn = ttnn_op(input_reshaped_ttnn, dim=dim, keepdim=keepdim)
+    else:
+        output_ttnn = ttnn_op(input_reshaped_ttnn)
+
+    output = ttnn.to_torch(output_ttnn)
+
+    # Verify the output matches the golden reference
+    assert golden_output.shape == output.shape, f"Shape mismatch: expected {golden_output.shape}, got {output.shape}"
+    assert torch.allclose(
+        golden_output, output, atol=1e-2, rtol=1e-2
+    ), f"Value mismatch for {reduce_op} dim={dim}: expected {golden_output}, got {output}"

--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
@@ -5,6 +5,52 @@
 #pragma once
 
 #include <tt-metalium/constants.hpp>
+#include "api/numeric/bfloat16.h"
+#include "api/numeric/float32.h"
+
+/**
+ * @brief Enumeration for neutral value policies used in reduction operations.
+ *
+ * Different reduction operations require different neutral (identity) values
+ * for padding to ensure correct results:
+ * - Zero: For sum/mean operations (adding 0 doesn't change the sum)
+ * - NegInf: For max operations (max with -inf gives the original value)
+ * - PosInf: For min operations (min with +inf gives the original value)
+ */
+enum class NeutralPolicy : uint32_t {
+    Zero = 0,    // Neutral element for sum/mean
+    NegInf = 1,  // Neutral element for max
+    PosInf = 2,  // Neutral element for min
+};
+
+/**
+ * @brief Get the neutral fill value for a given data format and policy.
+ *
+ * @tparam data_format The data format (Float32, Float16_b, etc.)
+ * @tparam policy The neutral value policy
+ * @return The appropriate fill value as a uint32_t (for Float32) or uint16_t (for Float16_b)
+ */
+template <DataFormat data_format, NeutralPolicy policy>
+constexpr auto get_neutral_value() {
+    if constexpr (data_format == DataFormat::Float32) {
+        if constexpr (policy == NeutralPolicy::Zero) {
+            return static_cast<uint32_t>(0);
+        } else if constexpr (policy == NeutralPolicy::NegInf) {
+            return NEG_INF_FLOAT32;
+        } else if constexpr (policy == NeutralPolicy::PosInf) {
+            return POS_INF_FLOAT32;
+        }
+    } else {
+        // Default to Float16_b for all other formats
+        if constexpr (policy == NeutralPolicy::Zero) {
+            return static_cast<uint16_t>(0);
+        } else if constexpr (policy == NeutralPolicy::NegInf) {
+            return NEG_INF_BFLOAT16;
+        } else if constexpr (policy == NeutralPolicy::PosInf) {
+            return POS_INF_BFLOAT16;
+        }
+    }
+}
 
 /**
  * @brief Pads a face within a tile.
@@ -177,6 +223,94 @@ void pad_last_ktile(uint32_t l1_write_addr_in0) {
     } else if constexpr (in0_data_format == DataFormat::Float16_b) {
         fill_pad_tile<uint16_t, in0_last_ktile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(
             l1_write_addr_in0, /*pad_value=*/0);
+    }
+}
+
+/**
+ * @brief Pads the last width tile in a reduction operation.
+ *
+ * This function handles padding for the last tile in the width dimension of a reduction operation.
+ * It applies the appropriate neutral value based on the data format and neutral policy.
+ *
+ * @tparam data_format The data format of the input tensor (Float32 or Float16_b)
+ * @tparam last_tile_w The unpadded width of the last tile (1 to TILE_WIDTH)
+ * @tparam policy The neutral value policy (Zero for sum/mean, NegInf for max, PosInf for min)
+ * @param l1_write_addr The L1 memory address where the padding should be written
+ */
+template <DataFormat data_format, uint32_t last_tile_w, NeutralPolicy policy>
+void pad_last_wtile(uint32_t l1_write_addr) {
+    using namespace tt::constants;
+    if constexpr (data_format == DataFormat::Float32) {
+        constexpr uint32_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint32_t, last_tile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(l1_write_addr, fill_value);
+    } else {
+        // Default to Float16_b for all other formats
+        constexpr uint16_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint16_t, last_tile_w, /*num_elements_unpadded_h=*/TILE_HEIGHT>(l1_write_addr, fill_value);
+    }
+}
+
+/**
+ * @brief Pads the last height tile in a reduction operation.
+ *
+ * This function handles padding for the last tile in the height dimension of a reduction operation.
+ * It applies the appropriate neutral value based on the data format and neutral policy.
+ *
+ * @tparam data_format The data format of the input tensor (Float32 or Float16_b)
+ * @tparam last_tile_h The unpadded height of the last tile (1 to TILE_HEIGHT)
+ * @tparam policy The neutral value policy (Zero for sum/mean, NegInf for max, PosInf for min)
+ * @param l1_write_addr The L1 memory address where the padding should be written
+ */
+template <DataFormat data_format, uint32_t last_tile_h, NeutralPolicy policy>
+void pad_last_htile(uint32_t l1_write_addr) {
+    using namespace tt::constants;
+    if constexpr (data_format == DataFormat::Float32) {
+        constexpr uint32_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint32_t, /*num_elements_unpadded_w=*/TILE_WIDTH, last_tile_h>(l1_write_addr, fill_value);
+    } else {
+        // Default to Float16_b for all other formats
+        constexpr uint16_t fill_value = get_neutral_value<data_format, policy>();
+        fill_pad_tile<uint16_t, /*num_elements_unpadded_w=*/TILE_WIDTH, last_tile_h>(l1_write_addr, fill_value);
+    }
+}
+
+/**
+ * @brief Applies width padding based on data format, dispatching to the appropriate typed function.
+ *
+ * This is a helper function that eliminates repeated if-constexpr blocks in reader kernels.
+ * It dispatches to pad_last_wtile with the correct data format type.
+ *
+ * @tparam IN_DF The input data format as uint32_t (cast of DataFormat)
+ * @tparam LAST_W The unpadded width of the last tile
+ * @tparam policy The neutral value policy
+ * @param l1_write_addr The L1 memory address where the padding should be written
+ */
+template <uint32_t IN_DF, uint32_t LAST_W, NeutralPolicy policy>
+void apply_width_padding(uint32_t l1_write_addr) {
+    if constexpr (IN_DF == static_cast<uint32_t>(DataFormat::Float16_b)) {
+        pad_last_wtile<DataFormat::Float16_b, LAST_W, policy>(l1_write_addr);
+    } else {
+        pad_last_wtile<DataFormat::Float32, LAST_W, policy>(l1_write_addr);
+    }
+}
+
+/**
+ * @brief Applies height padding based on data format, dispatching to the appropriate typed function.
+ *
+ * This is a helper function that eliminates repeated if-constexpr blocks in reader kernels.
+ * It dispatches to pad_last_htile with the correct data format type.
+ *
+ * @tparam IN_DF The input data format as uint32_t (cast of DataFormat)
+ * @tparam LAST_H The unpadded height of the last tile
+ * @tparam policy The neutral value policy
+ * @param l1_write_addr The L1 memory address where the padding should be written
+ */
+template <uint32_t IN_DF, uint32_t LAST_H, NeutralPolicy policy>
+void apply_height_padding(uint32_t l1_write_addr) {
+    if constexpr (IN_DF == static_cast<uint32_t>(DataFormat::Float16_b)) {
+        pad_last_htile<DataFormat::Float16_b, LAST_H, policy>(l1_write_addr);
+    } else {
+        pad_last_htile<DataFormat::Float32, LAST_H, policy>(l1_write_addr);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -6,6 +5,7 @@
 #pragma once
 
 #include "ttnn/tensor/tensor.hpp"
+#include <cstdint>
 
 namespace tt::tt_metal {
 
@@ -23,3 +23,27 @@ tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const tt::tt_metal::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
 }  // namespace ttnn::prim
+
+namespace ttnn::operations::reduction {
+
+/**
+ * @brief Returns the neutral policy value for a given reduce operation.
+ *
+ * Different reduction operations require different neutral (identity) values
+ * for padding to ensure correct results:
+ * - 0 (Zero): For sum/mean operations (adding 0 doesn't change the sum)
+ * - 1 (NegInf): For max operations (max with -inf gives the original value)
+ * - 2 (PosInf): For min operations (min with +inf gives the original value)
+ *
+ * @param math_op The reduction operation type
+ * @return uint32_t The neutral policy value (0=Zero, 1=NegInf, 2=PosInf)
+ */
+inline uint32_t get_neutral_policy(tt::tt_metal::ReduceOpMath math_op) {
+    switch (math_op) {
+        case tt::tt_metal::ReduceOpMath::MAX: return 1;  // NegInf
+        case tt::tt_metal::ReduceOpMath::MIN: return 2;  // PosInf
+        default: return 0;                               // Zero for SUM
+    }
+}
+
+}  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_w_with_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_w_with_padding.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#ifndef REDUCE_ROW_SUM_VIA_MM
+#include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#else
+#include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
+#endif
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t scaler = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t Ht = get_compile_time_arg_val(2);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(3);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(4);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(5);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(6);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
+    constexpr auto tensor_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t cb_id_in2 = 2;
+#ifndef REDUCE_ROW_SUM_VIA_MM
+    generate_reduce_scaler(cb_id_in2, scaler);
+#else
+    generate_mm_scaler(cb_id_in2, scaler);
+#endif
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+
+    auto tensor_accessor = TensorAccessor(tensor_args, src_addr, tile_bytes);
+
+    // Calculate starting position within the tile grid
+    // Tiles are arranged in row-major order: row 0 has tiles 0..Wt-1, row 1 has Wt..2*Wt-1, etc.
+    uint32_t start_row = start_id / Wt;
+    uint32_t start_col = start_id % Wt;
+
+    uint32_t current_row = start_row;
+    uint32_t current_col = start_col;
+
+    // Read tiles and apply padding as needed
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_page(i, tensor_accessor, l1_write_addr);
+        noc_async_read_barrier();
+
+        // Apply width padding to the last column of tiles
+        if constexpr (LAST_W > 0) {
+            if (current_col == Wt - 1) {
+                apply_width_padding<IN_DF, LAST_W, NEUTRAL>(l1_write_addr);
+            }
+        }
+
+        // Apply height padding to the last row of tiles (modulo Ht for batched tensors)
+        if constexpr (LAST_H > 0) {
+            if ((current_row % Ht) == Ht - 1) {
+                apply_height_padding<IN_DF, LAST_H, NEUTRAL>(l1_write_addr);
+            }
+        }
+
+        cb_push_back(cb_id_in0, onetile);
+
+        // Advance to next tile position
+        current_col++;
+        if (current_col == Wt) {
+            current_col = 0;
+            current_row++;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -8,6 +8,7 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/endpoints.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
@@ -16,13 +17,20 @@ void kernel_main() {
     uint32_t batch = get_arg_val<uint32_t>(3);
     uint32_t row_size_bytes = get_arg_val<uint32_t>(4);
     uint32_t batch_size_bytes = get_arg_val<uint32_t>(5);
+    uint32_t is_last_w_padded = get_arg_val<uint32_t>(6);
+    uint32_t is_last_h_padded = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(2);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(3);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(4);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(5);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
 
 #ifdef REDUCE_SCALER
-    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
-    uint32_t scalar = get_arg_val<uint32_t>(6);
+    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(6);
+    uint32_t scalar = get_arg_val<uint32_t>(8);
     generate_reduce_scaler(cb_id_in2, scalar);
 #endif
 
@@ -54,6 +62,18 @@ void kernel_main() {
                     {.offset_bytes = 0});
                 curr_l1_addr += row_size_bytes;
                 noc.async_read_barrier();
+                if constexpr (LAST_W > 0) {
+                    if (is_last_w_padded && (i == Wt - 1)) {
+                        uint32_t wr_addr = cb_in0.get_write_ptr();
+                        apply_width_padding<IN_DF, LAST_W, NEUTRAL>(wr_addr);
+                    }
+                }
+                if constexpr (LAST_H > 0) {
+                    if (is_last_h_padded && (j == Ht - 1)) {
+                        uint32_t wr_addr = cb_in0.get_write_ptr();
+                        apply_height_padding<IN_DF, LAST_H, NEUTRAL>(wr_addr);
+                    }
+                }
                 cb_in0.push_back(onetile);
             }
             col_l1_addr += tile_bytes;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -8,6 +8,7 @@
 #include "experimental/circular_buffer.h"
 #include "experimental/tensor.h"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -20,6 +21,11 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t HtWt = get_compile_time_arg_val(2);
     constexpr uint32_t row_chunk = get_compile_time_arg_val(3);
+    constexpr uint32_t IN_DF = get_compile_time_arg_val(4);
+    constexpr uint32_t LAST_W = get_compile_time_arg_val(5);
+    constexpr uint32_t LAST_H = get_compile_time_arg_val(6);
+    constexpr uint32_t NEUTRAL_POLICY = get_compile_time_arg_val(7);
+    constexpr NeutralPolicy NEUTRAL = static_cast<NeutralPolicy>(NEUTRAL_POLICY);
 
     constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
 
@@ -27,10 +33,10 @@ void kernel_main() {
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
 
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_2;
-    constexpr uint32_t scalar = get_compile_time_arg_val(4);
+    constexpr uint32_t scalar = get_compile_time_arg_val(8);
     generate_reduce_scaler(cb_id_in2, scalar);
 
-    constexpr auto tensor_args = TensorAccessorArgs<5>();
+    constexpr auto tensor_args = TensorAccessorArgs<9>();
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr, tile_bytes);
 
     experimental::Noc noc;
@@ -67,6 +73,18 @@ void kernel_main() {
                 cb_in0.reserve_back(onetile);
                 noc.async_read(tensor_accessor, cb_in0, tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
                 noc.async_read_barrier();
+                if constexpr (LAST_W > 0) {
+                    if (w == Wt - 1) {
+                        uint32_t wr_addr = cb_in0.get_write_ptr();
+                        apply_width_padding<IN_DF, LAST_W, NEUTRAL>(wr_addr);
+                    }
+                }
+                if constexpr (LAST_H > 0) {
+                    if (j == Ht - 1) {
+                        uint32_t wr_addr = cb_in0.get_write_ptr();
+                        apply_height_padding<IN_DF, LAST_H, NEUTRAL>(wr_addr);
+                    }
+                }
                 cb_in0.push_back(onetile);
 
                 ++w;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -4,10 +4,12 @@
 
 #include "reduce_op_multi_core_h_program_factory.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <cmath>
+using ttnn::operations::reduction::get_neutral_policy;
 
 namespace ttnn::prim {
 
@@ -26,6 +28,23 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
     uint32_t HtWt = Ht * Wt;
+
+    // Calculate padding dimensions from logical shape
+    const auto& logical_shape = a.logical_shape();
+    uint32_t logical_W = logical_shape[3];
+    uint32_t logical_H = logical_shape[2];
+    uint32_t last_w = logical_W % tile_width;   // 0 means no padding needed
+    uint32_t last_h = logical_H % tile_height;  // 0 means no padding needed
+    // If last_w or last_h is 0, it means the dimension is already tile-aligned
+    // In that case, we don't need to pad, so we set to tile_width/tile_height respectively
+    // which will result in no padding being applied
+    if (last_w == 0) {
+        last_w = tile_width;
+    }
+    if (last_h == 0) {
+        last_h = tile_height;
+    }
+    uint32_t neutral_policy = get_neutral_policy(operation_attributes.math_op);
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
@@ -142,7 +161,16 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
     }
 
     if (use_width_sharding) {
-        std::vector<uint32_t> reader_compile_time_args = {src0_cb_index, src1_cb_index, scaler_cb_index};
+        // Compile-time args for sharded reader:
+        // 0: src0_cb_index, 1: src1_cb_index, 2: IN_DF, 3: LAST_W, 4: LAST_H, 5: NEUTRAL_POLICY, 6: scaler_cb_index
+        std::vector<uint32_t> reader_compile_time_args = {
+            src0_cb_index,
+            src1_cb_index,
+            static_cast<uint32_t>(src0_cb_data_format),
+            last_w,
+            last_h,
+            neutral_policy,
+            scaler_cb_index};
         std::map<std::string, std::string> reader_defines;
         reader_defines["REDUCE_SCALER"] = "1";
         reader_kernel_id = tt_metal::CreateKernel(
@@ -152,7 +180,19 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
             all_cores,
             tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
     } else {
-        std::vector<uint32_t> reader_compile_time_args = {Ht, Wt, HtWt, chunk_size, packed_scaler_value};
+        // Compile-time args for interleaved reader:
+        // 0: Ht, 1: Wt, 2: HtWt, 3: row_chunk, 4: IN_DF, 5: LAST_W, 6: LAST_H, 7: NEUTRAL_POLICY, 8:
+        // packed_scaler_value
+        std::vector<uint32_t> reader_compile_time_args = {
+            Ht,
+            Wt,
+            HtWt,
+            chunk_size,
+            static_cast<uint32_t>(src0_cb_data_format),
+            last_w,
+            last_h,
+            neutral_policy,
+            packed_scaler_value};
         TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
         reader_kernel_id = tt_metal::CreateKernel(
@@ -244,8 +284,19 @@ ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory:
         uint32_t shard_Wt = num_cols_per_core_group_1 / NC;
         uint32_t shard_row_size = shard_Wt * src0_single_tile_size;
         uint32_t shard_batch_size = shard_row_size * Ht;
+        // Check if padding is needed (logical size is not tile-aligned)
+        uint32_t is_last_w_padded = (logical_W % tile_width != 0) ? 1 : 0;
+        uint32_t is_last_h_padded = (logical_H % tile_height != 0) ? 1 : 0;
         std::vector<uint32_t> reader_rt_args = {
-            num_cols_per_core_group_1 * Ht, shard_Wt, Ht, NC, shard_row_size, shard_batch_size, packed_scaler_value};
+            num_cols_per_core_group_1 * Ht,
+            shard_Wt,
+            Ht,
+            NC,
+            shard_row_size,
+            shard_batch_size,
+            is_last_w_padded,
+            is_last_h_padded,
+            packed_scaler_value};
         tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores, reader_rt_args);
 
         std::vector<uint32_t> writer_rt_args = {num_cols_per_core_group_1};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -4,10 +4,12 @@
 
 #include "reduce_op_multi_core_w_program_factory.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <cmath>
+using ttnn::operations::reduction::get_neutral_policy;
 
 namespace ttnn::prim {
 
@@ -24,6 +26,13 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
 
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
+
+    // Calculate padding dimensions from logical shape
+    const auto& logical_shape = a.logical_shape();
+    uint32_t logical_W = logical_shape[3];
+    uint32_t logical_H = logical_shape[2];
+    uint32_t last_w = logical_W % tile_width;   // 0 means no padding needed
+    uint32_t last_h = logical_H % tile_height;  // 0 means no padding needed
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
@@ -79,8 +88,14 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     bfloat16 bfloat_scaler_value = bfloat16::truncate(operation_attributes.scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
     tt_metal::Buffer* src_buffer = a.buffer();
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+
+    // Prepare reader compile-time args with padding support
+    uint32_t in_df = static_cast<uint32_t>(src0_cb_data_format);
+    uint32_t neutral_policy = get_neutral_policy(operation_attributes.math_op);
+    std::vector<uint32_t> reader_compile_time_args = {
+        packed_scaler_value, Wt, Ht, in_df, last_w, last_h, neutral_policy};
     TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+
     tt_metal::Buffer* dst_buffer = output.buffer();
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
@@ -107,7 +122,7 @@ ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory:
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
-        "reader_unary_reduce_universal_start_id.cpp",
+        "reader_unary_reduce_w_with_padding.cpp",
         all_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reduce_defines));
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -4,10 +4,12 @@
 
 #include "reduce_op_single_core_hw_program_factory.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <cmath>
+using ttnn::operations::reduction::get_neutral_policy;
 
 namespace ttnn::prim {
 
@@ -29,6 +31,13 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     uint32_t Wt = W / tile_width;
     uint32_t Ht = H / tile_height;
     float scaler = std::sqrt(operation_attributes.scaler);
+
+    // Calculate padding dimensions from logical shape
+    const auto& logical_shape = a.logical_shape();
+    uint32_t logical_W = logical_shape[3];
+    uint32_t logical_H = logical_shape[2];
+    uint32_t last_w = logical_W % tile_width;   // 0 means no padding needed
+    uint32_t last_h = logical_H % tile_height;  // 0 means no padding needed
 
     uint32_t num_tensor_tiles = NC * H * W / tile_hw;
 
@@ -78,7 +87,12 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
 
     bfloat16 bfloat_scaler_value = bfloat16::truncate(scaler);
     uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    std::vector<uint32_t> reader_compile_time_args = {packed_scaler_value};
+
+    // Prepare reader compile-time args with padding support
+    uint32_t in_df = static_cast<uint32_t>(src0_cb_data_format);
+    uint32_t neutral_policy = get_neutral_policy(operation_attributes.math_op);
+    std::vector<uint32_t> reader_compile_time_args = {
+        packed_scaler_value, Wt, Ht, in_df, last_w, last_h, neutral_policy};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     if (operation_attributes.negate) {
@@ -103,7 +117,7 @@ ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFact
     tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
-        "reader_unary_reduce_universal_start_id.cpp",
+        "reader_unary_reduce_w_with_padding.cpp",
         core,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -374,9 +374,15 @@ Tensor reduce(
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     ttnn::SmallVector<int> dim = reduction_common::generate_reduce_dim(input_tensor_arg, dim_arg);
-    float pad_value = get_pad_value(reduce_type);
-    bool is_tiled = input_tensor_arg.layout() == TILE_LAYOUT;
-    auto input_tensor = is_tiled ? ttnn::fill_implicit_tile_padding(input_tensor_arg, pad_value) : input_tensor_arg;
+    auto input_tensor = input_tensor_arg;
+
+    // Kernel-level tile padding only supports BFLOAT16 and FLOAT32.
+    // For BFLOAT8_B (shared-exponent format), fall back to host-side padding.
+    if (input_tensor.layout() == TILE_LAYOUT && input_tensor.dtype() == DataType::BFLOAT8_B) {
+        float pad_value = get_pad_value(reduce_type);
+        input_tensor = ttnn::fill_implicit_tile_padding(input_tensor, pad_value);
+    }
+
     // TODO: generalize to support all types, parameters, and formats. Issue #18566
     ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
     if (call_fast_nc<reduce_type>(input_tensor.dtype())) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-25549_red_pad)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-25549_red_pad)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-25549_red_pad)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-25549_red_pad)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-25549_red_pad)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-25549_red_pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-25549_red_pad)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
