### PR TITLE
[GPT-OSS] Fix test_min_tokens and ND hang in vllm-nightly sampling tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -102,10 +102,11 @@ jobs:
               "multimodal": false,
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D_RING\", \"sample_on_device_mode\": \"all\"}",
+              "tt_mm_throttle_perf": 2,
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32",
               "structured-output": true,
               "sampling-tests": true,
-              "sampling-test-filter": "not test_min_tokens and not test_bad_words and not test_mixed_params_batch",
+              "sampling-test-filter": "not test_bad_words and not test_mixed_params_batch",
               "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
               "co-owner-1-id": "U08TJ70UFRT",
               "co-owner-2-id": "U06F3ER8X9A"

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1146,8 +1146,12 @@ class Generator(WarmupForwardMixin):
             self.trace_inputs_decode[sampling_on_device] = device_inputs
             self.trace_output_decode[sampling_on_device] = tt_out_trace
 
-        # reset inputs when mode switches from prefill to decode
-        reset_inputs = reset_batch or not sampling_on_device
+        # reset inputs when mode switches from prefill to decode,
+        # or when sampling_on_device changes (different trace has stale inputs)
+        prev_sampling_on_device = getattr(self, "_prev_sampling_on_device", None)
+        self._prev_sampling_on_device = sampling_on_device
+        sampling_mode_changed = prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device
+        reset_inputs = reset_batch or not sampling_on_device or sampling_mode_changed
         if self.prev_page_table is None or any(
             not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table)
         ):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40605

### Problem description
- When running vllm-nightly tests there was ND hang happening on different tests
- Hang on test_min_tokens when switching from sampling on host to sampling on device 

### What's changed
- Added MM throttling to job setup for ND hang.
- Calling reset inputs when switching sampling from host to device and vice versa

### Tests

- [ ] [vllm nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23904023376)
