### PR TITLE
Enable LLK unit tests with LLK_ASSERTS enabled on nightly

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -94,6 +94,11 @@ on:
         required: false
         type: boolean
         default: true
+      enable-llk-asserts:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable LLK asserts"
       ttsim-version:
         required: false
         type: string
@@ -141,6 +146,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly conv tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -187,6 +193,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly matmul tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -231,6 +238,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly docs examples tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/docs_examples -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -274,6 +282,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly fused tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -320,6 +329,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly reduction tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -366,6 +376,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly experimental tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -412,6 +423,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly pool tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -462,6 +474,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly sdxl tests (wormhole)
         if: ${{ inputs.arch == 'wormhole_b0' }}
         timeout-minutes: ${{ inputs.timeout }}
@@ -524,6 +537,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: tt-train nightly tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/tt-train/tests/ttml_tests --gtest_filter=*NIGHTLY_*
@@ -570,6 +584,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: tt-sdpa-nightly tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
@@ -620,6 +635,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: tt-sdpa-stress tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
@@ -674,6 +690,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly eltwise tests group ${{ matrix.group }}
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group ${{ matrix.group }} -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -721,6 +738,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly transformers tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -767,6 +785,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn nightly moreh tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -814,6 +833,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           hang-detection-timeout: 10.0
       - name: ttnn nightly data_movement tests
         timeout-minutes: ${{ inputs.timeout }}
@@ -870,6 +890,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ttnn misc (rand and ssm) tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/rand tests/ttnn/nightly/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
@@ -915,6 +936,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: Compute ttsim asset name
         id: ttsim-info
         run: |

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -296,6 +296,7 @@ jobs:
       run_reduction_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',reduction,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
       run_compute_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',compute_fused,') }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   ttnn-ops-docs-check:
     needs: [build-artifact, generate-arch-matrix]
     if: |

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -104,6 +104,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      enable-llk-asserts:
+        description: 'Enable LLK asserts'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-artifact:
@@ -346,6 +351,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       gtest_filter: "*NIGHTLY_*"
       nightly-run: true
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # Metal IOMMU Unit Tests
   metal-iommu-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
@@ -382,6 +388,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # Fast Dispatch Unit Tests
   fast-dispatch-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
@@ -399,6 +406,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # TTNN Tutorials
   test-ttnn-tutorials:
     needs: [build-artifact, generate-arch-matrix]
@@ -417,6 +425,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.basic-ttnn-runtime-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   run-profiler-regression:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -434,6 +443,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   tt-train-cpp-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -452,6 +462,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       timeout: 90
       gtest_filter: "*"
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   tt-train-cpp-models:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -469,6 +480,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       timeout: 90
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   tt-train-python-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -487,6 +499,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       timeout: 10
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # FD Model Tests
   models-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
@@ -504,6 +517,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # Triage tests (including hang report generation test)
   triage-tests:
     needs: [build-artifact, generate-arch-matrix]
@@ -520,6 +534,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       run-hang-report-test: true
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
     needs: [build-artifact, generate-arch-matrix]
@@ -537,3 +552,4 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}

--- a/.github/workflows/tt-train-run-models.yaml
+++ b/.github/workflows/tt-train-run-models.yaml
@@ -23,6 +23,16 @@ on:
         required: false
         type: boolean
         default: false
+      enable-lightweight-kernel-asserts:
+        description: 'Enable lightweight kernel asserts'
+        required: false
+        type: boolean
+        default: false
+      enable-llk-asserts:
+        description: 'Enable LLK asserts'
+        required: false
+        type: boolean
+        default: false
       ref:
         required: false
         type: string

--- a/tests/tt_metal/tt_metal/llk/test_compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_compute_kernel_sentinel.cpp
@@ -104,6 +104,7 @@ bool single_core_compute_kernel_sentinel(
     defines["FORCE_WATCHER_OFF"] = "1";
     defines["LIGHTWEIGHT_KERNEL_ASSERTS"] = "1";
     defines["TT_METAL_COMPUTE_KERNEL_SENTINEL_ENABLED"] = "1";
+    defines["TT_METAL_COMPUTE_KERNEL_SENTINEL_DEFAULT_INJECTION"] = "1";
     defines["REDUCE_OP"] = "PoolType::SUM";
     defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -18,9 +18,8 @@ inline void tilizeA_B_binary_init(
 }
 
 inline void add_tiles_math(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
-    MATH(
-        (llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
-             icb0, icb1, idst, true)));
+    MATH((llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
+        icb0, icb1, idst, true)));
 }
 
 void kernel_main() {

--- a/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
+++ b/tt_metal/hw/inc/api/compute/sentinel/sentinel_core.h
@@ -185,7 +185,7 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            reconfig_data_format_srca<>(m_srca_cb, cb);
+            reconfig_data_format_srca<false, true>(m_srca_cb, cb);
         }
 
         DPRINT << "reconfig_data_format_srca - ";
@@ -196,7 +196,7 @@ ALWI void SentinelCore::inject_single_operand(uint32_t cb) {
             return;
         }
         if (m_enabled) {
-            reconfig_data_format_srcb<>(m_srcb_cb, cb);
+            reconfig_data_format_srcb<false, true>(m_srcb_cb, cb);
         }
 
         DPRINT << "reconfig_data_format_srcb - ";


### PR DESCRIPTION
### Ticket
#41374

### Problem description
Currently, there is no way to trigger LLK unit tests with LLK_ASSERT enabled. Also, when enabled, there were few tests not passing.

### What's changed
This PR makes LLK assert–enabled runs usable in CI and fixes a few LLK unit test / sentinel paths that tripped asserts when asserts are on. It wires the existing `enable-llk-asserts` flag through **L2 nightly** and the **tt-train run models** reusable workflow so a single manual dispatch can opt in across downstream jobs.

## What changed

- **Tests / kernels:** Adjustments in LLK-related unit tests and compute kernels (`test_compute_kernel_sentinel`, `unpack_tilizeA_B`, `sentinel_core.h`) so behavior matches expectations under **LLK_ASSERTS** (commit `101b7af4a8`).
- **L2 nightly:** New `workflow_dispatch` input `enable-llk-asserts` and pass-through to reusable jobs in `tt-metal-l2-nightly.yaml` (commit `a599732a5f`).
- **tt-train models:** Add `workflow_call` inputs `enable-lightweight-kernel-asserts` and `enable-llk-asserts` to `tt-train-run-models.yaml` and forward them to `setup-job` (commit `e126a522c0`).

## Testing

Manual **Nightly tt-metal L2 tests** run with LLK asserts enabled:

- Run: https://github.com/tenstorrent/tt-metal/actions/runs/23893156419

**Observed:** Wormhole_b0 **N150** / **N300** and Blackhole **P150** **LLK unit tests** completed successfully with LLK asserts enabled.

**Note:** Blackhole **P100** jobs were not exercised in that run due to runner / capacity limits at dispatch time; remaining matrix coverage can be validated when P100 capacity is available.



### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
