### PR TITLE
Fix EmbeddingOp handling of ND input tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -541,3 +541,89 @@ def test_embedding_oom(
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (10,),  # Rank 1
+        (5, 10),  # Rank 2
+        (2, 3, 10),  # Rank 3
+        (1, 2, 3, 10),  # Rank 4
+        (2, 1, 1, 8),  # Rank 4 with 1s in middle (common in models)
+    ],
+)
+@pytest.mark.parametrize("hidden_embedding_dim", [64, 128])
+@pytest.mark.parametrize("vocabulary_size", [256])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_embedding_nd_input(
+    device,
+    input_shape,
+    hidden_embedding_dim,
+    vocabulary_size,
+    layout,
+):
+    """Test embedding with N-dimensional input tensors (rank 1 through 4+)."""
+    torch.manual_seed(1234)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, input_shape)
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weights = ttnn.to_device(
+        ttnn.from_torch(torch_weights, dtype=ttnn.bfloat16), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.embedding(input_tensor, weights, layout=layout)
+
+    # Verify output shape: input_shape + (embedding_dim,)
+    expected_output_shape = input_shape + (hidden_embedding_dim,)
+    assert tuple(output_tensor.shape) == expected_output_shape, (
+        f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
+    )
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 2, 3, 4, 5),  # Rank 5
+    ],
+)
+@pytest.mark.parametrize("hidden_embedding_dim", [64])
+@pytest.mark.parametrize("vocabulary_size", [128])
+def test_embedding_rank5_input(
+    device,
+    input_shape,
+    hidden_embedding_dim,
+    vocabulary_size,
+):
+    """Test embedding with rank 5 input tensor."""
+    torch.manual_seed(1234)
+
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, input_shape)
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weights = ttnn.to_device(
+        ttnn.from_torch(torch_weights, dtype=ttnn.bfloat16), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.embedding(input_tensor, weights, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # Verify output shape: input_shape + (embedding_dim,)
+    expected_output_shape = input_shape + (hidden_embedding_dim,)
+    assert tuple(output_tensor.shape) == expected_output_shape, (
+        f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
+    )
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -543,14 +543,51 @@ def test_embedding_oom(
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("sentence_size", [8, 32])
+@pytest.mark.parametrize("hidden_embedding_dim", [64])
+@pytest.mark.parametrize("vocabulary_size", [256])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_embedding_kernel_ready_input_backward_compatible_shape(
+    device,
+    batch_size,
+    sentence_size,
+    hidden_embedding_dim,
+    vocabulary_size,
+    layout,
+):
+    """Kernel-ready logical [B,1,1,S] inputs preserve legacy output shape [B,S,D]."""
+    torch.manual_seed(1234)
+
+    input_shape = (batch_size, 1, 1, sentence_size)
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, input_shape)
+    torch_weights = torch_random((vocabulary_size, hidden_embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+    expected_torch_output = torch_output_tensor.reshape(batch_size, sentence_size, hidden_embedding_dim)
+
+    input_tensor = ttnn.to_device(
+        ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weights = ttnn.to_device(
+        ttnn.from_torch(torch_weights, dtype=ttnn.bfloat16), device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.embedding(input_tensor, weights, layout=layout)
+
+    assert tuple(output_tensor.shape) == tuple(expected_torch_output.shape)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(expected_torch_output, output_tensor)
+
+
 @pytest.mark.parametrize(
     "input_shape",
     [
         (10,),  # Rank 1
         (5, 10),  # Rank 2
         (2, 3, 10),  # Rank 3
-        (1, 2, 3, 10),  # Rank 4
-        (2, 1, 1, 8),  # Rank 4 with 1s in middle (common in models)
+        (1, 2, 3, 10),  # Rank 4 (non-kernel-ready)
+        (2, 3, 4, 8),  # Rank 4 (non-kernel-ready)
     ],
 )
 @pytest.mark.parametrize("hidden_embedding_dim", [64, 128])
@@ -563,7 +600,7 @@ def test_embedding_nd_input(
     vocabulary_size,
     layout,
 ):
-    """Test embedding with N-dimensional input tensors (rank 1 through 4+)."""
+    """Test embedding with non-kernel-ready N-dimensional inputs."""
     torch.manual_seed(1234)
 
     torch_input_tensor = torch.randint(0, vocabulary_size - 1, input_shape)
@@ -581,9 +618,9 @@ def test_embedding_nd_input(
 
     # Verify output shape: input_shape + (embedding_dim,)
     expected_output_shape = input_shape + (hidden_embedding_dim,)
-    assert tuple(output_tensor.shape) == expected_output_shape, (
-        f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
-    )
+    assert (
+        tuple(output_tensor.shape) == expected_output_shape
+    ), f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor)
@@ -621,9 +658,9 @@ def test_embedding_rank5_input(
 
     # Verify output shape: input_shape + (embedding_dim,)
     expected_output_shape = input_shape + (hidden_embedding_dim,)
-    assert tuple(output_tensor.shape) == expected_output_shape, (
-        f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
-    )
+    assert (
+        tuple(output_tensor.shape) == expected_output_shape
+    ), f"Output shape mismatch: expected {expected_output_shape}, got {tuple(output_tensor.shape)}"
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -87,14 +87,18 @@ void EmbeddingsDeviceOperation::validate_on_program_cache_miss(
                 "Embedding only supports height sharded Row Major outputs");
         }
     }
-    // Both ROW_MAJOR and TILE_LAYOUT require [B,1,1,S] shape for embedding kernel
-    TT_FATAL(
-        a.padded_shape()[1] == 1 && a.padded_shape()[2] == 1,
-        "Embedding input must have shape [B,1,1,S], got [{},{},{},{}]",
-        a.padded_shape()[0],
-        a.padded_shape()[1],
-        a.padded_shape()[2],
-        a.padded_shape()[3]);
+    const auto& input_logical_shape = a.logical_shape();
+    // Operator layer adapts ND inputs before kernel launch. Only enforce
+    // singleton logical dims when a rank-4 kernel view is provided.
+    if (input_logical_shape.rank() == 4) {
+        TT_FATAL(
+            input_logical_shape[1] == 1 && input_logical_shape[2] == 1,
+            "Embedding input must have logical shape [B,1,1,S], got [{},{},{},{}]",
+            input_logical_shape[0],
+            input_logical_shape[1],
+            input_logical_shape[2],
+            input_logical_shape[3]);
+    }
     switch (operation_attributes.embeddings_type) {
         case EmbeddingsType::PADDED:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -87,9 +87,14 @@ void EmbeddingsDeviceOperation::validate_on_program_cache_miss(
                 "Embedding only supports height sharded Row Major outputs");
         }
     }
-    if (a.layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(a.padded_shape()[1] == 1 && a.padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
-    }
+    // Both ROW_MAJOR and TILE_LAYOUT require [B,1,1,S] shape for embedding kernel
+    TT_FATAL(
+        a.padded_shape()[1] == 1 && a.padded_shape()[2] == 1,
+        "Embedding input must have shape [B,1,1,S], got [{},{},{},{}]",
+        a.padded_shape()[0],
+        a.padded_shape()[1],
+        a.padded_shape()[2],
+        a.padded_shape()[3]);
     switch (operation_attributes.embeddings_type) {
         case EmbeddingsType::PADDED:
             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -41,6 +41,11 @@ ttnn::Tensor embedding(
 
     auto weight = ttnn::unsqueeze_to_4D(mutable_weight);
 
+    bool is_kernel_ready = original_input_rank == 4;
+    if (is_kernel_ready) {
+        is_kernel_ready = (input_shape[1] == 1 && input_shape[2] == 1);
+    }
+
     // Compute batch_size as product of all dimensions except the last (sequence dimension)
     // This correctly handles ND inputs like [B, 1, 1, S] or [d1, d2, ..., dn]
     uint64_t batch_size = 1;
@@ -55,13 +60,9 @@ ttnn::Tensor embedding(
     auto sentence_size = input_shape[-1];
 
     auto embedding_input_tensor = input_tensor;
-    // Reshape ND inputs to [B,1,1,S] for kernel compatibility (all layouts)
-    // Skip only if already in correct shape to avoid unnecessary operation
-    if (!(original_input_rank == 4 &&
-          input_shape[0] == batch_size_u32 &&
-          input_shape[1] == 1 &&
-          input_shape[2] == 1 &&
-          input_shape[3] == sentence_size)) {
+    if (!is_kernel_ready) {
+        // Flatten leading dimensions for kernel invocation and preserve original ND
+        // structure for reconstruction after the kernel call.
         embedding_input_tensor = ttnn::reshape(input_tensor, ttnn::Shape({batch_size_u32, 1, 1, sentence_size}));
     }
 
@@ -81,6 +82,21 @@ ttnn::Tensor embedding(
         }
     }
 
+    // Enforce kernel contract at launch boundary: device op must receive
+    // logical [B,1,1,S].
+    const auto& kernel_input_shape = embedding_input_tensor.logical_shape();
+    TT_FATAL(
+        kernel_input_shape.rank() == 4,
+        "Embedding kernel input must have rank 4 [B,1,1,S], got rank {}",
+        kernel_input_shape.rank());
+    TT_FATAL(
+        kernel_input_shape[1] == 1 && kernel_input_shape[2] == 1,
+        "Embedding kernel input must have logical shape [B,1,1,S], got [{},{},{},{}]",
+        kernel_input_shape[0],
+        kernel_input_shape[1],
+        kernel_input_shape[2],
+        kernel_input_shape[3]);
+
     auto embeddings = ttnn::prim::embedding(
         embedding_input_tensor,
         weight,
@@ -90,15 +106,69 @@ ttnn::Tensor embedding(
         pad_token,
         optional_output_tensor);
 
-    // Restore original shape with embedding dimension appended
-    // Input: [d1, d2, ..., dn] -> Output: [d1, d2, ..., dn, embedding_dim]
-    ttsl::SmallVector<uint32_t> output_shape_vec;
-    output_shape_vec.reserve(original_input_rank + 1);
-    for (size_t i = 0; i < original_input_rank; ++i) {
-        output_shape_vec.push_back(input_shape[i]);
+    const uint64_t expected_embedding_volume = batch_size * sentence_size * hidden_embedding_dim;
+    TT_FATAL(
+        static_cast<uint64_t>(embeddings.logical_volume()) == expected_embedding_volume,
+        "Embedding output volume mismatch before reshape: expected {}, got {}",
+        expected_embedding_volume,
+        embeddings.logical_volume());
+
+    const auto& kernel_output_shape = embeddings.logical_shape();
+    const auto kernel_output_rank = kernel_output_shape.rank();
+    TT_FATAL(
+        kernel_output_rank == 3 || kernel_output_rank == 4,
+        "Embedding kernel output rank must be 3 or 4, got rank {}",
+        kernel_output_rank);
+
+    if (kernel_output_rank == 4) {
+        TT_FATAL(
+            kernel_output_shape[1] == 1,
+            "Embedding kernel output rank-4 shape must have singleton dim1, got [{},{},{},{}]",
+            kernel_output_shape[0],
+            kernel_output_shape[1],
+            kernel_output_shape[2],
+            kernel_output_shape[3]);
+        TT_FATAL(
+            kernel_output_shape[0] == batch_size_u32 && kernel_output_shape[2] == sentence_size &&
+                kernel_output_shape[3] == hidden_embedding_dim,
+            "Embedding kernel output rank-4 shape mismatch: expected [{},1,{},{}], got [{},{},{},{}]",
+            batch_size_u32,
+            sentence_size,
+            hidden_embedding_dim,
+            kernel_output_shape[0],
+            kernel_output_shape[1],
+            kernel_output_shape[2],
+            kernel_output_shape[3]);
+        embeddings = ttnn::reshape(
+            embeddings,
+            ttnn::Shape({kernel_output_shape[0], kernel_output_shape[2], kernel_output_shape[3]}));
+    } else {
+        TT_FATAL(
+            kernel_output_shape[0] == batch_size_u32 && kernel_output_shape[1] == sentence_size &&
+                kernel_output_shape[2] == hidden_embedding_dim,
+            "Embedding kernel output rank-3 shape mismatch: expected [{},{},{}], got [{},{},{}]",
+            batch_size_u32,
+            sentence_size,
+            hidden_embedding_dim,
+            kernel_output_shape[0],
+            kernel_output_shape[1],
+            kernel_output_shape[2]);
     }
-    output_shape_vec.push_back(hidden_embedding_dim);
-    embeddings = ttnn::reshape(embeddings, ttnn::Shape(std::move(output_shape_vec)));
+
+    if (is_kernel_ready) {
+        // Preserve legacy behavior for logical [B,1,1,S] inputs.
+        embeddings = ttnn::reshape(embeddings, ttnn::Shape({input_shape[0], sentence_size, hidden_embedding_dim}));
+    } else {
+        // Restore original ND shape with embedding dimension appended:
+        // [d1, d2, ..., dn] -> [d1, d2, ..., dn, embedding_dim]
+        ttsl::SmallVector<uint32_t> output_shape_vec;
+        output_shape_vec.reserve(original_input_rank + 1);
+        for (size_t i = 0; i < original_input_rank; ++i) {
+            output_shape_vec.push_back(input_shape[i]);
+        }
+        output_shape_vec.push_back(hidden_embedding_dim);
+        embeddings = ttnn::reshape(embeddings, ttnn::Shape(std::move(output_shape_vec)));
+    }
 
     embeddings = ttnn::to_layout(embeddings, layout.value_or(weight_arg.layout()));
     if (embeddings.layout() == ttnn::TILE_LAYOUT && embeddings.dtype() != dtype.value_or(weight.dtype())) {

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -42,16 +42,23 @@ ttnn::Tensor embedding(
 
     // Compute batch_size as product of all dimensions except the last (sequence dimension)
     // This correctly handles ND inputs like [B, 1, 1, S] or [d1, d2, ..., dn]
-    uint32_t batch_size = 1;
+    uint64_t batch_size = 1;
     for (size_t i = 0; i < original_input_rank - 1; ++i) {
         batch_size *= input_shape[i];
     }
     // For rank 1, batch_size remains 1
+
+    TT_FATAL(batch_size <= std::numeric_limits<uint32_t>::max(), "Batch size overflow: {}", batch_size);
+
+    uint32_t batch_size_u32 = static_cast<uint32_t>(batch_size);
     auto sentence_size = input_shape[-1];
 
     auto embedding_input_tensor = input_tensor;
-    if (input_tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) {
-        embedding_input_tensor = ttnn::reshape(input_tensor, ttnn::Shape({batch_size, 1, 1, sentence_size}));
+    if (input_tensor.layout() == ttnn::ROW_MAJOR_LAYOUT &&
+        !(original_input_rank == 4 &&
+          input_shape[1] == 1 &&
+          input_shape[2] == 1)) {
+        embedding_input_tensor = ttnn::reshape(input_tensor, ttnn::Shape({batch_size_u32, 1, 1, sentence_size}));
     }
 
     // If layout is row major, OR if the input tensor is not a multiple of TILE_HEIGHT, then we cannot use tilized

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/embedding/embedding.hpp"
 
+#include <limits>
 #include <utility>
 #include "ttnn/operations/core/core.hpp"
 #include "device/embedding_device_operation.hpp"
@@ -54,10 +55,13 @@ ttnn::Tensor embedding(
     auto sentence_size = input_shape[-1];
 
     auto embedding_input_tensor = input_tensor;
-    if (input_tensor.layout() == ttnn::ROW_MAJOR_LAYOUT &&
-        !(original_input_rank == 4 &&
+    // Reshape ND inputs to [B,1,1,S] for kernel compatibility (all layouts)
+    // Skip only if already in correct shape to avoid unnecessary operation
+    if (!(original_input_rank == 4 &&
+          input_shape[0] == batch_size_u32 &&
           input_shape[1] == 1 &&
-          input_shape[2] == 1)) {
+          input_shape[2] == 1 &&
+          input_shape[3] == sentence_size)) {
         embedding_input_tensor = ttnn::reshape(input_tensor, ttnn::Shape({batch_size_u32, 1, 1, sentence_size}));
     }
 

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 #include <ttnn/operations/copy/typecast/typecast.hpp>
+#include <tt_stl/small_vector.hpp>
 
 namespace ttnn {
 
@@ -31,12 +32,23 @@ ttnn::Tensor embedding(
         mutable_weight = ttnn::to_layout(mutable_weight, ttnn::ROW_MAJOR_LAYOUT);
     }
     auto hidden_embedding_dim = mutable_weight.logical_shape()[-1];
-    auto original_input_rank = input_tensor.logical_shape().rank();
+    const auto& input_shape = input_tensor.logical_shape();
+    auto original_input_rank = input_shape.rank();
+
+    TT_FATAL(original_input_rank >= 1, "Embedding input must have rank >= 1, got rank {}", original_input_rank);
+    TT_FATAL(input_shape[-1] > 0, "Last dimension of embedding input must be > 0");
+
     auto weight = ttnn::unsqueeze_to_4D(mutable_weight);
 
-    // If indices tensor is 1 dimensional, batch size is 1
-    auto batch_size = (input_tensor.logical_shape().rank() == 1) ? 1 : input_tensor.logical_shape()[0];
-    auto sentence_size = input_tensor.logical_shape()[-1];
+    // Compute batch_size as product of all dimensions except the last (sequence dimension)
+    // This correctly handles ND inputs like [B, 1, 1, S] or [d1, d2, ..., dn]
+    uint32_t batch_size = 1;
+    for (size_t i = 0; i < original_input_rank - 1; ++i) {
+        batch_size *= input_shape[i];
+    }
+    // For rank 1, batch_size remains 1
+    auto sentence_size = input_shape[-1];
+
     auto embedding_input_tensor = input_tensor;
     if (input_tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) {
         embedding_input_tensor = ttnn::reshape(input_tensor, ttnn::Shape({batch_size, 1, 1, sentence_size}));
@@ -66,12 +78,17 @@ ttnn::Tensor embedding(
         memory_config,
         pad_token,
         optional_output_tensor);
-    // Don't include batch_size if there was none
-    if (original_input_rank == 1) {
-        embeddings = ttnn::reshape(embeddings, Shape({sentence_size, hidden_embedding_dim}));
-    } else {
-        embeddings = ttnn::reshape(embeddings, Shape({batch_size, sentence_size, hidden_embedding_dim}));
+
+    // Restore original shape with embedding dimension appended
+    // Input: [d1, d2, ..., dn] -> Output: [d1, d2, ..., dn, embedding_dim]
+    ttsl::SmallVector<uint32_t> output_shape_vec;
+    output_shape_vec.reserve(original_input_rank + 1);
+    for (size_t i = 0; i < original_input_rank; ++i) {
+        output_shape_vec.push_back(input_shape[i]);
     }
+    output_shape_vec.push_back(hidden_embedding_dim);
+    embeddings = ttnn::reshape(embeddings, ttnn::Shape(std::move(output_shape_vec)));
+
     embeddings = ttnn::to_layout(embeddings, layout.value_or(weight_arg.layout()));
     if (embeddings.layout() == ttnn::TILE_LAYOUT && embeddings.dtype() != dtype.value_or(weight.dtype())) {
         embeddings = ttnn::typecast(embeddings, dtype.value_or(weight.dtype()));


### PR DESCRIPTION
### Ticket
Fixes #21157

---

### Problem description
EmbeddingOp did not correctly handle input tensors with rank > 2.

The implementation effectively used only the first and last dimensions, ignoring intermediate dimensions. This resulted in incorrect behavior for multi-dimensional inputs and could lead to unexpected outputs.

---

### What's changed
The input handling logic has been updated to correctly support N-dimensional tensors.

- Flatten all leading dimensions into a single batch dimension
- Preserve the last dimension as sequence length
- Maintain required 4D input shape `[B, 1, 1, S]` for kernel compatibility
- Restore the original N-dimensional shape with embedding dimension appended

Example:
- Input:  `[2, 3, 10]`
- Output: `[2, 3, 10, D]`

Impact:
- Fixes incorrect behavior for rank > 2 inputs
- Maintains backward compatibility for rank 1 and 2 inputs
- No changes to kernel or API contracts

Tests:
- Added coverage for rank 3–5 inputs
- Verified outputs match PyTorch embedding behavior

---

### Checklist
- [x] New/Existing tests provide coverage for changes

---

#### Model tests

Not applicable. Changes are limited to embedding input shape handling and do not modify model logic.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212832436210963