### PR TITLE
Fix hosts for deepseek multihost tests

### DIFF
--- a/tests/scripts/multihost/run_dual_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_dual_galaxy_tests.sh
@@ -17,11 +17,15 @@ run_dual_galaxy_unit_tests() {
   # tt-run --tcp-interface handles the extra mpi_run args
   local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile"
   local tcp_interface="cnx1"
-  local mpi_args="--host g02glx01,g02glx02 $mpi_args_base"
-  local mpi_args_reversed="--host g02glx02,g02glx01 $mpi_args_base"
+  # heuristic to extract only 2 first hosts from the hostfile
+  local hosts="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
+  local reversed_hosts="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | tac | paste -sd,)"
+
+  local mpi_args="--host $hosts $mpi_args_base"
+  local mpi_args_reversed="--host $reversed_hosts $mpi_args_base"
 
   local mpirun_args_base="$mpi_args_base --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
-  local mpirun_args="--host g02glx01,g02glx02 $mpirun_args_base"
+  local mpirun_args="--host $hosts $mpirun_args_base"
   local rank_binding="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
 
   mpirun-ulfm $mpirun_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -66,7 +66,8 @@ _resolve_deepseekv3_cache() {
 
 setup_dual_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
-    export HOSTS="g02glx01,g02glx02"
+    # heuristic to extract only 2 first hosts from the hostfile
+    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 2 | paste -sd,)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
     export TCP_INTERFACE="cnx1"
@@ -92,7 +93,8 @@ setup_dual_galaxy_env() {
 
 setup_quad_galaxy_env() {
     export RANK_BINDING_YAML="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
-    export HOSTS="g05glx04,g05glx03,g05glx02,g05glx01"
+    # heuristic to extract only 4 first hosts from the hostfile
+    export HOSTS="$(awk '!/^#/ && NF {print $1}' /etc/mpirun/hostfile | head -n 4 | paste -sd,)"
     export RANKFILE=/etc/mpirun/rankfile
     export MPI_ARGS="--host $HOSTS --map-by rankfile:file=$RANKFILE --bind-to none --output-filename logs/mpi_job"
     export TCP_INTERFACE="cnx1"


### PR DESCRIPTION
### Problem description
Deepseek multihost tests have hardcoded hosts as g02glx01,g02glx02 and it fails when it assigns to other machine [e.g. g05glx01 here](https://github.com/tenstorrent/tt-metal/actions/runs/23934373854/job/69808281563)

### What's changed
Created heuristic to extract first 2 (for dual) and first 4 for quad hosts from /etc/mpirun/hostfile

### Checklist

- [X] [Deepseek multi-host dual](https://github.com/tenstorrent/tt-metal/actions/runs/23943046144) - Hang is not related to changes, hosts were assigned correctly
- [ ] [Multi-host deployment dual](https://github.com/tenstorrent/tt-metal/actions/runs/23944215731) - Seems like g05glx01-02 is not healthy, hosts were assigned correctly