### PR TITLE
[QSR] Fix buff descriptor x and y dimension programming

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -135,8 +135,8 @@ inline void llk_pack_hw_configure(const std::uint32_t pack_output) {
         buffer_descriptor_u bd_val = {0};
         bd_val.f.l1_addr_16B = g_dfb_interface[i].tc_slots[0].base_addr;
         bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
-        bd_val.f.x_dim = pack_tile_face_r_dim[i];
-        bd_val.f.y_dim = ckernel::trisc::FACE_C_DIM;
+        bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
+        bd_val.f.y_dim = pack_tile_face_r_dim[i];
         bd_val.f.z_dim = pack_tile_num_faces[i];
 
         ckernel::trisc::_configure_buf_desc_table_(i, bd_val);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -41,8 +41,8 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         buffer_descriptor_u bd_val = {0};
         bd_val.f.l1_addr_16B = g_dfb_interface[i].tc_slots[0].base_addr;
         bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
-        bd_val.f.x_dim = unpack_tile_face_r_dim[i];
-        bd_val.f.y_dim = ckernel::trisc::FACE_C_DIM;
+        bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
+        bd_val.f.y_dim = unpack_tile_face_r_dim[i];
         bd_val.f.z_dim = unpack_tile_num_faces[i];
 
         ckernel::trisc::_configure_buf_desc_table_(i, bd_val);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
x and y dim are not programmed well in the pack/unpack hw llk api. The values are swapped.

### What's changed
Set x_dim to face_c_dim and y dim to face_r_dim

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/swap_xy_dim)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/swap_xy_dim)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/swap_xy_dim)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/swap_xy_dim)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/swap_xy_dim)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/swap_xy_dim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/swap_xy_dim)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
