### PR TITLE
[BrAIn] moe_gate_mm: replace UB with TT_FATAL for non-Wormhole architectures

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
@@ -27,6 +27,14 @@ MoEGateMMProgramFactory::cached_program_t MoEGateMMProgramFactory::create(
             tt::tt_metal::NOC::RISCV_0_default);
 
     const uint32_t num_cores = dram_bank2core_coords.size();
+    constexpr uint32_t required_cores = 12;
+    TT_FATAL(
+        num_cores == required_cores,
+        "moe_gate_mm requires exactly {} DRAM-aligned cores (Wormhole); got {}. "
+        "This op's ring algorithm is hardcoded for Wormhole's 12 DRAM views and does not support other "
+        "architectures.",
+        required_cores,
+        num_cores);
     auto all_cores = tt::tt_metal::CoreRangeSet(dram_bank2core_coords);
 
     // CBs used in the MoE Gate MM operation


### PR DESCRIPTION
## Summary

`moe_gate_mm_program_factory.cpp` has two silent out-of-bounds accesses when run on Blackhole (8 DRAM views instead of Wormhole's 12):

1. Loop `ring_pos += 3` with `num_cores=8`: last iteration accesses `ring_pos+2 = 8` (OOB for size-8 vector)
2. Hardcoded `ring_pos2bank_id[11]`: index 11 is OOB for size-8 vector

Both are UB → nondeterministic garbage `CoreCoord` values → `RuntimeError: No core coordinate found at location: (13740129102165327480, ...)`. The nondeterminism (sometimes passes, sometimes crashes) is classic UB stack-read behaviour.

## Root cause

- WH `dram_views`: 12 (6 channels × 2 sub-views) → `num_cores=12` → both accesses are in-bounds ✅
- BH `dram_views`: 8 (8 channels × 1 sub-view) → `num_cores=8` → both accesses are OOB 💥

The ring algorithm is fundamentally designed for `num_cores=12`. Generalising it for BH is a separate task.

## Fix

Add `TT_FATAL(num_cores == 12, ...)` immediately after computing `num_cores`, before any indexed access. Turns silent UB into a clear, actionable error message.

## Test plan
- [ ] Confirm clean `TT_FATAL` error on BH instead of garbage-coordinate crash
- [ ] WH behaviour unchanged