### PR TITLE
Investigate batch_norm/[group_]attn_matmul program cache hash functionionality

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
@@ -453,7 +453,7 @@ def test_group_attn_matmul_fp32(
 
 @pytest.mark.use_module_device
 @pytest.mark.parametrize(
-    "batch, K,seq_len, q_heads, kv_heads",
+    "batch, K, seq_len, q_heads, kv_heads",
     [
         pytest.param(32, 128, 96, 32, 4, id="b32-K128-s96-q32-kv4"),
         pytest.param(32, 64, 128, 16, 2, id="b32-K64-s128-q16-kv2"),
@@ -523,10 +523,6 @@ def test_group_attn_matmul_with_program_cache_exhaustive(
     in1_dtype = ttnn.bfloat16
     output_dtype = ttnn.bfloat16
 
-    num_cores_required = max(q_heads, 32)
-    if compute_grid.x * compute_grid.y < num_cores_required:
-        pytest.skip("compute grid too small for q_heads / minimum 32 cores")
-
     interleaved_input_mem = ttnn.DRAM_MEMORY_CONFIG if input_buffer_type == "dram" else ttnn.L1_MEMORY_CONFIG
     dram_interleaved = ttnn.DRAM_MEMORY_CONFIG
 
@@ -537,13 +533,11 @@ def test_group_attn_matmul_with_program_cache_exhaustive(
         pytest.skip("orientation is unused, dupilcate test")
 
     q_len = 1
-    TILE_SIZE = 32
-
     if in0_sharded:
-        if (q_len * batch) % TILE_SIZE != 0 or K % TILE_SIZE != 0:
+        if (q_len * batch) % ttnn.TILE_SIZE != 0 or K % ttnn.TILE_SIZE != 0:
             pytest.skip("Input 0 shard not supported")
     if in1_sharded:
-        if (kv_heads * K) % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+        if (kv_heads * K) % ttnn.TILE_SIZE != 0 or seq_len % ttnn.TILE_SIZE != 0:
             pytest.skip("Input 1 shard not supported")
 
     input_shape_a = [q_len, q_heads, batch, K]
@@ -711,7 +705,6 @@ def test_attn_matmul_with_program_cache_exhaustive(
 
     q_len = 1
     kv_heads = 1
-    TILE_SIZE = 32
 
     if cache_mode == "standard":
         assert from_cache_num_tokens is None
@@ -725,19 +718,19 @@ def test_attn_matmul_with_program_cache_exhaustive(
 
     if in0_sharded:
         a_k = n_round if cache_mode == "from_cache_post" else K
-        if (q_len * batch) % TILE_SIZE != 0 or a_k % TILE_SIZE != 0:
+        if (q_len * batch) % ttnn.TILE_SIZE != 0 or a_k % ttnn.TILE_SIZE != 0:
             pytest.skip("input 0 shard not supported for this shape")
 
     if in1_sharded:
         if cache_mode == "standard":
-            if (kv_heads * K) % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+            if (kv_heads * K) % ttnn.TILE_SIZE != 0 or seq_len % ttnn.TILE_SIZE != 0:
                 pytest.skip("input 1 shard not supported for standard layout")
         elif cache_mode == "from_cache_pre":
-            if (kv_heads * seq_len) % TILE_SIZE != 0 or K % TILE_SIZE != 0:
+            if (kv_heads * seq_len) % ttnn.TILE_SIZE != 0 or K % ttnn.TILE_SIZE != 0:
                 pytest.skip("input 1 shard not supported for from_cache_pre layout")
         elif cache_mode == "from_cache_post":
             cache_dim = _attn_align_up(max(n_round, K, seq_len))
-            if cache_dim % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+            if cache_dim % ttnn.TILE_SIZE != 0 or seq_len % ttnn.TILE_SIZE != 0:
                 pytest.skip("input 1 shard not supported for from_cache_post layout")
 
     if cache_mode == "from_cache_post":

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
@@ -449,3 +449,404 @@ def test_group_attn_matmul_fp32(
 
         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
         assert allclose, f"FAILED: {output}"
+
+
+@pytest.mark.use_module_device
+@pytest.mark.parametrize(
+    "batch, K,seq_len, q_heads, kv_heads",
+    [
+        pytest.param(32, 128, 96, 32, 4, id="b32-K128-s96-q32-kv4"),
+        pytest.param(32, 64, 128, 16, 2, id="b32-K64-s128-q16-kv2"),
+        pytest.param(32, 160, 128, 64, 4, id="b32-K160-s128-q64-kv4"),
+        pytest.param(32, 64, 256, 32, 2, id="b32-K64-s256-q32-kv2"),
+        pytest.param(32, 64, 384, 48, 4, id="b32-K64-s384-q48-kv4"),
+        pytest.param(32, 96, 512, 24, 2, id="b32-K96-s512-q24-kv2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_optional_output_tensor", [pytest.param(False, id="optout-none"), pytest.param(True, id="optout-prealloc")]
+)
+@pytest.mark.parametrize(
+    "shard_orientation",
+    [
+        pytest.param(ttnn.ShardOrientation.ROW_MAJOR, id="shardorient-row"),
+        pytest.param(ttnn.ShardOrientation.COL_MAJOR, id="shardorient-col"),
+    ],
+)
+@pytest.mark.parametrize(
+    "in0_sharded",
+    [
+        pytest.param(False, id="in0I"),
+        pytest.param(True, id="in0S"),
+    ],
+)
+@pytest.mark.parametrize(
+    "in1_sharded",
+    [
+        pytest.param(False, id="in1I"),
+        pytest.param(True, id="in1S"),
+    ],
+)
+@pytest.mark.parametrize(
+    "output_sharded",
+    [
+        pytest.param(False, id="outI"),
+        pytest.param(True, id="outS"),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_buffer_type",
+    [
+        pytest.param("dram", id="inbuf-dram"),
+        pytest.param("l1", id="inbuf-l1"),
+    ],
+)
+def test_group_attn_matmul_with_program_cache_exhaustive(
+    batch,
+    K,
+    seq_len,
+    q_heads,
+    kv_heads,
+    input_buffer_type,
+    in0_sharded,
+    in1_sharded,
+    output_sharded,
+    shard_orientation,
+    use_optional_output_tensor,
+    device,
+):
+    torch.manual_seed(42)
+    full_grid = device.compute_with_storage_grid_size()
+    compute_grid = ttnn.CoreCoord(full_grid.x, full_grid.y)
+
+    in0_dtype = ttnn.bfloat16
+    in1_dtype = ttnn.bfloat16
+    output_dtype = ttnn.bfloat16
+
+    num_cores_required = max(q_heads, 32)
+    if compute_grid.x * compute_grid.y < num_cores_required:
+        pytest.skip("compute grid too small for q_heads / minimum 32 cores")
+
+    interleaved_input_mem = ttnn.DRAM_MEMORY_CONFIG if input_buffer_type == "dram" else ttnn.L1_MEMORY_CONFIG
+    dram_interleaved = ttnn.DRAM_MEMORY_CONFIG
+
+    if use_optional_output_tensor and output_sharded:
+        pytest.skip("optional_output_tensor path only covered for interleaved (DRAM) output in this suite")
+
+    if (not in0_sharded) and (not in1_sharded) and shard_orientation == ttnn.ShardOrientation.COL_MAJOR:
+        pytest.skip("orientation is unused, dupilcate test")
+
+    q_len = 1
+    TILE_SIZE = 32
+
+    if in0_sharded:
+        if (q_len * batch) % TILE_SIZE != 0 or K % TILE_SIZE != 0:
+            pytest.skip("Input 0 shard not supported")
+    if in1_sharded:
+        if (kv_heads * K) % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+            pytest.skip("Input 1 shard not supported")
+
+    input_shape_a = [q_len, q_heads, batch, K]
+    input_shape_b = [batch, kv_heads, K, seq_len]
+
+    input_tensor_a = torch.randn(input_shape_a).bfloat16()
+    input_tensor_b = torch.randn(input_shape_b).bfloat16()
+
+    tt_input_tensor_a = ttnn.Tensor(input_tensor_a, in0_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_input_mem)
+    tt_input_tensor_b = ttnn.Tensor(input_tensor_b, in1_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_input_mem)
+
+    if in0_sharded:
+        tt_padded_shape_a = tt_input_tensor_a.padded_shape
+        tt_input_tensor_a = ttnn.interleaved_to_sharded(
+            tt_input_tensor_a,
+            compute_grid,
+            [tt_padded_shape_a[0] * tt_padded_shape_a[2], tt_padded_shape_a[3]],  # [q_len * batch, K]
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            shard_orientation,
+        )
+
+    if in1_sharded:
+        tt_padded_shape_b = tt_input_tensor_b.padded_shape
+        tt_input_tensor_b = ttnn.interleaved_to_sharded(
+            tt_input_tensor_b,
+            compute_grid,
+            [tt_padded_shape_b[1] * tt_padded_shape_b[2], tt_padded_shape_b[3]],  # [kv_heads * K, seq_len]
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            shard_orientation,
+        )
+
+    if output_sharded:
+        output_mem_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
+    else:
+        output_mem_config = dram_interleaved
+
+    optional_output_tensor = None
+    if use_optional_output_tensor:
+        out_shape = [q_len, q_heads, batch, seq_len]
+        torch_out_buf = torch.zeros(out_shape, dtype=torch.bfloat16)
+        optional_output_tensor = (
+            ttnn.Tensor(torch_out_buf, output_dtype).to(ttnn.TILE_LAYOUT).to(device, dram_interleaved)
+        )
+
+    kwargs = dict(
+        compute_with_storage_grid_size=compute_grid,
+        memory_config=output_mem_config,
+        dtype=output_dtype,
+    )
+    if optional_output_tensor is not None:
+        kwargs["optional_output_tensor"] = optional_output_tensor
+
+    tt_output_tensor_on_device = ttnn.experimental.group_attn_matmul(
+        tt_input_tensor_a,
+        tt_input_tensor_b,
+        **kwargs,
+    )
+
+    tt_input_tensor_a.deallocate()
+    tt_input_tensor_b.deallocate()
+
+    if output_sharded:
+        tt_output_tensor_on_device = ttnn.sharded_to_interleaved(tt_output_tensor_on_device, dram_interleaved)
+
+    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_output_tensor_on_device.deallocate()
+
+    input_tensor_a = input_tensor_a.to(torch.float)
+    input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
+    golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
+
+    allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+    assert allclose, f"FAILED: {output}"
+
+
+def _attn_round_up_tokens(n: int) -> int:
+    return ((max(1, int(n)) - 1) // 32 + 1) * 32
+
+
+def _attn_align_up(x: int, tile: int = 32) -> int:
+    return ((int(x) + tile - 1) // tile) * tile
+
+
+# Covers: standard attn_matmul vs attn_matmul_from_cache (pre/post)
+@pytest.mark.use_module_device
+@pytest.mark.parametrize(
+    "batch, K, seq_len, q_heads",  # kv_heads is always 1
+    [
+        pytest.param(32, 32, 64, 8, id="b32-K32-s64-q8"),
+        pytest.param(32, 64, 128, 16, id="b32-K64-s128-q16"),
+        pytest.param(32, 64, 256, 32, id="b32-K64-s256-q32"),
+        pytest.param(32, 96, 320, 10, id="b32-K96-s320-q10"),
+        pytest.param(32, 128, 96, 32, id="b32-K128-s96-q32"),
+        pytest.param(32, 48, 192, 24, id="b32-K48-s192-q24"),
+        pytest.param(32, 160, 128, 64, id="b32-K160-s128-q64"),
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_mode, from_cache_num_tokens",
+    [
+        pytest.param("standard", None, id="cache-std"),
+        pytest.param("from_cache_pre", 32, id="cache-pre-32"),
+        pytest.param("from_cache_pre", 64, id="cache-pre-64"),
+        pytest.param("from_cache_post", 32, id="cache-post-32"),
+        pytest.param("from_cache_post", 64, id="cache-post-64"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_optional_output_tensor", [pytest.param(False, id="optout-none"), pytest.param(True, id="optout-prealloc")]
+)
+@pytest.mark.parametrize(
+    "in0_sharded",
+    [
+        pytest.param(False, id="in0I"),
+        pytest.param(True, id="in0S"),
+    ],
+)
+@pytest.mark.parametrize(
+    "in1_sharded",
+    [
+        pytest.param(False, id="in1I"),
+        pytest.param(True, id="in1S"),
+    ],
+)
+@pytest.mark.parametrize(
+    "output_sharded",
+    [
+        pytest.param(False, id="outI"),
+    ],
+)
+def test_attn_matmul_with_program_cache_exhaustive(
+    batch,
+    K,
+    seq_len,
+    q_heads,
+    in0_sharded,
+    in1_sharded,
+    output_sharded,
+    use_optional_output_tensor,
+    cache_mode,
+    from_cache_num_tokens,
+    device,
+):
+    torch.manual_seed(42)
+
+    in0_dtype = ttnn.bfloat16
+    in1_dtype = ttnn.bfloat16
+    output_dtype = ttnn.bfloat16
+    shard_orientation = ttnn.ShardOrientation.ROW_MAJOR
+    interleaved_input_mem = ttnn.L1_MEMORY_CONFIG
+    dram_interleaved = ttnn.DRAM_MEMORY_CONFIG
+
+    full_grid = device.compute_with_storage_grid_size()
+    compute_grid = ttnn.CoreCoord(full_grid.x, full_grid.y)
+
+    num_cores_required = max(q_heads, 32)
+    if compute_grid.x * compute_grid.y < num_cores_required:
+        pytest.skip("compute grid too small for q_heads / minimum 32 cores")
+
+    if use_optional_output_tensor and output_sharded:
+        pytest.skip("optional output_tensor path only covered for interleaved (DRAM) output")
+
+    q_len = 1
+    kv_heads = 1
+    TILE_SIZE = 32
+
+    if cache_mode == "standard":
+        assert from_cache_num_tokens is None
+    else:
+        assert from_cache_num_tokens is not None
+
+    n_round = _attn_round_up_tokens(from_cache_num_tokens) if from_cache_num_tokens is not None else None
+
+    if cache_mode == "from_cache_pre" and seq_len < from_cache_num_tokens:
+        pytest.skip("max_seq (seq_len) must be >= num_tokens for from_cache_pre")
+
+    if in0_sharded:
+        a_k = n_round if cache_mode == "from_cache_post" else K
+        if (q_len * batch) % TILE_SIZE != 0 or a_k % TILE_SIZE != 0:
+            pytest.skip("input 0 shard not supported for this shape")
+
+    if in1_sharded:
+        if cache_mode == "standard":
+            if (kv_heads * K) % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+                pytest.skip("input 1 shard not supported for standard layout")
+        elif cache_mode == "from_cache_pre":
+            if (kv_heads * seq_len) % TILE_SIZE != 0 or K % TILE_SIZE != 0:
+                pytest.skip("input 1 shard not supported for from_cache_pre layout")
+        elif cache_mode == "from_cache_post":
+            cache_dim = _attn_align_up(max(n_round, K, seq_len))
+            if cache_dim % TILE_SIZE != 0 or seq_len % TILE_SIZE != 0:
+                pytest.skip("input 1 shard not supported for from_cache_post layout")
+
+    if cache_mode == "from_cache_post":
+        cache_dim_pre = _attn_align_up(max(n_round, K, seq_len))
+        if from_cache_num_tokens > cache_dim_pre:
+            pytest.skip("num_tokens must be <= B padded dim 2")
+
+    if cache_mode == "standard":
+        input_shape_a = [q_len, q_heads, batch, K]
+        input_shape_b = [batch, kv_heads, K, seq_len]
+    elif cache_mode == "from_cache_pre":
+        input_shape_a = [q_len, q_heads, batch, K]
+        input_shape_b = [batch, kv_heads, seq_len, K]
+    else:
+        cache_dim = _attn_align_up(max(n_round, K, seq_len))
+        input_shape_a = [q_len, q_heads, batch, n_round]
+        input_shape_b = [batch, kv_heads, cache_dim, seq_len]
+
+    input_tensor_a = torch.randn(input_shape_a).bfloat16()
+    input_tensor_b = torch.randn(input_shape_b).bfloat16()
+
+    tt_input_tensor_a = ttnn.Tensor(input_tensor_a, in0_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_input_mem)
+    tt_input_tensor_b = ttnn.Tensor(input_tensor_b, in1_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_input_mem)
+
+    if in0_sharded:
+        tt_padded_shape_a = tt_input_tensor_a.padded_shape
+        tt_input_tensor_a = ttnn.interleaved_to_sharded(
+            tt_input_tensor_a,
+            compute_grid,
+            [tt_padded_shape_a[0] * tt_padded_shape_a[2], tt_padded_shape_a[3]],
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            shard_orientation,
+        )
+
+    if in1_sharded:
+        tt_padded_shape_b = tt_input_tensor_b.padded_shape
+        tt_input_tensor_b = ttnn.interleaved_to_sharded(
+            tt_input_tensor_b,
+            compute_grid,
+            [tt_padded_shape_b[1] * tt_padded_shape_b[2], tt_padded_shape_b[3]],
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            shard_orientation,
+        )
+
+    if output_sharded:
+        output_mem_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
+    else:
+        output_mem_config = dram_interleaved
+
+    optional_output_tensor = None
+    if use_optional_output_tensor:
+        if cache_mode == "from_cache_pre":
+            out_seq = n_round
+        else:
+            out_seq = seq_len
+        out_shape = [q_len, q_heads, batch, out_seq]
+        torch_out_buf = torch.zeros(out_shape, dtype=torch.bfloat16)
+        optional_output_tensor = (
+            ttnn.Tensor(torch_out_buf, output_dtype).to(ttnn.TILE_LAYOUT).to(device, output_mem_config)
+        )
+
+    kwargs = dict(
+        compute_with_storage_grid_size=compute_grid,
+        dtype=output_dtype,
+    )
+    if optional_output_tensor is not None:
+        kwargs["output_tensor"] = optional_output_tensor
+    else:
+        kwargs["memory_config"] = output_mem_config
+
+    if cache_mode == "standard":
+        tt_output_tensor_on_device = ttnn.experimental.attn_matmul(
+            tt_input_tensor_a,
+            tt_input_tensor_b,
+            **kwargs,
+        )
+    else:
+        transpose_hw = cache_mode == "from_cache_pre"
+        tt_output_tensor_on_device = ttnn.experimental.attn_matmul_from_cache(
+            tt_input_tensor_a,
+            tt_input_tensor_b,
+            num_tokens=from_cache_num_tokens,
+            transpose_hw=transpose_hw,
+            **kwargs,
+        )
+
+    tt_input_tensor_a.deallocate()
+    tt_input_tensor_b.deallocate()
+
+    if output_sharded:
+        tt_output_tensor_on_device = ttnn.sharded_to_interleaved(tt_output_tensor_on_device, dram_interleaved)
+
+    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_output_tensor_on_device.deallocate()
+
+    input_tensor_a_f = input_tensor_a.to(torch.float32)
+    input_tensor_b_f = input_tensor_b.to(torch.float32)
+
+    if cache_mode == "standard":
+        golden_output_tensor = (input_tensor_a_f.transpose(0, 2) @ input_tensor_b_f).transpose(0, 2)
+    elif cache_mode == "from_cache_pre":
+        b_part = input_tensor_b_f[:, :, :n_round, :].transpose(-1, -2)
+        golden_output_tensor = torch.matmul(input_tensor_a_f.transpose(0, 2), b_part).transpose(0, 2)
+    else:
+        b_eff = input_tensor_b_f[:, :, :n_round, :]
+        golden_output_tensor = (input_tensor_a_f.transpose(0, 2) @ b_eff).transpose(0, 2)
+
+    allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+    assert allclose, f"FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -337,14 +337,28 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
     "input_shapes",
     [
         torch.Size([3, 2, 32, 32]),
+        torch.Size([1, 16, 32, 64]),
+        torch.Size([4, 2, 64, 32]),
+        torch.Size([1, 128, 14, 14]),
+        torch.Size([2, 16, 64, 120]),
     ],
 )
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.TensorMemoryLayout.HEIGHT_SHARDED])
-def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device):
+@pytest.mark.parametrize("prealloc_out_mem_config", [None, ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, prealloc_out_mem_config, device):
     N, H, W, C = input_shapes
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
     var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device)
+    output_tensor = None
+    if prealloc_out_mem_config is not None:
+        output_tensor = ttnn.from_torch(
+            torch.zeros(input_shapes, dtype=in_data.dtype),
+            device=device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=prealloc_out_mem_config,
+        )
 
     grid_size = ttnn.CoreGrid(y=1, x=8)
     grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
@@ -357,7 +371,11 @@ def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device):
         pytest.xfail("Input tensors to batch norm must be interleaved")
 
     tt_output_tensor_on_device = ttnn.batch_norm(
-        input_tensor, running_mean=mean_tensor, running_var=var_tensor, memory_config=sharded_mem_config
+        input_tensor,
+        running_mean=mean_tensor,
+        running_var=var_tensor,
+        memory_config=sharded_mem_config,
+        output=output_tensor,
     )
     tt_output = ttnn.to_torch(tt_output_tensor_on_device)
     torch_result = torch.nn.functional.batch_norm(input=in_data, running_mean=mean_data, running_var=var_data)

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -143,7 +143,8 @@ ttsl::hash::hash_t BatchNormOperation::compute_program_hash(
         get_optional_tensor_info(batch_mean),
         get_optional_tensor_info(batch_var),
         get_optional_tensor_info(weight),
-        get_optional_tensor_info(bias));
+        get_optional_tensor_info(bias),
+        get_optional_tensor_info(output));
 
     // Apply the hash operation
     return std::apply(


### PR DESCRIPTION
### Ticket
Investigate batch_norm/[group_]attn_matmul program cache hash functionionality #32915 

### Problem description
Check the program cache custom hash generation and verify if tensor shapes should be part of hash. If so will generic hash function be enough for these kernels.
```
- ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
- ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
- ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
```

### What's changed

-  Added the optional output tensor `memory_config()` to hash generation for `batch_norm_device_operation.cpp` to resolve improper cache reuse for cases with preallocated output tensors having different memory configs.
- Added extra test cases to check for above cases.
```
tests/ttnn/unit_tests/operations/fused/test_batch_norm.py::test_batch_norm_program_cache_and_default()
```
- Added exhaustive tensor shape test for [group_]attn_matmul nightly to check different `memory_configs()` 

```
tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py::test_group_attn_matmul_with_program_cache_exhaustive()
tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py::test_attn_matmul_with_program_cache_exhaustive()
```

### Summary and Findings:
- All three kernels can work with the generic hash function, however custom hash with above fixes work fine with different tensor shapes regardless.
- Introducing generic hash function will increase program cache misses for batch_norm and matmul operation.
- The [group_]attn_matmuls will be recompiled for every change in  `seq_len` if tensor shapes are added to hash.


### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/navaneeth_program_cache_investigation)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/navaneeth_program_cache_investigation)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/navaneeth_program_cache_investigation)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/navaneeth_program_cache_investigation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/navaneeth_program_cache_investigation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/navaneeth_program_cache_investigation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/navaneeth_program_cache_investigation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
