### PR TITLE
Skip warmup_model_decode in deepseek for vLLM flow

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -2801,6 +2801,11 @@ class DeepseekGenerator(WarmupForwardMixin):
         logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
         logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
 
+    def warmup_model_decode(
+        self, kv_cache, enable_trace, max_batch_size, num_blocks, can_sample_on_device, non_greedy_decoding_on_device
+    ) -> None:
+        logger.warning("Warmup model decode not implemented for DeepseekGenerator")
+
     def get_kv_cache(self):
         assert self.model_state is not None, "Model state is not initialized"
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -2804,8 +2804,18 @@ class DeepseekGenerator(WarmupForwardMixin):
     def warmup_model_decode(
         self, kv_cache, enable_trace, max_batch_size, num_blocks, can_sample_on_device, non_greedy_decoding_on_device
     ) -> None:
-        logger.warning("Warmup model decode not implemented for DeepseekGenerator")
+        """
+        Intentionally skip decode warmup for DeepseekGenerator.
 
+        For DeepSeek running under vLLM trace mode, decode warmup can hang due to
+        interactions between trace capture and allocator behavior (see #40958).
+        As a workaround, we disable decode warmup here, which may increase
+        time-to-first-token (TTFT) but avoids the trace-capture/alloc hang.
+        """
+        logger.warning(
+            "Skipping decode warmup for DeepseekGenerator to avoid vLLM trace "
+            "capture/allocator hang (#40958). This may increase time-to-first-token (TTFT)."
+        )
     def get_kv_cache(self):
         assert self.model_state is not None, "Model state is not initialized"
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40958

### Problem description
This control flow `trace capture -> allocate dev mem -> trace capture` corrupts the memory and hang is observed.

### What's changed
This is a work-around. Real fix should be capturing all traces and not allocating any dev mem after that. While real fix is WIP, this wa allows to run vLLM with trace ON. side effect it TTFT will be larger as warmup is skipped.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapti/fix_40958_wa)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapti/fix_40958_wa)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapti/fix_40958_wa)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapti/fix_40958_wa)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapti/fix_40958_wa)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapti/fix_40958_wa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapti/fix_40958_wa)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
