### PR TITLE
Fix BH tray isolation CI to run single test to avoid FW reinit failure

### DIFF
--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -108,7 +108,12 @@ jobs:
             container_prefix: bh_tray
             mesh_descriptor: p150_x8_mesh_graph_descriptor.textproto
             test_path: tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_gather_nightly.py
-            test_args: "-k 'non-trace and not ring and not broken'"
+            # The bh_1d_mesh_device fixture is function-scoped and opens/closes all 8 devices per test.
+            # Repeated open/close cycles can randomly cause firmware re-initialization failures
+            # ("Device N init: failed to initialize FW") due to a BH-specific firmware layer issue,
+            # not a tt-metal issue. Since this CI only needs one representative test to verify
+            # inter-container isolation, we narrow down to a single test combination to avoid the problem.
+            test_args: "-k 'non-trace and not ring and not broken and linear_2D and bfloat_8 and 2_links and not DRAM'"
     runs-on:
       - topology-6u
       - arch-${{ matrix.arch }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Failed a CI for BH tray isolation

https://github.com/tenstorrent/tt-metal/actions/runs/23826076121/job/69550706646

Repeated open/close of the 8-device mesh (bh_1d_mesh_device, function-scoped) can randomly cause Blackhole firmware re-initialization failures ("Device N init: failed to initialize FW"). This is a BH-specific firmware layer issue, not a tt-metal issue.

### What's changed
Since this CI only needs one representative test to verify inter-container isolation, narrow the test selection to a single combination (linear_2D, bfloat8, 2_links, L1-L1 memory config) to avoid accumulating open/close cycles.

Passed CI: https://github.com/tenstorrent/tt-metal/actions/runs/23883551453

Once firmware support for BH Galaxy stabilizes, we can revert from running only a single test to running additional tests as well, though this is not strictly necessary.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-bh-tray-isolation-ci-fw-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-bh-tray-isolation-ci-fw-init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-bh-tray-isolation-ci-fw-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-bh-tray-isolation-ci-fw-init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-bh-tray-isolation-ci-fw-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-bh-tray-isolation-ci-fw-init)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early
