### PR TITLE
Fix d2d_exchange_multiple_upstreams logic for ncrisc to handle socket multi-buffering

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_upstreams.cpp
@@ -192,9 +192,7 @@ void kernel_main() {
     }
 
     SocketSenderInterface sender_socket = create_sender_socket_interface(sender_socket_config_addr);
-#if defined(COMPILE_FOR_BRISC)
     set_sender_socket_page_size(sender_socket, page_size);
-#endif
     sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
 
     SocketReceiverInterface receiver_sockets[num_sockets_this_risc];
@@ -261,13 +259,8 @@ void kernel_main() {
         uint64_t dst_addr_base;
 #if defined(COMPILE_FOR_BRISC)
         noc_semaphore_set(page_ready_sem, 1);
-        dst_addr_base = downstream_data_addr + sender_socket.write_ptr;
-#elif defined(COMPILE_FOR_NCRISC)
-        {
-            SocketSenderInterface sender_socket_cur = create_sender_socket_interface(sender_socket_config_addr);
-            dst_addr_base = downstream_data_addr + sender_socket_cur.write_ptr;
-        }
 #endif
+        dst_addr_base = downstream_data_addr + sender_socket.write_ptr;
 
         terminated = process_upstream_sockets(
             receiver_sockets,
@@ -291,6 +284,9 @@ void kernel_main() {
         }
 #elif defined(COMPILE_FOR_NCRISC)
         noc_semaphore_set(ncrisc_done_sem, 1);
+        // Used to update NCRISC local copy of write_ptr
+        // Only brisc will update the actual socket config in l1 with the new write_ptr
+        socket_push_pages(sender_socket, 1);
 #endif
     }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The current d2d kernel splits work between brisc and ncrisc, but only brisc had the updated write ptr in local memory. ncrisc rereads the ptr out of l1, which is stale since brisc does not commit the updated ptr to memory in the loop.

### What's changed
Change ncrisc to also maintain an updated copy in local memory instead of going through l1.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/buffering)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/buffering)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/buffering)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/buffering)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/buffering)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/buffering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/buffering)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
