### PR TITLE
Enable mock device for Metal tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -43,7 +43,6 @@ using test_helpers::MakeMinimalWorker;
 class ProgramRunParamsTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
-        GTEST_SKIP() << "Re-enable tests after Quasar mock device support is checked in";
         //  Configure global mock mode for Quasar
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
     }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -42,7 +42,6 @@ using test_helpers::MakeMinimalWorker;
 class ProgramSpecTestQuasar : public ::testing::Test {
 protected:
     void SetUp() override {
-        GTEST_SKIP() << "Re-enable tests after Quasar mock device support is checked in";
         //  Configure global mock mode for Quasar
         //  This way, the HAL is initialized for arch check and Program creation.
         experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -47,3 +47,13 @@ install(
     PATTERN
     "*.yaml"
 )
+
+# Install SOC descriptor YAML files for mock device testing.
+# These are required by get_soc_description_file(), which looks for files in:
+# get_root_dir() + "/tt_metal/soc_descriptors/"
+install(
+    FILES
+        ${PROJECT_SOURCE_DIR}/tt_metal/soc_descriptors/quasar_32_arch.yaml
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/soc_descriptors
+    COMPONENT metalium-validation
+)

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -38,6 +38,7 @@ install(
 # Install cluster descriptor YAML files for mock device testing.
 # These are required by configure_mock_mode(), which looks for files in:
 # get_root_dir() + "/tt_metal/third_party/umd/tests/cluster_descriptor_examples/"
+# Install the whole mock cluster descriptor examples directory (as all are fictional)
 install(
     DIRECTORY
         ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/tests/cluster_descriptor_examples/
@@ -51,6 +52,7 @@ install(
 # Install SOC descriptor YAML files for mock device testing.
 # These are required by get_soc_description_file(), which looks for files in:
 # get_root_dir() + "/tt_metal/soc_descriptors/"
+# Install only the necessary (fictional) SOC descriptor file (to avoid duplication)
 install(
     FILES
         ${PROJECT_SOURCE_DIR}/tt_metal/soc_descriptors/quasar_32_arch.yaml

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -34,3 +34,16 @@ install(
         ASanCoverage
     COMPONENT metalium-runtime
 )
+
+# Install cluster descriptor YAML files for mock device testing.
+# These are required by configure_mock_mode(), which looks for files in:
+# get_root_dir() + "/tt_metal/third_party/umd/tests/cluster_descriptor_examples/"
+install(
+    DIRECTORY
+        ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/tests/cluster_descriptor_examples/
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/third_party/umd/tests/cluster_descriptor_examples
+    COMPONENT metalium-validation
+    FILES_MATCHING
+    PATTERN
+    "*.yaml"
+)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/40981

### PR type
Test infra

### Problem description
We want to use the Quasar mock device for API testing. To do so, the validation package needs to contain the mock device's fictional YAML files (see https://github.com/tenstorrent/tt-metal/pull/41170 and https://github.com/tenstorrent/tt-umd/pull/2396).



### What's changed

- Update the test directory's `CMake` to include the UMD mock device YAML files in the validation package
- Remove `GTEST_SKIP` from the two test files (added by https://github.com/tenstorrent/tt-metal/pull/41169)



### Checklist

- [x] New/Existing tests provide coverage for changes 