### PR TITLE
[bug fix, test] Fix HW exception tests

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -191,7 +191,6 @@ static void RunTest(
         case 7: hw_fault_info = 0xffffffffff000000; break;
         default: hw_fault_info = 0; break;
     }
-    log_critical(LogTest, "hw_fault_info: 0x{:x}, hw_assert_cause: 0x{:x}", hw_fault_info, hw_assert_cause);
     const std::string msg = get_debug_assert_message(
         assert_type,
         0,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -222,13 +222,13 @@ static void RunTest(
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else if (assert_type == dev_msgs::DebugAssertHwFault) {
-        // Build regex pattern from string expected, replacing PC 0x0 with PC 0x\d+
+        // Build regex pattern from string expected, replacing PC 0x0 with PC 0x[\da-fA-F]+
         std::string pattern = regex_escape(expected);
         const std::string pc_placeholder = "PC 0x0";
         size_t pos = pattern.find(pc_placeholder);
         ASSERT_NE(pos, std::string::npos)
             << "Expected placeholder '" << pc_placeholder << "' not found in exception: " << pattern;
-        pattern.replace(pos, pc_placeholder.length(), "PC 0x\\d+");
+        pattern.replace(pos, pc_placeholder.length(), "PC 0x[\\da-fA-F]+");
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -226,7 +226,7 @@ static void RunTest(
         const std::string pc_placeholder = "PC 0x0";
         size_t pos = pattern.find(pc_placeholder);
         ASSERT_NE(pos, std::string::npos)
-            << "Expected placeholder '" << pc_placeholder << "' not found in exception: " << pattern;
+            << "Expected placeholder '" << pc_placeholder << "' not found in escaped pattern: " << pattern;
         pattern.replace(pos, pc_placeholder.length(), "PC 0x[\\da-fA-F]+");
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some HW exceptions tests were failing although the correct assert was raised

### What's changed
The issue was with the place holder for PC value. The value is hexadecimal number where as the regex used only included decimal digits. I changed the regex to allow for hex values

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayaacob/hw_exception_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayaacob/hw_exception_test_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/hw_exception_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/hw_exception_test_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/hw_exception_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/hw_exception_test_fix)
- [x] New/Existing tests provide coverage for changes