### PR TITLE
ds_prefill(handle_buffer_overflow): bounds check in dispatch and combine kernels

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -494,3 +494,149 @@ def test_ttnn_dispatch_combine(
     result.assert_passed("Round-trip mismatch")
 
     logger.debug("✅ TTNN dispatch→combine round-trip matches input!")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
+            },
+            1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8-1link",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_ttnn_dispatch_combine_overflow(
+    mesh_device,
+    num_links,
+    topology,
+):
+    """Test that dispatch/combine hangs (or corrupts) when token count exceeds max_dispatched_tokens_per_expert.
+
+    This test fabricates indices that route ALL tokens to expert 0, causing a massive
+    overflow of the dispatch buffer. Before the device-side bounds check fix, this will
+    hang. After the fix, dispatch should complete (tokens silently dropped).
+    """
+    seq_len_per_chip = 256
+    emb_dim = 128
+    num_routed_experts = 16
+    num_experts_per_tok = 2
+    capacity_factor = 1
+
+    num_devices = mesh_device.get_num_devices()
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    experts_per_chip, metadata_len, max_dispatched_tokens_per_expert = compute_constants(
+        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, dispatch_group_size, capacity_factor
+    )
+
+    total_tokens_to_expert_0 = dispatch_group_size * seq_len_per_chip * num_experts_per_tok
+    logger.info(
+        f"[overflow test] max_dispatched_tokens_per_expert={max_dispatched_tokens_per_expert}, "
+        f"tokens routed to expert 0={total_tokens_to_expert_0} "
+        f"(overflow ratio: {total_tokens_to_expert_0 / max_dispatched_tokens_per_expert:.0f}x)"
+    )
+
+    # Fabricate inputs: route ALL tokens to expert 0 to cause overflow
+    x = torch.randn((dispatch_group_size, seq_len_per_chip, emb_dim), dtype=torch.bfloat16)
+    weights = torch.ones((dispatch_group_size, seq_len_per_chip, num_experts_per_tok), dtype=torch.bfloat16)
+    weights = weights / weights.sum(dim=-1, keepdim=True)
+    indices = torch.full(
+        (dispatch_group_size, seq_len_per_chip, num_experts_per_tok), num_routed_experts - 1, dtype=torch.int32
+    )
+
+    # Send to device
+    mesh_mapper_dispatch_inputs = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
+    tt_x = ttnn.from_torch(
+        x,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    tt_weights = ttnn.from_torch(
+        weights,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    tt_indices = ttnn.from_torch(
+        indices,
+        mesh_mapper=mesh_mapper_dispatch_inputs,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+
+    # Create dispatch table and routing setup
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=num_routed_experts,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    tt_moe_routing_setup = TtMoERoutingSetup(
+        mesh_device=mesh_device, expert_dispatch_table=expert_dispatch_table, num_links=num_links
+    )
+    tt_dispatch_offsets, tt_expert_token_counts, _ = tt_moe_routing_setup(
+        ttnn_top_k_experts_indices=indices,
+        num_routed_experts=num_routed_experts,
+        seq_len_per_chip=seq_len_per_chip,
+        num_experts_per_tok=num_experts_per_tok,
+    )
+
+    # Initialize dispatch module
+    tt_dispatch_module = TtDispatchModule(
+        mesh_device=mesh_device,
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=num_routed_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        metadata_len=metadata_len,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        seq_len_per_chip=seq_len_per_chip,
+        emb_dim=emb_dim,
+        cluster_axis=sp_axis,
+        num_links=num_links,
+        topology=topology,
+    )
+
+    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
+
+    # Run dispatch - this will hang without the device-side bounds check fix
+    logger.info("[overflow test] Running dispatch with overflow indices...")
+    tt_dispatched_buffer, tt_metadata = tt_dispatch_module(
+        tt_x, tt_weights, tt_indices, tt_dispatch_offsets, tt_expert_dispatch_table
+    )
+    ttnn.synchronize_device(mesh_device)
+    logger.info("[overflow test] Dispatch completed (did not hang)")
+
+    # Run combine
+    tt_combine_module = TtCombineModule(
+        mesh_device=mesh_device,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+        experts_per_chip=experts_per_chip,
+        num_experts_per_tok=num_experts_per_tok,
+        seq_len_per_chip=seq_len_per_chip,
+        cluster_axis=sp_axis,
+        num_links=num_links,
+        topology=topology,
+        init_zeros=True,
+    )
+
+    logger.info("[overflow test] Running combine with overflow data...")
+    tt_output = tt_combine_module(tt_dispatched_buffer, tt_metadata, tt_expert_token_counts)
+    ttnn.synchronize_device(mesh_device)
+    logger.info("[overflow test] Combine completed (did not hang)")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -16,6 +16,7 @@ This module assembles the full MoE pipeline:
 
 from typing import Optional, Union
 
+import torch
 from loguru import logger
 
 import ttnn
@@ -399,6 +400,21 @@ class TtMoe(LightweightModule):
         # Build intermediates if requested
         intermediates = None
         if return_intermediates:
+            # Check for buffer overflow (dispatch kernel silently drops overflow tokens)
+            _counts_4d = ttnn.unsqueeze_to_4D(tt_expert_token_counts)
+            _ep_composer = ttnn.create_mesh_composer(self.mesh_device, ttnn.MeshComposerConfig(dims=[1, 0]))
+            _counts_host = ttnn.to_torch(_counts_4d, mesh_composer=_ep_composer).squeeze(2)
+            max_token_count = int(_counts_host.to(torch.int64).max().item())
+            max_capacity = self.dispatch_module.max_dispatched_tokens_per_expert
+            if max_token_count > max_capacity:
+                logger.error(
+                    f"[TtMoe.forward] expert token count ({max_token_count}) exceeds "
+                    f"max_dispatched_tokens_per_expert ({max_capacity}). "
+                    f"Overflow tokens were dropped - output data is corrupted. "
+                    f"Increase capacity_factor or reduce sequence length."
+                )
+                logger.debug(f"[TtMoe.forward] expert_token_counts: {_counts_host.flatten().tolist()}")
+
             intermediates = TtMoEIntermediates(
                 gate_scores=weights,
                 gate_indices=indices,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -179,6 +179,9 @@ void kernel_main() {
     for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
         uint32_t start_page = local_expert * expert_stride;
         uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
+        if (expert_tokens > max_dispatched_tokens_per_expert) {
+            expert_tokens = max_dispatched_tokens_per_expert;
+        }
         uint32_t end_page = start_page + expert_tokens;
 
         DPRINT_COMBINE << "Expert=" << local_expert << " tokens=" << expert_tokens << ENDL();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -211,6 +211,12 @@ void kernel_main() {
                 auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
                 auto expert_index_within_chip = routed_expert % experts_per_chip;
                 auto& offset = offsets[routed_expert];
+                if (offset >= max_dispatched_tokens_per_expert) {
+                    // Token would overflow the dispatch buffer - skip to prevent
+                    // out-of-bounds DRAM writes that corrupt memory and cause hangs.
+                    offset++;
+                    continue;
+                }
                 auto page_idx = expert_index_within_chip * max_dispatched_tokens_per_expert + offset;
 
                 // Construct metadata


### PR DESCRIPTION
### Ticket
Related to DeepSeek V3 prefill MoE hang investigation

### Problem description
When the MoE gate router assigns more tokens to an expert than `max_dispatched_tokens_per_expert`, the dispatch kernel writes past the allocated buffer boundary. This corrupts adjacent expert metadata in DRAM, causing the combine kernel to deadlock on fabric semaphore exchanges.

Observed in production: `max_dispatched_tokens_per_expert=64` but actual max expert token count was `1024`, causing an indefinite hang requiring `tt-smi -r` to recover.

### What's changed
Added bounds checks in both dispatch and combine kernels:

- **reader_dispatch.cpp**: Skip tokens when `offset >= max_dispatched_tokens_per_expert` to prevent out-of-bounds DRAM writes that corrupt memory
- **reader_combine.cpp**: Clamp `expert_tokens` to `min(count, max_dispatched_tokens_per_expert)` as defense-in-depth

Both fixes are needed — the combine-only fix is insufficient because dispatch still corrupts the buffer metadata, which causes the combine fabric semaphore exchange to deadlock.

Added `test_ttnn_dispatch_combine_overflow` regression test that routes all tokens to the last expert, reproducing the hang (confirmed on 8-device Blackhole linear topology).

Additionally **tt_moe.py** when return_intermediates=True would check if `max (token count) > max_dispatch_tokens_per_expert` and print an error for user to correlate it with possible low pcc. 

### Checklist

#### Model tests

- [x] [![(T3K) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/ds-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/ds-overflow-fix) `deepseek_prefill`
- [x] [![(BH) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/ds-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/ds-overflow-fix) `deepseek_prefill`
- [x] [![Demo SP Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/ds-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/ds-overflow-fix) `deepseek_prefill`
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/ds-overflow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/ds-overflow-fix)