### PR TITLE
enable mpi-oversubscription for loopback/multi-rank-per-host functionality

### DIFF
--- a/tt_metal/distributed/multihost/mpi_distributed_context.cpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.cpp
@@ -166,7 +166,9 @@ inline void init_env(int& argc, char**& argv) {
     std::call_once(mpi_once, [&] {
         int already_initialized = 0;
         MPI_Initialized(&already_initialized);
-        if (already_initialized) return;
+        if (already_initialized) {
+            return;
+        }
 
         int provided = 0;
         if (MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided) != MPI_SUCCESS) {

--- a/tt_metal/distributed/multihost/mpi_distributed_context.cpp
+++ b/tt_metal/distributed/multihost/mpi_distributed_context.cpp
@@ -164,6 +164,10 @@ inline void init_env(int& argc, char**& argv) {
     static std::once_flag mpi_once;
 
     std::call_once(mpi_once, [&] {
+        int already_initialized = 0;
+        MPI_Initialized(&already_initialized);
+        if (already_initialized) return;
+
         int provided = 0;
         if (MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided) != MPI_SUCCESS) {
             TT_THROW("MPI_Init_thread failed");


### PR DESCRIPTION
This was identified while testing MPI dependent features with oversubscription + loopback on a single host. This allows us to have multiple MPI ranks/host without trying to re-initialize an already initialized MPI context.

Some more rationale for the change:

From [MPI_Init](https://www.open-mpi.org/doc/current/man3/MPI_Init.3.php):
▎ "MPI can be initialized at most once; subsequent calls to MPI_Init or MPI_Init_thread are erroneous."

From [MPI_Finalize](https://www.open-mpi.org/doc/current/man3/MPI_Finalize.3.php):
▎ "Once this routine is called, no MPI routine (not even MPI_Init) may be called, except for MPI_Get_version, MPI_Initialized, and MPI_Finalized."

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/mpi-oversubscribe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/mpi-oversubscribe)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/mpi-oversubscribe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/mpi-oversubscribe)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/mpi-oversubscribe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/mpi-oversubscribe)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early

