### PR TITLE
Pool Fixes

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -123,17 +123,12 @@ def test_avg_pool2d_post_commit(
         ([2, 32, 1024, 1024], 8),
         ([1, 320, 384, 384], 6),
         ([1, 64, 96, 96], 4),
+        ([1, 64, 96, 96], 0),  # auto num_slices: exercises L1 estimation -> slice determination path
     ),
 )
 @pytest.mark.parametrize(
     "kernel_size",
-    (
-        # Wide and normal reductions go to normal kernels
-        # Large reductions go to large kernels
-        # Reductions which are large and wide at the same time
-        # go to large kernels
-        (3, 3),
-    ),
+    ((3, 3),),
 )
 @pytest.mark.parametrize(
     "stride",
@@ -155,7 +150,7 @@ def test_avg_pool2d_post_commit(
 )
 @pytest.mark.parametrize(
     "count_include_pad",
-    [True],
+    [True, False],  # False exercises per-element scalar CB path in DRAM slicing L1 estimation
 )
 @pytest.mark.parametrize(
     "shard_scheme",

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_mpwi.cpp
@@ -7,7 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
 
-#define ENABLE_DEBUG_PRINT 1
+#define ENABLE_DEBUG_PRINT 0
 
 #if ENABLE_DEBUG_PRINT == 1
 #include "api/debug/dprint.h"
@@ -260,7 +260,7 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
         // junk/padding data
         if constexpr (zero_pages && reader_id == 0) {
             if (c_i == in_nblocks_c - 1 && last_tile_is_partial) {
-                zero_out_page<in_cb_id>();
+                zero_out_page<in_cb_id>(get_write_ptr(in_cb_id));
             }
         }
         for (uint32_t h = 0; h < kernel_h; ++h) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -25,8 +25,8 @@ void validate_pool2d(
     const bool return_indices,
     const Layout& output_layout) {
     // check the input tensor
-    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
-    TT_FATAL(input.buffer() != nullptr, "Operands to reshape need to be allocated in buffers on device!");
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Pool2D input must be on device!");
+    TT_FATAL(input.buffer() != nullptr, "Pool2D input must be allocated in buffers on device!");
     TT_FATAL(input.dtype() == DataType::BFLOAT16, "Only BFLOAT16 supported for now");
     TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR supported for now. Tracked by issue #23338");
 
@@ -172,31 +172,29 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t
     const auto& input_shape = input.logical_shape();
     auto sliding_window_config = op_attr.sliding_window_config_;
     uint32_t batch_size = sliding_window_config.batch_size;
-    uint32_t activation_h = sliding_window_config.input_hw.first;
-    uint32_t activation_w = sliding_window_config.input_hw.second;
-    uint32_t activation_c = input_shape[3];
-    uint32_t output_channels = input_shape[3];
+    uint32_t channels = input_shape[3];
 
     uint32_t filter_h = sliding_window_config.window_hw.first;
     uint32_t filter_w = sliding_window_config.window_hw.second;
-    uint32_t stride_h = sliding_window_config.stride_hw.first;
-    uint32_t stride_w = sliding_window_config.stride_hw.second;
-    uint32_t pad_h = sliding_window_config.get_pad_h();
-    uint32_t pad_w = sliding_window_config.get_pad_w();
 
-    // GS specific parameters
-    int num_cores = 9 * 12;
+    // Use sliding_window_config for output dimensions (accounts for dilation, ceil_mode, etc.)
+    auto output_shape = sliding_window_config.get_output_shape();
+    uint32_t output_height = output_shape[1];
+    uint32_t output_width = output_shape[2];
+
+    // Use actual core count from the operation's core range
+    int num_cores = static_cast<int>(sliding_window_config.num_cores_nhw * sliding_window_config.num_cores_c);
+    if (num_cores == 0) {
+        num_cores = 1;
+    }
     int tensix_mul_adds_per_cycle_lofi = 2048;
 
-    // Calculate output dimensions: relevant for window/stride based OPs (conv, pool, downsample)
-    int output_height = std::floor(((activation_h - filter_h + pad_h) / stride_h) + 1);
-    int output_width = std::floor(((activation_w - filter_w + pad_w) / stride_w) + 1);
+    // For pooling, each output element requires filter_h * filter_w operations per channel
+    // (comparisons for max pool, additions for avg pool), not cross-channel like convolution
+    int64_t num_ops_per_elem = filter_h * filter_w;
+    int64_t num_ops = num_ops_per_elem * output_height * output_width * channels * batch_size;
 
-    // Calculate number of mul/add / compare operations
-    int64_t num_mul_adds_per_elem = activation_c * filter_h * filter_w;  // 1 multiply and 1 add per element
-    int64_t num_mul_adds = num_mul_adds_per_elem * output_height * output_width * output_channels * batch_size;
-
-    int ideal_dev_clock_cycles = std::ceil((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
+    int ideal_dev_clock_cycles = std::ceil((float)num_ops / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
 
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         {input}, {outputs}, ideal_dev_clock_cycles);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -157,10 +157,13 @@ ttsl::hash::hash_t Pool2D::compute_program_hash(const operation_attributes_t& op
     return tt::tt_metal::operation::hash_operation<Pool2D>(
         op_attr.sliding_window_config_.get_hash(),
         op_attr.pool_type_,
+        op_attr.output_layout_,
         op_attr.memory_config_,
+        op_attr.compute_kernel_config_,
         op_attr.divisor_override_,
         op_attr.count_include_pad_,
         op_attr.return_indices_,
+        op_attr.config_tensor_in_dram,
         input_mem_config,
         in_dtype,
         out_dtype);

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -181,6 +181,24 @@ static std::vector<Tensor> pool2d_L1(
         .ceil_mode = ceil_mode,
     };
     auto output_shape = sliding_window_config.get_output_shape();
+    TT_FATAL(
+        output_shape[1] > 0 && output_shape[2] > 0,
+        "Pool2D: Computed output dimensions must be positive, got {}x{} "
+        "(input={}x{}, kernel={}x{}, stride={}x{}, dilation={}x{}, padding=[{},{},{},{}])",
+        output_shape[1],
+        output_shape[2],
+        input_h,
+        input_w,
+        kernel_size[0],
+        kernel_size[1],
+        stride[0],
+        stride[1],
+        dilation_h,
+        dilation_w,
+        padding_4d[0],
+        padding_4d[1],
+        padding_4d[2],
+        padding_4d[3]);
     const bool is_input_tensor_in_dram = input_tensor.memory_config().is_dram();
     sliding_window::ParallelConfig parallel_config;
     MemoryConfig out_memory_config = input_tensor.memory_config();

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -226,14 +226,9 @@ static std::vector<Tensor> pool2d_L1(
 
         // Apply zero padding to channels if needed - we need it in case when output dtype is block float because if we
         // have random values it would affect common exponent calculation
-
-        Tensor input_tensor_padded;
         if (padding_needed > 0 && is_block_float(dtype)) {
             ttnn::SmallVector<std::array<uint32_t, 2>> pad_spec = {{0, 0}, {0, 0}, {0, 0}, {0, padding_needed}};
-
-            input_tensor_padded = ttnn::pad(input_tensor, pad_spec, 0.0f);
-        } else {
-            input_tensor_padded = input_tensor;
+            input_tensor_flattened = ttnn::pad(input_tensor_flattened, pad_spec, 0.0f);
         }
         input_tensor_sharded = ttnn::to_memory_config(input_tensor_flattened, in_memory_config, std::nullopt);
         out_memory_config = input_tensor_sharded.memory_config();

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
@@ -74,19 +74,19 @@ void bind_max_pool2d_operation(nb::module_& mod) {
     ttnn::bind_function<"max_pool2d">(
         mod,
         R"doc(
-        Applies a max pool convolution to the input tensor. The resulting output Tensor will contain the maximum
-        value for each channel within a kernel window. The input tensor is expected to be in [NHW, C] format and
-        should be on the device. Height, width and block sharding schemes are supported.
+        Applies max pooling to the input tensor. Each output element contains the maximum value within a
+        sliding kernel window per channel. The input tensor is expected to be in [NHW, C] or [N, H, W, C]
+        format and should be on the device. Height, width and block sharding schemes are supported.
 
         Args:
-            input_tensor_a (ttnn.Tensor): the tensor to be convolved.
-            batch_size (int): the number of batches (N in a [N, C, H, W] shaped tensor).
-            input_h (int): the height of the input tensor (H in a [N, C, H, W] shaped tensor).
-            input_w (int): the width of the input tensor (W in a [N, C, H, W] shaped tensor).
-            channels (int): the number of channels (C in a [N, C, H, W] shaped tensor).
+            input_tensor (ttnn.Tensor): the input tensor.
+            batch_size (int): the number of batches (N).
+            input_h (int): the height of the input tensor (H).
+            input_w (int): the width of the input tensor (W).
+            channels (int): the number of channels (C).
             kernel_size (List of [int]): the (h, w) size of the kernel window.
             stride (List of [int]): the (h, w) stride of the kernel window.
-            padding (List of [int]): the (h, w) padding of the input tensor.
+            padding (List of [int]): the (h, w) or (top, bottom, left, right) padding.
             dilation (List of [int]): the (h, w) dilation of the kernel window.
             ceil_mode (bool): whether to use ceil mode for the output shape. Defaults to `False`.
 
@@ -100,7 +100,7 @@ void bind_max_pool2d_operation(nb::module_& mod) {
             output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
 
         Returns:
-            ttnn.Tensor or tuple[ttnn.Tensor, ttnn.Tensor]: the max pool convolved output tensor, or a tuple of (values, indices) if return_indices is True.
+            ttnn.Tensor or tuple[ttnn.Tensor, ttnn.Tensor]: the output tensor, or a tuple of (values, indices) if return_indices is True.
         )doc",
         &max_pool2d_nanobind_wrapper,
         nb::arg("input_tensor"),
@@ -129,22 +129,22 @@ void bind_avg_pool2d_operation(nb::module_& mod) {
     ttnn::bind_function<"avg_pool2d">(
         mod,
         R"doc(
-        Applies an average pool convolution to the input tensor. The resulting output Tensor will contain the average
-        value for each channel within a kernel window. The input tensor is expected to be in [NHW, C] format and
-        should be on the device. Height, width and block sharding schemes are supported.
+        Applies average pooling to the input tensor. Each output element contains the average value within a
+        sliding kernel window per channel. The input tensor is expected to be in [NHW, C] or [N, H, W, C]
+        format and should be on the device. Height, width and block sharding schemes are supported.
 
         Args:
-            input_tensor_a (ttnn.Tensor): the tensor to be convolved.
-            batch_size (int): the number of batches (N in a [N, C, H, W] shaped tensor).
-            input_h (int): the height of the input tensor (H in a [N, C, H, W] shaped tensor).
-            input_w (int): the width of the input tensor (W in a [N, C, H, W] shaped tensor).
-            channels (int): the number of channels (C in a [N, C, H, W] shaped tensor).
+            input_tensor (ttnn.Tensor): the input tensor.
+            batch_size (int): the number of batches (N).
+            input_h (int): the height of the input tensor (H).
+            input_w (int): the width of the input tensor (W).
+            channels (int): the number of channels (C).
             kernel_size (List of [int]): the (h, w) size of the kernel window.
             stride (List of [int]): the (h, w) stride of the kernel window.
-            padding (List of [int]): the (h, w) padding of the input tensor.
-            ceil_mode (bool): When True, uses 'ceiling' function instead of 'floor' function in the formula to compute output shape. Default: False.
+            padding (List of [int]): the (h, w) or (top, bottom, left, right) padding.
+            ceil_mode (bool): When True, uses 'ceiling' instead of 'floor' to compute output shape. Default: False.
             count_include_pad (bool): When True, includes zero-padding in the avg calculation. Default: True.
-            divisor_override (int, optional): If specified, it will be used as a divisor, otherwise size of the pooling region will be used. Default: None. Not currently supported in ttnn.
+            divisor_override (int, optional): If specified, it will be used as a divisor, otherwise size of the pooling region will be used. Default: None.
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
@@ -156,7 +156,7 @@ void bind_avg_pool2d_operation(nb::module_& mod) {
             compute_kernel_config (DeviceComputeKernelConfig, optional): the device compute kernel configuration. Defaults to `None`.
 
         Returns:
-            ttnn.Tensor: the average pool convolved output tensor.
+            ttnn.Tensor: the output tensor.
         )doc",
         &ttnn::avg_pool2d,
         nb::arg("input_tensor"),

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -540,7 +540,9 @@ void validate_input_params(
         dilation_h,
         dilation_w);
 
-    // check that padding is not excessive (should not be more than half the kernel size)
+    // Check that padding is not excessive (should not be more than half the kernel size).
+    // pad_right is intentionally excluded: DRAM slicing with TILE output can inflate it
+    // via width rounding in Pool2dSliceAttr::get_input_slice_and_padding.
     TT_FATAL(
         pad_top <= kernel_size[0] / 2 && pad_bottom <= kernel_size[0] / 2 && pad_left <= kernel_size[1] / 2,
         "Pool2D: Padding ({}, {}, {}) should not exceed half of kernel size ({}, {})",

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -716,8 +716,8 @@ pool2d_slice_l1_usage calculate_L1_usage_for_pool2d_slice(
         sliding_window_config.input_hw.first,
         sliding_window_config.input_hw.second,
         sliding_window_config.channels,
-        slice_padding[0],  // pad_h (top)
-        slice_padding[2],  // pad_w (left)
+        slice_padding[0] + slice_padding[1],  // pad_h (top + bottom)
+        slice_padding[2] + slice_padding[3],  // pad_w (left + right)
         slice_ceil_pad[0],
         slice_ceil_pad[1],
         sliding_window_config.ceil_mode,


### PR DESCRIPTION
### Problem description

The pool2d operations had several bugs across the core op, MPWI, DRAM slicing, and program caching:

  1. Block float (BFLOAT8_B/BFLOAT4_B) channel padding was computed but never applied — the padded tensor was discarded and the unpadded one sharded, allowing junk data to corrupt the block float common exponent.
  2. The performance model used a convolution formula (activation_c * filter_h * filter_w) instead of pooling (filter_h * filter_w), overestimating by a factor of channels. It also hardcoded Grayskull's core count and ignored dilation in output dimension calculation.
  3. The program cache hash was missing output_layout, compute_kernel_config, and config_tensor_in_dram, all of which affect kernel compilation. Conv2d hashes all three analogous fields.
  4. DRAM slice L1 estimation passed only top/left padding instead of total padding to calculate_L1_usage, causing the estimator to disagree with the factory about whether per-element scalar CBs are needed — particularly when TILE output width rounding inflates pad_right.           
  5. The MPWI reader kernel had ENABLE_DEBUG_PRINT left at 1 and a latent zero_out_page call missing its required argument.                                                                                                                                                                
  6. AvgPool DRAM slicing tests only covered count_include_pad=True with manual slice counts, leaving the L1 estimation and auto-determination paths untested.
  
### What's changed                                                                                                                                                                                                    
                                                                                                                                                                                                                                                          
- generic_pools.cpp: Fix block float padding to apply to the correct tensor. Add output dimension positivity assert after get_output_shape().                                                                                                                                            
- pool_op.cpp: Fix performance model formula, core count, and output dim calculation. Fix error messages. Add output_layout_, compute_kernel_config_, and config_tensor_in_dram to program hash.
- pool_utils.cpp: Fix DRAM slice L1 estimation to pass total padding (top+bottom, left+right). Document why pad_right is intentionally excluded from padding validation.                                                                                                                 
- reader_mpwi.cpp: Set ENABLE_DEBUG_PRINT to 0. Fix zero_out_page missing write_addr argument.                                                                                                                                                                                           
- test_avgpool2d.py: Add count_include_pad=False and auto num_slices=0 to DRAM slice tests (+5 cases).
  
### Checklist
Sanity APC:
https://github.com/tenstorrent/tt-metal/actions/runs/24089525341

Blackhole APC:
https://github.com/tenstorrent/tt-metal/actions/runs/23910406386

Nightly L2:
https://github.com/tenstorrent/tt-metal/actions/runs/23910420573

Frequent Model:
https://github.com/tenstorrent/tt-metal/actions/runs/24034528828

Model Perf:
https://github.com/tenstorrent/tt-metal/actions/runs/23905670922