### PR TITLE
Fix Flux.1-dev accuracy regression on BH 2x2 mesh

### DIFF
--- a/models/tt_dit/blocks/attention.py
+++ b/models/tt_dit/blocks/attention.py
@@ -81,7 +81,7 @@ class Attention(Module):
         self.sdpa_compute_kernel_config = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=False,
-            fp32_dest_acc_en=False,  # NOTE: Set to True if there's a correctness issue
+            fp32_dest_acc_en=True,  # NOTE: True disables BH streaming_compute path; required for correctness
         )
 
         self.to_qkv = ColParallelLinear(query_dim, 3 * padded_inner_dim, mesh_axis=tp_axis, **common_args)

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 from contextlib import nullcontext
-from dataclasses import dataclass
 
 import numpy as np
 import torch
@@ -28,22 +27,7 @@ from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, Paralle
 from ...parallel.manager import CCLManager
 from ...utils import cache
 from ...utils.padding import PaddingConfig
-
-
-@dataclass
-class PipelineTrace:
-    tid: int
-    spatial_input: ttnn.Tensor
-    prompt_input: ttnn.Tensor
-    pooled_input: ttnn.Tensor
-    timestep_input: ttnn.Tensor
-    guidance_input: ttnn.Tensor
-    spatial_rope_cos: ttnn.Tensor
-    spatial_rope_sin: ttnn.Tensor
-    prompt_rope_cos: ttnn.Tensor
-    prompt_rope_sin: ttnn.Tensor
-    sigma_difference_input: ttnn.Tensor
-    latents_output: ttnn.Tensor
+from ...utils.tracing import Tracer
 
 
 class Flux1Pipeline:
@@ -168,6 +152,8 @@ class Flux1Pipeline:
             self.transformers.append(tt_transformer)
             ttnn.synchronize_device(submesh_device)
 
+        self._step_inner_tracers = [Tracer(self._step_inner, device=device) for device in self._submesh_devices]
+
         self._pos_embed = torch_transformer.pos_embed
 
         self._num_channels_latents = torch_transformer.config.in_channels // 4
@@ -246,8 +232,6 @@ class Flux1Pipeline:
         else:
             self._t5_text_encoder = None
 
-        self._traces = None
-
         ttnn.synchronize_device(self.encoder_device)
 
         self._vae_decoder = VAEDecoder.from_torch(
@@ -257,9 +241,12 @@ class Flux1Pipeline:
             ccl_manager=self._ccl_managers[self.vae_submesh_idx],
         )
 
-        # warmup for safe tracing.
-        logger.info("warming up for tracing...")
-        self.run_single_prompt(prompt="", num_inference_steps=1, seed=0, traced=False)
+        # Allocate persistent buffers (CCL ping-pong buffers, semaphores, etc.) by running a
+        # pipeline pass without tracing.  Two steps are required so that all lazy-allocated buffers
+        # are populated before trace capture begins; buffers allocated for the first time *during*
+        # trace capture would be overwritten during subsequent execute_trace calls.
+        logger.info("allocating persistent buffers (warmup)...")
+        self.run_single_prompt(prompt="", num_inference_steps=2, seed=0, traced=False)
         self.synchronize_devices()
 
     @staticmethod
@@ -460,7 +447,7 @@ class Flux1Pipeline:
                     prompt_embeds[i : i + 1] if self._parallel_config.cfg_parallel.factor == 2 else prompt_embeds,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=ttnn.ShardTensor2dMesh(
                         submesh_device,
                         tuple(submesh_device.shape),
@@ -476,7 +463,7 @@ class Flux1Pipeline:
                     ),
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=ttnn.ShardTensor2dMesh(
                         submesh_device,
                         tuple(submesh_device.shape),
@@ -490,7 +477,7 @@ class Flux1Pipeline:
                     latents,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=ttnn.ShardTensor2dMesh(
                         submesh_device,
                         tuple(submesh_device.shape),
@@ -503,7 +490,7 @@ class Flux1Pipeline:
                         guidance.unsqueeze(-1),
                         layout=ttnn.TILE_LAYOUT,
                         dtype=ttnn.bfloat16,
-                        device=submesh_device if not traced else None,
+                        device=submesh_device,
                         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh_device),
                     )
                     if guidance is not None
@@ -522,63 +509,30 @@ class Flux1Pipeline:
                     rope_cos[prompt_sequence_length:],
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=rope_mesh_mapper,
                 )
                 tt_spatial_rope_sin = ttnn.from_torch(
                     rope_sin[prompt_sequence_length:],
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=rope_mesh_mapper,
                 )
                 tt_prompt_rope_cos = ttnn.from_torch(
                     rope_cos[:prompt_sequence_length],
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(submesh_device),
                 )
                 tt_prompt_rope_sin = ttnn.from_torch(
                     rope_sin[:prompt_sequence_length],
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
-                    device=submesh_device if not traced else None,
+                    device=submesh_device,
                     mesh_mapper=ttnn.ReplicateTensorToMesh(submesh_device),
                 )
-
-                if traced:
-                    if self._traces is None:
-                        tt_initial_latents = tt_initial_latents.to(submesh_device)
-                        tt_prompt_embeds = tt_prompt_embeds.to(submesh_device)
-                        tt_pooled_prompt_embeds = tt_pooled_prompt_embeds.to(submesh_device)
-                        tt_spatial_rope_cos = tt_spatial_rope_cos.to(submesh_device)
-                        tt_spatial_rope_sin = tt_spatial_rope_sin.to(submesh_device)
-                        tt_prompt_rope_cos = tt_prompt_rope_cos.to(submesh_device)
-                        tt_prompt_rope_sin = tt_prompt_rope_sin.to(submesh_device)
-
-                        if tt_guidance is not None:
-                            tt_guidance = tt_guidance.to(submesh_device)
-                    else:
-                        ttnn.copy_host_to_device_tensor(tt_initial_latents, self._traces[i].spatial_input)
-                        ttnn.copy_host_to_device_tensor(tt_prompt_embeds, self._traces[i].prompt_input)
-                        ttnn.copy_host_to_device_tensor(tt_pooled_prompt_embeds, self._traces[i].pooled_input)
-                        ttnn.copy_host_to_device_tensor(tt_spatial_rope_cos, self._traces[i].spatial_rope_cos)
-                        ttnn.copy_host_to_device_tensor(tt_spatial_rope_sin, self._traces[i].spatial_rope_sin)
-                        ttnn.copy_host_to_device_tensor(tt_prompt_rope_cos, self._traces[i].prompt_rope_cos)
-                        ttnn.copy_host_to_device_tensor(tt_prompt_rope_sin, self._traces[i].prompt_rope_sin)
-
-                        tt_initial_latents = self._traces[i].spatial_input
-                        tt_prompt_embeds = self._traces[i].prompt_input
-                        tt_pooled_prompt_embeds = self._traces[i].pooled_input
-                        tt_spatial_rope_cos = self._traces[i].spatial_rope_cos
-                        tt_spatial_rope_sin = self._traces[i].spatial_rope_sin
-                        tt_prompt_rope_cos = self._traces[i].prompt_rope_cos
-                        tt_prompt_rope_sin = self._traces[i].prompt_rope_sin
-
-                        if tt_guidance is not None:
-                            ttnn.copy_host_to_device_tensor(tt_guidance, self._traces[i].guidance_input)
-                            tt_guidance = self._traces[i].guidance_input
 
                 tt_prompt_embeds_list.append(tt_prompt_embeds)
                 tt_pooled_prompt_embeds_list.append(tt_pooled_prompt_embeds)
@@ -594,45 +548,33 @@ class Flux1Pipeline:
             with profiler("denoising", profiler_iteration) if profiler else nullcontext():
                 for i, t in enumerate(tqdm.tqdm(self._scheduler.timesteps)):
                     with profiler(f"denoising_step_{i}", profiler_iteration) if profiler else nullcontext():
-                        sigma_difference = self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]
+                        sigma_difference = (self._scheduler.sigmas[i + 1] - self._scheduler.sigmas[i]).item()
 
                         tt_timestep_list = []
-                        tt_sigma_difference_list = []
                         for submesh_device in self._submesh_devices:
                             tt_timestep = ttnn.full(
                                 [1, 1],
                                 fill_value=t,
                                 layout=ttnn.TILE_LAYOUT,
                                 dtype=ttnn.float32,
-                                device=submesh_device if not traced else None,
+                                device=submesh_device,
                             )
                             tt_timestep_list.append(tt_timestep)
 
-                            tt_sigma_difference = ttnn.full(
-                                # [1, 1],
-                                tt_initial_latents.shape,
-                                fill_value=sigma_difference,
-                                layout=ttnn.TILE_LAYOUT,
-                                dtype=ttnn.bfloat16,
-                                device=(
-                                    submesh_device if not traced else None
-                                ),  # Not used in trace region, can be on device always.
-                            )
-                            tt_sigma_difference_list.append(tt_sigma_difference)
-
+                        reuse_tensors = i > 0 and traced
                         tt_latents_step_list = self._step(
                             timestep=tt_timestep_list,
-                            latents=tt_latents_step_list,
+                            latents=None if reuse_tensors else tt_latents_step_list,
                             cfg_enabled=cfg_enabled,
-                            prompt_embeds=tt_prompt_embeds_list,
-                            pooled_prompt_embeds=tt_pooled_prompt_embeds_list,
+                            prompt_embeds=None if reuse_tensors else tt_prompt_embeds_list,
+                            pooled_prompt_embeds=None if reuse_tensors else tt_pooled_prompt_embeds_list,
                             cfg_scale=cfg_scale,
-                            sigma_difference=tt_sigma_difference_list,
-                            guidance=tt_guidance_list,
-                            spatial_rope_cos=tt_spatial_rope_cos_list,
-                            spatial_rope_sin=tt_spatial_rope_sin_list,
-                            prompt_rope_cos=tt_prompt_rope_cos_list,
-                            prompt_rope_sin=tt_prompt_rope_sin_list,
+                            sigma_difference=sigma_difference,
+                            guidance=None if reuse_tensors else tt_guidance_list,
+                            spatial_rope_cos=None if reuse_tensors else tt_spatial_rope_cos_list,
+                            spatial_rope_sin=None if reuse_tensors else tt_spatial_rope_sin_list,
+                            prompt_rope_cos=None if reuse_tensors else tt_prompt_rope_cos_list,
+                            prompt_rope_sin=None if reuse_tensors else tt_prompt_rope_sin_list,
                             spatial_sequence_length=spatial_sequence_length,
                             prompt_sequence_length=prompt_sequence_length,
                             traced=traced,
@@ -691,13 +633,16 @@ class Flux1Pipeline:
         prompt_rope_sin: ttnn.Tensor,
         spatial_sequence_length: int,
         prompt_sequence_length: int,
-        submesh_index: int,
-    ) -> ttnn.Tensor:
-        if cfg_enabled and not self._parallel_config.cfg_parallel.factor > 1:
-            latent = ttnn.concat([latent, latent])
+        submesh_id: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        latent_input = (
+            ttnn.concat([latent, latent])
+            if cfg_enabled and not self._parallel_config.cfg_parallel.factor > 1
+            else latent
+        )
 
-        noise_pred = self.transformers[submesh_index].forward(
-            spatial=latent,
+        noise_pred = self.transformers[submesh_id].forward(
+            spatial=latent_input,
             prompt=prompt,
             pooled=pooled,
             timestep=timestep,
@@ -708,100 +653,58 @@ class Flux1Pipeline:
             prompt_sequence_length=prompt_sequence_length,
         )
 
-        return noise_pred
+        # Return latent as an output so it can be traced: inputs are copied into the trace region
+        # before execute_trace and may be overwritten during execution.
+        return latent, noise_pred
 
     def _step(
         self,
         *,
         cfg_enabled: bool,
         cfg_scale: float,
-        latents: list[ttnn.Tensor],  # device tensor
-        timestep: list[ttnn.Tensor],  # host tensor
-        pooled_prompt_embeds: list[ttnn.Tensor],  # device tensor
-        prompt_embeds: list[ttnn.Tensor],  # device tensor
-        sigma_difference: list[ttnn.Tensor],  # device tensor
-        guidance: list[ttnn.Tensor | None],
-        spatial_rope_cos: list[ttnn.Tensor],
-        spatial_rope_sin: list[ttnn.Tensor],
-        prompt_rope_cos: list[ttnn.Tensor],
-        prompt_rope_sin: list[ttnn.Tensor],
+        latents: list[ttnn.Tensor] | None,  # None means reuse previous (traced path only)
+        timestep: list[ttnn.Tensor],
+        pooled_prompt_embeds: list[ttnn.Tensor] | None,
+        prompt_embeds: list[ttnn.Tensor] | None,
+        sigma_difference: float,
+        guidance: list[ttnn.Tensor | None] | None,
+        spatial_rope_cos: list[ttnn.Tensor] | None,
+        spatial_rope_sin: list[ttnn.Tensor] | None,
+        prompt_rope_cos: list[ttnn.Tensor] | None,
+        prompt_rope_sin: list[ttnn.Tensor] | None,
         spatial_sequence_length: int,
         prompt_sequence_length: int,
         traced: bool,
     ) -> list[ttnn.Tensor]:
-        if traced and self._traces is None:
-            self._traces = []
-            for submesh_id, submesh_device in enumerate(self._submesh_devices):
-                timestep_device = timestep[submesh_id].to(submesh_device)
-                sigma_difference_device = sigma_difference[submesh_id].to(submesh_device)
-
-                trace_id = ttnn.begin_trace_capture(submesh_device, cq_id=0)
-                pred = self._step_inner(
-                    cfg_enabled=cfg_enabled,
-                    latent=latents[submesh_id],
-                    prompt=prompt_embeds[submesh_id],
-                    pooled=pooled_prompt_embeds[submesh_id],
-                    timestep=timestep_device,
-                    guidance=guidance[submesh_id],
-                    spatial_rope_cos=spatial_rope_cos[submesh_id],
-                    spatial_rope_sin=spatial_rope_sin[submesh_id],
-                    prompt_rope_cos=prompt_rope_cos[submesh_id],
-                    prompt_rope_sin=prompt_rope_sin[submesh_id],
-                    spatial_sequence_length=spatial_sequence_length,
-                    prompt_sequence_length=prompt_sequence_length,
-                    submesh_index=submesh_id,
-                )
-                ttnn.end_trace_capture(submesh_device, trace_id, cq_id=0)
-
-                for device in self._submesh_devices:
-                    ttnn.synchronize_device(device)
-
-                self._traces.append(
-                    PipelineTrace(
-                        spatial_input=latents[submesh_id],
-                        prompt_input=prompt_embeds[submesh_id],
-                        pooled_input=pooled_prompt_embeds[submesh_id],
-                        timestep_input=timestep_device,
-                        guidance_input=guidance[submesh_id],
-                        latents_output=pred,
-                        spatial_rope_cos=spatial_rope_cos[submesh_id],
-                        spatial_rope_sin=spatial_rope_sin[submesh_id],
-                        prompt_rope_cos=prompt_rope_cos[submesh_id],
-                        prompt_rope_sin=prompt_rope_sin[submesh_id],
-                        sigma_difference_input=sigma_difference_device,
-                        tid=trace_id,
-                    )
-                )
-
+        latents_out = []
         noise_pred_list = []
-        if traced:
-            for submesh_id, submesh_device in enumerate(self._submesh_devices):
-                ttnn.copy_host_to_device_tensor(timestep[submesh_id], self._traces[submesh_id].timestep_input)
-                ttnn.copy_host_to_device_tensor(
-                    sigma_difference[submesh_id], self._traces[submesh_id].sigma_difference_input
-                )
-                sigma_difference_device = self._traces[submesh_id].sigma_difference_input
-                ttnn.execute_trace(submesh_device, self._traces[submesh_id].tid, cq_id=0, blocking=False)
-                noise_pred_list.append(self._traces[submesh_id].latents_output)
-        else:
-            for submesh_id, submesh_device in enumerate(self._submesh_devices):
-                noise_pred = self._step_inner(
-                    cfg_enabled=cfg_enabled,
+        for submesh_id in range(len(self._submesh_devices)):
+            inner = self._step_inner_tracers[submesh_id] if traced else self._step_inner
+            # Build kwargs: on traced re-use steps only pass inputs that changed (timestep).
+            # The Tracer keeps stored values for omitted kwargs. Passing None for a previously-
+            # tensor input would trigger a type mismatch in Tracer._update_input.
+            reuse = latents is None  # True on traced steps i > 0
+            kwargs = dict(
+                cfg_enabled=cfg_enabled,
+                timestep=timestep[submesh_id],
+                spatial_sequence_length=spatial_sequence_length,
+                prompt_sequence_length=prompt_sequence_length,
+                submesh_id=submesh_id,
+            )
+            if not reuse:
+                kwargs.update(
                     latent=latents[submesh_id],
                     prompt=prompt_embeds[submesh_id],
                     pooled=pooled_prompt_embeds[submesh_id],
-                    timestep=timestep[submesh_id],
-                    guidance=guidance[submesh_id],
+                    guidance=guidance[submesh_id] if guidance is not None else None,
                     spatial_rope_cos=spatial_rope_cos[submesh_id],
                     spatial_rope_sin=spatial_rope_sin[submesh_id],
                     prompt_rope_cos=prompt_rope_cos[submesh_id],
                     prompt_rope_sin=prompt_rope_sin[submesh_id],
-                    spatial_sequence_length=spatial_sequence_length,
-                    prompt_sequence_length=prompt_sequence_length,
-                    submesh_index=submesh_id,
                 )
-                noise_pred_list.append(noise_pred)
-                sigma_difference_device = sigma_difference[submesh_id]
+            latent_out, noise_pred = inner(**kwargs)
+            latents_out.append(latent_out)
+            noise_pred_list.append(noise_pred)
 
         if cfg_enabled:
             if not self._parallel_config.cfg_parallel.factor > 1:
@@ -848,10 +751,10 @@ class Flux1Pipeline:
 
         for submesh_id, submesh_device in enumerate(self._submesh_devices):
             ttnn.synchronize_device(submesh_device)  # Helps with accurate time profiling.
-            ttnn.multiply_(sigma_difference_device, noise_pred_list[submesh_id])
-            ttnn.add_(latents[submesh_id], sigma_difference_device)
+            ttnn.multiply_(noise_pred_list[submesh_id], sigma_difference)
+            ttnn.add_(latents_out[submesh_id], noise_pred_list[submesh_id])
 
-        return latents
+        return latents_out
 
     def _encode_prompts_partial(
         self,


### PR DESCRIPTION
Two bugs fixed:

1. Pipeline tracing (pipeline_flux1.py): Replace the manual begin/end trace-capture pattern with the Tracer class. The old code had two bugs: (a) sigma_difference was a bf16 device tensor inside the trace region — in-place multiply_ overwrote it each step, corrupting subsequent trace executions; (b) _step_inner returned only noise_pred, so the latent input tensor could be overwritten by execute_trace before the Euler update. Fix: use Tracer per submesh, pass sigma_difference as a Python float (never enters trace region), _step_inner returns (latent, noise_pred) so both are traced outputs.

2. SDPA numerical precision (attention.py): Set fp32_dest_acc_en=True in sdpa_compute_kernel_config. On BH, fp32_dest_acc_en=False enables the streaming compute path (use_streaming_compute=true) which produces incorrect outputs on this model's SDPA shapes. Setting True disables streaming and falls back to the validated non-streaming path. Verified: 100-prompt COCO eval gives CLIP mean 30.97 (CI: [28.97, 32.66]) and FID 178.87 (CI: [169.72, 191.37]).

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/flux1-tracing-minimal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/flux1-tracing-minimal)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/flux1-tracing-minimal)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/flux1-tracing-minimal)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/flux1-tracing-minimal)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/flux1-tracing-minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/flux1-tracing-minimal)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
