### PR TITLE
Batched rope matrix fetching for custom mROPE in Qwen3-VL

### DIFF
--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -180,19 +180,14 @@ class RotarySetup(LightweightModule):
         assert position_idxs.device != device, "rot_idxs must be on device"
 
         # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]
-        # todo)) { Optimize the slicing work-around below
         assert len(position_idxs.shape) == 1, "position_idxs must be a [batch] tensor"
-        batch_size = position_idxs.shape[0]
-        cos, sin = None, None
-        for i in range(batch_size):
-            pos_i = position_idxs[i : i + 1]
-            cos_i = ttnn.embedding(pos_i, self.cos_matrix)  # [1, head_dim]
-            sin_i = ttnn.embedding(pos_i, self.sin_matrix)  # [1, head_dim]
-            cos = cos_i if cos is None else ttnn.concat([cos, cos_i], dim=0)  # towards [batch_size, head_dim]
-            sin = sin_i if sin is None else ttnn.concat([sin, sin_i], dim=0)  # towards [batch_size, head_dim]
 
-        cos = ttnn.to_layout(cos, ttnn.TILE_LAYOUT)
-        sin = ttnn.to_layout(sin, ttnn.TILE_LAYOUT)
+        # Reshape from [batch] to [1, batch] for batched embedding
+        rot_idxs = ttnn.reshape(position_idxs, (1, position_idxs.shape[0]))
+
+        # Single batched embedding call instead of loop - much more efficient
+        cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
+        sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
 
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch_size, head_dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch_size, head_dim]

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -518,7 +518,7 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        argmax_on_device = sampling_params["temperature"] == 0
+        argmax_on_device = False
         if argmax_on_device:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -518,7 +518,7 @@ def test_demo(
 
         # Start decoding
         iteration = 0
-        argmax_on_device = False
+        argmax_on_device = sampling_params["temperature"] == 0
         if argmax_on_device:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
         else:

--- a/models/demos/qwen3_vl/tt/rope.py
+++ b/models/demos/qwen3_vl/tt/rope.py
@@ -180,19 +180,14 @@ class RotarySetup(LightweightModule):
         assert position_idxs.device != device, "rot_idxs must be on device"
 
         # [INFO] Qwen2.5 VL produces cos and sin matrices with shape [batch_size, 1, seq_len, head_dim]
-        # todo)) { Optimize the slicing work-around below
         assert len(position_idxs.shape) == 1, "position_idxs must be a [batch] tensor"
-        batch_size = position_idxs.shape[0]
-        cos, sin = None, None
-        for i in range(batch_size):
-            pos_i = position_idxs[i : i + 1]
-            cos_i = ttnn.embedding(pos_i, self.cos_matrix)  # [1, head_dim]
-            sin_i = ttnn.embedding(pos_i, self.sin_matrix)  # [1, head_dim]
-            cos = cos_i if cos is None else ttnn.concat([cos, cos_i], dim=0)  # towards [batch_size, head_dim]
-            sin = sin_i if sin is None else ttnn.concat([sin, sin_i], dim=0)  # towards [batch_size, head_dim]
 
-        cos = ttnn.to_layout(cos, ttnn.TILE_LAYOUT)
-        sin = ttnn.to_layout(sin, ttnn.TILE_LAYOUT)
+        # Reshape from [batch] to [1, batch] for batched embedding
+        rot_idxs = ttnn.reshape(position_idxs, (1, position_idxs.shape[0]))
+
+        # Single batched embedding call instead of loop - much more efficient
+        cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
+        sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
 
         cos = ttnn.unsqueeze_to_4D(cos)  # [1, 1, batch_size, head_dim]
         sin = ttnn.unsqueeze_to_4D(sin)  # [1, 1, batch_size, head_dim]


### PR DESCRIPTION
### Ticket
#40765 

### Problem description
We have a for loop in the current get rot matrices that goes through the rope offsets and fetches the corresponding element of the rot mat for each user. This leads to significantly higher kernel launches which partially explains the decode perf gap between the text model and the VL model despite them having identical decoder backbones.

### What's changed
This can actually be parallelized leading to fewer kernel launches (Almost 60 lesser for batch size 32) and higher decode speed (22-23 tok/s/u compared to 19-20 tok/s/u). 




#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.


- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssanjay/qwen3_vl_batched_rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssanjay/qwen3_vl_batched_rope)