### PR TITLE
Remove skip_for_simulator (test_reshape_replicated_tensor)

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1083,8 +1083,6 @@ def skip_with_llk_assert(reason_str="Test is not passing with LLK asserts enable
     return ti_skip(is_llk_assert_enabled(), reason=reason_str)
 
 
-def skip_for_simulator(reason_str="Test is not supported on simulator (tt-sim)"):
-    return ti_skip(os.environ.get("TT_METAL_SIMULATOR") is not None, reason=reason_str)
 
 
 def run_for_blackhole(reason_str="only runs for Blackhole"):

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1083,8 +1083,6 @@ def skip_with_llk_assert(reason_str="Test is not passing with LLK asserts enable
     return ti_skip(is_llk_assert_enabled(), reason=reason_str)
 
 
-
-
 def run_for_blackhole(reason_str="only runs for Blackhole"):
     return ti_skip(not is_blackhole(), reason=reason_str)
 

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from models.common.utility_functions import skip_for_simulator
-
 import pytest
 
 import torch
@@ -756,7 +754,6 @@ def test_reshape_zero_element(input_shape, output_shape, layout, ttnn_reshape, u
     assert tt_output_tensor.shape == torch.Size(output_shape)
 
 
-@skip_for_simulator()
 @pytest.mark.xfail(
     reason="Test that the previously supported reshape accounting for the physical shape is no longer possible"
 )


### PR DESCRIPTION
### Summary

The `@skip_for_simulator()` decorator on `test_reshape_replicated_tensor` was added in #40006 alongside the test itself, but it is not justified:

- The underlying reshape behaviour being tested is not simulator-specific
- `ttnn.reshape` with replicated tensors works fine on a 1-chip mesh — it does not require multi-chip hardware
- The test is already marked `@pytest.mark.xfail`, so a failure is handled gracefully; there is no reason to also skip it on the simulator

### Changes

- Remove `@skip_for_simulator()` and its import from `tests/ttnn/unit_tests/base_functionality/test_reshape.py`
- Delete `skip_for_simulator()` from `models/common/utility_functions.py` entirely to prevent future misuse

### Checklist

- [x] No functional change to production code
- [x] Test now runs on simulator (expected to xfail if it does fail, not silently skipped)
