### PR TITLE
Improve cumsum accuracy

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -117,6 +117,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
   - tests/ttnn/unit_tests/operations/reduce/test_manual_seed.py
   - tests/ttnn/unit_tests/operations/reduce/test_sum.py
+  - tests/ttnn/unit_tests/operations/reduce/test_intimg.py
 
 blackhole:
   # Multi-chip/CCL tests - require multi-device support
@@ -159,6 +160,7 @@ blackhole:
   - tests/ttnn/unit_tests/operations/reduce/test_moe.py
   - tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
   - tests/ttnn/unit_tests/operations/reduce/test_sum.py
+  - tests/ttnn/unit_tests/operations/reduce/test_intimg.py
 
   # Skipping due to CI failure - issue #41286
   - tests/ttnn/unit_tests/operations/fused/test_rms_norm.py::test_rms_norm_row_major

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -46,16 +46,14 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
 )
 def test_cumprod_normal(dim, shape, dtypes, device):
     torch.manual_seed(0)
-    torch_dtype, ttnn_output_dtype = dtypes
-
     if dim < len(shape) and -len(shape) <= dim:
         for _ in range(2):
-            torch_input_tensor = torch.randn(shape, dtype=torch_dtype)
+            torch_input_tensor = torch.randn(shape, dtype=dtypes[0])
             torch_result_tensor = torch.cumprod(torch_input_tensor, dim)
             ttnn_input_tensor = ttnn.from_torch(
                 torch_input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
             )
-            ttnn_result_tensor = ttnn.cumprod(ttnn_input_tensor, dim, dtype=ttnn_output_dtype)
+            ttnn_result_tensor = ttnn.cumprod(ttnn_input_tensor, dim, dtype=dtypes[1])
 
             # assert metadata
             assert ttnn_input_tensor.shape == ttnn_result_tensor.shape
@@ -74,7 +72,6 @@ def test_cumprod_normal(dim, shape, dtypes, device):
                 rtol = 0.03
                 atol = 1.04
                 frobenius_threshold = 0.01
-
             # test for equivalance
             assert_numeric_metrics(
                 torch_result_tensor,

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -46,14 +46,16 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
 )
 def test_cumprod_normal(dim, shape, dtypes, device):
     torch.manual_seed(0)
+    torch_dtype, ttnn_output_dtype = dtypes
+
     if dim < len(shape) and -len(shape) <= dim:
         for _ in range(2):
-            torch_input_tensor = torch.randn(shape, dtype=dtypes[0])
+            torch_input_tensor = torch.randn(shape, dtype=torch_dtype)
             torch_result_tensor = torch.cumprod(torch_input_tensor, dim)
             ttnn_input_tensor = ttnn.from_torch(
                 torch_input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
             )
-            ttnn_result_tensor = ttnn.cumprod(ttnn_input_tensor, dim, dtype=dtypes[1])
+            ttnn_result_tensor = ttnn.cumprod(ttnn_input_tensor, dim, dtype=ttnn_output_dtype)
 
             # assert metadata
             assert ttnn_input_tensor.shape == ttnn_result_tensor.shape
@@ -72,6 +74,7 @@ def test_cumprod_normal(dim, shape, dtypes, device):
                 rtol = 0.03
                 atol = 1.04
                 frobenius_threshold = 0.01
+
             # test for equivalance
             assert_numeric_metrics(
                 torch_result_tensor,

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -26,11 +26,6 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
 def is_supported(shape, dim, ttnn_dtype):
     tensor_rank = len(shape)
 
-    if dim < tensor_rank:
-        accumulation_length = shape[dim]
-        if ttnn_dtype == ttnn.bfloat16 and accumulation_length > 10000:
-            return False  # for bfloat16, accumulation errors can happen easily on long tensor
-
     return True
 
 
@@ -41,7 +36,8 @@ def is_supported(shape, dim, ttnn_dtype):
         ([1], 0),
         ([2, 3], 0),
         ([2, 3], -1),
-        ([1, 1024, 32], 0),
+        # ([1, 1024, 32], 0),
+        ([1, 64, 32], 0),
         ([33, 35, 37], -1),
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
@@ -60,12 +56,14 @@ def test_cumsum(size, dim, dtypes, device):
     torch.manual_seed(29112024)
 
     (torch_dtype, ttnn_dtype) = dtypes
+    torch.set_printoptions(threshold=10_000)
 
     # Generate integer input on [-2; 2];
     # by generating around 0, this avoids FP-related issues when adding large sums with small inputs
     # which are not handled yet
     for _ in range(2):
-        torch_input_tensor = torch.randint(-2, 3, size=size, dtype=torch_dtype)
+        torch_input_tensor = torch.full(size, 1, dtype=torch_dtype)
+        # torch_input_tensor = torch.randint(-2, 3, size=size, dtype=torch_dtype)
         input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.Layout.TILE)
 
         expected_output_dtype = ttnn_dtype if ttnn_dtype is not None else input_tensor.dtype
@@ -81,6 +79,9 @@ def test_cumsum(size, dim, dtypes, device):
         torch_output = ttnn.to_torch(output_tensor, dtype=torch_dtype)
 
         expected_output = torch.cumsum(torch_input_tensor, dim=dim, dtype=torch_dtype)
+
+        print(f"calculated = \n{torch_output}")
+        print(f"expected   =\n{expected_output}")
 
         if torch_output.numel() > 0:
             # test for equivalance

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
 def get_backward_tensors(output_grad_shape, input_grad_shape, device):
@@ -23,12 +23,6 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
     return tt_output_grad, tt_input_grad, torch_output_grad
 
 
-def is_supported(shape, dim, ttnn_dtype):
-    tensor_rank = len(shape)
-
-    return True
-
-
 @pytest.mark.parametrize(
     "size, dim",
     [
@@ -36,7 +30,7 @@ def is_supported(shape, dim, ttnn_dtype):
         ([1], 0),
         ([2, 3], 0),
         ([2, 3], -1),
-        # ([1, 1024, 32], 0),
+        ([1, 1024, 32], 0),
         ([1, 64, 32], 0),
         ([33, 35, 37], -1),
         ([7, 13, 129, 33], 1),
@@ -45,6 +39,7 @@ def is_supported(shape, dim, ttnn_dtype):
         ([19], -1),
         ([1, 19], -1),
         ([1, 151936], -1),
+        ([1, 2**17], -1),
         ([5], -1),
     ],
 )
@@ -56,20 +51,15 @@ def test_cumsum(size, dim, dtypes, device):
     torch.manual_seed(29112024)
 
     (torch_dtype, ttnn_dtype) = dtypes
-    torch.set_printoptions(threshold=10_000)
 
     # Generate integer input on [-2; 2];
     # by generating around 0, this avoids FP-related issues when adding large sums with small inputs
     # which are not handled yet
     for _ in range(2):
-        torch_input_tensor = torch.full(size, 1, dtype=torch_dtype)
-        # torch_input_tensor = torch.randint(-2, 3, size=size, dtype=torch_dtype)
+        torch_input_tensor = torch.randint(-2, 3, size=size, dtype=torch_dtype)
         input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.Layout.TILE)
 
         expected_output_dtype = ttnn_dtype if ttnn_dtype is not None else input_tensor.dtype
-
-        if not is_supported(size, dim, expected_output_dtype):
-            pytest.skip("Unsupported configuration by ttnn.cumsum")
 
         output_tensor = ttnn.cumsum(input_tensor, dim=dim, dtype=ttnn_dtype)
 
@@ -80,19 +70,10 @@ def test_cumsum(size, dim, dtypes, device):
 
         expected_output = torch.cumsum(torch_input_tensor, dim=dim, dtype=torch_dtype)
 
-        print(f"calculated = \n{torch_output}")
-        print(f"expected   =\n{expected_output}")
-
-        if torch_output.numel() > 0:
-            # test for equivalance
-            assert_numeric_metrics(
-                expected_output,
-                torch_output,
-                pcc_threshold=0.9999,
-                rtol=1e-06,
-                atol=1e-06,
-                frobenius_threshold=1e-09,
-            )
+        if torch_dtype == torch.bfloat16:
+            assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
+        else:
+            assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -128,9 +109,6 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
 
     expected_output_dtype = ttnn_dtype if ttnn_dtype is not None else input_tensor.dtype
 
-    if not is_supported(size, dim, expected_output_dtype):
-        pytest.skip("Unsupported configuration by ttnn.cumsum")
-
     preallocated_output_tensor = ttnn.zeros_like(input_tensor, dtype=ttnn_dtype, layout=ttnn.Layout.TILE)
 
     output_tensor = ttnn.cumsum(input_tensor, dim=dim, dtype=ttnn_dtype, out=preallocated_output_tensor)
@@ -146,16 +124,10 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
 
     assert preallocated_output_tensor == output_tensor
 
-    if torch_output.numel() > 0:
-        # test for equivalance
-        assert_numeric_metrics(
-            expected_output,
-            torch_output,
-            pcc_threshold=0.9999,
-            rtol=1e-06,
-            atol=1e-06,
-            frobenius_threshold=1e-09,
-        )
+    if torch_dtype == torch.bfloat16:
+        assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
+    else:
+        assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
 
     assert device.num_program_cache_entries() >= 1
 
@@ -172,7 +144,7 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
         ([5, 2, 3, 5, 33, 128], 0),
-        # ([1, 151936], -1), # low pcc issue, https://github.com/tenstorrent/tt-metal/issues/40878
+        ([1, 151936], -1),  # low pcc issue, https://github.com/tenstorrent/tt-metal/issues/40878
     ],
 )
 @pytest.mark.parametrize(
@@ -204,16 +176,10 @@ def test_cumsum_backward(size, dim, dtypes, device):
     )
 
     assert tt_input_grad_cpu.shape == torch_input_tensor.grad.shape
-
-    # test for equivalance
-    assert_numeric_metrics(
-        torch_input_tensor.grad,
-        tt_input_grad_cpu,
-        pcc_threshold=0.999,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-    )
+    if torch_dtype == torch.bfloat16:
+        assert_with_ulp(tt_input_grad_cpu, tt_input_grad, ulp_threshold=1)
+    else:
+        assert_allclose(tt_input_grad_cpu, tt_input_grad, rtol=1e-2, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -145,7 +145,7 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
         ([5, 2, 3, 5, 33, 128], 0),
-        ([1, 151936], -1),  # low pcc issue, https://github.com/tenstorrent/tt-metal/issues/40878
+        ([1, 151936], -1),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -177,7 +177,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
     )
 
     assert tt_input_grad_cpu.shape == torch_input_tensor.grad.shape
-    assert_cumsum_quality(tt_input_grad_cpu, torch_input_tensor.grad)
+    assert_cumsum_quality(torch_input_tensor.grad, tt_input_grad_cpu)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -31,7 +31,6 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
         ([2, 3], 0),
         ([2, 3], -1),
         ([1, 1024, 32], 0),
-        ([1, 64, 32], 0),
         ([33, 35, 37], -1),
         ([7, 13, 129, 33], 1),
         ([2, 3, 5, 33, 128], -1),
@@ -39,7 +38,6 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
         ([19], -1),
         ([1, 19], -1),
         ([1, 151936], -1),
-        ([1, 2**17], -1),
         ([5], -1),
     ],
 )
@@ -177,9 +175,9 @@ def test_cumsum_backward(size, dim, dtypes, device):
 
     assert tt_input_grad_cpu.shape == torch_input_tensor.grad.shape
     if torch_dtype == torch.bfloat16:
-        assert_with_ulp(tt_input_grad_cpu, tt_input_grad, ulp_threshold=1)
+        assert_with_ulp(tt_input_grad_cpu, torch_input_tensor.grad, ulp_threshold=1)
     else:
-        assert_allclose(tt_input_grad_cpu, tt_input_grad, rtol=1e-2, atol=1e-6)
+        assert_allclose(tt_input_grad_cpu, torch_input_tensor.grad, rtol=1e-2, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -6,7 +6,16 @@ import torch
 import pytest
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
+from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose, assert_equal
+
+
+def assert_cumsum_quality(expected_output, torch_output):
+    if torch_output.dtype == torch.int32:
+        assert_equal(expected_output, torch_output)
+    elif torch_output.dtype == torch.bfloat16:
+        assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
+    else:
+        assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
 
 
 def get_backward_tensors(output_grad_shape, input_grad_shape, device):
@@ -68,10 +77,7 @@ def test_cumsum(size, dim, dtypes, device):
 
         expected_output = torch.cumsum(torch_input_tensor, dim=dim, dtype=torch_dtype)
 
-        if torch_dtype == torch.bfloat16:
-            assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
-        else:
-            assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
+        assert_cumsum_quality(expected_output, torch_output)
 
 
 @pytest.mark.parametrize(
@@ -122,10 +128,7 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
 
     assert preallocated_output_tensor == output_tensor
 
-    if torch_dtype == torch.bfloat16:
-        assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
-    else:
-        assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
+    assert_cumsum_quality(expected_output, torch_output)
 
     assert device.num_program_cache_entries() >= 1
 
@@ -174,10 +177,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
     )
 
     assert tt_input_grad_cpu.shape == torch_input_tensor.grad.shape
-    if torch_dtype == torch.bfloat16:
-        assert_with_ulp(tt_input_grad_cpu, torch_input_tensor.grad, ulp_threshold=1)
-    else:
-        assert_allclose(tt_input_grad_cpu, torch_input_tensor.grad, rtol=1e-2, atol=1e-6)
+    assert_cumsum_quality(tt_input_grad_cpu, torch_input_tensor.grad)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -15,7 +15,7 @@ def assert_cumsum_quality(expected_output, torch_output):
     elif torch_output.dtype == torch.bfloat16:
         assert_with_ulp(expected_output, torch_output, ulp_threshold=1)
     else:
-        assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-6)
+        assert_allclose(expected_output, torch_output, rtol=1e-2, atol=1e-4)
 
 
 def get_backward_tensors(output_grad_shape, input_grad_shape, device):

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -86,6 +86,7 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     if (!is_integer_format(acc_dataformat)) {
         acc_dataformat = DataFormat::Float32;
     }
+    auto acc_dataformat_name = fmt::format("DataFormat::{}", acc_dataformat);
 
     const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
     const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
@@ -106,10 +107,10 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     if (is_integer_format(dst_cb_data_format)) {
         defines_kernel_args["BINARY_OP_INIT"] = operation_attributes.op == AccumulationOp::CUMSUM
                                                     ? "add_int_tile_init"
-                                                    : "mul_int_tile_init<DataFormat::Int32>";
+                                                    : fmt::format("mul_int_tile_init<{}>", acc_dataformat_name);
         defines_kernel_args["BINARY_OP"] = operation_attributes.op == AccumulationOp::CUMSUM
-                                               ? "add_int_tile<DataFormat::Int32>"
-                                               : "mul_int_tile<DataFormat::Int32>";
+                                               ? fmt::format("add_int_tile<{}>", acc_dataformat_name)
+                                               : fmt::format("mul_int_tile<{}>", acc_dataformat_name);
     } else {
         defines_kernel_args["BINARY_OP_INIT"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile_init" : "mul_binary_tile_init";

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -2,13 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "accumulation/device/accumulation_device_operation_types.hpp"
 #include "accumulation_device_operation.hpp"
 
 #include "tt-metalium/base_types.hpp"
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <bit>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
@@ -50,9 +53,6 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     auto* dst_buffer{output_tensor.buffer()};
 
     const auto dst_cb_data_format{datatype_to_dataformat_converter(output_tensor.dtype())};
-    const bool fp32_dest_acc_en{
-        (dst_cb_data_format == DataFormat::Float32) || (dst_cb_data_format == DataFormat::Int32) ||
-        (dst_cb_data_format == DataFormat::UInt32)};
 
     const uint32_t input_rank{input_tensor.padded_shape().rank()};
 
@@ -78,20 +78,58 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
             tt::tt_metal::split_work_to_cores(grid, num_rows_total);
 
     constexpr uint32_t in_tiles = 4;
-    constexpr uint32_t op_tiles = 4;
-    constexpr uint32_t start_tiles = 4;
+    constexpr uint32_t op_tiles = 1;
+    // constexpr uint32_t start_tiles = 4;
     constexpr uint32_t out_tiles = 4;
 
-    create_cb(program, input_tensor.dtype(), AccumulationCB::SRC, all_cores, in_tiles);
-    create_cb(program, output_tensor.dtype(), AccumulationCB::ACC, all_cores, op_tiles);
-    create_cb(program, output_tensor.dtype(), AccumulationCB::START, all_cores, start_tiles);
-    create_cb(program, output_tensor.dtype(), AccumulationCB::DST, all_cores, out_tiles);
+    auto acc_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
+    if (!is_integer_format(acc_dataformat)) {
+        acc_dataformat = DataFormat::Float32;
+    }
+
+    const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
+    const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
+
+    create_cb(program, input_dataformat, AccumulationCB::SRC, all_cores, in_tiles);
+    create_cb(program, acc_dataformat, AccumulationCB::ACC, all_cores, op_tiles);
+    create_cb(program, output_dataformat, AccumulationCB::DST, all_cores, out_tiles);
+
+    // TODO: Unpack to Dst for all CBs
+    std::vector<UnpackToDestMode> unpack_to_dst(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    unpack_to_dst[static_cast<unsigned>(AccumulationCB::ACC)] = UnpackToDestMode::UnpackToDestFp32;
 
     std::map<std::string, std::string> defines_kernel_args = {};
+
     if (is_integer_format(dst_cb_data_format)) {
-        // Used to switch to add_tile_int32() instead of add_tiles()
-        defines_kernel_args["CUMSUM_USE_INT32"] = "1";
+        defines_kernel_args["BINARY_OP_INIT"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_int_tile_init" : "mul_int_tile_init";
+        defines_kernel_args["BINARY_OP"] = operation_attributes.op == AccumulationOp::CUMSUM
+                                               ? "add_int_tile<DataFormat::Int32>"
+                                               : "mul_int_tile<DataFormat::Int32>";
+        unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
+
+    } else if (dst_cb_data_format == DataFormat::Float32 || operation_attributes.op == AccumulationOp::CUMSUM) {
+        defines_kernel_args["BINARY_OP_INIT"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile_init" : "mul_binary_tile_init";
+        defines_kernel_args["BINARY_OP"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile" : "mul_binary_tile";
+        unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
+    } else {
+        defines_kernel_args["USE_FPU"] = "1";
+        defines_kernel_args["BINARY_OP_INIT"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_tiles_init" : "mul_tiles_init";
+        defines_kernel_args["BINARY_OP"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_tiles" : "mul_tiles";
     }
+
+    float default_acc_value = 0.f;
+    if (operation_attributes.op == AccumulationOp::CUMPROD) {
+        default_acc_value = 1.f;
+        if (is_integer_format(dst_cb_data_format)) {
+            default_acc_value = std::bit_cast<float>(1U);
+        }
+    }
+    defines_kernel_args["DEFAULT_ACC_VALUE"] = fmt::format("{}", default_acc_value);
 
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
@@ -101,8 +139,9 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     const auto math_fidelity =
         (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
     const ComputeConfig compute_config{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .math_fidelity = MathFidelity::HiFi4,
+        .fp32_dest_acc_en = true,
+        .unpack_to_dest_mode = unpack_to_dst,
         .math_approx_mode = false,
         .compile_args = {},
         .defines = defines_kernel_args};
@@ -160,18 +199,10 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
              static_cast<uint32_t>(operation_attributes.flip)});
 
         if (core_group_1.contains(core)) {
-            SetRuntimeArgs(
-                program,
-                accumulation_compute_kernel_id,
-                core,
-                {num_tiles_per_core, tiles_per_row, static_cast<uint32_t>(operation_attributes.op)});
+            SetRuntimeArgs(program, accumulation_compute_kernel_id, core, {num_tiles_per_core, tiles_per_row});
         } else if (core_group_2.contains(core)) {
             TT_ASSERT(compute_kernel_2_id.has_value());
-            SetRuntimeArgs(
-                program,
-                compute_kernel_2_id.value(),
-                core,
-                {num_tiles_per_core, tiles_per_row, static_cast<uint32_t>(operation_attributes.op)});
+            SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_tiles_per_core, tiles_per_row});
         } else {
             TT_THROW("Core not in any predefined core range.");
         }
@@ -211,14 +242,14 @@ void AccumulationProgramFactory::override_runtime_arguments(
 
 CBHandle AccumulationProgramFactory::create_cb(
     Program& program,
-    const DataType& dtype,
+    const tt::DataFormat& data_format,
     const AccumulationCB& accumulation_cb,
     const CoreRangeSet& core_range_set,
     const uint32_t& num_tiles) {
     const uint32_t cb_id{static_cast<uint32_t>(accumulation_cb)};
-    const auto cb_data_format{datatype_to_dataformat_converter(dtype)};
-    const uint32_t single_tile_size{tt::tile_size(cb_data_format)};
-    const auto cb_config{CircularBufferConfig{num_tiles * single_tile_size, {{cb_id, cb_data_format}}}.set_page_size(
+
+    const uint32_t single_tile_size{tt::tile_size(data_format)};
+    const auto cb_config{CircularBufferConfig{num_tiles * single_tile_size, {{cb_id, data_format}}}.set_page_size(
         cb_id, single_tile_size)};
     return CreateCircularBuffer(program, core_range_set, cb_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -100,11 +100,11 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     std::map<std::string, std::string> defines_kernel_args = {};
 
     if (is_integer_format(dst_cb_data_format)) {
-        defines_kernel_args["BINARY_OP_INIT"] =
-            operation_attributes.op == AccumulationOp::CUMSUM ? "add_int_tile_init" : "mul_int_tile_init";
-        defines_kernel_args["BINARY_OP"] = operation_attributes.op == AccumulationOp::CUMSUM
-                                               ? "add_int_tile<DataFormat::Int32>"
-                                               : "mul_int_tile<DataFormat::Int32>";
+        defines_kernel_args["BINARY_OP_INIT"] = operation_attributes.op == AccumulationOp::CUMSUM
+                                                    ? "add_int_tile_init"
+                                                    : "mul_int_tile_init<DataFormat::Int32>";
+        defines_kernel_args["BINARY_OP"] =
+            operation_attributes.op == AccumulationOp::CUMSUM ? "add_int_tile" : "mul_int_tile<DataFormat::Int32>";
         unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
     } else {
         defines_kernel_args["BINARY_OP_INIT"] =
@@ -128,7 +128,6 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
     const ComputeConfig compute_config{
-        .math_fidelity = MathFidelity::HiFi4,
         .fp32_dest_acc_en = true,
         .unpack_to_dest_mode = unpack_to_dst,
         .math_approx_mode = false,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -128,8 +128,6 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
-    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
-    // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
     const ComputeConfig compute_config{
         .fp32_dest_acc_en = true,
         .unpack_to_dest_mode = unpack_to_dst,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -97,21 +97,24 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     std::vector<UnpackToDestMode> unpack_to_dst(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     unpack_to_dst[static_cast<unsigned>(AccumulationCB::ACC)] = UnpackToDestMode::UnpackToDestFp32;
 
+    if (input_dataformat != DataFormat::Float16_b) {
+        unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
     std::map<std::string, std::string> defines_kernel_args = {};
 
     if (is_integer_format(dst_cb_data_format)) {
         defines_kernel_args["BINARY_OP_INIT"] = operation_attributes.op == AccumulationOp::CUMSUM
                                                     ? "add_int_tile_init"
                                                     : "mul_int_tile_init<DataFormat::Int32>";
-        defines_kernel_args["BINARY_OP"] =
-            operation_attributes.op == AccumulationOp::CUMSUM ? "add_int_tile" : "mul_int_tile<DataFormat::Int32>";
-        unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
+        defines_kernel_args["BINARY_OP"] = operation_attributes.op == AccumulationOp::CUMSUM
+                                               ? "add_int_tile<DataFormat::Int32>"
+                                               : "mul_int_tile<DataFormat::Int32>";
     } else {
         defines_kernel_args["BINARY_OP_INIT"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile_init" : "mul_binary_tile_init";
         defines_kernel_args["BINARY_OP"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile" : "mul_binary_tile";
-        unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     float default_acc_value = 0.f;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -136,8 +136,9 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
-    const auto math_fidelity =
-        (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
+    // constexpr bool fp32_dest_acc_en = true;
+    // const auto math_fidelity =
+    //     (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const ComputeConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4,
         .fp32_dest_acc_en = true,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -125,10 +125,17 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
         }
     }
 
+    // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
+    // fp32_dest_acc_en will be True for FLOAT32 inputs (set below), so use HiFi3 as default on Wormhole B0.
+    const auto is_wormhole = device->arch() == tt::ARCH::WORMHOLE_B0;
+    const auto default_math_fidelity =
+        (is_wormhole && output_tensor.dtype() == DataType::FLOAT32) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
+
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
     const ComputeConfig compute_config{
+        .math_fidelity = default_math_fidelity,
         .fp32_dest_acc_en = true,
         .unpack_to_dest_mode = unpack_to_dst,
         .math_approx_mode = false,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -111,11 +111,13 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
         defines_kernel_args["BINARY_OP"] = operation_attributes.op == AccumulationOp::CUMSUM
                                                ? fmt::format("add_int_tile<{}>", acc_dataformat_name)
                                                : fmt::format("mul_int_tile<{}>", acc_dataformat_name);
+        defines_kernel_args["FILL_TILE"] = fmt::format("fill_tile_int<{}>", acc_dataformat_name);
     } else {
         defines_kernel_args["BINARY_OP_INIT"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile_init" : "mul_binary_tile_init";
         defines_kernel_args["BINARY_OP"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile" : "mul_binary_tile";
+        defines_kernel_args["FILL_TILE"] = "fill_tile_bitcast";
     }
 
     float default_acc_value = 0.f;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -90,11 +90,14 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
     const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
 
+    std::cout << "input_dataformat: " << input_dataformat << std::endl;
+    std::cout << "acc_dataformat: " << acc_dataformat << std::endl;
+    std::cout << "output_dataformat: " << output_dataformat << std::endl;
+
     create_cb(program, input_dataformat, AccumulationCB::SRC, all_cores, in_tiles);
     create_cb(program, acc_dataformat, AccumulationCB::ACC, all_cores, op_tiles);
     create_cb(program, output_dataformat, AccumulationCB::DST, all_cores, out_tiles);
 
-    // TODO: Unpack to Dst for all CBs
     std::vector<UnpackToDestMode> unpack_to_dst(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     unpack_to_dst[static_cast<unsigned>(AccumulationCB::ACC)] = UnpackToDestMode::UnpackToDestFp32;
 
@@ -107,19 +110,12 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
                                                ? "add_int_tile<DataFormat::Int32>"
                                                : "mul_int_tile<DataFormat::Int32>";
         unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
-
-    } else if (dst_cb_data_format == DataFormat::Float32 || operation_attributes.op == AccumulationOp::CUMSUM) {
+    } else {
         defines_kernel_args["BINARY_OP_INIT"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile_init" : "mul_binary_tile_init";
         defines_kernel_args["BINARY_OP"] =
             operation_attributes.op == AccumulationOp::CUMSUM ? "add_binary_tile" : "mul_binary_tile";
         unpack_to_dst[static_cast<unsigned>(AccumulationCB::SRC)] = UnpackToDestMode::UnpackToDestFp32;
-    } else {
-        defines_kernel_args["USE_FPU"] = "1";
-        defines_kernel_args["BINARY_OP_INIT"] =
-            operation_attributes.op == AccumulationOp::CUMSUM ? "add_tiles_init" : "mul_tiles_init";
-        defines_kernel_args["BINARY_OP"] =
-            operation_attributes.op == AccumulationOp::CUMSUM ? "add_tiles" : "mul_tiles";
     }
 
     float default_acc_value = 0.f;
@@ -129,7 +125,6 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
             default_acc_value = std::bit_cast<float>(1U);
         }
     }
-    defines_kernel_args["DEFAULT_ACC_VALUE"] = fmt::format("{}", default_acc_value);
 
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
@@ -144,7 +139,7 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
         .fp32_dest_acc_en = true,
         .unpack_to_dest_mode = unpack_to_dst,
         .math_approx_mode = false,
-        .compile_args = {},
+        .compile_args = {std::bit_cast<uint32_t>(default_acc_value)},
         .defines = defines_kernel_args};
 
     std::vector<uint32_t> writer_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -11,9 +11,10 @@
 #include "tt-metalium/kernel_types.hpp"
 #include "tt-metalium/tt_backend_api_types.hpp"
 #include "ttnn/tensor/types.hpp"
-#include <bit>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <bit>
 
 namespace ttnn::prim {
 
@@ -78,8 +79,7 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
             tt::tt_metal::split_work_to_cores(grid, num_rows_total);
 
     constexpr uint32_t in_tiles = 4;
-    constexpr uint32_t op_tiles = 1;
-    // constexpr uint32_t start_tiles = 4;
+    constexpr uint32_t acc_tiles = 1;
     constexpr uint32_t out_tiles = 4;
 
     auto acc_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
@@ -90,12 +90,8 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     const auto input_dataformat = datatype_to_dataformat_converter(input_tensor.dtype());
     const auto output_dataformat = datatype_to_dataformat_converter(output_tensor.dtype());
 
-    std::cout << "input_dataformat: " << input_dataformat << std::endl;
-    std::cout << "acc_dataformat: " << acc_dataformat << std::endl;
-    std::cout << "output_dataformat: " << output_dataformat << std::endl;
-
     create_cb(program, input_dataformat, AccumulationCB::SRC, all_cores, in_tiles);
-    create_cb(program, acc_dataformat, AccumulationCB::ACC, all_cores, op_tiles);
+    create_cb(program, acc_dataformat, AccumulationCB::ACC, all_cores, acc_tiles);
     create_cb(program, output_dataformat, AccumulationCB::DST, all_cores, out_tiles);
 
     std::vector<UnpackToDestMode> unpack_to_dst(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
@@ -131,9 +127,6 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
     const ReaderDataMovementConfig reader_config{reader_compile_time_args};
     // Due to hardware bug (#38306), HiFi4 + fp32_dest_acc_en can sometime produce incorrect results on Wormhole.
     // Use HiFi3 silently when fp32_dest_acc_en is True on Wormhole B0.
-    // constexpr bool fp32_dest_acc_en = true;
-    // const auto math_fidelity =
-    //     (fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0) ? MathFidelity::HiFi3 : MathFidelity::HiFi4;
     const ComputeConfig compute_config{
         .math_fidelity = MathFidelity::HiFi4,
         .fp32_dest_acc_en = true,
@@ -178,8 +171,7 @@ AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
              tile_offset,
              tile_offset / input_tile_offset,
              tile_offset % input_tile_offset,
-             static_cast<uint32_t>(operation_attributes.flip),
-             static_cast<uint32_t>(operation_attributes.op)});
+             static_cast<uint32_t>(operation_attributes.flip)});
 
         SetRuntimeArgs(
             program,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -58,7 +58,7 @@ struct AccumulationProgramFactory {
 
     static CBHandle create_cb(
         Program& program,
-        const tt::DataFormat& dtype,
+        const tt::DataFormat& data_format,
         const AccumulationCB& accumulation_cb,
         const CoreRangeSet& core_range_set,
         const uint32_t& num_tiles);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -26,7 +26,6 @@ struct AccumulationProgramFactory {
     enum class AccumulationCB : std::underlying_type_t<tt::CBIndex> {
         SRC = tt::CBIndex::c_0,
         DST = tt::CBIndex::c_1,
-        START = tt::CBIndex::c_2,
         ACC = tt::CBIndex::c_3
     };
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -26,7 +26,7 @@ struct AccumulationProgramFactory {
     enum class AccumulationCB : std::underlying_type_t<tt::CBIndex> {
         SRC = tt::CBIndex::c_0,
         DST = tt::CBIndex::c_1,
-        ACC = tt::CBIndex::c_3
+        ACC = tt::CBIndex::c_2
     };
 
     static constexpr std::array<const char*, 3> KERNEL_PATHS{

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -59,7 +59,7 @@ struct AccumulationProgramFactory {
 
     static CBHandle create_cb(
         Program& program,
-        const DataType& dtype,
+        const tt::DataFormat& dtype,
         const AccumulationCB& accumulation_cb,
         const CoreRangeSet& core_range_set,
         const uint32_t& num_tiles);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/accumulation_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/accumulation_common.hpp
@@ -10,7 +10,6 @@ constexpr uint32_t WORKING_REG{0};
 
 constexpr uint32_t cb_in = tt::CBIndex::c_0;
 constexpr uint32_t cb_out = tt::CBIndex::c_1;
-constexpr uint32_t cb_start = tt::CBIndex::c_2;
 constexpr uint32_t cb_acc = tt::CBIndex::c_3;
 
 constexpr uint32_t INT32_TILE_DEST = WORKING_REG;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/accumulation_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/accumulation_common.hpp
@@ -8,14 +8,9 @@ constexpr uint32_t ONE_TILE{1};
 constexpr uint32_t FIRST_TILE{0};
 constexpr uint32_t WORKING_REG{0};
 
-constexpr uint32_t cb_in = tt::CBIndex::c_0;
-constexpr uint32_t cb_out = tt::CBIndex::c_1;
-constexpr uint32_t cb_acc = tt::CBIndex::c_3;
-
-constexpr uint32_t INT32_TILE_DEST = WORKING_REG;
-constexpr uint32_t INT32_TILE_ACC = 1;
-
-enum class AccumulationOp : uint8_t { CUMSUM, CUMPROD };
+constexpr uint32_t CB_IN = tt::CBIndex::c_0;
+constexpr uint32_t CB_OUT = tt::CBIndex::c_1;
+constexpr uint32_t CB_ACC = tt::CBIndex::c_2;
 
 FORCE_INLINE uint32_t get_tile_id(
     uint32_t low_rank_offset,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -4,6 +4,7 @@
 
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/add_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/fill.h"

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -25,7 +25,6 @@ void kernel_main() {
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
 
-    experimental::CircularBuffer cb_start_obj(cb_start);
     experimental::CircularBuffer cb_in_obj(cb_in);
     experimental::CircularBuffer cb_out_obj(cb_out);
     experimental::CircularBuffer cb_acc_obj(cb_acc);
@@ -38,20 +37,12 @@ void kernel_main() {
     BINARY_OP_INIT();
 #endif  // USE_FPU
 
-    DPRINT << "default acc value = " << DEFAULT_ACC_VALUE << ENDL();
-    DPRINT << "tiles per row = " << tiles_per_row << ENDL();
-    DPRINT << "num rows = " << num_rows << ENDL();
-    DPRINT << "cb in = " << cb_in << ENDL();
-
     constexpr uint32_t DST_IN = 0;
     constexpr uint32_t DST_ACC = 1;
 
     for (uint32_t i = 0; i < num_rows; i++) {
-        DPRINT << "i = " << i << ENDL();
-
         cb_acc_obj.wait_front(ONE_TILE);
 
-        // Fill cb_acc to default values
         tile_regs_acquire();
 
         fill_tile_init();
@@ -70,10 +61,7 @@ void kernel_main() {
         cb_acc_obj.push_back(ONE_TILE);
 
         for (uint32_t j = 0; j < tiles_per_row; j++) {
-            UNPACK(DPRINT << "j = " << j << ENDL(););
-
             // Synchronize unpacker-packer
-
             cb_acc_obj.reserve_back(ONE_TILE);
             cb_acc_obj.push_back(ONE_TILE);
 
@@ -90,21 +78,9 @@ void kernel_main() {
             copy_tile_to_dst_init_short(cb_in);
             copy_tile(cb_in, 0, DST_IN);
 
-            // UNPACK(
-            //	DPRINT << "cb in = " << ENDL();
-            //	);
-            // dprint_tensix_dest_reg(DST_IN);
-
-            // TODO: reconfig buffer for fp32 acc if using bfloat16 or float32
-
             reconfig_data_format(cb_acc, cb_acc);
             copy_tile_to_dst_init_short(cb_acc);
             copy_tile(cb_acc, 0, DST_ACC);
-
-            // UNPACK(
-            //	DPRINT << "cb acc = " << ENDL();
-            //	);
-            // dprint_tensix_dest_reg(DST_ACC);
 
             BINARY_OP(DST_IN, DST_ACC, DST_ACC);
 #endif  // USE_FPU
@@ -130,5 +106,4 @@ void kernel_main() {
             cb_acc_obj.pop_front(ONE_TILE);
         }
     }
-    DPRINT << "done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/pack.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
+#include "ttnn/operations/normalization/kernel_util/generic/bit.h"
 
 #define APPROX false
 #include "api/compute/common.h"
@@ -17,25 +18,21 @@
 #include "experimental/circular_buffer.h"
 #include "../accumulation_common.hpp"
 
-#include "api/debug/dprint_tensix.h"
-
 void kernel_main() {
     using namespace ckernel;  // DEBUG
+
+    const float default_acc_value = norm::kernel_util::generic::bit_cast<float>(get_compile_time_arg_val(0));
 
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
 
     experimental::CircularBuffer cb_in_obj(cb_in);
     experimental::CircularBuffer cb_out_obj(cb_out);
-    experimental::CircularBuffer cb_acc_obj(cb_acc);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);  // note: only used in compute kernels
 
     binary_op_init_common(cb_in, cb_acc, cb_out);
 
-#ifdef USE_FPU
-    BINARY_OP_INIT(cb_in, cb_acc);
-#else
     BINARY_OP_INIT();
-#endif  // USE_FPU
 
     constexpr uint32_t DST_IN = 0;
     constexpr uint32_t DST_ACC = 1;
@@ -43,17 +40,22 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_rows; i++) {
         cb_acc_obj.wait_front(ONE_TILE);
 
+        reconfig_data_format(cb_acc, cb_acc);
+
         tile_regs_acquire();
 
         fill_tile_init();
-        fill_tile(DST_ACC, DEFAULT_ACC_VALUE);  // TODO: Check with int32 multiply
+        fill_tile(DST_ACC, default_acc_value);
+
         tile_regs_commit();
+
         cb_acc_obj.pop_front(ONE_TILE);
 
         cb_acc_obj.reserve_back(ONE_TILE);
 
-        // Pack to acc
         tile_regs_wait();
+
+        // out_of_order_output to keep packing to cb_acc at the same location
         pack_reconfig_data_format(cb_acc);
         pack_tile<true>(DST_ACC, cb_acc, 0);
         tile_regs_release();
@@ -70,10 +72,6 @@ void kernel_main() {
             tile_regs_acquire();
             cb_in_obj.wait_front(ONE_TILE);
 
-#ifdef USE_FPU
-            reconfig_data_format(cb_in, cb_acc);
-            BINARY_OP(cb_in, cb_acc, 0, 0, DST_ACC);
-#else
             reconfig_data_format(cb_in, cb_in);
             copy_tile_to_dst_init_short(cb_in);
             copy_tile(cb_in, 0, DST_IN);
@@ -83,7 +81,6 @@ void kernel_main() {
             copy_tile(cb_acc, 0, DST_ACC);
 
             BINARY_OP(DST_IN, DST_ACC, DST_ACC);
-#endif  // USE_FPU
 
             cb_in_obj.pop_front(ONE_TILE);
 
@@ -92,11 +89,11 @@ void kernel_main() {
             tile_regs_wait();
 
             cb_out_obj.reserve_back(ONE_TILE);
-            pack_reconfig_data_format(cb_acc, cb_out);  // If using fp32_acc_to_dest
+            pack_reconfig_data_format(cb_acc, cb_out);  // Nedded for fp32_acc_to_dest=True
             pack_tile(DST_ACC, cb_out);
             cb_out_obj.push_back(ONE_TILE);
 
-            pack_reconfig_data_format(cb_out, cb_acc);  // If using fp32_acc_to_dest
+            pack_reconfig_data_format(cb_out, cb_acc);  // Needed fp32_acc_to_dest=True
 
             // out_of_order_output to accumulate to not increment cb_acc write 'cursor'
             pack_tile<true>(DST_ACC, cb_acc, 0);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -19,8 +19,6 @@
 #include "../accumulation_common.hpp"
 
 void kernel_main() {
-    using namespace ckernel;  // DEBUG
-
     const float default_acc_value = norm::kernel_util::generic::bit_cast<float>(get_compile_time_arg_val(0));
 
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
@@ -28,46 +26,47 @@ void kernel_main() {
 
     experimental::CircularBuffer cb_in_obj(cb_in);
     experimental::CircularBuffer cb_out_obj(cb_out);
-    experimental::CircularBuffer cb_acc_obj(cb_acc);  // note: only used in compute kernels
-
-    binary_op_init_common(cb_in, cb_acc, cb_out);
+    experimental::CircularBuffer cb_acc_obj(cb_acc);  // note: only used in compute kernel
 
     BINARY_OP_INIT();
 
     constexpr uint32_t DST_IN = 0;
     constexpr uint32_t DST_ACC = 1;
 
-    for (uint32_t i = 0; i < num_rows; i++) {
-        cb_acc_obj.wait_front(ONE_TILE);
+    cb_acc_obj.reserve_back(ONE_TILE);
+    cb_acc_obj.push_back(ONE_TILE);
 
-        reconfig_data_format(cb_acc, cb_acc);
+    for (uint32_t i = 0; i < num_rows; i++) {
+        // Synchronize unpacker-packer between iterations
+        // This is necessary to avoid data-races on cb_acc
+        cb_acc_obj.wait_front(ONE_TILE);
+        cb_acc_obj.pop_front(ONE_TILE);
+        unary_op_init_common(cb_acc, cb_acc);
 
         tile_regs_acquire();
+        reconfig_data_format(cb_acc, cb_acc);
 
         fill_tile_init();
         fill_tile(DST_ACC, default_acc_value);
 
         tile_regs_commit();
 
-        cb_acc_obj.pop_front(ONE_TILE);
-
-        cb_acc_obj.reserve_back(ONE_TILE);
-
         tile_regs_wait();
 
         // out_of_order_output to keep packing to cb_acc at the same location
         pack_reconfig_data_format(cb_acc);
-        pack_tile<true>(DST_ACC, cb_acc, 0);
+        pack_tile(DST_ACC, cb_acc);
         tile_regs_release();
 
+        binary_op_init_common(cb_in, cb_acc, cb_out);
+
+        cb_acc_obj.reserve_back(ONE_TILE);
         cb_acc_obj.push_back(ONE_TILE);
 
         for (uint32_t j = 0; j < tiles_per_row; j++) {
-            // Synchronize unpacker-packer
-            cb_acc_obj.reserve_back(ONE_TILE);
-            cb_acc_obj.push_back(ONE_TILE);
-
+            // Synchronize unpacker-packer between iterations
             cb_acc_obj.wait_front(ONE_TILE);
+            cb_acc_obj.pop_front(ONE_TILE);
 
             tile_regs_acquire();
             cb_in_obj.wait_front(ONE_TILE);
@@ -89,18 +88,21 @@ void kernel_main() {
             tile_regs_wait();
 
             cb_out_obj.reserve_back(ONE_TILE);
-            pack_reconfig_data_format(cb_acc, cb_out);  // Nedded for fp32_acc_to_dest=True
+            pack_reconfig_data_format(cb_acc, cb_out);  // Needed for fp32_acc_to_dest=True
             pack_tile(DST_ACC, cb_out);
             cb_out_obj.push_back(ONE_TILE);
 
-            pack_reconfig_data_format(cb_out, cb_acc);  // Needed fp32_acc_to_dest=True
-
-            // out_of_order_output to accumulate to not increment cb_acc write 'cursor'
-            pack_tile<true>(DST_ACC, cb_acc, 0);
+            pack_reconfig_data_format(cb_out, cb_acc);  // Needed for fp32_acc_to_dest=True
+            pack_tile(DST_ACC, cb_acc);
 
             tile_regs_release();
 
-            cb_acc_obj.pop_front(ONE_TILE);
+            cb_acc_obj.reserve_back(ONE_TILE);
+            cb_acc_obj.push_back(ONE_TILE);
         }
     }
+
+    // Clean-up and empty CB
+    cb_acc_obj.wait_front(ONE_TILE);
+    cb_acc_obj.pop_front(ONE_TILE);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -11,8 +11,6 @@
 #include "api/compute/pack.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
-#include "ttnn/operations/normalization/kernel_util/generic/bit.h"
-
 #define APPROX false
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary_sfpu.h"
@@ -20,7 +18,7 @@
 #include "../accumulation_common.hpp"
 
 void kernel_main() {
-    const float default_acc_value = norm::kernel_util::generic::bit_cast<float>(get_compile_time_arg_val(0));
+    const uint32_t default_acc_value = get_compile_time_arg_val(0);
 
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
@@ -49,7 +47,7 @@ void kernel_main() {
         reconfig_data_format(CB_ACC, CB_ACC);
 
         fill_tile_init();
-        fill_tile(DST_ACC, default_acc_value);
+        FILL_TILE(DST_ACC, default_acc_value);
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -6,6 +6,9 @@
 #include "api/compute/add_int_sfpu.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/pack.h"
+#include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
 
 #define APPROX false
@@ -14,78 +17,118 @@
 #include "experimental/circular_buffer.h"
 #include "../accumulation_common.hpp"
 
+#include "api/debug/dprint_tensix.h"
+
 void kernel_main() {
+    using namespace ckernel;  // DEBUG
+
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
-    const AccumulationOp accumulation_op = static_cast<AccumulationOp>(get_arg_val<uint32_t>(2));
 
     experimental::CircularBuffer cb_start_obj(cb_start);
     experimental::CircularBuffer cb_in_obj(cb_in);
     experimental::CircularBuffer cb_out_obj(cb_out);
     experimental::CircularBuffer cb_acc_obj(cb_acc);
 
-    cb_start_obj.wait_front(ONE_TILE);
+    binary_op_init_common(cb_in, cb_acc, cb_out);
+
+#ifdef USE_FPU
+    BINARY_OP_INIT(cb_in, cb_acc);
+#else
+    BINARY_OP_INIT();
+#endif  // USE_FPU
+
+    DPRINT << "default acc value = " << DEFAULT_ACC_VALUE << ENDL();
+    DPRINT << "tiles per row = " << tiles_per_row << ENDL();
+    DPRINT << "num rows = " << num_rows << ENDL();
+    DPRINT << "cb in = " << cb_in << ENDL();
+
+    constexpr uint32_t DST_IN = 0;
+    constexpr uint32_t DST_ACC = 1;
 
     for (uint32_t i = 0; i < num_rows; i++) {
-        bool enable_reload = false;
+        DPRINT << "i = " << i << ENDL();
+
+        cb_acc_obj.wait_front(ONE_TILE);
+
+        // Fill cb_acc to default values
+        tile_regs_acquire();
+
+        fill_tile_init();
+        fill_tile(DST_ACC, DEFAULT_ACC_VALUE);  // TODO: Check with int32 multiply
+        tile_regs_commit();
+        cb_acc_obj.pop_front(ONE_TILE);
+
+        cb_acc_obj.reserve_back(ONE_TILE);
+
+        // Pack to acc
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_acc);
+        pack_tile<true>(DST_ACC, cb_acc, 0);
+        tile_regs_release();
+
+        cb_acc_obj.push_back(ONE_TILE);
 
         for (uint32_t j = 0; j < tiles_per_row; j++) {
-            tile_regs_acquire();
-            const uint32_t cb_op = enable_reload ? cb_acc : cb_start;
-            cb_in_obj.wait_front(ONE_TILE);
+            UNPACK(DPRINT << "j = " << j << ENDL(););
 
-            binary_op_init_common(cb_in, cb_op, cb_out);
-
-#ifdef CUMSUM_USE_INT32
-            copy_tile_to_dst_init_short(cb_in);
-            copy_tile(cb_in, FIRST_TILE, INT32_TILE_DEST);
-
-            copy_tile_to_dst_init_short(cb_op);
-            copy_tile(cb_op, FIRST_TILE, INT32_TILE_ACC);
-#endif  // CUMSUM_USE_INT32
-
-            // cumulating tiles along the first dimension,
-            // data is not dependent on itself within tiles
-            if (accumulation_op == AccumulationOp::CUMPROD) {
-                mul_tiles_init(cb_in, cb_op);
-                mul_tiles(cb_in, cb_op, FIRST_TILE, FIRST_TILE, WORKING_REG);
-            } else if (accumulation_op == AccumulationOp::CUMSUM) {
-#ifdef CUMSUM_USE_INT32
-                add_int_tile_init();
-                add_int_tile<DataFormat::Int32>(INT32_TILE_DEST, INT32_TILE_ACC, INT32_TILE_DEST);
-#else
-                add_tiles_init(cb_in, cb_op);
-                add_tiles(cb_in, cb_op, FIRST_TILE, FIRST_TILE, WORKING_REG);
-#endif  // CUMSUM_USE_INT32
-            }
-
-            cb_in_obj.pop_front(ONE_TILE);
-            if (enable_reload) {
-                cb_acc_obj.pop_front(ONE_TILE);
-            }
-
-            tile_regs_commit();
-            tile_regs_wait();
+            // Synchronize unpacker-packer
 
             cb_acc_obj.reserve_back(ONE_TILE);
-            pack_tile(WORKING_REG, cb_acc);
             cb_acc_obj.push_back(ONE_TILE);
 
             cb_acc_obj.wait_front(ONE_TILE);
+
+            tile_regs_acquire();
+            cb_in_obj.wait_front(ONE_TILE);
+
+#ifdef USE_FPU
+            reconfig_data_format(cb_in, cb_acc);
+            BINARY_OP(cb_in, cb_acc, 0, 0, DST_ACC);
+#else
+            reconfig_data_format(cb_in, cb_in);
+            copy_tile_to_dst_init_short(cb_in);
+            copy_tile(cb_in, 0, DST_IN);
+
+            // UNPACK(
+            //	DPRINT << "cb in = " << ENDL();
+            //	);
+            // dprint_tensix_dest_reg(DST_IN);
+
+            // TODO: reconfig buffer for fp32 acc if using bfloat16 or float32
+
+            reconfig_data_format(cb_acc, cb_acc);
             copy_tile_to_dst_init_short(cb_acc);
-            copy_tile(cb_acc, FIRST_TILE, WORKING_REG);
+            copy_tile(cb_acc, 0, DST_ACC);
+
+            // UNPACK(
+            //	DPRINT << "cb acc = " << ENDL();
+            //	);
+            // dprint_tensix_dest_reg(DST_ACC);
+
+            BINARY_OP(DST_IN, DST_ACC, DST_ACC);
+#endif  // USE_FPU
+
+            cb_in_obj.pop_front(ONE_TILE);
+
+            tile_regs_commit();
+
+            tile_regs_wait();
 
             cb_out_obj.reserve_back(ONE_TILE);
-            pack_tile(WORKING_REG, cb_out);
+            pack_reconfig_data_format(cb_acc, cb_out);  // If using fp32_acc_to_dest
+            pack_tile(DST_ACC, cb_out);
             cb_out_obj.push_back(ONE_TILE);
+
+            pack_reconfig_data_format(cb_out, cb_acc);  // If using fp32_acc_to_dest
+
+            // out_of_order_output to accumulate to not increment cb_acc write 'cursor'
+            pack_tile<true>(DST_ACC, cb_acc, 0);
 
             tile_regs_release();
 
-            enable_reload = true;
+            cb_acc_obj.pop_front(ONE_TILE);
         }
-
-        cb_acc_obj.pop_front(ONE_TILE);
     }
-
-    cb_start_obj.pop_front(ONE_TILE);
+    DPRINT << "done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -25,9 +25,9 @@ void kernel_main() {
     const uint32_t num_rows = get_arg_val<uint32_t>(0);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(1);
 
-    experimental::CircularBuffer cb_in_obj(cb_in);
-    experimental::CircularBuffer cb_out_obj(cb_out);
-    experimental::CircularBuffer cb_acc_obj(cb_acc);  // note: only used in compute kernel
+    experimental::CircularBuffer cb_in_obj(CB_IN);
+    experimental::CircularBuffer cb_out_obj(CB_OUT);
+    experimental::CircularBuffer cb_acc_obj(CB_ACC);  // note: only used in compute kernel
 
     BINARY_OP_INIT();
 
@@ -42,10 +42,10 @@ void kernel_main() {
         // This is necessary to avoid data-races on cb_acc
         cb_acc_obj.wait_front(ONE_TILE);
         cb_acc_obj.pop_front(ONE_TILE);
-        unary_op_init_common(cb_acc, cb_acc);
+        unary_op_init_common(CB_ACC, CB_ACC);
 
         tile_regs_acquire();
-        reconfig_data_format(cb_acc, cb_acc);
+        reconfig_data_format(CB_ACC, CB_ACC);
 
         fill_tile_init();
         fill_tile(DST_ACC, default_acc_value);
@@ -55,11 +55,11 @@ void kernel_main() {
         tile_regs_wait();
 
         // out_of_order_output to keep packing to cb_acc at the same location
-        pack_reconfig_data_format(cb_acc);
-        pack_tile(DST_ACC, cb_acc);
+        pack_reconfig_data_format(CB_ACC);
+        pack_tile(DST_ACC, CB_ACC);
         tile_regs_release();
 
-        binary_op_init_common(cb_in, cb_acc, cb_out);
+        binary_op_init_common(CB_IN, CB_ACC, CB_OUT);
 
         cb_acc_obj.reserve_back(ONE_TILE);
         cb_acc_obj.push_back(ONE_TILE);
@@ -72,13 +72,13 @@ void kernel_main() {
             tile_regs_acquire();
             cb_in_obj.wait_front(ONE_TILE);
 
-            reconfig_data_format(cb_in, cb_in);
-            copy_tile_to_dst_init_short(cb_in);
-            copy_tile(cb_in, 0, DST_IN);
+            reconfig_data_format(CB_IN, CB_IN);
+            copy_tile_to_dst_init_short(CB_IN);
+            copy_tile(CB_IN, 0, DST_IN);
 
-            reconfig_data_format(cb_acc, cb_acc);
-            copy_tile_to_dst_init_short(cb_acc);
-            copy_tile(cb_acc, 0, DST_ACC);
+            reconfig_data_format(CB_ACC, CB_ACC);
+            copy_tile_to_dst_init_short(CB_ACC);
+            copy_tile(CB_ACC, 0, DST_ACC);
 
             BINARY_OP(DST_IN, DST_ACC, DST_ACC);
 
@@ -89,12 +89,12 @@ void kernel_main() {
             tile_regs_wait();
 
             cb_out_obj.reserve_back(ONE_TILE);
-            pack_reconfig_data_format(cb_acc, cb_out);  // Needed for fp32_acc_to_dest=True
-            pack_tile(DST_ACC, cb_out);
+            pack_reconfig_data_format(CB_ACC, CB_OUT);  // Needed for fp32_acc_to_dest=True
+            pack_tile(DST_ACC, CB_OUT);
             cb_out_obj.push_back(ONE_TILE);
 
-            pack_reconfig_data_format(cb_out, cb_acc);  // Needed for fp32_acc_to_dest=True
-            pack_tile(DST_ACC, cb_acc);
+            pack_reconfig_data_format(CB_OUT, CB_ACC);  // Needed for fp32_acc_to_dest=True
+            pack_tile(DST_ACC, CB_ACC);
 
             tile_regs_release();
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -29,6 +29,8 @@ void kernel_main() {
     experimental::CircularBuffer cb_out_obj(CB_OUT);
     experimental::CircularBuffer cb_acc_obj(CB_ACC);  // note: only used in compute kernel
 
+    unary_op_init_common(CB_IN, CB_OUT);
+
     BINARY_OP_INIT();
 
     constexpr uint32_t DST_IN = 0;
@@ -42,7 +44,6 @@ void kernel_main() {
         // This is necessary to avoid data-races on cb_acc
         cb_acc_obj.wait_front(ONE_TILE);
         cb_acc_obj.pop_front(ONE_TILE);
-        unary_op_init_common(CB_ACC, CB_ACC);
 
         tile_regs_acquire();
         reconfig_data_format(CB_ACC, CB_ACC);
@@ -59,15 +60,12 @@ void kernel_main() {
         pack_tile(DST_ACC, CB_ACC);
         tile_regs_release();
 
-        binary_op_init_common(CB_IN, CB_ACC, CB_OUT);
-
         cb_acc_obj.reserve_back(ONE_TILE);
         cb_acc_obj.push_back(ONE_TILE);
 
         for (uint32_t j = 0; j < tiles_per_row; j++) {
             // Synchronize unpacker-packer between iterations
             cb_acc_obj.wait_front(ONE_TILE);
-            cb_acc_obj.pop_front(ONE_TILE);
 
             tile_regs_acquire();
             cb_in_obj.wait_front(ONE_TILE);
@@ -81,6 +79,7 @@ void kernel_main() {
             copy_tile(CB_ACC, 0, DST_ACC);
 
             BINARY_OP(DST_IN, DST_ACC, DST_ACC);
+            cb_acc_obj.pop_front(ONE_TILE);
 
             cb_in_obj.pop_front(ONE_TILE);
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/compute/accumulation_compute.cpp
@@ -56,11 +56,12 @@ void kernel_main() {
         tile_regs_wait();
 
         // out_of_order_output to keep packing to cb_acc at the same location
+        cb_acc_obj.reserve_back(ONE_TILE);
+
         pack_reconfig_data_format(CB_ACC);
         pack_tile(DST_ACC, CB_ACC);
         tile_regs_release();
 
-        cb_acc_obj.reserve_back(ONE_TILE);
         cb_acc_obj.push_back(ONE_TILE);
 
         for (uint32_t j = 0; j < tiles_per_row; j++) {
@@ -92,12 +93,13 @@ void kernel_main() {
             pack_tile(DST_ACC, CB_OUT);
             cb_out_obj.push_back(ONE_TILE);
 
+            cb_acc_obj.reserve_back(ONE_TILE);
+
             pack_reconfig_data_format(CB_OUT, CB_ACC);  // Needed for fp32_acc_to_dest=True
             pack_tile(DST_ACC, CB_ACC);
 
             tile_regs_release();
 
-            cb_acc_obj.reserve_back(ONE_TILE);
             cb_acc_obj.push_back(ONE_TILE);
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -28,9 +28,9 @@ void kernel_main() {
     const uint32_t flip = get_arg_val<uint32_t>(7);
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb_in_obj(cb_in);
+    experimental::CircularBuffer cb_in_obj(CB_IN);
 
-    const uint32_t ublock_size_bytes = get_tile_size(cb_in);
+    const uint32_t ublock_size_bytes = get_tile_size(CB_IN);
     const uint32_t input_tile_bytes = ublock_size_bytes;
 
     const auto input_addrg = TensorAccessor(input_addrg_args, input_base_addr, input_tile_bytes);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -33,16 +33,10 @@ void kernel_main() {
     const uint32_t ublock_size_bytes = get_tile_size(cb_in);
     const uint32_t input_tile_bytes = ublock_size_bytes;
 
-    DPRINT << "rows/core = " << num_rows_per_core << ENDL();
-    DPRINT << "tiles/row = " << tiles_per_row << ENDL();
-    DPRINT << "cb in = " << cb_in << ENDL();
-
     const auto input_addrg = TensorAccessor(input_addrg_args, input_base_addr, input_tile_bytes);
 
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; ++i) {
-        DPRINT << "reader i = " << i << ENDL();
         for (uint32_t j = 0; j < tiles_per_row; ++j) {
-            DPRINT << "writer j = " << j << ENDL();
             const uint32_t tile_j = flip ? (tiles_per_row - j - 1) : j;
             const uint32_t read_tile_id{
                 get_tile_id(low_rank_offset, high_rank_offset, tile_j, tiles_per_row, input_tile_offset)};
@@ -57,5 +51,4 @@ void kernel_main() {
             ++low_rank_offset;
         }
     }
-    DPRINT << "reader done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_reader.cpp
@@ -13,9 +13,9 @@
 #include "../accumulation_common.hpp"
 
 void kernel_main() {
-    uint32_t input_base_addr = get_arg_val<uint32_t>(0);
-
     constexpr auto input_addrg_args = TensorAccessorArgs<0>();
+
+    uint32_t input_base_addr = get_arg_val<uint32_t>(0);
     const uint32_t num_rows_per_core = get_arg_val<uint32_t>(1);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(2);
     const uint32_t input_tile_offset = get_arg_val<uint32_t>(3);
@@ -26,62 +26,23 @@ void kernel_main() {
     uint32_t high_rank_offset = get_arg_val<uint32_t>(6);
     // backward flag (from n-1 to 0)
     const uint32_t flip = get_arg_val<uint32_t>(7);
-    // type of accumulation
-    const AccumulationOp accumulation_op = static_cast<AccumulationOp>(get_arg_val<uint32_t>(8));
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb_start_obj(cb_start);
     experimental::CircularBuffer cb_in_obj(cb_in);
 
-    cb_start_obj.reserve_back(ONE_TILE);
-    uint32_t data_start_addr = cb_start_obj.get_write_ptr();
-
-    const float one_f = 1.0f;
-    int32_t ACC_START_VALUE_F32 = 0;
-    std::memcpy(&ACC_START_VALUE_F32, &one_f, sizeof(int32_t));
-    constexpr int32_t ACC_START_VALUE_F16{0x3F80};
-    // TODO(jbbieniekTT): the below ones will work only if applied LLK is preconfigured appropriately for those (issue
-    // #21108)
-    constexpr int32_t ACC_START_VALUE_I32{0x1};
-    constexpr int32_t ACC_START_VALUE_I16{0x1};
-    constexpr int32_t ACC_START_VALUE_I8{0x1};
-
-    uint32_t ublock_size_bytes = get_tile_size(cb_in);
-
+    const uint32_t ublock_size_bytes = get_tile_size(cb_in);
     const uint32_t input_tile_bytes = ublock_size_bytes;
-    uint32_t scaler = 0;
 
-    if (accumulation_op == AccumulationOp::CUMPROD) {
-        const auto& input_data_format = get_dataformat(cb_in);
-        switch (input_data_format) {
-            case DataFormat::Float32: scaler = ACC_START_VALUE_F32; break;
-            case DataFormat::Float16_b:
-            case DataFormat::Float16: scaler = (ACC_START_VALUE_F16 << 16) | ACC_START_VALUE_F16; break;
-            case DataFormat::UInt8:
-                scaler = (ACC_START_VALUE_I8 << 24) | (ACC_START_VALUE_I8 << 16) | (ACC_START_VALUE_I8 << 8) |
-                         (ACC_START_VALUE_I8);
-                break;
-            case DataFormat::UInt16: scaler = (ACC_START_VALUE_I16 << 16) | ACC_START_VALUE_I16; break;
-            case DataFormat::Int32:
-            case DataFormat::UInt32: scaler = ACC_START_VALUE_I32; break;
-            default: scaler = 1; break;
-        }
-    } else if (accumulation_op == AccumulationOp::CUMSUM) {
-        scaler = 0;
-    }
-
-    // TODO(jbbieniekTT): issue #21108
-    experimental::CoreLocalMem<volatile int32_t> data_start(data_start_addr);
-    for (uint32_t i = 0; i < ublock_size_bytes / sizeof(int32_t); i++) {
-        data_start[i] = scaler;
-    }
+    DPRINT << "rows/core = " << num_rows_per_core << ENDL();
+    DPRINT << "tiles/row = " << tiles_per_row << ENDL();
+    DPRINT << "cb in = " << cb_in << ENDL();
 
     const auto input_addrg = TensorAccessor(input_addrg_args, input_base_addr, input_tile_bytes);
 
-    cb_start_obj.push_back(ONE_TILE);
-
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; ++i) {
+        DPRINT << "reader i = " << i << ENDL();
         for (uint32_t j = 0; j < tiles_per_row; ++j) {
+            DPRINT << "writer j = " << j << ENDL();
             const uint32_t tile_j = flip ? (tiles_per_row - j - 1) : j;
             const uint32_t read_tile_id{
                 get_tile_id(low_rank_offset, high_rank_offset, tile_j, tiles_per_row, input_tile_offset)};
@@ -96,4 +57,5 @@ void kernel_main() {
             ++low_rank_offset;
         }
     }
+    DPRINT << "reader done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
@@ -10,9 +10,9 @@
 #include "../accumulation_common.hpp"
 
 void kernel_main() {
-    uint32_t output_base_addr = get_arg_val<uint32_t>(0);
-
     constexpr auto output_addrg_args = TensorAccessorArgs<0>();
+
+    uint32_t output_base_addr = get_arg_val<uint32_t>(0);
     const uint32_t num_rows_per_core = get_arg_val<uint32_t>(1);
     const uint32_t tiles_per_row = get_arg_val<uint32_t>(2);
     const uint32_t input_tile_offset = get_arg_val<uint32_t>(3);
@@ -25,7 +25,6 @@ void kernel_main() {
     const uint32_t flip = get_arg_val<uint32_t>(7);
 
     const uint32_t ublock_size_bytes = get_tile_size(cb_out);
-
     const uint32_t output_tile_bytes = ublock_size_bytes;
 
     const auto output_addrg = TensorAccessor(output_addrg_args, output_base_addr, output_tile_bytes);
@@ -50,4 +49,5 @@ void kernel_main() {
             ++low_rank_offset;
         }
     }
+    DPRINT << "done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
@@ -49,5 +49,4 @@ void kernel_main() {
             ++low_rank_offset;
         }
     }
-    DPRINT << "done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
@@ -24,13 +24,13 @@ void kernel_main() {
 
     const uint32_t flip = get_arg_val<uint32_t>(7);
 
-    const uint32_t ublock_size_bytes = get_tile_size(cb_out);
+    const uint32_t ublock_size_bytes = get_tile_size(CB_OUT);
     const uint32_t output_tile_bytes = ublock_size_bytes;
 
     const auto output_addrg = TensorAccessor(output_addrg_args, output_base_addr, output_tile_bytes);
 
     experimental::Noc noc;
-    experimental::CircularBuffer cb_out_obj(cb_out);
+    experimental::CircularBuffer cb_out_obj(CB_OUT);
 
     for (uint32_t i = start_id; i < start_id + num_rows_per_core; ++i) {
         for (uint32_t j = 0; j < tiles_per_row; ++j) {


### PR DESCRIPTION
### Ticket
#33742
#40878


### Problem description
cumsum (and likely cumprod as well) is inaccurate, especially on long bfloat16 tensors. 

### What's changed
- Switch accumulation to use fp32 accumulation by default, as well as SFPU operations (binary_add_tile / binary_mul_tile ).
- Clean-up implementation: 
  - for simplicity, 'accumulator' tile is set using `fill_tile`
  - LLKs are passed as defines instead of runtime switch
  - Miscellaneous cleanup (constants such as `cb_in` -> `CB_IN`)
- Update cumsum test (tighter margins such as 1 ULP tolerance for bfloat16, enable long tensor tests for bfloat16)
- Exclude `test_intimg.py` (integral image) from tt-sim tests: new cumsum setup (fp32_acc + unpack_to_dest) triggers Undefined behavior error in tt-sim (despite being the only _known_ (?) configuration that gives fp32-accurate outputs). For test_intimg.py, this happens because its tests can compare outputs against cumsum composite.

### Accuracy improvements

These changes significantly improve cumsum for both bfloat16 and float32:

- On main, error increase quickly as tensor length increase (10 000% relative error at 4000)
- For bfloat16, error is now relatively constant up to 4000 elements

Note: PSNR ~ normalized MSE on log scale

#### Before

**bfloat16**

<img width="2250" height="600" alt="cumsum_accuracy_bfloat16" src="https://github.com/user-attachments/assets/5f680fb2-63ff-40a9-bccf-420cbb34b8de" />


**float32**

<img width="2250" height="600" alt="cumsum_accuracy_float32" src="https://github.com/user-attachments/assets/d08867e3-f8f6-46a9-85a6-2b651e634c5c" />

#### After

**bfloat16**

<img width="2250" height="600" alt="cumsum_accuracy_bfloat16_after" src="https://github.com/user-attachments/assets/06d4026c-2ab4-4b52-beb0-ee1c699be77f" />

**float32**

<img width="2250" height="600" alt="cumsum_accuracy_float32_after" src="https://github.com/user-attachments/assets/3b2c59f5-f51a-4d0c-9706-49c5c4c839a5" />


### Performance evaluation

Switching from FPU to SFPU has a performance overhead. 
For long tensor (`[131072, 1, 32, 32]`, dim=0), performance goes from ~1.9 GElem/s to 1.2 GElem/s (uses single core)
For a 'wide' tensor (`[256, 1, 512, 512]`, dim=0), performance goes from. ~13.4 GElem/s to 12.9 GElem/s (multi-core).

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/fix-cumsum-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/fix-cumsum-accuracy)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
