### PR TITLE
[BrAIn] Skip topk_router_gpt tests on Blackhole

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_router_gpt.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_router_gpt.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 import ttnn
 from loguru import logger
 
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, skip_for_blackhole
 
 PCC_THRESHOLD = 0.95
 
@@ -51,6 +51,7 @@ def run_fused_op(device, torch_input, torch_weight, torch_bias, B, K, N, k=4):
     return weights, indices
 
 
+@skip_for_blackhole("topk_router_gpt requires 12 DRAM-aligned cores; Blackhole only has 8")
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -95,6 +96,7 @@ def test_topk_router_gpt_deterministic(device, B, K, N, TOP_K):
     assert pcc_val >= 0.99, f"Weight PCC {pcc_val} below threshold 0.99"
 
 
+@skip_for_blackhole("topk_router_gpt requires 12 DRAM-aligned cores; Blackhole only has 8")
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -150,6 +152,7 @@ def test_topk_router_gpt_random_matmul(device, B, K, N, TOP_K, seed):
     assert all_positive, "Some weights are not positive"
 
 
+@skip_for_blackhole("topk_router_gpt requires 12 DRAM-aligned cores; Blackhole only has 8")
 @pytest.mark.parametrize(
     "device_params",
     [


### PR DESCRIPTION
## Summary

`topk_router_gpt` requires at least 12 DRAM-aligned cores (hardcoded ring algorithm), but Blackhole only has 8 DRAM views vs Wormhole's 12.

All three tests in this file fail with:
```
RuntimeError: TT_FATAL @ topk_router_gpt_program_factory.cpp:40: num_cores >= required_cores
info: topk_router_gpt requires at least 12 DRAM-aligned cores, got 8
```

Adds `@skip_for_blackhole()` to all three test functions. The root cause (op algorithm hardcoded for WH's 12 DRAM views) is a separate issue to fix in the op itself.

## Root cause

- WH `dram_views`: 12 (6 channels × 2 sub-views each)
- BH `dram_views`: 8 (8 channels × 1 view each)
- `get_optimal_dram_bank_to_logical_worker_assignment()` returns one worker core per DRAM view
- `topk_router_gpt_program_factory.cpp` asserts `num_cores >= 12`

## Test plan
- [ ] Verify tests are skipped (not failed) on BH ttsim
- [ ] Verify tests still pass on WH