### PR TITLE
[llk] Add NE, LE, GE, GT, LT for FP32 

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -24,6 +24,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+  - tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_fp32.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""FP32 SFPU tensor–tensor binary comparisons (eq/ne/lt/gt/le/ge) on Blackhole and Wormhole."""
+
+import pytest
+import torch
+import ttnn
+
+pytestmark = pytest.mark.use_module_device
+
+# Scalars for Cartesian product in special_floats test: zeros, ±finite, ±inf, NaN.
+_SPECIAL_FP32_GRID = torch.tensor(
+    (
+        0.0,
+        -0.0,
+        1.0,
+        -1.0,
+        6573.837573,
+        float("inf"),
+        float("-inf"),
+        float("nan"),
+    ),
+    dtype=torch.float32,
+)
+
+
+def _bool_mask(tt: torch.Tensor) -> torch.Tensor:
+    """Normalize device output (float/bool/int) to a boolean mask for comparison with torch.*."""
+    if tt.dtype == torch.bool:
+        return tt
+    if tt.is_floating_point():
+        return tt != 0.0
+    return tt != 0
+
+
+def _assert_matches_torch(ttnn_op, torch_a: torch.Tensor, torch_b: torch.Tensor, device, *, mem_cfg=None):
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    golden = golden_fn(torch_a, torch_b)
+    assert golden.dtype == torch.bool
+
+    ta = ttnn.from_torch(torch_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(torch_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    kwargs = {}
+    if mem_cfg is not None:
+        kwargs["memory_config"] = mem_cfg
+    out = ttnn_op(ta, tb, **kwargs)
+    out_t = ttnn.to_torch(out)
+    assert torch.equal(_bool_mask(out_t), golden), f"mismatch for {ttnn_op.__name__}"
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        torch.Size([64, 64]),
+        torch.Size([1, 1, 32, 32]),
+        torch.Size([1, 3, 320, 384]),
+    ),
+)
+@pytest.mark.parametrize(
+    "mem_cfg",
+    (
+        None,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_tensor_tensor_random(input_shapes, mem_cfg, ttnn_op, device):
+    torch.manual_seed(0)
+    a = torch.empty(input_shapes, dtype=torch.float32).uniform_(-1000.0, 1000.0)
+    b = torch.empty(input_shapes, dtype=torch.float32).uniform_(-1000.0, 1000.0)
+    _assert_matches_torch(ttnn_op, a, b, device, mem_cfg=mem_cfg)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_broadcast_rhs_singleton(ttnn_op, device):
+    """RHS broadcasts from a scalar-shaped tensor (1,1,1)."""
+    torch.manual_seed(1)
+    a = torch.empty((2, 64, 64), dtype=torch.float32).uniform_(-50.0, 50.0)
+    b = torch.tensor([[[3.25]]], dtype=torch.float32)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_special_floats(ttnn_op, device):
+    """All pairs from `_SPECIAL_FP32_GRID` (Cartesian product): zeros, finites, ±inf ties, NaN/unordered."""
+    pairs = torch.cartesian_prod(_SPECIAL_FP32_GRID, _SPECIAL_FP32_GRID)
+    a = pairs[:, 0].unsqueeze(0).expand(32, -1)
+    b = pairs[:, 1].unsqueeze(0).expand(32, -1)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_adjacent_ulps(ttnn_op, device):
+    """Nearest float32 neighbors (1 ULP apart), not subnormal — border of the mantissa."""
+    f32 = torch.float32
+    t2 = torch.tensor(2.0, dtype=f32)
+    z0 = torch.tensor(0.0, dtype=f32)
+    n2 = torch.tensor(-2.0, dtype=f32)
+
+    one = torch.tensor(1.0, dtype=f32)
+    one_up = torch.nextafter(one, t2)
+    one_dn = torch.nextafter(one, z0)
+    m_one = torch.tensor(-1.0, dtype=f32)
+    m_one_up = torch.nextafter(m_one, z0)
+    m_one_dn = torch.nextafter(m_one, n2)
+
+    vals_a = torch.stack([one, one_up, one_dn, m_one, m_one_dn, m_one])
+    vals_b = torch.stack([one_up, one, one, m_one_dn, m_one, m_one_up])
+    a = vals_a.unsqueeze(0).expand(32, -1)
+    b = vals_b.unsqueeze(0).expand(32, -1)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_exact_equal_tile(ttnn_op, device):
+    """Two identical tiles (all elements pairwise equal)."""
+    torch.manual_seed(2)
+    a = torch.empty((128, 128), dtype=torch.float32).uniform_(-10.0, 10.0)
+    same = torch.cat([a, a], dim=0)
+    _assert_matches_torch(ttnn_op, same[:128], same[128:], device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -438,6 +438,11 @@ def test_subalpha_fp32(alpha, device):
     "op_name",
     [
         "eq",
+        "ne",
+        "lt",
+        "le",
+        "gt",
+        "ge",
     ],
 )
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <type_traits>
 
 #include "ckernel_addrmod.h"
 #include "sfpi.h"
@@ -106,11 +108,102 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
     }
 }
 
-// Float32 binary comparison
-// TODO: Add support for ne, gt, lt, ge, le operations
-template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
+// IEEE-754 float32 NaN: exponent all 1s and nonzero mantissa => |bits| > 0x7F800000.
+sfpi_inline auto is_nan(sfpi::vInt abs_bits) { return abs_bits > 0x7F800000; }
+// IEEE-754 float32 infinity: exponent all 1s, mantissa zero => |bits| == 0x7F800000.
+sfpi_inline auto is_inf(sfpi::vInt abs_bits) { return abs_bits == 0x7F800000; }
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_equal_compare_v = Op == SfpuType::eq || Op == SfpuType::ne;
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_ordered_compare_v =
+    Op == SfpuType::lt || Op == SfpuType::gt || Op == SfpuType::le || Op == SfpuType::ge;
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_compare_v = is_fp32_equal_compare_v<Op> || is_fp32_ordered_compare_v<Op>;
+
+template <SfpuType RELATIONAL_OP, std::enable_if_t<is_fp32_equal_compare_v<RELATIONAL_OP>, int> = 0>
+sfpi_inline sfpi::vFloat binary_comp_fp32_equal_mask(sfpi::vFloat in0, sfpi::vFloat in1) {
+    constexpr bool is_eq = (RELATIONAL_OP == SfpuType::eq);
+    const sfpi::vFloat positive = is_eq ? sfpi::vConst1 : sfpi::vConst0;
+    const sfpi::vFloat negative = is_eq ? sfpi::vConst0 : sfpi::vConst1;
+
+    sfpi::vFloat mask = negative;
+    sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
+    sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
+    sfpi::vInt in0_abs = in0_bits & 0x7FFFFFFF;
+    sfpi::vInt in1_abs = in1_bits & 0x7FFFFFFF;
+
+    // Equality (±0 / identical +inf/-inf bit patterns) then strip NaN lanes. For ne, NaN strip must
+    // follow so unordered NaN lanes stay "not equal" (1) and are not confused with same-infinity eq.
+    v_if(
+        (in0 == in1) ||                                 // Handle equal values
+        (in0_abs == 0 && in1_abs == 0) ||               // Handle ±0.0
+        ((in0_bits == in1_bits) && is_inf(in0_abs))) {  // Handle +inf/-inf bit patterns
+        mask = positive;
+    }
+    v_endif;
+    v_if(is_nan(in0_abs) || is_nan(in1_abs)) { mask = negative; }
+    v_endif;
+    return mask;
+}
+
+template <SfpuType RELATIONAL_OP, std::enable_if_t<is_fp32_ordered_compare_v<RELATIONAL_OP>, int> = 0>
+sfpi_inline sfpi::vFloat binary_comp_fp32_ordered_mask(sfpi::vFloat in0, sfpi::vFloat in1) {
+    sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
+    sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
+    sfpi::vInt in0_abs = in0_bits & 0x7FFFFFFF;
+    sfpi::vInt in1_abs = in1_bits & 0x7FFFFFFF;
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // +inf/+inf and -inf/-inf: IEEE tie rules.
+
+    if constexpr (RELATIONAL_OP == SfpuType::lt) {
+        v_if(in0 < in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst0; }
+        v_endif;
+    } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
+        v_if(in0 > in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst0; }
+        v_endif;
+    } else if constexpr (RELATIONAL_OP == SfpuType::le) {
+        v_if(in0 <= in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst1; }
+        v_endif;
+    } else {
+        v_if(in0 >= in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = 1.0f; }
+        v_endif;
+    }
+
+    // ±0.0 vs ±0.0: IEEE ties; HW may order signed zeros differently.
+    if constexpr (RELATIONAL_OP == SfpuType::lt || RELATIONAL_OP == SfpuType::gt) {
+        v_if((in0_abs == 0) && (in1_abs == 0)) { result = sfpi::vConst0; }
+        v_endif;
+    } else {
+        v_if((in0_abs == 0) && (in1_abs == 0)) { result = sfpi::vConst1; }
+        v_endif;
+    }
+
+    v_if(is_nan(in0_abs) || is_nan(in1_abs)) { result = sfpi::vConst0; }
+    v_endif;
+    return result;
+}
+
+// Float32 binary comparisons.
+// - lt/gt/le/ge: binary_comp_fp32_ordered_mask.
+// - eq/ne: binary_comp_fp32_equal_mask.
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS,
+    SfpuType RELATIONAL_OP,
+    std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
 inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-    static_assert(RELATIONAL_OP == SfpuType::eq, "Supported operation types: eq ");
     constexpr uint dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8
@@ -118,20 +211,12 @@ inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_
         // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = 0.0f;
+        sfpi::vFloat result = sfpi::vConst0;
 
-        if constexpr (RELATIONAL_OP == SfpuType::eq) {
-            sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
-            sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
-            sfpi::vInt in0_abs = in0_bits & 0x7FFFFFFF;
-            sfpi::vInt in1_abs = in1_bits & 0x7FFFFFFF;
-
-            // Standard float comparison (handles normal values and NaN correctly)
-            // Note: In Blackhole, (-0.0 == 0.0) returns false
-            v_if((in0 == in1) || (in0_abs == 0 && in1_abs == 0)) { result = 1.0f; }
-            // Special handling for infinity
-            v_elseif((in0_bits == in1_bits) && ((in0_abs == 0x7F800000))) { result = 1.0f; }
-            v_endif;
+        if constexpr (is_fp32_equal_compare_v<RELATIONAL_OP>) {
+            result = binary_comp_fp32_equal_mask<RELATIONAL_OP>(in0, in1);
+        } else {
+            result = binary_comp_fp32_ordered_mask<RELATIONAL_OP>(in0, in1);
         }
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -90,4 +90,84 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
         vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ne_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lt_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gt_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -156,4 +156,5 @@ enum class SfpuType {
     xielu,
     lgamma,
     polygamma,
+    ne,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <type_traits>
 
 #include "ckernel_addrmod.h"
 #include "sfpi.h"
@@ -106,11 +108,102 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
     }
 }
 
-// Float32 binary comparison
-// TODO: Add support for ne, gt, lt, ge, le operations
-template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
+// IEEE-754 float32 NaN: exponent all 1s and nonzero mantissa => |bits| > 0x7F800000.
+sfpi_inline auto is_nan(sfpi::vInt abs_bits) { return abs_bits > 0x7F800000; }
+// IEEE-754 float32 infinity: exponent all 1s, mantissa zero => |bits| == 0x7F800000.
+sfpi_inline auto is_inf(sfpi::vInt abs_bits) { return abs_bits == 0x7F800000; }
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_equal_compare_v = Op == SfpuType::eq || Op == SfpuType::ne;
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_ordered_compare_v =
+    Op == SfpuType::lt || Op == SfpuType::gt || Op == SfpuType::le || Op == SfpuType::ge;
+
+template <SfpuType Op>
+inline constexpr bool is_fp32_compare_v = is_fp32_equal_compare_v<Op> || is_fp32_ordered_compare_v<Op>;
+
+template <SfpuType RELATIONAL_OP, std::enable_if_t<is_fp32_equal_compare_v<RELATIONAL_OP>, int> = 0>
+sfpi_inline sfpi::vFloat binary_comp_fp32_equal_mask(sfpi::vFloat in0, sfpi::vFloat in1) {
+    constexpr bool is_eq = (RELATIONAL_OP == SfpuType::eq);
+    const sfpi::vFloat positive = is_eq ? sfpi::vConst1 : sfpi::vConst0;
+    const sfpi::vFloat negative = is_eq ? sfpi::vConst0 : sfpi::vConst1;
+
+    sfpi::vFloat mask = negative;
+    sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
+    sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
+    sfpi::vInt in0_abs = in0_bits & 0x7FFFFFFF;
+    sfpi::vInt in1_abs = in1_bits & 0x7FFFFFFF;
+
+    // Equality (±0 / identical +inf/-inf bit patterns) then strip NaN lanes. For ne, NaN strip must
+    // follow so unordered NaN lanes stay "not equal" (1) and are not confused with same-infinity eq.
+    v_if(
+        (in0 == in1) ||                                 // Handle equal values
+        (in0_abs == 0 && in1_abs == 0) ||               // Handle ±0.0
+        ((in0_bits == in1_bits) && is_inf(in0_abs))) {  // Handle +inf/-inf bit patterns
+        mask = positive;
+    }
+    v_endif;
+    v_if(is_nan(in0_abs) || is_nan(in1_abs)) { mask = negative; }
+    v_endif;
+    return mask;
+}
+
+template <SfpuType RELATIONAL_OP, std::enable_if_t<is_fp32_ordered_compare_v<RELATIONAL_OP>, int> = 0>
+sfpi_inline sfpi::vFloat binary_comp_fp32_ordered_mask(sfpi::vFloat in0, sfpi::vFloat in1) {
+    sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
+    sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
+    sfpi::vInt in0_abs = in0_bits & 0x7FFFFFFF;
+    sfpi::vInt in1_abs = in1_bits & 0x7FFFFFFF;
+    sfpi::vFloat result = sfpi::vConst0;
+
+    // +inf/+inf and -inf/-inf: IEEE tie rules.
+
+    if constexpr (RELATIONAL_OP == SfpuType::lt) {
+        v_if(in0 < in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst0; }
+        v_endif;
+    } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
+        v_if(in0 > in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst0; }
+        v_endif;
+    } else if constexpr (RELATIONAL_OP == SfpuType::le) {
+        v_if(in0 <= in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = sfpi::vConst1; }
+        v_endif;
+    } else {
+        v_if(in0 >= in1) { result = sfpi::vConst1; }
+        v_endif;
+        v_if((in0_bits == in1_bits) && is_inf(in0_abs)) { result = 1.0f; }
+        v_endif;
+    }
+
+    // ±0.0 vs ±0.0: IEEE ties; HW may order signed zeros differently.
+    if constexpr (RELATIONAL_OP == SfpuType::lt || RELATIONAL_OP == SfpuType::gt) {
+        v_if((in0_abs == 0) && (in1_abs == 0)) { result = sfpi::vConst0; }
+        v_endif;
+    } else {
+        v_if((in0_abs == 0) && (in1_abs == 0)) { result = sfpi::vConst1; }
+        v_endif;
+    }
+
+    v_if(is_nan(in0_abs) || is_nan(in1_abs)) { result = sfpi::vConst0; }
+    v_endif;
+    return result;
+}
+
+// Float32 binary comparisons.
+// - lt/gt/le/ge: binary_comp_fp32_ordered_mask.
+// - eq/ne: binary_comp_fp32_equal_mask.
+template <
+    bool APPROXIMATION_MODE,
+    int ITERATIONS,
+    SfpuType RELATIONAL_OP,
+    std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
 inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-    static_assert(RELATIONAL_OP == SfpuType::eq, "Supported operation types: eq ");
     constexpr uint dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8
@@ -118,17 +211,12 @@ inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_
         // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = 0.0f;
+        sfpi::vFloat result = sfpi::vConst0;
 
-        if constexpr (RELATIONAL_OP == SfpuType::eq) {
-            sfpi::vInt in0_bits = sfpi::reinterpret<sfpi::vInt>(in0);
-            sfpi::vInt in1_bits = sfpi::reinterpret<sfpi::vInt>(in1);
-
-            // Standard float comparison (handles normal values and NaN correctly)
-            v_if(in0 == in1) { result = 1.0f; }
-            // Special handling for infinity
-            v_elseif((in0_bits == in1_bits) && ((in0_bits & 0x7FFFFFFF) == 0x7F800000)) { result = 1.0f; }
-            v_endif;
+        if constexpr (is_fp32_equal_compare_v<RELATIONAL_OP>) {
+            result = binary_comp_fp32_equal_mask<RELATIONAL_OP>(in0, in1);
+        } else {
+            result = binary_comp_fp32_ordered_mask<RELATIONAL_OP>(in0, in1);
         }
 
         sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -90,4 +90,84 @@ inline void llk_math_eltwise_binary_sfpu_eq_fp32(
         vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ne_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ne, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ne_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ne>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lt_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lt, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lt_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::lt>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gt_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gt, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gt_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::gt>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::le, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_le_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::le>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_fp32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::ge, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_ge_fp32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_fp32<APPROXIMATE, 8, SfpuType::ge>,
+        dst_index0,
+        dst_index1,
+        odst,
+        vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -156,4 +156,5 @@ enum class SfpuType {
     xielu,
     lgamma,
     polygamma,
+    ne,
 };

--- a/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
@@ -60,6 +60,26 @@ ALWI void eq_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_eq_fp32<APPROX>(idst0, idst1, odst)));
 }
 
+ALWI void ne_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_ne_fp32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void lt_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_lt_fp32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void gt_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_gt_fp32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void le_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_le_fp32<APPROX>(idst0, idst1, odst)));
+}
+
+ALWI void ge_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_ge_fp32<APPROX>(idst0, idst1, odst)));
+}
+
 /**
  * Please refer to documentation for any_init.
  */
@@ -78,5 +98,15 @@ ALWI void rsub_binary_tile_init() {
 ALWI void power_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_pow_init<APPROX>())); }
 
 ALWI void eq_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_eq_fp32_init<APPROX>())); }
+
+ALWI void ne_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ne_fp32_init<APPROX>())); }
+
+ALWI void lt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lt_fp32_init<APPROX>())); }
+
+ALWI void gt_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gt_fp32_init<APPROX>())); }
+
+ALWI void le_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_le_fp32_init<APPROX>())); }
+
+ALWI void ge_binary_tile_init() { MATH((llk_math_eltwise_binary_sfpu_ge_fp32_init<APPROX>())); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -176,31 +176,31 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             }
             break;
         case BinaryOpType::LT:
-            if (dtype != DataType::INT32) {
-                postprocess = unary::UnaryOpType::LTZ;
-            } else {
+            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
                 binary_op = SfpuBinaryOp::LT;
+            } else {
+                postprocess = unary::UnaryOpType::LTZ;
             }
             break;
         case BinaryOpType::GT:
-            if (dtype != DataType::INT32) {
-                postprocess = unary::UnaryOpType::GTZ;
-            } else {
+            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
                 binary_op = SfpuBinaryOp::GT;
+            } else {
+                postprocess = unary::UnaryOpType::GTZ;
             }
             break;
         case BinaryOpType::GE:
-            if (dtype != DataType::INT32) {
-                postprocess = unary::UnaryOpType::GEZ;
-            } else {
+            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
                 binary_op = SfpuBinaryOp::GE;
+            } else {
+                postprocess = unary::UnaryOpType::GEZ;
             }
             break;
         case BinaryOpType::LE:
-            if (dtype != DataType::INT32) {
-                postprocess = unary::UnaryOpType::LEZ;
-            } else {
+            if ((is_sfpu_op() && dtype == DataType::FLOAT32) || dtype == DataType::INT32) {
                 binary_op = SfpuBinaryOp::LE;
+            } else {
+                postprocess = unary::UnaryOpType::LEZ;
             }
             break;
         case BinaryOpType::EQ:
@@ -210,7 +210,13 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
                 postprocess = unary::UnaryOpType::EQZ;
             }
             break;
-        case BinaryOpType::NE: postprocess = unary::UnaryOpType::NEZ; break;
+        case BinaryOpType::NE:
+            if (is_sfpu_op() && dtype == DataType::FLOAT32) {
+                binary_op = SfpuBinaryOp::NE;
+            } else {
+                postprocess = unary::UnaryOpType::NEZ;
+            }
+            break;
         // (a-b)**2
         case BinaryOpType::SQUARED_DIFFERENCE: postprocess = unary::UnaryOpType::SQUARE; break;
         // gelu(a+b)
@@ -493,11 +499,36 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
-        case LT: return {"lt_int32_tile_init();", "lt_int32_tile"};
-        case GT: return {"gt_int32_tile_init();", "gt_int32_tile"};
-        case GE: return {"ge_int32_tile_init();", "ge_int32_tile"};
-        case LE: return {"le_int32_tile_init();", "le_int32_tile"};
-        case EQ: return {"eq_binary_tile_init();", "eq_binary_tile"};
+        case LT:
+            if (dtype == DataType::FLOAT32) {
+                return {"lt_binary_tile_init();", "lt_binary_tile"};
+            }
+            return {"lt_int32_tile_init();", "lt_int32_tile"};
+        case GT:
+            if (dtype == DataType::FLOAT32) {
+                return {"gt_binary_tile_init();", "gt_binary_tile"};
+            }
+            return {"gt_int32_tile_init();", "gt_int32_tile"};
+        case GE:
+            if (dtype == DataType::FLOAT32) {
+                return {"ge_binary_tile_init();", "ge_binary_tile"};
+            }
+            return {"ge_int32_tile_init();", "ge_int32_tile"};
+        case LE:
+            if (dtype == DataType::FLOAT32) {
+                return {"le_binary_tile_init();", "le_binary_tile"};
+            }
+            return {"le_int32_tile_init();", "le_int32_tile"};
+        case EQ:
+            if (dtype == DataType::FLOAT32) {
+                return {"eq_binary_tile_init();", "eq_binary_tile"};
+            }
+            TT_THROW("SFPU EQ binary tile is only defined for Float32");
+        case NE:
+            if (dtype == DataType::FLOAT32) {
+                return {"ne_binary_tile_init();", "ne_binary_tile"};
+            }
+            TT_THROW("SFPU NE binary tile is only defined for Float32");
         case WHERE: {
             const char* data_format = (dtype == DataType::INT32)     ? "Int32"
                                       : (dtype == DataType::UINT32)  ? "UInt32"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -86,6 +86,7 @@ struct OpConfig {
         HYPOT,
         WHERE,
         EQ,
+        NE,
     };
 
     template <class EnumT>


### PR DESCRIPTION
### Ticket
[Testing comparison ops in WH and BH for special values for float32 dtype](https://github.com/tenstorrent/tt-metal/issues/36665)

### Problem description
There is only 1/6 comparison ops is implemented: EQ.
Sub+gtz approach is vulnerable to [catastrophic cancellation](https://en.wikipedia.org/wiki/Catastrophic_cancellation), so we need to use comparison directly.

### What's changed
Add NE, LE, GE, GT, LT for FP32.
Adapt it to torch behavior (for example force -0.0 == +0.0).
Use permutation in the "special_floats" test to verify all possible combinations.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/compare_fp32)
-- FAILED tests/ttnn/unit_tests/operations/fused/test_group_norm.py::test_group_norm_with_block_sharded_v2_8x4_grid[legacy-N=1-C=1280-H=16-W=16-num_groups=32-device_params={'l1_small_size': 0}] - AssertionError: Max ATOL Delta: 0.138671875, Max RTOL Delta: inf, **not relevant**
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/compare_fp32)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/compare_fp32)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/compare_fp32) | [#2839](https://github.com/tenstorrent/tt-metal/actions/runs/24460189324) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/compare_fp32) | [#17515](https://github.com/tenstorrent/tt-metal/actions/runs/24453027720) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/compare_fp32) | [#5226](https://github.com/tenstorrent/tt-metal/actions/runs/24453042390) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/compare_fp32) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/compare_fp32) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/compare_fp32) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/compare_fp32) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/compare_fp32) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/compare_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/compare_fp32) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/compare_fp32) |