### PR TITLE
#0 native row major binary pcc error, BH only

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1688,19 +1688,19 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
 
 class TestBinaryRowMajor:
     SHAPES = [
-        pytest.param((1, 1, 32, 32), id="tile_aligned"),
-        pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
-        # pytest.param((4, 2, 17, 19), id="weird_nc_hw"),
-        pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
-        pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
-        pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
-        pytest.param((1, 1, 1, 1), id="tiny"),
-        pytest.param((1, 1, 1, 1024), id="width_eq_stride"),
-        pytest.param((1, 1, 1, 1025), id="width_gt_stride_remainder"),
-        pytest.param((1, 1, 1, 2048), id="two_full_chunks"),
-        pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
-        pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
-        pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
+        # pytest.param((1, 1, 32, 32), id="tile_aligned"),
+        # pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
+        pytest.param((4, 2, 17, 19), id="weird_nc_hw"),
+        # pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
+        # pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
+        # pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
+        # pytest.param((1, 1, 1, 1), id="tiny"),
+        # pytest.param((1, 1, 1, 1024), id="width_eq_stride"),
+        # pytest.param((1, 1, 1, 1025), id="width_gt_stride_remainder"),
+        # pytest.param((1, 1, 1, 2048), id="two_full_chunks"),
+        # pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
+        # pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
+        # pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
     ]
 
     DTYPE_CASES = [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1688,19 +1688,19 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
 
 class TestBinaryRowMajor:
     SHAPES = [
-        # pytest.param((1, 1, 32, 32), id="tile_aligned"),
-        # pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
+        pytest.param((1, 1, 32, 32), id="tile_aligned"),
+        pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
         pytest.param((4, 2, 17, 19), id="weird_nc_hw"),
-        # pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
-        # pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
-        # pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
-        # pytest.param((1, 1, 1, 1), id="tiny"),
-        # pytest.param((1, 1, 1, 1024), id="width_eq_stride"),
-        # pytest.param((1, 1, 1, 1025), id="width_gt_stride_remainder"),
-        # pytest.param((1, 1, 1, 2048), id="two_full_chunks"),
-        # pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
-        # pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
-        # pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
+        pytest.param((2, 3, 33, 64), id="multi_nc_multi_row"),
+        pytest.param((1, 1, 3, 1025), id="wide_over_1024"),
+        pytest.param((1, 1, 1025, 32), id="tall_over_1024"),
+        pytest.param((1, 1, 1, 1), id="tiny"),
+        pytest.param((1, 1, 1, 1024), id="width_eq_stride"),
+        pytest.param((1, 1, 1, 1025), id="width_gt_stride_remainder"),
+        pytest.param((1, 1, 1, 2048), id="two_full_chunks"),
+        pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
+        pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
+        pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
     ]
 
     DTYPE_CASES = [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1701,6 +1701,14 @@ class TestBinaryRowMajor:
         pytest.param((1, 1, 1, 2049), id="two_full_chunks_remainder"),
         pytest.param((1, 1, 1, 4096), id="extreme_row_width"),
         pytest.param((1, 1, 2, 1, 1, 3, 1025), id="rank7_weird_wide"),
+        # Alignment boundary edge cases (element_size vs element_size_aligned)
+        pytest.param((1, 1, 1, 2), id="w2_4bytes"),
+        pytest.param((1, 1, 1, 16), id="w16_wh_dram_align"),
+        pytest.param((1, 1, 1, 31), id="w31_just_under_bh_align"),
+        pytest.param((1, 1, 1, 32), id="w32_exact_bh_align"),
+        pytest.param((1, 1, 1, 33), id="w33_just_over_bh_align"),
+        pytest.param((1, 1, 512, 3), id="many_rows_narrow_w3"),
+        pytest.param((1, 1, 7, 13), id="prime_dims_7x13"),
     ]
 
     DTYPE_CASES = [
@@ -1791,6 +1799,48 @@ class TestBinaryRowMajor:
             assert torch.equal(tt_out, torch.add(pt_a, pt_b))
         else:
             assert_with_pcc(tt_out, torch.add(pt_a, pt_b))
+
+    SCALAR_SHAPES = [
+        pytest.param((1, 1, 32, 32), id="tile_aligned"),
+        pytest.param((1, 1, 35, 35), id="non_tile_aligned"),
+        pytest.param((4, 2, 17, 19), id="weird_nc_hw"),
+        pytest.param((1, 1, 1, 1), id="tiny"),
+        pytest.param((1, 1, 1, 33), id="w33_just_over_bh_align"),
+        pytest.param((1, 1, 512, 3), id="many_rows_narrow_w3"),
+    ]
+
+    SCALAR_DTYPE_CASES = [
+        pytest.param(torch.bfloat16, ttnn.bfloat16, id="bfloat16"),
+        pytest.param(torch.float32, ttnn.float32, id="float32"),
+    ]
+
+    @pytest.mark.parametrize("shape", SCALAR_SHAPES)
+    @pytest.mark.parametrize("dtype_pt,dtype_tt", SCALAR_DTYPE_CASES)
+    @pytest.mark.parametrize(
+        "a_config",
+        [
+            pytest.param(ttnn.DRAM_MEMORY_CONFIG, id="dram"),
+            pytest.param(ttnn.L1_MEMORY_CONFIG, id="l1"),
+        ],
+    )
+    def test_binary_row_major_scalar(self, device, shape, dtype_pt, dtype_tt, a_config):
+        torch.manual_seed(0)
+        scalar_val = 2.5
+
+        pt_a = torch.randn(shape, dtype=dtype_pt)
+        tt_a = ttnn.from_torch(
+            pt_a,
+            dtype=dtype_tt,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=a_config,
+        )
+
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            tt_out = ttnn.add(tt_a, scalar_val, use_legacy=None)
+
+        tt_out = ttnn.to_torch(tt_out)
+        assert_with_pcc(tt_out, torch.add(pt_a, scalar_val))
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
                                 const uint64_t addr_a = get_noc_addr(row_idx_a, src);
-                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
@@ -194,7 +194,7 @@ void kernel_main() {
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
                                 const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
-                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -164,7 +164,7 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
+                                noc_async_read(addr_a, scratch_l1_addr, element_size);
                                 noc_async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
@@ -199,7 +199,7 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
+                                noc_async_read(addr_b, scratch_l1_addr, element_size);
                                 noc_async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -164,7 +164,7 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
+                                noc_async_read(addr_a, scratch_l1_addr, element_size);
                                 noc_async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
@@ -186,7 +186,7 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
+                                noc_async_read(addr_b, scratch_l1_addr, element_size);
                                 noc_async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
                                 const uint64_t addr_a = get_noc_addr(row_idx_a, src);
-                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
@@ -181,7 +181,7 @@ void kernel_main() {
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
                                 const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
-                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                                const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
 #if SRC_BCAST
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
                             const uint64_t addr_a = get_noc_addr(row_block_a, src);
-                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & 0xF);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
                             noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
@@ -187,7 +187,7 @@ void kernel_main() {
                             noc_async_read_barrier();
 
                             const uint64_t addr_b = get_noc_addr(row_block_b, src_b);
-                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & 0xF);
+                            const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 
                             noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
-                            noc_async_read(addr_a, scratch_l1_addr, element_size_aligned_a);
+                            noc_async_read(addr_a, scratch_l1_addr, element_size);
                             noc_async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
@@ -190,7 +190,7 @@ void kernel_main() {
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 
-                            noc_async_read(addr_b, scratch_l1_addr, element_size_aligned_b);
+                            noc_async_read(addr_b, scratch_l1_addr, element_size);
                             noc_async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src_b, scratch_l1_addr);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
native row major binary op pcc error, BH only

### What's changed
In some kernels, change to correct read behavior.
Add more edge test cases for input shapes.
Also added test case for scalar-value.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/row_major_bh)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/row_major_bh)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/row_major_bh)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/row_major_bh)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/row_major_bh)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/row_major_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/row_major_bh)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
