### PR TITLE
Fix slice output shape with height-sharded input

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1255,6 +1255,64 @@ def test_slice_subcores(input_shape, dim, start, end, step, layout, args_as_tens
 
 
 @pytest.mark.parametrize(
+    "input_shape, begins, ends, num_cores_x, num_cores_y, shard_shape, shard_layout",
+    [
+        # Single core: slice height from 32 to 18 (non-tile-aligned)
+        [[1, 1, 32, 64], [0, 0, 0, 0], [1, 1, 18, 64], 1, 1, [32, 64], "HEIGHT_SHARDED"],
+        # Multi-core: slice height from 128 to 64 (4 cores -> 2 cores worth)
+        [[1, 1, 128, 64], [0, 0, 0, 0], [1, 1, 64, 64], 2, 2, [32, 64], "HEIGHT_SHARDED"],
+        # Single core: slice height from 64 to 48 (non-tile-aligned logical, tile-aligned padded)
+        [[1, 1, 64, 64], [0, 0, 0, 0], [1, 1, 48, 64], 1, 1, [64, 64], "HEIGHT_SHARDED"],
+        # Non-zero begins: slice from middle of height dimension
+        [[1, 1, 128, 64], [0, 0, 32, 0], [1, 1, 96, 64], 2, 2, [32, 64], "HEIGHT_SHARDED"],
+        # Width-sharded: slice width from 128 to 64
+        [[1, 1, 32, 128], [0, 0, 0, 0], [1, 1, 32, 64], 1, 2, [32, 64], "WIDTH_SHARDED"],
+    ],
+)
+def test_slice_sharded_auto_shard_spec_recomputation(
+    input_shape, begins, ends, num_cores_x, num_cores_y, shard_shape, shard_layout, device
+):
+    """Regression test for issue #38016: ttnn.slice on a sharded tensor
+    without specifying output memory_config should produce correct logical output shape.
+
+    Previously, the output inherited the input's shard spec, causing the output shape
+    to retain the input's padded dimensions instead of the sliced dimensions."""
+
+    torch.manual_seed(2005)
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(
+        torch_input, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    tensor_memory_layout = (
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+        if shard_layout == "HEIGHT_SHARDED"
+        else ttnn.types.TensorMemoryLayout.WIDTH_SHARDED
+    )
+    grid_coord = ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+    tt_input_sharded = ttnn.to_memory_config(tt_input, sharded_mem_config)
+
+    # Key: no memory_config argument -- this is the bug scenario from issue #38016
+    tt_output = ttnn.slice(tt_input_sharded, begins, ends)
+
+    expected_shape = [ends[i] - begins[i] for i in range(len(begins))]
+    assert (
+        list(tt_output.shape) == expected_shape
+    ), f"Expected output shape {expected_shape}, got {list(tt_output.shape)}"
+
+    tt_output_cpu = ttnn.to_memory_config(tt_output, ttnn.DRAM_MEMORY_CONFIG)
+    tt_output_torch = ttnn.to_torch(tt_output_cpu)
+    torch_expected = torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]]
+
+    assert_with_pcc(torch_expected, tt_output_torch, 0.9999)
+
+
+@pytest.mark.parametrize(
     "input_shape, begins, ends, layout, use_sharding, description",
     [
         # Test 1: Slicing within a tile (should use RM path)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -111,6 +111,65 @@ ttnn::Tensor slice(
     // The tile path handles any end values (they get padded to tile boundaries
     // downstream), so only begin alignment matters.
     rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
+
+    // When no explicit output memory config is provided and the input is sharded,
+    // recompute the shard spec to match the output dimensions. Without this, the output
+    // tensor inherits the input's shard spec which may be too large for the sliced shape.
+    // (Issue #38016)
+    if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
+        input_rank >= 2) {
+        const auto& mem_layout = memory_config.memory_layout();
+        // Note: BLOCK_SHARDED is not handled here — it would require adjusting both
+        // shard height and width simultaneously, which is more complex. For now, callers
+        // using BLOCK_SHARDED should provide an explicit output memory_config.
+        if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+            mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+            const auto& shard_spec_val = memory_config.shard_spec().value();
+            uint32_t num_cores = shard_spec_val.num_cores();
+
+            // Compute output dimensions, tile-aligned if using TILE path
+            ttnn::SmallVector<uint32_t> output_dims(input_rank);
+            for (size_t i = 0; i < input_rank; i++) {
+                output_dims[i] = output_dim_i(i, modified_ends);
+            }
+            if (!rm_only) {
+                output_dims[input_rank - 2] =
+                    std::max(tt::round_up(output_dims[input_rank - 2], tile_shape[0]), tile_shape[0]);
+                output_dims[input_rank - 1] =
+                    std::max(tt::round_up(output_dims[input_rank - 1], tile_shape[1]), tile_shape[1]);
+            }
+
+            // Flatten to 2D: height = product of all dims except last, width = last dim
+            uint32_t output_height = 1;
+            for (size_t i = 0; i + 1 < input_rank; i++) {
+                output_height *= output_dims[i];
+            }
+            uint32_t output_width = output_dims[input_rank - 1];
+
+            std::array<uint32_t, 2> new_shard_shape = shard_spec_val.shape;
+            if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+                uint32_t new_shard_h = tt::div_up(output_height, num_cores);
+                if (!rm_only) {
+                    new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
+                }
+                new_shard_shape = {new_shard_h, output_width};
+            } else {  // WIDTH_SHARDED
+                uint32_t new_shard_w = tt::div_up(output_width, num_cores);
+                if (!rm_only) {
+                    new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
+                }
+                new_shard_shape = {output_height, new_shard_w};
+            }
+
+            if (new_shard_shape != shard_spec_val.shape) {
+                auto new_shard_spec =
+                    tt::tt_metal::ShardSpec(shard_spec_val.grid, new_shard_shape, shard_spec_val.orientation);
+                memory_config =
+                    MemoryConfig(memory_config.memory_layout(), memory_config.buffer_type(), new_shard_spec);
+            }
+        }
+    }
+
     if (rm_only) {
         if (!no_step) {
             TT_FATAL(input.dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -54,10 +54,14 @@ ttnn::Tensor slice(
 
     auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
                                                             : memory_config_arg.value_or(input_tensor.memory_config());
+    // output_memory_config may be recomputed below for sharded tensors to match the
+    // sliced output dimensions. memory_config stays as the original (input-compatible)
+    // config and is used for input layout conversion (to_layout in the rm_only path).
+    auto output_memory_config = memory_config;
 
     auto ret_adjustment([&](const ttnn::Tensor& input_tensor) {
         if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto tensor = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            auto tensor = ttnn::to_memory_config(input_tensor, output_memory_config, std::nullopt);
             tensor = ttnn::to_layout(tensor, input_layout);
             return tensor;
         }
@@ -118,13 +122,14 @@ ttnn::Tensor slice(
     // (Issue #38016)
     if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
         input_rank >= 2) {
-        const auto& mem_layout = memory_config.memory_layout();
-        // Note: BLOCK_SHARDED is not handled here — it would require adjusting both
-        // shard height and width simultaneously, which is more complex. For now, callers
-        // using BLOCK_SHARDED should provide an explicit output memory_config.
+        const auto& mem_layout = output_memory_config.memory_layout();
+        TT_FATAL(
+            mem_layout != tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+            "ttnn::slice does not support implicit memory_config inheritance for BLOCK_SHARDED tensors. "
+            "Please provide an explicit output memory_config.");
         if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
             mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-            const auto& shard_spec_val = memory_config.shard_spec().value();
+            const auto& shard_spec_val = output_memory_config.shard_spec().value();
             uint32_t num_cores = shard_spec_val.num_cores();
 
             // Compute output dimensions, tile-aligned if using TILE path
@@ -164,8 +169,8 @@ ttnn::Tensor slice(
             if (new_shard_shape != shard_spec_val.shape) {
                 auto new_shard_spec =
                     tt::tt_metal::ShardSpec(shard_spec_val.grid, new_shard_shape, shard_spec_val.orientation);
-                memory_config =
-                    MemoryConfig(memory_config.memory_layout(), memory_config.buffer_type(), new_shard_spec);
+                output_memory_config = MemoryConfig(
+                    output_memory_config.memory_layout(), output_memory_config.buffer_type(), new_shard_spec);
             }
         }
     }
@@ -220,7 +225,7 @@ ttnn::Tensor slice(
         ttnn::Shape(modified_begins),
         ttnn::Shape(padded_ends),
         ttnn::Shape(modified_step),
-        memory_config,
+        output_memory_config,
         /*use_tensor_args*/ false,
         std::nullopt,
         std::nullopt,


### PR DESCRIPTION
## Summary
- Fixes #38016: `ttnn.slice` produces wrong output shape when input tensor is height-sharded in L1 and no explicit output `memory_config` is provided
- Recomputes the output shard spec (height/width) based on sliced output dimensions for HEIGHT_SHARDED and WIDTH_SHARDED tensors
- BLOCK_SHARDED is not handled and requires callers to provide an explicit output `memory_config`

## Changes
- **`ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp`**: After determining the TILE vs RM path, recompute the output memory config's shard spec when inheriting from a sharded input. Adjusts shard height (for HEIGHT_SHARDED) or shard width (for WIDTH_SHARDED), tile-aligning when on the TILE path.
- **`tests/ttnn/unit_tests/operations/data_movement/test_slice.py`**: Added `test_slice_sharded_auto_shard_spec_recomputation` with 5 parametrized cases covering single-core, multi-core, non-zero begins, non-tile-aligned, and WIDTH_SHARDED scenarios.

## Pipelines triggered
- [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/23913942607)
- [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/23913997234)
- [(Single-card) Fast dispatch frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/23913999464)
- [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/23914004159)

Note: `ops-post-commit`, `ttnn-post-commit`, `models-post-commit`, and `tt-train-post-commit` are `workflow_call` only and cannot be dispatched directly. The pipelines above cover their functionality.

## Test plan
- [x] New regression test passes locally (5/5 cases: height-sharded single/multi-core, non-zero begins, width-sharded)
- [x] Existing slice sharded tests pass (`test_slice_rm_sharded_with_program_cache`, `test_slice_sharding_independence`, `test_issue_38841_regression`, `test_slice_within_tile_vs_across_tiles`)
- [ ] CI pipelines listed above