### PR TITLE
[skip ci] ci: parallelize L2 nightly eltwise tests via matrix strategy

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -676,7 +676,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ttnn nightly eltwise tests group ${{ matrix.group }}
         timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group ${{ matrix.group }} -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -636,6 +636,10 @@ jobs:
 
   ttnn-eltwise-tests:
     if: ${{ inputs.run_eltwise_tests }}
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
@@ -652,7 +656,7 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    name: ttnn nightly eltwise tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    name: ttnn nightly eltwise tests group ${{ matrix.group }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
         ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
@@ -670,21 +674,9 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: ttnn nightly eltwise tests group 1
+      - name: ttnn nightly eltwise tests group ${{ matrix.group }}
         timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 1  -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
-      - name: ttnn nightly eltwise tests group 2
-        if: ${{ !cancelled() }}
-        timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 2  -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
-      - name: ttnn nightly eltwise tests group 3
-        if: ${{ !cancelled() }}
-        timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 3  -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
-      - name: ttnn nightly eltwise tests group 4
-        if: ${{ !cancelled() }}
-        timeout-minutes: ${{ inputs.timeout }}
-        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 4  -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
Parallelize the L2 nightly eltwise test groups to run on separate runners instead of sequentially on one.

### Problem
The 4 pytest-split groups currently run **sequentially** in a single job, taking ~72 min on N300:
- Group 1: ~30 min
- Group 2: ~9 min
- Group 3: ~9 min
- Group 4: ~17 min

### Solution
Convert the 4 sequential steps to a **matrix strategy** with `group: [1, 2, 3, 4]`, so each group gets its own runner and runs in parallel.

### Expected impact
- **Wall-clock time**: ~72 min → ~30 min (limited by Group 1, the heaviest)
- **Runner cost**: 4× more runners, but same total compute time

## CI
| Workflow | Run |
|----------|-----|
| L2 Nightly (eltwise) | [run](https://github.com/tenstorrent/tt-metal/actions/runs/23945964605) |

## Test plan
- [ ] Trigger L2 nightly on this branch and verify all 4 groups run in parallel
- [ ] Verify all groups pass independently
- [ ] Compare wall-clock time vs sequential baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)