### PR TITLE
ds_prefill(fix init): Remove seed manipulation from init_helpers

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -10,6 +10,7 @@ PyTorch reference implementation when dispatching tokens to experts.
 """
 
 import pytest
+import torch
 from loguru import logger
 from tracy import signpost
 
@@ -95,6 +96,7 @@ def test_prep_dispatch_combine(
     use_predictable_data,
 ):
     """Test TTNN dispatch operation against PyTorch reference."""
+    torch.manual_seed(42)
     num_devices = mesh_device.get_num_devices()
 
     mesh_config = extract_mesh_config(mesh_device)
@@ -136,7 +138,6 @@ def test_prep_dispatch_combine(
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-            seed=42,
             num_dispatch_groups=num_dispatch_groups,
         )
         logger.debug("Using RANDOM test data")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -208,6 +208,7 @@ def test_ttnn_combine(
     use_predictable_data,
 ):
     """Test TTNN combine operation in isolation using torch reference inputs."""
+    torch.manual_seed(42)
 
     num_devices = mesh_device.get_num_devices()
 
@@ -254,7 +255,6 @@ def test_ttnn_combine(
             num_routed_experts,
             num_experts_per_tok,
             max_dispatched_tokens_per_expert,
-            seed=42,
             num_dispatch_groups=num_dispatch_groups,
         )
         logger.debug("Using RANDOM test data")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -256,6 +256,7 @@ def test_ttnn_dispatch(
     verbose,
 ):
     """Test TTNN dispatch operation against PyTorch reference."""
+    torch.manual_seed(42)
     num_devices = mesh_device.get_num_devices()
 
     mesh_config = extract_mesh_config(mesh_device)
@@ -296,7 +297,6 @@ def test_ttnn_dispatch(
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-            seed=42,
             num_dispatch_groups=num_dispatch_groups,
         )
         logger.debug("Using RANDOM test data")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
@@ -62,6 +62,7 @@ def test_ttnn_reduce(
     use_weights,
 ):
     """Test TTNN reduce module in isolation using synthetic sparse inputs."""
+    torch.manual_seed(42)
 
     signpost(f"reduce-{mesh_device.shape}-seq{seq_len}-{'weighted' if use_weights else 'unweighted'}")
 
@@ -85,7 +86,6 @@ def test_ttnn_reduce(
         topk=topk,
         emb_dim=emb_dim,
         sparsity=0.75,
-        seed=42,
     )
     logger.debug(f"Created sparse combine output: {torch_combine_output.shape}")
 
@@ -99,7 +99,6 @@ def test_ttnn_reduce(
             num_routed_experts=64,
             num_experts_per_tok=topk,
             max_dispatched_tokens_per_expert=1000,
-            seed=123,
             validate=False,
             skip_x_initialization=True,
         )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -56,7 +56,7 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     - Per device: (1, 1, isl_per_chip, 1792) - 7168 / 4 = 1792
     - Stats gathered along cluster_axis=1 (mesh columns)
     """
-    torch.manual_seed(1234)
+    torch.manual_seed(42)
 
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape
@@ -153,7 +153,7 @@ def test_rmsnorm_single_chip(device, isl_per_chip, emb_dim, epsilon):
     - Input shape: (1, 1, isl_per_chip, emb_dim) - 4D format
     - Full embedding dimension on single chip
     """
-    torch.manual_seed(1234)
+    torch.manual_seed(42)
 
     inp_shape = (1, 1, isl_per_chip, emb_dim)
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -222,6 +222,7 @@ def test_ttnn_dispatch_combine(
     use_predictable_data,
 ):
     """Test end-to-end TTNN dispatch→combine round-trip with host reduction."""
+    torch.manual_seed(42)
 
     num_devices = mesh_device.get_num_devices()
 
@@ -267,7 +268,6 @@ def test_ttnn_dispatch_combine(
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-            seed=42,
             num_dispatch_groups=num_dispatch_groups,
         )
         logger.debug("Using RANDOM test data")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -156,8 +156,8 @@ def test_ttnn_moe(
     # ========================================
     if run_pcc_check:
         profiler.start("weights_creation")
-        all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim, seed=42)
-        shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim, seed=123)
+        all_routed_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
+        shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
         profiler.end("weights_creation")
     else:
         all_routed_weights = None

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -39,7 +39,7 @@ def random_weights(config_only):
     """
     config = config_only
 
-    torch.manual_seed(42)
+    torch.manual_seed(42)  # this is likely tied to already cached reference results, so keep it consistent for now
 
     # Use proper initialization scale from config (typically 0.02)
     std = config.initializer_range

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe.py
@@ -67,6 +67,7 @@ def test_moe(
     With gate: gate_weights are passed to TorchMoe, forward only takes x.
     Can run with random weights (fast) or real HF weights (slow).
     """
+    torch.manual_seed(42)
     use_hf_weights = model_id is not None
 
     logger.debug(f"\n{'='*60}")
@@ -100,10 +101,9 @@ def test_moe(
         gate_weights_dict = None
     else:
         logger.debug("Creating random weights for experts...")
-        routed_expert_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim, seed=42)
-        shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim, seed=123)
+        routed_expert_weights = create_torch_expert_weights(num_routed_experts, emb_dim, hidden_dim)
+        shared_expert_weights = create_shared_expert_weights(emb_dim, hidden_dim)
         if use_gate:
-            torch.manual_seed(42)
             gate_weights_dict = create_gate_weights(num_routed_experts, emb_dim, dtype=torch.float32)
         else:
             gate_weights_dict = None
@@ -117,7 +117,6 @@ def test_moe(
             num_routed_experts=num_routed_experts,
             num_experts_per_tok=num_experts_per_tok,
             max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-            seed=42,
         )
         expert_offsets, expert_token_counts, _ = get_gate_outputs(
             indices,
@@ -129,7 +128,6 @@ def test_moe(
             expert_dispatch_table=expert_dispatch_table,
         )
     else:
-        torch.manual_seed(42)
         x = torch.randn(dispatch_group_size, seq_len_per_chip, emb_dim, dtype=torch.float32)
 
     # Create TorchMoe module

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
@@ -21,7 +21,6 @@ from unittest.mock import MagicMock
 # (the kernel functions are only used for fp8 quantization, not needed for bf16 testing)
 sys.modules["models.demos.deepseek_v3.reference.deepseek.kernel"] = MagicMock()
 
-import pytest
 import torch
 import torch.nn as nn
 from loguru import logger
@@ -105,7 +104,6 @@ def create_shared_weights(
     hidden_dim: int,
     n_routed_experts: int,
     n_shared_experts: int,
-    seed: int,
 ) -> tuple[list[dict], dict]:
     """
     Create random weights compatible with both implementations.
@@ -119,7 +117,6 @@ def create_shared_weights(
         routed_weights: List of dicts with gate_proj, up_proj, down_proj per expert
         shared_weights: Dict with gate_proj, up_proj, down_proj for shared expert
     """
-    torch.manual_seed(seed)
 
     routed_weights = []
     for _ in range(n_routed_experts):
@@ -202,8 +199,7 @@ def create_gate(emb_dim: int, n_routed_experts: int, num_experts_per_tok: int) -
     return gate
 
 
-@pytest.mark.parametrize("seed", [42])
-def test_moe_reference_pcc(seed: int):
+def test_moe_reference_pcc():
     """
     Compare tt_ref_moe vs ds_ref_moe (without gate).
 
@@ -213,6 +209,8 @@ def test_moe_reference_pcc(seed: int):
     - ISL: 1024
     - 256 routed experts, top-8 routing (topk=8 is gate constraint)
     """
+    torch.manual_seed(42)
+
     # Test configuration (scaled down from 671B)
     seq_len = 1024
     emb_dim = 224  # 7168 / 32
@@ -224,7 +222,7 @@ def test_moe_reference_pcc(seed: int):
     dispatch_group_size = 1  # Single "chip" for host-side test
     capacity_factor = 2.0
 
-    logger.debug(f"Test config: seed={seed}, seq_len={seq_len}, emb_dim={emb_dim}, hidden_dim={hidden_dim}")
+    logger.debug(f"Test config: seq_len={seq_len}, emb_dim={emb_dim}, hidden_dim={hidden_dim}")
     logger.debug(f"  n_routed_experts={n_routed_experts}, num_experts_per_tok={num_experts_per_tok}")
 
     # Create shared weights for both implementations
@@ -233,7 +231,6 @@ def test_moe_reference_pcc(seed: int):
         hidden_dim=hidden_dim,
         n_routed_experts=n_routed_experts,
         n_shared_experts=n_shared_experts,
-        seed=seed,
     )
 
     # 1. Create ds_ref_moe using reference/model.py Expert and MLP
@@ -290,7 +287,6 @@ def test_moe_reference_pcc(seed: int):
     )
 
     # 4. Generate test input
-    torch.manual_seed(seed + 1000)  # Different seed for input
     x = torch.randn(batch_size, seq_len, emb_dim, dtype=torch.float32)
     logger.debug(f"Input shape: {x.shape}")
 

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_torch_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_torch_dispatch_combine.py
@@ -37,6 +37,7 @@ def test_torch_dispatch_combine(
     seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_group_size, capacity_factor
 ):
     """Test dispatch→combine round-trip using PyTorch reference implementation."""
+    torch.manual_seed(42)
     experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
         seq_len_per_chip,
         num_routed_experts,
@@ -55,7 +56,6 @@ def test_torch_dispatch_combine(
         num_routed_experts=num_routed_experts,
         num_experts_per_tok=num_experts_per_tok,
         max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
-        seed=42,
     )
     # Squeeze the dispatch_group dimension since this is a single-rank pure torch test
     weights = weights.squeeze(0)

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -367,7 +367,6 @@ def initialize_test_inputs(
     num_routed_experts: int,
     num_experts_per_tok: int,
     max_dispatched_tokens_per_expert: int,
-    seed: int = 42,
     validate: bool = True,
     num_dispatch_groups: int = 1,
     skip_x_initialization: bool = False,
@@ -382,7 +381,6 @@ def initialize_test_inputs(
         num_routed_experts: Total number of routed experts across all chips
         num_experts_per_tok: Number of experts each token is routed to
         max_dispatched_tokens_per_expert: Maximum number of tokens per expert
-        seed: Random seed for reproducibility
         validate: Whether to validate expert activations
         num_dispatch_groups: Number of parallel dispatch groups
 
@@ -391,7 +389,6 @@ def initialize_test_inputs(
         weights: Router weights (num_dispatch_groups, dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
         indices: Expert indices (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
     """
-    torch.manual_seed(seed)
 
     input_shape = (dispatch_group_size, seq_len_per_chip, emb_dim)
     x = torch.randn(input_shape, dtype=torch.bfloat16) if not skip_x_initialization else None
@@ -636,7 +633,6 @@ def create_torch_expert_weights(
     num_experts: int,
     emb_dim: int,
     hidden_dim: int,
-    seed: int = 42,
 ) -> list[dict]:
     """
     Create random weights for torch experts.
@@ -645,12 +641,10 @@ def create_torch_expert_weights(
         num_experts: Number of experts to create weights for
         emb_dim: Embedding dimension
         hidden_dim: Hidden/intermediate dimension
-        seed: Random seed
 
     Returns:
         List of dicts with gate_proj, up_proj, down_proj per expert
     """
-    torch.manual_seed(seed)
     weights_list = []
     for _ in tqdm(range(num_experts), desc="Creating expert weights"):
         weights = {
@@ -665,7 +659,6 @@ def create_torch_expert_weights(
 def create_shared_expert_weights(
     emb_dim: int,
     hidden_dim: int,
-    seed: int = 123,
 ) -> dict:
     """
     Create random weights for shared expert in HF format.
@@ -673,12 +666,10 @@ def create_shared_expert_weights(
     Args:
         emb_dim: Embedding dimension
         hidden_dim: Hidden/intermediate dimension
-        seed: Random seed
 
     Returns:
         Dict with gate_proj, up_proj, down_proj in HF format (out_features, in_features)
     """
-    torch.manual_seed(seed)
     return {
         "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
         "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
@@ -692,7 +683,6 @@ def create_sparse_combine_output(
     topk: int,
     emb_dim: int,
     sparsity: float = 0.75,
-    seed: int = 42,
 ) -> torch.Tensor:
     """
     Create synthetic sparse combine output for testing.
@@ -706,12 +696,10 @@ def create_sparse_combine_output(
         topk: Number of expert slots per token
         emb_dim: Embedding dimension
         sparsity: Fraction of positions that are zero (default 0.75)
-        seed: Random seed for reproducibility
 
     Returns:
         Sparse tensor of shape [num_chips, seq_len, topk, emb_dim]
     """
-    torch.manual_seed(seed)
 
     # Create random data
     data = torch.randn(num_chips, seq_len, topk, emb_dim, dtype=torch.bfloat16)


### PR DESCRIPTION
### Problem description
Helper functions in `init_helpers.py` internally call `torch.manual_seed(seed)`, silently resetting the global RNG state every time they're called. This makes test behavior fragile and hard to reason about — a helper function should not have the side effect of changing global random state.

### What's changed
- Removed `seed` parameter and `torch.manual_seed(seed)` from 4 functions in `init_helpers.py`: `initialize_test_inputs`, `create_torch_expert_weights`, `create_shared_expert_weights`, `create_sparse_combine_output`
- Each test function now owns its seed by calling `torch.manual_seed(42)` once at the top
- Removed `seed=` keyword args from all call sites in test files
- Standardized all test seeds to `42` for consistency

#### Model tests

- [x] [![(T3K) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-ds-init-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2603-ds-init-fix) `deepseek_prefill`
- [x] [![(BH) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2603-ds-init-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2603-ds-init-fix) `deepseek_prefill`
- [x] [![Demo SP Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2603-ds-init-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2603-ds-init-fix) `deepseek_prefill`
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2603-ds-init-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2603-ds-init-fix)