### PR TITLE
Fix model traced sweep - zero

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1261,11 +1261,8 @@ jobs:
       - name: Download sweep results
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          pattern: |
-            sweeps-run-result
-            sweeps-results-*
+          name: sweeps-run-result
           path: tests/sweep_framework/results_export
-          merge-multiple: true
       - name: List all downloaded files
         run: |
           ls -hal tests/sweep_framework/results_export

--- a/tests/sweep_framework/sweep_utils/op_kwargs_utils.py
+++ b/tests/sweep_framework/sweep_utils/op_kwargs_utils.py
@@ -41,6 +41,9 @@ _INFRA_KEYS = frozenset(
         "sweep_name",
         "storage_type",
         "mesh_coords",
+        "timestamp",
+        "input_hash",
+        "tag",
     }
 )
 

--- a/tests/sweep_framework/sweeps/model_traced/zeros_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/zeros_model_traced.py
@@ -11,7 +11,7 @@ from tests.sweep_framework.sweep_utils.mesh_tensor_utils import (
     mesh_tensor_to_torch,
 )
 
-from tests.sweep_framework.master_config_loader_v2 import MasterConfigLoader
+from tests.sweep_framework.master_config_loader_v2 import MasterConfigLoader, parse_dtype, parse_layout
 from tests.sweep_framework.sweep_utils.op_kwargs_utils import build_op_kwargs
 
 TIMEOUT = 300
@@ -56,15 +56,18 @@ def mesh_device_fixture():
 
 
 def run(
-    input_a_shape,
-    input_a_dtype,
-    input_a_layout,
-    input_a_memory_config,
+    input_a_shape=None,
+    input_a_dtype=None,
+    input_a_layout=None,
+    input_a_memory_config=None,
     output_memory_config=None,
     memory_config=None,
     storage_type="StorageType::DEVICE",
     *,
     device,
+    shape=None,
+    dtype=None,
+    layout=None,
     **kwargs,
 ) -> list:
     torch.manual_seed(0)
@@ -72,10 +75,30 @@ def run(
     is_mesh_device = hasattr(device, "get_num_devices")
     op_kwargs = build_op_kwargs(kwargs, output_memory_config=output_memory_config)
 
+    # V2 / model_traced_sample vectors use input_a_*; vectors_export JSON uses shape/dtype/layout/memory_config.
+    shape_val = input_a_shape if input_a_shape is not None else shape
+    dtype_val = input_a_dtype if input_a_dtype is not None else dtype
+    layout_val = input_a_layout if input_a_layout is not None else layout
+
+    if shape_val is None:
+        raise ValueError("Missing tensor shape (expected input_a_shape or shape).")
+
+    if isinstance(dtype_val, str):
+        dtype_val = parse_dtype(dtype_val)
+    if dtype_val is None:
+        dtype_val = ttnn.bfloat16
+
+    if isinstance(layout_val, str):
+        layout_val = parse_layout(layout_val)
+    if layout_val is None:
+        layout_val = ttnn.TILE_LAYOUT
+
     if output_memory_config is None and memory_config is not None:
         output_memory_config = memory_config
+    if output_memory_config is None and input_a_memory_config is not None:
+        output_memory_config = input_a_memory_config
 
-    shape = tuple(input_a_shape) if isinstance(input_a_shape, (list, tuple)) else input_a_shape
+    shape = tuple(shape_val) if isinstance(shape_val, (list, tuple)) else shape_val
 
     # PyTorch reference: zeros with the given shape
     torch_output_tensor = torch.zeros(shape, dtype=torch.float32)
@@ -84,8 +107,8 @@ def run(
     # ttnn.zeros creates a zero tensor with the given shape
     output_tensor = ttnn.zeros(
         shape,
-        dtype=input_a_dtype,
-        layout=input_a_layout,
+        dtype=dtype_val,
+        layout=layout_val,
         device=device,
         memory_config=output_memory_config,
         **op_kwargs,


### PR DESCRIPTION
### Problem description
The zeros model-traced sweep did not line up with V2 / vectors_export JSON, which passes shape, dtype, layout, and memory_config instead of input_a_shape, input_a_dtype, input_a_layout, and input_a_memory_config. That mismatch broke runs or produced wrong kwargs. Metadata fields from the sweep pipeline (timestamp, input_hash, tag) could also leak into build_op_kwargs and be forwarded where they should not. The ttnn-run-sweeps workflow downloaded sweep results with a glob pattern and merge-multiple, which no longer matched how artifacts are published.

### What's changed
zeros_model_traced.py: Accept both naming styles (input_a_* and shape / dtype / layout), resolve string dtype / layout via parse_dtype / parse_layout, apply sensible defaults (bfloat16, TILE_LAYOUT), use input_a_memory_config for output memory when appropriate, and fail fast with a clear error if shape is missing.
op_kwargs_utils.py: Treat timestamp, input_hash, and tag as reserved metadata so they are not passed through as op kwargs.
.github/workflows/ttnn-run-sweeps.yaml: Download the single artifact sweeps-run-result by name instead of pattern + merge-multiple.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stevendae/fix_zero_lead_model)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/fix_zero_lead_model)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/fix_zero_lead_model)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/fix_zero_lead_model)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/fix_zero_lead_model)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/fix_zero_lead_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/fix_zero_lead_model)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
