### PR TITLE
[skip ci] Legal: Update copyright for files added/modified after PR #41389

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_parallel_embedding.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_eth_cores.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_invalid_print_core.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <map>

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <fmt/base.h>

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/erisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/erisc_print.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_tiles_multiple_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_tiles_multiple_brisc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_fusion_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_fusion_cache.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_device_operation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/device/patchable_generic_op_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/patchable_generic_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/patchable_generic_op_nanobind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/generic/patchable_generic_op_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/generic/patchable_generic_op_nanobind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Follow-up to PR #41389 which updated copyright headers to 'Tenstorrent USA, Inc.' These 70 files were added or modified after the main PR was created:

- 48 Python files (.py)
- 15 C++ source files (.cpp)
- 4 C++ headers (.hpp)
- 2 hardware headers (.h)
- 1 file with non-standard (c) format

All files now use correct company name with original years preserved.

Files updated:
- New device_print tests (12 files)
- New generic patchable op files (7 files)
- tt-train examples and tools (18 files)
- models/experimental updates (26 files)
- New ttnn test files (2 files)
- Hardware register files (2 files)
- deepseek_v3_d_p updates (2 files)
- gsm8k_finetune serialization (1 file)

Validation: 0 violations across 11,926 files.