### PR TITLE
Fix NOC alignment in LLK reduce scaler zeros reader (BH ttsim)

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -47,10 +47,12 @@ void kernel_main() {
 #endif
     constexpr uint32_t scaler = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     experimental::UnicastEndpoint mem_zero_endpoint;
 
-    // Fill tile with zeros
+    // Fill tile with zeros by reading from local core's MEM_ZEROS region.
+    // Must supply local NOC coordinates explicitly — UnicastEndpoint defaults to (0,0) which on
+    // Blackhole is a DRAM bank, causing a stricter 64-byte DRAM alignment check in ttsim to fail
+    // because MEM_ZEROS_BASE (0x32e0) is only 32-byte aligned.
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
 #ifdef ARCH_QUASAR
         noc.async_read(
@@ -60,7 +62,7 @@ void kernel_main() {
             mem_zero_endpoint,
             experimental::use<experimental::CircularBuffer::AddrSelector::WRITE_PTR>(cb2),
             MEM_ZEROS_SIZE,
-            {.addr = MEM_ZEROS_BASE},
+            {.noc_x = NOC_X(my_x()), .noc_y = NOC_Y(my_y()), .addr = MEM_ZEROS_BASE},
             {.offset_bytes = i * MEM_ZEROS_SIZE});
 #endif
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -62,7 +62,7 @@ void kernel_main() {
             mem_zero_endpoint,
             experimental::use<experimental::CircularBuffer::AddrSelector::WRITE_PTR>(cb2),
             MEM_ZEROS_SIZE,
-            {.noc_x = NOC_X(my_x()), .noc_y = NOC_Y(my_y()), .addr = MEM_ZEROS_BASE},
+            {.noc_x = my_x[noc_index], .noc_y = my_y[noc_index], .addr = MEM_ZEROS_BASE},
             {.offset_bytes = i * MEM_ZEROS_SIZE});
 #endif
     }


### PR DESCRIPTION
### Problem

`TensixComputeReduceH` and `TensixComputeReduceHMathOnly` fail on BH ttsim:
```
noc_cmd_ctrl: read: alignment of src_addr=0x32e0 and dst_addr=0x3b200 does not match
```

### Root cause

`reader_unary_transpose_wh_interleaved.cpp` fills a scaler tile (CB c_2) with zeros by reading from `MEM_ZEROS_BASE` using `experimental::UnicastEndpoint`. The `UnicastEndpoint::src_args_type` has `noc_x{}` and `noc_y{}` that default to **0**. Since the kernel only passes `{.addr = MEM_ZEROS_BASE}` (not `noc_x`/`noc_y`), the resulting NOC address is `get_noc_addr(0, 0, 0x32e0)`.

On Blackhole, NOC coordinate `(0,0)` is a **DRAM bank**. ttsim therefore applies the BH DRAM→L1 alignment check — `(src_addr & 63) == (dst_addr & 63)` — which fails because `MEM_ZEROS_BASE = 0x32e0` is only 32-byte aligned (`0x32e0 & 63 = 32 ≠ 0`).

On Wormhole the same bug exists but the WH check is only 32-byte (`src & 31 == dst & 31`), and `0x32e0 & 31 = 0`, so WH passes silently.

There is also a **dead variable**: `zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE)` was computed correctly but never used — a leftover from the migration to the experimental 2.0 NOC API.

The tests were added to BH in a324801582 ("[QSR] Add Quasar reduce llk api, compute api and tests"); before that commit they were skipped on BH, hiding the bug.

### Fix

Explicitly supply the local core's NOC coordinates in the `async_read` src_args:
```cpp
{.noc_x = NOC_X(my_x()), .noc_y = NOC_Y(my_y()), .addr = MEM_ZEROS_BASE}
```

This makes ttsim classify the read as L1→L1 (local core read), using the 16-byte check instead of 64-byte DRAM check — and the read is semantically correct (reading from local L1 zeros region, not from a remote DRAM bank).

Also removes the dead `zeros_noc_addr` variable.

### Affected tests

```
TensixComputeReduceH        (BH ttsim — FAILING → should PASS)
TensixComputeReduceHMathOnly (BH ttsim — FAILING → should PASS)
```

### Checklist
- [ ] Post-commit tests
- [ ] Blackhole post-commit
