### PR TITLE
Added mesh_mapper parameter to ttnn.empty op

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_creation.py
@@ -436,6 +436,95 @@ def test_empty_multi_device(mesh_device, input_shapes):
 @pytest.mark.parametrize(
     "input_shapes",
     [
+        [1, 1, 32, 32],
+        [2, 640, 64, 64],
+    ],
+)
+def test_empty_with_mesh_mapper_replicate(mesh_device, input_shapes):
+    # Reference
+    torch_ref = torch.ones(input_shapes, dtype=torch.bfloat16)
+    ref_tensor = ttnn.from_torch(
+        torch_ref,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    # TTNN empty
+    output_tensor = ttnn.empty(
+        input_shapes,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    assert output_tensor.tensor_topology() == ref_tensor.tensor_topology()
+
+    # Each device shard should have the full shape (replicated)
+    shards = ttnn.get_device_tensors(output_tensor)
+    for shard in shards:
+        assert list(shard.shape) == input_shapes
+
+
+@pytest.mark.parametrize(
+    "input_shapes, dims",
+    [
+        ([4, 4, 32, 32], (0, 1)),
+        ([4, 8, 64, 64], (0, 2)),
+    ],
+)
+def test_empty_with_mesh_mapper_shard(mesh_device, input_shapes, dims):
+    mesh_shape = mesh_device.shape
+
+    # Reference
+    torch_ref = torch.ones(input_shapes, dtype=torch.bfloat16)
+    ref_tensor = ttnn.from_torch(
+        torch_ref,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            mesh_shape=mesh_shape,
+            dims=dims,
+        ),
+    )
+
+    # TTNN empty
+    output_tensor = ttnn.empty(
+        input_shapes,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            mesh_shape=mesh_shape,
+            dims=dims,
+        ),
+    )
+
+    assert output_tensor.tensor_topology() == ref_tensor.tensor_topology()
+
+    # Compute expected shard shape: each dims entry shards the corresponding tensor dim
+    # by the corresponding mesh dimension size
+    expected_shard_shape = list(input_shapes)
+    expected_shard_shape[dims[0]] //= mesh_shape[0]
+    expected_shard_shape[dims[1]] //= mesh_shape[1]
+
+    shards = ttnn.get_device_tensors(output_tensor)
+    for shard in shards:
+        assert list(shard.shape) == expected_shard_shape
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
         [2, 1, 4, 4],
         [2, 1280, 8, 8],
         [2, 640, 16, 16],

--- a/ttnn/cpp/ttnn/operations/creation/creation.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include <ttnn/distributed/tensor_topology.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace ttnn {
 
@@ -292,8 +294,53 @@ Tensor empty(
     const DataType& dtype,
     const Layout& layout,
     MeshDevice* device,
-    const MemoryConfig& memory_config) {
-    return create_device_tensor(TensorSpec(shape, TensorLayout(dtype, PageConfig(layout), memory_config)), device);
+    const MemoryConfig& memory_config,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mesh_mapper) {
+    if (!mesh_mapper.has_value()) {
+        return create_device_tensor(TensorSpec(shape, TensorLayout(dtype, PageConfig(layout), memory_config)), device);
+    }
+
+    const auto& config = mesh_mapper.value();
+    auto mesh_shape = config.mesh_shape_override.value_or(device->shape());
+    TT_FATAL(
+        config.placements.size() == mesh_shape.dims(),
+        "ttnn::empty: placements size ({}) must match mesh dimensions ({})",
+        config.placements.size(),
+        mesh_shape.dims());
+
+    // Compute per-device shard shape
+    ttnn::Shape::Container shard_dims(shape.view().begin(), shape.view().end());
+    for (size_t i = 0; i < config.placements.size() && i < mesh_shape.dims(); ++i) {
+        if (const auto* shard =
+                std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&config.placements[i])) {
+            auto dim = static_cast<size_t>(shard->dim);
+            TT_FATAL(
+                dim < shard_dims.size(),
+                "ttnn::empty: MeshMapperConfig shard dim {} exceeds tensor rank {}",
+                dim,
+                shard_dims.size());
+            TT_FATAL(
+                shard_dims[dim] % mesh_shape[i] == 0,
+                "ttnn::empty: shape[{}]={} is not divisible by mesh dimension size {}",
+                dim,
+                shard_dims[dim],
+                mesh_shape[i]);
+            shard_dims[dim] /= mesh_shape[i];
+        }
+    }
+    ttnn::Shape device_shape(std::move(shard_dims));
+
+    std::vector<tt::tt_metal::distributed::MeshCoordinate> coords;
+    coords.reserve(mesh_shape.mesh_size());
+    tt::tt_metal::distributed::MeshShape physical_mesh_shape =
+        mesh_shape.dims() == 1 ? tt::tt_metal::distributed::MeshShape(1, mesh_shape[0]) : mesh_shape;
+    for (const auto& coord : tt::tt_metal::distributed::MeshCoordinateRange(physical_mesh_shape)) {
+        coords.push_back(coord);
+    }
+
+    tt::tt_metal::TensorTopology topology(mesh_shape, config.placements, coords);
+    return create_device_tensor(
+        TensorSpec(device_shape, TensorLayout(dtype, PageConfig(layout), memory_config)), device, std::move(topology));
 }
 
 template <typename BufferType>

--- a/ttnn/cpp/ttnn/operations/creation/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation.hpp
@@ -12,6 +12,7 @@
 #include "ttnn/types.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/types.hpp"
+#include <ttnn/distributed/distributed_configs.hpp>
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -52,7 +53,8 @@ Tensor empty(
     const DataType& dtype,
     const Layout& layout,
     MeshDevice* device,
-    const MemoryConfig& memory_config);
+    const MemoryConfig& memory_config,
+    const std::optional<tt::tt_metal::distributed::MeshMapperConfig>& mesh_mapper = std::nullopt);
 
 template <typename BufferType>
 Tensor from_buffer(

--- a/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/creation/creation_nanobind.cpp
@@ -22,6 +22,7 @@
 #include "ttnn-nanobind/types.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <ttnn/distributed/distributed_tensor.hpp>
 
 namespace ttnn::operations::creation {
 namespace {
@@ -414,8 +415,19 @@ Tensor empty_impl(
     const DataType& dtype,
     const Layout& layout,
     MeshDevice* device,
-    const MemoryConfig& memory_config) {
-    return ttnn::empty(ttnn::Shape{shape}, dtype, layout, device, memory_config);
+    const MemoryConfig& memory_config,
+    const nb::object& mesh_mapper) {
+    std::optional<tt::tt_metal::distributed::MeshMapperConfig> config = std::nullopt;
+    if (!mesh_mapper.is_none()) {
+        // Handle ReplicateTensorToMeshWrapper by calling .unwrap()
+        nb::object mapper_obj = mesh_mapper;
+        if (nb::hasattr(mesh_mapper, "unwrap")) {
+            mapper_obj = mesh_mapper.attr("unwrap")();
+        }
+        auto* mapper = nb::cast<ttnn::distributed::TensorToMesh*>(mapper_obj);
+        config = mapper->config();
+    }
+    return ttnn::empty(ttnn::Shape{shape}, dtype, layout, device, memory_config, config);
 }
 
 // Helper function to bind empty operation
@@ -429,6 +441,9 @@ void bind_empty(nb::module_& mod) {
             layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR`.
             device (ttnn.Device | ttnn.MeshDevice): The device where the tensor will be allocated.
             memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+            mesh_mapper (ttnn.TensorToMesh, optional): The mesh mapper for distributing the tensor across devices.
+                Use ``ttnn.ReplicateTensorToMesh(mesh_device)`` to replicate, or
+                ``ttnn.ShardTensorToMesh(mesh_device, dims)`` to shard. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: The output uninitialized tensor.
@@ -453,7 +468,8 @@ void bind_empty(nb::module_& mod) {
         nb::arg("dtype") = DataType::BFLOAT16,
         nb::arg("layout") = Layout::ROW_MAJOR,
         nb::arg("device"),
-        nb::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG);
+        nb::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG,
+        nb::arg("mesh_mapper") = nb::none());
 }
 
 Tensor empty_like_impl(


### PR DESCRIPTION
### Problem description
In case of multi device tensors, `tensor_topology` was always set to its default value `Replicate`  in case of `ttnn.empty` which limited the op's flexibility.

### What's changed
Now, new attribute was added to `ttnn.empty` op that enables custom `mesh_mapper` config to be passed.

### Checklist
- [ ] [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/runs/23947613001)
- [ ] [TT-metal L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/23947635337)