### PR TITLE
Feature: Add DPRINT and watcher support for DRAM programmable cores

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -67,7 +67,7 @@ jobs:
               ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=$GTEST_FILTER
               TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
                 ./build/test/tt_metal/unit_tests_debug_tools \
-                --gtest_filter=*Drisc*:*DramTestPrint*
+                --gtest_filter=*Drisc*:*Dram*Print*
               ./build/test/tt_metal/unit_tests_inspector --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_device --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=$GTEST_FILTER

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -65,6 +65,9 @@ jobs:
           - name: debug_tools and device and dispatch
             cmd: |
               ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=$GTEST_FILTER
+              TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1 \
+                ./build/test/tt_metal/unit_tests_debug_tools \
+                --gtest_filter=*Drisc*:*DramTestPrint*
               ./build/test/tt_metal/unit_tests_inspector --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_device --gtest_filter=$GTEST_FILTER
               ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=$GTEST_FILTER

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -90,6 +90,8 @@ protected:
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::DRAM, tt::llrt::RunTimeDebugClassWorker);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_mesh_coords(
             tt::llrt::RunTimeDebugFeatureDprint, {});
@@ -125,6 +127,8 @@ protected:
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassNoneSpecified);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassNoneSpecified);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::DRAM, tt::llrt::RunTimeDebugClassNoneSpecified);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_mesh_coords(
             tt::llrt::RunTimeDebugFeatureDprint, {});
@@ -335,6 +339,8 @@ protected:
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::DRAM, tt::llrt::RunTimeDebugClassWorker);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(
             tt::llrt::RunTimeDebugFeatureDprint, true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_feature_mesh_coords(

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include "gtest/gtest.h"
+#include <tt-logger/tt-logger.hpp>
+#include "impl/context/metal_context.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// DEVICE_PRINT tests for DRAM programmable cores (DRISC, Blackhole only).
+// Mirrors select tests from test_print_output.cpp but targets DRAM core 0,0.
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+class DevicePrintDramFixture : public DevicePrintFixture {
+public:
+    void RunDramProgram(
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+        const std::string& kernel_path,
+        stl::Span<const uint32_t> runtime_args = {}) {
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program = Program();
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        constexpr CoreCoord core = {0, 0};
+        KernelHandle kernel_handle = CreateKernel(program_, kernel_path, core, DramConfig{.noc = tt_metal::NOC::NOC_0});
+
+        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+
+        DebugToolsMeshFixture::RunProgram(mesh_device, workload);
+        MetalContext::instance().dprint_server()->await();
+    }
+
+    void TestDramOutput(
+        const std::string& kernel_path,
+        const std::vector<std::string>& expected_messages,
+        stl::Span<const uint32_t> runtime_args = {}) {
+        for (auto& mesh_device : this->devices_) {
+            RunDramProgram(mesh_device, kernel_path, runtime_args);
+            EXPECT_TRUE(FileContainsAllStrings(dprint_file_name, expected_messages));
+        }
+    }
+};
+
+#define DRAM_SKIP_GUARDS()                                                                                  \
+    if (!this->IsSlowDispatch()) {                                                                          \
+        log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");  \
+        GTEST_SKIP();                                                                                       \
+    }                                                                                                       \
+    do {                                                                                                    \
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();                                     \
+        if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {                               \
+            log_info(tt::LogTest, "Skipping: DRAM programmable cores not available on this architecture."); \
+            GTEST_SKIP();                                                                                   \
+        }                                                                                                   \
+    } while (0)
+
+TEST_F(DevicePrintDramFixture, DramPrintSimpleString) {
+    DRAM_SKIP_GUARDS();
+    std::vector<std::string> messages = {
+        "Hello world!",
+        "First line.",
+        "Second line.",
+    };
+    TestDramOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_simple_string.cpp", messages);
+}
+
+TEST_F(DevicePrintDramFixture, DramPrintSingleUintArg) {
+    DRAM_SKIP_GUARDS();
+    std::vector<uint32_t> runtime_args = {42};
+    std::vector<std::string> messages = {
+        "Printing uint32_t from arg: 42",
+    };
+    TestDramOutput(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_single_uint_arg.cpp", messages, runtime_args);
+}
+
+TEST_F(DevicePrintDramFixture, DramPrintBasicTypes) {
+    DRAM_SKIP_GUARDS();
+    std::vector<std::string> messages = {
+        "int8_t: -8",
+        "uint8_t: 8",
+        "int16_t: -16",
+        "uint16_t: 16",
+        "int32_t: -32",
+        "uint32_t: 32",
+        "int64_t: -64",
+        "uint64_t: 64",
+        "float: 3.14",
+        "double: 6.28",
+        "bool: true",
+        "bf4_t: 0.5",
+        "bf8_t: 0.375",
+        "bf16_t: 0.122558594",
+        "Reordered args: true -16 -32 -64",
+        "Reordered args: true -16 -32 -64",
+    };
+    TestDramOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_basic_types.cpp", messages);
+}
+
+TEST_F(DevicePrintDramFixture, DramPrintFactorial) {
+    DRAM_SKIP_GUARDS();
+    std::vector<uint32_t> runtime_args = {5};
+    std::vector<std::string> messages = {
+        "factorial(5) = 120",
+    };
+    TestDramOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_factorial.cpp", messages, runtime_args);
+}
+
+#undef DRAM_SKIP_GUARDS

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
@@ -56,11 +56,11 @@ public:
 };
 
 #define DRAM_SKIP_GUARDS()                                                                                  \
-    if (!this->IsSlowDispatch()) {                                                                          \
-        log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");  \
-        GTEST_SKIP();                                                                                       \
-    }                                                                                                       \
     do {                                                                                                    \
+        if (!this->IsSlowDispatch()) {                                                                      \
+            log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");  \
+            GTEST_SKIP();                                                                                   \
+        }                                                                                                   \
         const auto& hal = tt::tt_metal::MetalContext::instance().hal();                                     \
         if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {                               \
             log_info(tt::LogTest, "Skipping: DRAM programmable cores not available on this architecture."); \

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_dram_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_dram_cores.cpp
@@ -49,8 +49,7 @@ SETW:
 HEX/OCT/DEC:
 1e240361100123456)";
 
-void RunTest(
-    DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+void RunTest(DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     auto* device = mesh_device->get_devices()[0];
 
     // Test printing on a single DRAM core

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_dram_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_dram_cores.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/host_api.hpp>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include <tt-metalium/device.hpp>
+#include "gtest/gtest.h"
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include "impl/context/metal_context.hpp"
+#include "impl/kernels/kernel.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// A test for printing from DRAM programmable cores (DRISC, Blackhole only).
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+const std::string golden_output =
+    R"(Test Debug Print: DRISC
+Basic Types:
+101-1.618@0.122559
+1015551234569123456789
+-17-343-44444-5123456789
+10
+Pointer:
+123
+456
+789
+SETPRECISION/FIXED/DEFAULTFLOAT:
+3.1416
+3.14159012
+3.14159
+3.141590118
+SETW:
+    123456123456  ab
+HEX/OCT/DEC:
+1e240361100123456)";
+
+void RunTest(
+    DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    auto* device = mesh_device->get_devices()[0];
+
+    // Test printing on a single DRAM core
+    std::vector<CoreCoord> dram_cores = {CoreCoord{0, 0}};
+
+    for (const auto& logical_core : dram_cores) {
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program = Program();
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/misc/drisc_print.cpp",
+            logical_core,
+            DramConfig{.noc = tt_metal::NOC::NOC_0});
+
+        log_info(
+            tt::LogTest,
+            "Running DPRINT test on DRAM core device {} logical ({},{})",
+            device->id(),
+            logical_core.x,
+            logical_core.y);
+        fixture->RunProgram(mesh_device, workload);
+
+        EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, golden_output));
+
+        MetalContext::instance().dprint_server()->clear_log_file();
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+TEST_F(DPrintMeshFixture, DramTestPrint) {
+    if (!this->IsSlowDispatch()) {
+        log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");
+        GTEST_SKIP();
+    }
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+        log_info(tt::LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
+        GTEST_SKIP();
+    }
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [](DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device);
+            },
+            mesh_device);
+    }
+}

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -17,6 +17,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_print_tiles_multiple.cpp
     device_print/test_checkpoint.cpp
     dprint/test_dprint_mesh_coords.cpp
+    dprint/test_dram_cores.cpp
     dprint/test_eth_cores.cpp
     dprint/test_invalid_print_core.cpp
     dprint/test_mute_device.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -3,6 +3,7 @@
 
 set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_compilation_failures.cpp
+    device_print/test_dram_print_output.cpp
     device_print/test_eth_cores.cpp
     device_print/test_format_updates.cpp
     device_print/test_invalid_print_core.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -28,6 +28,7 @@
 #include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/host_api.hpp>
 #include "impl/debug/debug_helpers.hpp"
+#include <umd/device/types/core_coordinates.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.
@@ -134,9 +135,17 @@ static void RunTest(
             risc = is_active ? "erisc" : "ierisc";
             break;
         }
-        case HalProgrammableCoreType::DRAM:
-            log_info(LogTest, "Skipping: DRAM cores do not support watcher assert tests.");
-            GTEST_SKIP();
+        case HalProgrammableCoreType::DRAM: {
+            if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+                log_info(LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
+                GTEST_SKIP();
+            }
+            logical_core = {0, 0};
+            virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
+            assert_kernel = CreateKernel(program_, kernel, logical_core, DramConfig{.noc = tt_metal::NOC::NOC_0});
+            risc = "drisc";
+            break;
+        }
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
     }
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
@@ -179,6 +188,7 @@ static void RunTest(
     switch (processor.core_type) {
         case HalProgrammableCoreType::ACTIVE_ETH: core_str = "acteth"; break;
         case HalProgrammableCoreType::IDLE_ETH: core_str = "idleth"; break;
+        case HalProgrammableCoreType::DRAM: core_str = "dram"; break;
         default: core_str = "worker";
     }
 
@@ -257,6 +267,9 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
 
     // Skip if processor type is not available on this architecture
     const auto& hal = MetalContext::instance().hal();
+    if (!hal.has_programmable_core_type(params.processor.core_type)) {
+        GTEST_SKIP() << "Test " << params.test_name << " skipped: core type not available on this architecture";
+    }
     uint32_t core_type_index = hal.get_programmable_core_type_index(params.processor.core_type);
     uint32_t available_processors =
         hal.get_processor_types_count(core_type_index, static_cast<uint32_t>(params.processor.processor_class));
@@ -266,18 +279,20 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
     }
 
     // Dispatch mode validation:
-    // - IDLE_ETH cores only support SD (FD not yet implemented)
+    // - IDLE_ETH and DRAM cores only support SD (FD not yet implemented)
     // - TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
     bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    bool is_dram = (params.processor.core_type == HalProgrammableCoreType::DRAM);
     bool is_quasar = (tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR);
     bool using_slow_dispatch = this->IsSlowDispatch();
 
-    if (is_idle_eth && !using_slow_dispatch) {
-        log_info(tt::LogTest, "IDLE_ETH requires Slow Dispatch (Fast Dispatch not yet supported).");
+    if ((is_idle_eth || is_dram) && !using_slow_dispatch) {
+        log_info(tt::LogTest, "{} requires Slow Dispatch (Fast Dispatch not yet supported).",
+                 is_dram ? "DRAM" : "IDLE_ETH");
         GTEST_SKIP();
     }
-    if (using_slow_dispatch && !is_quasar && !is_idle_eth) {
-        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+    if (using_slow_dispatch && !is_quasar && !is_idle_eth && !is_dram) {
+        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar, IDLE_ETH, or DRAM cores";
     }
     this->RunTestOnDevice(
         [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
@@ -309,7 +324,8 @@ INSTANTIATE_TEST_SUITE_P(
         WatcherTestParams{"Trisc2", {TENSIX, COMPUTE, 2}},
         WatcherTestParams{"Trisc3", {TENSIX, COMPUTE, 3}},  // Trisc3 only Runs on Quasar
         WatcherTestParams{"Erisc", {ACTIVE_ETH, DM, 0}},
-        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}}),
+        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}},
+        WatcherTestParams{"Drisc", {DRAM, DM, 0}}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -341,7 +357,8 @@ INSTANTIATE_TEST_SUITE_P(
         WatcherTestParams{
             "Trisc3", {TENSIX, COMPUTE, 3}, dev_msgs::DebugAssertRtaOutOfBounds},  // Trisc3 only Runs on Quasar
         WatcherTestParams{"Erisc", {ACTIVE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
-        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped}),
+        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
+        WatcherTestParams{"Drisc", {DRAM, DM, 0}, dev_msgs::DebugAssertTripped}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -287,8 +287,8 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
     bool using_slow_dispatch = this->IsSlowDispatch();
 
     if ((is_idle_eth || is_dram) && !using_slow_dispatch) {
-        log_info(tt::LogTest, "{} requires Slow Dispatch (Fast Dispatch not yet supported).",
-                 is_dram ? "DRAM" : "IDLE_ETH");
+        log_info(
+            tt::LogTest, "{} requires Slow Dispatch (Fast Dispatch not yet supported).", is_dram ? "DRAM" : "IDLE_ETH");
         GTEST_SKIP();
     }
     if (using_slow_dispatch && !is_quasar && !is_idle_eth && !is_dram) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -20,7 +20,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
+#include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
+#include <umd/device/types/core_coordinates.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.
@@ -114,9 +116,21 @@ void RunTest(
                 logical_core,
                 EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
             break;
-        case HalProgrammableCoreType::DRAM:
-            log_info(LogTest, "Skipping: DRAM cores do not support watcher ring buffer tests.");
-            GTEST_SKIP();
+        case HalProgrammableCoreType::DRAM: {
+            const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+            if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+                log_info(LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
+                GTEST_SKIP();
+            }
+            logical_core = CoreCoord{0, 0};
+            virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
+            CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                DramConfig{.noc = tt_metal::NOC::NOC_0});
+            break;
+        }
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported core type");
     }
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
@@ -207,6 +221,25 @@ TEST_F(MeshWatcherFixture, TestWatcherRingBufferIErisc) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                 RunTest(fixture, mesh_device, {IDLE_ETH, DM, 0});
+            },
+            mesh_device);
+    }
+}
+
+TEST_F(MeshWatcherFixture, TensixDramTestWatcherRingBufferDrisc) {
+    if (!this->IsSlowDispatch()) {
+        log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");
+        GTEST_SKIP();
+    }
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+        log_info(tt::LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
+        GTEST_SKIP();
+    }
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunTest(fixture, mesh_device, {DRAM, DM, 0});
             },
             mesh_device);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_print.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "internal/debug/dprint_test_common.h"
+
+/*
+ * Test printing from a kernel running on a DRAM programmable core (DRISC).
+ */
+
+void kernel_main() {
+    DPRINT << "Test Debug Print: DRISC" << ENDL();
+    print_test_data();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -32,10 +32,10 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM))
+    (defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DRISC) or defined(COMPILE_FOR_DM))
     WATCHER_RING_BUFFER_PUSH(a);
     WATCHER_RING_BUFFER_PUSH(b);
-#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DRISC) or defined(COMPILE_FOR_DM)
     //For Erisc do a dummy increment since there is no worker kernel that would increment dispatch message addr to signal compute kernel completion.
     if (a == b) {
         //We will assert later. This kernel will hang.
@@ -45,9 +45,9 @@ void kernel_main() {
         volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
 
         // Signal completion to dispatcher before assert hangs the kernel
-        // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
+        // SD signaling: IDLE_ERISC, DRISC (SD only), and Quasar DM require RUN_MSG_DONE
         // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
-#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DRISC) or defined(COMPILE_FOR_DM)
         go_message_in->signal = RUN_MSG_DONE;
 #else
         // FD: ACTIVE_ETH, BRISC, NCRISC notify dispatcher via NOC

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -9,7 +9,7 @@
  * A test for the watcher waypointing feature.
 */
 #if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && \
-    !defined(COMPILE_FOR_IDLE_ERISC)
+    !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_DRISC)
 #include "api/compute/common.h"
 #endif
 
@@ -18,7 +18,8 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
+     defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DRISC))
     for (uint32_t idx = 0; idx < 40; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }

--- a/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/drisc.cc
@@ -11,6 +11,8 @@
 #include "hostdev/dev_msgs.h"
 #include "internal/risc_attribs.h"
 #include "api/debug/waypoint.h"
+#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 
 uint8_t noc_index;
 
@@ -60,6 +62,8 @@ int main() {
         noc_local_state_init(n);
     }
 
+    DEVICE_PRINT_INITIALIZE_LOCK();
+
     mailboxes->go_messages[0].signal = RUN_MSG_DONE;
     mailboxes->launch_msg_rd_ptr = 0;
 
@@ -82,6 +86,7 @@ int main() {
         WAYPOINT("R");
         reinterpret_cast<uint32_t (*)()>(kernel_lma)();
         WAYPOINT("D");
+        DEVICE_PRINT_KERNEL_FINISHED();
 
         mailboxes->go_messages[0].signal = RUN_MSG_DONE;
 

--- a/tt_metal/hw/inc/internal/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/internal/debug/dprint_test_common.h
@@ -36,8 +36,8 @@ inline void print_test_data() {
     DPRINT << DEFAULTFLOAT();
     DPRINT << "SETW:\n" << SETW(10) << my_uint32 << my_uint32 << SETW(4) << "ab" << ENDL();
     DPRINT << "HEX/OCT/DEC:\n" << HEX() << my_uint32 << OCT() << my_uint32 << DEC() << my_uint32 << ENDL();
-#if !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_IDLE_ERISC)
-    // Eth cores don't have CBs, so don't try TSLICE printing.
+#if !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_DRISC)
+    // Eth and DRAM (DRISC) cores don't have CBs, so don't try TSLICE printing.
     DPRINT << "SLICE:\n";
     cb_wait_front(tt::CBIndex::c_0, 1);
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -78,13 +78,14 @@ inline static CoreDescriptorSet GetAllCores(
 }
 
 inline uint64_t GetDprintBufAddr(ChipId device_id, const CoreCoord& virtual_core, int risc_id) {
-    uint64_t addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
-        llrt::get_core_type(device_id, virtual_core), tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
+    auto core_type = llrt::get_core_type(device_id, virtual_core);
+    uint64_t addr = tt::tt_metal::MetalContext::instance().hal().get_dev_noc_addr(
+        core_type, tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
     return addr + (sizeof(DebugPrintMemLayout) * risc_id);
 }
 
 inline uint64_t GetDevicePrintBufAddr(ChipId device_id, const CoreCoord& virtual_core) {
-    return tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+    return tt::tt_metal::MetalContext::instance().hal().get_dev_noc_addr(
         llrt::get_core_type(device_id, virtual_core), tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
 }
 

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -40,7 +40,7 @@ using CoreDescriptorSet = std::set<umd::CoreDescriptor, CoreDescriptorComparator
 inline static CoreDescriptorSet GetAllCores(
     tt::Cluster& cluster, tt::tt_fabric::ControlPlane& control_plane, ChipId device_id) {
     CoreDescriptorSet all_cores;
-    // The set of all printable cores is Tensix + Eth cores
+    // The set of all printable cores is Tensix + Eth + DRAM (when supported)
     CoreCoord logical_grid_size = cluster.get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t x = 0; x < logical_grid_size.x; x++) {
         for (uint32_t y = 0; y < logical_grid_size.y; y++) {
@@ -52,6 +52,13 @@ inline static CoreDescriptorSet GetAllCores(
     }
     for (const auto& logical_core : control_plane.get_inactive_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
+    }
+    const auto& hal = MetalContext::instance().hal();
+    if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+        const auto& soc_desc = cluster.get_soc_desc(device_id);
+        for (const auto& dram_core : soc_desc.get_cores(CoreType::DRAM, CoordSystem::LOGICAL)) {
+            all_cores.insert({{dram_core.x, dram_core.y}, CoreType::DRAM});
+        }
     }
 
     return all_cores;
@@ -194,6 +201,16 @@ inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_ty
                 }
                 add_legacy_entry(std::string{name[0]}, name);
             }
+        }
+    } else if (core_type == HalProgrammableCoreType::DRAM) {
+        // DRAM cores (Blackhole DRISC): single processor
+        uint32_t num = hal.get_num_risc_processors(core_type);
+        for (uint32_t i = 0; i < num; ++i) {
+            info.processor_names.push_back(hal.get_processor_class_name(core_type, i, false));
+        }
+        for (uint32_t i = 0; i < num; ++i) {
+            std::string abbrev = hal.get_processor_class_name(core_type, i, true);
+            add_legacy_entry(abbrev, info.processor_names[i]);
         }
     } else {
         // ACTIVE_ETH/IDLE_ETH: collect names (arch-independent), then symbols (arch-specific)

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -594,7 +594,7 @@ bool DevicePrintImpl::poll_one_core(
     uint32_t risc_state_bytes = ((num_processors + 3) / 4) * 4;  // Round up to nearest word
     auto from_dev = cluster.read_core(device_id, virtual_core, buffer_address, eightbytes);
     uint32_t wpos = from_dev[0], rpos = from_dev[1];
-    uint32_t print_buffer_address =
+    uint64_t print_buffer_address =
         buffer_address + eightbytes + risc_state_bytes + sizeof(uint32_t);  // Skip wpos, rpos, risc state, and lock
     uint32_t print_buffer_size = buffer_size - eightbytes - risc_state_bytes - sizeof(uint32_t);
 
@@ -1039,7 +1039,7 @@ bool DPrintImpl::peek_one_risc_non_blocking(
     }
 
     // compute the buffer address for the requested risc
-    uint32_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
+    uint64_t base_addr = tt::tt_metal::GetDprintBufAddr(device_id, virtual_core, risc_id);
     ChipId chip_id = device_id;
     RiscKey risc_key{chip_id, logical_core, risc_id};
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -50,7 +50,6 @@
 #include "hostdevcommon/dprint_common.h"
 #include "hostdevcommon/kernel_structs.h"
 #include "llrt.hpp"
-#include "impl/context/metal_context.hpp"
 #include "impl/context/metal_env_impl.hpp"
 #include "tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
@@ -806,7 +805,7 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
 
     // Core range depends on whether dprint_all_cores flag is set.
     std::vector<umd::CoreDescriptor> print_cores_sanitized;
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& hal = env_.get_hal();
     std::vector<CoreType> core_types_to_check = {CoreType::WORKER, CoreType::ETH};
     if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
         core_types_to_check.push_back(CoreType::DRAM);

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -806,7 +806,12 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
 
     // Core range depends on whether dprint_all_cores flag is set.
     std::vector<umd::CoreDescriptor> print_cores_sanitized;
-    for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    std::vector<CoreType> core_types_to_check = {CoreType::WORKER, CoreType::ETH};
+    if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+        core_types_to_check.push_back(CoreType::DRAM);
+    }
+    for (CoreType core_type : core_types_to_check) {
         if (rtoptions.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
             tt::llrt::RunTimeDebugClassAll) {
             // Print from all cores of the given type, cores returned here are guaranteed to be valid.

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -414,7 +414,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
         bool has_dram_fw = hal.has_programmable_core_type(HalProgrammableCoreType::DRAM);
         if (has_dram_fw) {
             const auto& soc_d = env.get_cluster().get_soc_desc(device_id);
-            for (const auto& dram_core : soc_d.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
+            for (const auto& dram_core : soc_d.get_cores(CoreType::DRAM, CoordSystem::LOGICAL)) {
                 Core::Create(CoreCoord{dram_core.x, dram_core.y}, HalProgrammableCoreType::DRAM, *this, dump_data)
                     .Dump();
             }
@@ -518,13 +518,8 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
     const auto& rtoptions = reader.env.get_rtoptions();
     const auto& hal = reader.env.get_hal();
     CoreType core_type = hal.get_core_type(hal.get_programmable_core_type_index(programmable_core_type));
-    CoreCoord virtual_coord;
-    if (programmable_core_type == HalProgrammableCoreType::DRAM) {
-        virtual_coord = logical_coord;
-    } else {
-        virtual_coord = reader.env.get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            reader.device_id, logical_coord, core_type);
-    }
+    CoreCoord virtual_coord = reader.env.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+        reader.device_id, logical_coord, core_type);
 
     // Print device id, core coords (logical)
     string core_type_str;

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -195,8 +195,7 @@ HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
         }
     }
     if (set.empty()) {
-        TT_THROW(
-            "Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR0,DR*.", spec);
+        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR0,DR*.", spec);
     }
     return set;
 }

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -189,13 +189,13 @@ HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
         set.add(HalProgrammableCoreType::IDLE_ETH, 0);
         set.add(HalProgrammableCoreType::IDLE_ETH, 1);
     }
-    if (spec.find("DR0") != std::string_view::npos || spec.find("DR*") != std::string_view::npos) {
+    if (spec.find("DR") != std::string_view::npos) {
         if (has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
             set.add(HalProgrammableCoreType::DRAM, 0);
         }
     }
     if (set.empty()) {
-        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR0,DR*.", spec);
+        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR.", spec);
     }
     return set;
 }

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -195,7 +195,10 @@ HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
         }
     }
     if (set.empty()) {
-        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR.", spec);
+        TT_THROW(
+            "Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*{}.",
+            spec,
+            has_programmable_core_type(HalProgrammableCoreType::DRAM) ? ",DR" : "");
     }
     return set;
 }

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -189,8 +189,14 @@ HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
         set.add(HalProgrammableCoreType::IDLE_ETH, 0);
         set.add(HalProgrammableCoreType::IDLE_ETH, 1);
     }
+    if (spec.find("DR0") != std::string_view::npos || spec.find("DR*") != std::string_view::npos) {
+        if (has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+            set.add(HalProgrammableCoreType::DRAM, 0);
+        }
+    }
     if (set.empty()) {
-        TT_THROW("Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*.", spec);
+        TT_THROW(
+            "Invalid RISC selection: \"{}\". Valid values are BR,NC,TR0,TR1,TR2,TR*,ER0,ER1,ER*,DR0,DR*.", spec);
     }
     return set;
 }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_dram.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_dram.cpp
@@ -96,7 +96,7 @@ HalCoreInfoType create_dram_mem_map() {
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {
         // DM
         {
-            {"DR0", "DRISC0"},
+            {"DR", "DRISC"},
         },
     };
     std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 1};

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -177,6 +177,7 @@ enum class EnvVarID {
     // ========================================
     TT_METAL_DPRINT_CORES,                     // Worker cores for debug printing
     TT_METAL_DPRINT_ETH_CORES,                 // Ethernet cores for debug printing
+    TT_METAL_DPRINT_DRAM_CORES,                // DRAM cores for debug printing
     TT_METAL_DPRINT_CHIPS,                     // Chip IDs for debug printing
     TT_METAL_DPRINT_NODES,                     // Fabric node IDs for debug printing
     TT_METAL_DPRINT_MESH_COORDS,               // Global system mesh (row,col) coordinates for debug printing
@@ -1277,6 +1278,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             // Handled by ParseFeatureEnv() - this is for documentation
             break;
 
+        // TT_METAL_DPRINT_DRAM_CORES
+        // Specifies DRAM programmable cores (Blackhole DRISC) for debug printing. Same syntax as DPRINT_CORES.
+        // Default: disabled (no debug printing on DRAM cores)
+        // Usage: export TT_METAL_DPRINT_DRAM_CORES=all
+        case EnvVarID::TT_METAL_DPRINT_DRAM_CORES:
+            // Handled by ParseFeatureEnv() - this is for documentation
+            break;
+
         // TT_METAL_DPRINT_CHIPS
         // Specifies chip IDs for debug printing. Supports 'all' or comma-separated list of chip IDs.
         // Mutually exclusive with TT_METAL_DPRINT_NODES and TT_METAL_DPRINT_MESH_COORDS.
@@ -1623,6 +1632,7 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature, const tt_meta
 
     ParseFeatureCoreRange(feature, feature_env_prefix + "_CORES", CoreType::WORKER);
     ParseFeatureCoreRange(feature, feature_env_prefix + "_ETH_CORES", CoreType::ETH);
+    ParseFeatureCoreRange(feature, feature_env_prefix + "_DRAM_CORES", CoreType::DRAM);
     bool chips_specified = ParseFeatureChipIds(feature, feature_env_prefix + "_CHIPS");
     bool nodes_specified = ParseFeatureNodeIds(feature, feature_env_prefix + "_NODES");
     bool mesh_coords_specified = ParseFeatureMeshCoords(feature, feature_env_prefix + "_MESH_COORDS");


### PR DESCRIPTION
### Ticket
N/A

### Problem description
DRAM programmable cores (DRISC, Blackhole only) had no support for debug printing (DPRINT/DEVICE_PRINT) or watcher features (assert, ring buffer). This made debugging kernels running on DRAM cores difficult.

### What's changed
**Category: Feature**

Extends DPRINT, DEVICE_PRINT, and watcher debug infrastructure to work on Blackhole DRAM programmable cores (DRISC). Previously these only worked on Tensix and Ethernet cores.

- **Firmware**: Added DPRINT and DEVICE_PRINT includes and lifecycle hooks to `drisc.cc`, matching what all other firmware files already do.
- **DPRINT server**: Fixed NOC addressing bugs (missing `0x2000000000` DRAM offset, `uint32_t` truncation of 64-bit addresses) and extended device attachment to iterate DRAM cores.
- **HAL & runtime options**: Added `TT_METAL_DPRINT_DRAM_CORES` env var and `DR` processor set token. Renamed DRAM processor class from `DRISC0`/`DR0` to `DRISC`/`DR` to match the build target name (fixing DEVICE_PRINT's ELF path lookup).
- **Watcher**: Fixed coordinate reporting for DRAM cores and extended assert/ring buffer tests with DRISC parameters.
- **Tests**: New DPRINT kernel and test, 4 new DEVICE_PRINT tests reusing existing kernels on DRAM cores, extended watcher tests. All gated on slow dispatch and `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1`.
- **CI**: Added DRAM debug tools tests to the slow dispatch workflow.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/drammorefeatures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/drammorefeatures)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/drammorefeatures)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/drammorefeatures)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/drammorefeatures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/drammorefeatures)
- [ ] New/Existing tests provide coverage for changes