### PR TITLE
Rename UMD CMake target to umd::tt-umd

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(
     scaleout_tools
     PUBLIC
         TT::STL
-        umd::device
+        umd::tt-umd
     PRIVATE
         enchantum::enchantum
         tt-logger::tt-logger

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 target_link_libraries(
     tt_metal
     PUBLIC
-        umd::device
+        umd::tt-umd
         enchantum::enchantum
         fmt::fmt-header-only
         TracyClient

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
         fmt::fmt-header-only
         TT::STL
         umd::Firmware
-        umd::device
+        umd::tt-umd
         simde::simde
         Taskflow::Taskflow
     PRIVATE

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(
     PRIVATE
         TT::ScaleoutTools
         Metalium::Metal::LLRT
-        umd::device
+        umd::tt-umd
         metal_common_libs
         enchantum::enchantum
         fmt::fmt-header-only

--- a/tt_metal/hostdevcommon/CMakeLists.txt
+++ b/tt_metal/hostdevcommon/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(
     ttmetalium_hostdevcommon
     INTERFACE
         fmt::fmt-header-only
-        umd::device
+        umd::tt-umd
 )
 
 install(

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -15,7 +15,7 @@ add_dependencies(llrt hal_generate_dev_msgs_header)
 target_link_libraries(
     llrt
     PUBLIC
-        umd::device
+        umd::tt-umd
         TT::Metalium::HostDevCommon
     PRIVATE
         HAL::1xx

--- a/tt_metal/llrt/hal/tt-1xx/CMakeLists.txt
+++ b/tt_metal/llrt/hal/tt-1xx/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
         Tracy::TracyClient
         hw
         fmt::fmt-header-only
-        umd::device
+        umd::tt-umd
         TT::STL
         tt-logger::tt-logger
 )
@@ -44,7 +44,7 @@ target_link_libraries(
         Tracy::TracyClient
         hw
         fmt::fmt-header-only
-        umd::device
+        umd::tt-umd
         TT::STL
         tt-logger::tt-logger
 )
@@ -61,7 +61,7 @@ target_link_libraries(
     PRIVATE
         fmt::fmt-header-only
         hw
-        umd::device
+        umd::tt-umd
         TT::STL
         tt-logger::tt-logger
 )

--- a/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
+++ b/tt_metal/llrt/hal/tt-2xx/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
         Tracy::TracyClient
         hw
         fmt::fmt-header-only
-        umd::device
+        umd::tt-umd
         TT::STL
         tt-logger::tt-logger
 )
@@ -37,7 +37,7 @@ target_link_libraries(
     PRIVATE
         fmt::fmt-header-only
         hw
-        umd::device
+        umd::tt-umd
         TT::STL
         tt-logger::tt-logger
 )


### PR DESCRIPTION
### Ticket
/

### Problem description
Rename UMD CMake target from umd::device to umd::tt-umd.
umd::device is now an alias which will be removed in the future. The purpose of this change on UMD's side is to have a precise target and output artifact name when packaging (libtt-umd.so instead of libdevice.so).

### What's changed
- Changed all occurences of umd::device in CMake files to use umd::tt-umd, the new name of the UMD CMake target.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aleksamarkovic/rename_umd)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aleksamarkovic/rename_umd)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aleksamarkovic/rename_umd)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aleksamarkovic/rename_umd)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aleksamarkovic/rename_umd)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aleksamarkovic/rename_umd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aleksamarkovic/rename_umd)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
