### PR TITLE
fix(sweeps): SFTP upload downloads only homogenized artifact

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1261,7 +1261,7 @@ jobs:
       - name: Download sweep results
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: sweeps-run-result 
+          name: sweeps-run-result
           path: tests/sweep_framework/results_export
       - name: List all downloaded files
         run: |

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1261,11 +1261,8 @@ jobs:
       - name: Download sweep results
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          pattern: |
-            sweeps-run-result
-            sweeps-results-*
+          name: sweeps-run-result
           path: tests/sweep_framework/results_export
-          merge-multiple: true
       - name: List all downloaded files
         run: |
           ls -hal tests/sweep_framework/results_export

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1261,7 +1261,7 @@ jobs:
       - name: Download sweep results
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          name: sweeps-run-result
+          name: sweeps-run-result 
           path: tests/sweep_framework/results_export
       - name: List all downloaded files
         run: |


### PR DESCRIPTION
## Summary

- Fix SFTP upload step downloading raw batch artifacts (`sweeps-results-*-batch-*`) alongside the homogenized artifact (`sweeps-run-result`), causing raw `oprun_*.json` files to overwrite homogenized ones
- Switch from `pattern: sweeps-*` + `merge-multiple: true` to `name: sweeps-run-result` so only the homogenized artifact is downloaded

### Bug

The SFTP upload step used `pattern: sweeps-*` which matched both:
1. `sweeps-run-result` — homogenized by `run_collective_update.py` with normalized `run_contents`
2. `sweeps-results-*-batch-*` — raw per-batch artifacts with per-batch `run_contents`

With `merge-multiple: true`, raw batch `oprun_*.json` files overwrote the homogenized versions (same filenames). This caused:

- **model_traced (run 3908)**: 50 raw oprun files uploaded with per-batch `run_contents` (e.g. `"model_traced.where_model_traced, model_traced"`) instead of `"model traced"` → Superset created 9+ split entries instead of one
- **lead_models (run 3909)**: 3 raw oprun files uploaded with Galaxy batch-specific `run_contents` instead of `"lead models"` → results invisible in Superset

### Fix

Both code paths already produce a `sweeps-run-result` artifact:
- **Single sweep**: uploaded directly by `ttnn-run-single-sweep`
- **Parallel runs**: uploaded by `ttnn-homogenize-run-result` after normalizing metadata

So the SFTP upload only needs `name: sweeps-run-result` (exact match), not `pattern: sweeps-*` (glob).

## Test plan

- [ ] Trigger model_traced sweep run → verify single Superset entry with `run_contents: "model traced"`
- [ ] Trigger lead_models sweep run → verify results appear in Superset with `run_contents: "lead models"`
- [ ] Trigger single sweep run → verify SFTP upload still works (downloads `sweeps-run-result` from single-sweep path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)