### PR TITLE
Qwen3-32B QB2 (p300x2) optimizations

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -220,6 +220,59 @@ class ModelOptimizations:
         inst.__name__ = "performance"
         return inst
 
+    @classmethod
+    def max_performance(cls, model_name):
+        """Configuration for maximum throughput: BFP4 all MLP weights, HiFi2 for FF2 accumulation.
+
+        Uses BFP4 for FF2 down_proj (saves ~19% DRAM reads vs performance preset)
+        but keeps HiFi2 math fidelity for FF2 to maintain numerical stability.
+        FF1/FF3 use LoFi (same as performance preset).
+        """
+        inst = cls(
+            {
+                "TensorPrecision": {
+                    TensorGroup.FF1_FF3: PrecisionSetting.BFP4,
+                    TensorGroup.FF2: PrecisionSetting.BFP4,
+                },
+                "OpFidelity": {
+                    OpGroup.LI_FF1_FF3: MathFidelitySetting.LOFI,
+                    OpGroup.LI_FF2: MathFidelitySetting.HIFI2,
+                },
+            }
+        )
+        inst.__name__ = "max_performance"
+        return inst
+
+    @classmethod
+    def ultra_performance(cls, model_name):
+        """Maximum throughput: BFP4 all MLP + BFP8 attention + LoFi QKV/O decode.
+
+        Builds on max_performance by also reducing attention weight precision
+        from BF16 to BFP8 (~50% less DRAM reads for WQKV and WO) and using
+        LoFi math for QKV and O decode matmuls.
+        """
+        inst = cls(
+            {
+                "TensorPrecision": {
+                    TensorGroup.FF1_FF3: PrecisionSetting.BFP4,
+                    TensorGroup.FF2: PrecisionSetting.BFP4,
+                    TensorGroup.WQKV: PrecisionSetting.BFP8,
+                    TensorGroup.WO: PrecisionSetting.BFP8,
+                    TensorGroup.KV_CACHE: PrecisionSetting.BFP4,
+                    TensorGroup.ACTIVATION: PrecisionSetting.BFP8,
+                },
+                "OpFidelity": {
+                    OpGroup.LI_FF1_FF3: MathFidelitySetting.LOFI,
+                    OpGroup.LI_FF2: MathFidelitySetting.LOFI,
+                    OpGroup.LI_QKV_DECODE: MathFidelitySetting.LOFI,
+                    OpGroup.LI_O_DECODE: MathFidelitySetting.LOFI,
+                    OpGroup.SDPA_DECODE: MathFidelitySetting.LOFI,
+                },
+            }
+        )
+        inst.__name__ = "ultra_performance"
+        return inst
+
     def __init__(self, settings: dict = None):
         if settings:
             self._validate_settings(settings)
@@ -646,7 +699,7 @@ class ModelArgs:
             # NOTE: Fused all gather matmul only supports a core grid of size num_devices x 1
             # TODO: #26657 refactor ACTUAL_DEVICE environment variable usage
             self._use_fused_all_gather_matmul = (
-                self.num_devices == 8
+                self.num_devices >= 4
                 and os.getenv("ACTUAL_DEVICE", "") != "TG"
                 and (self.dim // ttnn.TILE_SIZE // self.num_devices) % self.num_devices == 0
                 and self.num_devices > 1
@@ -996,15 +1049,16 @@ class ModelArgs:
             self.set_tg_attention_config()
 
             self.is_multichip = self.num_devices > 1
-            self.num_reduce_scatter_links = 1
+            self.is_p300 = self.device_name == "P300"
+            self.num_reduce_scatter_links = 2 if (self.is_galaxy or self.is_p300) else 1
             self.num_all_gather_links = (
-                2 if self.is_galaxy else 1
+                2 if (self.is_galaxy or self.is_p300) else 1
             )  # TODO: try out 3 for short axis and 4 for long axis (TG only) <- should work but untested in model
             self.ccl_dtype = ttnn.bfloat8_b
 
             # model specific CCL configs
-            default_ln_ag = {"num_links": 1, "chunks_per_sync": 10, "num_workers_per_link": 2}
-            default_agmm = {"num_links": 1, "chunks_per_sync": 10, "num_workers_per_link": 2}
+            default_ln_ag = {"num_links": self.num_all_gather_links, "chunks_per_sync": 10, "num_workers_per_link": 2}
+            default_agmm = {"num_links": self.num_all_gather_links, "chunks_per_sync": 10, "num_workers_per_link": 2}
             default_mlp_rs = {
                 "num_links": self.num_reduce_scatter_links,
                 "chunks_per_sync": 10,
@@ -1013,7 +1067,7 @@ class ModelArgs:
             }
             default_sampling_force_argmax = {
                 "allow_force_argmax": False,
-                "num_links": 1,
+                "num_links": self.num_all_gather_links,
                 "chunks_per_sync": 10,
                 "num_workers_per_link": 2,
                 "topology": ttnn.Topology.Linear,
@@ -1038,6 +1092,17 @@ class ModelArgs:
                     },
                 }
             }
+            # P300-specific CCL tuning: reduce fabric mux overhead for small decode tensors
+            # num_workers_per_link=1 bypasses fabric mux (proven by Llama-8B team, commit 70cc1aec3f)
+            # chunks_per_sync=1 reduces sync overhead for tiny payloads
+            if self.is_p300:
+                default_ln_ag["num_workers_per_link"] = 1
+                default_ln_ag["chunks_per_sync"] = 2
+                default_agmm["num_workers_per_link"] = 1
+                default_agmm["chunks_per_sync"] = 1
+                default_mlp_rs["num_workers_per_link"] = 1
+                default_mlp_rs["chunks_per_sync"] = 1
+
             # Model-specific CCL configs are tuned for Galaxy (TG) with 4 links
             # Only apply them on Galaxy, otherwise use defaults
             executed_on_galaxy = ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
@@ -1236,6 +1301,21 @@ class ModelArgs:
                 if not self.is_galaxy
                 else None,
             )
+
+    @lru_cache(maxsize=None)
+    def get_mlp_ff1_3_fused_prg_config(self, mode: Mode, seq_len: int = 1):
+        """Program config for fused W1|W3 matmul (doubled output width)."""
+        if mode == Mode.DECODE:
+            fused_n = 2 * self.hidden_dim // self.cluster_shape[1]
+            fused_grid = self.dram_shard_core_grid_for_k_and_n(self.dim, fused_n)
+            return self.dram_matmul_config(
+                m=self.tile_padded_batch_rows,
+                k=self.dim,
+                n=fused_n,
+                num_cores=fused_grid.num_cores,
+            )
+        else:
+            return None
 
     @lru_cache(maxsize=None)
     def get_mlp_ff2_prg_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None):
@@ -1823,15 +1903,20 @@ class ModelArgs:
                 )
             else:
                 if self.use_fused_all_gather_matmul:
-                    do_core_grid_size = (8, 1)
+                    do_core_grid_size = (self.num_devices, 1)
+                    # K dimension is the gathered heads: n_heads * head_dim (not dim)
+                    gathered_k = self.n_heads * self.head_dim
                     do_per_core_N = (
                         self.dim // self.num_devices // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1])
                     )
+                    # Cap in0_block_w to 32 to avoid L1 overflow
+                    in0_block_w = min(
+                        gathered_k // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1]),
+                        32,
+                    )
                     return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                         compute_with_storage_grid_size=do_core_grid_size,
-                        in0_block_w=self.dim
-                        // ttnn.TILE_SIZE
-                        // (do_core_grid_size[0] * do_core_grid_size[1]),  # [32 x 8k] x [8k x 1k] = [32 x 1k]
+                        in0_block_w=in0_block_w,
                         out_subblock_h=1,
                         out_subblock_w=get_out_subblock_w(
                             do_per_core_N, out_subblock_h=1
@@ -4178,9 +4263,13 @@ class DecodersPrecision:
             return cls.performance
         elif optimizations == "accuracy":
             return cls.accuracy
+        elif optimizations == "max_performance":
+            return cls.max_performance
+        elif optimizations == "ultra_performance":
+            return cls.ultra_performance
         else:
             raise ValueError(
-                f"Invalid optimization configuration: {optimizations}. Allowed values are 'performance' or 'accuracy'"
+                f"Invalid optimization configuration: {optimizations}. Allowed values are 'performance', 'accuracy', 'max_performance', or 'ultra_performance'"
             )
 
     @classmethod
@@ -4193,6 +4282,18 @@ class DecodersPrecision:
     def performance(cls, num_decoders, model_name):
         inst = cls._precision_factory(num_decoders, model_name, ModelOptimizations.performance)
         inst.__name__ = "performance"
+        return inst
+
+    @classmethod
+    def max_performance(cls, num_decoders, model_name):
+        inst = cls._precision_factory(num_decoders, model_name, ModelOptimizations.max_performance)
+        inst.__name__ = "max_performance"
+        return inst
+
+    @classmethod
+    def ultra_performance(cls, num_decoders, model_name):
+        inst = cls._precision_factory(num_decoders, model_name, ModelOptimizations.ultra_performance)
+        inst.__name__ = "ultra_performance"
         return inst
 
     def __init__(self, num_decoders, model_name, decoder_conf: dict = None):
@@ -4277,14 +4378,21 @@ class DecodersPrecision:
                 decoder_config_filename = ACCURACY_DECODER_CONFIG_FILENAME
             case ModelOptimizations.performance:
                 decoder_config_filename = PERFORMANCE_DECODER_CONFIG_FILENAME
+            case ModelOptimizations.max_performance:
+                decoder_config_filename = None  # No JSON config; use ModelOptimizations.max_performance directly
+            case ModelOptimizations.ultra_performance:
+                decoder_config_filename = None  # No JSON config; use ModelOptimizations.ultra_performance directly
             case _:
                 raise ValueError(f"optimization_level ({optimization_level}) not implemented")
 
         # check if decoder config exists, if it exists load it else use optimization_level
         model_params_dir = Path(__file__).parent.parent
-        decoder_config_path = model_params_dir / "model_params" / model_name / decoder_config_filename
         inst = None
-        if decoder_config_path.exists():
+        if decoder_config_filename is not None:
+            decoder_config_path = model_params_dir / "model_params" / model_name / decoder_config_filename
+        else:
+            decoder_config_path = None
+        if decoder_config_path is not None and decoder_config_path.exists():
             inst = parse_decoder_json(decoder_config_path, default_optimization=optimization_level)
             logger.info(
                 f"Model {model_name} requires specific TensorPrecision and OpFidelity configuration, using {decoder_config_path}"

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -699,7 +699,7 @@ class ModelArgs:
             # NOTE: Fused all gather matmul only supports a core grid of size num_devices x 1
             # TODO: #26657 refactor ACTUAL_DEVICE environment variable usage
             self._use_fused_all_gather_matmul = (
-                self.num_devices >= 4
+                (self.num_devices == 8 or (self.num_devices >= 4 and self.device_name == "P300"))
                 and os.getenv("ACTUAL_DEVICE", "") != "TG"
                 and (self.dim // ttnn.TILE_SIZE // self.num_devices) % self.num_devices == 0
                 and self.num_devices > 1
@@ -1050,15 +1050,16 @@ class ModelArgs:
 
             self.is_multichip = self.num_devices > 1
             self.is_p300 = self.device_name == "P300"
-            self.num_reduce_scatter_links = 2 if (self.is_galaxy or self.is_p300) else 1
+            self.num_reduce_scatter_links = 2 if self.is_p300 else 1
             self.num_all_gather_links = (
                 2 if (self.is_galaxy or self.is_p300) else 1
             )  # TODO: try out 3 for short axis and 4 for long axis (TG only) <- should work but untested in model
             self.ccl_dtype = ttnn.bfloat8_b
 
-            # model specific CCL configs
-            default_ln_ag = {"num_links": self.num_all_gather_links, "chunks_per_sync": 10, "num_workers_per_link": 2}
-            default_agmm = {"num_links": self.num_all_gather_links, "chunks_per_sync": 10, "num_workers_per_link": 2}
+            # model specific CCL configs — defaults use hardcoded 1 link (original behavior)
+            # P300-specific overrides are applied below
+            default_ln_ag = {"num_links": 1, "chunks_per_sync": 10, "num_workers_per_link": 2}
+            default_agmm = {"num_links": 1, "chunks_per_sync": 10, "num_workers_per_link": 2}
             default_mlp_rs = {
                 "num_links": self.num_reduce_scatter_links,
                 "chunks_per_sync": 10,
@@ -1067,7 +1068,7 @@ class ModelArgs:
             }
             default_sampling_force_argmax = {
                 "allow_force_argmax": False,
-                "num_links": self.num_all_gather_links,
+                "num_links": 1,
                 "chunks_per_sync": 10,
                 "num_workers_per_link": 2,
                 "topology": ttnn.Topology.Linear,
@@ -1092,16 +1093,19 @@ class ModelArgs:
                     },
                 }
             }
-            # P300-specific CCL tuning: reduce fabric mux overhead for small decode tensors
+            # P300-specific CCL tuning: 2-link defaults and reduced fabric mux overhead
             # num_workers_per_link=1 bypasses fabric mux (proven by Llama-8B team, commit 70cc1aec3f)
             # chunks_per_sync=1 reduces sync overhead for tiny payloads
             if self.is_p300:
+                default_ln_ag["num_links"] = 2
                 default_ln_ag["num_workers_per_link"] = 1
                 default_ln_ag["chunks_per_sync"] = 2
+                default_agmm["num_links"] = 2
                 default_agmm["num_workers_per_link"] = 1
                 default_agmm["chunks_per_sync"] = 1
                 default_mlp_rs["num_workers_per_link"] = 1
                 default_mlp_rs["chunks_per_sync"] = 1
+                default_sampling_force_argmax["num_links"] = 2
 
             # Model-specific CCL configs are tuned for Galaxy (TG) with 4 links
             # Only apply them on Galaxy, otherwise use defaults
@@ -1904,16 +1908,19 @@ class ModelArgs:
             else:
                 if self.use_fused_all_gather_matmul:
                     do_core_grid_size = (self.num_devices, 1)
-                    # K dimension is the gathered heads: n_heads * head_dim (not dim)
-                    gathered_k = self.n_heads * self.head_dim
                     do_per_core_N = (
                         self.dim // self.num_devices // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1])
                     )
-                    # Cap in0_block_w to 32 to avoid L1 overflow
-                    in0_block_w = min(
-                        gathered_k // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1]),
-                        32,
-                    )
+                    if self.is_p300:
+                        # P300: K dimension is gathered heads (n_heads*head_dim), cap at 32 to avoid L1 overflow
+                        gathered_k = self.n_heads * self.head_dim
+                        in0_block_w = min(
+                            gathered_k // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1]),
+                            32,
+                        )
+                    else:
+                        # Original 8-device behavior: in0_block_w from dim
+                        in0_block_w = self.dim // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1])
                     return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                         compute_with_storage_grid_size=do_core_grid_size,
                         in0_block_w=in0_block_w,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
@@ -56,7 +56,7 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
     auto tensor_slicer =
         ttnn::ccl::InterleavedRingAllGatherTensorSlicer(input_tensor, all_gather_output_tensor, dim, ring_index);
     bool is_clockwise_direction = true;
-    const uint32_t num_transfers = 4;
+    const uint32_t num_transfers = ring_size - 1;
     const uint32_t weight_tensor_width = weight_tensor.padded_shape()[3] / 32;
 
     ////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
@@ -56,7 +56,9 @@ AllGatherMatmulAsyncMeshWorkloadFactory::cached_program_t AllGatherMatmulAsyncMe
     auto tensor_slicer =
         ttnn::ccl::InterleavedRingAllGatherTensorSlicer(input_tensor, all_gather_output_tensor, dim, ring_index);
     bool is_clockwise_direction = true;
-    const uint32_t num_transfers = ring_size - 1;
+    // For 8-device bidirectional rings, num_transfers = ring_size/2 = 4 (original behavior).
+    // For smaller rings (e.g. 4-device P300x2), use ring_size-1 (unidirectional).
+    const uint32_t num_transfers = (ring_size == 8) ? 4 : ring_size - 1;
     const uint32_t weight_tensor_width = weight_tensor.padded_shape()[3] / 32;
 
     ////////////////////////////////////////////////////////


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41432

### Problem description
Qwen3-32B on batch=32 on QB2 gives 20 t/s/u, due to unoptimized Blackhole implementation.

ISL=128, OSL=128, TP=4 across 1x4 mesh (4 Blackhole chips)
Container: tt-metal `e867533` + vLLM `8f36910`/`22be241`

| Batch | TTFT (s) | Tok/s/user | Agg Tok/s |
|------:|---------:|-----------:|----------:|
|     1 |    0.088 |       19.0 |      56.9 |
|     2 |    0.165 |       17.9 |     107.5 |
|     4 |    0.308 |       16.3 |     195.1 |
|     8 |    0.596 |       13.7 |     329.4 |
|    16 |    1.177 |        9.8 |     471.1 |
|    32 |    2.169 |        6.2 |     589.9 |

### Summary

This PR adds aggressive quantization presets that trade numerical precision for throughput, achieving up to **31.6 tok/s/user (+29.5% over baseline)** on batch=32, and resolve QB2 specific issues.

- Add `max_performance` and `ultra_performance` optimization presets for Qwen3-32B on P300x2 (QuietBox 2)
- Enable fused all_gather_matmul for P300 4-device ring topology
- Fix `num_transfers` deadlock in all_gather_matmul_async for non-8-device rings
- All changes scoped to P300 only — zero behavioral impact on T3K, Galaxy, or other devices

### Changes

models/tt_transformers/tt/model_config.py
  1. Add ModelOptimizations.max_performance() — BFP4 all MLP weights + HiFi2 FF2
  2. Add ModelOptimizations.ultra_performance() — BFP4 MLP + BFP8 attention + BFP4 KV cache + BFP8 activations + LoFi all ops
  3. Enable fused all_gather_matmul for P300 with num_devices >= 4 (gated by device_name  == "P300")
  4. Fix AGMM program config: in0_block_w from gathered_k (n_heads*head_dim) with cap at 32, P300 only
  5. Add is_p300 device detection (self.device_name == "P300")
  6. Add P300-specific 2-link CCL defaults (num_links, num_workers_per_link, chunks_per_sync)
  7. Add DecodersPrecision.max_performance() and ultra_performance() factory methods
  8. Add DecodersPrecision.from_string() support for "max_performance" and "ultra_performance"
  9. Handle None decoder_config_filename for new presets in _precision_factory
  10. Add get_mlp_ff1_3_fused_prg_config() for fused W1|W3 matmul decode

  ttnn/.../all_gather_matmul_async_program_factory.cpp
  11. Fix num_transfers: (ring_size == 8) ? 4 : ring_size - 1 — preserves 8-device behavior, fixes 4-device deadlock

  ### Isolation guarantee
  All behavioral changes are gated to P300 hardware:
  | Change | Gate |
  |--------|------|
  | Fused AGMM enable | `num_devices == 8 or (num_devices >= 4 and device_name == "P300")` |
  | CCL link defaults | Hardcoded `1` preserved; `is_p300` block overrides to `2` |
  | AGMM program config | `is_p300` branch for new formula; else original `self.dim`  formula |
  | C++ num_transfers | `ring_size == 8` preserves original `4` |
  | New presets | Opt-in only, never auto-selected |

  ## Benchmark Results

  **Hardware:** 2x P300c (4 Blackhole chips, 1x4 mesh, TP=4)
  **Config:** ISL=128, OSL=128, on-device sampling enabled, 3 iterations per batch size

  ### Decode throughput (tok/s/user)

 | Batch | Baseline (555f240) | `performance` | `max_performance` | `ultra_performance` |
|------:|-------------------:|--------------:|-------------------:|--------------------:|
|     1 |               24.4 |          26.4 |               26.8 |           **31.6** |
|     2 |               24.3 |          26.3 |               26.8 |           **31.6** |
|     4 |               24.1 |          26.3 |               26.7 |           **31.6** |
|     8 |               23.8 |          26.4 |               26.8 |           **31.6** |
|    16 |               23.1 |          26.4 |               26.6 |           **31.5** |
|    32 |               21.3 |          25.7 |               26.0 |           **30.5** |

  ### Improvement vs baseline

  | Batch | `performance` | `max_performance` | `ultra_performance` |
  |------:|--------------:|-------------------:|--------------------:|
  |     1 |         +8.2% |             +9.8% |          **+29.5%** |
  |     8 |        +10.9% |            +12.6% |          **+32.8%** |
  |    32 |        +20.7% |            +22.1% |          **+43.2%** |

  ### Aggregate throughput (tok/s)

  | Batch | Baseline | `ultra_performance` | Improvement |
  |------:|---------:|--------------------:|------------:|
  |     1 |     24.4 |                31.6 |      +29.5% |
  |     8 |    190.4 |               252.9 |      +32.8% |
  |    32 |    681.7 |               976.5 |      +43.2% |

  ### Preset details

  | Preset | MLP Weights | Attention Weights | KV Cache | Activations | Math Fidelity |
  |--------|------------|-------------------|----------|-------------|---------------|
  | `performance` | BFP4 FF1/FF3 | BF16 | BF16 | BF16 | LoFi FF1/FF3 |
  | `max_performance` | BFP4 all | BF16 | BF16 | BF16 | LoFi FF1/FF3, HiFi2 FF2 |
  | `ultra_performance` | BFP4 all | BFP8 | BFP4 | BFP8 | LoFi all |

  ### Accuracy (max_performance vs performance)
  Math (17*23=391), code (isPrime), knowledge (general relativity), reasoning — all
  match. Factual answers differ in phrasing but are correct.

  ## Remaining gap
  - Current best: 31.6 tok/s/user @ b1 (85% of 37 target)
  - Bottleneck: per-matmul kernel fixed overhead (~250μs/layer), not DRAM bandwidth
  - Further gains require tt-metal commit bump (blocked by vLLM incompatibility) or
  kernel-level optimizations

### What's changed

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=changh95/qwen3-32b-p300x2-optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:changh95/qwen3-32b-p300x2-optimizations)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
