### PR TITLE
ds_prefill(Add TtParallelEmbedding)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -52,17 +52,16 @@ def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):
 
     sp_factor = mesh_device.shape[0]
     tp_factor = mesh_device.shape[1]
-    seq_per_chip = isl_per_chip
 
     signpost(f"embedding-{mesh_device.shape}-isl_per_chip{isl_per_chip}-v{vocab_size}-e{emb_dim}")
 
     logger.debug(
-        f"Config: {mesh_device.shape=}, {sp_factor=}, {tp_factor=}, " f"{seq_per_chip=}, {vocab_size=}, {emb_dim=}"
+        f"Config: {mesh_device.shape=}, {sp_factor=}, {tp_factor=}, " f"{isl_per_chip=}, {vocab_size=}, {emb_dim=}"
     )
 
     assert (
-        seq_per_chip % ttnn.TILE_SIZE == 0
-    ), f"isl_per_chip ({seq_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
+        isl_per_chip % ttnn.TILE_SIZE == 0
+    ), f"isl_per_chip ({isl_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
     assert emb_dim % tp_factor == 0, f"emb_dim ({emb_dim}) must be divisible by tp_factor ({tp_factor})"
 
     ttnn.visualize_mesh_device(mesh_device)
@@ -73,10 +72,10 @@ def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):
     torch.manual_seed(42)
     torch_weight = torch.randn(vocab_size, emb_dim, dtype=torch.float32)
 
-    # Tokens shaped as [sp_factor, 1, seq_per_chip] — one chunk per SP device
-    torch_tokens = torch.randint(0, vocab_size, (sp_factor, 1, seq_per_chip))
+    # Tokens shaped as [sp_factor, 1, isl_per_chip] — one chunk per SP device
+    torch_tokens = torch.randint(0, vocab_size, (sp_factor, 1, isl_per_chip))
 
-    # Reference output: [sp_factor, 1, seq_per_chip, emb_dim]
+    # Reference output: [sp_factor, 1, isl_per_chip, emb_dim]
     torch_output = F.embedding(torch_tokens, torch_weight)
     logger.debug(f"Torch reference output: {torch_output.shape}")
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -55,7 +55,7 @@ def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):
     seq_per_chip = isl_per_chip
     seq_len = isl_per_chip * sp_factor
 
-    signpost(f"embedding-{mesh_device.shape}-seq{seq_len}-v{vocab_size}-e{emb_dim}")
+    signpost(f"embedding-{mesh_device.shape}-isl_per_chip{isl_per_chip}-v{vocab_size}-e{emb_dim}")
 
     logger.debug(
         f"Config: {mesh_device.shape=}, {sp_factor=}, {tp_factor=}, " f"{seq_per_chip=}, {vocab_size=}, {emb_dim=}"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test for TtParallelEmbedding module.
+
+Verifies that the TTNN parallel embedding produces the same output as
+torch.nn.functional.embedding for SP+TP distributed configurations.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
+from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from tests.ttnn.utils_for_testing import comp_pcc
+
+
+@pytest.mark.parametrize(
+    "seq_len, vocab_size, emb_dim",
+    [
+        (128, 1024, 256),
+        (512, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
+    ],
+    ids=["small", "deepseek"],
+)
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (1, 4),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
+            id="linear-4",
+        ),
+        pytest.param(
+            (2, 4),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="mesh-2x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_parallel_embedding(mesh_device, seq_len, vocab_size, emb_dim):
+    """Test TtParallelEmbedding against torch reference."""
+
+    sp_factor = mesh_device.shape[0]
+    tp_factor = mesh_device.shape[1]
+    seq_per_chip = seq_len // sp_factor
+
+    signpost(f"embedding-{mesh_device.shape}-seq{seq_len}-v{vocab_size}-e{emb_dim}")
+
+    logger.debug(
+        f"Config: {mesh_device.shape=}, {sp_factor=}, {tp_factor=}, " f"{seq_per_chip=}, {vocab_size=}, {emb_dim=}"
+    )
+
+    assert seq_len % sp_factor == 0, f"seq_len ({seq_len}) must be divisible by sp_factor ({sp_factor})"
+    assert (
+        seq_per_chip % ttnn.TILE_SIZE == 0
+    ), f"seq_per_chip ({seq_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
+    assert emb_dim % tp_factor == 0, f"emb_dim ({emb_dim}) must be divisible by tp_factor ({tp_factor})"
+
+    ttnn.visualize_mesh_device(mesh_device)
+
+    # ========================================
+    # Reference: torch embedding
+    # ========================================
+    torch.manual_seed(42)
+    torch_weight = torch.randn(vocab_size, emb_dim, dtype=torch.float32)
+
+    # Tokens shaped as [sp_factor, 1, seq_per_chip] — one chunk per SP device
+    torch_tokens = torch.randint(0, vocab_size, (sp_factor, 1, seq_per_chip))
+
+    # Reference output: [sp_factor, 1, seq_per_chip, emb_dim]
+    torch_output = F.embedding(torch_tokens, torch_weight)
+    logger.debug(f"Torch reference output: {torch_output.shape}")
+
+    # ========================================
+    # TTNN: create module and shard inputs
+    # ========================================
+    tt_emb = TtParallelEmbedding(
+        mesh_device=mesh_device,
+        vocab_size=vocab_size,
+        emb_dim=emb_dim,
+        torch_weight=torch_weight,
+    )
+
+    # Shard tokens: dim 0 across SP axis (rows), replicate across TP axis (cols)
+    token_mapper = ttnn.ShardTensor2dMesh(
+        mesh_device,
+        mesh_shape=mesh_device.shape,
+        dims=(0, None),
+    )
+    tt_tokens = ttnn.from_torch(
+        torch_tokens,
+        mesh_mapper=token_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.uint32,
+    )
+    logger.debug(f"TT tokens shape: {tt_tokens.shape}")
+
+    # ========================================
+    # Forward
+    # ========================================
+    tt_output = tt_emb(tt_tokens)
+    logger.debug(f"TT output shape: {tt_output.shape}")
+
+    # ========================================
+    # Compose back to host and compare
+    # ========================================
+    composer = get_tp_mesh_composer(mesh_device)
+    tt_host = ttnn.to_torch(tt_output, mesh_composer=composer, dtype=torch.bfloat16)
+    logger.debug(f"TT host output shape: {tt_host.shape}")
+
+    threshold = 0.999
+    _, pcc = comp_pcc(torch_output.float(), tt_host.float())
+    logger.debug(f"PCC: {pcc:.6f} (threshold: {threshold})")
+
+    assert pcc > threshold, f"PCC {pcc:.6f} below threshold {threshold}"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -23,12 +23,11 @@ from tests.ttnn.utils_for_testing import comp_pcc
 
 
 @pytest.mark.parametrize(
-    "seq_len, vocab_size, emb_dim",
+    "isl_per_chip, vocab_size, emb_dim",
     [
-        (128, 1024, 256),
-        (512, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
+        (3200, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
     ],
-    ids=["small", "deepseek"],
+    ids=["deepseek_prefill_100K"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
@@ -48,12 +47,13 @@ from tests.ttnn.utils_for_testing import comp_pcc
     ],
     indirect=["mesh_device", "device_params"],
 )
-def test_parallel_embedding(mesh_device, seq_len, vocab_size, emb_dim):
+def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):
     """Test TtParallelEmbedding against torch reference."""
 
     sp_factor = mesh_device.shape[0]
     tp_factor = mesh_device.shape[1]
-    seq_per_chip = seq_len // sp_factor
+    seq_per_chip = isl_per_chip
+    seq_len = isl_per_chip * sp_factor
 
     signpost(f"embedding-{mesh_device.shape}-seq{seq_len}-v{vocab_size}-e{emb_dim}")
 
@@ -61,10 +61,9 @@ def test_parallel_embedding(mesh_device, seq_len, vocab_size, emb_dim):
         f"Config: {mesh_device.shape=}, {sp_factor=}, {tp_factor=}, " f"{seq_per_chip=}, {vocab_size=}, {emb_dim=}"
     )
 
-    assert seq_len % sp_factor == 0, f"seq_len ({seq_len}) must be divisible by sp_factor ({sp_factor})"
     assert (
         seq_per_chip % ttnn.TILE_SIZE == 0
-    ), f"seq_per_chip ({seq_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
+    ), f"isl_per_chip ({seq_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
     assert emb_dim % tp_factor == 0, f"emb_dim ({emb_dim}) must be divisible by tp_factor ({tp_factor})"
 
     ttnn.visualize_mesh_device(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -53,7 +53,6 @@ def test_parallel_embedding(mesh_device, isl_per_chip, vocab_size, emb_dim):
     sp_factor = mesh_device.shape[0]
     tp_factor = mesh_device.shape[1]
     seq_per_chip = isl_per_chip
-    seq_len = isl_per_chip * sp_factor
 
     signpost(f"embedding-{mesh_device.shape}-isl_per_chip{isl_per_chip}-v{vocab_size}-e{emb_dim}")
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN implementation of Parallel Embedding for DeepSeek V3 prefill.
+
+Sequence-parallel and tensor-parallel embedding that converts token IDs
+into hidden representations distributed across a 2D mesh.
+
+Weight Sharding:
+    - Replicated across SP axis (mesh rows) — each SP device has full vocab
+    - Sharded on emb_dim across TP axis (mesh columns)
+    - Each device stores [vocab_size, emb_dim / tp_factor]
+
+Forward:
+    Input:  token_ids [1, 1, seq_len_per_chip] (SP-sharded by caller)
+    Output: embeddings [1, 1, seq_len_per_chip, emb_dim / tp_factor] TILE_LAYOUT
+"""
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+
+
+class TtParallelEmbedding(LightweightModule):
+    """
+    SP+TP parallel embedding for DeepSeek V3 prefill.
+
+    No CCL operations are needed inside this module:
+    - TP sharding: each device does an independent lookup on its weight slice
+    - SP sharding: each device processes its own token chunk
+    """
+
+    def __init__(
+        self,
+        mesh_device: ttnn.MeshDevice,
+        vocab_size: int = DeepSeekV3Config.VOCAB_SIZE,
+        emb_dim: int = DeepSeekV3Config.EMB_SIZE,
+        torch_weight: torch.Tensor = None,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        dtype: ttnn.DataType = ttnn.bfloat16,
+    ):
+        """
+        Initialize parallel embedding module.
+
+        Args:
+            mesh_device: TTNN mesh device
+            vocab_size: Vocabulary size (default: 129280)
+            emb_dim: Embedding dimension (default: 7168)
+            torch_weight: Optional weight tensor [vocab_size, emb_dim].
+                          If None, creates random weight for testing.
+            sp_axis: Mesh axis for sequence parallelism (default: 0, rows)
+            tp_axis: Mesh axis for tensor parallelism (default: 1, columns)
+            dtype: Weight data type (default: bfloat16)
+        """
+        super().__init__()
+        self.mesh_device = mesh_device
+        self.vocab_size = vocab_size
+        self.emb_dim = emb_dim
+        self.sp_axis = sp_axis
+        self.tp_axis = tp_axis
+        self.dtype = dtype
+
+        tp_factor = mesh_device.shape[tp_axis]
+        assert emb_dim % tp_factor == 0, f"emb_dim ({emb_dim}) must be divisible by tp_factor ({tp_factor})"
+
+        logger.debug(
+            f"Initializing TtParallelEmbedding: vocab_size={vocab_size}, emb_dim={emb_dim}, "
+            f"mesh_shape={mesh_device.shape}, tp_factor={tp_factor}"
+        )
+
+        if torch_weight is not None:
+            self.weight = self._create_weight_from_torch(torch_weight)
+        else:
+            self.weight = self._create_random_weight()
+
+    def _create_weight_from_torch(self, torch_weight: torch.Tensor) -> ttnn.Tensor:
+        """
+        Convert torch embedding weight to TP-sharded ttnn tensor.
+
+        Unlike linear layers, embedding weight does NOT need transposition.
+        HuggingFace format [vocab_size, emb_dim] matches TTNN lookup table format.
+
+        Args:
+            torch_weight: [vocab_size, emb_dim]
+
+        Returns:
+            Sharded ttnn tensor: each TP device gets [vocab_size, emb_dim / tp_factor]
+        """
+        assert torch_weight.shape == (self.vocab_size, self.emb_dim), (
+            f"Weight shape mismatch: got {torch_weight.shape}, " f"expected ({self.vocab_size}, {self.emb_dim})"
+        )
+
+        shard_dims = [None, None]
+        shard_dims[self.tp_axis] = -1  # shard emb_dim across TP axis
+
+        mesh_mapper = ttnn.ShardTensor2dMesh(
+            self.mesh_device,
+            mesh_shape=self.mesh_device.shape,
+            dims=tuple(shard_dims),
+        )
+
+        tt_weight = ttnn.from_torch(
+            torch_weight,
+            mesh_mapper=mesh_mapper,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.mesh_device,
+            dtype=self.dtype,
+        )
+
+        logger.debug(f"Created sharded weight: {tt_weight.shape}")
+        return tt_weight
+
+    def _create_random_weight(self) -> ttnn.Tensor:
+        """Create random sharded weight for testing."""
+        torch_weight = torch.randn(self.vocab_size, self.emb_dim, dtype=torch.float32)
+        return self._create_weight_from_torch(torch_weight)
+
+    def forward(self, token_ids: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Embedding lookup producing TP-sharded output.
+
+        Args:
+            token_ids: [1, 1, seq_len_per_chip] uint32, already SP-sharded by caller.
+                       seq_len_per_chip must be a multiple of TILE_SIZE (32).
+
+        Returns:
+            embeddings: [1, 1, seq_len_per_chip, emb_dim / tp_factor] TILE_LAYOUT
+        """
+        seq_len = token_ids.shape[-1]
+        assert seq_len % ttnn.TILE_SIZE == 0, (
+            f"seq_len ({seq_len}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE}). "
+            f"Pad input before calling forward."
+        )
+
+        logger.debug(f"Forward: token_ids shape={token_ids.shape}")
+
+        embeddings = ttnn.embedding(
+            token_ids,
+            self.weight,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        logger.debug(f"Output: embeddings shape={embeddings.shape}")
+        return embeddings


### PR DESCRIPTION
### Ticket
Related to DeepSeek V3 prefill implementation (#2603)

### Problem description
The DeepSeek V3 prefill pipeline needs a parallel embedding layer that converts token IDs into hidden representations distributed across a 2D mesh (SP + TP).

### What's changed
Add `TtParallelEmbedding` module and PCC test:

- **`tt_parallel_embedding.py`**: `LightweightModule` that shards embedding weight on `emb_dim` across TP axis (mesh cols) and replicates across SP axis (mesh rows). Each device does an independent lookup on its weight slice — no CCL needed. Output: `[1, 1, isl_per_chip, emb_dim/tp_factor]` TILE_LAYOUT.
- **`test_parallel_embedding.py`**: PCC test comparing against `torch.nn.functional.embedding` with small and production-scale (vocab=129280, emb=7168) configs on linear-4 and mesh-2x4 topologies. Threshold: 0.999. Signpost label and all internal variables use `isl_per_chip` to identify per-chip sequence length.

<img src="https://github.com/user-attachments/assets/9251a13f-2841-4501-b8d1-0be1df59e737">

### Checklist



- [x] <a href="https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2603-tok-emb-layer"> <img src="https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-tok-emb-layer"></a>
- [x] <a href="https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2603-tok-emb-layer"> <img src="https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-tok-emb-layer"></a>
- [x] <a href="https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2603-tok-emb-layer"> <img src="https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2603-tok-emb-layer"></a>
- [x] <a href="https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2603-tok-emb-layer"> <img src="https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2603-tok-emb-layer"></a> ⚠️ waiver: wan failing irrelevant; 