### PR TITLE
Adding missing DEVICE_PRINT tests from DPRINT tests

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -313,7 +313,6 @@ public:
 
 class DevicePrintFixture : public DebugToolsMeshFixture {
 protected:
-    std::string dprint_file_name;
     int memfd_;
 
     void SetUp() override {
@@ -367,6 +366,8 @@ protected:
     virtual void ExtraTearDown() {}
 
 public:
+    std::string dprint_file_name;
+
     std::string CompileKernel(const std::string& kernel_path, stl::Span<const uint32_t> runtime_args = {}) {
         // Get the first available mesh device
         auto mesh_device = this->devices_.at(0);
@@ -427,6 +428,21 @@ public:
         // up after running a test.
         DebugToolsMeshFixture::RunProgram(mesh_device, workload);
         MetalContext::instance().dprint_server()->await();
+    }
+
+    // A function to run a program, according to which dispatch mode is set.
+    void RunProgram(const std::shared_ptr<distributed::MeshDevice>& mesh_device, distributed::MeshWorkload& workload) {
+        // Only difference is that we need to wait for the print server to catch
+        // up after running a test.
+        DebugToolsMeshFixture::RunProgram(mesh_device, workload);
+        MetalContext::instance().dprint_server()->await();
+    }
+
+    void RunTestOnDevice(
+        const std::function<void(DevicePrintFixture*, std::shared_ptr<distributed::MeshDevice>)>& run_function,
+        const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+        DebugToolsMeshFixture::RunTestOnDevice(run_function, mesh_device);
+        MetalContext::instance().dprint_server()->clear_log_file();
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/host_api.hpp>
+#include <functional>
+#include <string>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include <tt-metalium/device.hpp>
+#include "gtest/gtest.h"
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include <umd/device/types/arch.hpp>
+#include <umd/device/types/xy_pair.hpp>
+#include "tests/tt_metal/tt_metal/eth/eth_test_common.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// A test for printing from ethernet cores.
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+void RunTest(
+    DevicePrintFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    bool active,
+    DataMovementProcessor processor = DataMovementProcessor::RISCV_0) {
+    auto* device = mesh_device->get_devices()[0];
+    // Try printing on all ethernet cores on this device
+    std::unordered_set<CoreCoord> test_cores;
+    tt_metal::EthernetConfig config = {.noc = static_cast<tt_metal::NOC>(processor), .processor = processor};
+    if (active) {
+        test_cores = device->get_active_ethernet_cores(true);
+        config.eth_mode = Eth::SENDER;
+    } else {
+        test_cores = device->get_inactive_ethernet_cores();
+        config.eth_mode = Eth::IDLE;
+    }
+    eth_test_common::set_arch_specific_eth_config(config);
+    for (const auto& core : test_cores) {
+        // Set up program and command queue
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program = Program();
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        // Create the kernel
+        CreateKernel(program_, "tests/tt_metal/tt_metal/test_kernels/device_print/erisc_print.cpp", core, config);
+
+        // Run the program
+        log_info(tt::LogTest, "Running print test on eth core {}:({},{}), {}", device->id(), core.x, core.y, processor);
+        fixture->RunProgram(mesh_device, workload);
+
+        // Check the print log against golden output.
+        EXPECT_TRUE(FilesMatchesString(fixture->dprint_file_name, "Test Debug Print: ERISC"));
+
+        // Clear the log file for the next core's test
+        MetalContext::instance().dprint_server()->clear_log_file();
+    }
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+TEST_F(DevicePrintFixture, ActiveEthTestPrint) {
+    for (auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        // Skip if no ethernet cores on this device
+        if (device->get_active_ethernet_cores(true).empty()) {
+            log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
+            continue;
+        }
+
+        const auto erisc_count = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
+            tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
+        for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
+            log_info(tt::LogTest, "Test active ethernet DM{}", erisc_idx);
+            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            this->RunTestOnDevice(
+                [=](DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                    CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device, true, dm_processor);
+                },
+                mesh_device);
+        }
+    }
+}
+TEST_F(DevicePrintFixture, IdleEthTestPrint) {
+    if (!this->IsSlowDispatch()) {
+        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        GTEST_SKIP();
+    }
+    for (auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        // Skip if no ethernet cores on this device
+        if (device->get_inactive_ethernet_cores().empty()) {
+            log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
+            continue;
+        }
+        const auto erisc_count = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
+            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH);
+        for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
+            log_info(tt::LogTest, "Test idle ethernet DM{}", erisc_idx);
+            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+
+            this->RunTestOnDevice(
+                [=](DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                    CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device, false, dm_processor);
+                },
+                mesh_device);
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
@@ -23,7 +23,7 @@ using namespace tt::tt_metal;
 
 TEST_F(DevicePrintFixture, TensixTestPrintInvalidCore) {
     // Set DPRINT enabled on a mix of invalid and valid cores. Previously this would hang during
-    // device setup, but not the print server should simply ignore the invalid cores.
+    // device setup, but now the print server should simply ignore the invalid cores.
     std::map<tt::CoreType, std::vector<CoreCoord>> dprint_cores;
     dprint_cores[tt::CoreType::WORKER] = {{0, 0}, {1, 1}, {100, 100}};
     tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <map>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include "debug_tools_fixture.hpp"
+#include "gtest/gtest.h"
+#include "impl/context/metal_context.hpp"
+#include <umd/device/types/core_coordinates.hpp>
+#include <umd/device/types/xy_pair.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+}  // namespace tt::tt_metal
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking that the DPRINT server can detect an invalid core.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt::tt_metal;
+
+TEST_F(DevicePrintFixture, TensixTestPrintInvalidCore) {
+    // Set DPRINT enabled on a mix of invalid and valid cores. Previously this would hang during
+    // device setup, but not the print server should simply ignore the invalid cores.
+    std::map<tt::CoreType, std::vector<CoreCoord>> dprint_cores;
+    dprint_cores[tt::CoreType::WORKER] = {{0, 0}, {1, 1}, {100, 100}};
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(
+        tt::llrt::RunTimeDebugFeatureDprint, dprint_cores);
+
+    // We expect that even though illegal worker cores were requested, device setup did not hang.
+    // So just make sure that device setup worked and then close the device.
+    for (auto& mesh_device : this->devices_) {
+        EXPECT_TRUE(mesh_device != nullptr);
+    }
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/system_mesh.hpp>
+
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include "impl/context/metal_context.hpp"
+
+namespace tt::tt_metal {
+
+// Restricts DEVICE_PRINT output to a single mesh coordinate.
+// Tears down and re-initializes MetalContext so resolve_mesh_coords_to_chip_ids()
+// fires during device open and populates chip_ids from the stored mesh_coords.
+class DevicePrintMeshCoordsFixture : public DevicePrintFixture {
+public:
+    // The global system-mesh coordinate currently targeted by the DEVICE_PRINT filter.
+    std::pair<uint32_t, uint32_t> target_coord = {0, 0};
+
+protected:
+    void ExtraSetUp() override;
+    void ExtraTearDown() override;
+};
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+std::string ReadLogFile(const std::string& path) {
+    std::ifstream f(path);
+    return {std::istreambuf_iterator<char>(f), {}};
+}
+
+// Returns a unique search token for a device's DEVICE_PRINT line.
+// The trailing '\n' (produced by ENDL()) prevents "(0,1)" matching inside "(0,10)".
+std::string MeshCoordToken(uint32_t row, uint32_t col) { return fmt::format("mesh_coord=({},{})\n", row, col); }
+
+// Returns the global system-mesh coordinate for the given local chip_id.
+std::pair<uint32_t, uint32_t> GetGlobalCoord(ChipId chip_id) {
+    auto mapped = distributed::SystemMesh::instance().get_mapped_devices(std::nullopt);
+    for (const auto& coord : distributed::MeshCoordinateRange(mapped.mesh_shape)) {
+        auto idx = coord.to_linear_index(mapped.mesh_shape);
+        if (mapped.device_ids[idx].is_local() && *mapped.device_ids[idx] == chip_id) {
+            return {coord[0], coord[1]};
+        }
+    }
+    TT_THROW("No global mesh coord found for chip_id={}", chip_id);
+}
+
+// Configures rtopts to restrict DEVICE_PRINT to a single mesh coordinate.
+// Called after each MetalContext teardown to restore the intended filter before device open.
+void ConfigureDevicePrintForCoord(
+    tt::llrt::RunTimeOptions& rtopts, const std::string& file_name, uint32_t row, uint32_t col) {
+    constexpr auto kDprint = tt::llrt::RunTimeDebugFeatureDprint;
+    rtopts.set_feature_enabled(kDprint, true);
+    rtopts.set_feature_all_cores(kDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
+    rtopts.set_feature_all_cores(kDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
+    rtopts.set_feature_file_name(kDprint, file_name);
+    rtopts.set_test_mode_enabled(true);
+    rtopts.set_watcher_enabled(false);
+    rtopts.set_feature_prepend_device_core_risc(kDprint, true);
+    rtopts.set_feature_mesh_coords(kDprint, {{row, col}});
+    rtopts.set_feature_all_chips(kDprint, false);
+    rtopts.set_use_device_print(true);
+}
+
+// Builds a MeshWorkload where each device DEVICE_PRINTs its global mesh coordinate (row, col).
+// The kernel takes the global system-mesh row and col of each device as compile-time args,
+// so the DEVICE_PRINT output directly matches what was configured in the DEVICE_PRINT filter.
+distributed::MeshWorkload BuildMeshCoordWorkload(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    distributed::MeshWorkload workload;
+    constexpr CoreCoord kCore = {0, 0};
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+        auto [row, col] = GetGlobalCoord(mesh_device->get_device(coord)->id());
+        Program program;
+        CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp",
+            kCore,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {row, col}});
+        workload.add_program(distributed::MeshCoordinateRange(coord, coord), std::move(program));
+    }
+    return workload;
+}
+
+// Runs a kernel on every device (log accumulates across all), then asserts that only
+// fixture->target_coord produced output and all others were silenced by the DEVICE_PRINT filter.
+void RunFilteringTest(
+    DevicePrintMeshCoordsFixture* fixture, const std::vector<std::shared_ptr<distributed::MeshDevice>>& all_devices) {
+    for (const auto& mesh_device : all_devices) {
+        auto workload = BuildMeshCoordWorkload(mesh_device);
+        fixture->RunProgram(mesh_device, workload);
+    }
+
+    const std::string log = ReadLogFile(fixture->dprint_file_name);
+    auto [trow, tcol] = fixture->target_coord;
+
+    EXPECT_NE(log.find(MeshCoordToken(trow, tcol)), std::string::npos)
+        << "Expected DEVICE_PRINT from target coord (" << trow << "," << tcol << ") not found.\n"
+        << "Log:\n"
+        << log;
+
+    for (const auto& mesh_device : all_devices) {
+        auto [row, col] = GetGlobalCoord(mesh_device->get_devices()[0]->id());
+        if (std::make_pair(row, col) == fixture->target_coord) {
+            continue;
+        }
+        EXPECT_EQ(log.find(MeshCoordToken(row, col)), std::string::npos)
+            << "Unexpected DEVICE_PRINT from coord (" << row << "," << col << ") "
+            << "(only coord (" << trow << "," << tcol << ") should print).";
+    }
+}
+
+// Runs a kernel that DEVICE_PRINTs the device's global mesh coord, verifies the output appears,
+// then cross-checks that resolve_mesh_coords_to_chip_ids maps that coord back to the same chip_id.
+void RunAllChipsVerificationTest(
+    DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    constexpr auto kDprint = tt::llrt::RunTimeDebugFeatureDprint;
+    ChipId chip_id = mesh_device->get_devices()[0]->id();
+    auto [row, col] = GetGlobalCoord(chip_id);
+
+    auto workload = BuildMeshCoordWorkload(mesh_device);
+    fixture->RunProgram(mesh_device, workload);
+
+    const std::string log = ReadLogFile(fixture->dprint_file_name);
+    EXPECT_NE(log.find(MeshCoordToken(row, col)), std::string::npos)
+        << "Missing DEVICE_PRINT for coord (" << row << "," << col << "), chip_id=" << chip_id;
+
+    // Cross-check: resolve (row,col) → chip_id via the rtoptions API.
+    auto& rtopts = MetalContext::instance().rtoptions();
+    rtopts.set_feature_mesh_coords(kDprint, {{row, col}});
+    rtopts.resolve_mesh_coords_to_chip_ids(distributed::SystemMesh::instance());
+
+    const auto& resolved = rtopts.get_feature_chip_ids(kDprint);
+    ASSERT_EQ(resolved.size(), 1u) << "Expected exactly one chip_id for coord (" << row << "," << col << ")";
+    EXPECT_EQ(resolved[0], chip_id) << "Coord (" << row << "," << col << ") resolved to wrong chip_id";
+
+    rtopts.set_feature_mesh_coords(kDprint, {});
+    rtopts.set_feature_chip_ids(kDprint, {});
+    rtopts.set_feature_all_chips(kDprint, true);
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+void DevicePrintMeshCoordsFixture::ExtraSetUp() {
+    // Teardown forces MetalContext to re-initialize (including resolve_mesh_coords_to_chip_ids)
+    // when devices are opened by DebugToolsMeshFixture::SetUp().  Re-apply rtoptions afterwards
+    // because ParseAllFeatureEnv resets them to defaults on re-initialization.
+    MetalContext::instance().teardown();
+    CMAKE_UNIQUE_NAMESPACE::ConfigureDevicePrintForCoord(
+        MetalContext::instance().rtoptions(), dprint_file_name, target_coord.first, target_coord.second);
+}
+
+void DevicePrintMeshCoordsFixture::ExtraTearDown() { MetalContext::instance().teardown(); }
+
+// Test 1: Only the device at mesh coord (0,0) should produce DEVICE_PRINT output.
+TEST_F(DevicePrintMeshCoordsFixture, TensixTestDevicePrintMeshCoordsFiltersCorrectDevice) {
+    // ExtraSetUp configured (0,0) as the DEVICE_PRINT target.
+    this->target_coord = {0, 0};
+    CMAKE_UNIQUE_NAMESPACE::RunFilteringTest(this, this->devices_);
+}
+
+// Test 2: For every mesh coordinate, restrict DEVICE_PRINT to that coord and verify filtering.
+// Each iteration tears down MetalContext and reopens devices so resolve_mesh_coords_to_chip_ids
+// fires fresh with the new target coord.
+TEST_F(DevicePrintMeshCoordsFixture, TensixTestDevicePrintMeshCoordsFiltersAllCoords) {
+    // Snapshot before any teardown invalidates the SystemMesh reference.
+    std::vector<std::pair<uint32_t, uint32_t>> local_coords;
+    {
+        auto mapped = distributed::SystemMesh::instance().get_mapped_devices(std::nullopt);
+        for (const auto& coord : distributed::MeshCoordinateRange(mapped.mesh_shape)) {
+            auto linear_idx = coord.to_linear_index(mapped.mesh_shape);
+            if (mapped.device_ids[linear_idx].is_local()) {
+                local_coords.push_back({coord[0], coord[1]});
+            }
+        }
+    }
+
+    for (auto [row, col] : local_coords) {
+        DevicePrintFixture::TearDown();
+        this->target_coord = {row, col};  // set before SetUp so ExtraSetUp picks it up
+        DevicePrintFixture::SetUp();
+
+        ASSERT_FALSE(
+            MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint).empty())
+            << "No chip resolved for coord (" << row << "," << col << ").";
+
+        log_info(tt::LogTest, "Filtering test: coord ({},{})", row, col);
+        CMAKE_UNIQUE_NAMESPACE::RunFilteringTest(this, this->devices_);
+        MetalContext::instance().dprint_server()->clear_log_file();
+    }
+}
+
+// Test 3: Every mesh coordinate resolves to the correct chip_id and the device prints its coord.
+TEST_F(DevicePrintMeshCoordsFixture, TensixTestDevicePrintMeshCoordsAllDevicesMapping) {
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(CMAKE_UNIQUE_NAMESPACE::RunAllChipsVerificationTest, mesh_device);
+    }
+}
+
+// Test 4: Coordinates outside the system mesh shape must produce a clear error.
+TEST_F(DevicePrintMeshCoordsFixture, TensixTestDevicePrintMeshCoordsOutOfBounds) {
+    auto& rtoptions = MetalContext::instance().rtoptions();
+    rtoptions.set_feature_mesh_coords(tt::llrt::RunTimeDebugFeatureDprint, {{999, 999}});
+    rtoptions.set_test_mode_enabled(true);  // makes TT_FATAL throw instead of abort
+    EXPECT_THROW(
+        rtoptions.resolve_mesh_coords_to_chip_ids(MetalContext::instance().get_system_mesh()), std::runtime_error);
+    rtoptions.set_feature_mesh_coords(tt::llrt::RunTimeDebugFeatureDprint, {});
+    rtoptions.set_test_mode_enabled(false);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <string>
+#include <variant>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include "hostdevcommon/kernel_structs.h"
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+}  // namespace tt::tt_metal
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A simple test for checking that disabling DPRINTs on a device won't cause a hang.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+// For usage by tests that need the DPRINT server devices disabled.
+class DevicePrintDisableMeshDevicesFixture : public DevicePrintFixture {
+protected:
+    void ExtraSetUp() override {
+        // For this test, mute each devices using the environment variable
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(
+            tt::llrt::RunTimeDebugFeatureDprint, false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_chip_ids(
+            tt::llrt::RunTimeDebugFeatureDprint, {});
+    }
+    void ExtraTearDown() override {
+        MetalContext::instance()
+            .teardown();  // Teardown dprint server so we can re-init later with all devices enabled again
+    }
+};
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    // Set up program and command queue
+    constexpr CoreCoord core = {0, 0};  // Print on first core only
+    distributed::MeshWorkload workload;
+    auto device_range =
+        distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(0, 0));
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+
+    // Create a CB for testing TSLICE, dimensions are 32x32 bfloat16s
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    constexpr uint32_t buffer_size = 32 * 32 * sizeof(bfloat16);
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(buffer_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, buffer_size);
+    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+
+    // This kernel is enough to fill up the print buffer, even though the device is not being
+    // printed from, we still need to drain the print buffer to prevent hanging the core.
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // Run the program
+    fixture->RunProgram(mesh_device, workload);
+
+    // Check that the log file is empty.
+    std::fstream log_file;
+    std::string file_name = fixture->dprint_file_name;
+    EXPECT_TRUE(OpenFile(file_name, log_file, std::fstream::in));
+    EXPECT_TRUE(log_file.peek() == std::ifstream::traits_type::eof());
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+TEST_F(DevicePrintDisableMeshDevicesFixture, TensixTestPrintMuteDevice) {
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(CMAKE_UNIQUE_NAMESPACE::RunTest, mesh_device);
+    }
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking that the finish command can wait for the last dprint.
+//////////////////////////////////////////////////////////////////////////////////////////
+using std::vector;
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+namespace {
+
+void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    // Set up program
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto* device = mesh_device->get_devices()[0];
+
+    // This tests prints only on a single core
+    CoreCoord xy_start = {0, 0};
+    CoreCoord xy_end = {0, 0};
+
+    KernelHandle brisc_print_kernel_id = CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp",
+        CoreRange(xy_start, xy_end),
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // Run the program, use a large delay for the last print to emulate a long-running kernel.
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
+    uint32_t delay_cycles = clk_mhz * 4000000;  // 4 seconds
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            const std::vector<uint32_t> args = {delay_cycles, x, y};
+            SetRuntimeArgs(program_, brisc_print_kernel_id, CoreCoord{x, y}, args);
+        }
+    }
+    fixture->RunProgram(mesh_device, workload);
+    // Close system instantly after running to attempt to cut off prints.
+    fixture->TearDownTestSuite();
+
+    // Check the print log against expected output.
+    vector<std::string> expected_output;
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            expected_output.push_back(fmt::format("({},{}) Before wait...", x, y));
+            expected_output.push_back(fmt::format("({},{}) After wait...", x, y));
+        }
+    }
+    EXPECT_TRUE(FileContainsAllStrings(fixture->dprint_file_name, expected_output));
+}
+
+TEST_F(DevicePrintFixture, TensixTestPrintFinish) {
+    auto mesh_devices = this->devices_;
+    // Run only on the first device, as this tests disconnects devices and this can cause
+    // issues on multi-device setups.
+    this->RunTestOnDevice(RunTest, mesh_devices.at(0));
+}
+
+}  // namespace
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <functional>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include "debug_tools_fixture.hpp"
+#include "debug_tools_test_utils.hpp"
+#include <tt-metalium/device.hpp>
+#include "gtest/gtest.h"
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/tt_metal/eth/eth_test_common.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// A test for checking that prints are prepended with their corresponding device, core and RISC.
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+void UpdateGoldenOutput(
+    std::vector<std::string>& golden_output,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const std::string& risc) {
+    // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
+    // by machine
+    const std::string& device_core_risc =
+        std::to_string(mesh_device->get_devices()[0]->id()) + ":(x=?,y=?):" + risc + ": ";
+
+    const std::string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
+    golden_output.push_back(output_line_all_riscs);
+
+    if (risc != "ER0" && risc != "ER") {
+        const std::string& output_line_risc = device_core_risc + "Printing on " + risc + ".";
+        golden_output.push_back(output_line_risc);
+    }
+}
+
+void RunTest(
+    DevicePrintFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const bool add_active_eth_kernel = false) {
+    std::vector<std::string> golden_output;
+
+    CoreRange cores({0, 0}, {0, 1});
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto* device = mesh_device->get_devices()[0];
+
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    CreateKernel(
+        program_, "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp", cores, ComputeConfig{});
+
+    for ([[maybe_unused]] const CoreCoord& core : cores) {
+        UpdateGoldenOutput(golden_output, mesh_device, "BR");
+        UpdateGoldenOutput(golden_output, mesh_device, "NC");
+        UpdateGoldenOutput(golden_output, mesh_device, "TR0");
+        UpdateGoldenOutput(golden_output, mesh_device, "TR1");
+        UpdateGoldenOutput(golden_output, mesh_device, "TR2");
+    }
+
+    if (add_active_eth_kernel) {
+        const std::unordered_set<CoreCoord>& active_eth_cores = device->get_active_ethernet_cores(true);
+        CoreRangeSet crs(std::set<CoreRange>(active_eth_cores.begin(), active_eth_cores.end()));
+        tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_0};
+        eth_test_common::set_arch_specific_eth_config(config);
+        CreateKernel(program_, "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp", crs, config);
+
+        for ([[maybe_unused]] const CoreCoord& core : active_eth_cores) {
+            if (tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
+                    HalProgrammableCoreType::ACTIVE_ETH) > 1) {
+                UpdateGoldenOutput(golden_output, mesh_device, "ER0");
+            } else {
+                UpdateGoldenOutput(golden_output, mesh_device, "ER");
+            }
+        }
+    }
+
+    fixture->RunProgram(mesh_device, workload);
+
+    // Check the print log against golden output.
+    EXPECT_TRUE(FileContainsAllStrings(fixture->dprint_file_name, golden_output));
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+TEST_F(DevicePrintFixture, TensixTestPrintPrependDeviceCoreRisc) {
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
+        tt::llrt::RunTimeDebugFeatureDprint, true);
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [](DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device);
+            },
+            mesh_device);
+    }
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
+        tt::llrt::RunTimeDebugFeatureDprint, false);
+}
+
+TEST_F(DevicePrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
+        tt::llrt::RunTimeDebugFeatureDprint, true);
+    for (auto& mesh_device : this->devices_) {
+        if (mesh_device->get_devices()[0]->get_active_ethernet_cores(true).empty()) {
+            log_info(
+                tt::LogTest,
+                "Skipping device {} due to no active ethernet cores...",
+                mesh_device->get_devices()[0]->id());
+            continue;
+        }
+        this->RunTestOnDevice(
+            [](DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device, true);
+            },
+            mesh_device);
+    }
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
+        tt::llrt::RunTimeDebugFeatureDprint, false);
+}

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +18,7 @@
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -34,8 +35,7 @@
 #include <tt-metalium/tt_metal.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// A simple test for checking DPRINTs from all harts.
-// Note that in this test the kernels print only 1 tile.
+// A test checking that DEVICE_PRINT prints multiple tiles correctly.
 //////////////////////////////////////////////////////////////////////////////////////////
 using namespace tt;
 using namespace tt::tt_metal;
@@ -44,21 +44,13 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 namespace {
 
-std::vector<std::string> GenerateGoldenOutput(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
-    using tt::tt_metal::test::dprint::GenerateExpectedData;
-    std::string data = GenerateExpectedData(data_format, input_tile, true);
-    std::vector<std::string> expected;
-    expected.push_back(fmt::format("Print tile from Data0:{}", data));
-    expected.push_back(fmt::format("Print tile from Data1:{}", data));
-    expected.push_back(fmt::format("Print tile from Unpack:{}", data));
-    expected.push_back(fmt::format(
-        "Print tile from Math:\nWarning: MATH core does not support TileSlice printing, omitting print..."));
-    expected.push_back(fmt::format("Print tile from Pack:{}", data));
-    return expected;
-}
+constexpr uint32_t elements_in_tile = 32 * 32;
+
+/* Number of tiles in a circular buffer. The kernels will print num_tiles tiles. */
+constexpr uint32_t num_tiles = 4;
 
 void RunTest(
-    DevicePrintSeparateFilesFixture* fixture,
+    DevicePrintFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     tt::DataFormat data_format) {
     // Set up program + CQ, run on just one core
@@ -71,73 +63,70 @@ void RunTest(
     auto& program_ = workload.get_programs().at(device_range);
     auto& cq = mesh_device->mesh_command_queue();
 
-    // Create an input CB with the right data format
+    /* Creating input CB. Page size of CB = tile size. Each tile is a separate page for CB. */
     uint32_t tile_size = tt::tile_size(data_format);
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(tile_size, {{CBIndex::c_0, data_format}}).set_page_size(CBIndex::c_0, tile_size);
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(tile_size * num_tiles, {{CBIndex::c_0, data_format}})
+                                              .set_page_size(CBIndex::c_0, tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
-    CircularBufferConfig cb_intermed_config =
-        CircularBufferConfig(tile_size, {{CBIndex::c_1, data_format}}).set_page_size(CBIndex::c_1, tile_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_intermed_config);
 
-    // Dram buffer to send data to, device will read it out of here to print
     distributed::DeviceLocalBufferConfig dram_config{.page_size = tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = tile_size};
+    dram_config.sharding_args = BufferShardingArgs(std::nullopt, TensorMemoryLayout::INTERLEAVED);
+
+    distributed::ReplicatedBufferConfig buffer_config{.size = tile_size * num_tiles};
     auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
 
-    // Create kernels on device
     KernelHandle brisc_print_kernel_id = CreateKernel(
         program_,
         tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_tile_brisc.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/device_print/print_tiles_multiple_brisc.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    KernelHandle ncrisc_print_kernel_id = CreateKernel(
-        program_,
-        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_tile_ncrisc.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
-    KernelHandle trisc_print_kernel_id = CreateKernel(
-        program_,
-        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_tile_trisc.cpp",
-        core,
-        ComputeConfig{});
 
-    // BRISC kernel needs dram info via rtargs, every risc needs to know if data is tilized
     bool is_tilized = (data_format == tt::DataFormat::Bfp8_b) || (data_format == tt::DataFormat::Bfp4_b);
     tt_metal::SetRuntimeArgs(
-        program_, brisc_print_kernel_id, core, {dram_buffer_src_addr, (std::uint32_t)0, is_tilized});
-    tt_metal::SetRuntimeArgs(program_, ncrisc_print_kernel_id, core, {is_tilized});
-    tt_metal::SetRuntimeArgs(program_, trisc_print_kernel_id, core, {is_tilized});
+        program_, brisc_print_kernel_id, core, {dram_buffer_src_addr, (std::uint32_t)0, is_tilized, num_tiles});
 
-    using tt::tt_metal::test::dprint::GenerateInputTile;
-    // Create input tile
-    std::vector<uint32_t> u32_vec = GenerateInputTile(data_format);
+    using tt::tt_metal::test::dprint::GenerateInputTileWithOffset;
 
-    // Send input tile to dram
-    distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord);
+    std::vector<uint32_t> u32_vec{};
+    std::string expected_output_write;
+    std::string expected_output_read;
 
-    // Run the program
+    /* Generating input tiles so that all numbers are consecutive in the uint32_t representation.
+       Tile with i=0 starts at 0, tile with i=1 starts at tile_size, etc.
+    */
+    for (int i = 0; i < num_tiles; i++) {
+        std::vector<uint32_t> tile = GenerateInputTileWithOffset(data_format, i * elements_in_tile);
+
+        u32_vec.insert(u32_vec.end(), tile.begin(), tile.end());
+
+        using tt::tt_metal::test::dprint::GenerateExpectedData;
+        std::string golden_output = GenerateExpectedData(data_format, tile, true);
+        expected_output_write += fmt::format("Write tile {}:{}\n", i, golden_output);
+        expected_output_read += fmt::format("Read tile {}:{}\n", i, golden_output);
+    }
+
+    distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord, true);
     fixture->RunProgram(mesh_device, workload);
 
-    // Check against expected prints
-    auto expected = GenerateGoldenOutput(data_format, u32_vec);
-    DevicePrintSeparateFilesFixture::check_output(expected);
+    auto filename = tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() +
+                    "generated/dprint/device-0_worker-core-0-0_BRISC.txt";
+    auto expected_output = expected_output_write + expected_output_read;
+
+    EXPECT_TRUE(FilesMatchesString(filename, expected_output));
 }
 
 struct TestParams {
     tt::DataFormat data_format;
 };
 
-class DevicePrintTileFixture : public DevicePrintSeparateFilesFixture,
-                               public ::testing::WithParamInterface<TestParams> {};
+class DevicePrintTilesMultipleFixture : public DevicePrintSeparateFilesFixture,
+                                        public ::testing::WithParamInterface<TestParams> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    DevicePrintTileTests,
-    DevicePrintTileFixture,
+    DevicePrintTilesMultipleTests,
+    DevicePrintTilesMultipleFixture,
     ::testing::Values(
         TestParams{tt::DataFormat::Float32},
         TestParams{tt::DataFormat::Float16_b},
@@ -148,14 +137,14 @@ INSTANTIATE_TEST_SUITE_P(
         TestParams{tt::DataFormat::UInt8},
         TestParams{tt::DataFormat::UInt16},
         TestParams{tt::DataFormat::UInt32}),
-    [](const ::testing::TestParamInfo<DevicePrintTileFixture::ParamType>& info) {
+    [](const ::testing::TestParamInfo<DevicePrintTilesMultipleFixture::ParamType>& info) {
         return std::string(enchantum::to_string(info.param.data_format));
     });
 
-TEST_P(DevicePrintTileFixture, TestPrintTile) {
+TEST_P(DevicePrintTilesMultipleFixture, TestPrintTilesMultiple) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
-            [&](DevicePrintSeparateFilesFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            [&](DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                 RunTest(fixture, mesh_device, GetParam().data_format);
             },
             mesh_device);

--- a/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
@@ -91,12 +91,13 @@ inline std::vector<uint32_t> GenerateInputTileWithOffset(tt::DataFormat data_for
     return u32_vec;
 }
 
-inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
+inline std::string GenerateExpectedData(
+    tt::DataFormat data_format, std::vector<uint32_t>& input_tile, bool device_print = false) {
     std::string data;
     if (data_format == tt::DataFormat::Float32) {
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
+                fmt::runtime(device_print ? "\n{} {} {} {}" : "\n{:.6} {:.6} {:.6} {:.6}"),
                 *reinterpret_cast<float*>(&input_tile[(col * 32) + 0]),
                 *reinterpret_cast<float*>(&input_tile[(col * 32) + 8]),
                 *reinterpret_cast<float*>(&input_tile[(col * 32) + 16]),
@@ -106,7 +107,7 @@ inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<
         std::vector<bfloat16> fp16b_vec = unpack_uint32_vec_into_bfloat16_vec(input_tile);
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
+                fmt::runtime(device_print ? "\n{} {} {} {}" : "\n{:.6} {:.6} {:.6} {:.6}"),
                 static_cast<float>(fp16b_vec[(col * 32) + 0]),
                 static_cast<float>(fp16b_vec[(col * 32) + 8]),
                 static_cast<float>(fp16b_vec[(col * 32) + 16]),
@@ -116,7 +117,7 @@ inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<
         std::vector<float> float_vec = unpack_bfp8_tiles_into_float_vec(input_tile, true, false);
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
+                fmt::runtime(device_print ? "\n{} {} {} {}" : "\n{:.6} {:.6} {:.6} {:.6}"),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),
@@ -126,7 +127,7 @@ inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<
         std::vector<float> float_vec = unpack_bfp4_tiles_into_float_vec(input_tile, true, false);
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
+                fmt::runtime(device_print ? "\n{} {} {} {}" : "\n{:.6} {:.6} {:.6} {:.6}"),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -5,6 +5,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_compilation_failures.cpp
     device_print/test_eth_cores.cpp
     device_print/test_format_updates.cpp
+    device_print/test_invalid_print_core.cpp
     device_print/test_mesh_coords.cpp
     device_print/test_print_output.cpp
     device_print/test_print_tile.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -4,6 +4,7 @@
 set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_compilation_failures.cpp
     device_print/test_format_updates.cpp
+    device_print/test_mesh_coords.cpp
     device_print/test_print_output.cpp
     device_print/test_print_tile.cpp
     dprint/test_dprint_mesh_coords.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -12,6 +12,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_print_output.cpp
     device_print/test_print_prepend_device_core_risc.cpp
     device_print/test_print_tile.cpp
+    device_print/test_print_tiles_multiple.cpp
     dprint/test_dprint_mesh_coords.cpp
     dprint/test_eth_cores.cpp
     dprint/test_invalid_print_core.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -10,6 +10,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_mute_device.cpp
     device_print/test_print_before_finish.cpp
     device_print/test_print_output.cpp
+    device_print/test_print_prepend_device_core_risc.cpp
     device_print/test_print_tile.cpp
     dprint/test_dprint_mesh_coords.cpp
     dprint/test_eth_cores.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -3,6 +3,7 @@
 
 set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_compilation_failures.cpp
+    device_print/test_eth_cores.cpp
     device_print/test_format_updates.cpp
     device_print/test_mesh_coords.cpp
     device_print/test_print_output.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -8,6 +8,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_invalid_print_core.cpp
     device_print/test_mesh_coords.cpp
     device_print/test_mute_device.cpp
+    device_print/test_print_before_finish.cpp
     device_print/test_print_output.cpp
     device_print/test_print_tile.cpp
     dprint/test_dprint_mesh_coords.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/sources.cmake
+++ b/tests/tt_metal/tt_metal/debug_tools/sources.cmake
@@ -7,6 +7,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     device_print/test_format_updates.cpp
     device_print/test_invalid_print_core.cpp
     device_print/test_mesh_coords.cpp
+    device_print/test_mute_device.cpp
     device_print/test_print_output.cpp
     device_print/test_print_tile.cpp
     dprint/test_dprint_mesh_coords.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/erisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/erisc_print.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+/*
+ * Test printing from a kernel running on ERISC.
+ */
+
+void kernel_main() { DEVICE_PRINT("Test Debug Print: ERISC\n"); }

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+/**
+ * Minimal kernel used by test_mesh_coords.cpp.
+ * Compile-time args 0 and 1 must be the global system-mesh row and column of the device
+ * this kernel is running on.  The DEVICE_PRINT line lets the test verify that DEVICE_PRINT output is
+ * restricted to the expected mesh coordinate when TT_METAL_DPRINT_MESH_COORDS is configured.
+ */
+void kernel_main() {
+    constexpr uint32_t row = get_compile_time_arg_val(0);
+    constexpr uint32_t col = get_compile_time_arg_val(1);
+    DEVICE_PRINT("mesh_coord=({},{})\n", row, col);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/common.h"
+#endif
+void kernel_main() {
+    DEVICE_PRINT("Printing on a RISC.\n");
+    DEVICE_PRINT_UNPACK("Printing on TR0.\n");
+    DEVICE_PRINT_MATH("Printing on TR1.\n");
+    DEVICE_PRINT_PACK("Printing on TR2.\n");
+    DEVICE_PRINT_DATA0("Printing on BR.\n");
+    DEVICE_PRINT_DATA1("Printing on NC.\n");
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_tiles_multiple_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_tiles_multiple_brisc.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+#include "api/debug/ring_buffer.h"
+
+#include "api/dataflow/dataflow_api.h"
+void kernel_main() {
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+
+    uint32_t tile_size_bytes = get_tile_size(cb_id);
+    uint32_t log2_tile_size = __builtin_ctz(tile_size_bytes);
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t is_tilized = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        uint64_t noc_addr = get_dram_noc_addr(i, tile_size_bytes, src_addr);
+
+        cb_reserve_back(cb_id, 1);
+        noc_async_read(noc_addr, get_write_ptr(cb_id), tile_size_bytes);
+        noc_async_read_barrier();
+
+        DEVICE_PRINT(
+            "Write tile {}:\n{}",
+            i,
+            TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_WR_PTR, true, is_tilized));
+
+        cb_push_back(cb_id, 1);
+    }
+
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        cb_wait_front(cb_id, 1);
+        DEVICE_PRINT(
+            "Read tile {}:\n{}",
+            i,
+            TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_RD_PTR, true, is_tilized));
+        cb_pop_front(cb_id, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "ckernel.h"
+#include "api/debug/device_print.h"
+
+void kernel_main() {
+    uint32_t wait_cycles = get_arg_val<uint32_t>(0);
+    uint32_t x = get_arg_val<uint32_t>(1);
+    uint32_t y = get_arg_val<uint32_t>(2);
+    DEVICE_PRINT("({},{}) Before wait...\n", x, y);
+    ckernel::wait(wait_cycles);
+    DEVICE_PRINT("({},{}) After wait...\n", x, y);
+}


### PR DESCRIPTION
Porting 7 more tests from `DPRINT` tests to `DEVICE_PRINT` tests.
This will let us remove `DPRINT` tests later easier.