### PR TITLE
Potential fix for batch prefill isolation bug

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -17,6 +17,17 @@ from .tt_penalties import TTPenalties
 from .tt_sampling import TTSampling
 
 MAX_UINT32 = 2**32 - 1
+_SAMPLING_PARAM_DEFAULTS = {
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "top_k": 1,
+    "presence_penalty": 0.0,
+    "frequency_penalty": 0.0,
+    "repetition_penalty": 1.0,
+    "seed": None,
+    "num_logprobs": 0,
+    "enable_log_probs": False,
+}
 
 
 @dataclass(frozen=True)
@@ -383,23 +394,11 @@ def format_sampling_params(sampling_params, max_batch_size):
     assert target_len % 32 == 0, f"Sampling batch size must be a multiple of 32, got {target_len}"
 
     # Defaults used when padding short lists to target_len
-    defaults = {
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "top_k": 1,
-        "presence_penalty": 0.0,
-        "frequency_penalty": 0.0,
-        "repetition_penalty": 1.0,
-        "seed": None,
-        "num_logprobs": 0,
-        "enable_log_probs": False,
-    }
-
     def _pad(lst, name):
         """Return a new list padded to target_len with the default for *name*."""
         if len(lst) >= target_len:
             return list(lst)
-        return list(lst) + [defaults[name]] * (target_len - len(lst))
+        return list(lst) + [_SAMPLING_PARAM_DEFAULTS[name]] * (target_len - len(lst))
 
     # Pad core sampling fields (scalar→list already done above)
     temperature = _pad(sampling_params.temperature, "temperature")
@@ -426,7 +425,7 @@ def format_sampling_params(sampling_params, max_batch_size):
     def _normalise_and_pad(name):
         value = getattr(sampling_params, name, None)
         if value is None:
-            lst = [defaults[name]]
+            lst = [_SAMPLING_PARAM_DEFAULTS[name]]
         elif isinstance(value, List):
             lst = list(value)
         else:
@@ -459,7 +458,7 @@ def format_sampling_params(sampling_params, max_batch_size):
             top_k[i] = 32
 
         if repetition_penalty[i] == 0:
-            repetition_penalty[i] = defaults["repetition_penalty"]
+            repetition_penalty[i] = _SAMPLING_PARAM_DEFAULTS["repetition_penalty"]
 
     kwargs = dict(
         temperature=temperature,
@@ -479,6 +478,48 @@ def format_sampling_params(sampling_params, max_batch_size):
         kwargs["enable_log_probs"] = enable_log_probs
 
     return replace(sampling_params, **kwargs)
+
+
+def _scatter_sampling_params_to_slots(
+    formatted_sampling_params: SamplingParams,
+    occupied_slots: list[int],
+    max_batch_size: int,
+) -> SamplingParams:
+    """
+    Scatter compact request-order params onto physical batch slots.
+
+    This is used by batched prefill, where request params arrive in compact order
+    but the requests may occupy arbitrary physical slots in the padded batch.
+
+    Seeds intentionally remain in compact request order because
+    ``SeedManager.reset_seed`` maps them onto ``occupied_slots`` separately.
+    """
+    if not occupied_slots:
+        return formatted_sampling_params
+
+    if max_batch_size % 32 != 0:
+        raise ValueError(f"Sampling batch size must be a multiple of 32, got {max_batch_size}")
+
+    kwargs = {}
+    for field_name in SAMPLING_PARAM_FIELDS:
+        value = getattr(formatted_sampling_params, field_name)
+        if field_name == "seed" or not isinstance(value, list):
+            kwargs[field_name] = value
+            continue
+
+        if len(value) < len(occupied_slots):
+            raise ValueError(
+                f"Sampling param '{field_name}' length {len(value)} is smaller than occupied slot count {len(occupied_slots)}"
+            )
+
+        scattered = [_SAMPLING_PARAM_DEFAULTS[field_name]] * max_batch_size
+        for request_idx, slot in enumerate(occupied_slots):
+            if slot < 0 or slot >= max_batch_size:
+                raise IndexError(f"Slot index {slot} is out of range for batch size {max_batch_size}")
+            scattered[slot] = value[request_idx]
+        kwargs[field_name] = scattered
+
+    return replace(formatted_sampling_params, **kwargs)
 
 
 def broadcast_sampling_params(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,6 +24,7 @@ from models.common.sampling import (
     chunk_sampling_params,
     format_sampling_params,
 )
+from models.common.sampling.generator import _scatter_sampling_params_to_slots
 from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
@@ -625,6 +626,9 @@ class Generator(WarmupForwardMixin):
                     sampling_executed = True
 
                     combined_params = format_sampling_params(sampling_params, padded_batch)
+                    # Batched prefill receives params in compact request order, but the
+                    # requests themselves may occupy arbitrary physical slots.
+                    slot_aligned_params = _scatter_sampling_params_to_slots(combined_params, empty_slots, padded_batch)
                     max_prompt_len = max(int(prompt_lens[i]) for i in range(len(empty_slots)))
                     combined_prompt_tokens = torch.zeros(padded_batch, max_prompt_len, dtype=torch.long)
                     for local_idx, slot in enumerate(empty_slots):
@@ -632,7 +636,7 @@ class Generator(WarmupForwardMixin):
                         combined_prompt_tokens[slot, :plen] = prefill_ids[slot, :plen]
 
                     sampling_module = self.model[model_id].sampling
-                    sampling_module.reset_sampling_params(combined_params)
+                    sampling_module.reset_sampling_params(slot_aligned_params)
                     if getattr(combined_params, "seed", None) is not None:
                         sampling_module.seed_manager.reset_seed(combined_params.seed, empty_slots)
                     sampling_module.seed_manager.get_new_values(empty_slots, replicate_seeds=False)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/llama_batched_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/llama_batched_prefill_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
