### PR TITLE
Fix incorrect buffer sizing for sdpa fwd buffer

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import (
     get_max_page_size_and_num_pages,
     get_noc_max_page_size,
 )
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     PerCoreCompileTimeDescriptor,
     PerCoreRuntimeArgsDescriptor,
@@ -2629,6 +2630,17 @@ class AttentionBlock:
         sdpa_kv_cache_running_offset_post_sdpa = 0
         sdpa_out_interm_running_offset_post_sdpa = 0
 
+        sdpa_fwd_buffer_bytes = compute_forwarder_scratch_size(
+            batch_size=SDPA_L_HEIGHT,
+            l_width=sdpa_l_per_worker,
+            num_cores=NUM_SDPA_WORKERS,
+        )
+
+        # This is used to overlap the sdpa forwarder scratch buffer with the kv cache buffer
+        # TODO: We can better overlap this if necessary
+        forwarder_buffer_base = ref_sdpa_kv_cache_buffer.buffer_address() + sdpa_kv_cache_running_offset_post_sdpa
+        sdpa_kv_cache_running_offset_post_sdpa += sdpa_fwd_buffer_bytes
+
         # CB 0: Matmul4 input (from sharded tensor, kv_b2 grid)
         matmul4_in0_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         matmul4_in0_cb_format = ttnn.CBFormatDescriptor(
@@ -3313,7 +3325,6 @@ class AttentionBlock:
         # ========================================================================
         # Pre-compute device-invariant SDPA addresses
         # ========================================================================
-        forwarder_buffer_base = ref_sdpa_forwarder_scratch.buffer_address()
         ncrisc_buffer_offset = sdpa_fwd_slots_per_round * sdpa_fwd_slot_size * 2  # After BRISC R1+R2
         r1_recv_buffer_addr = ref_sdpa_intermediate_recv.buffer_address()
         r2_recv_buffer_addr = r1_recv_buffer_addr + (sdpa_l_tiles_per_worker + 1) * sdpa_l_tile_size

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -39,6 +39,50 @@ def _get_element_size_bytes(dtype):
     raise ValueError(f"Unsupported dtype for sdpa_reduce_to_all: {dtype}")
 
 
+def compute_forwarder_scratch_size(
+    batch_size: int,
+    l_width: int,
+    num_cores: int,
+    tile_height: int = 8,
+    tile_width: int = 32,
+    bytes_per_element: int = 2,
+    num_links: int = 2,
+):
+    """
+    Compute the total forwarder scratch buffer size in bytes for SDPA reduce-to-all.
+
+    This matches the calculation in sdpa_reduce_to_all/op.py for proper L1 allocation.
+    """
+    input_page_size_bytes = tile_height * tile_width * bytes_per_element
+    input_l_num_pages = (batch_size // tile_height) * (l_width // tile_width)
+
+    PNH = 8
+    DH = input_l_num_pages * tile_width
+    DHt = DH // tile_width
+    PNHt = PNH // tile_height
+    out_tiles = PNHt * DHt
+
+    max_tiles_per_chunk = 8
+    min_num_l_chunks = (out_tiles + max_tiles_per_chunk - 1) // max_tiles_per_chunk
+    num_l_chunks = max(min_num_l_chunks, 4)
+    if out_tiles % num_l_chunks != 0:
+        raise ValueError("out_tiles must be divisible by num_l_chunks")
+
+    tiles_per_l_chunk = out_tiles // num_l_chunks
+    l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
+
+    header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
+    l1_alignment = 16
+    slot_size = _round_up(header_size + l_chunk_size_bytes, l1_alignment)
+
+    num_workers_per_link = num_cores // num_links
+    workers_per_type = num_workers_per_link // 2
+    slots_per_worker = 1 + num_l_chunks
+    slots_per_round = workers_per_type * slots_per_worker
+
+    return 2 * slots_per_round * slot_size * 2
+
+
 class SdpaReduceToAll:
     @staticmethod
     def golden(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_attention_block.py
@@ -25,8 +25,8 @@ from models.demos.deepseek_v3_b1.blitz_decode_weights import (
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
 from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import create_fabric_router_config
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_post_sdpa import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
 from models.demos.deepseek_v3_b1.utils import generate_mm_weights
 
@@ -821,6 +821,8 @@ def test_attention_block(
     sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
     # WIDTH_SHARDED across 2 forwarder cores, each gets half
     num_forwarders = 2
+    # THIS BUFFER SIZE IS NOT CORRECT BECAUSE WE'RE INCORRECTLY DIVIDING BY 2
+    # TODO: Plan to remove this scratch buffer entirely once we reduce cb memory usage currently being overlapped with this buffer.
     sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // num_forwarders
     sdpa_forwarder_shard_shape = (1, sdpa_fwd_per_forwarder)
     sdpa_forwarder_shard_spec = ttnn.ShardSpec(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBl
 from models.demos.deepseek_v3_b1.fused_ops.decoder_block.op import DecoderBlock
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.prepare_weights import (
     create_gate_indices_tensor,
     get_layer_raw_tensors,
@@ -38,7 +39,6 @@ from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe_mlp import (
     SharedExpert,
     extract_routed_expert_output,
 )
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_post_sdpa import compute_forwarder_scratch_size
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_pre_sdpa import deinterleave_kv_cache
 from models.demos.deepseek_v3_b1.utils import get_pinned_optimal_dram_bank_to_logical_worker_assignment
 
@@ -584,6 +584,8 @@ def create_decoder_block_tensors(
         num_cores=NUM_SDPA_WORKERS,
     )
     sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
+    # THIS BUFFER SIZE IS NOT CORRECT BECAUSE WE'RE INCORRECTLY DIVIDING BY 2
+    # TODO: Plan to remove this scratch buffer entirely once we reduce cb memory usage currently being overlapped with this buffer.
     sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // 2
     sdpa_forwarder_mem = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
@@ -1393,6 +1395,7 @@ def test_decoder(
         127,
         pytest.param(511, marks=pytest.mark.skip_post_commit),
         pytest.param(1023, marks=pytest.mark.skip_post_commit),
+        pytest.param(11664, marks=pytest.mark.skip_post_commit),  # (3,3,3,2 + partial): partial into dev3 (if SP = 4)
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -46,7 +46,7 @@ from models.demos.deepseek_v3_b1.blitz_decode_weights import (
 )
 from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import PostSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
-from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import SdpaReduceToAll
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import SdpaReduceToAll, compute_forwarder_scratch_size
 
 
 def create_fabric_router_config(max_payload_size):
@@ -54,55 +54,6 @@ def create_fabric_router_config(max_payload_size):
     config = ttnn._ttnn.fabric.FabricRouterConfig()
     config.max_packet_payload_size_bytes = max_payload_size
     return config
-
-
-def _round_up(value: int, alignment: int) -> int:
-    """Round up value to the nearest multiple of alignment."""
-    return ((value + alignment - 1) // alignment) * alignment
-
-
-def compute_forwarder_scratch_size(
-    batch_size: int,
-    l_width: int,
-    num_cores: int,
-    tile_height: int = 8,
-    tile_width: int = 32,
-    bytes_per_element: int = 2,
-    num_links: int = 2,
-):
-    """
-    Compute the total forwarder scratch buffer size in bytes for SDPA reduce-to-all.
-
-    This matches the calculation in sdpa_reduce_to_all/op.py for proper L1 allocation.
-    """
-    input_page_size_bytes = tile_height * tile_width * bytes_per_element
-    input_l_num_pages = (batch_size // tile_height) * (l_width // tile_width)
-
-    PNH = 8
-    DH = input_l_num_pages * tile_width
-    DHt = DH // tile_width
-    PNHt = PNH // tile_height
-    out_tiles = PNHt * DHt
-
-    max_tiles_per_chunk = 8
-    min_num_l_chunks = (out_tiles + max_tiles_per_chunk - 1) // max_tiles_per_chunk
-    num_l_chunks = max(min_num_l_chunks, 4)
-    if out_tiles % num_l_chunks != 0:
-        raise ValueError("out_tiles must be divisible by num_l_chunks")
-
-    tiles_per_l_chunk = out_tiles // num_l_chunks
-    l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
-
-    header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
-    l1_alignment = 16
-    slot_size = _round_up(header_size + l_chunk_size_bytes, l1_alignment)
-
-    num_workers_per_link = num_cores // num_links
-    workers_per_type = num_workers_per_link // 2
-    slots_per_worker = 1 + num_l_chunks
-    slots_per_round = workers_per_type * slots_per_worker
-
-    return 2 * slots_per_round * slot_size * 2
 
 
 @pytest.mark.parametrize("mesh_rows, mesh_cols", [(1, 1), (4, 2)], ids=["single_device", "multi_device"])
@@ -1029,10 +980,9 @@ def test_post_sdpa_with_sdpa_phase(
         num_cores=NUM_SDPA_WORKERS,
     )
     # Total elements (bfloat16 = 2 bytes per element)
-    sdpa_fwd_total_elements = sdpa_fwd_buffer_bytes // 2
-    # WIDTH_SHARDED across 2 forwarder cores, each gets half
+    sdpa_fwd_per_forwarder = sdpa_fwd_buffer_bytes // 2
     num_forwarders = 2
-    sdpa_fwd_per_forwarder = sdpa_fwd_total_elements // num_forwarders
+    sdpa_fwd_total_elements = sdpa_fwd_per_forwarder * num_forwarders
     sdpa_forwarder_shard_shape = (1, sdpa_fwd_per_forwarder)
     sdpa_forwarder_shard_spec = ttnn.ShardSpec(
         sdpa_forwarder_grid, sdpa_forwarder_shard_shape, ttnn.ShardOrientation.ROW_MAJOR

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -8,51 +8,12 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import skip_for_wormhole_b0
-from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import SdpaReduceToAll
+from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import (
+    SdpaReduceToAll,
+    _round_up,
+    compute_forwarder_scratch_size,
+)
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
-
-
-def _round_up(value: int, alignment: int) -> int:
-    return ((value + alignment - 1) // alignment) * alignment
-
-
-def compute_forwarder_scratch_size(
-    batch_size: int,
-    l_width: int,
-    num_cores: int,
-    tile_height: int = 8,
-    tile_width: int = 32,
-    bytes_per_element: int = 2,
-    num_links: int = 2,
-):
-    input_page_size_bytes = tile_height * tile_width * bytes_per_element
-    input_l_num_pages = (batch_size // tile_height) * (l_width // tile_width)
-
-    PNH = 8
-    DH = input_l_num_pages * tile_width
-    DHt = DH // tile_width
-    PNHt = PNH // tile_height
-    out_tiles = PNHt * DHt
-
-    max_tiles_per_chunk = 8
-    min_num_l_chunks = (out_tiles + max_tiles_per_chunk - 1) // max_tiles_per_chunk
-    num_l_chunks = max(min_num_l_chunks, 4)
-    if out_tiles % num_l_chunks != 0:
-        raise ValueError("out_tiles must be divisible by num_l_chunks")
-
-    tiles_per_l_chunk = out_tiles // num_l_chunks
-    l_chunk_size_bytes = tiles_per_l_chunk * input_page_size_bytes
-
-    header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
-    l1_alignment = 16
-    slot_size = _round_up(header_size + l_chunk_size_bytes, l1_alignment)
-
-    num_workers_per_link = num_cores // num_links
-    workers_per_type = num_workers_per_link // 2
-    slots_per_worker = 1 + num_l_chunks
-    slots_per_round = workers_per_type * slots_per_worker
-
-    return 2 * slots_per_round * slot_size * 2
 
 
 @skip_for_wormhole_b0("This test is for blackhole")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
sdpa fwd buffer was being incorrectly sized for post sdpa/attn/decoder tests. It was being set to half the expected size, so when these ops run they end up corrupting memory.

### What's changed
Update post sdpa to correctly size the buffer.
Switch attn/decoder to overlap the correctly sized fwd buffer with the kv cache read buffer in order to save memory. We still keep the current incorrectly sized buffer since other cbs were overlapped with it. The plan is to reduce the size of these other cbs in order to overlap it elsewhere and remove this fwd buffer entirely.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/fix-fwd)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/fix-fwd)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/fix-fwd)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/fix-fwd)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/fix-fwd)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/fix-fwd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/fix-fwd)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
