### PR TITLE
Fix conv3d default C_in_block to minimize L1 pressure

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -816,3 +816,59 @@ def test_conv3d_interleaved_vs_sharded_equivalence(
     pcc_passed_gt, pcc_message_gt = check_with_pcc(gt_output, tt_output_sharded, pcc=PCC_TOLERANCE)
     logger.info(f"Sharded vs PyTorch: {pcc_message_gt}")
     assert pcc_passed_gt, f"{pcc_message_gt} - Sharded output differs from PyTorch"
+
+
+@pytest.mark.parametrize(
+    "input_shape, out_channels, kernel_size, stride, padding, padding_mode",
+    [
+        # Issue #35436: large C_in with default config caused L1 OOM because C_in_block
+        # defaulted to full C_in, making patch_size = 3*3*3*768 = 20736 elements (648 tiles).
+        # Fixed by defaulting C_in_block to TILE_WIDTH (32).
+        # Using small spatial dims to keep runtime reasonable; the bug is in C_in blocking, not spatial size.
+        [(1, 768, 4, 8, 8), 768, (3, 3, 3), (1, 1, 1), (0, 1, 1), "zeros"],
+    ],
+    ids=["issue_35436_large_c_in"],
+)
+def test_conv3d_auto_blocking_large_c_in(device, input_shape, out_channels, kernel_size, stride, padding, padding_mode):
+    """Regression test for issue #35436: default conv3d config L1 OOM with large C_in.
+
+    When C_in is large (768) and no config is provided, auto-blocking must pick a
+    C_in_block small enough to fit circular buffers in L1.
+    """
+    tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
+        input_shape, out_channels, kernel_size, stride, 1, padding, padding_mode, device
+    )
+    N, D_out, H_out, W_out = output_dims
+
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+    tt_bias = ttnn.from_torch(
+        conv3d_module.bias.data.reshape(1, -1),
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        pad_value=0,
+    )
+
+    # No config — relies on auto-blocking defaults
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=tt_bias,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode=padding_mode,
+        groups=1,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    logger.info(f"Conv3d auto-blocking large C_in (issue #35436): {pcc_message}")
+    assert pcc_passed, pcc_message

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -55,15 +55,15 @@ ttnn::Tensor conv3d(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
     // If no config provided, use conservative default blocking:
-    // minimal spatial blocks (1,1,1), smallest valid C_out_block (32), full C_in (no reduction)
+    // minimal spatial blocks (1,1,1), smallest valid channel blocks (TILE_WIDTH) to minimize L1 pressure
     auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
         tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
         tt::tt_metal::Layout::ROW_MAJOR,                         // output_layout
         1,                                                       // T_out_block
         1,                                                       // W_out_block
         1,                                                       // H_out_block
-        32,                                                      // C_out_block (one tile width)
-        0,                                                       // C_in_block (0 = full C_in)
+        tt::constants::TILE_WIDTH,                               // C_out_block (one tile width)
+        tt::constants::TILE_WIDTH,                               // C_in_block (one tile width, min L1)
         dilation_,                                               // dilation (match the op's dilation)
         32,                                                      // alignment
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -72,7 +72,7 @@ void bind_conv3d(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("weight_tensor"),
         nb::arg("groups") = 1u,
-        nb::arg("C_in_block") = 0u,
+        nb::arg("C_in_block") = tt::constants::TILE_WIDTH,
         nb::arg("alignment") = 32u,
         nb::arg("device") = nb::none());
 


### PR DESCRIPTION
## Summary

- Fix default `C_in_block` from `0` (full C_in) to `TILE_WIDTH` (32) in conv3d auto-config and `prepare_conv3d_weights` Python API
- With large C_in (e.g. 768), the old default made `patch_size = 3*3*3*768 = 20736` elements (648 tiles), causing `vol2col_tiled` and `weight_tiled` CBs to each consume ~1.3 MB — exceeding the 1.5 MB L1 limit
- With `C_in_block=32`, patch_size drops to 864 elements (27 tiles) and total CB usage falls to ~126 KB
- Original auto-blocking introduced in #38595 (`f4df94abe9`)
- Fixes #35436

## Test plan
- [ ] [![(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=pjosipovic%2Fconv3d_conservative_blocking)](https://github.com/tenstorrent/tt-metal/actions/runs/23894081400)
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Fconv3d_conservative_blocking)](https://github.com/tenstorrent/tt-metal/actions/runs/23894083250)
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic%2Fconv3d_conservative_blocking)](https://github.com/tenstorrent/tt-metal/actions/runs/23894084888) (conv tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)