### PR TITLE
FEATURE: Add multihost rank support for Inspector

### DIFF
--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -183,7 +183,7 @@ def run(args, context) -> InspectorData:
         if rank is not None:
             rpc_port = int(rpc_port) + rank
         return InspectorRpcController(rpc_host, rpc_port)
-    except:
+    except Exception:
         pass
 
     # Check for Inspector log directory

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -175,7 +175,7 @@ def run(args, context) -> InspectorData:
             size = MPI.COMM_WORLD.Get_size()
             if size > 1:
                 rank = MPI.COMM_WORLD.Get_rank()
-        except:
+        except Exception:
             pass
 
     # First try to connect to Inspector RPC

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -5,12 +5,13 @@
 
 """
 Usage:
-    inspector_data [--inspector-rpc-port=<inspector_rpc_port>] [--inspector-rpc-host=<inspector_rpc_host>] [--inspector-log-path=<inspector_log_path>]
+    inspector_data [--inspector-rpc-port=<inspector_rpc_port>] [--inspector-rpc-host=<inspector_rpc_host>] [--inspector-disable-rank] [--inspector-log-path=<inspector_log_path>]
 
 Options:
     --inspector-rpc-port=<inspector_rpc_port>  Port for the inspector RPC server. [default: 50051]
     --inspector-rpc-host=<inspector_rpc_host>  Host for the inspector RPC server. [default: localhost]
     --inspector-log-path=<inspector_log_path>  Path to the inspector log directory.
+    --inspector-disable-rank                   If you want manually to connect to the RPC and do not want rank to be automatically added to the RPC host and port.
 
 Description:
     Provides inspector data for other scripts.
@@ -24,6 +25,7 @@ Owner:
 
 from triage import triage_singleton, ScriptConfig, run_script
 from parse_inspector_logs import get_data as get_logs_data, get_log_directory
+from mpi4py import MPI
 import asyncio
 import capnp
 import os
@@ -165,15 +167,29 @@ def run(args, context) -> InspectorData:
     log_directory = args["--inspector-log-path"]
     rpc_port = args["--inspector-rpc-port"]
     rpc_host = args["--inspector-rpc-host"]
+    rank: int | None = None
+
+    if not args["--inspector-disable-rank"]:
+        # If MPI is available, add rank to the RPC host and port
+        try:
+            size = MPI.COMM_WORLD.Get_size()
+            if size > 1:
+                rank = MPI.COMM_WORLD.Get_rank()
+        except:
+            pass
 
     # First try to connect to Inspector RPC
     try:
+        if rank is not None:
+            rpc_port = int(rpc_port) + rank
         return InspectorRpcController(rpc_host, rpc_port)
     except:
         pass
 
     # Check for Inspector log directory
     log_directory = get_log_directory(log_directory)
+    if rank is not None:
+        log_directory = os.path.join(log_directory, f"_rank_{rank}")
     if not os.path.exists(log_directory):
         raise ValueError(
             f"\n\tLog directory {log_directory} does not exist."

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -11,7 +11,7 @@ Options:
     --inspector-rpc-port=<inspector_rpc_port>  Port for the inspector RPC server. [default: 50051]
     --inspector-rpc-host=<inspector_rpc_host>  Host for the inspector RPC server. [default: localhost]
     --inspector-log-path=<inspector_log_path>  Path to the inspector log directory.
-    --inspector-disable-rank                   If you want manually to connect to the RPC and do not want rank to be automatically added to the RPC host and port.
+    --inspector-disable-rank                   If you want to manually connect to the RPC and do not want rank to be automatically added to the RPC port and log directory.
 
 Description:
     Provides inspector data for other scripts.

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -176,6 +176,7 @@ def run(args, context) -> InspectorData:
             if size > 1:
                 rank = MPI.COMM_WORLD.Get_rank()
         except Exception:
+            # If MPI is not available or fails, fall back to rank-less mode without aborting.
             pass
 
     # First try to connect to Inspector RPC

--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,2 +1,3 @@
 pycapnp==2.0.0
+mpi4py>=4.1.1
 tt-exalens==0.3.13; platform_machine == "x86_64"

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -59,6 +59,7 @@ _triage_requirements_path = str(Path(__file__).resolve().parent / "requirements.
 try:
     from ttexalens.tt_exalens_init import init_ttexalens, init_ttexalens_remote
     import capnp
+    from mpi4py import MPI
 except ImportError as e:
     RST = "\033[0m" if utils.should_use_color() else ""
     GREEN = "\033[32m" if utils.should_use_color() else ""  # For instructions

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -211,7 +211,12 @@ void MetalContext::initialize(
 
     // Initialize inspector
     if (this->get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
-        inspector_data_ = Inspector::initialize();
+        std::optional<int> rank;
+        const auto& distributed_context = global_distributed_context();
+        if (*(distributed_context.size()) > 1) {
+            rank = *distributed_context.rank();
+        }
+        inspector_data_ = Inspector::initialize(rank);
         // Set fw_compile_hash for Inspector RPC build environment info
         Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
     }

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -39,14 +39,17 @@ std::string stringify_tensor_specs(const std::vector<TensorSpec>& tensor_specs) 
     return std::string(buf.data(), buf.size());
 }
 
-Data::Data()
-    : logger(MetalContext::instance().rtoptions().get_inspector_log_path()) {
-
+Data::Data(std::optional<int> rank) : logger(MetalContext::instance().rtoptions().get_inspector_log_path(), rank) {
     // Initialize RPC server if enabled
     const auto& rtoptions = MetalContext::instance().rtoptions();
     if (rtoptions.get_inspector_rpc_server_enabled()) {
         try {
-            auto address = rtoptions.get_inspector_rpc_server_address();
+            int port = rtoptions.get_inspector_rpc_server_port();
+            std::string host = rtoptions.get_inspector_rpc_server_host();
+            if (rank.has_value()) {
+                port += *rank;  // Offset port by rank to allow multiple instances on the same machine
+            }
+            std::string address = host + ":" + std::to_string(port);
             rpc_server_controller.start(address);
 
             // Connect callbacks that we want to respond to
@@ -608,7 +611,6 @@ void collect_rtoptions_entries(std::vector<ConfigurationEntry>& entries, const t
     RT(inspector_rpc_server_enabled);
     RT(inspector_rpc_server_host);
     RT(inspector_rpc_server_port);
-    RT(inspector_rpc_server_address);
     RT(inspector_capture_tensor_specs);
     RT(inspector_log_runtime_entries);
     RT_CUSTOM("inspector_log_path", rt.get_inspector_log_path().string());

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <optional>
 
 namespace tt::tt_metal::inspector {
 
@@ -18,7 +19,7 @@ public:
     ~Data();
 
 private:
-    Data(); // NOLINT - False alarm, tt::tt_metal::Inspector is calling this constructor.
+    Data(std::optional<int> rank);  // NOLINT - False alarm, tt::tt_metal::Inspector is calling this constructor.
 
     void serialize_rpc();
     RpcServer& get_rpc_server();

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -42,13 +42,13 @@ bool Inspector::is_enabled() {
     return false;
 }
 
-std::unique_ptr<inspector::Data> Inspector::initialize() {
+std::unique_ptr<inspector::Data> Inspector::initialize(std::optional<int> rank) {
     if (!is_enabled()) {
         // Inspector is not enabled, skipping initialization.
         return nullptr;
     }
     try {
-        auto* data = new inspector::Data();
+        auto* data = new inspector::Data(rank);
 
         return std::unique_ptr<inspector::Data>(data);
     } catch (const std::exception& e) {

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <vector>
 #include <string>
 #include "impl/program/program_impl.hpp"
@@ -28,7 +29,7 @@ class Inspector {
 public:
     static bool is_enabled();
 
-    static std::unique_ptr<inspector::Data> initialize();
+    static std::unique_ptr<inspector::Data> initialize(std::optional<int> rank);
     static void serialize_rpc();
 
     static void program_created(const detail::ProgramImpl* program) noexcept;

--- a/tt_metal/impl/debug/inspector/logger.cpp
+++ b/tt_metal/impl/debug/inspector/logger.cpp
@@ -12,31 +12,40 @@
 
 namespace tt::tt_metal::inspector {
 
-Logger::Logger(const std::filesystem::path& logging_path) : logging_path(logging_path) {
+Logger::Logger(const std::filesystem::path& logging_path, std::optional<int> rank) : logging_path(logging_path) {
     constexpr std::string_view additional_text =
         "\nYou can disable exception by setting TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 in your environment "
         "variables. Note that this will not throw an exception, but will log a warning instead. Running without "
         "Inspector logger will impact tt-triage functionality.";
 
+    // If rank is provided, append it to the logging path to allow multiple instances of the inspector on the same
+    // machine
+    if (rank.has_value()) {
+        this->logging_path /= "_rank_" + std::to_string(*rank);
+    }
+
     try {
         // Recreate the logging directory if it doesn't exist or clear it if it does.
-        std::filesystem::remove_all(logging_path);
-        std::filesystem::create_directories(logging_path);
+        std::filesystem::remove_all(this->logging_path);
+        std::filesystem::create_directories(this->logging_path);
     }
     catch (const std::exception& e) {
         TT_INSPECTOR_THROW(
-            "Failed to create logging directory: {}. Error: {}\n{}", logging_path.string(), e.what(), additional_text);
+            "Failed to create logging directory: {}. Error: {}\n{}",
+            this->logging_path.string(),
+            e.what(),
+            additional_text);
     }
 
     // Write startup information to the inspector files.
     {
         try {
-            std::ofstream inspector_startup_ostream(logging_path / "startup.yaml", std::ios::trunc);
+            std::ofstream inspector_startup_ostream(this->logging_path / "startup.yaml", std::ios::trunc);
 
             if (!inspector_startup_ostream.is_open()) {
                 TT_INSPECTOR_THROW(
                     "Failed to create inspector file: {}\n{}",
-                    (logging_path / "startup.yaml").string(),
+                    (this->logging_path / "startup.yaml").string(),
                     additional_text);
             } else {
                 // Log current system time and high_resolution_clock time_point
@@ -60,25 +69,31 @@ Logger::Logger(const std::filesystem::path& logging_path) : logging_path(logging
         }
     }
 
-    programs_ostream.open(logging_path / "programs_log.yaml", std::ios::trunc);
+    programs_ostream.open(this->logging_path / "programs_log.yaml", std::ios::trunc);
     if (!programs_ostream.is_open()) {
         TT_INSPECTOR_THROW(
-            "Failed to create inspector file: {}\n{}", (logging_path / "programs_log.yaml").string(), additional_text);
+            "Failed to create inspector file: {}\n{}",
+            (this->logging_path / "programs_log.yaml").string(),
+            additional_text);
     }
-    kernels_ostream.open(logging_path / "kernels.yaml", std::ios::trunc);
+    kernels_ostream.open(this->logging_path / "kernels.yaml", std::ios::trunc);
     if (!kernels_ostream.is_open()) {
         TT_INSPECTOR_THROW(
-            "Failed to create inspector file: {}\n{}", (logging_path / "kernels.yaml").string(), additional_text);
+            "Failed to create inspector file: {}\n{}", (this->logging_path / "kernels.yaml").string(), additional_text);
     }
-    mesh_devices_ostream.open(logging_path / "mesh_devices_log.yaml", std::ios::trunc);
+    mesh_devices_ostream.open(this->logging_path / "mesh_devices_log.yaml", std::ios::trunc);
     if (!mesh_devices_ostream.is_open()) {
         TT_INSPECTOR_THROW(
-            "Failed to create inspector file: {}\n{}", (logging_path / "mesh_devices_log.yaml").string(), additional_text);
+            "Failed to create inspector file: {}\n{}",
+            (this->logging_path / "mesh_devices_log.yaml").string(),
+            additional_text);
     }
-    mesh_workloads_ostream.open(logging_path / "mesh_workloads_log.yaml", std::ios::trunc);
+    mesh_workloads_ostream.open(this->logging_path / "mesh_workloads_log.yaml", std::ios::trunc);
     if (!mesh_workloads_ostream.is_open()) {
         TT_INSPECTOR_THROW(
-            "Failed to create inspector file: {}\n{}", (logging_path / "mesh_workloads_log.yaml").string(), additional_text);
+            "Failed to create inspector file: {}\n{}",
+            (this->logging_path / "mesh_workloads_log.yaml").string(),
+            additional_text);
     }
 
     initialized = true;

--- a/tt_metal/impl/debug/inspector/logger.hpp
+++ b/tt_metal/impl/debug/inspector/logger.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <fstream>
+#include <optional>
 
 #include "impl/debug/inspector/types.hpp"
 #include "mesh_coord.hpp"
@@ -39,7 +40,7 @@ private:
     }
 
 public:
-    Logger(const std::filesystem::path& logging_path);
+    Logger(const std::filesystem::path& logging_path, std::optional<int> rank);
 
     std::filesystem::path get_logging_path() const noexcept {
         return logging_path;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -117,7 +117,6 @@ struct InspectorSettings {
     bool serialize_on_dispatch_timeout = true;
     bool capture_tensor_specs = true;
     bool log_runtime_entries = false;
-    std::string rpc_server_address() const { return rpc_server_host + ":" + std::to_string(rpc_server_port); }
 };
 
 template <typename T>
@@ -438,9 +437,6 @@ public:
     }
     bool get_inspector_warn_on_write_exceptions() const { return inspector_settings.warn_on_write_exceptions; }
     void set_inspector_warn_on_write_exceptions(bool warn) { inspector_settings.warn_on_write_exceptions = warn; }
-    std::string get_inspector_rpc_server_address() const {
-        return inspector_settings.rpc_server_host + ":" + std::to_string(inspector_settings.rpc_server_port);
-    }
     void set_inspector_rpc_server_enabled(bool enabled) { inspector_settings.rpc_server_enabled = enabled; }
     bool get_inspector_capture_tensor_specs() const { return inspector_settings.capture_tensor_specs; }
     void set_inspector_capture_tensor_specs(bool enabled) { inspector_settings.capture_tensor_specs = enabled; }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Inspector and tt-triage didn't support multihost ranking which caused failures in multiinstance scenarios.

### What's changed
We are reading `rank` from `global_distributed_context` in Metal runtime and from MPI library in tt-triage.
`rank` is being set by `ttrun.py`.

Because of Python and child process limitation, exposing `TT_RUN_RANK` as an environment variable.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/multihost_triage)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/multihost_triage)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/multihost_triage)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/multihost_triage)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/multihost_triage)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/multihost_triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/multihost_triage)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
