### PR TITLE
test_matmul: skip test_matmul_on_subdevice_1d_mcast for slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -10,7 +10,7 @@ import torch
 import math
 import ttnn
 
-from models.common.utility_functions import comp_pcc, is_blackhole, is_llk_assert_enabled, skip_for_blackhole
+from models.common.utility_functions import comp_pcc, is_blackhole, is_llk_assert_enabled, skip_for_blackhole, skip_for_slow_dispatch
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 from ttnn.operations.activations import get_golden_function_for_activation
 
@@ -3252,6 +3252,7 @@ def _teardown_subdevice(device, sub_device_manager):
     device.remove_sub_device_manager(sub_device_manager)
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize(
     "m_size, k_size, n_size",
     [

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -10,7 +10,7 @@ import torch
 import math
 import ttnn
 
-from models.common.utility_functions import comp_pcc, is_blackhole, is_llk_assert_enabled, skip_for_blackhole, skip_for_slow_dispatch
+from models.common.utility_functions import is_blackhole, is_llk_assert_enabled, skip_for_blackhole, skip_for_slow_dispatch
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 from ttnn.operations.activations import get_golden_function_for_activation
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -10,7 +10,12 @@ import torch
 import math
 import ttnn
 
-from models.common.utility_functions import is_blackhole, is_llk_assert_enabled, skip_for_blackhole, skip_for_slow_dispatch
+from models.common.utility_functions import (
+    is_blackhole,
+    is_llk_assert_enabled,
+    skip_for_blackhole,
+    skip_for_slow_dispatch,
+)
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
 from ttnn.operations.activations import get_golden_function_for_activation
 


### PR DESCRIPTION
## Summary

- `test_matmul_on_subdevice_1d_mcast` uses sub-device managers, which are unsupported with slow dispatch.
- Tests hit `TT_FATAL` in `sub_device_manager_tracker.cpp:87` when run under slow dispatch.
- Fix: add `@skip_for_slow_dispatch()` decorator and import it alongside the existing `skip_for_blackhole`.

## Test plan

- [ ] Confirm the two failing parametrize variants are now skipped under slow dispatch
- [ ] Confirm they still run and pass under fast dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)