### PR TITLE
tests/ttnn: fix test_embedding test_base_case with uint32 indices

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -15,7 +15,7 @@ def test_base_case(device):
     embedding_matrix = ttnn.to_device(ttnn.from_torch(torch.rand(10, 2), dtype=ttnn.bfloat16), device)
     indices_torch = ttnn.to_torch(ttnn.from_device(indices))
     embedding_matrix_torch = ttnn.to_torch(ttnn.from_device(embedding_matrix))
-    expected_embeddings = torch.nn.functional.embedding(indices_torch, embedding_matrix_torch)
+    expected_embeddings = torch.nn.functional.embedding(indices_torch.to(torch.int64), embedding_matrix_torch)
     embeddings = ttnn.embedding(indices, embedding_matrix)
     assert tuple(expected_embeddings.shape) == tuple(embeddings.shape)
     embeddings = ttnn.to_torch(ttnn.from_device(embeddings))


### PR DESCRIPTION
### Problem

`test_base_case` in `tests/ttnn/unit_tests/operations/data_movement/test_embedding.py` fails with:

```
RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got torch.uint32 instead
```

### Root cause

`ttnn.to_torch` correctly maps TTNN `uint32` → `torch.uint32` (via dlpack in PyTorch ≥ 2.3). However, `torch.nn.functional.embedding` only accepts `torch.int32` or `torch.int64` indices — not `torch.uint32`.

The test computes its golden reference by round-tripping indices through the device (`ttnn.to_torch(ttnn.from_device(indices))`) and then calling `torch.nn.functional.embedding` on the result. This breaks on PyTorch ≥ 2.3 because `to_torch` now returns the correct unsigned type instead of silently casting to `int32`.

### Fix

Cast `indices_torch` to `torch.int64` before passing to `torch.nn.functional.embedding`. Index values are non-negative and fit in `int64` with no loss.

```python
# Before
expected_embeddings = torch.nn.functional.embedding(indices_torch, embedding_matrix_torch)

# After
expected_embeddings = torch.nn.functional.embedding(indices_torch.to(torch.int64), embedding_matrix_torch)
```

### Checklist

- [x] Single-line fix, no functional change to TTNN embedding op
- [x] Fixes golden reference computation to be compatible with PyTorch ≥ 2.3 dlpack behaviour
