### PR TITLE
Curl must be installed in the base layer of the basic-dev dockerfile.

### DIFF
--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -15,6 +15,7 @@ ARG PYTHON_VERSION
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     && apt-get update && apt-get install -y \
+    curl \
     cmake \
     ninja-build \
     g++-12 \
@@ -61,7 +62,6 @@ RUN set -e; \
 
 # Install basic runtime dependencies
 RUN apt-get update && apt-get install -y \
-    curl \
     git \
     python3-dev \
     python3-pip \


### PR DESCRIPTION
## Problem

PR #41277 added `curl` to the `basic-ttnn-runtime` stage, but `basic-dev` is built with `--target base` — which stops before `basic-ttnn-runtime` begins. So the built image never had curl, and any job using `basic-dev` that runs `curl` got:

```
curl: command not found
```

## Root cause

`Dockerfile.basic-dev` has two stages:

```
FROM ubuntu AS base                  <-- basic-dev target stops here
  RUN apt-get install cmake ninja g++...
  RUN apt-get install wget ca-certificates  <-- no curl

FROM base AS basic-ttnn-runtime      <-- curl was added here by #41277
  RUN apt-get install curl git python3-dev...
```

The `build-docker-artifact` workflow builds `basic-dev` with `--target base`, so the `basic-ttnn-runtime` layer (and its `curl` install) is never executed.

A new image tag *was* built and pushed after #41277 merged (the Dockerfile hash changed), but the image itself was missing curl because it was in the wrong stage. This caused `ttsim` and other jobs to fail with `curl: command not found` even on branches that had the #41277 patch.

## Fix

Move `curl` into the `base` stage and remove it from `basic-ttnn-runtime` (which inherits from `base` anyway).