### PR TITLE
Fix zigzag balancing and chain forwarding in ring joint SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -235,7 +235,7 @@ void kernel_main() {
             }
 
             // Chain forwarding conditions are k_chunk-invariant — compute once before the KV loop
-            const uint32_t q_iter_local = global_q_chunk - global_q_start;
+            const uint32_t q_iter_local = q_iter;
             const bool should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
                                         (q_iter_local < next_core_q_chunks);
             const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -765,8 +765,22 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     // Evenly distribute flat global q chunks across cores
     const uint32_t total_q_chunks = B * NH * num_q_chunks;
-    const uint32_t base_chunks_per_core = (num_cores == 0) ? 0 : (total_q_chunks / num_cores);
-    const uint32_t extra_chunks = (num_cores == 0) ? 0 : (total_q_chunks % num_cores);
+
+    uint32_t base_chunks_per_core = 0;
+    uint32_t extra_chunks_per_core = 0;
+    uint32_t cores_doing_extra_work = 0;
+    if (enable_zigzag_balancing) {
+        log_debug(tt::LogOp, "Enabling zigzag balancing with even num_q_chunks: {}", num_q_chunks);
+        const uint32_t total_pairs = total_q_chunks / 2;
+        cores_doing_extra_work = total_pairs % num_cores;
+        base_chunks_per_core = (num_cores == 0) ? 0 : (total_pairs / num_cores) * 2;
+        extra_chunks_per_core = (num_cores == 0) ? 0 : 2;
+    } else {
+        cores_doing_extra_work = total_q_chunks % num_cores;
+        base_chunks_per_core = (num_cores == 0) ? 0 : (total_q_chunks / num_cores);
+        extra_chunks_per_core = (num_cores == 0) ? 0 : 1;
+    }
+
     uint32_t next_global_chunk = 0;
 
     auto decode_flat_chunk = [&](uint32_t flat_chunk_index) {
@@ -780,7 +794,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
-        uint32_t chunk_count = base_chunks_per_core + ((i < extra_chunks) ? 1 : 0);
+        uint32_t chunk_count = base_chunks_per_core + ((i < cores_doing_extra_work) ? extra_chunks_per_core : 0);
         if (next_global_chunk >= total_q_chunks) {
             chunk_count = 0;
         } else if (chunk_count > total_q_chunks - next_global_chunk) {
@@ -829,7 +843,7 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
     // Injector reselection for DRAM channel spreading is deferred to the
     // mcast eligibility pass below.
     for (auto& segments : head_segments) {
-        if (segments.size() < 2 || args.is_balanced) {
+        if (segments.size() < 2) {
             continue;
         }
 
@@ -854,7 +868,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         for (std::size_t idx = start; idx < segments.size(); ++idx) {
             const auto& seg = segments.at(idx);
             const uint32_t core_idx = seg.core_idx;
-            const auto& hw = core_work.at(core_idx).head_work.at(seg.head_work_index);
+            const auto& work = core_work.at(core_idx);
+            const auto& hw = work.head_work.at(seg.head_work_index);
             auto& chain = core_chain_info.at(core_idx);
 
             chain.participates = true;


### PR DESCRIPTION
### Ticket
[Causal Ring Joint Attention - work distribution on a single chip](https://github.com/tenstorrent/tt-metal/issues/40181)

### Problem description

Causal ring joint attention distributes work **across devices** in a zigzag manner where each devices gets a pair of early (lightweight) and late (heavyweight) Qs. This approach ensures balanced work distribution across devices for causal ring attention.
Work distribution across cores on a single device for causal ring attention currently uses a uses zigzag approach which results in balanced and functional work across cores, but that is DRAM bound since there is no chaining and KV chunk forwarding between the cores.

### What's changed

*Essentially, **chaining** is now enabled for causal ring joint attention.*

- Zigzag balancing now distributes pairs of (lightweight, heavyweight) q chunks to cores, ensuring balanced compute across the ring
- Fix chain forwarding condition: use q_iter (work completed) instead of remapped q chunk index for determining when to forward KV data

#### Performance Impact Summary

For deep seek demo: models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py

| Test | Baseline (main) | chaining | chaining + balanced chunks* |
|------|-----------------|----------|----------------------------|
| seq_len=131,072 | 17.03 ms | 11.84 ms (**-30%**) | 11.53 ms (**-32%**) |
| seq_len=102,400 | 10.01 ms | 9.47 ms (-5%) | 6.69 ms (**-33%**) |

\* - *for 100k sequence length: `q_chunk_size = k_chunk_size = 160`; for 128k sequence length `q_chunk_size = k_chunk_size = 128`*

For SDPA ring joint tests: `pytest tests/nightly/blackhole/ccl/test_ring_joint_sdpa.py::test_ring_joint_attention_create_perf_table[mla_100k]`
Math util improved: 24.1% -> 47.2%

## Test plan

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/chaining_pr)
- [x] [![Nightly tt-metal L2 tests (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/chaining_pr)
- [x] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mvasilijevic/chaining_pr)
- [x] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mvasilijevic/chaining_pr)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:mvasilijevic/chaining_pr) ⚠️ Job canceled (infra). Main branch also failing.
- [x] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mvasilijevic/chaining_pr)
- [x] [![(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml?query=branch:mvasilijevic/chaining_pr)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mvasilijevic/chaining_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mvasilijevic/chaining_pr) ⚠️ t3k_ccl_tests (infra). Main branch also failing.