### PR TITLE
[UMD Bump] Automated UMD Bump 03.04.2026

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -330,7 +330,7 @@ void Cluster::initialize_device_drivers() {
         const auto& mmio_ids = this->driver_->get_target_mmio_device_ids();
         if (!mmio_ids.empty()) {
             ChipId mmio_id = *mmio_ids.begin();
-            auto pci = this->driver_->get_chip(mmio_id)->get_tt_device()->get_pci_device();
+            auto* pci = this->driver_->get_chip(mmio_id)->get_tt_device()->get_pci_device();
             if (pci) {
                 this->iommu_enabled_ = pci->is_iommu_enabled();
                 this->noc_mapping_enabled_ = tt::umd::PCIDevice::is_mapping_buffer_to_noc_supported();


### PR DESCRIPTION
Automated UMD bump to latest version

### Changes
- tenstorrent/tt-umd#2398
- tenstorrent/tt-umd#2410
- tenstorrent/tt-umd#2375
- tenstorrent/tt-umd#2381
- tenstorrent/tt-umd#2341

### Testing
All the runs also have a corresponding closest run on main branch, for comparing failures.
All the runs have corresponding statuses. The runs will be retried 3 times automatically, after which failures will be reported.

| Status | Workflow | Run | Main Run |
|--------|----------|-----|----------|
| Success | [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927584449) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23919675585) |
| Success | [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927597707) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23926232557) |
| Success | [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927608344) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23926338174) |
| No new failures | [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927618058) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23924426650) |
| No new failures | [Galaxy unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927629481) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23891463486) |
| No new failures | [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/23927640879) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/23934271326/job/69807942003) |

### Overall Test Status: Success

### Manual intervention

Minor clang-tidy styling fix.
