### PR TITLE
[feature]: add KV Cache Chunk address lookup table definition  (#40866)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -194,4 +194,4 @@ CheckOptions:
 
 FormatStyle: 'file'
 
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '(?!.*\.pb\.h$).*'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,6 +121,8 @@ tt_metal/tools/profiler/fabric_event_profiler.hpp @bgrady-tt @sohaibnadeemTT @te
 tt_metal/tools/profiler/noc_event_profiler.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/**/CMakeLists.txt @kmabeeTT @mo-tenstorrent @ihamer-tt @tenstorrent/metalium-developers-infra
+tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
+tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl
 tt_metal/api/tt-metalium/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -25,6 +25,14 @@ function(GENERATE_PROTO_FILES PROTO_FILE)
 
     file(MAKE_DIRECTORY ${PROTO_GENERATED_DIR})
 
+    # Place a no-op .clang-tidy in the generated directory so that generated
+    # .pb.h headers are not scanned when included by other translation units.
+    configure_file(
+        "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/clang-tidy.d/.clang-tidy.disable.yaml"
+        "${PROTO_GENERATED_DIR}/.clang-tidy"
+        COPYONLY
+    )
+
     set(GENERATED_CC ${PROTO_GENERATED_DIR}/${PROTO_FILE_NAME}.pb.cc)
     set(GENERATED_H ${PROTO_GENERATED_DIR}/${PROTO_FILE_NAME}.pb.h)
 

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Include source file lists (module owners maintain sources.cmake)
 include(sources.cmake)
 
-add_executable(fabric_unit_tests ${UNIT_TESTS_FABRIC_SRC})
+add_executable(
+    fabric_unit_tests
+    ${UNIT_TESTS_FABRIC_SRC}
+    ${PROJECT_SOURCE_DIR}/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
+)
 
 target_link_libraries(
     fabric_unit_tests
@@ -9,6 +13,7 @@ target_link_libraries(
         tt_metal
         test_common_libs
         yaml-cpp::yaml-cpp
+        protobuf::libprotobuf
 )
 
 target_include_directories(

--- a/tests/tt_metal/tt_fabric/disaggregation/test_kv_chunk_address_table_protobuf.cpp
+++ b/tests/tt_metal/tt_fabric/disaggregation/test_kv_chunk_address_table_protobuf.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp"
+
+namespace tt::tt_metal::experimental::disaggregation {
+namespace {
+
+using tt::tt_fabric::FabricNodeId;
+using tt::tt_fabric::MeshId;
+
+FabricNodeId make_fnid(uint32_t mesh, uint32_t chip) { return FabricNodeId(MeshId{mesh}, chip); }
+
+// Simple deterministic hash to produce pseudo-random but reproducible data from indices.
+uint64_t pseudo_rand(uint32_t a, uint32_t b, uint32_t c) {
+    uint64_t h = static_cast<uint64_t>(a) * 2654435761ULL;
+    h ^= static_cast<uint64_t>(b) * 2246822519ULL;
+    h ^= static_cast<uint64_t>(c) * 3266489917ULL;
+    h ^= h >> 16;
+    h *= 0x45d9f3b;
+    h ^= h >> 16;
+    return h;
+}
+
+// Builds a table with asymmetric dimensions and randomized data:
+//   7 layers, 384 seq_len (12 chunks of 32), 5 slots, 6 device groups
+KvChunkAddressTable make_test_table() {
+    constexpr uint32_t kNumLayers = 7;
+    constexpr uint32_t kSeqLen = 384;
+    constexpr uint32_t kNumSlots = 5;
+    constexpr uint32_t kChunkSize = 32;
+
+    KvChunkAddressTableConfig cfg{
+        .num_layers = kNumLayers,
+        .max_sequence_length = kSeqLen,
+        .num_slots = kNumSlots,
+        .chunk_n_tokens = kChunkSize,
+    };
+    KvChunkAddressTable table(cfg);
+
+    // 6 device groups with varying sizes across 3 meshes.
+    auto grp0 = table.add_device_group({make_fnid(0, 0)});
+    auto grp1 = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1)});
+    auto grp2 = table.add_device_group({make_fnid(0, 2), make_fnid(0, 3), make_fnid(0, 4)});
+    auto grp3 = table.add_device_group({make_fnid(1, 0), make_fnid(1, 1), make_fnid(1, 2), make_fnid(1, 3)});
+    auto grp4 = table.add_device_group({make_fnid(2, 0), make_fnid(2, 1)});
+    auto grp5 =
+        table.add_device_group({make_fnid(0, 0), make_fnid(1, 0), make_fnid(2, 0), make_fnid(2, 1), make_fnid(2, 2)});
+    std::array<DeviceGroupIndex, 6> groups = {grp0, grp1, grp2, grp3, grp4, grp5};
+
+    // Host mappings across 3 hosts.
+    for (uint32_t chip = 0; chip < 5; chip++) {
+        table.set_fabric_node_host(make_fnid(0, chip), "alpha-host");
+    }
+    for (uint32_t chip = 0; chip < 4; chip++) {
+        table.set_fabric_node_host(make_fnid(1, chip), "beta-host");
+    }
+    for (uint32_t chip = 0; chip < 3; chip++) {
+        table.set_fabric_node_host(make_fnid(2, chip), "gamma-host");
+    }
+
+    // Populate every entry with pseudo-random data.
+    for (uint32_t slot = 0; slot < kNumSlots; slot++) {
+        for (uint32_t layer = 0; layer < kNumLayers; layer++) {
+            for (uint32_t pos = 0; pos < kSeqLen; pos += kChunkSize) {
+                uint64_t h = pseudo_rand(slot, layer, pos);
+                uint64_t addr = 0x1'0000'0000ULL + (h & 0xFFFF'FFFF'FFFF'FF00ULL);
+                uint32_t size = 512 + (static_cast<uint32_t>((h >> 8) % 8) * 128);
+                DeviceGroupIndex grp_idx = groups[h % groups.size()];
+                table.set(
+                    layer,
+                    pos,
+                    slot,
+                    KvCacheLocation{.noc_addr = addr, .size_bytes = size, .device_group_index = grp_idx});
+            }
+        }
+    }
+
+    return table;
+}
+
+TEST(KvChunkAddressTableProtobuf, RoundTripViaString) {
+    auto original = make_test_table();
+    std::string data = export_to_protobuf(original);
+    auto restored = import_from_protobuf(data);
+
+    EXPECT_EQ(restored.config().num_layers, original.config().num_layers);
+    EXPECT_EQ(restored.config().max_sequence_length, original.config().max_sequence_length);
+    EXPECT_EQ(restored.config().num_slots, original.config().num_slots);
+    EXPECT_EQ(restored.config().chunk_n_tokens, original.config().chunk_n_tokens);
+
+    ASSERT_EQ(restored.num_device_groups(), original.num_device_groups());
+    for (size_t i = 0; i < original.num_device_groups(); i++) {
+        EXPECT_EQ(
+            original.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)}),
+            restored.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)}));
+    }
+
+    for (size_t i = 0; i < original.num_device_groups(); i++) {
+        const auto& group = original.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)});
+        for (const auto& fnid : group.fabric_node_ids) {
+            ASSERT_TRUE(restored.has_host(fnid));
+            EXPECT_EQ(restored.get_host(fnid), original.get_host(fnid));
+        }
+    }
+
+    const auto& cfg = original.config();
+    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                const auto& orig = original.lookup(layer, pos, slot);
+                const auto& rest = restored.lookup(layer, pos, slot);
+                EXPECT_EQ(rest.noc_addr, orig.noc_addr)
+                    << "mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(rest.size_bytes, orig.size_bytes);
+                EXPECT_EQ(rest.device_group_index, orig.device_group_index);
+            }
+        }
+    }
+}
+
+TEST(KvChunkAddressTableProtobuf, RoundTripViaFile) {
+    auto original = make_test_table();
+
+    std::string tmp_path = std::filesystem::temp_directory_path() / "kv_chunk_address_table_test.pb";
+    export_to_protobuf_file(original, tmp_path);
+
+    auto restored = import_from_protobuf_file(tmp_path);
+
+    EXPECT_EQ(restored.config().num_layers, original.config().num_layers);
+    EXPECT_EQ(restored.config().max_sequence_length, original.config().max_sequence_length);
+    EXPECT_EQ(restored.total_entries(), original.total_entries());
+
+    // Exhaustive check through file round-trip too.
+    const auto& cfg = original.config();
+    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                const auto& orig = original.lookup(layer, pos, slot);
+                const auto& rest = restored.lookup(layer, pos, slot);
+                EXPECT_EQ(rest.noc_addr, orig.noc_addr)
+                    << "mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(rest.size_bytes, orig.size_bytes);
+                EXPECT_EQ(rest.device_group_index, orig.device_group_index);
+            }
+        }
+    }
+
+    std::filesystem::remove(tmp_path);
+}
+
+TEST(KvChunkAddressTableProtobuf, LargeAddressPreserved) {
+    KvChunkAddressTableConfig cfg{.num_layers = 1, .max_sequence_length = 32, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(cfg);
+    table.add_device_group({make_fnid(0, 0)});
+    table.set(
+        0,
+        0,
+        0,
+        KvCacheLocation{
+            .noc_addr = 0xDEAD'BEEF'CAFE'0000ULL, .size_bytes = 100, .device_group_index = DeviceGroupIndex{0}});
+
+    std::string data = export_to_protobuf(table);
+    auto restored = import_from_protobuf(data);
+
+    EXPECT_EQ(restored.lookup(0, 0, 0).noc_addr, 0xDEAD'BEEF'CAFE'0000ULL);
+}
+
+TEST(KvChunkAddressTableProtobuf, EmptyTableRoundTrip) {
+    KvChunkAddressTableConfig cfg{.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(cfg);
+
+    std::string data = export_to_protobuf(table);
+    auto restored = import_from_protobuf(data);
+
+    EXPECT_EQ(restored.config().num_layers, 2u);
+    EXPECT_EQ(restored.config().max_sequence_length, 64u);
+    EXPECT_EQ(restored.total_entries(), table.total_entries());
+    EXPECT_EQ(restored.num_device_groups(), 0u);
+}
+
+TEST(KvChunkAddressTableProtobuf, SparseTableRoundTrip) {
+    KvChunkAddressTableConfig cfg{.num_layers = 4, .max_sequence_length = 256, .num_slots = 2, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(cfg);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    table.set(2, 64, 0, KvCacheLocation{.noc_addr = 0xAAAA, .size_bytes = 100, .device_group_index = grp});
+    table.set(2, 128, 0, KvCacheLocation{.noc_addr = 0xBBBB, .size_bytes = 200, .device_group_index = grp});
+
+    std::string data = export_to_protobuf(table);
+    auto restored = import_from_protobuf(data);
+
+    EXPECT_EQ(restored.lookup(2, 64, 0).noc_addr, 0xAAAAu);
+    EXPECT_EQ(restored.lookup(2, 128, 0).noc_addr, 0xBBBBu);
+    EXPECT_EQ(restored.lookup(0, 0, 0).noc_addr, 0u);
+    EXPECT_EQ(restored.lookup(3, 0, 1).noc_addr, 0u);
+}
+
+// --- Text format round-trip (debug API) ---
+
+TEST(KvChunkAddressTableProtobuf, TextFormatRoundTripViaString) {
+    auto original = make_test_table();
+    std::string text = export_to_protobuf_text(original);
+    auto restored = import_from_protobuf_text(text);
+
+    EXPECT_EQ(restored.config().num_layers, original.config().num_layers);
+    EXPECT_EQ(restored.config().max_sequence_length, original.config().max_sequence_length);
+    EXPECT_EQ(restored.config().num_slots, original.config().num_slots);
+    EXPECT_EQ(restored.config().chunk_n_tokens, original.config().chunk_n_tokens);
+
+    ASSERT_EQ(restored.num_device_groups(), original.num_device_groups());
+    for (size_t i = 0; i < original.num_device_groups(); i++) {
+        EXPECT_EQ(
+            original.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)}),
+            restored.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)}));
+    }
+
+    const auto& cfg = original.config();
+    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                const auto& orig = original.lookup(layer, pos, slot);
+                const auto& rest = restored.lookup(layer, pos, slot);
+                EXPECT_EQ(rest.noc_addr, orig.noc_addr)
+                    << "mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(rest.size_bytes, orig.size_bytes);
+                EXPECT_EQ(rest.device_group_index, orig.device_group_index);
+            }
+        }
+    }
+}
+
+TEST(KvChunkAddressTableProtobuf, TextFormatRoundTripViaFile) {
+    auto original = make_test_table();
+
+    std::string tmp_path = std::filesystem::temp_directory_path() / "kv_chunk_address_table_test.textproto";
+    export_to_protobuf_text_file(original, tmp_path);
+
+    auto restored = import_from_protobuf_text_file(tmp_path);
+
+    const auto& cfg = original.config();
+    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                const auto& orig = original.lookup(layer, pos, slot);
+                const auto& rest = restored.lookup(layer, pos, slot);
+                EXPECT_EQ(rest.noc_addr, orig.noc_addr)
+                    << "mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(rest.size_bytes, orig.size_bytes);
+                EXPECT_EQ(rest.device_group_index, orig.device_group_index);
+            }
+        }
+    }
+
+    std::filesystem::remove(tmp_path);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tests/tt_metal/tt_fabric/sources.cmake
+++ b/tests/tt_metal/tt_fabric/sources.cmake
@@ -26,6 +26,7 @@ set(UNIT_TESTS_FABRIC_SRC
     fabric_router/test_fabric_topology_helpers.cpp
     fabric_router/test_fabric_opt_level.cpp
     fabric_router/test_channel_trimming_capture.cpp
+    disaggregation/test_kv_chunk_address_table_protobuf.cpp
     fabric_data_movement/test_basic_fabric_apis.cpp
     fabric_data_movement/test_basic_1d_fabric.cpp
     fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
+++ b/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "experimental/disaggregation/kv_chunk_address_table.hpp"
+#include "experimental/fabric/fabric_types.hpp"
+
+namespace tt::tt_metal::experimental::disaggregation {
+namespace {
+
+using tt::tt_fabric::FabricNodeId;
+using tt::tt_fabric::MeshId;
+
+// Helper to create a FabricNodeId.
+FabricNodeId make_fnid(uint32_t mesh, uint32_t chip) { return FabricNodeId(MeshId{mesh}, chip); }
+
+// Helper to create a KvCacheLocation with a pre-registered device group.
+KvCacheLocation make_location(uint64_t noc_addr, uint32_t size_bytes, DeviceGroupIndex device_group_index) {
+    return KvCacheLocation{.noc_addr = noc_addr, .size_bytes = size_bytes, .device_group_index = device_group_index};
+}
+
+// --- Construction Tests ---
+
+TEST(KvChunkAddressTable, ConstructWithValidConfig) {
+    KvChunkAddressTableConfig config{
+        .num_layers = 10, .max_sequence_length = 1024, .num_slots = 4, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_EQ(table.config().num_layers, 10u);
+    EXPECT_EQ(table.config().max_sequence_length, 1024u);
+    EXPECT_EQ(table.config().num_slots, 4u);
+    EXPECT_EQ(table.config().chunk_n_tokens, 32u);
+    EXPECT_EQ(table.num_position_chunks(), 1024u / 32u);
+    EXPECT_EQ(table.total_entries(), 10u * 32u * 4u);
+}
+
+TEST(KvChunkAddressTable, ConstructWithNonAlignedSequenceLength) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 100, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    // ceil(100/32) = 4 chunks
+    EXPECT_EQ(table.num_position_chunks(), 4u);
+    EXPECT_EQ(table.total_entries(), 1u * 4u * 1u);
+}
+
+TEST(KvChunkAddressTable, ConstructWithZeroChunkSizeThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 0};
+    EXPECT_ANY_THROW(KvChunkAddressTable table(config));
+}
+
+TEST(KvChunkAddressTable, ConstructEmptyTable) {
+    KvChunkAddressTableConfig config{.num_layers = 0, .max_sequence_length = 0, .num_slots = 0, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    EXPECT_EQ(table.total_entries(), 0u);
+}
+
+// --- Device Group Tests ---
+
+TEST(KvChunkAddressTable, AddDeviceGroupSingle) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto idx = table.add_device_group({make_fnid(0, 0)});
+    EXPECT_EQ(idx, DeviceGroupIndex{0});
+    EXPECT_EQ(table.num_device_groups(), 1u);
+
+    const auto& group = table.get_device_group(idx);
+    ASSERT_EQ(group.fabric_node_ids.size(), 1u);
+    EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, 0));
+}
+
+TEST(KvChunkAddressTable, AddDeviceGroupDeduplicates) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto idx1 = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1)});
+    auto idx2 = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1)});
+    EXPECT_EQ(idx1, idx2);
+    EXPECT_EQ(table.num_device_groups(), 1u);
+}
+
+TEST(KvChunkAddressTable, AddDeviceGroupSortsForDedup) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    // Same nodes, different insertion order — should dedup to same index.
+    auto idx1 = table.add_device_group({make_fnid(0, 2), make_fnid(0, 0), make_fnid(0, 1)});
+    auto idx2 = table.add_device_group({make_fnid(0, 1), make_fnid(0, 2), make_fnid(0, 0)});
+    EXPECT_EQ(idx1, idx2);
+    EXPECT_EQ(table.num_device_groups(), 1u);
+
+    // Verify stored sorted.
+    const auto& group = table.get_device_group(idx1);
+    ASSERT_EQ(group.fabric_node_ids.size(), 3u);
+    EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, 0));
+    EXPECT_EQ(group.fabric_node_ids[1], make_fnid(0, 1));
+    EXPECT_EQ(group.fabric_node_ids[2], make_fnid(0, 2));
+}
+
+TEST(KvChunkAddressTable, AddDeviceGroupDistinctGroups) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto idx1 = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1)});
+    auto idx2 = table.add_device_group({make_fnid(0, 2), make_fnid(0, 3)});
+    EXPECT_NE(idx1, idx2);
+    EXPECT_EQ(table.num_device_groups(), 2u);
+}
+
+TEST(KvChunkAddressTable, GetDeviceGroupOutOfRangeThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.get_device_group(DeviceGroupIndex{0}));
+}
+
+// --- Set/Lookup Tests ---
+
+TEST(KvChunkAddressTable, SetAndLookupSingleEntry) {
+    KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto grp = table.add_device_group({make_fnid(0, 1)});
+    table.set(0, 0, 0, make_location(0xDEAD'0000, 1088 * 18, grp));
+
+    const auto& loc = table.lookup(0, 0, 0);
+    EXPECT_EQ(loc.noc_addr, 0xDEAD'0000u);
+    EXPECT_EQ(loc.size_bytes, 1088u * 18u);
+    EXPECT_EQ(loc.device_group_index, grp);
+
+    const auto& group = table.get_device_group(loc.device_group_index);
+    ASSERT_EQ(group.fabric_node_ids.size(), 1u);
+    EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, 1));
+}
+
+TEST(KvChunkAddressTable, SetAndLookupMultipleLayers) {
+    KvChunkAddressTableConfig config{
+        .num_layers = 80, .max_sequence_length = 8192, .num_slots = 8, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    for (uint32_t layer = 0; layer < 80; layer++) {
+        uint64_t addr = static_cast<uint64_t>(layer) * 0x1000;
+        table.set(layer, 0, 0, make_location(addr, 1088 * 18, grp));
+    }
+
+    for (uint32_t layer = 0; layer < 80; layer++) {
+        const auto& loc = table.lookup(layer, 0, 0);
+        EXPECT_EQ(loc.noc_addr, static_cast<uint64_t>(layer) * 0x1000);
+    }
+}
+
+TEST(KvChunkAddressTable, SetAndLookupMultiplePositions) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    for (uint32_t pos = 0; pos < 256; pos += 32) {
+        uint64_t addr = static_cast<uint64_t>(pos) * 0x100;
+        table.set(0, pos, 0, make_location(addr, 1088 * 18, grp));
+    }
+
+    for (uint32_t pos = 0; pos < 256; pos += 32) {
+        const auto& loc = table.lookup(0, pos, 0);
+        EXPECT_EQ(loc.noc_addr, static_cast<uint64_t>(pos) * 0x100);
+    }
+}
+
+TEST(KvChunkAddressTable, SetAndLookupMultipleSlots) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 4, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    constexpr size_t num_slots_to_test = 4;
+    std::vector<DeviceGroupIndex> grps;
+    grps.reserve(num_slots_to_test);
+    for (uint32_t slot = 0; slot < num_slots_to_test; slot++) {
+        grps.push_back(table.add_device_group({make_fnid(0, slot)}));
+    }
+
+    for (uint32_t slot = 0; slot < num_slots_to_test; slot++) {
+        table.set(0, 0, slot, make_location(slot * 0x1000, 100, grps[slot]));
+    }
+
+    for (uint32_t slot = 0; slot < num_slots_to_test; slot++) {
+        const auto& loc = table.lookup(0, 0, slot);
+        EXPECT_EQ(loc.noc_addr, slot * 0x1000u);
+        const auto& group = table.get_device_group(loc.device_group_index);
+        ASSERT_EQ(group.fabric_node_ids.size(), 1u);
+        EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, slot));
+    }
+}
+
+TEST(KvChunkAddressTable, SetAndLookupMultipleSlotsAndLayersAndPositions) {
+    // Asymmetric dimensions: 5 layers, 7 slots, 384 tokens (12 chunks of 32).
+    constexpr uint32_t kNumLayers = 5;
+    constexpr uint32_t kSeqLen = 384;
+    constexpr uint32_t kNumSlots = 7;
+    constexpr uint32_t kChunkSize = 32;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = kNumLayers,
+        .max_sequence_length = kSeqLen,
+        .num_slots = kNumSlots,
+        .chunk_n_tokens = kChunkSize,
+    };
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    // Encode (slot, layer, position) into noc_addr so each entry is uniquely identifiable.
+    // Layout: noc_addr = (slot << 40) | (layer << 24) | position
+    for (uint32_t slot = 0; slot < kNumSlots; slot++) {
+        for (uint32_t layer = 0; layer < kNumLayers; layer++) {
+            for (uint32_t pos = 0; pos < kSeqLen; pos += kChunkSize) {
+                uint64_t addr = (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) |
+                                static_cast<uint64_t>(pos);
+                uint32_t size = 1000 + (slot * 100) + (layer * 10) + (pos / kChunkSize);
+                table.set(
+                    layer, pos, slot, KvCacheLocation{.noc_addr = addr, .size_bytes = size, .device_group_index = grp});
+            }
+        }
+    }
+
+    // Verify every entry by decoding the coordinate from noc_addr.
+    for (uint32_t slot = 0; slot < kNumSlots; slot++) {
+        for (uint32_t layer = 0; layer < kNumLayers; layer++) {
+            for (uint32_t pos = 0; pos < kSeqLen; pos += kChunkSize) {
+                const auto& loc = table.lookup(layer, pos, slot);
+
+                uint64_t expected_addr = (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) |
+                                         static_cast<uint64_t>(pos);
+                uint32_t expected_size = 1000 + (slot * 100) + (layer * 10) + (pos / kChunkSize);
+
+                EXPECT_EQ(loc.noc_addr, expected_addr)
+                    << "addr mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(loc.size_bytes, expected_size)
+                    << "size mismatch at slot=" << slot << " layer=" << layer << " pos=" << pos;
+                EXPECT_EQ(loc.device_group_index, grp);
+            }
+        }
+    }
+
+    // Also verify via lookup_range that spans are correct per (slot, layer).
+    for (uint32_t slot = 0; slot < kNumSlots; slot++) {
+        for (uint32_t layer = 0; layer < kNumLayers; layer++) {
+            auto range = table.lookup_range(layer, 0, kSeqLen, slot);
+            ASSERT_EQ(range.size(), kSeqLen / kChunkSize);
+            for (uint32_t chunk = 0; chunk < range.size(); chunk++) {
+                uint32_t pos = chunk * kChunkSize;
+                uint64_t expected_addr = (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) |
+                                         static_cast<uint64_t>(pos);
+                EXPECT_EQ(range[chunk].noc_addr, expected_addr);
+            }
+        }
+    }
+}
+
+TEST(KvChunkAddressTable, ReplicatedLocation) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    // Column-replicated across 4 chips.
+    auto grp = table.add_device_group({make_fnid(0, 0), make_fnid(0, 1), make_fnid(0, 2), make_fnid(0, 3)});
+    table.set(0, 0, 0, make_location(0xBEEF, 1088 * 18, grp));
+
+    const auto& loc = table.lookup(0, 0, 0);
+    const auto& group = table.get_device_group(loc.device_group_index);
+    EXPECT_EQ(group.fabric_node_ids.size(), 4u);
+}
+
+// --- Overwrite Tests ---
+
+TEST(KvChunkAddressTable, OverwriteEntry) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto grp0 = table.add_device_group({make_fnid(0, 0)});
+    auto grp1 = table.add_device_group({make_fnid(0, 1)});
+
+    table.set(0, 0, 0, make_location(0x1111, 100, grp0));
+    EXPECT_EQ(table.lookup(0, 0, 0).noc_addr, 0x1111u);
+
+    table.set(0, 0, 0, make_location(0x2222, 200, grp1));
+    EXPECT_EQ(table.lookup(0, 0, 0).noc_addr, 0x2222u);
+    EXPECT_EQ(table.lookup(0, 0, 0).size_bytes, 200u);
+    EXPECT_EQ(table.lookup(0, 0, 0).device_group_index, grp1);
+}
+
+// --- Range Lookup Tests ---
+
+TEST(KvChunkAddressTable, LookupRangeContiguous) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    for (uint32_t pos = 0; pos < 256; pos += 32) {
+        table.set(0, pos, 0, make_location(pos, 1088 * 18, grp));
+    }
+
+    // Lookup range [64, 192) — should get chunks at positions 64, 96, 128, 160
+    auto range = table.lookup_range(0, 64, 192, 0);
+    EXPECT_EQ(range.size(), 4u);
+    EXPECT_EQ(range[0].noc_addr, 64u);
+    EXPECT_EQ(range[1].noc_addr, 96u);
+    EXPECT_EQ(range[2].noc_addr, 128u);
+    EXPECT_EQ(range[3].noc_addr, 160u);
+}
+
+TEST(KvChunkAddressTable, LookupRangeFullSequence) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    for (uint32_t pos = 0; pos < 128; pos += 32) {
+        table.set(0, pos, 0, make_location(pos, 100, grp));
+    }
+
+    auto range = table.lookup_range(0, 0, 128, 0);
+    EXPECT_EQ(range.size(), 4u);
+}
+
+TEST(KvChunkAddressTable, LookupRangeEmptyWhenStartEqualsEnd) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto range = table.lookup_range(0, 64, 64, 0);
+    EXPECT_TRUE(range.empty());
+}
+
+TEST(KvChunkAddressTable, LookupRangeIsZeroCopy) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    table.set(0, 32, 0, make_location(0xAAAA, 100, grp));
+
+    auto range = table.lookup_range(0, 32, 64, 0);
+    ASSERT_EQ(range.size(), 1u);
+    // The span should point into the same memory as a direct lookup.
+    EXPECT_EQ(range.data(), &table.lookup(0, 32, 0));
+}
+
+// --- Boundary / Error Tests ---
+
+TEST(KvChunkAddressTable, LookupOutOfRangeLayerThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.lookup(2, 0, 0));
+}
+
+TEST(KvChunkAddressTable, LookupOutOfRangePositionThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.lookup(0, 64, 0));
+}
+
+TEST(KvChunkAddressTable, LookupOutOfRangeSlotThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 2, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.lookup(0, 0, 2));
+}
+
+TEST(KvChunkAddressTable, SetOutOfRangeThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.set(1, 0, 0, KvCacheLocation{}));
+    EXPECT_ANY_THROW(table.set(0, 64, 0, KvCacheLocation{}));
+    EXPECT_ANY_THROW(table.set(0, 0, 1, KvCacheLocation{}));
+}
+
+TEST(KvChunkAddressTable, LookupRangeEndPosBeyondMaxThrows) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_ANY_THROW(table.lookup_range(0, 0, 129, 0));
+}
+
+// --- FabricNodeId -> Host Mapping Tests ---
+
+TEST(KvChunkAddressTable, SetAndGetHost) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    auto fnid = make_fnid(0, 0);
+    table.set_fabric_node_host(fnid, "host-0");
+
+    EXPECT_TRUE(table.has_host(fnid));
+    EXPECT_EQ(table.get_host(fnid), "host-0");
+}
+
+TEST(KvChunkAddressTable, GetHostThrowsForUnknownNode) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    EXPECT_FALSE(table.has_host(make_fnid(0, 0)));
+    EXPECT_ANY_THROW(table.get_host(make_fnid(0, 0)));
+}
+
+TEST(KvChunkAddressTable, MultipleHostMappings) {
+    KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
+    KvChunkAddressTable table(config);
+
+    // 32 devices across 4 meshes, 8 chips each.
+    for (uint32_t mesh = 0; mesh < 4; mesh++) {
+        for (uint32_t chip = 0; chip < 8; chip++) {
+            auto fnid = make_fnid(mesh, chip);
+            std::string host = "host-" + std::to_string(mesh);
+            table.set_fabric_node_host(fnid, host);
+        }
+    }
+
+    for (uint32_t mesh = 0; mesh < 4; mesh++) {
+        for (uint32_t chip = 0; chip < 8; chip++) {
+            EXPECT_EQ(table.get_host(make_fnid(mesh, chip)), "host-" + std::to_string(mesh));
+        }
+    }
+}
+
+// --- Realistic Scale Test ---
+
+TEST(KvChunkAddressTable, RealisticPrefillScale) {
+    // Simulates a realistic prefill scenario:
+    // 80 layers, 102400 seq_len (3200 chunks of 32), 8 slots
+    constexpr uint32_t kNumLayers = 80;
+    constexpr uint32_t kSeqLen = 102400;
+    constexpr uint32_t kNumSlots = 8;
+    constexpr uint32_t kChunkSize = 32;
+    constexpr uint32_t kPageSizeBytes = 1088 * 18;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = kNumLayers,
+        .max_sequence_length = kSeqLen,
+        .num_slots = kNumSlots,
+        .chunk_n_tokens = kChunkSize,
+    };
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    EXPECT_EQ(table.num_position_chunks(), kSeqLen / kChunkSize);
+
+    // Populate a single slot/layer to verify addressing.
+    uint32_t layer = 0;
+    uint32_t slot = 0;
+    for (uint32_t pos = 0; pos < kSeqLen; pos += kChunkSize) {
+        uint64_t addr = 0x8000'0000 + (static_cast<uint64_t>(pos / kChunkSize) * kPageSizeBytes);
+        table.set(layer, pos, slot, make_location(addr, kPageSizeBytes, grp));
+    }
+
+    // Verify a range lookup.
+    auto range = table.lookup_range(layer, 0, kSeqLen, slot);
+    EXPECT_EQ(range.size(), kSeqLen / kChunkSize);
+    EXPECT_EQ(range[0].noc_addr, 0x8000'0000u);
+    EXPECT_EQ(range[1].noc_addr, 0x8000'0000u + kPageSizeBytes);
+}
+
+// --- Decode Scale Test ---
+
+TEST(KvChunkAddressTable, DecodeAccessPattern) {
+    // Simulates the decode migrate() access pattern:
+    // For a fixed slot, iterate layers, then iterate positions.
+    constexpr uint32_t kNumLayers = 80;
+    constexpr uint32_t kSeqLen = 8192;
+    constexpr uint32_t kNumSlots = 4;
+    constexpr uint32_t kChunkSize = 32;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = kNumLayers, .max_sequence_length = kSeqLen, .num_slots = kNumSlots, .chunk_n_tokens = kChunkSize};
+    KvChunkAddressTable table(config);
+    auto grp = table.add_device_group({make_fnid(0, 0)});
+
+    // Populate all entries.
+    for (uint32_t slot = 0; slot < kNumSlots; slot++) {
+        for (uint32_t layer = 0; layer < kNumLayers; layer++) {
+            for (uint32_t pos = 0; pos < kSeqLen; pos += kChunkSize) {
+                uint64_t addr = (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) |
+                                static_cast<uint64_t>(pos);
+                table.set(layer, pos, slot, make_location(addr, 1088 * 18, grp));
+            }
+        }
+    }
+
+    // Simulate migrate(start_pos=1024, end_pos=4096, slot_id=2, layer=5)
+    uint32_t slot = 2;
+    uint32_t layer = 5;
+    uint32_t start_pos = 1024;
+    uint32_t end_pos = 4096;
+
+    auto range = table.lookup_range(layer, start_pos, end_pos, slot);
+    uint32_t expected_chunks = (end_pos - start_pos) / kChunkSize;
+    EXPECT_EQ(range.size(), expected_chunks);
+
+    // Verify first and last entry addresses.
+    uint64_t expected_first = (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) | start_pos;
+    uint64_t expected_last =
+        (static_cast<uint64_t>(slot) << 40) | (static_cast<uint64_t>(layer) << 24) | (end_pos - kChunkSize);
+    EXPECT_EQ(range.front().noc_addr, expected_first);
+    EXPECT_EQ(range.back().noc_addr, expected_last);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -55,4 +55,5 @@ set(UNIT_TESTS_API_SOURCES
     test_blockfloat_common.cpp
     test_duplicate_kernel.cpp
     test_core_local_mem_api.cpp
+    disaggregation/test_kv_chunk_address_table.cpp
 )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -25,6 +25,23 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
     if(${TEST_SRC} STREQUAL "dispatch/benchmark_rw_buffer.cpp")
         target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
     endif()
+    if(${TEST_SRC} STREQUAL "disaggregation/bench_kv_chunk_address_table.cpp")
+        target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
+    endif()
+    if(${TEST_SRC} STREQUAL "disaggregation/bench_kv_chunk_address_table_serialization.cpp")
+        target_link_libraries(
+            ${TEST_TARGET}
+            PRIVATE
+                benchmark::benchmark
+                protobuf::libprotobuf
+        )
+        target_include_directories(${TEST_TARGET} PRIVATE ${PROJECT_SOURCE_DIR}/tt_metal)
+        target_sources(
+            ${TEST_TARGET}
+            PRIVATE
+                ${PROJECT_SOURCE_DIR}/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
+        )
+    endif()
 
     if(${TEST_SRC} STREQUAL "routing/test_tt_fabric.cpp")
         target_sources(${TEST_TARGET} PRIVATE ${TEST_TT_FABRIC_ADDITIONAL_SOURCES})

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table.cpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark suite for KvChunkAddressTable lookup performance.
+//
+// Measures the typical decode access pattern:
+//   for a fixed slot_id:
+//     for layer in [0, num_layers):
+//       for position in range(start_pos, end_pos, chunk_n_tokens):
+//         lookup(layer, position, slot_id)
+//
+// Also benchmarks lookup_range() which returns a contiguous span.
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+
+#include "experimental/disaggregation/kv_chunk_address_table.hpp"
+#include "experimental/fabric/fabric_types.hpp"
+
+namespace {
+
+using tt::tt_fabric::FabricNodeId;
+using tt::tt_fabric::MeshId;
+using tt::tt_metal::experimental::disaggregation::KvCacheLocation;
+using tt::tt_metal::experimental::disaggregation::KvChunkAddressTable;
+using tt::tt_metal::experimental::disaggregation::KvChunkAddressTableConfig;
+
+constexpr uint32_t kPageSizeBytes = 1088 * 18;  // bfp8 KV chunk size
+
+// Populate the entire table with synthetic data.
+void populate_table(KvChunkAddressTable& table) {
+    const auto& config = table.config();
+
+    // Register a single device group (typical for non-replicated case).
+    auto grp = table.add_device_group({FabricNodeId(MeshId{0}, 0)});
+
+    for (uint32_t slot = 0; slot < config.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < config.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < config.max_sequence_length; pos += config.chunk_n_tokens) {
+                KvCacheLocation loc{
+                    .noc_addr = 0x8000'0000 + (static_cast<uint64_t>(pos / config.chunk_n_tokens) * kPageSizeBytes),
+                    .size_bytes = kPageSizeBytes,
+                    .device_group_index = grp,
+                };
+                table.set(layer, pos, slot, loc);
+            }
+        }
+    }
+}
+
+// --- Individual lookup benchmark ---
+// Simulates: for layer in layers: for pos in range(start, end, 32): lookup(layer, pos, slot)
+//
+// Args: [num_layers, max_seq_len, num_slots]
+void BM_LookupIndividual(benchmark::State& state) {
+    const uint32_t num_layers = static_cast<uint32_t>(state.range(0));
+    const uint32_t max_seq_len = static_cast<uint32_t>(state.range(1));
+    const uint32_t num_slots = static_cast<uint32_t>(state.range(2));
+    constexpr uint32_t chunk_n_tokens = 32;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = num_layers,
+        .max_sequence_length = max_seq_len,
+        .num_slots = num_slots,
+        .chunk_n_tokens = chunk_n_tokens,
+    };
+    KvChunkAddressTable table(config);
+    populate_table(table);
+
+    // Fixed slot, iterate all layers and positions.
+    const uint32_t slot = 0;
+
+    for ([[maybe_unused]] auto _ : state) {
+        uint64_t sink = 0;
+        for (uint32_t layer = 0; layer < num_layers; layer++) {
+            for (uint32_t pos = 0; pos < max_seq_len; pos += chunk_n_tokens) {
+                sink += table.lookup(layer, pos, slot).noc_addr;
+            }
+        }
+        benchmark::DoNotOptimize(sink);
+    }
+
+    // Report throughput in lookups/second.
+    uint64_t lookups_per_iter = static_cast<uint64_t>(num_layers) * (max_seq_len / chunk_n_tokens);
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(lookups_per_iter));
+    state.counters["lookups/iter"] = benchmark::Counter(static_cast<double>(lookups_per_iter));
+}
+
+// --- Range lookup benchmark ---
+// Simulates: for layer in layers: lookup_range(layer, 0, seq_len, slot)
+//
+// Args: [num_layers, max_seq_len, num_slots]
+void BM_LookupRange(benchmark::State& state) {
+    const uint32_t num_layers = static_cast<uint32_t>(state.range(0));
+    const uint32_t max_seq_len = static_cast<uint32_t>(state.range(1));
+    const uint32_t num_slots = static_cast<uint32_t>(state.range(2));
+    constexpr uint32_t chunk_n_tokens = 32;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = num_layers,
+        .max_sequence_length = max_seq_len,
+        .num_slots = num_slots,
+        .chunk_n_tokens = chunk_n_tokens,
+    };
+    KvChunkAddressTable table(config);
+    populate_table(table);
+
+    const uint32_t slot = 0;
+
+    for ([[maybe_unused]] auto _ : state) {
+        uint64_t sink = 0;
+        for (uint32_t layer = 0; layer < num_layers; layer++) {
+            auto range = table.lookup_range(layer, 0, max_seq_len, slot);
+            for (const auto& loc : range) {
+                sink += loc.noc_addr;
+            }
+        }
+        benchmark::DoNotOptimize(sink);
+    }
+
+    uint64_t lookups_per_iter = static_cast<uint64_t>(num_layers) * (max_seq_len / chunk_n_tokens);
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(lookups_per_iter));
+    state.counters["lookups/iter"] = benchmark::Counter(static_cast<double>(lookups_per_iter));
+}
+
+// --- Partial range lookup (migrate pattern) ---
+// Simulates migrate(start_pos, end_pos, slot, layer) called per-layer.
+//
+// Args: [num_layers, max_seq_len, num_slots, range_size_tokens]
+void BM_LookupMigratePattern(benchmark::State& state) {
+    const uint32_t num_layers = static_cast<uint32_t>(state.range(0));
+    const uint32_t max_seq_len = static_cast<uint32_t>(state.range(1));
+    const uint32_t num_slots = static_cast<uint32_t>(state.range(2));
+    const uint32_t range_tokens = static_cast<uint32_t>(state.range(3));
+    constexpr uint32_t chunk_n_tokens = 32;
+
+    KvChunkAddressTableConfig config{
+        .num_layers = num_layers,
+        .max_sequence_length = max_seq_len,
+        .num_slots = num_slots,
+        .chunk_n_tokens = chunk_n_tokens,
+    };
+    KvChunkAddressTable table(config);
+    populate_table(table);
+
+    const uint32_t slot = 0;
+    const uint32_t start_pos = 0;
+    const uint32_t end_pos = std::min(range_tokens, max_seq_len);
+
+    for ([[maybe_unused]] auto _ : state) {
+        uint64_t sink = 0;
+        for (uint32_t layer = 0; layer < num_layers; layer++) {
+            auto range = table.lookup_range(layer, start_pos, end_pos, slot);
+            for (const auto& loc : range) {
+                sink += loc.noc_addr;
+            }
+        }
+        benchmark::DoNotOptimize(sink);
+    }
+
+    uint64_t lookups_per_iter = static_cast<uint64_t>(num_layers) * ((end_pos - start_pos) / chunk_n_tokens);
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(lookups_per_iter));
+    state.counters["lookups/iter"] = benchmark::Counter(static_cast<double>(lookups_per_iter));
+}
+
+// --- Register benchmarks ---
+
+// Small model: 10 layers, 1024 seq, 4 slots
+//                         layers  seq_len  slots
+BENCHMARK(BM_LookupIndividual)->Args({10, 1024, 4})->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_LookupRange)->Args({10, 1024, 4})->Unit(benchmark::kMicrosecond);
+
+// Medium model: 80 layers, 8192 seq, 8 slots
+BENCHMARK(BM_LookupIndividual)->Args({80, 8192, 8})->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_LookupRange)->Args({80, 8192, 8})->Unit(benchmark::kMicrosecond);
+
+// Large model: 80 layers, 131072 seq (128K), 8 slots
+BENCHMARK(BM_LookupIndividual)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_LookupRange)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+
+// Very large: 100 layers, 2097152 seq (2M), 4 slots
+BENCHMARK(BM_LookupRange)->Args({100, 2097152, 4})->Unit(benchmark::kMillisecond);
+
+// Migrate pattern: partial range lookups
+//                                layers  seq_len  slots  range_tokens
+BENCHMARK(BM_LookupMigratePattern)->Args({80, 8192, 8, 1024})->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_LookupMigratePattern)->Args({80, 8192, 8, 4096})->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_LookupMigratePattern)->Args({80, 131072, 8, 8192})->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_LookupMigratePattern)->Args({100, 2097152, 4, 8192})->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table_serialization.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table_serialization.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Serialization benchmark: Protobuf binary vs text export/import for KvChunkAddressTable.
+//
+// Args: [num_layers, max_seq_len, num_slots]
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <string>
+
+#include "impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp"
+
+namespace {
+
+using tt::tt_fabric::FabricNodeId;
+using tt::tt_fabric::MeshId;
+using tt::tt_metal::experimental::disaggregation::KvCacheLocation;
+using tt::tt_metal::experimental::disaggregation::KvChunkAddressTable;
+using tt::tt_metal::experimental::disaggregation::KvChunkAddressTableConfig;
+
+constexpr uint32_t kPageSizeBytes = 1088 * 18;
+
+KvChunkAddressTable make_table(uint32_t num_layers, uint32_t max_seq_len, uint32_t num_slots) {
+    constexpr uint32_t chunk_n_tokens = 32;
+    KvChunkAddressTableConfig cfg{
+        .num_layers = num_layers,
+        .max_sequence_length = max_seq_len,
+        .num_slots = num_slots,
+        .chunk_n_tokens = chunk_n_tokens,
+    };
+    KvChunkAddressTable table(cfg);
+    auto grp = table.add_device_group({FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 1)});
+    table.set_fabric_node_host(FabricNodeId(MeshId{0}, 0), "host-0");
+    table.set_fabric_node_host(FabricNodeId(MeshId{0}, 1), "host-0");
+
+    for (uint32_t slot = 0; slot < num_slots; slot++) {
+        for (uint32_t layer = 0; layer < num_layers; layer++) {
+            for (uint32_t pos = 0; pos < max_seq_len; pos += chunk_n_tokens) {
+                KvCacheLocation loc{
+                    .noc_addr = 0x8000'0000 + (static_cast<uint64_t>(pos / chunk_n_tokens) * kPageSizeBytes),
+                    .size_bytes = kPageSizeBytes,
+                    .device_group_index = grp,
+                };
+                table.set(layer, pos, slot, loc);
+            }
+        }
+    }
+    return table;
+}
+
+uint64_t count_entries(const KvChunkAddressTable& table) {
+    const auto& cfg = table.config();
+    return static_cast<uint64_t>(cfg.num_layers) * (cfg.max_sequence_length / cfg.chunk_n_tokens) * cfg.num_slots;
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf binary benchmarks
+// ---------------------------------------------------------------------------
+
+void BM_ExportProtobuf(benchmark::State& state) {
+    auto table = make_table(
+        static_cast<uint32_t>(state.range(0)),
+        static_cast<uint32_t>(state.range(1)),
+        static_cast<uint32_t>(state.range(2)));
+
+    size_t bytes = 0;
+    for ([[maybe_unused]] auto _ : state) {
+        std::string data = tt::tt_metal::experimental::disaggregation::export_to_protobuf(table);
+        bytes = data.size();
+        benchmark::DoNotOptimize(data);
+    }
+
+    state.counters["bytes"] = benchmark::Counter(static_cast<double>(bytes));
+    state.counters["entries"] = benchmark::Counter(static_cast<double>(count_entries(table)));
+}
+
+void BM_ImportProtobuf(benchmark::State& state) {
+    auto table = make_table(
+        static_cast<uint32_t>(state.range(0)),
+        static_cast<uint32_t>(state.range(1)),
+        static_cast<uint32_t>(state.range(2)));
+
+    std::string data = tt::tt_metal::experimental::disaggregation::export_to_protobuf(table);
+
+    for ([[maybe_unused]] auto _ : state) {
+        auto restored = tt::tt_metal::experimental::disaggregation::import_from_protobuf(data);
+        benchmark::DoNotOptimize(restored.total_entries());
+    }
+
+    state.counters["bytes"] = benchmark::Counter(static_cast<double>(data.size()));
+    state.counters["entries"] = benchmark::Counter(static_cast<double>(count_entries(table)));
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf text format benchmarks (debug path)
+// ---------------------------------------------------------------------------
+
+void BM_ExportProtobufText(benchmark::State& state) {
+    auto table = make_table(
+        static_cast<uint32_t>(state.range(0)),
+        static_cast<uint32_t>(state.range(1)),
+        static_cast<uint32_t>(state.range(2)));
+
+    size_t bytes = 0;
+    for ([[maybe_unused]] auto _ : state) {
+        std::string text = tt::tt_metal::experimental::disaggregation::export_to_protobuf_text(table);
+        bytes = text.size();
+        benchmark::DoNotOptimize(text);
+    }
+
+    state.counters["bytes"] = benchmark::Counter(static_cast<double>(bytes));
+    state.counters["entries"] = benchmark::Counter(static_cast<double>(count_entries(table)));
+}
+
+void BM_ImportProtobufText(benchmark::State& state) {
+    auto table = make_table(
+        static_cast<uint32_t>(state.range(0)),
+        static_cast<uint32_t>(state.range(1)),
+        static_cast<uint32_t>(state.range(2)));
+
+    std::string text = tt::tt_metal::experimental::disaggregation::export_to_protobuf_text(table);
+
+    for ([[maybe_unused]] auto _ : state) {
+        auto restored = tt::tt_metal::experimental::disaggregation::import_from_protobuf_text(text);
+        benchmark::DoNotOptimize(restored.total_entries());
+    }
+
+    state.counters["bytes"] = benchmark::Counter(static_cast<double>(text.size()));
+    state.counters["entries"] = benchmark::Counter(static_cast<double>(count_entries(table)));
+}
+
+// ---------------------------------------------------------------------------
+// Register benchmarks
+// ---------------------------------------------------------------------------
+
+//                     layers  seq_len  slots
+// Small: 1280 entries
+BENCHMARK(BM_ExportProtobufText)->Args({10, 1024, 4})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobufText)->Args({10, 1024, 4})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ExportProtobuf)->Args({10, 1024, 4})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobuf)->Args({10, 1024, 4})->Unit(benchmark::kMillisecond);
+
+// Medium: 163840 entries
+BENCHMARK(BM_ExportProtobufText)->Args({80, 8192, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobufText)->Args({80, 8192, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ExportProtobuf)->Args({80, 8192, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobuf)->Args({80, 8192, 8})->Unit(benchmark::kMillisecond);
+
+// Large: 2621440 entries
+BENCHMARK(BM_ExportProtobufText)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobufText)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ExportProtobuf)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ImportProtobuf)->Args({80, 131072, 8})->Unit(benchmark::kMillisecond);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
@@ -2,6 +2,8 @@
 # Module owners should update this file when adding/removing/renaming source files
 
 set(PERF_MICROBENCH_TESTS_SRCS
+    disaggregation/bench_kv_chunk_address_table.cpp
+    disaggregation/bench_kv_chunk_address_table_serialization.cpp
     dispatch/test_pgm_dispatch.cpp
     dispatch/benchmark_rw_buffer.cpp
     ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp

--- a/tt_metal/api/tt-metalium/experimental/disaggregation/README.md
+++ b/tt_metal/api/tt-metalium/experimental/disaggregation/README.md
@@ -1,0 +1,11 @@
+This directory contains utilities and datastructures to facilitate disaggregated inference.
+
+A tensor chunk location table (`KvChunkAddressTable`) is included. The table is used as a "common language" interface so various components that are particants in KV Cache lifecycle management (in the future weights management) can understand where given pieces of data are located.
+
+The table is intended to be used to have a representation for where data (KV chunks) in a tensor are located. The tensor may be distributed across multiple hosts and devices.
+
+Users of this datastructure include:
+1) Models: to specify their kv cache tensor layout
+2) KV Cache Migration Service: to consume the table to understand how to migrate data (where to read from and send to, how to breakdown high level requests)
+3) KV Cache Tiering Service: To consume and produce the mapping to understand how to move KV cache data throughout different levels and locations in a cache swarm
+4) Weights Caching Service: To consume and produce the mapping to understand how to distribute weights data when loading/running models

--- a/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt_stl/strong_type.hpp>
+
+namespace tt::tt_metal::experimental::disaggregation {
+
+// Strongly-typed index into the device group side table.
+using DeviceGroupIndex = tt::stl::StrongType<uint32_t, struct DeviceGroupIndexTag>;
+
+// A unique group of fabric nodes that hold replicas of a KV cache chunk.
+// FabricNodeIds are stored sorted so that identical replica sets
+// always produce the same DeviceGroup, enabling deduplication.
+struct DeviceGroup {
+    std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
+
+    bool operator==(const DeviceGroup& other) const { return fabric_node_ids == other.fabric_node_ids; }
+};
+
+// Describes the physical location of a single KV cache chunk in device memory.
+// 16 bytes — 4 entries per cache line.
+struct KvCacheLocation {
+    uint64_t noc_addr = 0;
+    uint32_t size_bytes = 0;
+    DeviceGroupIndex device_group_index{0};
+};
+static_assert(sizeof(KvCacheLocation) == 16, "KvCacheLocation must be 16 bytes for cache-line packing");
+
+// Configuration for constructing a KvChunkAddressTable.
+struct KvChunkAddressTableConfig {
+    uint32_t num_layers = 0;
+    uint32_t max_sequence_length = 0;  // in tokens
+    uint32_t num_slots = 0;
+    uint32_t chunk_n_tokens = 32;       // tokens per chunk (KV atomic block granularity)
+    uint32_t chunk_size_bytes = 19584;  // physical size of one chunk in bytes (18 x 1088 bfp8 tiles)
+};
+
+// Lookup table mapping (layer, position, slot) -> KvCacheLocation.
+//
+// Describes how a KV cache is allocated/laid out across a multi-host,
+// multi-chip, multi-memory system. Used by the migration layer to locate
+// KV cache chunks for transfer.
+//
+// Device replica groups are stored in a separate side table and referenced
+// by index from each KvCacheLocation. Groups are deduplicated: identical
+// sorted sets of FabricNodeIds share the same index. The side table is
+// typically tiny (handful of entries) and stays in L1 cache.
+//
+// Internal storage is ordered [slot][layer][position_chunk] so that the
+// typical access pattern (fixed slot, iterate layers, iterate positions)
+// gets contiguous position-chunk reads — the innermost loop.
+//
+// Position indices are in units of tokens and are converted internally
+// to chunk indices via (position / chunk_n_tokens).
+class KvChunkAddressTable {
+public:
+    explicit KvChunkAddressTable(const KvChunkAddressTableConfig& config);
+
+    // --- Device Group Management ---
+
+    // Register a device group (set of replica FabricNodeIds).
+    // The FabricNodeIds are sorted internally for dedup.
+    // Returns the index for this group. If an identical sorted group
+    // already exists, returns the existing index.
+    DeviceGroupIndex add_device_group(std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids);
+
+    // Lookup a device group by index.
+    const DeviceGroup& get_device_group(DeviceGroupIndex index) const;
+
+    // Number of unique device groups registered.
+    size_t num_device_groups() const { return device_groups_.size(); }
+
+    // --- Mutators ---
+
+    // Set the location for a specific (layer, position, slot).
+    // `position` is in tokens and must be chunk-aligned (multiple of chunk_n_tokens).
+    void set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location);
+
+    // Register a mapping from FabricNodeId to its host name.
+    void set_fabric_node_host(const tt::tt_fabric::FabricNodeId& node_id, const std::string& host_name);
+
+    // --- Accessors ---
+
+    // Lookup a single entry. `position` is in tokens (chunk-aligned).
+    const KvCacheLocation& lookup(uint32_t layer, uint32_t position, uint32_t slot) const;
+
+    // Lookup a contiguous range of position chunks for a given (layer, slot).
+    // Returns a span over the internal storage — zero-copy.
+    // `start_pos` must be chunk-aligned. `end_pos` need not be aligned —
+    // it is rounded up to include the enclosing chunk.
+    // Returns entries for chunks covering positions [start_pos, end_pos).
+    std::span<const KvCacheLocation> lookup_range(
+        uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) const;
+
+    // Resolve a FabricNodeId to its host name.
+    const std::string& get_host(const tt::tt_fabric::FabricNodeId& node_id) const;
+
+    // Check if a FabricNodeId has a registered host mapping.
+    bool has_host(const tt::tt_fabric::FabricNodeId& node_id) const;
+
+    const KvChunkAddressTableConfig& config() const { return config_; }
+    uint32_t num_position_chunks() const { return num_position_chunks_; }
+    size_t total_entries() const { return entries_.size(); }
+
+private:
+    size_t flat_index(uint32_t layer, uint32_t position_chunk, uint32_t slot) const;
+    uint32_t to_chunk_index(uint32_t position) const;
+    void validate_args(uint32_t layer, uint32_t position, uint32_t slot) const;
+
+    KvChunkAddressTableConfig config_;
+    uint32_t num_position_chunks_;
+    uint32_t num_layers_x_chunks_;  // cached: num_layers * num_position_chunks_
+    std::vector<KvCacheLocation> entries_;
+    std::vector<DeviceGroup> device_groups_;
+    std::unordered_map<tt::tt_fabric::FabricNodeId, std::string> fabric_node_to_host_;
+};
+
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -65,6 +65,14 @@ if(TARGET all_generated_files)
     add_dependencies(all_generated_files capnp_generated_files)
 endif()
 
+# Generate protobuf files for KvChunkAddressTable serialization
+include(protobuf)
+GENERATE_PROTO_FILES(
+    ${CMAKE_CURRENT_SOURCE_DIR}/experimental/disaggregation/protobuf/kv_chunk_address_table.proto
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/experimental/disaggregation
+)
+list(APPEND IMPL_SRC ${PROTO_SRCS})
+
 add_library(impl OBJECT ${IMPL_SRC})
 add_library(Metalium::Metal::Impl ALIAS impl)
 
@@ -86,6 +94,7 @@ target_link_libraries(
         Metalium::Metal::LLRT
         capnp
         capnp-rpc
+        protobuf::libprotobuf
 )
 
 target_include_directories(
@@ -99,6 +108,7 @@ target_include_directories(
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_include_directories(impl SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)
+target_include_directories(impl SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/experimental/disaggregation)
 
 # Set KJ_NO_EXCEPTIONS=0 to enable exceptions in Cap'n Proto code due to a detection bug with g++-12.
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast PRIVATE -DKJ_NO_EXCEPTIONS=0)

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp"
+
+#include <algorithm>
+
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental::disaggregation {
+
+size_t KvChunkAddressTable::flat_index(uint32_t layer, uint32_t position_chunk, uint32_t slot) const {
+    return (static_cast<size_t>(slot) * num_layers_x_chunks_) + (static_cast<size_t>(layer) * num_position_chunks_) +
+           static_cast<size_t>(position_chunk);
+}
+
+uint32_t KvChunkAddressTable::to_chunk_index(uint32_t position) const { return position / config_.chunk_n_tokens; }
+
+void KvChunkAddressTable::validate_args(uint32_t layer, uint32_t position, uint32_t slot) const {
+    TT_FATAL(layer < config_.num_layers, "layer {} >= num_layers {}", layer, config_.num_layers);
+    TT_FATAL(
+        position < config_.max_sequence_length,
+        "position {} >= max_sequence_length {}",
+        position,
+        config_.max_sequence_length);
+    TT_FATAL(slot < config_.num_slots, "slot {} >= num_slots {}", slot, config_.num_slots);
+    TT_FATAL(
+        position % config_.chunk_n_tokens == 0,
+        "position {} is not a multiple of chunk_n_tokens {}",
+        position,
+        config_.chunk_n_tokens);
+}
+
+KvChunkAddressTable::KvChunkAddressTable(const KvChunkAddressTableConfig& config) : config_(config) {
+    TT_FATAL(config.chunk_n_tokens > 0, "chunk_n_tokens must be > 0");
+    num_position_chunks_ = (config.max_sequence_length + config.chunk_n_tokens - 1) / config.chunk_n_tokens;
+    num_layers_x_chunks_ = config.num_layers * num_position_chunks_;
+    entries_.resize(static_cast<size_t>(config.num_slots) * config.num_layers * num_position_chunks_);
+}
+
+DeviceGroupIndex KvChunkAddressTable::add_device_group(std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids) {
+    std::sort(fabric_node_ids.begin(), fabric_node_ids.end());
+
+    // Check for existing identical group.
+    for (uint32_t i = 0; i < device_groups_.size(); i++) {
+        if (device_groups_[i].fabric_node_ids == fabric_node_ids) {
+            return DeviceGroupIndex{i};
+        }
+    }
+
+    uint32_t index = static_cast<uint32_t>(device_groups_.size());
+    device_groups_.push_back(DeviceGroup{std::move(fabric_node_ids)});
+    return DeviceGroupIndex{index};
+}
+
+const DeviceGroup& KvChunkAddressTable::get_device_group(DeviceGroupIndex index) const {
+    TT_FATAL(
+        *index < device_groups_.size(), "device_group_index {} >= num_device_groups {}", *index, device_groups_.size());
+    return device_groups_[*index];
+}
+
+void KvChunkAddressTable::set(uint32_t layer, uint32_t position, uint32_t slot, KvCacheLocation location) {
+    validate_args(layer, position, slot);
+    entries_[flat_index(layer, to_chunk_index(position), slot)] = location;
+}
+
+void KvChunkAddressTable::set_fabric_node_host(
+    const tt::tt_fabric::FabricNodeId& node_id, const std::string& host_name) {
+    fabric_node_to_host_[node_id] = host_name;
+}
+
+const KvCacheLocation& KvChunkAddressTable::lookup(uint32_t layer, uint32_t position, uint32_t slot) const {
+    validate_args(layer, position, slot);
+    return entries_[flat_index(layer, to_chunk_index(position), slot)];
+}
+
+std::span<const KvCacheLocation> KvChunkAddressTable::lookup_range(
+    uint32_t layer, uint32_t start_pos, uint32_t end_pos, uint32_t slot) const {
+    validate_args(layer, start_pos, slot);
+    TT_FATAL(
+        end_pos <= config_.max_sequence_length,
+        "end_pos {} > max_sequence_length {}",
+        end_pos,
+        config_.max_sequence_length);
+    if (start_pos >= end_pos) {
+        return {};
+    }
+    uint32_t start_chunk = to_chunk_index(start_pos);
+    uint32_t end_chunk = to_chunk_index(end_pos + config_.chunk_n_tokens - 1);
+    size_t base = flat_index(layer, start_chunk, slot);
+    return std::span<const KvCacheLocation>(entries_.data() + base, end_chunk - start_chunk);
+}
+
+const std::string& KvChunkAddressTable::get_host(const tt::tt_fabric::FabricNodeId& node_id) const {
+    auto it = fabric_node_to_host_.find(node_id);
+    TT_FATAL(it != fabric_node_to_host_.end(), "FabricNodeId not found in host map");
+    return it->second;
+}
+
+bool KvChunkAddressTable::has_host(const tt::tt_fabric::FabricNodeId& node_id) const {
+    return fabric_node_to_host_.contains(node_id);
+}
+
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp"
+
+#include <fstream>
+#include <stdexcept>
+#include <unordered_set>
+
+#include <google/protobuf/text_format.h>
+
+#include "protobuf/kv_chunk_address_table.pb.h"
+
+namespace tt::tt_metal::experimental::disaggregation {
+
+namespace detail {
+
+::tt::disaggregation::proto::KvChunkAddressTable to_proto_message(const KvChunkAddressTable& table) {
+    const auto& cfg = table.config();
+
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+
+    pb.set_num_layers(cfg.num_layers);
+    pb.set_max_sequence_length(cfg.max_sequence_length);
+    pb.set_num_slots(cfg.num_slots);
+    pb.set_chunk_n_tokens(cfg.chunk_n_tokens);
+    pb.set_chunk_size_bytes(cfg.chunk_size_bytes);
+
+    for (size_t i = 0; i < table.num_device_groups(); i++) {
+        const auto& group = table.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)});
+        auto* pb_group = pb.add_device_groups();
+        for (const auto& fnid : group.fabric_node_ids) {
+            auto* pb_fnid = pb_group->add_fabric_node_ids();
+            pb_fnid->set_mesh_id(*fnid.mesh_id);
+            pb_fnid->set_chip_id(fnid.chip_id);
+        }
+    }
+
+    // Export host mappings, deduplicating across device groups.
+    // Only hosts for nodes that appear in at least one device group are exported.
+    std::unordered_set<tt::tt_fabric::FabricNodeId> exported_hosts;
+    for (size_t i = 0; i < table.num_device_groups(); i++) {
+        const auto& group = table.get_device_group(DeviceGroupIndex{static_cast<uint32_t>(i)});
+        for (const auto& fnid : group.fabric_node_ids) {
+            if (table.has_host(fnid) && exported_hosts.insert(fnid).second) {
+                auto* pb_host = pb.add_fabric_node_hosts();
+                pb_host->set_mesh_id(*fnid.mesh_id);
+                pb_host->set_chip_id(fnid.chip_id);
+                pb_host->set_host_name(table.get_host(fnid));
+            }
+        }
+    }
+
+    for (uint32_t slot = 0; slot < cfg.num_slots; slot++) {
+        for (uint32_t layer = 0; layer < cfg.num_layers; layer++) {
+            for (uint32_t pos = 0; pos < cfg.max_sequence_length; pos += cfg.chunk_n_tokens) {
+                const auto& loc = table.lookup(layer, pos, slot);
+                if (loc.noc_addr == 0 && loc.size_bytes == 0 && *loc.device_group_index == 0) {
+                    continue;
+                }
+                auto* entry = pb.add_entries();
+                entry->set_slot(slot);
+                entry->set_layer(layer);
+                entry->set_position(pos);
+                entry->set_noc_addr(loc.noc_addr);
+                entry->set_size_bytes(loc.size_bytes);
+                entry->set_device_group_index(*loc.device_group_index);
+            }
+        }
+    }
+
+    return pb;
+}
+
+KvChunkAddressTable from_proto_message(const ::tt::disaggregation::proto::KvChunkAddressTable& pb) {
+    KvChunkAddressTableConfig cfg{
+        .num_layers = pb.num_layers(),
+        .max_sequence_length = pb.max_sequence_length(),
+        .num_slots = pb.num_slots(),
+        .chunk_n_tokens = pb.chunk_n_tokens(),
+        .chunk_size_bytes = pb.chunk_size_bytes(),
+    };
+    KvChunkAddressTable table(cfg);
+
+    for (const auto& pb_group : pb.device_groups()) {
+        std::vector<tt::tt_fabric::FabricNodeId> fnids;
+        fnids.reserve(pb_group.fabric_node_ids_size());
+        for (const auto& pb_fnid : pb_group.fabric_node_ids()) {
+            fnids.emplace_back(tt::tt_fabric::MeshId{pb_fnid.mesh_id()}, pb_fnid.chip_id());
+        }
+        table.add_device_group(std::move(fnids));
+    }
+
+    for (const auto& pb_host : pb.fabric_node_hosts()) {
+        tt::tt_fabric::FabricNodeId fnid(tt::tt_fabric::MeshId{pb_host.mesh_id()}, pb_host.chip_id());
+        table.set_fabric_node_host(fnid, pb_host.host_name());
+    }
+
+    for (const auto& entry : pb.entries()) {
+        KvCacheLocation loc{
+            .noc_addr = entry.noc_addr(),
+            .size_bytes = entry.size_bytes(),
+            .device_group_index = DeviceGroupIndex{entry.device_group_index()},
+        };
+        table.set(entry.layer(), entry.position(), entry.slot(), loc);
+    }
+
+    return table;
+}
+
+}  // namespace detail
+
+// --- Binary wire format ---
+
+std::string export_to_protobuf(const KvChunkAddressTable& table) {
+    auto pb = detail::to_proto_message(table);
+    std::string out;
+    if (!pb.SerializeToString(&out)) {
+        throw std::runtime_error("Failed to serialize KvChunkAddressTable to protobuf");
+    }
+    return out;
+}
+
+void export_to_protobuf_file(const KvChunkAddressTable& table, const std::string& path) {
+    std::string data = export_to_protobuf(table);
+    std::ofstream out(path, std::ios::binary);
+    if (!out.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + path);
+    }
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+}
+
+KvChunkAddressTable import_from_protobuf(const std::string& data) {
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+    if (!pb.ParseFromString(data)) {
+        throw std::runtime_error("Failed to parse protobuf data as KvChunkAddressTable");
+    }
+    return detail::from_proto_message(pb);
+}
+
+KvChunkAddressTable import_from_protobuf_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in.is_open()) {
+        throw std::runtime_error("Failed to open file for reading: " + path);
+    }
+    std::string data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return import_from_protobuf(data);
+}
+
+// --- Text format (debug only) ---
+
+std::string export_to_protobuf_text(const KvChunkAddressTable& table) {
+    auto pb = detail::to_proto_message(table);
+    std::string out;
+    if (!google::protobuf::TextFormat::PrintToString(pb, &out)) {
+        throw std::runtime_error("Failed to serialize KvChunkAddressTable to protobuf text format");
+    }
+    return out;
+}
+
+void export_to_protobuf_text_file(const KvChunkAddressTable& table, const std::string& path) {
+    std::string text = export_to_protobuf_text(table);
+    std::ofstream out(path);
+    if (!out.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + path);
+    }
+    out << text;
+}
+
+KvChunkAddressTable import_from_protobuf_text(const std::string& text) {
+    ::tt::disaggregation::proto::KvChunkAddressTable pb;
+    if (!google::protobuf::TextFormat::ParseFromString(text, &pb)) {
+        throw std::runtime_error("Failed to parse protobuf text format as KvChunkAddressTable");
+    }
+    return detail::from_proto_message(pb);
+}
+
+KvChunkAddressTable import_from_protobuf_text_file(const std::string& path) {
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        throw std::runtime_error("Failed to open file for reading: " + path);
+    }
+    std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return import_from_protobuf_text(text);
+}
+
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table_protobuf.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Protobuf export/import for KvChunkAddressTable.
+//
+// Consumers must:
+//   1. Generate the proto with GENERATE_PROTO_FILES() and add the .pb.cc to their target
+//   2. Add the protobuf .cpp to their target sources
+//   3. Add appropriate include directories for the generated .pb.h
+//   4. Link protobuf::libprotobuf
+
+#pragma once
+
+#include <string>
+
+#include "tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp"
+
+namespace tt::tt_metal::experimental::disaggregation {
+
+// --- Binary wire format ---
+
+std::string export_to_protobuf(const KvChunkAddressTable& table);
+void export_to_protobuf_file(const KvChunkAddressTable& table, const std::string& path);
+KvChunkAddressTable import_from_protobuf(const std::string& data);
+KvChunkAddressTable import_from_protobuf_file(const std::string& path);
+
+// --- Human-readable text format (debug only) ---
+
+std::string export_to_protobuf_text(const KvChunkAddressTable& table);
+void export_to_protobuf_text_file(const KvChunkAddressTable& table, const std::string& path);
+KvChunkAddressTable import_from_protobuf_text(const std::string& text);
+KvChunkAddressTable import_from_protobuf_text_file(const std::string& path);
+
+}  // namespace tt::tt_metal::experimental::disaggregation

--- a/tt_metal/impl/experimental/disaggregation/protobuf/kv_chunk_address_table.proto
+++ b/tt_metal/impl/experimental/disaggregation/protobuf/kv_chunk_address_table.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package tt.disaggregation.proto;
+
+message FabricNodeId {
+    uint32 mesh_id = 1;
+    uint32 chip_id = 2;
+}
+
+message DeviceGroup {
+    repeated FabricNodeId fabric_node_ids = 1;
+}
+
+message FabricNodeHost {
+    uint32 mesh_id = 1;
+    uint32 chip_id = 2;
+    string host_name = 3;
+}
+
+message KvCacheEntry {
+    uint32 slot = 1;
+    uint32 layer = 2;
+    uint32 position = 3;
+    uint64 noc_addr = 4;
+    uint32 size_bytes = 5;
+    uint32 device_group_index = 6;
+}
+
+message KvChunkAddressTable {
+    uint32 num_layers = 1;
+    uint32 max_sequence_length = 2;
+    uint32 num_slots = 3;
+    uint32 chunk_n_tokens = 4;
+    uint32 chunk_size_bytes = 5;
+    repeated DeviceGroup device_groups = 6;
+    repeated FabricNodeHost fabric_node_hosts = 7;
+    repeated KvCacheEntry entries = 8;
+}

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -1,4 +1,5 @@
 set(IMPL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/experimental/disaggregation/kv_chunk_address_table.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -109,6 +109,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/udm/mesh_tensor_builder.hpp
     api/tt-metalium/experimental/udm/mesh_utils.hpp
     api/tt-metalium/experimental/context/metal_env.hpp
+    api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
 )
 
 set(TT_METAL_SOURCES


### PR DESCRIPTION
The table stores addresses for each KV cache chunk for a given model instance. It can span multiple hosts and multiple devices.

The table provides a lookup from `{layer, position, slot} -> KvCacheLocation` that describes how KV cache chunks are allocated across a disaggregated memory system. For best performance, the table is intended to be looked up by slot for adjacent position IDs: position should be the internal iterator.

Note that the logical `KvCacheLocation` was split into two parts. The first is inline in the location entry and the second is in a global table:
1) noc_addr and size; inline
2) fabric node id (fnid) -> hostname mapping table is globally shared for the table

The fnid->hostname table for (2) is outlined as a standalone table for cache efficiency as these mappings are static for the lifetime of the table (or for "a very long time" when dynamic reprovisioning becomes supported). This keeps the core lookup table entry sizes the same, regardless of system size

Key design decisions:
- Flat contiguous array with [slot][layer][position_chunk] layout, optimized for the typical access pattern: fixed slot, iterate layers, iterate positions
- Device replica groups (FabricNodeId sets) stored in a deduplicated side table referenced by index, keeping KvCacheLocation at 16 bytes (4 per cache line)
- Groups are sorted on insertion for automatic dedup
- FabricNodeId -> HostName mapping stored as a separate fixed-size map
- lookup_range() returns std::span for zero-copy contiguous access

Flat contiguous array: entries_[slot * (L * P) + layer * P + position_chunk]
```
  slot 0                                    slot 1
  ┌────────────────────────────────┐      ┌────────────────────────────────┐
  │ layer 0                        │      │ layer 0                        │
  │ ┌───┬───┬───┬───┬───┬───┬───┐  │      │ ┌───┬───┬───┬───┬───┬───┬───┐  │
  │ │p0 │p32│p64│p96│...│   │   │  │      │ │p0 │p32│p64│p96│...│   │   │  │
  │ └───┴───┴───┴───┴───┴───┴───┘  │      │ └───┴───┴───┴───┴───┴───┴───┘  │
  │ layer 1           ▲            │      │ layer 1                        │
  │ ┌───┬───┬───┬───┬─┤─┬───┬───┐  │      │ ┌───┬───┬───┬───┬───┬───┬───┐  │
  │ │p0 │p32│p64│p96│...│   │   │  │      │ │p0 │p32│p64│p96│...│   │   │  │
  │ └───┴───┴───┴───┴───┴───┴───┘  │      │ └───┴───┴───┴───┴───┴───┴───┘  │
  │ ...               │            │      │ ...                            │
  │ layer N-1         │ contiguous │      │ layer N-1                      │
  │ ┌───┬───┬───┬───┬─┤─┬───┬───┐  │      │ ┌───┬───┬───┬───┬───┬───┬───┐  │
  │ │p0 │p32│p64│p96│...│   │   │  │      │ │p0 │p32│p64│p96│...│   │   │  │
  │ └───┴───┴───┴───┴───┴───┴───┘  │      │ └───┴───┴───┴───┴───┴───┴───┘  │
  └────────────────────────────────┘      └────────────────────────────────┘

  Each entry: 16 bytes                     Device group side table (in L1):
  ┌──────────────┬───────────┬──────┐      ┌─────┬──────────────────────────┐
  │ noc_addr u64 │ size u32  │dg u32│      │  0  │ [fnid(0,0), fnid(0,1)]   │
  └──────────────┴───────────┴──┬───┘      │  1  │ [fnid(0,2)..fnid(0,4)]   │
     4 entries per cache line   │          │  2  │ [fnid(1,0)..fnid(1,3)]   │
                                │          │ ... │                          │
                                └─────────►└─────┴──────────────────────────┘
                             device_group_index
```
Position chunks are contiguous for a given (slot, layer), so `lookup_range()` returns a zero-copy `std::span`. The typical access pattern — fixed slot, loop layers, loop positions —
   walks memory sequentially.

Throughput stays flat across sequence lengths (1K to 2M) because the 16-byte entries are fully prefetchable and the device group side table stays in L1.

All benchmarks run on 32-core x86_64, 16 MB L3 cache. (AMD EPYC 8124P 16-Core (32 threads) @ 2450 MHz.)

KvCacheLocation is 16 bytes (noc_addr + size_bytes + device_group_index). Device replica groups stored in a deduplicated side table, keeping the hot path free of heap pointers.

| Benchmark | Entries | Throughput |
|-----------|---------|------------|
| `BM_LookupIndividual/80/8192/8` | 20K | 296 M lookups/s | | `BM_LookupRange/80/8192/8` | 20K | 4.72 G lookups/s | | `BM_LookupRange/80/131072/8` | 328K | 4.83 G lookups/s | | `BM_LookupRange/100/2097152/4` | 6.5M | 2.61 G lookups/s | | `BM_LookupMigratePattern/80/8192/8/4096` | 10K | 3.63 G lookups/s | | `BM_LookupMigratePattern/100/2097152/4/8192` | 25.6K | 3.36 G lookups/s |

Benchmark naming:
`BM_<method>/<num_layers>/<max_seq_len>/<num_slots>[/<range_tokens>]`
- `LookupIndividual` — per-entry `lookup()` calls in a loop
- `LookupRange` — `lookup_range()` returning a `std::span` over the full sequence
- `LookupMigratePattern` — `lookup_range()` for a partial token range per layer (simulates `migrate()`)

Assuming only 1 KV Chunk is contiguous per lookup (18 tiles), the above performance is enough to lookup all addresses for migration of one layer (seq_len=100k; hidden dim=576; lookups needed = 3125) in 750ns (basically free in the migration context).

`lookup_range()` returns a `std::span` over contiguous memory — throughput stays flat from 20K to 6.5M entries.

| Entries | Binary Export | Binary Import | Binary Size | Text Export | Text Import | Text Size |
|---------|--------------|---------------|-------------|-------------|-------------|-----------|
| 1.3K | 0.08 ms | 0.10 ms | 23 KB | 0.86 ms | 1.96 ms | 113 KB | | 164K | 10.4 ms | 12.3 ms | 3.1 MB | 126 ms | 260 ms | 15.1 MB | | 2.6M | 205 ms | 243 ms | 51 MB | 2,018 ms | 4,100 ms | 245 MB |

Binary export is ~10-17x faster than text format. Text format is available for debug/inspection.

| Test Suite | Binary | Test Count | CI Workflow |
|------------|--------|------------|-------------|
| `KvChunkAddressTable.*` | `unit_tests_api` | 29 | `build-and-unit-tests.yaml` |
| `KvChunkAddressTableProtobuf.*` | `fabric_unit_tests` | 7 | `fabric-cpu-only-tests-impl.yaml` |

- Test Command: `./build/test/tt_metal/unit_tests_api --gtest_filter="KvChunkAddressTable*"`

| File | Description |
|------|-------------|
| `test_kv_chunk_address_table.cpp` | Construction, set/lookup, range lookup, device groups, host mapping, boundary errors, realistic scale | | `test_kv_chunk_address_table_protobuf.cpp` | Protobuf binary + text format round-trip with randomized data (7 layers, 5 slots, 6 device groups, 3 hosts) |
| `bench_kv_chunk_address_table.cpp` | Lookup throughput: individual, range, migrate pattern |
| `bench_kv_chunk_address_table_serialization.cpp` | Serialization throughput: protobuf binary vs text export/import |

| Test Suite | Binary | Source File | CI Workflow |
|------------|--------|-------------|-------------|
| `KvChunkAddressTable.*` (29 tests) | `unit_tests_api` | `tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp` | `build-and-unit-tests.yaml` |
| `KvChunkAddressTableProtobuf.*` (7 tests) | `fabric_unit_tests` | `tests/tt_metal/tt_fabric/disaggregation/test_kv_chunk_address_table_protobuf.cpp` |
  `fabric-cpu-only-tests-impl.yaml` |
| Lookup benchmarks | `bench_kv_chunk_address_table` | `tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table.cpp` | Manual only |
| Serialization benchmarks |
`bench_kv_chunk_address_table_serialization` |

`tests/tt_metal/tt_metal/perf_microbenchmark/disaggregation/bench_kv_chunk_address_table_serialization.cpp` | Manual only |

Closes https://github.com/tenstorrent/tt-metal/issues/40829

- [x] All new tests in merge gate
- [x] New/Existing tests provide coverage for changes

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/kv-chunk-table-blaze-branch-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/kv-chunk-table-blaze-branch-import)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
