### PR TITLE
Update script.

### DIFF
--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -199,30 +199,44 @@ def dump_lightweight_asserts(
         )
         arguments_and_locals = None
         assert_code = "?"
-        if callstack_data.kernel_callstack_with_message.callstack[0] is not None:
+        callstack = callstack_data.kernel_callstack_with_message.callstack
+        # Try to extract the ASSERT macro from frame #0. If frame #0 is a helper like
+        # llk_assert_break() that doesn't contain the ASSERT itself, fall back to
+        # frame #1 (the actual caller). Whichever frame contains the ASSERT is used
+        # to display template parameters, runtime arguments, and locals.
+        if callstack[0] is not None:
             assert_code = extract_assert_code(
-                callstack_data.kernel_callstack_with_message.callstack[0].file,
-                callstack_data.kernel_callstack_with_message.callstack[0].line,
-                callstack_data.kernel_callstack_with_message.callstack[0].column,
+                callstack[0].file,
+                callstack[0].line,
+                callstack[0].column,
             )
+            assert_frame = callstack[0]
+            if "ASSERT() not found" in assert_code and len(callstack) > 1 and callstack[1] is not None:
+                fallback_code = extract_assert_code(
+                    callstack[1].file,
+                    callstack[1].line,
+                    callstack[1].column,
+                )
+                if "ASSERT() not found" not in fallback_code:
+                    assert_code = fallback_code
+                    assert_frame = callstack[1]
             arguments_and_locals = ""
-            top_frame = callstack_data.kernel_callstack_with_message.callstack[0]
-            if len(top_frame.template_parameters) > 0:
+            if len(assert_frame.template_parameters) > 0:
                 arguments_and_locals += "\nTemplate parameters:\n"
-                arguments_and_locals += serialize_variables(top_frame.template_parameters, assert_code)
-                for var in top_frame.template_parameters:
+                arguments_and_locals += serialize_variables(assert_frame.template_parameters, assert_code)
+                for var in assert_frame.template_parameters:
                     if var.name is not None:
                         assert_code = assert_code.replace(var.name, f"[info]{var.name}[/]")
-            if len(top_frame.arguments) > 0:
+            if len(assert_frame.arguments) > 0:
                 arguments_and_locals += "\nRuntime arguments:\n"
-                arguments_and_locals += serialize_variables(top_frame.arguments, assert_code)
-                for var in top_frame.arguments:
+                arguments_and_locals += serialize_variables(assert_frame.arguments, assert_code)
+                for var in assert_frame.arguments:
                     if var.name is not None:
                         assert_code = assert_code.replace(var.name, f"[info]{var.name}[/]")
-            if len(top_frame.locals) > 0:
+            if len(assert_frame.locals) > 0:
                 arguments_and_locals += "\nLocals:\n"
-                arguments_and_locals += serialize_variables(top_frame.locals, assert_code)
-                for var in top_frame.locals:
+                arguments_and_locals += serialize_variables(assert_frame.locals, assert_code)
+                for var in assert_frame.locals:
                     if var.name is not None:
                         assert_code = assert_code.replace(var.name, f"[info]{var.name}[/]")
         return LightweightAssertInfo(


### PR DESCRIPTION
### Ticket
#41335 

### Problem description
Currently, dump_lightweight_assert.py can print template, runtime and local variables only from function in frame 0. However, in case of LLK_ASSERT, the idea is to have a helper noinline function which contains only ebreak, so the actual assert will be part of frame 1. In order to keep the same behavior as before, the script should be able to find an assert in either frame 0 or frame 1.

### What's changed
Fix lightweight assert dump to show the actual ASSERT macro and its variables when frame #0 is a helper like llk_assert_break() that doesn't contain the assert itself — falls back to frame #1 (the caller) and displays its template parameters, runtime arguments, and locals.

The change can be verified:
Run a test that triggers an LLK assert (e.g. TT_METAL_LLK_ASSERTS=1) and verify the dump now shows the LLK_ASSERT(...) condition and function parameters instead of "ASSERT() not found!".

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/update_dump_lw_script)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/update_dump_lw_script)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/update_dump_lw_script)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/update_dump_lw_script)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/update_dump_lw_script)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/update_dump_lw_script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/update_dump_lw_script)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
