### PR TITLE
Run Merge Gate LLMBox Smoke Tests On Priority Runner

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -187,8 +187,8 @@ jobs:
       matrix:
         # run t3k tests on CIv1 for now in order to have dedicated machine
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N300-viommu","n300-llmbox-viommu-prio","p150b-viommu-prio"]')
-            || fromJSON('["N300-viommu","n300-llmbox-viommu","p150b-viommu"]') }}
+            && fromJSON('["N300-viommu","N300-llmbox-viommu-prio","P150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","N300-llmbox-viommu","P150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
@@ -210,8 +210,8 @@ jobs:
       matrix:
         # run t3k tests on CIv1 for now in order to have dedicated machine
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N300-viommu","n300-llmbox-viommu-prio","p150b-viommu-prio"]')
-            || fromJSON('["N300-viommu","n300-llmbox-viommu","p150b-viommu"]') }}
+            && fromJSON('["N300-viommu","N300-llmbox-viommu-prio","p150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","N300-llmbox-viommu","p150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -210,8 +210,8 @@ jobs:
       matrix:
         # run t3k tests on CIv1 for now in order to have dedicated machine
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N300-viommu","N300-llmbox-viommu-prio","p150b-viommu-prio"]')
-            || fromJSON('["N300-viommu","N300-llmbox-viommu","p150b-viommu"]') }}
+            && fromJSON('["N300-viommu","N300-llmbox-viommu-prio","P150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","N300-llmbox-viommu","P150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
@@ -257,8 +257,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N150-viommu","p150b-viommu-prio"]')
-            || fromJSON('["N150-viommu","p150b-viommu"]') }}
+            && fromJSON('["N150-viommu","P150b-viommu-prio"]')
+            || fromJSON('["N150-viommu","P150b-viommu"]') }}
     uses: ./.github/workflows/basic.yaml
     with:
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
@@ -279,8 +279,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N150-viommu","p150b-viommu-prio"]')
-            || fromJSON('["N150-viommu","p150b-viommu"]') }}
+            && fromJSON('["N150-viommu","P150b-viommu-prio"]')
+            || fromJSON('["N150-viommu","P150b-viommu"]') }}
     uses: ./.github/workflows/basic.yaml
     with:
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -187,8 +187,8 @@ jobs:
       matrix:
         # run t3k tests on CIv1 for now in order to have dedicated machine
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu-prio"]')
-            || fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu"]') }}
+            && fromJSON('["N300-viommu","n300-llmbox-viommu-prio","p150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","n300-llmbox-viommu","p150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
@@ -210,8 +210,8 @@ jobs:
       matrix:
         # run t3k tests on CIv1 for now in order to have dedicated machine
         platform: ${{ github.event_name == 'merge_group'
-            && fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu-prio"]')
-            || fromJSON('["N300-viommu","in-service-dedicated-merge-gate","p150b-viommu"]') }}
+            && fromJSON('["N300-viommu","n300-llmbox-viommu-prio","p150b-viommu-prio"]')
+            || fromJSON('["N300-viommu","n300-llmbox-viommu","p150b-viommu"]') }}
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -43,7 +43,7 @@ jobs:
         - /work
         - ${{ (!contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
-      options: --device /dev/tenstorrent ${{ contains(fromJSON('["N300-llmbox", "in-service-dedicated-merge-gate"]'), inputs.runner) && '--memory 256g' || '' }}
+      options: --device /dev/tenstorrent ${{ contains(fromJSON('["N300-llmbox", "N300-llmbox-viommu", "N300-llmbox-viommu-prio", "in-service-dedicated-merge-gate"]'), inputs.runner) && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Problem description
To include n300 LLMBoxes in merge gate smoke tests, a dedicated static runner had to be used since normal n300 LLMBox queue times were too unpredictable. This static runner requires more manual maintenance than our regular ephemeral runners. A priority runner is now available and can be used for more consistent queue times.

### What's changed
In merge-gate.yaml, replaced in-service-dedicated-merge-gate with n300-llmbox-viommu-prio in both metalium and ttnn smoke tests, and capitalized P150b runner names for consistency. In smoke.yaml, added N300-llmbox-viommu and N300-llmbox-viommu-prio to the memory-limit allowlist so LLMBox runners correctly receive --memory 256g. All other jobs are unaffected.