### PR TITLE
[tt-train] fix double bf16 parameters allocation in fp32 adamw

### DIFF
--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -6,32 +6,29 @@
 
 #include "core/tt_tensor_utils.hpp"
 
-namespace {
-
-inline bool is_castable_tensor(const tt::tt_metal::Tensor &tensor) {
-    return tensor.dtype() == ttnn::DataType::FLOAT32;
-}
-
-}  // namespace
-
 namespace ttml::autograd {
 
 void AutocastTensor::set_tensor(const tt::tt_metal::Tensor &tensor) {
     if (tensor.dtype() == ttnn::DataType::FLOAT32) {
         m_full_precision_tensor = tensor;
-        m_half_precision_tensor = ttnn::typecast(tensor, ttnn::DataType::BFLOAT16);
-        return;
+        m_half_precision_tensor = ttnn::Tensor();
+    } else {
+        m_half_precision_tensor = tensor;
+        m_full_precision_tensor = ttnn::Tensor();
     }
-
-    m_full_precision_tensor = tensor;
-    m_half_precision_tensor = ttnn::Tensor();  // Reset the half precision tensor
 }
 
 const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision) const {
-    if (preferred_precision == PreferredPrecision::HALF && is_castable_tensor(m_full_precision_tensor)) {
+    if (preferred_precision == PreferredPrecision::HALF) {
+        if (!core::is_tensor_initialized(m_half_precision_tensor)) {
+            m_half_precision_tensor = ttnn::typecast(m_full_precision_tensor, ttnn::DataType::BFLOAT16);
+        }
         return m_half_precision_tensor;
     }
 
+    if (!core::is_tensor_initialized(m_full_precision_tensor)) {
+        m_full_precision_tensor = ttnn::typecast(m_half_precision_tensor, ttnn::DataType::FLOAT32);
+    }
     return m_full_precision_tensor;
 }
 

--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -9,6 +9,11 @@
 namespace ttml::autograd {
 
 void AutocastTensor::set_tensor(const tt::tt_metal::Tensor &tensor) {
+    TT_FATAL(
+        tensor.dtype() == ttnn::DataType::FLOAT32 || tensor.dtype() == ttnn::DataType::BFLOAT16,
+        "AutocastTensor only supports FLOAT32 and BFLOAT16, got {}",
+        tensor.dtype());
+
     if (tensor.dtype() == ttnn::DataType::FLOAT32) {
         m_full_precision_tensor = tensor;
         m_half_precision_tensor = ttnn::Tensor();
@@ -18,15 +23,23 @@ void AutocastTensor::set_tensor(const tt::tt_metal::Tensor &tensor) {
     }
 }
 
+bool AutocastTensor::has_half() const {
+    return core::is_tensor_initialized(m_half_precision_tensor);
+}
+
+bool AutocastTensor::has_full() const {
+    return core::is_tensor_initialized(m_full_precision_tensor);
+}
+
 const tt::tt_metal::Tensor &AutocastTensor::get_tensor(PreferredPrecision preferred_precision) const {
     if (preferred_precision == PreferredPrecision::HALF) {
-        if (!core::is_tensor_initialized(m_half_precision_tensor)) {
+        if (!has_half()) {
             m_half_precision_tensor = ttnn::typecast(m_full_precision_tensor, ttnn::DataType::BFLOAT16);
         }
         return m_half_precision_tensor;
     }
 
-    if (!core::is_tensor_initialized(m_full_precision_tensor)) {
+    if (!has_full()) {
         m_full_precision_tensor = ttnn::typecast(m_half_precision_tensor, ttnn::DataType::FLOAT32);
     }
     return m_full_precision_tensor;

--- a/tt-train/sources/ttml/autograd/autocast_tensor.hpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.hpp
@@ -27,6 +27,9 @@ public:
     void set_tensor(const tt::tt_metal::Tensor &tensor);
     [[nodiscard]] const tt::tt_metal::Tensor &get_tensor(
         PreferredPrecision preferred_precision = PreferredPrecision::HALF) const;
+
+    [[nodiscard]] bool has_half() const;
+    [[nodiscard]] bool has_full() const;
 };
 
 }  // namespace ttml::autograd

--- a/tt-train/sources/ttml/autograd/autocast_tensor.hpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.hpp
@@ -12,8 +12,8 @@ namespace ttml::autograd {
 enum class PreferredPrecision : uint8_t { HALF = 0, FULL = 1 };
 
 class AutocastTensor {
-    tt::tt_metal::Tensor m_half_precision_tensor{};
-    tt::tt_metal::Tensor m_full_precision_tensor{};
+    mutable tt::tt_metal::Tensor m_half_precision_tensor{};
+    mutable tt::tt_metal::Tensor m_full_precision_tensor{};
 
 public:
     AutocastTensor() = default;

--- a/tt-train/sources/ttml/optimizers/adamw.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw.cpp
@@ -25,12 +25,12 @@ AdamW::AdamW(ttml::serialization::NamedParameters parameters, const AdamWConfig&
             m_exp_avg.emplace(
                 name,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
             m_exp_avg_sq.emplace(
                 name,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
         }
     }
@@ -63,14 +63,14 @@ void AdamW::step() {
         }
 
         auto gradients = theta_ptr->get_grad();
-        auto param = theta_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto param = theta_ptr->get_value(autograd::PreferredPrecision::HALF);
 
-        const auto& exp_avg = m_exp_avg.at(name)->get_value(autograd::PreferredPrecision::FULL);
-        const auto& exp_avg_sq = m_exp_avg_sq.at(name)->get_value(autograd::PreferredPrecision::FULL);
+        const auto& exp_avg = m_exp_avg.at(name)->get_value(autograd::PreferredPrecision::HALF);
+        const auto& exp_avg_sq = m_exp_avg_sq.at(name)->get_value(autograd::PreferredPrecision::HALF);
 
         std::optional<ttnn::Tensor> max_exp_avg_sq;
         if (m_config.amsgrad) {
-            max_exp_avg_sq = m_max_exp_avg_sq.at(name)->get_value(autograd::PreferredPrecision::FULL);
+            max_exp_avg_sq = m_max_exp_avg_sq.at(name)->get_value(autograd::PreferredPrecision::HALF);
         }
 
         ttml::metal::adamw(
@@ -193,7 +193,7 @@ void AdamW::init_max_exp_avg_sq() {
             m_max_exp_avg_sq.emplace(
                 name,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
         }
     }

--- a/tt-train/sources/ttml/optimizers/adamw_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_composite.cpp
@@ -35,12 +35,12 @@ MorehAdamW::MorehAdamW(serialization::NamedParameters parameters, const AdamWCom
             m_first_moment.emplace(
                 key,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
             m_second_moment.emplace(
                 key,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
         }
     }
@@ -67,14 +67,14 @@ void MorehAdamW::step() {
             continue;
         }
         auto& second_moment_ptr = m_second_moment.at(key);
-        const auto& first_moment = first_moment_ptr->get_value(autograd::PreferredPrecision::FULL);
-        const auto& second_moment = second_moment_ptr->get_value(autograd::PreferredPrecision::FULL);
+        const auto& first_moment = first_moment_ptr->get_value(autograd::PreferredPrecision::HALF);
+        const auto& second_moment = second_moment_ptr->get_value(autograd::PreferredPrecision::HALF);
 
         auto gradients = tensor_ptr->get_grad();
 
-        auto output_tensor = tensor_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto output_tensor = tensor_ptr->get_value(autograd::PreferredPrecision::HALF);
         ttnn::moreh_adamw(
-            tensor_ptr->get_value(autograd::PreferredPrecision::FULL),
+            tensor_ptr->get_value(autograd::PreferredPrecision::HALF),
             gradients,
             first_moment,
             second_moment,
@@ -135,25 +135,25 @@ AdamWComposite::AdamWComposite(serialization::NamedParameters parameters, const 
             m_first_moment.emplace(
                 key,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
             m_second_moment.emplace(
                 key,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
             if (m_config.amsgrad) {
                 m_max_exp_avg_sq.emplace(
                     key,
                     autograd::create_tensor(
-                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                         /* requires_grad */ false));
             }
             if (m_config.kahan_summation) {
                 m_kahan_compensation.emplace(
                     key,
                     autograd::create_tensor(
-                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                         /* requires_grad */ false));
             }
         }
@@ -181,17 +181,17 @@ void AdamWComposite::step() {
             continue;
         }
         auto& second_moment_ptr = m_second_moment.at(key);
-        auto first_moment = first_moment_ptr->get_value(autograd::PreferredPrecision::FULL);
-        auto second_moment = second_moment_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto first_moment = first_moment_ptr->get_value(autograd::PreferredPrecision::HALF);
+        auto second_moment = second_moment_ptr->get_value(autograd::PreferredPrecision::HALF);
 
         auto gradients = tensor_ptr->get_grad();
 
         if (m_config.weight_decay != 0.0F) {
             auto weight_decay_update = ttnn::multiply(
-                tensor_ptr->get_value(autograd::PreferredPrecision::FULL), m_config.weight_decay * m_config.lr);
+                tensor_ptr->get_value(autograd::PreferredPrecision::HALF), m_config.weight_decay * m_config.lr);
             // weights -= weight_decay * lr * weights
             tensor_ptr->set_value(
-                ttnn::subtract(tensor_ptr->get_value(autograd::PreferredPrecision::FULL), weight_decay_update));
+                ttnn::subtract(tensor_ptr->get_value(autograd::PreferredPrecision::HALF), weight_decay_update));
         }
 
         // first moment = beta1 * first moment + (1 - beta1) * gradients
@@ -211,7 +211,7 @@ void AdamWComposite::step() {
         ttnn::Tensor denom_tensor;
         if (m_config.amsgrad) {
             auto& max_exp_avg_sq_ptr = m_max_exp_avg_sq.at(key);
-            auto max_exp_avg_sq = max_exp_avg_sq_ptr->get_value(autograd::PreferredPrecision::FULL);
+            auto max_exp_avg_sq = max_exp_avg_sq_ptr->get_value(autograd::PreferredPrecision::HALF);
             // max_exp_avg_sq = max(max_exp_avg_sq, second_moment)
             max_exp_avg_sq = ttnn::maximum(max_exp_avg_sq, second_moment);
             max_exp_avg_sq_ptr->set_value(max_exp_avg_sq);
@@ -228,13 +228,13 @@ void AdamWComposite::step() {
         auto update_tensor = ttnn_fixed::divide(ttnn::multiply(first_moment_hat, -m_config.lr), denom_tensor);
 
         if (!m_config.kahan_summation) {
-            tensor_ptr->set_value(ttnn::add(tensor_ptr->get_value(autograd::PreferredPrecision::FULL), update_tensor));
+            tensor_ptr->set_value(ttnn::add(tensor_ptr->get_value(autograd::PreferredPrecision::HALF), update_tensor));
         } else {
-            auto value_tensor = tensor_ptr->get_value(autograd::PreferredPrecision::FULL);
+            auto value_tensor = tensor_ptr->get_value(autograd::PreferredPrecision::HALF);
 
             const auto& kahan_compensation_ptr = m_kahan_compensation.at(key);
             // A running compensation for lost low-order bits
-            auto compensation_tensor = kahan_compensation_ptr->get_value(autograd::PreferredPrecision::FULL);
+            auto compensation_tensor = kahan_compensation_ptr->get_value(autograd::PreferredPrecision::HALF);
             // Adjust the update with the compensation
             auto adjusted_update = ttnn::subtract(update_tensor, compensation_tensor);
             // Update the value with the adjusted update

--- a/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
@@ -24,7 +24,7 @@ AdamWFullPrecision::AdamWFullPrecision(
     for (const auto& [name, tensor_ptr] : m_parameters) {
         if (tensor_ptr->get_requires_grad()) {
             // Create fp32 master weights from the initial bf16 weights
-            auto bf16_weights = tensor_ptr->get_value(autograd::PreferredPrecision::FULL);
+            auto bf16_weights = tensor_ptr->get_value(autograd::PreferredPrecision::HALF);
             auto fp32_master = ttnn::typecast(bf16_weights, tt::tt_metal::DataType::FLOAT32);
             m_master_weights.emplace(name, autograd::create_tensor(fp32_master, /* requires_grad */ false));
 

--- a/tt-train/sources/ttml/optimizers/muon_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/muon_composite.cpp
@@ -19,7 +19,7 @@ MuonComposite::MuonComposite(ttml::serialization::NamedParameters parameters, co
             m_momentum_buffer.emplace(
                 name,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
         }
     }
@@ -39,7 +39,7 @@ void MuonComposite::step() {
     }
 
     for (auto& [name, buffer_ptr] : m_momentum_buffer) {
-        auto buffer = buffer_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto buffer = buffer_ptr->get_value(autograd::PreferredPrecision::HALF);
         const auto& tensor_ptr = m_parameters.at(name);
         if (!tensor_ptr->is_grad_initialized()) {
             continue;
@@ -59,7 +59,7 @@ void MuonComposite::step() {
         const auto update_direction = ops::newtonschulz5(buffer, m_config.ns_steps, 1e-7f);
 
         tensor_ptr->set_value(ttnn::subtract(
-            tensor_ptr->get_value(autograd::PreferredPrecision::FULL), ttnn::multiply(update_direction, m_config.lr)));
+            tensor_ptr->get_value(autograd::PreferredPrecision::HALF), ttnn::multiply(update_direction, m_config.lr)));
     }
     m_steps++;
 }

--- a/tt-train/sources/ttml/optimizers/sgd.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd.cpp
@@ -24,7 +24,7 @@ SGD::SGD(ttml::serialization::NamedParameters parameters, const SGDConfig& confi
                 m_momentum.emplace(
                     name,
                     autograd::create_tensor(
-                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                        core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                         /* requires_grad */ false));
             }
         }
@@ -51,7 +51,7 @@ void SGD::step() {
             continue;
         }
         auto gradients = theta_ptr->get_grad();
-        auto param = theta_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto param = theta_ptr->get_value(autograd::PreferredPrecision::HALF);
 
         std::optional<ttnn::Tensor> momentum_buffer;
         if (m_config.momentum > 0.0) {
@@ -62,7 +62,7 @@ void SGD::step() {
                     /* requires_grad */ false);
                 it = m_momentum.emplace(name, std::move(buf)).first;
             }
-            momentum_buffer = it->second->get_value(autograd::PreferredPrecision::FULL);
+            momentum_buffer = it->second->get_value(autograd::PreferredPrecision::HALF);
         }
 
         // The first step should not apply dampening

--- a/tt-train/sources/ttml/optimizers/sgd_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.cpp
@@ -21,7 +21,7 @@ SGDComposite::SGDComposite(ttml::serialization::NamedParameters parameters, cons
             m_theta.emplace(
                 name,
                 autograd::create_tensor(
-                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::FULL)),
+                    core::zeros_like(tensor_ptr->get_value(autograd::PreferredPrecision::HALF)),
                     /* requires_grad */ false));
         }
     }
@@ -41,7 +41,7 @@ void SGDComposite::step() {
     }
 
     for (auto& [name, theta_ptr] : m_theta) {
-        auto theta = theta_ptr->get_value(autograd::PreferredPrecision::FULL);
+        auto theta = theta_ptr->get_value(autograd::PreferredPrecision::HALF);
         const auto& tensor_ptr = m_parameters.at(name);
         if (!tensor_ptr->is_grad_initialized()) {
             continue;
@@ -52,7 +52,7 @@ void SGDComposite::step() {
         if (m_config.weight_decay != 0.0F) {
             gradients = ttnn::add(
                 ttnn::multiply(
-                    tensor_ptr->get_value(autograd::PreferredPrecision::FULL),
+                    tensor_ptr->get_value(autograd::PreferredPrecision::HALF),
                     m_config.weight_decay,
                     /* fast_and_approximate_mode*/ true),
                 gradients);
@@ -93,7 +93,7 @@ void SGDComposite::step() {
         }
         theta_ptr->set_value(theta);
         tensor_ptr->set_value(ttnn::subtract(
-            tensor_ptr->get_value(autograd::PreferredPrecision::FULL),
+            tensor_ptr->get_value(autograd::PreferredPrecision::HALF),
             ttnn::multiply(
                 gradients,
                 m_config.lr,

--- a/tt-train/tests/autograd/autograd_tensor.cpp
+++ b/tt-train/tests/autograd/autograd_tensor.cpp
@@ -46,50 +46,34 @@ TEST_F(AutogradTensorTest, AutocastTensorFromFLOAT32) {
     auto tt_tensor =
         ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
     auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
-    const auto& half_precision_tensor = autocast_tensor.get_tensor();
-    const auto& full_precision_tensor = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
 
-    EXPECT_EQ(half_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
-    EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::FLOAT32);
+    EXPECT_TRUE(autocast_tensor.has_full());
+    EXPECT_FALSE(autocast_tensor.has_half());
+
+    const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+    EXPECT_EQ(full.dtype(), ttnn::DataType::FLOAT32);
+    EXPECT_FALSE(autocast_tensor.has_half());
+
+    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
+    EXPECT_TRUE(autocast_tensor.has_half());
 }
 
 TEST_F(AutogradTensorTest, AutocastTensorFromBFLOAT16) {
     auto tt_tensor =
         ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
     auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
-    const auto& half_precision_tensor = autocast_tensor.get_tensor();
-    const auto& full_precision_tensor = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
 
-    EXPECT_EQ(half_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
-    EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::FLOAT32);
-}
+    EXPECT_TRUE(autocast_tensor.has_half());
+    EXPECT_FALSE(autocast_tensor.has_full());
 
-TEST_F(AutogradTensorTest, AutocastTensorLazyHalfNotCreatedWhenUnused) {
-    auto tt_tensor =
-        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
-    auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
-
-    // Only request FULL — the BF16 half should not be created
-    const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
-    EXPECT_EQ(full.dtype(), ttnn::DataType::FLOAT32);
-
-    // Now request HALF — it should be lazily created
     const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
     EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
-}
+    EXPECT_FALSE(autocast_tensor.has_full());
 
-TEST_F(AutogradTensorTest, AutocastTensorLazyFullNotCreatedWhenUnused) {
-    auto tt_tensor =
-        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
-    auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
-
-    // Only request HALF — the FP32 full should not be created
-    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
-    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
-
-    // Now request FULL — it should be lazily created
     const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
     EXPECT_EQ(full.dtype(), ttnn::DataType::FLOAT32);
+    EXPECT_TRUE(autocast_tensor.has_full());
 }
 
 TEST_F(AutogradTensorTest, AutocastTensorSetTensorInvalidatesCache) {
@@ -97,19 +81,21 @@ TEST_F(AutogradTensorTest, AutocastTensorSetTensorInvalidatesCache) {
         ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
     auto autocast_tensor = autograd::AutocastTensor(fp32_tensor);
 
-    // Trigger lazy BF16 creation
-    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
-    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
+    EXPECT_TRUE(autocast_tensor.has_full());
+    EXPECT_FALSE(autocast_tensor.has_half());
 
-    // Overwrite with a BF16 tensor — should invalidate the FP32 cache
+    [[maybe_unused]] const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_TRUE(autocast_tensor.has_full());
+    EXPECT_TRUE(autocast_tensor.has_half());
+
     auto bf16_tensor =
         ttml::core::zeros(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
     autocast_tensor.set_tensor(bf16_tensor);
 
-    const auto& new_half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
-    EXPECT_EQ(new_half.dtype(), ttnn::DataType::BFLOAT16);
+    EXPECT_TRUE(autocast_tensor.has_half());
+    EXPECT_FALSE(autocast_tensor.has_full());
 
-    // FP32 should be lazily recreated from the new BF16 tensor
-    const auto& new_full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
-    EXPECT_EQ(new_full.dtype(), ttnn::DataType::FLOAT32);
+    [[maybe_unused]] const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+    EXPECT_TRUE(autocast_tensor.has_half());
+    EXPECT_TRUE(autocast_tensor.has_full());
 }

--- a/tt-train/tests/autograd/autograd_tensor.cpp
+++ b/tt-train/tests/autograd/autograd_tensor.cpp
@@ -39,10 +39,10 @@ TEST_F(AutogradTensorTest, AutogradTensorBFLOAT16) {
     const auto& full_precision_tensor = tensor->get_value(autograd::PreferredPrecision::FULL);
 
     EXPECT_EQ(half_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
-    EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
+    EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::FLOAT32);
 }
 
-TEST_F(AutogradTensorTest, AutocastTensor) {
+TEST_F(AutogradTensorTest, AutocastTensorFromFLOAT32) {
     auto tt_tensor =
         ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
     auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
@@ -51,4 +51,65 @@ TEST_F(AutogradTensorTest, AutocastTensor) {
 
     EXPECT_EQ(half_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
     EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::FLOAT32);
+}
+
+TEST_F(AutogradTensorTest, AutocastTensorFromBFLOAT16) {
+    auto tt_tensor =
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
+    auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
+    const auto& half_precision_tensor = autocast_tensor.get_tensor();
+    const auto& full_precision_tensor = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+
+    EXPECT_EQ(half_precision_tensor.dtype(), ttnn::DataType::BFLOAT16);
+    EXPECT_EQ(full_precision_tensor.dtype(), ttnn::DataType::FLOAT32);
+}
+
+TEST_F(AutogradTensorTest, AutocastTensorLazyHalfNotCreatedWhenUnused) {
+    auto tt_tensor =
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
+    auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
+
+    // Only request FULL — the BF16 half should not be created
+    const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+    EXPECT_EQ(full.dtype(), ttnn::DataType::FLOAT32);
+
+    // Now request HALF — it should be lazily created
+    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
+}
+
+TEST_F(AutogradTensorTest, AutocastTensorLazyFullNotCreatedWhenUnused) {
+    auto tt_tensor =
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
+    auto autocast_tensor = autograd::AutocastTensor(tt_tensor);
+
+    // Only request HALF — the FP32 full should not be created
+    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
+
+    // Now request FULL — it should be lazily created
+    const auto& full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+    EXPECT_EQ(full.dtype(), ttnn::DataType::FLOAT32);
+}
+
+TEST_F(AutogradTensorTest, AutocastTensorSetTensorInvalidatesCache) {
+    auto fp32_tensor =
+        ttml::core::ones(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::FLOAT32);
+    auto autocast_tensor = autograd::AutocastTensor(fp32_tensor);
+
+    // Trigger lazy BF16 creation
+    const auto& half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_EQ(half.dtype(), ttnn::DataType::BFLOAT16);
+
+    // Overwrite with a BF16 tensor — should invalidate the FP32 cache
+    auto bf16_tensor =
+        ttml::core::zeros(ttnn::Shape({1, 1, 1, 32}), &autograd::ctx().get_device(), ttnn::DataType::BFLOAT16);
+    autocast_tensor.set_tensor(bf16_tensor);
+
+    const auto& new_half = autocast_tensor.get_tensor(autograd::PreferredPrecision::HALF);
+    EXPECT_EQ(new_half.dtype(), ttnn::DataType::BFLOAT16);
+
+    // FP32 should be lazily recreated from the new BF16 tensor
+    const auto& new_full = autocast_tensor.get_tensor(autograd::PreferredPrecision::FULL);
+    EXPECT_EQ(new_full.dtype(), ttnn::DataType::FLOAT32);
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fix autocast tensor always creating bf16 copy for fp32 tensors. 
Reduces AdamW FullPrecision optimizer state by a factor of **1.5**

### What's changed
- Create copy of different precision lazily, when requested via get_tensor()
- Add tests

tinyllama / char tokenizer / AdamWFullPrecision memory usage change: 

<img width="1782" height="1185" alt="image" src="https://github.com/user-attachments/assets/4ed3398f-1378-4557-9273-0a80dd739d61" />


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/fix-double-bf16-parameters-allocation-in-fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/fix-double-bf16-parameters-allocation-in-fp32)