### PR TITLE
#39785: Fix row_major support in unary_ng for sharding cases

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -74,6 +74,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_sharded_interleaved  #39185
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_row_major_sharded  #39185
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_rm_interleaved  #39185
+  - tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py::test_unary_ng_rm_block_shard  #39185
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py  #38203
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::test_resnet50_e2e_graph_capture  # ResNet-50 uses ops unsupported by ttsim
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestFastOperationGraphTracking  # Fast dispatch with ttnn.add crashes ttsim worker on teardown

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_ulp, assert_with_pcc
 
 
 height_sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -437,3 +437,38 @@ def test_unary_ng_rm_interleaved(device, shape, torch_dtype, ttnn_dtype):
     ttnn_output = ttnn.to_torch(ttnn.abs(ttnn_input))
     golden_output = torch.abs(torch_input)
     assert torch.equal(ttnn_output, golden_output)
+
+
+def test_unary_ng_rm_block_shard(device):
+    """Test block-sharded ROW_MAJOR with non-tile-aligned shard shape (32, 80).
+
+    Shard element count (2560) is not a multiple of tile_hw (1024), so
+    get_shard_specs returns nullopt and the interleaved path is used instead.
+    TensorAccessor resolves sharded addresses correctly via page_id.
+    """
+    torch.manual_seed(42)
+    input_shape = [1, 1, 256, 640]
+    torch_input = torch.empty(input_shape, dtype=torch.bfloat16).uniform_(-10, 10)
+
+    golden_function = ttnn.get_golden_function(ttnn.square)
+    torch_output = golden_function(torch_input, device=device)
+
+    shard_mem_config = ttnn.create_sharded_memory_config(
+        [32, 80],
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (7, 7))}),
+        strategy=ttnn.ShardStrategy.BLOCK,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn_input = ttnn.to_memory_config(ttnn_input, memory_config=shard_mem_config)
+
+    ttnn_output = ttnn.to_torch(ttnn.square(ttnn_input, memory_config=shard_mem_config))
+    assert_with_pcc(torch_output, ttnn_output, 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ng.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_ulp, assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 height_sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -439,7 +439,8 @@ def test_unary_ng_rm_interleaved(device, shape, torch_dtype, ttnn_dtype):
     assert torch.equal(ttnn_output, golden_output)
 
 
-def test_unary_ng_rm_block_shard(device):
+@pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32)])
+def test_unary_ng_rm_block_shard(device, torch_dtype, ttnn_dtype):
     """Test block-sharded ROW_MAJOR with non-tile-aligned shard shape (32, 80).
 
     Shard element count (2560) is not a multiple of tile_hw (1024), so
@@ -448,10 +449,10 @@ def test_unary_ng_rm_block_shard(device):
     """
     torch.manual_seed(42)
     input_shape = [1, 1, 256, 640]
-    torch_input = torch.empty(input_shape, dtype=torch.bfloat16).uniform_(-10, 10)
+    torch_input = torch.empty(input_shape, dtype=torch_dtype).uniform_(-10, 10)
 
-    golden_function = ttnn.get_golden_function(ttnn.square)
-    torch_output = golden_function(torch_input, device=device)
+    golden_function = ttnn.get_golden_function(ttnn.abs)
+    torch_output = golden_function(torch_input)
 
     shard_mem_config = ttnn.create_sharded_memory_config(
         [32, 80],
@@ -463,12 +464,12 @@ def test_unary_ng_rm_block_shard(device):
 
     ttnn_input = ttnn.from_torch(
         torch_input,
-        dtype=ttnn.bfloat16,
+        dtype=ttnn_dtype,
         device=device,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     ttnn_input = ttnn.to_memory_config(ttnn_input, memory_config=shard_mem_config)
 
-    ttnn_output = ttnn.to_torch(ttnn.square(ttnn_input, memory_config=shard_mem_config))
-    assert_with_pcc(torch_output, ttnn_output, 0.999)
+    ttnn_output = ttnn.to_torch(ttnn.abs(ttnn_input, memory_config=shard_mem_config))
+    assert torch.equal(ttnn_output, torch_output)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.cpp
@@ -5,6 +5,8 @@
 #include "ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
+#include <mutex>
+
 namespace ttnn::operations::unary_ng {
 
 const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
@@ -62,13 +64,26 @@ std::optional<UnaryShardSpecs> get_shard_specs(const TensorSpec& input_spec, con
         return std::nullopt;
     }
 
-    // For ROW_MAJOR layout, shard bytes must be a multiple of tile_size for the
-    // sharded path to work.  Fall back to the interleaved path otherwise.
-    if (input_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR && input_sharded) {
-        const auto& shard = *get_shard_spec(input_spec);
-        const auto tile_hw = input_spec.tile().get_tile_hw();
-        const uint32_t shard_elements = shard.shape[0] * shard.shape[1];
-        if (shard_elements % tile_hw != 0) {
+    // For ROW_MAJOR layout, shard element count must be a multiple of tile_hw
+    // for the sharded CB-aliasing path to work (it requires whole-tile pages).
+    // Fall back to the interleaved path otherwise.
+    if (input_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR) {
+        auto is_shard_tile_aligned = [](const TensorSpec& spec) {
+            const auto& shard = *get_shard_spec(spec);
+            const auto tile_hw = spec.tile().get_tile_hw();
+            const uint64_t shard_elements = static_cast<uint64_t>(shard.shape[0]) * shard.shape[1];
+            return shard_elements % tile_hw == 0;
+        };
+
+        if ((input_sharded && !is_shard_tile_aligned(input_spec)) ||
+            (output_sharded && !is_shard_tile_aligned(output_spec))) {
+            static std::once_flag warn_flag;
+            std::call_once(warn_flag, [] {
+                log_warning(
+                    tt::LogOp,
+                    "UnaryNg: ROW_MAJOR shard element count is not tile-aligned; "
+                    "falling back to interleaved path");
+            });
             return std::nullopt;
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/common/unary_ng_utils.cpp
@@ -62,6 +62,17 @@ std::optional<UnaryShardSpecs> get_shard_specs(const TensorSpec& input_spec, con
         return std::nullopt;
     }
 
+    // For ROW_MAJOR layout, shard bytes must be a multiple of tile_size for the
+    // sharded path to work.  Fall back to the interleaved path otherwise.
+    if (input_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR && input_sharded) {
+        const auto& shard = *get_shard_spec(input_spec);
+        const auto tile_hw = input_spec.tile().get_tile_hw();
+        const uint32_t shard_elements = shard.shape[0] * shard.shape[1];
+        if (shard_elements % tile_hw != 0) {
+            return std::nullopt;
+        }
+    }
+
     TT_FATAL(get_shard_spec(output_spec).has_value(), "Output must have shard spec when using native sharded path");
 
     const auto& out_shape = output_spec.padded_shape();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
@@ -399,12 +399,6 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
             auto df = datatype_to_dataformat_converter(t.dtype());
             uint32_t ts = tile_size(df);
             uint32_t shard_bytes = spec.shape[0] * spec.shape[1] * datum_size(df);
-            // TODO: Support non-tile-aligned shard sizes for ROW_MAJOR (#39785)
-            TT_FATAL(
-                shard_bytes % ts == 0,
-                "Shard size in bytes ({}) must be a multiple of tile size ({})",
-                shard_bytes,
-                ts);
             return shard_bytes / ts;
         }
         return spec.numel() / t.tensor_spec().tile().get_tile_hw();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_ng/device/unary_ng_program_factory.cpp
@@ -399,6 +399,11 @@ UnaryNgDeviceOperation::ProgramFactory::cached_program_t UnaryNgDeviceOperation:
             auto df = datatype_to_dataformat_converter(t.dtype());
             uint32_t ts = tile_size(df);
             uint32_t shard_bytes = spec.shape[0] * spec.shape[1] * datum_size(df);
+            TT_ASSERT(
+                shard_bytes % ts == 0,
+                "ROW_MAJOR shard size in bytes ({}) must be a multiple of CB page size ({})",
+                shard_bytes,
+                ts);
             return shard_bytes / ts;
         }
         return spec.numel() / t.tensor_spec().tile().get_tile_hw();


### PR DESCRIPTION
### Ticket
Link to Github Issue #39785 

### Problem description
ROW_MAJOR sharded inputs with non-tile-aligned shard element counts (e.g., shard (32, 80) = 2560 elements, tile_hw = 1024) hit a TT_FATAL or silently corrupt data in the sharded CB-aliasing path, which requires whole-tile pages.

### What's changed

- Added a tile-alignment check in get_shard_specs() (unary_ng_utils.cpp): if the input is ROW_MAJOR, sharded, and shard_elements % tile_hw != 0, return std::nullopt to skip the sharded path
- The interleaved path is used instead; TensorAccessor resolves sharded buffer addresses correctly via page_id .
- Added test_unary_ng_rm_block_shard in test_unary_ng.py to cover the non-tile-aligned RM block sharding path

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
- [ ] New/Existing tests provide coverage for changes
- [x] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/unary_ng_sharded_rm_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/unary_ng_sharded_rm_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
