### PR TITLE
Bug-Fixes and Cleanup In Deepseek B1 Model Runner

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -8,6 +8,7 @@ import argparse
 import contextlib
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Literal
 
@@ -123,8 +124,12 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--io-socket-descriptor-prefix",
         type=str,
-        default="deepseek_v3_b1",
-        help="Prefix used when exporting H2D/D2H socket descriptors; sockets will be named <prefix>_h2d and <prefix>_d2h.",
+        default=None,
+        help=(
+            "If set, export H2D/D2H socket descriptors on mesh 0 after pipeline setup "
+            "(files named <prefix>_h2d / <prefix>_d2h). When --launch-only is used and "
+            "this is omitted, defaults to deepseek_v3_b1."
+        ),
     )
     return parser
 
@@ -203,8 +208,8 @@ def run_demo(
             except KeyboardInterrupt:
                 logger.info("Shutting down launch-only pipeline after interrupt.")
 
-    model_pipeline.barrier()
-    logger.info("Pod pipeline complete")
+        model_pipeline.barrier()
+        logger.info("Pod pipeline complete")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -221,6 +226,10 @@ def main(argv: list[str] | None = None) -> int:
         if not index_path.is_file():
             parser.error(f"--model-path must contain model.safetensors.index.json (missing {index_path})")
 
+    io_socket_descriptor_prefix = args.io_socket_descriptor_prefix
+    if args.launch_only and io_socket_descriptor_prefix is None:
+        io_socket_descriptor_prefix = "deepseek_v3_b1"
+
     run_demo(
         prompt=args.prompt,
         max_new_tokens=args.max_new_tokens,
@@ -233,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
         dense_layer_id_override=args.dense_layer_id_override,
         moe_layer_id_override=args.moe_layer_id_override,
         launch_only=args.launch_only,
-        io_socket_descriptor_prefix=args.io_socket_descriptor_prefix,
+        io_socket_descriptor_prefix=io_socket_descriptor_prefix,
     )
     print(file=sys.stdout, flush=True)
     return 0

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -95,12 +95,7 @@ class ModelPipeline:
             )
 
             if io_socket_descriptor_prefix is not None:
-                pipeline_block = self.pipeline._pipeline_block
-                if pipeline_block is None:
-                    raise RuntimeError(
-                        "Pipeline.setup_and_run() must complete before exporting host socket descriptors"
-                    )
-                pipeline_block.export_host_socket_descriptors(io_socket_descriptor_prefix)
+                self.pipeline.export_host_socket_descriptors(io_socket_descriptor_prefix)
 
         logger.info(f"Created ModelPipeline for mesh id {self.pipeline.my_mesh_id}.")
 

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -295,6 +295,11 @@ class Pipeline:
             raise RuntimeError("Pipeline.setup_and_run() or configure_block() must be called first")
         self._pipeline_block.read_output(output_tensor)
 
+    def export_host_socket_descriptors(self, prefix: str) -> None:
+        if self._pipeline_block is None:
+            raise RuntimeError("Pipeline.setup_and_run() must complete before exporting host socket descriptors")
+        self._pipeline_block.export_host_socket_descriptors(prefix)
+
     def barrier(self) -> None:
         ttnn.distributed_context_barrier()
 

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -10,8 +10,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
-#include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
 
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include <tt-metalium/experimental/sockets/d2h_socket.hpp>
@@ -171,6 +171,10 @@ void py_module_types(nb::module_& mod) {
 
                 Args:
                     socket_id (str): A user-provided identifier used in the descriptor filename.
+
+                Returns:
+                    str: Full filesystem path to the exported descriptor file, typically
+                    ``/dev/shm/tt_h2d_<socket_id>.bin``.
             )doc")
         .def_static(
             "connect",
@@ -307,6 +311,13 @@ void py_module_types(nb::module_& mod) {
             nb::arg("socket_id"),
             R"doc(
                 Exports a descriptor file for cross-process socket attachment.
+
+                Args:
+                    socket_id (str): Identifier used to name the exported descriptor.
+
+                Returns:
+                    str: Full filesystem path to the exported descriptor file, typically
+                    ``/dev/shm/tt_d2h_<socket_id>.bin``.
             )doc")
         .def_static(
             "connect",


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- PR supporting remote pipeline launch was missing a follow on commit with bug-fixes and cleanup

### What's changed
- This PR adds that commit

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/socket_desc_export)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/socket_desc_export)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/socket_desc_export)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/socket_desc_export)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/socket_desc_export)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/socket_desc_export)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/socket_desc_export)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
