### PR TITLE
tests/ttnn: skip sub-device tests under slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -9,7 +9,7 @@ from ttnn.operations.activations import get_golden_function_for_activation
 from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
-from models.common.utility_functions import torch_random
+from models.common.utility_functions import torch_random, skip_for_slow_dispatch
 
 pytestmark = pytest.mark.use_module_device
 
@@ -798,6 +798,7 @@ def _teardown_subdevice(device, sub_device_manager):
     device.remove_sub_device_manager(sub_device_manager)
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize("m_size", [128, 384])
 @pytest.mark.parametrize("k_size", [512])
 @pytest.mark.parametrize("n_size", [512])
@@ -859,6 +860,7 @@ def test_linear_on_subdevice(device, m_size, k_size, n_size, use_bias, transpose
         _teardown_subdevice(device, sub_device_manager)
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize("m_size", [128])
 @pytest.mark.parametrize("k_size", [512])
 @pytest.mark.parametrize("n_size", [512])

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -8,6 +8,7 @@ import ttnn
 import pytest
 import numpy as np
 from ttnn import ReplicateTensorToMesh, ShardTensorToMesh, ShardTensor2dMesh
+from models.common.utility_functions import skip_for_slow_dispatch
 
 
 def is_ttnn_float_type(tt_dtype) -> bool:
@@ -852,6 +853,7 @@ def test_from_torch_mesh_mapper_preserves_memory_config(
     assert ttnn_tensor.layout == layout, f"Layout mismatch: expected {layout}, got {ttnn_tensor.layout}"
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize(
     "device_params",
     [{"trace_region_size": 1000000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
@@ -962,6 +964,7 @@ def test_from_torch_row_major_sharded_non_tile_aligned_shard_shape(mesh_device, 
     torch.testing.assert_close(torch_tensor, result.to(torch.int32))
 
 
+@skip_for_slow_dispatch()
 @pytest.mark.parametrize(
     "ttnn_dtype,torch_dtype,ttnn_layout",
     [


### PR DESCRIPTION
Sub-device managers are only supported in fast dispatch mode. These tests call  /  and hit  at  when run under slow dispatch.

Add  to:

- : , 
- : , 

Related: #41306 (same fix for )