### PR TITLE
Add CosyVoice demo

### DIFF
--- a/models/demos/audio/cosy_voice/PERF.md
+++ b/models/demos/audio/cosy_voice/PERF.md
@@ -1,0 +1,59 @@
+# CosyVoice Performance
+
+## Scope
+
+This demo tracks the public CosyVoice 300M bringup workload for:
+
+- semantic token generation
+- flow-based acoustic decoding
+- HiFT vocoder synthesis
+
+The current measured backend split is `tt_semantic_tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder`.
+
+The public performance command is:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
+  --suite performance \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output-json /tmp/cosy_voice_performance.json
+```
+
+The public quality command is:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
+  --suite quality \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output-json /tmp/cosy_voice_quality.json
+```
+
+## Public Gate
+
+The target public workload should eventually prove:
+
+- semantic token generation `>= 30 tokens/s`
+- end-to-end `RTF < 0.5`
+
+Only publish measured numbers from the accepted public workload and repo-local runtime.
+
+## Report Fields
+
+The public performance report should include:
+
+- mode
+- model id or local model path
+- wall-clock seconds
+- output audio seconds
+- RTF
+- semantic token count when available
+- semantic tokens per second when available
+- runtime verification fields
+
+## Notes
+
+- Keep README, CLI behavior, test thresholds, and measured artifacts aligned.
+- Keep quality reports separate from semantic-parity and throughput reports.
+- Do not publish full end-to-end TT performance claims until the diffusion decoder loop and HiFT vocoder are also on the TT path.

--- a/models/demos/audio/cosy_voice/README.md
+++ b/models/demos/audio/cosy_voice/README.md
@@ -1,0 +1,159 @@
+# CosyVoice
+
+## Platforms
+
+- Wormhole single-device
+
+## Introduction
+
+This demo brings up the public CosyVoice 300M model family on TT-Metal with a minimal public surface.
+The demo is scoped to the CosyVoice 1.0 model split:
+
+- `CosyVoice-300M-SFT` for SFT mode
+- `CosyVoice-300M` for zero-shot and cross-lingual modes
+- `CosyVoice-300M-Instruct` for instruct mode
+
+The implementation is organized around the real CosyVoice pipeline:
+
+- semantic token generation LLM
+- flow-based acoustic decoder
+- HiFT vocoder
+
+The pinned upstream reference repo is used for frontend processing and reference behavior:
+
+- https://github.com/FunAudioLLM/CosyVoice
+
+## Prerequisites
+
+- Cloned `tt-metal`
+- Installed repo-local TT runtime
+- Cloned the official CosyVoice repo
+- Downloaded CosyVoice checkpoints
+
+The public runners expect a local CosyVoice checkout and local model directories. A typical layout is:
+
+```text
+/path/to/CosyVoice
+/path/to/pretrained_models/CosyVoice-300M
+/path/to/pretrained_models/CosyVoice-300M-SFT
+/path/to/pretrained_models/CosyVoice-300M-Instruct
+```
+
+## Runtime Verification
+
+Use the repo-local runtime before running the demo or validation:
+
+```bash
+python_env/bin/python - <<'PY'
+import sys
+import ttnn
+print(sys.executable)
+print(ttnn.__file__)
+PY
+```
+
+## How To Run
+
+### Demo
+
+SFT:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/demo.py \
+  --mode sft \
+  --text '你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？' \
+  --speaker-id '中文女' \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output /tmp/cosy_voice_sft.wav
+```
+
+Zero-shot:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/demo.py \
+  --mode zero_shot \
+  --text '收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐。' \
+  --prompt-text '希望你以后能够做的比我还好呦。' \
+  --prompt-audio /path/to/CosyVoice/asset/zero_shot_prompt.wav \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output /tmp/cosy_voice_zero_shot.wav
+```
+
+Cross-lingual:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/demo.py \
+  --mode cross_lingual \
+  --text '<|en|>And then later on, fully acquiring that company.' \
+  --prompt-audio /path/to/CosyVoice/asset/cross_lingual_prompt.wav \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output /tmp/cosy_voice_cross_lingual.wav
+```
+
+Instruct:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/demo.py \
+  --mode instruct \
+  --text '在面对挑战时，他展现了非凡的勇气与智慧。' \
+  --speaker-id '中文男' \
+  --instruction "Theo 'Crimson', is a fiery, passionate rebel leader.<|endofprompt|>" \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output /tmp/cosy_voice_instruct.wav
+```
+
+### Validation
+
+Accuracy manifest:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
+  --suite accuracy \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output-json /tmp/cosy_voice_accuracy.json
+```
+
+The accuracy suite measures semantic-token parity against deterministic greedy
+reference targets under teacher forcing. This avoids treating the reference
+model's sampled top-k outputs as a deterministic correctness oracle.
+
+Quality manifest:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
+  --suite quality \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output-json /tmp/cosy_voice_quality.json
+```
+
+The quality suite measures:
+
+- output waveform validity
+- Whisper-based transcription WER against the case transcript
+- CampPlus speaker-embedding similarity against the target speaker or prompt audio
+
+Performance manifest:
+
+```bash
+python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
+  --suite performance \
+  --reference-repo /path/to/CosyVoice \
+  --model-root /path/to/pretrained_models \
+  --output-json /tmp/cosy_voice_performance.json
+```
+
+## Known Limitations
+
+- This branch is single-device only.
+- The public tree is intentionally small and excludes multi-device and streaming runtime variants.
+- The frontend stays on the pinned upstream reference stack.
+- The current public backend is `tt_semantic_tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder`: the semantic LLM path is on TT, the flow acoustic frontend up through the learned length regulator is on TT, and the diffusion decoder loop is now implemented in-tree in torch parity form.
+- The HiFT vocoder still runs on the pinned reference path.
+- The public quality suite is real, but it evaluates the current mixed backend rather than a full end-to-end TT pipeline.
+- Public metrics should only be published from benchmark-backed runs of the current backend split.

--- a/models/demos/audio/cosy_voice/demo/accuracy_cases.json
+++ b/models/demos/audio/cosy_voice/demo/accuracy_cases.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "sft_zh",
+    "mode": "sft",
+    "language": "zh",
+    "text": "你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？",
+    "speaker_id": "中文女"
+  },
+  {
+    "name": "zero_shot_zh",
+    "mode": "zero_shot",
+    "language": "zh",
+    "text": "收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。",
+    "prompt_text": "希望你以后能够做的比我还好呦。",
+    "prompt_audio": "asset/zero_shot_prompt.wav"
+  },
+  {
+    "name": "cross_lingual_en",
+    "mode": "cross_lingual",
+    "language": "en",
+    "text": "<|en|>And then later on, fully acquiring that company. So keeping management in line, interest in line with the asset that is coming into the family is a reason why sometimes we do not buy the whole thing.",
+    "prompt_audio": "asset/cross_lingual_prompt.wav"
+  },
+  {
+    "name": "cross_lingual_ja",
+    "mode": "cross_lingual",
+    "language": "ja",
+    "text": "<|ja|>コンニチハ。キョウ ワ テンストレント デ コジーボイス ノ テスト オ シマス。",
+    "prompt_audio": "asset/cross_lingual_prompt.wav"
+  },
+  {
+    "name": "cross_lingual_yue",
+    "mode": "cross_lingual",
+    "language": "yue",
+    "text": "<|yue|>今日我哋会用广东话试下呢个语音模型。",
+    "prompt_audio": "asset/cross_lingual_prompt.wav"
+  },
+  {
+    "name": "cross_lingual_ko",
+    "mode": "cross_lingual",
+    "language": "ko",
+    "text": "<|ko|>안녕하세요. 오늘은 코지보이스 모델을 테스트합니다.",
+    "prompt_audio": "asset/cross_lingual_prompt.wav"
+  },
+  {
+    "name": "instruct_zh",
+    "mode": "instruct",
+    "language": "zh",
+    "text": "在面对挑战时，他展现了非凡的勇气与智慧。",
+    "speaker_id": "中文男",
+    "instruction": "Theo 'Crimson', is a fiery, passionate rebel leader. Fights with fervor for justice, but struggles with impulsiveness.<|endofprompt|>"
+  }
+]

--- a/models/demos/audio/cosy_voice/demo/common.py
+++ b/models/demos/audio/cosy_voice/demo/common.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torchaudio
+from huggingface_hub import snapshot_download
+
+SUPPORTED_MODES = ("sft", "zero_shot", "cross_lingual", "instruct")
+MODE_TO_MODEL_SUBDIR = {
+    "sft": "CosyVoice-300M-SFT",
+    "zero_shot": "CosyVoice-300M",
+    "cross_lingual": "CosyVoice-300M",
+    "instruct": "CosyVoice-300M-Instruct",
+}
+MODE_TO_MODEL_ID = {
+    "sft": "FunAudioLLM/CosyVoice-300M-SFT",
+    "zero_shot": "FunAudioLLM/CosyVoice-300M",
+    "cross_lingual": "FunAudioLLM/CosyVoice-300M",
+    "instruct": "FunAudioLLM/CosyVoice-300M-Instruct",
+}
+DEFAULT_REFERENCE_REPO_ENV = "COSYVOICE_REFERENCE_REPO"
+DEFAULT_MODEL_ROOT_ENV = "COSYVOICE_MODEL_ROOT"
+DEFAULT_DOWNLOAD_ROOT_ENV = "COSYVOICE_DOWNLOAD_ROOT"
+DEFAULT_REFERENCE_REPO_CANDIDATES = (
+    "/vol/stor/reference_repos/CosyVoice",
+    "/vol/stor/CosyVoice",
+)
+
+
+@dataclass(frozen=True)
+class CosyVoiceCase:
+    name: str
+    mode: str
+    text: str
+    language: str | None = None
+    speaker_id: str | None = None
+    prompt_text: str | None = None
+    prompt_audio: str | None = None
+    instruction: str | None = None
+    model: str | None = None
+    target_tokens_per_second: float | None = None
+    target_rtf: float | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "CosyVoiceCase":
+        case = cls(**raw)
+        case.validate()
+        return case
+
+    def validate(self) -> None:
+        if self.mode not in SUPPORTED_MODES:
+            raise ValueError(f"Unsupported CosyVoice mode: {self.mode}")
+        if not self.text:
+            raise ValueError(f"Case {self.name} must provide non-empty text")
+        if self.mode in {"sft", "instruct"} and not self.speaker_id:
+            raise ValueError(f"Case {self.name} requires speaker_id for mode={self.mode}")
+        if self.mode == "zero_shot" and (not self.prompt_text or not self.prompt_audio):
+            raise ValueError(f"Case {self.name} requires prompt_text and prompt_audio for zero_shot mode")
+        if self.mode == "cross_lingual" and not self.prompt_audio:
+            raise ValueError(f"Case {self.name} requires prompt_audio for cross_lingual mode")
+        if self.mode == "instruct" and not self.instruction:
+            raise ValueError(f"Case {self.name} requires instruction for instruct mode")
+
+
+def load_cases(manifest_path: str | os.PathLike[str]) -> list[CosyVoiceCase]:
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        return [CosyVoiceCase.from_dict(item) for item in json.load(handle)]
+
+
+def resolve_reference_repo(reference_repo: str | None = None) -> Path:
+    candidates: list[str] = []
+    if reference_repo:
+        candidates.append(reference_repo)
+    env_repo = os.environ.get(DEFAULT_REFERENCE_REPO_ENV)
+    if env_repo:
+        candidates.append(env_repo)
+    candidates.extend(DEFAULT_REFERENCE_REPO_CANDIDATES)
+    for candidate in candidates:
+        repo_path = Path(candidate).expanduser().resolve()
+        if (repo_path / "cosyvoice").exists():
+            return repo_path
+    raise FileNotFoundError(
+        "Could not resolve the CosyVoice reference repo. Pass --reference-repo or set COSYVOICE_REFERENCE_REPO."
+    )
+
+
+def configure_reference_imports(reference_repo: str | os.PathLike[str]) -> None:
+    repo = str(Path(reference_repo).resolve())
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+    matcha = Path(repo) / "third_party" / "Matcha-TTS"
+    if matcha.exists():
+        matcha_str = str(matcha.resolve())
+        if matcha_str not in sys.path:
+            sys.path.insert(0, matcha_str)
+
+
+def resolve_model_dir(mode: str, model_root: str | None = None, explicit_model: str | None = None) -> Path:
+    model_name = explicit_model or MODE_TO_MODEL_SUBDIR[mode]
+    model_root = model_root or os.environ.get(DEFAULT_MODEL_ROOT_ENV)
+    if model_root:
+        root = Path(model_root).expanduser().resolve()
+        candidate = root / model_name
+        if candidate.exists():
+            return candidate
+        if Path(model_name).exists():
+            return Path(model_name).resolve()
+    if explicit_model and Path(explicit_model).exists():
+        return Path(explicit_model).resolve()
+
+    download_root = os.environ.get(DEFAULT_DOWNLOAD_ROOT_ENV)
+    if download_root is None:
+        download_root = str(Path.home() / ".cache" / "cosy_voice")
+    local_dir = Path(download_root).expanduser().resolve() / MODE_TO_MODEL_SUBDIR[mode]
+    local_dir.parent.mkdir(parents=True, exist_ok=True)
+    return Path(snapshot_download(explicit_model or MODE_TO_MODEL_ID[mode], local_dir=str(local_dir))).resolve()
+
+
+def resolve_prompt_audio(reference_repo: str | os.PathLike[str], prompt_audio: str | None) -> str | None:
+    if prompt_audio is None:
+        return None
+    candidate = Path(prompt_audio).expanduser()
+    if candidate.exists():
+        return str(candidate.resolve())
+    relative = Path(reference_repo) / prompt_audio
+    if relative.exists():
+        return str(relative.resolve())
+    raise FileNotFoundError(f"Could not resolve prompt audio path: {prompt_audio}")
+
+
+def save_audio(output_path: str | os.PathLike[str], waveform: torch.Tensor, sample_rate: int) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if waveform.dim() == 1:
+        waveform = waveform.unsqueeze(0)
+    torchaudio.save(str(output_path), waveform.cpu(), sample_rate)
+
+
+def write_json(output_path: str | os.PathLike[str], payload: dict[str, Any]) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def runtime_summary() -> dict[str, str]:
+    summary = {"python": sys.executable}
+    try:
+        import ttnn  # noqa: PLC0415
+
+        summary["ttnn"] = ttnn.__file__
+    except Exception as exc:  # pragma: no cover - used for runtime reporting
+        summary["ttnn_error"] = repr(exc)
+    return summary

--- a/models/demos/audio/cosy_voice/demo/demo.py
+++ b/models/demos/audio/cosy_voice/demo/demo.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
+
+from models.demos.audio.cosy_voice.tt.pipeline import CosyVoicePipeline
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Public CosyVoice demo runner")
+    parser.add_argument("--mode", choices=("sft", "zero_shot", "cross_lingual", "instruct"), required=True)
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--reference-repo", default=None)
+    parser.add_argument("--model-root", default=None)
+    parser.add_argument("--speaker-id", default=None)
+    parser.add_argument("--prompt-text", default=None)
+    parser.add_argument("--prompt-audio", default=None)
+    parser.add_argument("--instruction", default=None)
+    parser.add_argument("--disable-text-frontend", action="store_true")
+    return parser
+
+
+def validate_mode_args(args: argparse.Namespace) -> None:
+    if args.mode in {"sft", "instruct"} and not args.speaker_id:
+        raise ValueError(f"--speaker-id is required for mode={args.mode}")
+    if args.mode == "zero_shot" and (not args.prompt_text or not args.prompt_audio):
+        raise ValueError("--prompt-text and --prompt-audio are required for zero_shot mode")
+    if args.mode == "cross_lingual" and not args.prompt_audio:
+        raise ValueError("--prompt-audio is required for cross_lingual mode")
+    if args.mode == "instruct" and not args.instruction:
+        raise ValueError("--instruction is required for instruct mode")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_argparser()
+    args = parser.parse_args(argv)
+    validate_mode_args(args)
+
+    pipeline = CosyVoicePipeline(
+        reference_repo=args.reference_repo,
+        model_root=args.model_root,
+        text_frontend=not args.disable_text_frontend,
+    )
+    try:
+        result = pipeline.generate_mode(
+            mode=args.mode,
+            text=args.text,
+            output_path=args.output,
+            speaker_id=args.speaker_id,
+            prompt_text=args.prompt_text,
+            prompt_audio=args.prompt_audio,
+            instruction=args.instruction,
+        )
+        summary = {
+            "mode": args.mode,
+            "model_dir": result.model_dir,
+            "output": args.output,
+            "sample_rate": result.sample_rate,
+            "audio_seconds": result.audio_seconds,
+            "wall_seconds": result.wall_seconds,
+            "rtf": result.rtf,
+        }
+        print(json.dumps(summary, indent=2, ensure_ascii=False, sort_keys=True))
+        return 0
+    finally:
+        pipeline.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/demos/audio/cosy_voice/demo/performance_cases.json
+++ b/models/demos/audio/cosy_voice/demo/performance_cases.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "zero_shot_long_zh",
+    "mode": "zero_shot",
+    "language": "zh",
+    "text": "收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。窗外的风轻轻吹过，仿佛也在分享这份喜悦，让整个下午都变得温暖而明亮。",
+    "prompt_text": "希望你以后能够做的比我还好呦。",
+    "prompt_audio": "asset/zero_shot_prompt.wav",
+    "target_tokens_per_second": 30.0,
+    "target_rtf": 0.5
+  }
+]

--- a/models/demos/audio/cosy_voice/demo/quality_cases.json
+++ b/models/demos/audio/cosy_voice/demo/quality_cases.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "sft_zh_quality",
+    "mode": "sft",
+    "language": "zh",
+    "text": "你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？",
+    "speaker_id": "中文女"
+  },
+  {
+    "name": "zero_shot_zh_quality",
+    "mode": "zero_shot",
+    "language": "zh",
+    "text": "收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐。",
+    "prompt_text": "希望你以后能够做的比我还好呦。",
+    "prompt_audio": "asset/zero_shot_prompt.wav"
+  },
+  {
+    "name": "cross_lingual_en_quality",
+    "mode": "cross_lingual",
+    "language": "en",
+    "text": "<|en|>And then later on, fully acquiring that company.",
+    "prompt_audio": "asset/cross_lingual_prompt.wav"
+  },
+  {
+    "name": "instruct_zh_quality",
+    "mode": "instruct",
+    "language": "zh",
+    "text": "在面对挑战时，他展现了非凡的勇气与智慧。",
+    "speaker_id": "中文男",
+    "instruction": "Theo 'Crimson', is a fiery, passionate rebel leader. Fights with fervor for justice, but struggles with impulsiveness.<|endofprompt|>"
+  }
+]

--- a/models/demos/audio/cosy_voice/demo/validate_tt.py
+++ b/models/demos/audio/cosy_voice/demo/validate_tt.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
+
+from models.demos.audio.cosy_voice.demo.common import load_cases, runtime_summary, write_json
+from models.demos.audio.cosy_voice.tt.pipeline import CosyVoicePipeline
+
+DEMO_ROOT = Path(__file__).resolve().parent
+ACCURACY_MANIFEST = DEMO_ROOT / "accuracy_cases.json"
+PERFORMANCE_MANIFEST = DEMO_ROOT / "performance_cases.json"
+QUALITY_MANIFEST = DEMO_ROOT / "quality_cases.json"
+
+
+def validate_accuracy_metrics(token_accuracy_pct: float, minimum: float = 95.0) -> None:
+    if token_accuracy_pct < minimum:
+        raise AssertionError(f"Semantic token accuracy {token_accuracy_pct:.2f}% is below {minimum:.2f}%")
+
+
+def validate_audio_metrics(sample_rate: int, audio_seconds: float, minimum_audio_seconds: float = 0.1) -> None:
+    if sample_rate <= 0:
+        raise AssertionError(f"Invalid sample rate: {sample_rate}")
+    if audio_seconds < minimum_audio_seconds:
+        raise AssertionError(f"Audio duration {audio_seconds:.4f}s is below {minimum_audio_seconds:.4f}s")
+
+
+def validate_performance_metrics(
+    tokens_per_second: float, rtf: float, min_tokens_per_second: float = 30.0, max_rtf: float = 0.5
+) -> None:
+    if tokens_per_second < min_tokens_per_second:
+        raise AssertionError(
+            f"Semantic generation speed {tokens_per_second:.2f} tok/s is below {min_tokens_per_second:.2f} tok/s"
+        )
+    if rtf >= max_rtf:
+        raise AssertionError(f"RTF {rtf:.4f} is not below {max_rtf:.4f}")
+
+
+def validate_quality_metrics(
+    wer_pct: float, speaker_similarity_pct: float, max_wer_pct: float = 3.0, min_similarity_pct: float = 60.0
+) -> None:
+    if wer_pct >= max_wer_pct:
+        raise AssertionError(f"WER {wer_pct:.4f}% is not below {max_wer_pct:.4f}%")
+    if speaker_similarity_pct <= min_similarity_pct:
+        raise AssertionError(f"Speaker similarity {speaker_similarity_pct:.4f}% is not above {min_similarity_pct:.4f}%")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Public CosyVoice accuracy/performance/quality runner")
+    parser.add_argument("--suite", choices=("accuracy", "performance", "quality"), required=True)
+    parser.add_argument("--reference-repo", default=None)
+    parser.add_argument("--model-root", default=None)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-dir", default="/tmp/cosy_voice_outputs")
+    parser.add_argument("--disable-text-frontend", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    return parser
+
+
+def manifest_for_suite(suite: str) -> Path:
+    if suite == "accuracy":
+        return ACCURACY_MANIFEST
+    if suite == "performance":
+        return PERFORMANCE_MANIFEST
+    return QUALITY_MANIFEST
+
+
+def run_suite(args: argparse.Namespace) -> dict:
+    pipeline = CosyVoicePipeline(
+        reference_repo=args.reference_repo,
+        model_root=args.model_root,
+        text_frontend=not args.disable_text_frontend,
+    )
+    try:
+        cases = load_cases(manifest_for_suite(args.suite))
+        report_cases = []
+        for case in cases:
+            output_path = str(Path(args.output_dir) / f"{case.name}.wav")
+            prepared = pipeline.prepare_case(case)
+            semantic_result = pipeline.generate_semantic_tokens(case, prepared=prepared)
+            result = pipeline.synthesize_semantic_tokens(
+                case, semantic_result, prepared=prepared, output_path=output_path
+            )
+            total_wall_seconds = semantic_result.wall_seconds + result.wall_seconds
+            semantic_accuracy_pct = (
+                pipeline.evaluate_semantic_token_accuracy(case, prepared=prepared) if args.suite == "accuracy" else None
+            )
+            quality_metrics = pipeline.evaluate_quality(case, output_path) if args.suite == "quality" else None
+            entry = {
+                "name": case.name,
+                "mode": case.mode,
+                "language": case.language,
+                "model_dir": result.model_dir,
+                "output_path": output_path,
+                "sample_rate": result.sample_rate,
+                "audio_seconds": result.audio_seconds,
+                "wall_seconds": total_wall_seconds,
+                "semantic_wall_seconds": semantic_result.wall_seconds,
+                "acoustic_wall_seconds": result.wall_seconds,
+                "rtf": total_wall_seconds / result.audio_seconds if result.audio_seconds > 0 else None,
+                "semantic_token_count": semantic_result.token_count,
+                "target_tokens_per_second": case.target_tokens_per_second,
+                "target_rtf": case.target_rtf,
+                "semantic_token_accuracy_pct": semantic_accuracy_pct,
+                "semantic_tokens_per_second": semantic_result.tokens_per_second,
+                "reference_text": None if quality_metrics is None else quality_metrics["reference_text"],
+                "transcribed_text": None if quality_metrics is None else quality_metrics["transcribed_text"],
+                "wer_pct": None if quality_metrics is None else quality_metrics["wer_pct"],
+                "speaker_similarity_pct": None
+                if quality_metrics is None
+                else quality_metrics["speaker_similarity_pct"],
+            }
+            if args.check:
+                validate_audio_metrics(entry["sample_rate"], entry["audio_seconds"])
+            if args.check and args.suite == "performance":
+                validate_performance_metrics(
+                    entry["semantic_tokens_per_second"],
+                    entry["rtf"],
+                    min_tokens_per_second=case.target_tokens_per_second or 30.0,
+                    max_rtf=case.target_rtf or 0.5,
+                )
+            if args.check and args.suite == "accuracy":
+                validate_accuracy_metrics(entry["semantic_token_accuracy_pct"])
+            if args.check and args.suite == "quality":
+                validate_quality_metrics(entry["wer_pct"], entry["speaker_similarity_pct"])
+            report_cases.append(entry)
+
+        return {
+            "suite": args.suite,
+            "backend": "tt_semantic_tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder",
+            "semantic_backend": "tt_transformer",
+            "acoustic_backend": "tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder",
+            "semantic_accuracy_mode": "teacher_forced_greedy_argmax" if args.suite == "accuracy" else None,
+            "quality_asr_model": quality_metrics["quality_asr_model"]
+            if args.suite == "quality" and report_cases
+            else None,
+            "throw_exception_on_fallback": bool(pipeline._ttnn.CONFIG.throw_exception_on_fallback)
+            if pipeline._ttnn is not None
+            else None,
+            "runtime": runtime_summary(),
+            "cases": report_cases,
+        }
+    finally:
+        pipeline.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_argparser().parse_args(argv)
+    report = run_suite(args)
+    write_json(args.output_json, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/demos/audio/cosy_voice/tests/test_accuracy.py
+++ b/models/demos/audio/cosy_voice/tests/test_accuracy.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from models.demos.audio.cosy_voice.demo.common import CosyVoiceCase, load_cases
+from models.demos.audio.cosy_voice.demo.validate_tt import validate_accuracy_metrics, validate_audio_metrics
+from models.demos.audio.cosy_voice.tt.flow import (
+    CosyVoiceTorchFlowDecoder,
+    CosyVoiceTTFlowBridge,
+    CosyVoiceTTFlowEncoder,
+    CosyVoiceTTFlowLengthRegulator,
+    apply_flow_encoder_layer_torch,
+    apply_flow_encoder_projection_torch,
+    apply_flow_conditional_decoder_torch,
+    apply_flow_length_regulator_torch,
+    apply_flow_speaker_projection_torch,
+    build_flow_condition,
+    build_flow_inputs_from_model_input,
+    compute_decode_mel_length,
+    extract_flow_decoder_parameters,
+    extract_flow_bridge_parameters,
+    extract_flow_encoder_layer_parameters,
+    extract_flow_length_regulator_parameters,
+)
+from models.demos.audio.cosy_voice.tt.llm import (
+    apply_legacy_embed_torch,
+    apply_semantic_layer_torch,
+    build_autoregressive_attention_mask,
+    build_semantic_inputs_from_model_input,
+    compute_decode_length_bounds,
+    extract_legacy_embed_parameters,
+    extract_semantic_layer_parameters,
+    extract_semantic_output_parameters,
+)
+from models.demos.audio.cosy_voice.tt.pipeline import CosyVoicePipeline
+from models.demos.audio.cosy_voice.tt.reference import SemanticTokenResult
+
+DEMO_ROOT = Path(__file__).resolve().parents[1] / "demo"
+REFERENCE_REPO = Path("/vol/stor/reference_repos/CosyVoice")
+MODEL_ROOT = Path("/root/.cache/cosyvoice_models")
+
+
+def _dummy_semantic_tokens(length: int = 12) -> torch.Tensor:
+    return (torch.arange(length, dtype=torch.int32) % 128).reshape(1, -1)
+
+
+def _build_projected_flow_hidden(_real_pipeline, case_name: str, token_length: int = 24):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}[case_name]
+    prepared = _real_pipeline.prepare_case(case)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    flow_module = model.model.flow
+    flow_inputs = build_flow_inputs_from_model_input(
+        flow_module=flow_module,
+        model_input=prepared.payload,
+        source_speech_token=_dummy_semantic_tokens(token_length),
+    )
+    masks = torch.ones((1, 1, flow_inputs.token_embedding.shape[1]), dtype=torch.bool)
+    hidden_states, positional_embedding, _ = flow_module.encoder.embed(flow_inputs.token_embedding, masks)
+    for layer_idx in range(len(flow_module.encoder.encoders)):
+        parameters = extract_flow_encoder_layer_parameters(flow_module.state_dict(), layer_num=layer_idx)
+        hidden_states = apply_flow_encoder_layer_torch(hidden_states, positional_embedding, parameters, num_heads=8)
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        flow_module.encoder.after_norm.weight,
+        flow_module.encoder.after_norm.bias,
+        flow_module.encoder.after_norm.eps,
+    )
+    projected_hidden = apply_flow_encoder_projection_torch(
+        hidden_states,
+        extract_flow_bridge_parameters(flow_module.state_dict()),
+    )
+    return case, flow_module, flow_inputs, projected_hidden
+
+
+def test_accuracy_manifest_is_public_and_valid():
+    cases = load_cases(DEMO_ROOT / "accuracy_cases.json")
+    assert {case.mode for case in cases} == {"sft", "zero_shot", "cross_lingual", "instruct"}
+    assert {"zh", "en", "ja", "yue", "ko"}.issubset({case.language for case in cases})
+
+
+def test_decode_length_bounds_match_public_ratios():
+    min_len, max_len = compute_decode_length_bounds(text_token_len=48, prompt_text_token_len=8)
+    assert min_len == 80
+    assert max_len == 800
+
+
+def test_autoregressive_attention_mask_is_lower_triangular():
+    mask = build_autoregressive_attention_mask(4)
+    assert mask.shape == (1, 4, 4)
+    assert mask[0, 0, 3].item() is False
+    assert mask[0, 3, 0].item() is True
+
+
+def test_flow_condition_pads_decode_region():
+    import torch
+
+    prompt_feat = torch.ones((1, 10, 80))
+    cond = build_flow_condition(prompt_feat, decode_mel_length=7)
+    assert cond.shape == (1, 17, 80)
+    assert cond[:, :10].sum().item() == 800
+    assert cond[:, 10:].sum().item() == 0
+
+
+def test_compute_decode_mel_length():
+    assert compute_decode_mel_length(50) == 86
+
+
+def test_flow_bridge_parameter_extraction_matches_public_checkpoint_shapes(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["sft_zh"]
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    parameters = extract_flow_bridge_parameters(model.model.flow.state_dict())
+    assert parameters.input_embedding_weight.shape == (4096, 512)
+    assert parameters.speaker_weight.shape == (80, 192)
+    assert parameters.speaker_bias.shape == (80,)
+    assert parameters.encoder_proj_weight.shape == (80, 512)
+    assert parameters.encoder_proj_bias.shape == (80,)
+
+
+def test_validate_accuracy_metrics_accepts_public_gate():
+    validate_accuracy_metrics(96.0)
+
+
+def test_validate_accuracy_metrics_rejects_regression():
+    with pytest.raises(AssertionError):
+        validate_accuracy_metrics(94.9)
+
+
+def test_validate_audio_metrics_accepts_realistic_output():
+    validate_audio_metrics(22050, 0.25)
+
+
+@pytest.mark.parametrize(
+    ("sample_rate", "audio_seconds"),
+    [
+        (0, 0.5),
+        (22050, 0.01),
+    ],
+)
+def test_validate_audio_metrics_rejects_invalid_outputs(sample_rate, audio_seconds):
+    with pytest.raises(AssertionError):
+        validate_audio_metrics(sample_rate, audio_seconds)
+
+
+class _FakeLegacyEmbed(torch.nn.Module):
+    def forward(self, x, mask, offset=0):
+        return x + 4.0, torch.full_like(x, 5.0), mask
+
+
+class _FakeSemanticLLM(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.llm_input_size = 4
+        self.sos = 0
+        self.task_id = 1
+        self.text_embedding = torch.nn.Embedding(32, 4)
+        self.spk_embed_affine_layer = torch.nn.Linear(2, 4)
+        self.llm_embedding = torch.nn.Embedding(2, 4)
+        self.speech_embedding = torch.nn.Embedding(16, 4)
+        self.llm = SimpleNamespace(embed=_FakeLegacyEmbed())
+
+    def encode(self, text, text_lengths):
+        return text + 3.0, text_lengths
+
+
+def test_build_semantic_inputs_from_model_input_handles_optional_inputs():
+    llm = _FakeSemanticLLM()
+    payload = {
+        "text": torch.tensor([[1, 2, 3]], dtype=torch.int32),
+        "text_len": torch.tensor([3], dtype=torch.int32),
+        "llm_embedding": torch.tensor([[0.25, -0.5]], dtype=torch.float32),
+    }
+    semantic_inputs = build_semantic_inputs_from_model_input(llm_module=llm, model_input=payload)
+    assert semantic_inputs.prompt_text.shape == (1, 0)
+    assert semantic_inputs.prompt_speech_token.shape == (1, 0)
+    assert semantic_inputs.prefill_seq_len == 6
+    assert semantic_inputs.min_decode_length == 6
+    assert semantic_inputs.max_decode_length == 60
+    assert semantic_inputs.lm_input_embed.shape == semantic_inputs.lm_input.shape
+    assert semantic_inputs.lm_input_mask.shape == (1, 1, semantic_inputs.prefill_seq_len)
+
+
+@pytest.fixture(scope="module")
+def _real_pipeline():
+    if not REFERENCE_REPO.exists() or not MODEL_ROOT.exists():
+        pytest.skip("CosyVoice reference repo or checkpoints are unavailable")
+    pipeline = CosyVoicePipeline(
+        reference_repo=str(REFERENCE_REPO),
+        model_root=str(MODEL_ROOT),
+        text_frontend=False,
+    )
+    yield pipeline
+    pipeline.close()
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["sft_zh", "zero_shot_zh", "cross_lingual_en", "instruct_zh"],
+)
+def test_prepare_semantic_inputs_matches_public_mode_contract(_real_pipeline, case_name):
+    case_map = {case.name: case for case in load_cases(DEMO_ROOT / "accuracy_cases.json")}
+    case = case_map[case_name]
+    prepared = _real_pipeline.prepare_case(case)
+    semantic_inputs = _real_pipeline.prepare_semantic_inputs(case, prepared=prepared)
+    assert semantic_inputs.prefill_seq_len > 0
+    assert semantic_inputs.lm_input_embed.shape == semantic_inputs.lm_input.shape
+    assert semantic_inputs.lm_input_positional_embedding.shape[-1] == semantic_inputs.lm_input.shape[-1]
+    assert semantic_inputs.max_decode_length > semantic_inputs.min_decode_length >= 0
+    if case.mode == "sft":
+        assert semantic_inputs.prompt_text.shape[1] == 0
+        assert semantic_inputs.prompt_speech_token.shape[1] == 0
+        assert semantic_inputs.speaker_projection.shape[1] == 1
+    if case.mode == "zero_shot":
+        assert semantic_inputs.prompt_text.shape[1] > 0
+        assert semantic_inputs.prompt_speech_token.shape[1] > 0
+    if case.mode == "cross_lingual":
+        assert semantic_inputs.prompt_text.shape[1] == 0
+        assert semantic_inputs.prompt_speech_token.shape[1] == 0
+    if case.mode == "instruct":
+        assert semantic_inputs.prompt_text.shape[1] > 0
+        assert semantic_inputs.speaker_projection.shape[1] == 0
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["sft_zh", "zero_shot_zh", "cross_lingual_en", "instruct_zh"],
+)
+def test_prepare_flow_inputs_matches_public_mode_contract(_real_pipeline, case_name):
+    case_map = {case.name: case for case in load_cases(DEMO_ROOT / "accuracy_cases.json")}
+    case = case_map[case_name]
+    prepared = _real_pipeline.prepare_case(case)
+    semantic_tokens = SemanticTokenResult(
+        case=case,
+        model_dir="/tmp/fake-model",
+        tokens=_dummy_semantic_tokens(),
+        wall_seconds=0.0,
+    )
+    flow_inputs = _real_pipeline.prepare_flow_inputs(case, semantic_tokens, prepared=prepared)
+    assert flow_inputs.source_speech_token.shape[1] == semantic_tokens.tokens.shape[1]
+    assert int(flow_inputs.source_speech_token_len.item()) == semantic_tokens.tokens.shape[1]
+    assert int(flow_inputs.full_token_len.item()) == flow_inputs.full_token.shape[1]
+    assert flow_inputs.token_embedding.shape == (1, flow_inputs.full_token.shape[1], 512)
+    assert flow_inputs.speaker_projection.shape == (1, 80)
+    assert flow_inputs.condition.shape == (1, flow_inputs.prompt_mel_length + flow_inputs.decode_mel_length, 80)
+    assert flow_inputs.condition[:, : flow_inputs.prompt_mel_length].shape[1] == flow_inputs.prompt_mel_length
+    if case.mode == "sft":
+        assert flow_inputs.prompt_speech_token.shape[1] == 0
+        assert flow_inputs.prompt_speech_feat.shape[1] == 0
+    elif case.mode in {"zero_shot", "cross_lingual"}:
+        assert flow_inputs.prompt_speech_token.shape[1] > 0
+        assert flow_inputs.prompt_speech_feat.shape[1] > 0
+    else:
+        assert flow_inputs.prompt_speech_token.shape[1] == 0
+        assert flow_inputs.prompt_speech_feat.shape[1] == 0
+
+
+def test_legacy_embed_projection_matches_real_checkpoint(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["sft_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    semantic_inputs = _real_pipeline.prepare_semantic_inputs(case, prepared=prepared)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    parameters = extract_legacy_embed_parameters(model.model.llm.state_dict(), prefix="llm.embed.out")
+    legacy_embed = apply_legacy_embed_torch(semantic_inputs.lm_input, parameters)
+    assert legacy_embed.shape == semantic_inputs.lm_input.shape
+    assert torch.allclose(
+        legacy_embed * (semantic_inputs.lm_input.shape[-1] ** 0.5),
+        semantic_inputs.lm_input_embed,
+        atol=1e-4,
+        rtol=1e-4,
+    )
+
+
+def test_semantic_layer_parameter_extraction_matches_real_checkpoint(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["sft_zh"]
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    layer = extract_semantic_layer_parameters(model.model.llm.state_dict(), layer_num=0, prefix="llm.encoders")
+    assert layer.q_weight.shape == (1024, 1024)
+    assert layer.k_weight.shape == (1024, 1024)
+    assert layer.v_weight.shape == (1024, 1024)
+    assert layer.out_weight.shape == (1024, 1024)
+    assert layer.pos_weight.shape == (1024, 1024)
+    assert layer.ffn_w1_weight.shape == (4096, 1024)
+    assert layer.ffn_w2_weight.shape == (1024, 4096)
+    assert layer.pos_bias_u.shape == (16, 64)
+    assert layer.pos_bias_v.shape == (16, 64)
+
+
+def test_semantic_output_parameter_extraction_matches_real_checkpoint(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["sft_zh"]
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    output = extract_semantic_output_parameters(model.model.llm.state_dict())
+    assert output.after_norm_weight.shape == (1024,)
+    assert output.decoder_weight.shape == (4097, 1024)
+    assert output.decoder_bias.shape == (4097,)
+    assert output.speech_embedding_weight.shape == (4096, 1024)
+
+
+def test_flow_bridge_torch_helpers_match_reference_modules(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["zero_shot_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    flow_module = model.model.flow
+    flow_inputs = build_flow_inputs_from_model_input(
+        flow_module=flow_module,
+        model_input=prepared.payload,
+        source_speech_token=_dummy_semantic_tokens(24),
+    )
+    parameters = extract_flow_bridge_parameters(flow_module.state_dict())
+
+    expected_embedding = flow_module.input_embedding(torch.clamp(flow_inputs.full_token, min=0))
+    assert torch.allclose(flow_inputs.token_embedding, expected_embedding, atol=1e-4, rtol=1e-4)
+
+    normalized_embedding, speaker_projection = apply_flow_speaker_projection_torch(
+        flow_inputs.flow_embedding, parameters
+    )
+    assert torch.allclose(normalized_embedding, F.normalize(flow_inputs.flow_embedding, dim=1), atol=1e-6, rtol=1e-6)
+    assert torch.allclose(speaker_projection, flow_inputs.speaker_projection, atol=1e-4, rtol=1e-4)
+
+    encoded_hidden, encoded_mask = flow_module.encoder(flow_inputs.token_embedding, flow_inputs.full_token_len)
+    projected_hidden = apply_flow_encoder_projection_torch(encoded_hidden, parameters)
+    reference_projected_hidden = flow_module.encoder_proj(encoded_hidden)
+    assert encoded_mask.shape[-1] == flow_inputs.full_token.shape[1]
+    assert torch.allclose(projected_hidden, reference_projected_hidden, atol=1e-4, rtol=1e-4)
+
+
+def test_flow_bridge_ttnn_matches_reference_bridge_ops(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["zero_shot_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    flow_module = model.model.flow
+    flow_inputs = build_flow_inputs_from_model_input(
+        flow_module=flow_module,
+        model_input=prepared.payload,
+        source_speech_token=_dummy_semantic_tokens(24),
+    )
+    bridge = CosyVoiceTTFlowBridge(flow_module, _real_pipeline._get_device())
+    encoded_hidden, _ = flow_module.encoder(flow_inputs.token_embedding, flow_inputs.full_token_len)
+    parameters = extract_flow_bridge_parameters(flow_module.state_dict())
+
+    tt_embedding = bridge.embed_tokens(flow_inputs.full_token, flow_inputs.full_token_len)
+    tt_speaker_projection = bridge.project_speaker_embedding(flow_inputs.flow_embedding)
+    tt_encoder_projection = bridge.project_encoder_output(encoded_hidden)
+
+    assert torch.allclose(tt_embedding, flow_inputs.token_embedding, atol=2e-1, rtol=2e-1)
+    assert torch.allclose(
+        tt_speaker_projection,
+        apply_flow_speaker_projection_torch(flow_inputs.flow_embedding, parameters)[1],
+        atol=1e-1,
+        rtol=1e-1,
+    )
+    assert torch.allclose(
+        tt_encoder_projection,
+        apply_flow_encoder_projection_torch(encoded_hidden, parameters),
+        atol=2e-1,
+        rtol=2e-1,
+    )
+
+
+def test_flow_encoder_layer_torch_matches_reference_layer(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["zero_shot_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    flow_module = model.model.flow
+    flow_inputs = build_flow_inputs_from_model_input(
+        flow_module=flow_module,
+        model_input=prepared.payload,
+        source_speech_token=_dummy_semantic_tokens(24),
+    )
+    masks = torch.ones((1, 1, flow_inputs.token_embedding.shape[1]), dtype=torch.bool)
+    embedded_hidden, positional_embedding, _ = flow_module.encoder.embed(flow_inputs.token_embedding, masks)
+    parameters = extract_flow_encoder_layer_parameters(flow_module.state_dict(), layer_num=0)
+    chunk_mask = torch.ones(
+        (1, embedded_hidden.shape[1], embedded_hidden.shape[1]),
+        dtype=torch.bool,
+        device=embedded_hidden.device,
+    )
+    reference_hidden, _, _, _ = flow_module.encoder.encoders[0](
+        embedded_hidden, chunk_mask, positional_embedding, masks
+    )
+    torch_hidden = apply_flow_encoder_layer_torch(
+        embedded_hidden,
+        positional_embedding,
+        parameters,
+        num_heads=8,
+    )
+    assert torch.allclose(torch_hidden, reference_hidden, atol=1e-4, rtol=1e-4)
+
+
+def test_flow_encoder_ttnn_matches_reference_encoder(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["zero_shot_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    flow_module = model.model.flow
+    flow_inputs = build_flow_inputs_from_model_input(
+        flow_module=flow_module,
+        model_input=prepared.payload,
+        source_speech_token=_dummy_semantic_tokens(24),
+    )
+    tt_encoder = CosyVoiceTTFlowEncoder(flow_module, _real_pipeline._get_device())
+    tt_hidden = tt_encoder.encode(flow_inputs.token_embedding, flow_inputs.full_token_len)
+    reference_hidden, _ = flow_module.encoder(flow_inputs.token_embedding, flow_inputs.full_token_len)
+    assert torch.allclose(tt_hidden, reference_hidden, atol=3e-1, rtol=3e-1)
+
+
+def test_flow_length_regulator_torch_matches_reference_module(_real_pipeline):
+    _, flow_module, flow_inputs, projected_hidden = _build_projected_flow_hidden(_real_pipeline, "zero_shot_zh")
+    prompt_token_len = int(flow_inputs.prompt_speech_token.shape[1])
+    parameters = extract_flow_length_regulator_parameters(flow_module.state_dict())
+    torch_hidden, torch_mel_length = apply_flow_length_regulator_torch(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        parameters,
+        input_frame_rate=flow_module.input_frame_rate,
+    )
+    reference_hidden, reference_mel_length = flow_module.length_regulator.inference(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        flow_module.input_frame_rate,
+    )
+    assert torch_mel_length == reference_mel_length
+    assert torch.allclose(torch_hidden, reference_hidden, atol=1e-4, rtol=1e-4)
+
+
+def test_flow_length_regulator_ttnn_matches_reference_module(_real_pipeline):
+    _, flow_module, flow_inputs, projected_hidden = _build_projected_flow_hidden(_real_pipeline, "zero_shot_zh")
+    prompt_token_len = int(flow_inputs.prompt_speech_token.shape[1])
+    tt_length_regulator = CosyVoiceTTFlowLengthRegulator(flow_module, _real_pipeline._get_device())
+    tt_hidden, tt_mel_length = tt_length_regulator.inference(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        flow_module.input_frame_rate,
+    )
+    reference_hidden, reference_mel_length = flow_module.length_regulator.inference(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        flow_module.input_frame_rate,
+    )
+    assert tt_mel_length == reference_mel_length
+    assert torch.allclose(tt_hidden, reference_hidden, atol=4e-1, rtol=4e-1)
+
+
+def test_flow_decoder_parameter_extraction_matches_reference_decoder(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["zero_shot_zh"]
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    parameters = extract_flow_decoder_parameters(model.model.flow.decoder)
+    assert len(parameters.down_blocks) == 2
+    assert len(parameters.mid_blocks) == 12
+    assert len(parameters.up_blocks) == 2
+    assert parameters.in_channels == 320
+    assert parameters.out_channels == 80
+    assert parameters.num_heads == 8
+    assert parameters.head_dim == 64
+    assert parameters.final_proj_weight.shape == (80, 256, 1)
+
+
+def test_flow_decoder_estimator_torch_matches_reference_module(_real_pipeline):
+    _, flow_module, flow_inputs, projected_hidden = _build_projected_flow_hidden(_real_pipeline, "zero_shot_zh", token_length=8)
+    prompt_token_len = int(flow_inputs.prompt_speech_token.shape[1])
+    regulator_parameters = extract_flow_length_regulator_parameters(flow_module.state_dict())
+    acoustic_hidden, _ = apply_flow_length_regulator_torch(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        regulator_parameters,
+        input_frame_rate=flow_module.input_frame_rate,
+    )
+    mu = acoustic_hidden.transpose(1, 2).contiguous()
+    mask = torch.ones((1, 1, mu.shape[-1]), dtype=torch.bool, device=mu.device)
+    cond = flow_inputs.condition.transpose(1, 2).contiguous()
+    parameters = extract_flow_decoder_parameters(flow_module.decoder)
+
+    torch.manual_seed(0)
+    reference_hidden = flow_module.decoder.estimator(
+        x=torch.randn_like(mu),
+        mask=mask,
+        mu=mu,
+        t=torch.ones((1,), dtype=mu.dtype),
+        spks=flow_inputs.speaker_projection.to(dtype=mu.dtype),
+        cond=cond,
+    )
+
+    torch.manual_seed(0)
+    torch_hidden = apply_flow_conditional_decoder_torch(
+        x=torch.randn_like(mu),
+        mask=mask,
+        mu=mu,
+        timesteps=torch.ones((1,), dtype=mu.dtype),
+        parameters=parameters,
+        spks=flow_inputs.speaker_projection.to(dtype=mu.dtype),
+        cond=cond,
+    )
+    assert torch.allclose(torch_hidden, reference_hidden, atol=1e-4, rtol=1e-4)
+
+
+def test_flow_decoder_torch_matches_reference_module(_real_pipeline):
+    _, flow_module, flow_inputs, projected_hidden = _build_projected_flow_hidden(_real_pipeline, "zero_shot_zh", token_length=8)
+    prompt_token_len = int(flow_inputs.prompt_speech_token.shape[1])
+    regulator_parameters = extract_flow_length_regulator_parameters(flow_module.state_dict())
+    acoustic_hidden, total_mel_length = apply_flow_length_regulator_torch(
+        projected_hidden[:, :prompt_token_len],
+        projected_hidden[:, prompt_token_len:],
+        flow_inputs.prompt_mel_length,
+        flow_inputs.decode_mel_length,
+        regulator_parameters,
+        input_frame_rate=flow_module.input_frame_rate,
+    )
+    mu = acoustic_hidden.transpose(1, 2).contiguous()
+    mask = torch.ones((1, 1, total_mel_length), dtype=torch.bool, device=mu.device)
+    cond = flow_inputs.condition.transpose(1, 2).contiguous()
+    cache = torch.zeros((1, 80, 0, 2), dtype=mu.dtype, device=mu.device)
+    decoder = CosyVoiceTorchFlowDecoder(flow_module)
+
+    torch.manual_seed(0)
+    reference_feat, reference_cache = flow_module.decoder(
+        mu=mu,
+        mask=mask,
+        spks=flow_inputs.speaker_projection.to(dtype=mu.dtype),
+        cond=cond,
+        n_timesteps=2,
+        prompt_len=flow_inputs.prompt_mel_length,
+        cache=cache.clone(),
+    )
+
+    torch.manual_seed(0)
+    torch_feat, torch_cache = decoder.inference(
+        mu=mu,
+        mask=mask,
+        spks=flow_inputs.speaker_projection.to(dtype=mu.dtype),
+        cond=cond,
+        n_timesteps=2,
+        prompt_len=flow_inputs.prompt_mel_length,
+        cache=cache.clone(),
+    )
+    assert torch.allclose(torch_feat, reference_feat, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(torch_cache, reference_cache, atol=1e-4, rtol=1e-4)
+
+
+def test_semantic_layer_torch_matches_reference_layer(_real_pipeline):
+    case = {item.name: item for item in load_cases(DEMO_ROOT / "accuracy_cases.json")}["sft_zh"]
+    prepared = _real_pipeline.prepare_case(case)
+    semantic_inputs = _real_pipeline.prepare_semantic_inputs(case, prepared=prepared)
+    model, _ = _real_pipeline.reference.get_model(case.mode)
+    parameters = extract_semantic_layer_parameters(model.model.llm.state_dict(), layer_num=0, prefix="llm.encoders")
+    causal_mask = build_autoregressive_attention_mask(semantic_inputs.prefill_seq_len)
+    reference_hidden, _, reference_cache, _ = model.model.llm.llm.encoders[0](
+        semantic_inputs.lm_input_embed,
+        causal_mask,
+        semantic_inputs.lm_input_positional_embedding,
+    )
+    hidden_states, cache = apply_semantic_layer_torch(
+        semantic_inputs.lm_input_embed,
+        semantic_inputs.lm_input_positional_embedding,
+        parameters,
+        num_heads=16,
+        causal=True,
+    )
+    reference_key, reference_value = torch.split(reference_cache, reference_cache.shape[-1] // 2, dim=-1)
+    assert torch.allclose(hidden_states, reference_hidden, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(cache[0], reference_key, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(cache[1], reference_value, atol=1e-4, rtol=1e-4)
+
+
+def test_pipeline_accuracy_uses_greedy_reference_targets():
+    calls = {}
+
+    class _FakeReference:
+        def prepare_semantic_inputs(self, case, payload):
+            calls["prepare_semantic_inputs"] = (case.name, payload)
+            return "semantic-inputs"
+
+        def generate_semantic_greedy_tokens(self, case, payload):
+            calls["generate_semantic_greedy_tokens"] = (case.name, payload)
+            return SemanticTokenResult(
+                case=case,
+                model_dir="/tmp/fake-model",
+                tokens=torch.tensor([[1, 2, 3]], dtype=torch.int32),
+                wall_seconds=0.1,
+            )
+
+        def generate_semantic_tokens(self, case, payload):  # pragma: no cover - should not be used
+            raise AssertionError("sampled semantic tokens are not a valid public accuracy target")
+
+    class _FakeGenerator:
+        def teacher_forced_accuracy(self, semantic_inputs, tokens):
+            calls["teacher_forced_accuracy"] = (semantic_inputs, tokens.clone())
+            return 99.0
+
+    pipeline = CosyVoicePipeline.__new__(CosyVoicePipeline)
+    pipeline.reference = _FakeReference()
+    pipeline.prepare_case = lambda case: SimpleNamespace(payload="prepared-payload")
+    pipeline._get_semantic_generator = lambda mode: _FakeGenerator()
+
+    case = CosyVoiceCase(name="fake", mode="sft", text="hi", speaker_id="spk")
+    accuracy = pipeline.evaluate_semantic_token_accuracy(case)
+
+    assert accuracy == 99.0
+    assert calls["prepare_semantic_inputs"] == ("fake", "prepared-payload")
+    assert calls["generate_semantic_greedy_tokens"] == ("fake", "prepared-payload")
+    assert calls["teacher_forced_accuracy"][0] == "semantic-inputs"
+    assert torch.equal(calls["teacher_forced_accuracy"][1], torch.tensor([[1, 2, 3]], dtype=torch.int32))

--- a/models/demos/audio/cosy_voice/tests/test_demo.py
+++ b/models/demos/audio/cosy_voice/tests/test_demo.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from models.demos.audio.cosy_voice.demo.demo import build_argparser, validate_mode_args
+
+
+def test_build_argparser_accepts_public_modes():
+    parser = build_argparser()
+    args = parser.parse_args(["--mode", "sft", "--text", "hello", "--output", "/tmp/out.wav", "--speaker-id", "中文女"])
+    assert args.mode == "sft"
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_message"),
+    [
+        (["--mode", "sft", "--text", "hello", "--output", "/tmp/out.wav"], "--speaker-id"),
+        (
+            ["--mode", "zero_shot", "--text", "hello", "--output", "/tmp/out.wav", "--prompt-audio", "a.wav"],
+            "--prompt-text",
+        ),
+        (["--mode", "cross_lingual", "--text", "hello", "--output", "/tmp/out.wav"], "--prompt-audio"),
+        (
+            ["--mode", "instruct", "--text", "hello", "--output", "/tmp/out.wav", "--speaker-id", "中文男"],
+            "--instruction",
+        ),
+    ],
+)
+def test_validate_mode_args_rejects_incomplete_cases(argv, expected_message):
+    parser = build_argparser()
+    args = parser.parse_args(argv)
+    with pytest.raises(ValueError, match=expected_message):
+        validate_mode_args(args)

--- a/models/demos/audio/cosy_voice/tests/test_performance.py
+++ b/models/demos/audio/cosy_voice/tests/test_performance.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from models.demos.audio.cosy_voice.demo.common import load_cases
+from models.demos.audio.cosy_voice.demo.validate_tt import validate_performance_metrics
+from models.demos.audio.cosy_voice.tt.vocoder import audio_seconds
+
+DEMO_ROOT = Path(__file__).resolve().parents[1] / "demo"
+
+
+def test_performance_manifest_contains_single_public_case():
+    cases = load_cases(DEMO_ROOT / "performance_cases.json")
+    assert len(cases) == 1
+    assert cases[0].mode == "zero_shot"
+    assert cases[0].target_tokens_per_second == 30.0
+    assert cases[0].target_rtf == 0.5
+
+
+def test_validate_performance_metrics_accepts_public_gate():
+    validate_performance_metrics(30.0, 0.49)
+
+
+@pytest.mark.parametrize(
+    ("tokens_per_second", "rtf"),
+    [
+        (29.99, 0.49),
+        (30.0, 0.5),
+    ],
+)
+def test_validate_performance_metrics_rejects_gate_failures(tokens_per_second, rtf):
+    with pytest.raises(AssertionError):
+        validate_performance_metrics(tokens_per_second, rtf)
+
+
+def test_audio_seconds_helper():
+    assert audio_seconds(22050, 22050) == 1.0

--- a/models/demos/audio/cosy_voice/tests/test_quality.py
+++ b/models/demos/audio/cosy_voice/tests/test_quality.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from models.demos.audio.cosy_voice.demo.common import load_cases
+from models.demos.audio.cosy_voice.demo.validate_tt import validate_quality_metrics
+from models.demos.audio.cosy_voice.tt.reference import (
+    cosine_similarity_percent,
+    normalize_transcript_text,
+    transcript_tokens,
+    word_error_rate_percent,
+)
+
+DEMO_ROOT = Path(__file__).resolve().parents[1] / "demo"
+
+
+def test_quality_manifest_contains_public_mode_coverage():
+    cases = load_cases(DEMO_ROOT / "quality_cases.json")
+    assert {case.mode for case in cases} == {"sft", "zero_shot", "cross_lingual", "instruct"}
+
+
+@pytest.mark.parametrize(
+    ("text", "language", "expected"),
+    [
+        ("<|en|>Hello, World!", "en", "hello world"),
+        ("<|yue|>今日我哋会用广东话试下呢个语音模型。", "yue", "今日我哋会用广东话试下呢个语音模型"),
+    ],
+)
+def test_normalize_transcript_text(text, language, expected):
+    assert normalize_transcript_text(text, language) == expected
+
+
+def test_transcript_tokens_use_character_granularity_for_cjk():
+    assert transcript_tokens("你好 世界", "zh") == list("你好世界")
+
+
+def test_word_error_rate_percent():
+    assert word_error_rate_percent("hello world", "hello brave world", "en") == 50.0
+
+
+def test_cosine_similarity_percent():
+    similarity = cosine_similarity_percent(torch.tensor([1.0, 0.0]), torch.tensor([1.0, 0.0]))
+    assert similarity == pytest.approx(100.0)
+
+
+def test_validate_quality_metrics_accepts_public_gate():
+    validate_quality_metrics(2.5, 75.0)
+
+
+@pytest.mark.parametrize(
+    ("wer_pct", "speaker_similarity_pct"),
+    [
+        (3.1, 75.0),
+        (2.5, 59.9),
+    ],
+)
+def test_validate_quality_metrics_rejects_gate_failures(wer_pct, speaker_similarity_pct):
+    with pytest.raises(AssertionError):
+        validate_quality_metrics(wer_pct, speaker_similarity_pct)

--- a/models/demos/audio/cosy_voice/tt/flow.py
+++ b/models/demos/audio/cosy_voice/tt/flow.py
@@ -1,0 +1,1633 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowConfig:
+    input_size: int = 512
+    output_size: int = 80
+    vocab_size: int = 4096
+    input_frame_rate: int = 50
+    sample_rate: int = 22050
+    hop_length: int = 256
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowInputs:
+    source_speech_token: torch.Tensor
+    source_speech_token_len: torch.Tensor
+    prompt_speech_token: torch.Tensor
+    prompt_speech_token_len: torch.Tensor
+    prompt_speech_feat: torch.Tensor
+    prompt_speech_feat_len: torch.Tensor
+    flow_embedding: torch.Tensor
+    normalized_embedding: torch.Tensor
+    speaker_projection: torch.Tensor
+    full_token: torch.Tensor
+    full_token_len: torch.Tensor
+    token_embedding: torch.Tensor
+    decode_mel_length: int
+    prompt_mel_length: int
+    condition: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowBridgeParameters:
+    input_embedding_weight: torch.Tensor
+    speaker_weight: torch.Tensor
+    speaker_bias: torch.Tensor
+    encoder_proj_weight: torch.Tensor
+    encoder_proj_bias: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowEncoderLayerParameters:
+    q_weight: torch.Tensor
+    q_bias: torch.Tensor
+    k_weight: torch.Tensor
+    k_bias: torch.Tensor
+    v_weight: torch.Tensor
+    v_bias: torch.Tensor
+    out_weight: torch.Tensor
+    out_bias: torch.Tensor
+    pos_weight: torch.Tensor
+    pos_bias_u: torch.Tensor
+    pos_bias_v: torch.Tensor
+    ffn_w1_weight: torch.Tensor
+    ffn_w1_bias: torch.Tensor
+    ffn_w2_weight: torch.Tensor
+    ffn_w2_bias: torch.Tensor
+    norm_mha_weight: torch.Tensor
+    norm_mha_bias: torch.Tensor
+    norm_ff_weight: torch.Tensor
+    norm_ff_bias: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowEncoderOutputParameters:
+    after_norm_weight: torch.Tensor
+    after_norm_bias: torch.Tensor
+    epsilon: float = 1e-5
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowLengthRegulatorLayerParameters:
+    conv_weight: torch.Tensor
+    conv_bias: torch.Tensor
+    norm_weight: torch.Tensor
+    norm_bias: torch.Tensor
+    kernel_size: int
+    padding: int
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowLengthRegulatorParameters:
+    hidden_layers: tuple[CosyVoiceFlowLengthRegulatorLayerParameters, ...]
+    output_weight: torch.Tensor
+    output_bias: torch.Tensor
+    num_groups: int = 1
+    epsilon: float = 1e-5
+
+
+def _empty_token_tensor(reference: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1, 0), dtype=torch.int32, device=reference.device)
+
+
+def _empty_length_tensor(reference: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1,), dtype=torch.int32, device=reference.device)
+
+
+def _empty_prompt_feature_tensor(reference: torch.Tensor, output_size: int) -> torch.Tensor:
+    return torch.zeros((1, 0, output_size), dtype=torch.float32, device=reference.device)
+
+
+def _default_flow_embedding(flow_module: Any, reference: torch.Tensor) -> torch.Tensor:
+    return torch.zeros(
+        (1, flow_module.spk_embed_affine_layer.in_features), dtype=torch.float32, device=reference.device
+    )
+
+
+def compute_decode_mel_length(
+    token_count: int, *, input_frame_rate: int = 50, sample_rate: int = 22050, hop_length: int = 256
+) -> int:
+    return int(token_count / input_frame_rate * sample_rate / hop_length)
+
+
+def build_prompt_plus_decode_tokens(prompt_token: torch.Tensor, token: torch.Tensor) -> tuple[torch.Tensor, int, int]:
+    prompt_len = prompt_token.shape[1]
+    decode_len = token.shape[1]
+    return torch.cat([prompt_token, token], dim=1), prompt_len, decode_len
+
+
+def build_flow_condition(prompt_feat: torch.Tensor, decode_mel_length: int) -> torch.Tensor:
+    condition = torch.zeros(
+        (prompt_feat.shape[0], prompt_feat.shape[1] + decode_mel_length, prompt_feat.shape[2]),
+        dtype=prompt_feat.dtype,
+        device=prompt_feat.device,
+    )
+    condition[:, : prompt_feat.shape[1]] = prompt_feat
+    return condition
+
+
+def apply_flow_token_embedding_torch(
+    token: torch.Tensor,
+    token_len: torch.Tensor,
+    parameters: CosyVoiceFlowBridgeParameters,
+) -> torch.Tensor:
+    mask = (torch.arange(token.shape[1], device=token.device).unsqueeze(0) < token_len.unsqueeze(1)).unsqueeze(-1)
+    token = torch.clamp(token, min=0)
+    return F.embedding(token, parameters.input_embedding_weight) * mask.to(parameters.input_embedding_weight.dtype)
+
+
+def apply_flow_speaker_projection_torch(
+    embedding: torch.Tensor,
+    parameters: CosyVoiceFlowBridgeParameters,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    normalized = F.normalize(embedding, dim=1)
+    projected = F.linear(normalized, parameters.speaker_weight, parameters.speaker_bias)
+    return normalized, projected
+
+
+def apply_flow_encoder_projection_torch(
+    hidden_states: torch.Tensor,
+    parameters: CosyVoiceFlowBridgeParameters,
+) -> torch.Tensor:
+    return F.linear(hidden_states, parameters.encoder_proj_weight, parameters.encoder_proj_bias)
+
+
+def extract_flow_bridge_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    input_embedding_prefix: str = "input_embedding",
+    speaker_prefix: str = "spk_embed_affine_layer",
+    encoder_proj_prefix: str = "encoder_proj",
+) -> CosyVoiceFlowBridgeParameters:
+    input_embedding_prefix = input_embedding_prefix.rstrip(".")
+    speaker_prefix = speaker_prefix.rstrip(".")
+    encoder_proj_prefix = encoder_proj_prefix.rstrip(".")
+    return CosyVoiceFlowBridgeParameters(
+        input_embedding_weight=state_dict[f"{input_embedding_prefix}.weight"],
+        speaker_weight=state_dict[f"{speaker_prefix}.weight"],
+        speaker_bias=state_dict[f"{speaker_prefix}.bias"],
+        encoder_proj_weight=state_dict[f"{encoder_proj_prefix}.weight"],
+        encoder_proj_bias=state_dict[f"{encoder_proj_prefix}.bias"],
+    )
+
+
+def extract_flow_encoder_layer_parameters(
+    state_dict: dict[str, torch.Tensor],
+    layer_num: int,
+    *,
+    prefix: str = "encoder.encoders",
+) -> CosyVoiceFlowEncoderLayerParameters:
+    layer_prefix = f"{prefix.rstrip('.')}.{layer_num}"
+    return CosyVoiceFlowEncoderLayerParameters(
+        q_weight=state_dict[f"{layer_prefix}.self_attn.linear_q.weight"],
+        q_bias=state_dict[f"{layer_prefix}.self_attn.linear_q.bias"],
+        k_weight=state_dict[f"{layer_prefix}.self_attn.linear_k.weight"],
+        k_bias=state_dict[f"{layer_prefix}.self_attn.linear_k.bias"],
+        v_weight=state_dict[f"{layer_prefix}.self_attn.linear_v.weight"],
+        v_bias=state_dict[f"{layer_prefix}.self_attn.linear_v.bias"],
+        out_weight=state_dict[f"{layer_prefix}.self_attn.linear_out.weight"],
+        out_bias=state_dict[f"{layer_prefix}.self_attn.linear_out.bias"],
+        pos_weight=state_dict[f"{layer_prefix}.self_attn.linear_pos.weight"],
+        pos_bias_u=state_dict[f"{layer_prefix}.self_attn.pos_bias_u"],
+        pos_bias_v=state_dict[f"{layer_prefix}.self_attn.pos_bias_v"],
+        ffn_w1_weight=state_dict[f"{layer_prefix}.feed_forward.w_1.weight"],
+        ffn_w1_bias=state_dict[f"{layer_prefix}.feed_forward.w_1.bias"],
+        ffn_w2_weight=state_dict[f"{layer_prefix}.feed_forward.w_2.weight"],
+        ffn_w2_bias=state_dict[f"{layer_prefix}.feed_forward.w_2.bias"],
+        norm_mha_weight=state_dict[f"{layer_prefix}.norm_mha.weight"],
+        norm_mha_bias=state_dict[f"{layer_prefix}.norm_mha.bias"],
+        norm_ff_weight=state_dict[f"{layer_prefix}.norm_ff.weight"],
+        norm_ff_bias=state_dict[f"{layer_prefix}.norm_ff.bias"],
+    )
+
+
+def extract_flow_encoder_output_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str = "encoder.after_norm",
+) -> CosyVoiceFlowEncoderOutputParameters:
+    prefix = prefix.rstrip(".")
+    return CosyVoiceFlowEncoderOutputParameters(
+        after_norm_weight=state_dict[f"{prefix}.weight"],
+        after_norm_bias=state_dict[f"{prefix}.bias"],
+    )
+
+
+def extract_flow_length_regulator_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str = "length_regulator.model",
+) -> CosyVoiceFlowLengthRegulatorParameters:
+    prefix = prefix.rstrip(".")
+    hidden_layers = []
+    for conv_index, norm_index in ((0, 1), (3, 4), (6, 7), (9, 10)):
+        hidden_layers.append(
+            CosyVoiceFlowLengthRegulatorLayerParameters(
+                conv_weight=state_dict[f"{prefix}.{conv_index}.weight"],
+                conv_bias=state_dict[f"{prefix}.{conv_index}.bias"],
+                norm_weight=state_dict[f"{prefix}.{norm_index}.weight"],
+                norm_bias=state_dict[f"{prefix}.{norm_index}.bias"],
+                kernel_size=3,
+                padding=1,
+            )
+        )
+    return CosyVoiceFlowLengthRegulatorParameters(
+        hidden_layers=tuple(hidden_layers),
+        output_weight=state_dict[f"{prefix}.12.weight"],
+        output_bias=state_dict[f"{prefix}.12.bias"],
+    )
+
+
+def build_flow_inputs(
+    *,
+    flow_module: Any,
+    source_speech_token: torch.Tensor,
+    source_speech_token_len: torch.Tensor,
+    prompt_speech_token: torch.Tensor,
+    prompt_speech_token_len: torch.Tensor,
+    prompt_speech_feat: torch.Tensor,
+    prompt_speech_feat_len: torch.Tensor,
+    embedding: torch.Tensor,
+) -> CosyVoiceFlowInputs:
+    parameters = extract_flow_bridge_parameters(flow_module.state_dict())
+    full_token, _, decode_token_len = build_prompt_plus_decode_tokens(prompt_speech_token, source_speech_token)
+    full_token_len = prompt_speech_token_len + source_speech_token_len
+    normalized_embedding, speaker_projection = apply_flow_speaker_projection_torch(embedding, parameters)
+    token_embedding = apply_flow_token_embedding_torch(full_token, full_token_len, parameters)
+    decode_mel_length = compute_decode_mel_length(
+        decode_token_len,
+        input_frame_rate=flow_module.input_frame_rate,
+    )
+    condition = build_flow_condition(prompt_speech_feat, decode_mel_length)
+    return CosyVoiceFlowInputs(
+        source_speech_token=source_speech_token,
+        source_speech_token_len=source_speech_token_len,
+        prompt_speech_token=prompt_speech_token,
+        prompt_speech_token_len=prompt_speech_token_len,
+        prompt_speech_feat=prompt_speech_feat,
+        prompt_speech_feat_len=prompt_speech_feat_len,
+        flow_embedding=embedding,
+        normalized_embedding=normalized_embedding,
+        speaker_projection=speaker_projection,
+        full_token=full_token,
+        full_token_len=full_token_len,
+        token_embedding=token_embedding,
+        decode_mel_length=decode_mel_length,
+        prompt_mel_length=int(prompt_speech_feat.shape[1]),
+        condition=condition,
+    )
+
+
+def build_flow_inputs_from_model_input(
+    *,
+    flow_module: Any,
+    model_input: dict[str, Any],
+    source_speech_token: torch.Tensor,
+) -> CosyVoiceFlowInputs:
+    prompt_speech_token = model_input.get("flow_prompt_speech_token")
+    if prompt_speech_token is None:
+        prompt_speech_token = _empty_token_tensor(source_speech_token)
+    prompt_speech_token_len = model_input.get("flow_prompt_speech_token_len")
+    if prompt_speech_token_len is None:
+        prompt_speech_token_len = _empty_length_tensor(source_speech_token)
+    prompt_speech_feat = model_input.get("prompt_speech_feat")
+    if prompt_speech_feat is None:
+        prompt_speech_feat = _empty_prompt_feature_tensor(source_speech_token, flow_module.output_size)
+    prompt_speech_feat_len = model_input.get("prompt_speech_feat_len")
+    if prompt_speech_feat_len is None:
+        prompt_speech_feat_len = _empty_length_tensor(source_speech_token)
+    embedding = model_input.get("flow_embedding")
+    if embedding is None:
+        embedding = _default_flow_embedding(flow_module, source_speech_token)
+    return build_flow_inputs(
+        flow_module=flow_module,
+        source_speech_token=source_speech_token,
+        source_speech_token_len=torch.tensor(
+            [source_speech_token.shape[1]], dtype=torch.int32, device=source_speech_token.device
+        ),
+        prompt_speech_token=prompt_speech_token,
+        prompt_speech_token_len=prompt_speech_token_len,
+        prompt_speech_feat=prompt_speech_feat,
+        prompt_speech_feat_len=prompt_speech_feat_len,
+        embedding=embedding,
+    )
+
+
+def prepare_tt_flow_condition(condition: torch.Tensor, mesh_device, *, dtype=None, memory_config=None):
+    import ttnn  # noqa: PLC0415
+
+    return ttnn.from_torch(
+        condition,
+        device=mesh_device,
+        dtype=dtype or ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=memory_config or ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def preprocess_tt_flow_bridge_parameters(parameters: CosyVoiceFlowBridgeParameters, *, dtype):
+    from ttnn.model_preprocessing import preprocess_linear_bias, preprocess_linear_weight  # noqa: PLC0415
+
+    import ttnn  # noqa: PLC0415
+
+    return {
+        "input_embedding_weight": ttnn.from_torch(
+            parameters.input_embedding_weight.unsqueeze(0).unsqueeze(0),
+            dtype=dtype,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        ),
+        "speaker_weight": preprocess_linear_weight(parameters.speaker_weight, dtype=dtype),
+        "speaker_bias": preprocess_linear_bias(parameters.speaker_bias, dtype=dtype),
+        "encoder_proj_weight": preprocess_linear_weight(parameters.encoder_proj_weight, dtype=dtype),
+        "encoder_proj_bias": preprocess_linear_bias(parameters.encoder_proj_bias, dtype=dtype),
+    }
+
+
+def preprocess_tt_flow_encoder_layer_parameters(parameters: CosyVoiceFlowEncoderLayerParameters, *, dtype):
+    from ttnn.model_preprocessing import (  # noqa: PLC0415
+        preprocess_layernorm_parameter,
+        preprocess_linear_bias,
+        preprocess_linear_weight,
+    )
+
+    import ttnn  # noqa: PLC0415
+
+    return {
+        "q_weight": preprocess_linear_weight(parameters.q_weight, dtype=dtype),
+        "q_bias": preprocess_linear_bias(parameters.q_bias, dtype=dtype),
+        "k_weight": preprocess_linear_weight(parameters.k_weight, dtype=dtype),
+        "k_bias": preprocess_linear_bias(parameters.k_bias, dtype=dtype),
+        "v_weight": preprocess_linear_weight(parameters.v_weight, dtype=dtype),
+        "v_bias": preprocess_linear_bias(parameters.v_bias, dtype=dtype),
+        "out_weight": preprocess_linear_weight(parameters.out_weight, dtype=dtype),
+        "out_bias": preprocess_linear_bias(parameters.out_bias, dtype=dtype),
+        "pos_weight": preprocess_linear_weight(parameters.pos_weight, dtype=dtype),
+        "pos_bias_u": ttnn.from_torch(
+            parameters.pos_bias_u.unsqueeze(0).unsqueeze(0),
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        "pos_bias_v": ttnn.from_torch(
+            parameters.pos_bias_v.unsqueeze(0).unsqueeze(0),
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        "ffn_w1_weight": preprocess_linear_weight(parameters.ffn_w1_weight, dtype=dtype),
+        "ffn_w1_bias": preprocess_linear_bias(parameters.ffn_w1_bias, dtype=dtype),
+        "ffn_w2_weight": preprocess_linear_weight(parameters.ffn_w2_weight, dtype=dtype),
+        "ffn_w2_bias": preprocess_linear_bias(parameters.ffn_w2_bias, dtype=dtype),
+        "norm_mha_weight": preprocess_layernorm_parameter(parameters.norm_mha_weight, dtype=dtype),
+        "norm_mha_bias": preprocess_layernorm_parameter(parameters.norm_mha_bias, dtype=dtype),
+        "norm_ff_weight": preprocess_layernorm_parameter(parameters.norm_ff_weight, dtype=dtype),
+        "norm_ff_bias": preprocess_layernorm_parameter(parameters.norm_ff_bias, dtype=dtype),
+        "norm_epsilon": 1e-12,
+    }
+
+
+def preprocess_tt_flow_encoder_output_parameters(parameters: CosyVoiceFlowEncoderOutputParameters, *, dtype):
+    from ttnn.model_preprocessing import preprocess_layernorm_parameter  # noqa: PLC0415
+
+    return {
+        "after_norm_weight": preprocess_layernorm_parameter(parameters.after_norm_weight, dtype=dtype),
+        "after_norm_bias": preprocess_layernorm_parameter(parameters.after_norm_bias, dtype=dtype),
+        "after_norm_epsilon": parameters.epsilon,
+    }
+
+
+def preprocess_tt_flow_length_regulator_parameters(parameters: CosyVoiceFlowLengthRegulatorParameters, *, dtype):
+    from ttnn.model_preprocessing import preprocess_linear_bias, preprocess_linear_weight  # noqa: PLC0415
+
+    import ttnn  # noqa: PLC0415
+
+    hidden_layers = []
+    for layer in parameters.hidden_layers:
+        hidden_layers.append(
+            {
+                "conv_weight": preprocess_linear_weight(
+                    layer.conv_weight.reshape(layer.conv_weight.shape[0], -1),
+                    dtype=dtype,
+                ),
+                "conv_bias": preprocess_linear_bias(layer.conv_bias, dtype=dtype),
+                "norm_weight": ttnn.from_torch(
+                    ttnn.create_group_norm_weight_bias_rm(
+                        layer.norm_weight,
+                        num_channels=layer.conv_weight.shape[0],
+                        num_cores_x=1,
+                    ),
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                ),
+                "norm_bias": ttnn.from_torch(
+                    ttnn.create_group_norm_weight_bias_rm(
+                        layer.norm_bias,
+                        num_channels=layer.conv_weight.shape[0],
+                        num_cores_x=1,
+                    ),
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                ),
+                "kernel_size": layer.kernel_size,
+                "padding": layer.padding,
+            }
+        )
+    return {
+        "hidden_layers": tuple(hidden_layers),
+        "output_weight": preprocess_linear_weight(
+            parameters.output_weight.reshape(parameters.output_weight.shape[0], -1),
+            dtype=dtype,
+        ),
+        "output_bias": preprocess_linear_bias(parameters.output_bias, dtype=dtype),
+        "num_groups": parameters.num_groups,
+        "epsilon": parameters.epsilon,
+    }
+
+
+def interpolate_length_regulator_hidden_states(
+    prompt_hidden_states: torch.Tensor,
+    decode_hidden_states: torch.Tensor,
+    prompt_mel_length: int,
+    decode_mel_length: int,
+    *,
+    input_frame_rate: int = 50,
+    sample_rate: int = 22050,
+    hop_length: int = 256,
+) -> torch.Tensor:
+    segment_mel_length = int(20 / input_frame_rate * sample_rate / hop_length)
+    if decode_hidden_states.shape[1] > 40:
+        decode_head = F.interpolate(
+            decode_hidden_states[:, :20].transpose(1, 2).contiguous(),
+            size=segment_mel_length,
+            mode="linear",
+        )
+        decode_mid = F.interpolate(
+            decode_hidden_states[:, 20:-20].transpose(1, 2).contiguous(),
+            size=decode_mel_length - segment_mel_length * 2,
+            mode="linear",
+        )
+        decode_tail = F.interpolate(
+            decode_hidden_states[:, -20:].transpose(1, 2).contiguous(),
+            size=segment_mel_length,
+            mode="linear",
+        )
+        decode_hidden_states = torch.cat([decode_head, decode_mid, decode_tail], dim=2)
+    else:
+        decode_hidden_states = F.interpolate(
+            decode_hidden_states.transpose(1, 2).contiguous(),
+            size=decode_mel_length,
+            mode="linear",
+        )
+    if prompt_hidden_states.shape[1] != 0:
+        prompt_hidden_states = F.interpolate(
+            prompt_hidden_states.transpose(1, 2).contiguous(),
+            size=prompt_mel_length,
+            mode="linear",
+        )
+        return torch.cat([prompt_hidden_states, decode_hidden_states], dim=2)
+    return decode_hidden_states
+
+
+def apply_flow_length_regulator_torch(
+    prompt_hidden_states: torch.Tensor,
+    decode_hidden_states: torch.Tensor,
+    prompt_mel_length: int,
+    decode_mel_length: int,
+    parameters: CosyVoiceFlowLengthRegulatorParameters,
+    *,
+    input_frame_rate: int = 50,
+) -> tuple[torch.Tensor, int]:
+    hidden_states = interpolate_length_regulator_hidden_states(
+        prompt_hidden_states,
+        decode_hidden_states,
+        prompt_mel_length,
+        decode_mel_length,
+        input_frame_rate=input_frame_rate,
+    )
+    for layer in parameters.hidden_layers:
+        hidden_states = F.conv1d(
+            hidden_states,
+            layer.conv_weight,
+            layer.conv_bias,
+            stride=1,
+            padding=layer.padding,
+        )
+        hidden_states = F.group_norm(
+            hidden_states,
+            num_groups=parameters.num_groups,
+            weight=layer.norm_weight,
+            bias=layer.norm_bias,
+            eps=parameters.epsilon,
+        )
+        hidden_states = F.mish(hidden_states)
+    hidden_states = F.conv1d(hidden_states, parameters.output_weight, parameters.output_bias, stride=1, padding=0)
+    return hidden_states.transpose(1, 2).contiguous(), prompt_mel_length + decode_mel_length
+
+
+def apply_flow_encoder_layer_torch(
+    hidden_states: torch.Tensor,
+    positional_embedding: torch.Tensor,
+    parameters: CosyVoiceFlowEncoderLayerParameters,
+    *,
+    num_heads: int = 8,
+) -> torch.Tensor:
+    head_dim = hidden_states.shape[-1] // num_heads
+
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm_mha_weight,
+        parameters.norm_mha_bias,
+        1e-12,
+    )
+    q = F.linear(hidden_states, parameters.q_weight, parameters.q_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    k = F.linear(hidden_states, parameters.k_weight, parameters.k_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    v = F.linear(hidden_states, parameters.v_weight, parameters.v_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+
+    pos = F.linear(positional_embedding, parameters.pos_weight, None).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    q_t = q.transpose(1, 2)
+    q_with_bias_u = (q_t + parameters.pos_bias_u).transpose(1, 2)
+    q_with_bias_v = (q_t + parameters.pos_bias_v).transpose(1, 2)
+
+    matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+    matrix_bd = torch.matmul(q_with_bias_v, pos.transpose(-2, -1))
+    if matrix_ac.shape != matrix_bd.shape:
+        matrix_bd = _rel_shift_torch(matrix_bd)
+    scores = (matrix_ac + matrix_bd) / torch.sqrt(torch.tensor(float(head_dim), device=hidden_states.device))
+    attention = torch.softmax(scores, dim=-1)
+    attention_output = torch.matmul(attention, v).transpose(1, 2).contiguous().view(1, -1, num_heads * head_dim)
+    attention_output = F.linear(attention_output, parameters.out_weight, parameters.out_bias)
+    hidden_states = residual + attention_output
+
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm_ff_weight,
+        parameters.norm_ff_bias,
+        1e-12,
+    )
+    hidden_states = F.linear(hidden_states, parameters.ffn_w1_weight, parameters.ffn_w1_bias)
+    hidden_states = F.silu(hidden_states)
+    hidden_states = F.linear(hidden_states, parameters.ffn_w2_weight, parameters.ffn_w2_bias)
+    return residual + hidden_states
+
+
+def _rel_shift_torch(x: torch.Tensor) -> torch.Tensor:
+    zero_pad = torch.zeros((*x.shape[:-1], 1), dtype=x.dtype, device=x.device)
+    x_padded = torch.cat([zero_pad, x], dim=-1)
+    x_padded = x_padded.view(x.size(0), x.size(1), x.size(3) + 1, x.size(2))
+    shifted = x_padded[:, :, 1:].view_as(x)
+    return shifted[:, :, :, : x.size(-1) // 2 + 1]
+
+
+class CosyVoiceTTFlowBridge:
+    def __init__(self, flow_module: Any, mesh_device, *, dtype=None, memory_config=None):
+        import ttnn  # noqa: PLC0415
+
+        self.ttnn = ttnn
+        self.flow_module = flow_module
+        self.mesh_device = mesh_device
+        self.dtype = dtype or ttnn.bfloat16
+        self.memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+        parameters = preprocess_tt_flow_bridge_parameters(
+            extract_flow_bridge_parameters(flow_module.state_dict()),
+            dtype=self.dtype,
+        )
+        self.parameters = self._move_parameters_to_device(parameters)
+
+    def _move_parameters_to_device(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        moved: dict[str, Any] = {}
+        for name, value in parameters.items():
+            if isinstance(value, self.ttnn.Tensor):
+                moved[name] = self.ttnn.to_device(value, self.mesh_device, memory_config=self.memory_config)
+            else:
+                moved[name] = value
+        return moved
+
+    def _torch_hidden_to_tt(self, hidden_states: torch.Tensor):
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.unsqueeze(1)
+        return self.ttnn.from_torch(
+            hidden_states,
+            device=self.mesh_device,
+            dtype=self.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+
+    def embed_tokens(self, token: torch.Tensor, token_len: torch.Tensor) -> torch.Tensor:
+        token_tt = self.ttnn.from_torch(
+            token.reshape(1, 1, 1, token.shape[1]).to(torch.int32),
+            device=self.mesh_device,
+            dtype=self.ttnn.uint32,
+            layout=self.ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=self.ttnn.DRAM_MEMORY_CONFIG,
+        )
+        embedded = self.ttnn.embedding(
+            token_tt,
+            self.parameters["input_embedding_weight"],
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        embedded = self.ttnn.reshape(embedded, (1, 1, token.shape[1], self.flow_module.input_size))
+        if int(token_len.item()) != int(token.shape[1]):
+            mask = (torch.arange(token.shape[1], device=token.device).unsqueeze(0) < token_len.unsqueeze(1)).unsqueeze(
+                -1
+            )
+            mask_tt = self._torch_hidden_to_tt(mask.to(dtype=torch.float32))
+            embedded = self.ttnn.mul(embedded, mask_tt, memory_config=self.memory_config)
+        return self.ttnn.to_torch(embedded).squeeze(0).float()
+
+    def project_speaker_embedding(self, embedding: torch.Tensor) -> torch.Tensor:
+        normalized = F.normalize(embedding, dim=1)
+        projected = self.ttnn.linear(
+            self._torch_hidden_to_tt(normalized),
+            self.parameters["speaker_weight"],
+            bias=self.parameters["speaker_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        return self.ttnn.to_torch(projected).squeeze(0).squeeze(0).float()
+
+    def project_encoder_output(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        projected = self.ttnn.linear(
+            self._torch_hidden_to_tt(hidden_states),
+            self.parameters["encoder_proj_weight"],
+            bias=self.parameters["encoder_proj_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        return self.ttnn.to_torch(projected).squeeze(0).float()
+
+
+class CosyVoiceTTFlowEncoder:
+    def __init__(self, flow_module: Any, mesh_device, *, dtype=None, memory_config=None):
+        import ttnn  # noqa: PLC0415
+
+        self.ttnn = ttnn
+        self.flow_module = flow_module
+        self.mesh_device = mesh_device
+        self.dtype = dtype or ttnn.bfloat16
+        self.memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+        self.num_heads = int(flow_module.encoder.encoders[0].self_attn.h)
+        self.head_dim = int(flow_module.encoder.encoders[0].self_attn.d_k)
+        self.hidden_dim = self.num_heads * self.head_dim
+        state_dict = flow_module.state_dict()
+        self.layer_parameters = [
+            self._move_parameters_to_device(
+                preprocess_tt_flow_encoder_layer_parameters(
+                    extract_flow_encoder_layer_parameters(state_dict, layer_num=layer_idx),
+                    dtype=self.dtype,
+                )
+            )
+            for layer_idx in range(len(flow_module.encoder.encoders))
+        ]
+        self.output_parameters = self._move_parameters_to_device(
+            preprocess_tt_flow_encoder_output_parameters(
+                extract_flow_encoder_output_parameters(state_dict),
+                dtype=self.dtype,
+            )
+        )
+
+    def _move_parameters_to_device(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        moved: dict[str, Any] = {}
+        for name, value in parameters.items():
+            if isinstance(value, self.ttnn.Tensor):
+                moved[name] = self.ttnn.to_device(value, self.mesh_device, memory_config=self.memory_config)
+            else:
+                moved[name] = value
+        return moved
+
+    def _torch_hidden_to_tt(self, hidden_states: torch.Tensor):
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.unsqueeze(1)
+        return self.ttnn.from_torch(
+            hidden_states,
+            device=self.mesh_device,
+            dtype=self.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+
+    def _reshape_positional_heads(self, positional_embedding, parameters):
+        position_seq_len = positional_embedding.shape[2]
+        positional_embedding = self.ttnn.linear(
+            positional_embedding,
+            parameters["pos_weight"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        positional_embedding = self.ttnn.reshape(
+            positional_embedding, (1, position_seq_len, self.num_heads, self.head_dim)
+        )
+        return self.ttnn.transpose(positional_embedding, 1, 2)
+
+    def _rel_shift(self, x):
+        zero_pad = self.ttnn.zeros(
+            (x.shape[0], x.shape[1], x.shape[2], 1),
+            device=self.mesh_device,
+            dtype=x.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+        x_padded = self.ttnn.concat([zero_pad, x], dim=-1, memory_config=self.memory_config)
+        x_padded = self.ttnn.reshape(x_padded, (x.shape[0], x.shape[1], x.shape[3] + 1, x.shape[2]))
+        shifted = self.ttnn.slice(x_padded, (0, 0, 1, 0), (x.shape[0], x.shape[1], x.shape[3] + 1, x.shape[2]))
+        shifted = self.ttnn.reshape(shifted, tuple(x.shape))
+        return self.ttnn.slice(shifted, (0, 0, 0, 0), (x.shape[0], x.shape[1], x.shape[2], x.shape[3] // 2 + 1))
+
+    def _apply_layer(self, hidden_states, positional_embedding, parameters):
+        residual = hidden_states
+        hidden_states = self.ttnn.layer_norm(
+            hidden_states,
+            weight=parameters["norm_mha_weight"],
+            bias=parameters["norm_mha_bias"],
+            epsilon=parameters["norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        q = self.ttnn.linear(
+            hidden_states,
+            parameters["q_weight"],
+            bias=parameters["q_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        k = self.ttnn.linear(
+            hidden_states,
+            parameters["k_weight"],
+            bias=parameters["k_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        v = self.ttnn.linear(
+            hidden_states,
+            parameters["v_weight"],
+            bias=parameters["v_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        qkv = self.ttnn.concat([q, k, v], dim=-1, memory_config=self.memory_config)
+        q_heads, k_heads, v_heads = self.ttnn.experimental.nlp_create_qkv_heads(
+            qkv,
+            memory_config=self.memory_config,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_heads,
+            transpose_k_heads=False,
+        )
+        positional_heads = self._reshape_positional_heads(positional_embedding, parameters)
+        q_transposed = self.ttnn.transpose(q_heads, 1, 2)
+        q_with_bias_u = self.ttnn.add(q_transposed, parameters["pos_bias_u"], memory_config=self.memory_config)
+        q_with_bias_v = self.ttnn.add(q_transposed, parameters["pos_bias_v"], memory_config=self.memory_config)
+        q_with_bias_u = self.ttnn.transpose(q_with_bias_u, 1, 2)
+        q_with_bias_v = self.ttnn.transpose(q_with_bias_v, 1, 2)
+        matrix_ac = self.ttnn.matmul(
+            q_with_bias_u, self.ttnn.transpose(k_heads, -2, -1), memory_config=self.memory_config
+        )
+        matrix_bd = self.ttnn.matmul(
+            q_with_bias_v, self.ttnn.transpose(positional_heads, -2, -1), memory_config=self.memory_config
+        )
+        if tuple(matrix_ac.shape) != tuple(matrix_bd.shape):
+            matrix_bd = self._rel_shift(matrix_bd)
+        scores = self.ttnn.mul(
+            self.ttnn.add(matrix_ac, matrix_bd, memory_config=self.memory_config),
+            1.0 / torch.sqrt(torch.tensor(float(self.head_dim))).item(),
+        )
+        attention = self.ttnn.softmax_in_place(scores)
+        attention_output = self.ttnn.matmul(attention, v_heads, memory_config=self.memory_config)
+        attention_output = self.ttnn.transpose(attention_output, 1, 2)
+        attention_output = self.ttnn.reshape(attention_output, (1, 1, attention_output.shape[1], self.hidden_dim))
+        attention_output = self.ttnn.linear(
+            attention_output,
+            parameters["out_weight"],
+            bias=parameters["out_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        hidden_states = self.ttnn.add(residual, attention_output, memory_config=self.memory_config)
+
+        residual = hidden_states
+        hidden_states = self.ttnn.layer_norm(
+            hidden_states,
+            weight=parameters["norm_ff_weight"],
+            bias=parameters["norm_ff_bias"],
+            epsilon=parameters["norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        hidden_states = self.ttnn.linear(
+            hidden_states,
+            parameters["ffn_w1_weight"],
+            bias=parameters["ffn_w1_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        hidden_states = self.ttnn.silu(hidden_states, memory_config=self.memory_config)
+        hidden_states = self.ttnn.linear(
+            hidden_states,
+            parameters["ffn_w2_weight"],
+            bias=parameters["ffn_w2_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        return self.ttnn.add(residual, hidden_states, memory_config=self.memory_config)
+
+    def encode(self, token_embedding: torch.Tensor, token_len: torch.Tensor) -> torch.Tensor:
+        masks = torch.ones(
+            (token_embedding.shape[0], 1, token_embedding.shape[1]), dtype=torch.bool, device=token_embedding.device
+        )
+        embedded_hidden, positional_embedding, _ = self.flow_module.encoder.embed(token_embedding, masks)
+        hidden_tt = self._torch_hidden_to_tt(embedded_hidden)
+        pos_tt = self._torch_hidden_to_tt(positional_embedding)
+        for parameters in self.layer_parameters:
+            hidden_tt = self._apply_layer(hidden_tt, pos_tt, parameters)
+        hidden_tt = self.ttnn.layer_norm(
+            hidden_tt,
+            weight=self.output_parameters["after_norm_weight"],
+            bias=self.output_parameters["after_norm_bias"],
+            epsilon=self.output_parameters["after_norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        return self.ttnn.to_torch(hidden_tt).squeeze(0).float()
+
+
+class CosyVoiceTTFlowLengthRegulator:
+    def __init__(self, flow_module: Any, mesh_device, *, dtype=None, memory_config=None):
+        import ttnn  # noqa: PLC0415
+
+        self.ttnn = ttnn
+        self.flow_module = flow_module
+        self.mesh_device = mesh_device
+        self.dtype = dtype or ttnn.bfloat16
+        self.memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+        self.input_frame_rate = int(flow_module.input_frame_rate)
+        self.group_norm_core_grid = ttnn.CoreGrid(y=1, x=1)
+        self.group_norm_input_mask = ttnn.to_device(
+            ttnn.create_group_norm_input_mask(
+                num_channel=flow_module.output_size,
+                num_groups=1,
+                num_cores_across_channel=1,
+                data_type=ttnn.bfloat16,
+            ),
+            mesh_device,
+        )
+        self.parameters = self._move_parameters_to_device(
+            preprocess_tt_flow_length_regulator_parameters(
+                extract_flow_length_regulator_parameters(flow_module.state_dict()),
+                dtype=self.dtype,
+            )
+        )
+
+    def _move_parameters_to_device(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        moved: dict[str, Any] = {
+            "hidden_layers": [],
+            "num_groups": parameters["num_groups"],
+            "epsilon": parameters["epsilon"],
+        }
+        for layer in parameters["hidden_layers"]:
+            moved_layer: dict[str, Any] = {}
+            for name, value in layer.items():
+                if isinstance(value, self.ttnn.Tensor):
+                    moved_layer[name] = self.ttnn.to_device(value, self.mesh_device, memory_config=self.memory_config)
+                else:
+                    moved_layer[name] = value
+            moved["hidden_layers"].append(moved_layer)
+        moved["output_weight"] = self.ttnn.to_device(
+            parameters["output_weight"], self.mesh_device, memory_config=self.memory_config
+        )
+        moved["output_bias"] = self.ttnn.to_device(
+            parameters["output_bias"], self.mesh_device, memory_config=self.memory_config
+        )
+        return moved
+
+    def _torch_nlc_to_tt(self, hidden_states: torch.Tensor):
+        return self.ttnn.from_torch(
+            hidden_states.unsqueeze(1).contiguous(),
+            device=self.mesh_device,
+            dtype=self.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+
+    def _tt_to_torch_nlc(self, hidden_states) -> torch.Tensor:
+        return self.ttnn.to_torch(hidden_states).squeeze(1).float()
+
+    def _extract_temporal_patches(self, hidden_states: torch.Tensor, *, kernel_size: int, padding: int) -> torch.Tensor:
+        hidden_states = F.pad(hidden_states, (padding, padding))
+        hidden_states = hidden_states.unfold(dimension=2, size=kernel_size, step=1)
+        return hidden_states.permute(0, 2, 1, 3).reshape(
+            hidden_states.shape[0], -1, hidden_states.shape[1] * kernel_size
+        )
+
+    def _apply_linear_conv(self, hidden_states: torch.Tensor, *, weight, bias) -> torch.Tensor:
+        return self.ttnn.linear(
+            self._torch_nlc_to_tt(hidden_states),
+            weight,
+            bias=bias,
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+
+    def inference(
+        self,
+        prompt_hidden_states: torch.Tensor,
+        decode_hidden_states: torch.Tensor,
+        prompt_mel_length: int,
+        decode_mel_length: int,
+        input_frame_rate: int | None = None,
+    ) -> tuple[torch.Tensor, int]:
+        hidden_states = interpolate_length_regulator_hidden_states(
+            prompt_hidden_states,
+            decode_hidden_states,
+            prompt_mel_length,
+            decode_mel_length,
+            input_frame_rate=input_frame_rate or self.input_frame_rate,
+        )
+        hidden_states = hidden_states.contiguous()
+        for layer in self.parameters["hidden_layers"]:
+            hidden_states_tt = self._apply_linear_conv(
+                self._extract_temporal_patches(
+                    hidden_states,
+                    kernel_size=layer["kernel_size"],
+                    padding=layer["padding"],
+                ),
+                weight=layer["conv_weight"],
+                bias=layer["conv_bias"],
+            )
+            hidden_states_tt = self.ttnn.group_norm(
+                hidden_states_tt,
+                num_groups=self.parameters["num_groups"],
+                input_mask=self.group_norm_input_mask,
+                weight=layer["norm_weight"],
+                bias=layer["norm_bias"],
+                epsilon=self.parameters["epsilon"],
+                memory_config=self.memory_config,
+                core_grid=self.group_norm_core_grid,
+                inplace=False,
+                output_layout=self.ttnn.TILE_LAYOUT,
+            )
+            hidden_states_tt = self.ttnn.mish(hidden_states_tt, memory_config=self.memory_config)
+            hidden_states = self._tt_to_torch_nlc(hidden_states_tt).transpose(1, 2).contiguous()
+        hidden_states_tt = self._apply_linear_conv(
+            hidden_states.transpose(1, 2).contiguous(),
+            weight=self.parameters["output_weight"],
+            bias=self.parameters["output_bias"],
+        )
+        return self._tt_to_torch_nlc(hidden_states_tt), prompt_mel_length + decode_mel_length
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderBlockParameters:
+    conv_weight: torch.Tensor
+    conv_bias: torch.Tensor
+    norm_weight: torch.Tensor
+    norm_bias: torch.Tensor
+    kernel_size: int
+    padding: int
+    num_groups: int = 8
+    epsilon: float = 1e-5
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderResnetBlockParameters:
+    time_mlp_weight: torch.Tensor
+    time_mlp_bias: torch.Tensor
+    block1: CosyVoiceFlowDecoderBlockParameters
+    block2: CosyVoiceFlowDecoderBlockParameters
+    res_conv_weight: torch.Tensor
+    res_conv_bias: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderTransformerBlockParameters:
+    norm1_weight: torch.Tensor
+    norm1_bias: torch.Tensor
+    attn_q_weight: torch.Tensor
+    attn_k_weight: torch.Tensor
+    attn_v_weight: torch.Tensor
+    attn_out_weight: torch.Tensor
+    attn_out_bias: torch.Tensor
+    norm3_weight: torch.Tensor
+    norm3_bias: torch.Tensor
+    ff_proj_weight: torch.Tensor
+    ff_proj_bias: torch.Tensor
+    ff_activation: str
+    ff_alpha: torch.Tensor | None
+    ff_beta: torch.Tensor | None
+    ff_out_weight: torch.Tensor
+    ff_out_bias: torch.Tensor
+    num_heads: int
+    head_dim: int
+    epsilon: float = 1e-5
+    snake_alpha_logscale: bool = True
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderDownBlockParameters:
+    resnet: CosyVoiceFlowDecoderResnetBlockParameters
+    transformer_blocks: tuple[CosyVoiceFlowDecoderTransformerBlockParameters, ...]
+    sample_weight: torch.Tensor
+    sample_bias: torch.Tensor
+    sample_stride: int
+    sample_padding: int
+    sample_transpose: bool = False
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderMidBlockParameters:
+    resnet: CosyVoiceFlowDecoderResnetBlockParameters
+    transformer_blocks: tuple[CosyVoiceFlowDecoderTransformerBlockParameters, ...]
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderUpBlockParameters:
+    resnet: CosyVoiceFlowDecoderResnetBlockParameters
+    transformer_blocks: tuple[CosyVoiceFlowDecoderTransformerBlockParameters, ...]
+    sample_weight: torch.Tensor
+    sample_bias: torch.Tensor
+    sample_stride: int
+    sample_padding: int
+    sample_transpose: bool = False
+
+
+@dataclass(frozen=True)
+class CosyVoiceFlowDecoderParameters:
+    time_linear_1_weight: torch.Tensor
+    time_linear_1_bias: torch.Tensor
+    time_linear_2_weight: torch.Tensor
+    time_linear_2_bias: torch.Tensor
+    down_blocks: tuple[CosyVoiceFlowDecoderDownBlockParameters, ...]
+    mid_blocks: tuple[CosyVoiceFlowDecoderMidBlockParameters, ...]
+    up_blocks: tuple[CosyVoiceFlowDecoderUpBlockParameters, ...]
+    final_block: CosyVoiceFlowDecoderBlockParameters
+    final_proj_weight: torch.Tensor
+    final_proj_bias: torch.Tensor
+    in_channels: int
+    out_channels: int
+    num_heads: int
+    head_dim: int
+    t_scheduler: str
+    inference_cfg_rate: float
+    time_scale: float = 1000.0
+
+
+def _extract_flow_decoder_block_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str,
+    kernel_size: int,
+    padding: int,
+    num_groups: int = 8,
+    epsilon: float = 1e-5,
+) -> CosyVoiceFlowDecoderBlockParameters:
+    prefix = prefix.rstrip(".")
+    return CosyVoiceFlowDecoderBlockParameters(
+        conv_weight=state_dict[f"{prefix}.block.0.weight"],
+        conv_bias=state_dict[f"{prefix}.block.0.bias"],
+        norm_weight=state_dict[f"{prefix}.block.1.weight"],
+        norm_bias=state_dict[f"{prefix}.block.1.bias"],
+        kernel_size=kernel_size,
+        padding=padding,
+        num_groups=num_groups,
+        epsilon=epsilon,
+    )
+
+
+def _extract_flow_decoder_resnet_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str,
+    num_groups: int = 8,
+    epsilon: float = 1e-5,
+) -> CosyVoiceFlowDecoderResnetBlockParameters:
+    prefix = prefix.rstrip(".")
+    return CosyVoiceFlowDecoderResnetBlockParameters(
+        time_mlp_weight=state_dict[f"{prefix}.mlp.1.weight"],
+        time_mlp_bias=state_dict[f"{prefix}.mlp.1.bias"],
+        block1=_extract_flow_decoder_block_parameters(
+            state_dict,
+            prefix=f"{prefix}.block1",
+            kernel_size=3,
+            padding=1,
+            num_groups=num_groups,
+            epsilon=epsilon,
+        ),
+        block2=_extract_flow_decoder_block_parameters(
+            state_dict,
+            prefix=f"{prefix}.block2",
+            kernel_size=3,
+            padding=1,
+            num_groups=num_groups,
+            epsilon=epsilon,
+        ),
+        res_conv_weight=state_dict[f"{prefix}.res_conv.weight"],
+        res_conv_bias=state_dict[f"{prefix}.res_conv.bias"],
+    )
+
+
+def _extract_flow_decoder_transformer_block_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str,
+    num_heads: int,
+    transformer_block_module: Any,
+    epsilon: float = 1e-5,
+) -> CosyVoiceFlowDecoderTransformerBlockParameters:
+    prefix = prefix.rstrip(".")
+    attn_q_weight = state_dict[f"{prefix}.attn1.to_q.weight"]
+    inner_dim = int(attn_q_weight.shape[0])
+    activation_module = transformer_block_module.ff.net[0]
+    activation_name = type(activation_module).__name__.lower()
+    ff_activation = "gelu"
+    ff_alpha = None
+    ff_beta = None
+    if activation_name == "snakebeta":
+        ff_activation = "snakebeta"
+        ff_alpha = state_dict[f"{prefix}.ff.net.0.alpha"]
+        ff_beta = state_dict[f"{prefix}.ff.net.0.beta"]
+    elif activation_name == "geglu":
+        ff_activation = "geglu"
+    elif activation_name == "approximategelu":
+        ff_activation = "gelu_approximate"
+    return CosyVoiceFlowDecoderTransformerBlockParameters(
+        norm1_weight=state_dict[f"{prefix}.norm1.weight"],
+        norm1_bias=state_dict[f"{prefix}.norm1.bias"],
+        attn_q_weight=attn_q_weight,
+        attn_k_weight=state_dict[f"{prefix}.attn1.to_k.weight"],
+        attn_v_weight=state_dict[f"{prefix}.attn1.to_v.weight"],
+        attn_out_weight=state_dict[f"{prefix}.attn1.to_out.0.weight"],
+        attn_out_bias=state_dict[f"{prefix}.attn1.to_out.0.bias"],
+        norm3_weight=state_dict[f"{prefix}.norm3.weight"],
+        norm3_bias=state_dict[f"{prefix}.norm3.bias"],
+        ff_proj_weight=state_dict[f"{prefix}.ff.net.0.proj.weight"],
+        ff_proj_bias=state_dict[f"{prefix}.ff.net.0.proj.bias"],
+        ff_activation=ff_activation,
+        ff_alpha=ff_alpha,
+        ff_beta=ff_beta,
+        ff_out_weight=state_dict[f"{prefix}.ff.net.2.weight"],
+        ff_out_bias=state_dict[f"{prefix}.ff.net.2.bias"],
+        num_heads=num_heads,
+        head_dim=inner_dim // num_heads,
+        epsilon=epsilon,
+    )
+
+
+def extract_flow_decoder_parameters(
+    flow_decoder_module: Any,
+    *,
+    prefix: str = "estimator",
+    num_groups: int = 8,
+    epsilon: float = 1e-5,
+) -> CosyVoiceFlowDecoderParameters:
+    state_dict = flow_decoder_module.state_dict()
+    estimator = flow_decoder_module.estimator
+    prefix = prefix.rstrip(".")
+    num_heads = int(estimator.down_blocks[0][1][0].attn1.heads)
+
+    down_blocks: list[CosyVoiceFlowDecoderDownBlockParameters] = []
+    for block_idx, (_, transformer_blocks, sample) in enumerate(estimator.down_blocks):
+        block_prefix = f"{prefix}.down_blocks.{block_idx}"
+        sample_prefix = f"{block_prefix}.2"
+        if hasattr(sample, "conv"):
+            sample_weight = state_dict[f"{sample_prefix}.conv.weight"]
+            sample_bias = state_dict[f"{sample_prefix}.conv.bias"]
+            sample_stride = int(sample.conv.stride[0])
+            sample_padding = int(sample.conv.padding[0])
+        else:
+            sample_weight = state_dict[f"{sample_prefix}.weight"]
+            sample_bias = state_dict[f"{sample_prefix}.bias"]
+            sample_stride = int(sample.stride[0])
+            sample_padding = int(sample.padding[0])
+        down_blocks.append(
+            CosyVoiceFlowDecoderDownBlockParameters(
+                resnet=_extract_flow_decoder_resnet_parameters(
+                    state_dict,
+                    prefix=f"{block_prefix}.0",
+                    num_groups=num_groups,
+                    epsilon=epsilon,
+                ),
+                transformer_blocks=tuple(
+                    _extract_flow_decoder_transformer_block_parameters(
+                        state_dict,
+                        prefix=f"{block_prefix}.1.{transformer_idx}",
+                        num_heads=num_heads,
+                        transformer_block_module=transformer_blocks[transformer_idx],
+                        epsilon=epsilon,
+                    )
+                    for transformer_idx in range(len(transformer_blocks))
+                ),
+                sample_weight=sample_weight,
+                sample_bias=sample_bias,
+                sample_stride=sample_stride,
+                sample_padding=sample_padding,
+                sample_transpose=False,
+            )
+        )
+
+    mid_blocks: list[CosyVoiceFlowDecoderMidBlockParameters] = []
+    for block_idx, (_, transformer_blocks) in enumerate(estimator.mid_blocks):
+        block_prefix = f"{prefix}.mid_blocks.{block_idx}"
+        mid_blocks.append(
+            CosyVoiceFlowDecoderMidBlockParameters(
+                resnet=_extract_flow_decoder_resnet_parameters(
+                    state_dict,
+                    prefix=f"{block_prefix}.0",
+                    num_groups=num_groups,
+                    epsilon=epsilon,
+                ),
+                transformer_blocks=tuple(
+                    _extract_flow_decoder_transformer_block_parameters(
+                        state_dict,
+                        prefix=f"{block_prefix}.1.{transformer_idx}",
+                        num_heads=num_heads,
+                        transformer_block_module=transformer_blocks[transformer_idx],
+                        epsilon=epsilon,
+                    )
+                    for transformer_idx in range(len(transformer_blocks))
+                ),
+            )
+        )
+
+    up_blocks: list[CosyVoiceFlowDecoderUpBlockParameters] = []
+    for block_idx, (_, transformer_blocks, sample) in enumerate(estimator.up_blocks):
+        block_prefix = f"{prefix}.up_blocks.{block_idx}"
+        sample_prefix = f"{block_prefix}.2"
+        if hasattr(sample, "conv"):
+            sample_weight = state_dict[f"{sample_prefix}.conv.weight"]
+            sample_bias = state_dict[f"{sample_prefix}.conv.bias"]
+            sample_stride = int(sample.conv.stride[0])
+            sample_padding = int(sample.conv.padding[0])
+            sample_transpose = True
+        else:
+            sample_weight = state_dict[f"{sample_prefix}.weight"]
+            sample_bias = state_dict[f"{sample_prefix}.bias"]
+            sample_stride = int(sample.stride[0])
+            sample_padding = int(sample.padding[0])
+            sample_transpose = False
+        up_blocks.append(
+            CosyVoiceFlowDecoderUpBlockParameters(
+                resnet=_extract_flow_decoder_resnet_parameters(
+                    state_dict,
+                    prefix=f"{block_prefix}.0",
+                    num_groups=num_groups,
+                    epsilon=epsilon,
+                ),
+                transformer_blocks=tuple(
+                    _extract_flow_decoder_transformer_block_parameters(
+                        state_dict,
+                        prefix=f"{block_prefix}.1.{transformer_idx}",
+                        num_heads=num_heads,
+                        transformer_block_module=transformer_blocks[transformer_idx],
+                        epsilon=epsilon,
+                    )
+                    for transformer_idx in range(len(transformer_blocks))
+                ),
+                sample_weight=sample_weight,
+                sample_bias=sample_bias,
+                sample_stride=sample_stride,
+                sample_padding=sample_padding,
+                sample_transpose=sample_transpose,
+            )
+        )
+
+    return CosyVoiceFlowDecoderParameters(
+        time_linear_1_weight=state_dict[f"{prefix}.time_mlp.linear_1.weight"],
+        time_linear_1_bias=state_dict[f"{prefix}.time_mlp.linear_1.bias"],
+        time_linear_2_weight=state_dict[f"{prefix}.time_mlp.linear_2.weight"],
+        time_linear_2_bias=state_dict[f"{prefix}.time_mlp.linear_2.bias"],
+        down_blocks=tuple(down_blocks),
+        mid_blocks=tuple(mid_blocks),
+        up_blocks=tuple(up_blocks),
+        final_block=_extract_flow_decoder_block_parameters(
+            state_dict,
+            prefix=f"{prefix}.final_block",
+            kernel_size=3,
+            padding=1,
+            num_groups=num_groups,
+            epsilon=epsilon,
+        ),
+        final_proj_weight=state_dict[f"{prefix}.final_proj.weight"],
+        final_proj_bias=state_dict[f"{prefix}.final_proj.bias"],
+        in_channels=int(estimator.in_channels),
+        out_channels=int(estimator.out_channels),
+        num_heads=num_heads,
+        head_dim=int(estimator.down_blocks[0][1][0].attn1.to_q.weight.shape[0] // num_heads),
+        t_scheduler=str(flow_decoder_module.t_scheduler),
+        inference_cfg_rate=float(flow_decoder_module.inference_cfg_rate),
+    )
+
+
+def apply_flow_decoder_time_embedding_torch(
+    timesteps: torch.Tensor,
+    parameters: CosyVoiceFlowDecoderParameters,
+) -> torch.Tensor:
+    timesteps = timesteps.reshape(-1).float()
+    half_dim = parameters.in_channels // 2
+    scale = torch.exp(
+        torch.arange(half_dim, device=timesteps.device, dtype=torch.float32)
+        * (-torch.log(torch.tensor(10000.0, device=timesteps.device, dtype=torch.float32)) / (half_dim - 1))
+    )
+    sinusoidal = parameters.time_scale * timesteps.unsqueeze(1) * scale.unsqueeze(0)
+    hidden_states = torch.cat([sinusoidal.sin(), sinusoidal.cos()], dim=-1)
+    hidden_states = F.linear(hidden_states, parameters.time_linear_1_weight, parameters.time_linear_1_bias)
+    hidden_states = F.silu(hidden_states)
+    return F.linear(hidden_states, parameters.time_linear_2_weight, parameters.time_linear_2_bias)
+
+
+def apply_flow_decoder_block_torch(
+    hidden_states: torch.Tensor,
+    mask: torch.Tensor,
+    parameters: CosyVoiceFlowDecoderBlockParameters,
+) -> torch.Tensor:
+    hidden_states = F.conv1d(
+        hidden_states * mask,
+        parameters.conv_weight,
+        parameters.conv_bias,
+        stride=1,
+        padding=parameters.padding,
+    )
+    hidden_states = F.group_norm(
+        hidden_states,
+        num_groups=parameters.num_groups,
+        weight=parameters.norm_weight,
+        bias=parameters.norm_bias,
+        eps=parameters.epsilon,
+    )
+    hidden_states = F.mish(hidden_states)
+    return hidden_states * mask
+
+
+def apply_flow_decoder_resnet_block_torch(
+    hidden_states: torch.Tensor,
+    mask: torch.Tensor,
+    time_embedding: torch.Tensor,
+    parameters: CosyVoiceFlowDecoderResnetBlockParameters,
+) -> torch.Tensor:
+    residual = F.conv1d(hidden_states * mask, parameters.res_conv_weight, parameters.res_conv_bias, stride=1, padding=0)
+    hidden_states = apply_flow_decoder_block_torch(hidden_states, mask, parameters.block1)
+    hidden_states = hidden_states + F.linear(F.mish(time_embedding), parameters.time_mlp_weight, parameters.time_mlp_bias).unsqueeze(-1)
+    hidden_states = apply_flow_decoder_block_torch(hidden_states, mask, parameters.block2)
+    return hidden_states + residual
+
+
+def _flow_mask_to_attention_bias(mask: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+    attention_mask = mask.bool().repeat(1, hidden_states.shape[1], 1)
+    return (1.0 - attention_mask.to(dtype=hidden_states.dtype)) * -1.0e10
+
+
+def apply_flow_decoder_transformer_block_torch(
+    hidden_states: torch.Tensor,
+    attention_bias: torch.Tensor,
+    parameters: CosyVoiceFlowDecoderTransformerBlockParameters,
+) -> torch.Tensor:
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm1_weight,
+        parameters.norm1_bias,
+        parameters.epsilon,
+    )
+
+    q = F.linear(hidden_states, parameters.attn_q_weight).view(
+        hidden_states.shape[0], hidden_states.shape[1], parameters.num_heads, parameters.head_dim
+    ).transpose(1, 2)
+    k = F.linear(hidden_states, parameters.attn_k_weight).view(
+        hidden_states.shape[0], hidden_states.shape[1], parameters.num_heads, parameters.head_dim
+    ).transpose(1, 2)
+    v = F.linear(hidden_states, parameters.attn_v_weight).view(
+        hidden_states.shape[0], hidden_states.shape[1], parameters.num_heads, parameters.head_dim
+    ).transpose(1, 2)
+
+    scores = torch.matmul(q, k.transpose(-2, -1)) * (parameters.head_dim**-0.5)
+    scores = scores + attention_bias.unsqueeze(1)
+    attention = torch.softmax(scores, dim=-1)
+    hidden_states = torch.matmul(attention, v).transpose(1, 2).contiguous().view(
+        residual.shape[0], residual.shape[1], -1
+    )
+    hidden_states = F.linear(hidden_states, parameters.attn_out_weight, parameters.attn_out_bias)
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm3_weight,
+        parameters.norm3_bias,
+        parameters.epsilon,
+    )
+    hidden_states = F.linear(hidden_states, parameters.ff_proj_weight, parameters.ff_proj_bias)
+    if parameters.ff_activation == "snakebeta":
+        assert parameters.ff_alpha is not None
+        assert parameters.ff_beta is not None
+        alpha = parameters.ff_alpha.exp() if parameters.snake_alpha_logscale else parameters.ff_alpha
+        beta = parameters.ff_beta.exp() if parameters.snake_alpha_logscale else parameters.ff_beta
+        hidden_states = hidden_states + (1.0 / (beta + 1.0e-9)) * torch.sin(hidden_states * alpha).pow(2)
+    elif parameters.ff_activation == "geglu":
+        hidden_states, gate = hidden_states.chunk(2, dim=-1)
+        hidden_states = hidden_states * F.gelu(gate)
+    elif parameters.ff_activation == "gelu_approximate":
+        hidden_states = F.gelu(hidden_states, approximate="tanh")
+    else:
+        hidden_states = F.gelu(hidden_states)
+    hidden_states = F.linear(hidden_states, parameters.ff_out_weight, parameters.ff_out_bias)
+    return residual + hidden_states
+
+
+def apply_flow_conditional_decoder_torch(
+    x: torch.Tensor,
+    mask: torch.Tensor,
+    mu: torch.Tensor,
+    timesteps: torch.Tensor,
+    parameters: CosyVoiceFlowDecoderParameters,
+    *,
+    spks: torch.Tensor | None = None,
+    cond: torch.Tensor | None = None,
+    streaming: bool = False,
+) -> torch.Tensor:
+    if streaming:
+        raise NotImplementedError("Streaming ConditionalDecoder is out of scope for the public CosyVoice TT path")
+
+    time_embedding = apply_flow_decoder_time_embedding_torch(timesteps, parameters).to(dtype=x.dtype, device=x.device)
+    hidden_states = torch.cat([x, mu], dim=1)
+    if spks is not None:
+        hidden_states = torch.cat([hidden_states, spks.unsqueeze(-1).expand(-1, -1, hidden_states.shape[-1])], dim=1)
+    if cond is not None:
+        hidden_states = torch.cat([hidden_states, cond], dim=1)
+
+    hiddens: list[torch.Tensor] = []
+    masks = [mask]
+    for block in parameters.down_blocks:
+        mask_down = masks[-1]
+        hidden_states = apply_flow_decoder_resnet_block_torch(hidden_states, mask_down, time_embedding, block.resnet)
+        hidden_states_btc = hidden_states.transpose(1, 2).contiguous()
+        attention_bias = _flow_mask_to_attention_bias(mask_down, hidden_states_btc)
+        for transformer_block in block.transformer_blocks:
+            hidden_states_btc = apply_flow_decoder_transformer_block_torch(
+                hidden_states_btc, attention_bias, transformer_block
+            )
+        hidden_states = hidden_states_btc.transpose(1, 2).contiguous()
+        hiddens.append(hidden_states)
+        hidden_states = F.conv1d(
+            hidden_states * mask_down,
+            block.sample_weight,
+            block.sample_bias,
+            stride=block.sample_stride,
+            padding=block.sample_padding,
+        )
+        masks.append(mask_down[:, :, ::2])
+
+    masks = masks[:-1]
+    mask_mid = masks[-1]
+    for block in parameters.mid_blocks:
+        hidden_states = apply_flow_decoder_resnet_block_torch(hidden_states, mask_mid, time_embedding, block.resnet)
+        hidden_states_btc = hidden_states.transpose(1, 2).contiguous()
+        attention_bias = _flow_mask_to_attention_bias(mask_mid, hidden_states_btc)
+        for transformer_block in block.transformer_blocks:
+            hidden_states_btc = apply_flow_decoder_transformer_block_torch(
+                hidden_states_btc, attention_bias, transformer_block
+            )
+        hidden_states = hidden_states_btc.transpose(1, 2).contiguous()
+
+    for block in parameters.up_blocks:
+        mask_up = masks.pop()
+        skip = hiddens.pop()
+        hidden_states = torch.cat([hidden_states[:, :, : skip.shape[-1]], skip], dim=1)
+        hidden_states = apply_flow_decoder_resnet_block_torch(hidden_states, mask_up, time_embedding, block.resnet)
+        hidden_states_btc = hidden_states.transpose(1, 2).contiguous()
+        attention_bias = _flow_mask_to_attention_bias(mask_up, hidden_states_btc)
+        for transformer_block in block.transformer_blocks:
+            hidden_states_btc = apply_flow_decoder_transformer_block_torch(
+                hidden_states_btc, attention_bias, transformer_block
+            )
+        hidden_states = hidden_states_btc.transpose(1, 2).contiguous()
+        if block.sample_transpose:
+            hidden_states = F.conv_transpose1d(
+                hidden_states * mask_up,
+                block.sample_weight,
+                block.sample_bias,
+                stride=block.sample_stride,
+                padding=block.sample_padding,
+            )
+        else:
+            hidden_states = F.conv1d(
+                hidden_states * mask_up,
+                block.sample_weight,
+                block.sample_bias,
+                stride=block.sample_stride,
+                padding=block.sample_padding,
+            )
+
+    hidden_states = apply_flow_decoder_block_torch(hidden_states, mask_up, parameters.final_block)
+    output = F.conv1d(hidden_states * mask_up, parameters.final_proj_weight, parameters.final_proj_bias, stride=1, padding=0)
+    return output * mask
+
+
+def apply_flow_cfm_inference_torch(
+    mu: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    n_timesteps: int,
+    parameters: CosyVoiceFlowDecoderParameters,
+    temperature: float = 1.0,
+    spks: torch.Tensor | None = None,
+    cond: torch.Tensor | None = None,
+    prompt_len: int = 0,
+    cache: torch.Tensor | None = None,
+    streaming: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    z = torch.randn_like(mu).to(mu.dtype) * temperature
+    if cache is None:
+        cache = torch.zeros((mu.shape[0], mu.shape[1], 0, 2), dtype=mu.dtype, device=mu.device)
+    cache_size = int(cache.shape[2])
+    if cache_size != 0:
+        z[:, :, :cache_size] = cache[:, :, :, 0]
+        mu[:, :, :cache_size] = cache[:, :, :, 1]
+
+    overlap_start = max(mu.shape[2] - 34, 0)
+    z_cache = torch.cat([z[:, :, :prompt_len], z[:, :, overlap_start:]], dim=2)
+    mu_cache = torch.cat([mu[:, :, :prompt_len], mu[:, :, overlap_start:]], dim=2)
+    cache = torch.stack([z_cache, mu_cache], dim=-1)
+
+    t_span = torch.linspace(0, 1, n_timesteps + 1, device=mu.device, dtype=mu.dtype)
+    if parameters.t_scheduler == "cosine":
+        t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
+
+    batch_size = int(mu.shape[0])
+    conditioning_dtype = spks.dtype if spks is not None else mu.dtype
+    x = z
+    t = t_span[0].reshape(1)
+    dt = t_span[1] - t
+
+    for step in range(1, len(t_span)):
+        x_in = torch.cat([x, x], dim=0).to(dtype=conditioning_dtype)
+        mask_in = torch.cat([mask, mask], dim=0).to(dtype=conditioning_dtype)
+        mu_in = torch.zeros((batch_size * 2, *mu.shape[1:]), dtype=conditioning_dtype, device=mu.device)
+        mu_in[:batch_size] = mu.to(dtype=conditioning_dtype)
+        t_in = t.expand(batch_size * 2).to(dtype=conditioning_dtype)
+        spks_in = None
+        if spks is not None:
+            spks_in = torch.zeros((batch_size * 2, spks.shape[1]), dtype=conditioning_dtype, device=mu.device)
+            spks_in[:batch_size] = spks.to(dtype=conditioning_dtype)
+        cond_in = None
+        if cond is not None:
+            cond_in = torch.zeros((batch_size * 2, *cond.shape[1:]), dtype=conditioning_dtype, device=mu.device)
+            cond_in[:batch_size] = cond.to(dtype=conditioning_dtype)
+
+        dphi_dt = apply_flow_conditional_decoder_torch(
+            x_in,
+            mask_in,
+            mu_in,
+            t_in,
+            parameters,
+            spks=spks_in,
+            cond=cond_in,
+            streaming=streaming,
+        )
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [batch_size, batch_size], dim=0)
+        dphi_dt = ((1.0 + parameters.inference_cfg_rate) * dphi_dt) - (parameters.inference_cfg_rate * cfg_dphi_dt)
+        x = x + dt * dphi_dt
+        t = t + dt
+        if step < len(t_span) - 1:
+            dt = t_span[step + 1] - t
+
+    return x.float(), cache
+
+
+class CosyVoiceTorchFlowDecoder:
+    def __init__(self, flow_module: Any):
+        self.flow_module = flow_module
+        self.parameters = extract_flow_decoder_parameters(flow_module.decoder)
+
+    def inference(
+        self,
+        *,
+        mu: torch.Tensor,
+        mask: torch.Tensor,
+        spks: torch.Tensor | None,
+        cond: torch.Tensor | None,
+        n_timesteps: int,
+        prompt_len: int = 0,
+        cache: torch.Tensor | None = None,
+        temperature: float = 1.0,
+        streaming: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return apply_flow_cfm_inference_torch(
+            mu=mu,
+            mask=mask,
+            n_timesteps=n_timesteps,
+            parameters=self.parameters,
+            temperature=temperature,
+            spks=spks,
+            cond=cond,
+            prompt_len=prompt_len,
+            cache=cache,
+            streaming=streaming,
+        )

--- a/models/demos/audio/cosy_voice/tt/frontend.py
+++ b/models/demos/audio/cosy_voice/tt/frontend.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from models.demos.audio.cosy_voice.demo.common import CosyVoiceCase, resolve_prompt_audio
+from models.demos.audio.cosy_voice.tt.reference import CosyVoiceReferenceSession
+
+
+@dataclass
+class PreparedFrontendInput:
+    mode: str
+    payload: dict[str, Any]
+
+
+class CosyVoiceFrontendAdapter:
+    def __init__(self, session: CosyVoiceReferenceSession):
+        self.session = session
+
+    def prepare(self, case: CosyVoiceCase) -> PreparedFrontendInput:
+        model, _ = self.session.get_model(case.mode)
+        frontend = model.frontend
+        prompt_audio = resolve_prompt_audio(self.session.reference_repo, case.prompt_audio)
+        if case.mode == "sft":
+            payload = frontend.frontend_sft(case.text, case.speaker_id)
+        elif case.mode == "zero_shot":
+            payload = frontend.frontend_zero_shot(
+                case.text,
+                case.prompt_text,
+                prompt_audio,
+                model.sample_rate,
+                "",
+            )
+        elif case.mode == "cross_lingual":
+            payload = frontend.frontend_cross_lingual(case.text, prompt_audio, model.sample_rate, "")
+        elif case.mode == "instruct":
+            payload = frontend.frontend_instruct(case.text, case.speaker_id, case.instruction)
+        else:  # pragma: no cover - protected by CosyVoiceCase validation
+            raise ValueError(f"Unsupported mode: {case.mode}")
+        return PreparedFrontendInput(mode=case.mode, payload=payload)

--- a/models/demos/audio/cosy_voice/tt/llm.py
+++ b/models/demos/audio/cosy_voice/tt/llm.py
@@ -1,0 +1,831 @@
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class CosyVoiceLLMConfig:
+    text_encoder_input_size: int = 512
+    llm_input_size: int = 1024
+    llm_output_size: int = 1024
+    text_token_size: int = 51866
+    speech_token_size: int = 4096
+    text_encoder_blocks: int = 6
+    transformer_blocks: int = 14
+    num_heads: int = 16
+
+
+@dataclass(frozen=True)
+class CosyVoiceSemanticInputs:
+    text: torch.Tensor
+    text_len: torch.Tensor
+    prompt_text: torch.Tensor
+    prompt_text_len: torch.Tensor
+    prompt_speech_token: torch.Tensor
+    prompt_speech_token_len: torch.Tensor
+    llm_embedding: torch.Tensor
+    merged_text: torch.Tensor
+    merged_text_len: torch.Tensor
+    encoded_text: torch.Tensor
+    encoded_text_len: torch.Tensor
+    speaker_projection: torch.Tensor
+    sos_embedding: torch.Tensor
+    task_embedding: torch.Tensor
+    prompt_speech_embeddings: torch.Tensor
+    lm_input: torch.Tensor
+    lm_input_embed: torch.Tensor
+    lm_input_positional_embedding: torch.Tensor
+    lm_input_mask: torch.Tensor
+    min_decode_length: int
+    max_decode_length: int
+
+    @property
+    def prompt_speech_length(self) -> int:
+        return int(self.prompt_speech_token.shape[1])
+
+    @property
+    def prefill_seq_len(self) -> int:
+        return int(self.lm_input.shape[1])
+
+
+@dataclass(frozen=True)
+class CosyVoiceLegacyEmbedParameters:
+    linear_weight: torch.Tensor
+    linear_bias: torch.Tensor
+    norm_weight: torch.Tensor
+    norm_bias: torch.Tensor
+    epsilon: float = 1e-5
+
+
+@dataclass(frozen=True)
+class CosyVoiceSemanticLayerParameters:
+    q_weight: torch.Tensor
+    q_bias: torch.Tensor
+    k_weight: torch.Tensor
+    k_bias: torch.Tensor
+    v_weight: torch.Tensor
+    v_bias: torch.Tensor
+    out_weight: torch.Tensor
+    out_bias: torch.Tensor
+    pos_weight: torch.Tensor
+    pos_bias_u: torch.Tensor
+    pos_bias_v: torch.Tensor
+    ffn_w1_weight: torch.Tensor
+    ffn_w1_bias: torch.Tensor
+    ffn_w2_weight: torch.Tensor
+    ffn_w2_bias: torch.Tensor
+    norm1_weight: torch.Tensor
+    norm1_bias: torch.Tensor
+    norm2_weight: torch.Tensor
+    norm2_bias: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CosyVoiceSemanticOutputParameters:
+    after_norm_weight: torch.Tensor
+    after_norm_bias: torch.Tensor
+    decoder_weight: torch.Tensor
+    decoder_bias: torch.Tensor
+    speech_embedding_weight: torch.Tensor
+    after_norm_epsilon: float = 1e-5
+
+
+def compute_decode_length_bounds(
+    text_token_len: int,
+    prompt_text_token_len: int,
+    min_token_text_ratio: float = 2.0,
+    max_token_text_ratio: float = 20.0,
+) -> tuple[int, int]:
+    decode_text_tokens = max(text_token_len - prompt_text_token_len, 0)
+    min_len = int(decode_text_tokens * min_token_text_ratio)
+    max_len = int(decode_text_tokens * max_token_text_ratio)
+    return min_len, max_len
+
+
+def build_autoregressive_attention_mask(seq_len: int) -> torch.Tensor:
+    return torch.tril(torch.ones((1, seq_len, seq_len), dtype=torch.bool))
+
+
+def build_next_decode_embedding(speech_embedding_weight: torch.Tensor, token_id: int) -> torch.Tensor:
+    return speech_embedding_weight[token_id].reshape(1, 1, -1)
+
+
+def extract_legacy_embed_parameters(
+    state_dict: dict[str, torch.Tensor],
+    prefix: str = "llm.embed.out",
+) -> CosyVoiceLegacyEmbedParameters:
+    prefix = prefix.rstrip(".")
+    return CosyVoiceLegacyEmbedParameters(
+        linear_weight=state_dict[f"{prefix}.0.weight"],
+        linear_bias=state_dict[f"{prefix}.0.bias"],
+        norm_weight=state_dict[f"{prefix}.1.weight"],
+        norm_bias=state_dict[f"{prefix}.1.bias"],
+    )
+
+
+def extract_semantic_layer_parameters(
+    state_dict: dict[str, torch.Tensor],
+    layer_num: int,
+    prefix: str = "llm.encoders",
+) -> CosyVoiceSemanticLayerParameters:
+    layer_prefix = f"{prefix.rstrip('.')}.{layer_num}"
+    return CosyVoiceSemanticLayerParameters(
+        q_weight=state_dict[f"{layer_prefix}.self_attn.linear_q.weight"],
+        q_bias=state_dict[f"{layer_prefix}.self_attn.linear_q.bias"],
+        k_weight=state_dict[f"{layer_prefix}.self_attn.linear_k.weight"],
+        k_bias=state_dict[f"{layer_prefix}.self_attn.linear_k.bias"],
+        v_weight=state_dict[f"{layer_prefix}.self_attn.linear_v.weight"],
+        v_bias=state_dict[f"{layer_prefix}.self_attn.linear_v.bias"],
+        out_weight=state_dict[f"{layer_prefix}.self_attn.linear_out.weight"],
+        out_bias=state_dict[f"{layer_prefix}.self_attn.linear_out.bias"],
+        pos_weight=state_dict[f"{layer_prefix}.self_attn.linear_pos.weight"],
+        pos_bias_u=state_dict[f"{layer_prefix}.self_attn.pos_bias_u"],
+        pos_bias_v=state_dict[f"{layer_prefix}.self_attn.pos_bias_v"],
+        ffn_w1_weight=state_dict[f"{layer_prefix}.feed_forward.w_1.weight"],
+        ffn_w1_bias=state_dict[f"{layer_prefix}.feed_forward.w_1.bias"],
+        ffn_w2_weight=state_dict[f"{layer_prefix}.feed_forward.w_2.weight"],
+        ffn_w2_bias=state_dict[f"{layer_prefix}.feed_forward.w_2.bias"],
+        norm1_weight=state_dict[f"{layer_prefix}.norm1.weight"],
+        norm1_bias=state_dict[f"{layer_prefix}.norm1.bias"],
+        norm2_weight=state_dict[f"{layer_prefix}.norm2.weight"],
+        norm2_bias=state_dict[f"{layer_prefix}.norm2.bias"],
+    )
+
+
+def extract_semantic_output_parameters(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    llm_prefix: str = "llm",
+    decoder_prefix: str = "llm_decoder",
+    speech_embedding_prefix: str = "speech_embedding",
+) -> CosyVoiceSemanticOutputParameters:
+    llm_prefix = llm_prefix.rstrip(".")
+    decoder_prefix = decoder_prefix.rstrip(".")
+    speech_embedding_prefix = speech_embedding_prefix.rstrip(".")
+    return CosyVoiceSemanticOutputParameters(
+        after_norm_weight=state_dict[f"{llm_prefix}.after_norm.weight"],
+        after_norm_bias=state_dict[f"{llm_prefix}.after_norm.bias"],
+        decoder_weight=state_dict[f"{decoder_prefix}.weight"],
+        decoder_bias=state_dict[f"{decoder_prefix}.bias"],
+        speech_embedding_weight=state_dict[f"{speech_embedding_prefix}.weight"],
+    )
+
+
+def apply_legacy_embed_torch(
+    hidden_states: torch.Tensor,
+    parameters: CosyVoiceLegacyEmbedParameters,
+) -> torch.Tensor:
+    hidden_states = F.linear(hidden_states, parameters.linear_weight, parameters.linear_bias)
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm_weight,
+        parameters.norm_bias,
+        parameters.epsilon,
+    )
+    return torch.relu(hidden_states)
+
+
+def preprocess_tt_legacy_embed_parameters(parameters: CosyVoiceLegacyEmbedParameters, *, dtype):
+    from ttnn.model_preprocessing import (  # noqa: PLC0415
+        preprocess_layernorm_parameter,
+        preprocess_linear_bias,
+        preprocess_linear_weight,
+    )
+
+    import ttnn  # noqa: PLC0415
+
+    return {
+        "linear_weight": preprocess_linear_weight(parameters.linear_weight, dtype=dtype),
+        "linear_bias": preprocess_linear_bias(parameters.linear_bias, dtype=dtype),
+        "norm_weight": preprocess_layernorm_parameter(parameters.norm_weight, dtype=dtype),
+        "norm_bias": preprocess_layernorm_parameter(parameters.norm_bias, dtype=dtype),
+        "epsilon": parameters.epsilon,
+    }
+
+
+def preprocess_tt_semantic_layer_parameters(parameters: CosyVoiceSemanticLayerParameters, *, dtype):
+    from ttnn.model_preprocessing import (  # noqa: PLC0415
+        preprocess_layernorm_parameter,
+        preprocess_linear_bias,
+        preprocess_linear_weight,
+    )
+
+    import ttnn  # noqa: PLC0415
+
+    return {
+        "q_weight": preprocess_linear_weight(parameters.q_weight, dtype=dtype),
+        "q_bias": preprocess_linear_bias(parameters.q_bias, dtype=dtype),
+        "k_weight": preprocess_linear_weight(parameters.k_weight, dtype=dtype),
+        "k_bias": preprocess_linear_bias(parameters.k_bias, dtype=dtype),
+        "v_weight": preprocess_linear_weight(parameters.v_weight, dtype=dtype),
+        "v_bias": preprocess_linear_bias(parameters.v_bias, dtype=dtype),
+        "out_weight": preprocess_linear_weight(parameters.out_weight, dtype=dtype),
+        "out_bias": preprocess_linear_bias(parameters.out_bias, dtype=dtype),
+        "pos_weight": preprocess_linear_weight(parameters.pos_weight, dtype=dtype),
+        "pos_bias_u": ttnn.from_torch(
+            parameters.pos_bias_u.unsqueeze(0).unsqueeze(0),
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        "pos_bias_v": ttnn.from_torch(
+            parameters.pos_bias_v.unsqueeze(0).unsqueeze(0),
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        "ffn_w1_weight": preprocess_linear_weight(parameters.ffn_w1_weight, dtype=dtype),
+        "ffn_w1_bias": preprocess_linear_bias(parameters.ffn_w1_bias, dtype=dtype),
+        "ffn_w2_weight": preprocess_linear_weight(parameters.ffn_w2_weight, dtype=dtype),
+        "ffn_w2_bias": preprocess_linear_bias(parameters.ffn_w2_bias, dtype=dtype),
+        "norm1_weight": preprocess_layernorm_parameter(parameters.norm1_weight, dtype=dtype),
+        "norm1_bias": preprocess_layernorm_parameter(parameters.norm1_bias, dtype=dtype),
+        "norm2_weight": preprocess_layernorm_parameter(parameters.norm2_weight, dtype=dtype),
+        "norm2_bias": preprocess_layernorm_parameter(parameters.norm2_bias, dtype=dtype),
+        "norm_epsilon": 1e-12,
+    }
+
+
+def preprocess_tt_semantic_output_parameters(parameters: CosyVoiceSemanticOutputParameters, *, dtype):
+    from ttnn.model_preprocessing import (  # noqa: PLC0415
+        preprocess_layernorm_parameter,
+        preprocess_linear_bias,
+        preprocess_linear_weight,
+    )
+
+    import ttnn  # noqa: PLC0415
+
+    return {
+        "after_norm_weight": preprocess_layernorm_parameter(parameters.after_norm_weight, dtype=dtype),
+        "after_norm_bias": preprocess_layernorm_parameter(parameters.after_norm_bias, dtype=dtype),
+        "decoder_weight": preprocess_linear_weight(parameters.decoder_weight, dtype=dtype),
+        "decoder_bias": preprocess_linear_bias(parameters.decoder_bias, dtype=dtype),
+        "speech_embedding_weight": parameters.speech_embedding_weight,
+        "after_norm_epsilon": parameters.after_norm_epsilon,
+    }
+
+
+def apply_legacy_embed_ttnn(hidden_states, parameters, *, memory_config=None, dtype=None, core_grid=None):
+    import ttnn  # noqa: PLC0415
+
+    hidden_states = ttnn.linear(
+        hidden_states,
+        parameters["linear_weight"],
+        bias=parameters["linear_bias"],
+        memory_config=memory_config or ttnn.L1_MEMORY_CONFIG,
+        dtype=dtype or ttnn.bfloat16,
+        core_grid=core_grid,
+    )
+    hidden_states = ttnn.layer_norm(
+        hidden_states,
+        weight=parameters["norm_weight"],
+        bias=parameters["norm_bias"],
+        epsilon=parameters["epsilon"],
+        memory_config=memory_config or ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
+    )
+    return ttnn.relu(hidden_states, memory_config=memory_config or ttnn.L1_MEMORY_CONFIG)
+
+
+def apply_semantic_layer_torch(
+    hidden_states: torch.Tensor,
+    positional_embedding: torch.Tensor,
+    parameters: CosyVoiceSemanticLayerParameters,
+    *,
+    num_heads: int = 16,
+    cache: tuple[torch.Tensor, torch.Tensor] | None = None,
+    causal: bool = False,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    head_dim = hidden_states.shape[-1] // num_heads
+
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm1_weight,
+        parameters.norm1_bias,
+        1e-12,
+    )
+    q = F.linear(hidden_states, parameters.q_weight, parameters.q_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    k = F.linear(hidden_states, parameters.k_weight, parameters.k_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    v = F.linear(hidden_states, parameters.v_weight, parameters.v_bias).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    if cache is not None:
+        k = torch.cat([cache[0], k], dim=2)
+        v = torch.cat([cache[1], v], dim=2)
+    new_cache = (k, v)
+
+    pos = F.linear(positional_embedding, parameters.pos_weight, None).view(1, -1, num_heads, head_dim).transpose(1, 2)
+    q_t = q.transpose(1, 2)
+    q_with_bias_u = (q_t + parameters.pos_bias_u).transpose(1, 2)
+    q_with_bias_v = (q_t + parameters.pos_bias_v).transpose(1, 2)
+
+    matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+    matrix_bd = torch.matmul(q_with_bias_v, pos.transpose(-2, -1))
+    if matrix_ac.shape != matrix_bd.shape:
+        matrix_bd = _rel_shift_torch(matrix_bd)
+    scores = (matrix_ac + matrix_bd) / math.sqrt(head_dim)
+    if causal:
+        causal_mask = torch.triu(torch.ones(scores.shape[-2:], dtype=torch.bool, device=scores.device), diagonal=1)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), -1.0e4)
+    attention = torch.softmax(scores, dim=-1)
+    attention_output = torch.matmul(attention, v).transpose(1, 2).contiguous().view(1, -1, num_heads * head_dim)
+    attention_output = F.linear(attention_output, parameters.out_weight, parameters.out_bias)
+    hidden_states = residual + attention_output
+
+    residual = hidden_states
+    hidden_states = F.layer_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        parameters.norm2_weight,
+        parameters.norm2_bias,
+        1e-12,
+    )
+    hidden_states = F.linear(hidden_states, parameters.ffn_w1_weight, parameters.ffn_w1_bias)
+    hidden_states = torch.relu(hidden_states)
+    hidden_states = F.linear(hidden_states, parameters.ffn_w2_weight, parameters.ffn_w2_bias)
+    return residual + hidden_states, new_cache
+
+
+def _rel_shift_torch(x: torch.Tensor) -> torch.Tensor:
+    zero_pad = torch.zeros((*x.shape[:-1], 1), dtype=x.dtype, device=x.device)
+    x_padded = torch.cat([zero_pad, x], dim=-1)
+    x_padded = x_padded.view(x.size(0), x.size(1), x.size(3) + 1, x.size(2))
+    shifted = x_padded[:, :, 1:].view_as(x)
+    return shifted[:, :, :, : x.size(-1) // 2 + 1]
+
+
+def assemble_prefill_embeddings(
+    sos_embedding: torch.Tensor,
+    speaker_embedding: torch.Tensor,
+    encoded_text: torch.Tensor,
+    task_embedding: torch.Tensor,
+    prompt_speech_embeddings: torch.Tensor,
+) -> torch.Tensor:
+    return torch.cat(
+        [sos_embedding, speaker_embedding, encoded_text, task_embedding, prompt_speech_embeddings],
+        dim=1,
+    )
+
+
+def _empty_token_tensor(reference: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1, 0), dtype=torch.int32, device=reference.device)
+
+
+def _empty_length_tensor(reference: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1,), dtype=torch.int32, device=reference.device)
+
+
+def _project_optional_speaker_embedding(
+    llm_module: Any, embedding: torch.Tensor, reference: torch.Tensor
+) -> torch.Tensor:
+    if embedding.numel() == 0 or embedding.shape[0] == 0:
+        return torch.zeros((1, 0, llm_module.llm_input_size), dtype=reference.dtype, device=reference.device)
+    projected = llm_module.spk_embed_affine_layer(F.normalize(embedding, dim=1))
+    return projected.unsqueeze(dim=1).to(dtype=reference.dtype)
+
+
+def _embed_optional_prompt_speech(
+    llm_module: Any, prompt_speech_token: torch.Tensor, reference: torch.Tensor
+) -> torch.Tensor:
+    if prompt_speech_token.numel() == 0 or prompt_speech_token.shape[1] == 0:
+        return torch.zeros((1, 0, llm_module.llm_input_size), dtype=reference.dtype, device=reference.device)
+    return llm_module.speech_embedding(prompt_speech_token).to(dtype=reference.dtype)
+
+
+def build_semantic_inputs(
+    *,
+    llm_module: Any,
+    text: torch.Tensor,
+    text_len: torch.Tensor,
+    prompt_text: torch.Tensor,
+    prompt_text_len: torch.Tensor,
+    prompt_speech_token: torch.Tensor,
+    prompt_speech_token_len: torch.Tensor,
+    embedding: torch.Tensor,
+    min_token_text_ratio: float = 2.0,
+    max_token_text_ratio: float = 20.0,
+) -> CosyVoiceSemanticInputs:
+    merged_text = torch.concat([prompt_text, text], dim=1)
+    merged_text_len = text_len + prompt_text_len
+    text_embeddings = llm_module.text_embedding(merged_text)
+    encoded_text, encoded_text_len = llm_module.encode(text_embeddings, merged_text_len)
+
+    speaker_projection = _project_optional_speaker_embedding(llm_module, embedding, encoded_text)
+    sos_embedding = llm_module.llm_embedding.weight[llm_module.sos].reshape(1, 1, -1).to(dtype=encoded_text.dtype)
+    task_embedding = llm_module.llm_embedding.weight[llm_module.task_id].reshape(1, 1, -1).to(dtype=encoded_text.dtype)
+    prompt_speech_embeddings = _embed_optional_prompt_speech(llm_module, prompt_speech_token, encoded_text)
+
+    lm_input = assemble_prefill_embeddings(
+        sos_embedding=sos_embedding,
+        speaker_embedding=speaker_projection,
+        encoded_text=encoded_text,
+        task_embedding=task_embedding,
+        prompt_speech_embeddings=prompt_speech_embeddings,
+    )
+    lm_input_mask = torch.ones((1, 1, lm_input.shape[1]), dtype=torch.bool, device=lm_input.device)
+    lm_input_embed, lm_input_positional_embedding, _ = llm_module.llm.embed(lm_input, lm_input_mask)
+    min_decode_length, max_decode_length = compute_decode_length_bounds(
+        text_token_len=int(encoded_text_len.item()),
+        prompt_text_token_len=int(prompt_text_len.item()),
+        min_token_text_ratio=min_token_text_ratio,
+        max_token_text_ratio=max_token_text_ratio,
+    )
+    return CosyVoiceSemanticInputs(
+        text=text,
+        text_len=text_len,
+        prompt_text=prompt_text,
+        prompt_text_len=prompt_text_len,
+        prompt_speech_token=prompt_speech_token,
+        prompt_speech_token_len=prompt_speech_token_len,
+        llm_embedding=embedding,
+        merged_text=merged_text,
+        merged_text_len=merged_text_len,
+        encoded_text=encoded_text,
+        encoded_text_len=encoded_text_len,
+        speaker_projection=speaker_projection,
+        sos_embedding=sos_embedding,
+        task_embedding=task_embedding,
+        prompt_speech_embeddings=prompt_speech_embeddings,
+        lm_input=lm_input,
+        lm_input_embed=lm_input_embed,
+        lm_input_positional_embedding=lm_input_positional_embedding,
+        lm_input_mask=lm_input_mask,
+        min_decode_length=min_decode_length,
+        max_decode_length=max_decode_length,
+    )
+
+
+def build_semantic_inputs_from_model_input(
+    *,
+    llm_module: Any,
+    model_input: dict[str, Any],
+    min_token_text_ratio: float = 2.0,
+    max_token_text_ratio: float = 20.0,
+) -> CosyVoiceSemanticInputs:
+    text = model_input["text"]
+    prompt_text = model_input.get("prompt_text")
+    if prompt_text is None:
+        prompt_text = _empty_token_tensor(text)
+    prompt_text_len = model_input.get("prompt_text_len")
+    if prompt_text_len is None:
+        prompt_text_len = _empty_length_tensor(text)
+    prompt_speech_token = model_input.get("llm_prompt_speech_token")
+    if prompt_speech_token is None:
+        prompt_speech_token = _empty_token_tensor(text)
+    prompt_speech_token_len = model_input.get("llm_prompt_speech_token_len")
+    if prompt_speech_token_len is None:
+        prompt_speech_token_len = _empty_length_tensor(text)
+    embedding = model_input.get("llm_embedding")
+    if embedding is None:
+        embedding = torch.zeros(
+            (0, llm_module.spk_embed_affine_layer.in_features),
+            dtype=torch.float32,
+            device=text.device,
+        )
+    return build_semantic_inputs(
+        llm_module=llm_module,
+        text=text,
+        text_len=model_input["text_len"],
+        prompt_text=prompt_text,
+        prompt_text_len=prompt_text_len,
+        prompt_speech_token=prompt_speech_token,
+        prompt_speech_token_len=prompt_speech_token_len,
+        embedding=embedding,
+        min_token_text_ratio=min_token_text_ratio,
+        max_token_text_ratio=max_token_text_ratio,
+    )
+
+
+def prepare_tt_prefill_input(
+    lm_input: torch.Tensor,
+    mesh_device,
+    *,
+    dtype=None,
+    memory_config=None,
+):
+    import ttnn  # noqa: PLC0415
+
+    return ttnn.from_torch(
+        lm_input,
+        device=mesh_device,
+        dtype=dtype or ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=memory_config or ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def prepare_next_decode_input(
+    speech_embedding_weight: torch.Tensor,
+    token_id: int,
+    mesh_device,
+    *,
+    dtype=None,
+    memory_config=None,
+):
+    import ttnn  # noqa: PLC0415
+
+    token_embedding = build_next_decode_embedding(speech_embedding_weight, token_id)
+    return ttnn.from_torch(
+        token_embedding,
+        device=mesh_device,
+        dtype=dtype or ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=memory_config or ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+class CosyVoiceTTSemanticGenerator:
+    def __init__(self, llm_module: Any, mesh_device, *, dtype=None, memory_config=None):
+        import ttnn  # noqa: PLC0415
+
+        self.ttnn = ttnn
+        self.llm_module = llm_module
+        self.mesh_device = mesh_device
+        self.dtype = dtype or ttnn.bfloat16
+        self.memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+        self.num_heads = int(llm_module.llm.encoders[0].self_attn.h)
+        self.head_dim = int(llm_module.llm.encoders[0].self_attn.d_k)
+        self.hidden_dim = self.num_heads * self.head_dim
+        self.xscale = math.sqrt(self.hidden_dim)
+
+        state_dict = llm_module.state_dict()
+        num_layers = len(llm_module.llm.encoders)
+        self.layer_parameters = [
+            self._move_parameters_to_device(
+                preprocess_tt_semantic_layer_parameters(
+                    extract_semantic_layer_parameters(state_dict, layer_num=layer_idx, prefix="llm.encoders"),
+                    dtype=self.dtype,
+                )
+            )
+            for layer_idx in range(num_layers)
+        ]
+        self.output_parameters = self._move_parameters_to_device(
+            preprocess_tt_semantic_output_parameters(
+                extract_semantic_output_parameters(state_dict),
+                dtype=self.dtype,
+            )
+        )
+        self._causal_bias_cache: dict[int, Any] = {}
+
+    def _move_parameters_to_device(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        moved: dict[str, Any] = {}
+        for name, value in parameters.items():
+            if name.endswith("epsilon"):
+                moved[name] = value
+            elif isinstance(value, self.ttnn.Tensor):
+                moved[name] = self.ttnn.to_device(value, self.mesh_device, memory_config=self.memory_config)
+            else:
+                moved[name] = value
+        return moved
+
+    def _torch_hidden_to_tt(self, hidden_states: torch.Tensor):
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.unsqueeze(1)
+        return self.ttnn.from_torch(
+            hidden_states,
+            device=self.mesh_device,
+            dtype=self.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+
+    def _get_causal_bias(self, seq_len: int):
+        if seq_len not in self._causal_bias_cache:
+            bias = torch.zeros((1, 1, seq_len, seq_len), dtype=torch.float32)
+            bias.masked_fill_(torch.triu(torch.ones((seq_len, seq_len), dtype=torch.bool), diagonal=1), -1.0e4)
+            self._causal_bias_cache[seq_len] = self._torch_hidden_to_tt(bias.squeeze(1))
+        return self._causal_bias_cache[seq_len]
+
+    def _reshape_positional_heads(self, positional_embedding, parameters):
+        position_seq_len = positional_embedding.shape[2]
+        positional_embedding = self.ttnn.linear(
+            positional_embedding,
+            parameters["pos_weight"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        positional_embedding = self.ttnn.reshape(
+            positional_embedding, (1, position_seq_len, self.num_heads, self.head_dim)
+        )
+        return self.ttnn.transpose(positional_embedding, 1, 2)
+
+    def _rel_shift(self, x):
+        zero_pad = self.ttnn.zeros(
+            (x.shape[0], x.shape[1], x.shape[2], 1),
+            device=self.mesh_device,
+            dtype=x.dtype,
+            layout=self.ttnn.TILE_LAYOUT,
+            memory_config=self.memory_config,
+        )
+        x_padded = self.ttnn.concat([zero_pad, x], dim=-1, memory_config=self.memory_config)
+        x_padded = self.ttnn.reshape(x_padded, (x.shape[0], x.shape[1], x.shape[3] + 1, x.shape[2]))
+        shifted = self.ttnn.slice(x_padded, (0, 0, 1, 0), (x.shape[0], x.shape[1], x.shape[3] + 1, x.shape[2]))
+        shifted = self.ttnn.reshape(shifted, tuple(x.shape))
+        return self.ttnn.slice(shifted, (0, 0, 0, 0), (x.shape[0], x.shape[1], x.shape[2], x.shape[3] // 2 + 1))
+
+    def _apply_layer(self, hidden_states, positional_embedding, parameters, *, causal_bias=None, cache=None):
+        residual = hidden_states
+        hidden_states = self.ttnn.layer_norm(
+            hidden_states,
+            weight=parameters["norm1_weight"],
+            bias=parameters["norm1_bias"],
+            epsilon=parameters["norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        q = self.ttnn.linear(
+            hidden_states,
+            parameters["q_weight"],
+            bias=parameters["q_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        k = self.ttnn.linear(
+            hidden_states,
+            parameters["k_weight"],
+            bias=parameters["k_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        v = self.ttnn.linear(
+            hidden_states,
+            parameters["v_weight"],
+            bias=parameters["v_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        qkv = self.ttnn.concat([q, k, v], dim=-1, memory_config=self.memory_config)
+        q_heads, k_heads, v_heads = self.ttnn.experimental.nlp_create_qkv_heads(
+            qkv,
+            memory_config=self.memory_config,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_heads,
+            transpose_k_heads=False,
+        )
+        if cache is not None:
+            k_heads = self.ttnn.concat([cache[0], k_heads], dim=2, memory_config=self.memory_config)
+            v_heads = self.ttnn.concat([cache[1], v_heads], dim=2, memory_config=self.memory_config)
+        positional_heads = self._reshape_positional_heads(positional_embedding, parameters)
+        q_transposed = self.ttnn.transpose(q_heads, 1, 2)
+        q_with_bias_u = self.ttnn.add(q_transposed, parameters["pos_bias_u"], memory_config=self.memory_config)
+        q_with_bias_v = self.ttnn.add(q_transposed, parameters["pos_bias_v"], memory_config=self.memory_config)
+        q_with_bias_u = self.ttnn.transpose(q_with_bias_u, 1, 2)
+        q_with_bias_v = self.ttnn.transpose(q_with_bias_v, 1, 2)
+        matrix_ac = self.ttnn.matmul(
+            q_with_bias_u, self.ttnn.transpose(k_heads, -2, -1), memory_config=self.memory_config
+        )
+        matrix_bd = self.ttnn.matmul(
+            q_with_bias_v, self.ttnn.transpose(positional_heads, -2, -1), memory_config=self.memory_config
+        )
+        if tuple(matrix_ac.shape) != tuple(matrix_bd.shape):
+            matrix_bd = self._rel_shift(matrix_bd)
+        scores = self.ttnn.mul(
+            self.ttnn.add(matrix_ac, matrix_bd, memory_config=self.memory_config), 1.0 / math.sqrt(self.head_dim)
+        )
+        if causal_bias is not None:
+            scores = self.ttnn.add(scores, causal_bias, memory_config=self.memory_config)
+        attention = self.ttnn.softmax_in_place(scores)
+        attention_output = self.ttnn.matmul(attention, v_heads, memory_config=self.memory_config)
+        attention_output = self.ttnn.transpose(attention_output, 1, 2)
+        attention_output = self.ttnn.reshape(attention_output, (1, 1, attention_output.shape[1], self.hidden_dim))
+        attention_output = self.ttnn.linear(
+            attention_output,
+            parameters["out_weight"],
+            bias=parameters["out_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        hidden_states = self.ttnn.add(residual, attention_output, memory_config=self.memory_config)
+
+        residual = hidden_states
+        hidden_states = self.ttnn.layer_norm(
+            hidden_states,
+            weight=parameters["norm2_weight"],
+            bias=parameters["norm2_bias"],
+            epsilon=parameters["norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        hidden_states = self.ttnn.linear(
+            hidden_states,
+            parameters["ffn_w1_weight"],
+            bias=parameters["ffn_w1_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        hidden_states = self.ttnn.relu(hidden_states, memory_config=self.memory_config)
+        hidden_states = self.ttnn.linear(
+            hidden_states,
+            parameters["ffn_w2_weight"],
+            bias=parameters["ffn_w2_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        return self.ttnn.add(residual, hidden_states, memory_config=self.memory_config), (k_heads, v_heads)
+
+    def _decode_step(self, hidden_states: torch.Tensor, positional_embedding: torch.Tensor, caches):
+        hidden_tt = self._torch_hidden_to_tt(hidden_states)
+        pos_tt = self._torch_hidden_to_tt(positional_embedding)
+        new_caches = []
+        for layer_index, parameters in enumerate(self.layer_parameters):
+            hidden_tt, new_cache = self._apply_layer(
+                hidden_tt,
+                pos_tt,
+                parameters,
+                causal_bias=None,
+                cache=caches[layer_index],
+            )
+            new_caches.append(new_cache)
+        hidden_tt = self.ttnn.layer_norm(
+            hidden_tt,
+            weight=self.output_parameters["after_norm_weight"],
+            bias=self.output_parameters["after_norm_bias"],
+            epsilon=self.output_parameters["after_norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        logits_tt = self.ttnn.linear(
+            hidden_tt,
+            self.output_parameters["decoder_weight"],
+            bias=self.output_parameters["decoder_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        logits = self.ttnn.to_torch(logits_tt).squeeze(0).squeeze(0).squeeze(0).float()
+        return logits, new_caches
+
+    def _prefill(self, semantic_inputs: CosyVoiceSemanticInputs):
+        hidden_tt = self._torch_hidden_to_tt(semantic_inputs.lm_input_embed)
+        pos_tt = self._torch_hidden_to_tt(semantic_inputs.lm_input_positional_embedding)
+        causal_bias = self._get_causal_bias(semantic_inputs.prefill_seq_len)
+        caches = []
+        for parameters in self.layer_parameters:
+            hidden_tt, cache = self._apply_layer(hidden_tt, pos_tt, parameters, causal_bias=causal_bias, cache=None)
+            caches.append(cache)
+        hidden_tt = self.ttnn.layer_norm(
+            hidden_tt,
+            weight=self.output_parameters["after_norm_weight"],
+            bias=self.output_parameters["after_norm_bias"],
+            epsilon=self.output_parameters["after_norm_epsilon"],
+            memory_config=self.memory_config,
+        )
+        logits_tt = self.ttnn.linear(
+            hidden_tt,
+            self.output_parameters["decoder_weight"],
+            bias=self.output_parameters["decoder_bias"],
+            memory_config=self.memory_config,
+            dtype=self.dtype,
+        )
+        logits = self.ttnn.to_torch(logits_tt).squeeze(0).squeeze(0)[-1].float()
+        return logits, caches
+
+    def _prepare_next_embeds(self, token_id: int, offset: int) -> tuple[torch.Tensor, torch.Tensor]:
+        next_embedding = build_next_decode_embedding(self.output_parameters["speech_embedding_weight"], token_id)
+        next_mask = torch.ones((1, 1, next_embedding.shape[1]), dtype=torch.bool, device=next_embedding.device)
+        hidden_states, positional_embedding, _ = self.llm_module.llm.embed(next_embedding, next_mask, offset)
+        return hidden_states, positional_embedding
+
+    def generate(
+        self,
+        semantic_inputs: CosyVoiceSemanticInputs,
+        *,
+        sampling: int = 25,
+    ) -> torch.Tensor:
+        start = time.perf_counter()
+        logits, caches = self._prefill(semantic_inputs)
+        tokens: list[int] = []
+        for step_index in range(semantic_inputs.max_decode_length):
+            ignore_eos = step_index < semantic_inputs.min_decode_length
+            next_token = int(self.llm_module.sampling_ids(logits.clone(), tokens, sampling, ignore_eos=ignore_eos))
+            if next_token == self.llm_module.eos_token:
+                break
+            tokens.append(next_token)
+            next_hidden, next_pos = self._prepare_next_embeds(next_token, semantic_inputs.prefill_seq_len + step_index)
+            logits, caches = self._decode_step(next_hidden, next_pos, caches)
+        wall_seconds = time.perf_counter() - start
+        token_tensor = (
+            torch.tensor(tokens, dtype=torch.int32).unsqueeze(0) if tokens else torch.zeros((1, 0), dtype=torch.int32)
+        )
+        return token_tensor, wall_seconds
+
+    def teacher_forced_accuracy(
+        self,
+        semantic_inputs: CosyVoiceSemanticInputs,
+        reference_tokens: torch.Tensor,
+    ) -> float:
+        if reference_tokens.numel() == 0:
+            return 100.0
+        logits, caches = self._prefill(semantic_inputs)
+        predictions = [int(torch.argmax(logits).item())]
+        for step_index in range(1, reference_tokens.shape[1]):
+            next_hidden, next_pos = self._prepare_next_embeds(
+                int(reference_tokens[0, step_index - 1].item()),
+                semantic_inputs.prefill_seq_len + step_index - 1,
+            )
+            logits, caches = self._decode_step(next_hidden, next_pos, caches)
+            predictions.append(int(torch.argmax(logits).item()))
+        predicted = torch.tensor(predictions, dtype=torch.int32)
+        target = reference_tokens.reshape(-1).to(torch.int32)
+        return float((predicted == target).float().mean().item() * 100.0)

--- a/models/demos/audio/cosy_voice/tt/pipeline.py
+++ b/models/demos/audio/cosy_voice/tt/pipeline.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from models.demos.audio.cosy_voice.demo.common import CosyVoiceCase, save_audio
+from models.demos.audio.cosy_voice.tt.flow import (
+    CosyVoiceFlowInputs,
+    CosyVoiceTTFlowBridge,
+    CosyVoiceTorchFlowDecoder,
+    CosyVoiceTTFlowEncoder,
+    CosyVoiceTTFlowLengthRegulator,
+    build_flow_inputs_from_model_input,
+)
+from models.demos.audio.cosy_voice.tt.frontend import CosyVoiceFrontendAdapter, PreparedFrontendInput
+from models.demos.audio.cosy_voice.tt.llm import CosyVoiceSemanticInputs, CosyVoiceTTSemanticGenerator
+from models.demos.audio.cosy_voice.tt.reference import (
+    CosyVoiceReferenceSession,
+    GeneratedAudioResult,
+    SemanticTokenResult,
+)
+
+
+class CosyVoicePipeline:
+    def __init__(self, reference_repo: str | None = None, model_root: str | None = None, text_frontend: bool = True):
+        self.reference = CosyVoiceReferenceSession(
+            reference_repo=reference_repo,
+            model_root=model_root,
+            text_frontend=text_frontend,
+        )
+        self.frontend = CosyVoiceFrontendAdapter(self.reference)
+        self._ttnn = None
+        self._device = None
+        self._previous_fallback_setting: bool | None = None
+        self._semantic_generators: dict[str, CosyVoiceTTSemanticGenerator] = {}
+        self._flow_bridges: dict[str, CosyVoiceTTFlowBridge] = {}
+        self._flow_encoders: dict[str, CosyVoiceTTFlowEncoder] = {}
+        self._flow_length_regulators: dict[str, CosyVoiceTTFlowLengthRegulator] = {}
+        self._flow_decoders: dict[str, CosyVoiceTorchFlowDecoder] = {}
+
+    def _get_device(self):
+        if self._device is None:
+            import ttnn  # noqa: PLC0415
+
+            self._ttnn = ttnn
+            self._previous_fallback_setting = ttnn.CONFIG.throw_exception_on_fallback
+            ttnn.CONFIG.throw_exception_on_fallback = True
+            self._device = ttnn.open_device(device_id=0)
+        return self._device
+
+    def _get_semantic_generator(self, mode: str) -> CosyVoiceTTSemanticGenerator:
+        if mode not in self._semantic_generators:
+            model, _ = self.reference.get_model(mode)
+            self._semantic_generators[mode] = CosyVoiceTTSemanticGenerator(
+                model.model.llm,
+                self._get_device(),
+            )
+        return self._semantic_generators[mode]
+
+    def _get_flow_bridge(self, mode: str) -> CosyVoiceTTFlowBridge:
+        if mode not in self._flow_bridges:
+            model, _ = self.reference.get_model(mode)
+            self._flow_bridges[mode] = CosyVoiceTTFlowBridge(
+                model.model.flow,
+                self._get_device(),
+            )
+        return self._flow_bridges[mode]
+
+    def _get_flow_encoder(self, mode: str) -> CosyVoiceTTFlowEncoder:
+        if mode not in self._flow_encoders:
+            model, _ = self.reference.get_model(mode)
+            self._flow_encoders[mode] = CosyVoiceTTFlowEncoder(
+                model.model.flow,
+                self._get_device(),
+            )
+        return self._flow_encoders[mode]
+
+    def _get_flow_length_regulator(self, mode: str) -> CosyVoiceTTFlowLengthRegulator:
+        if mode not in self._flow_length_regulators:
+            model, _ = self.reference.get_model(mode)
+            self._flow_length_regulators[mode] = CosyVoiceTTFlowLengthRegulator(
+                model.model.flow,
+                self._get_device(),
+            )
+        return self._flow_length_regulators[mode]
+
+    def _get_flow_decoder(self, mode: str) -> CosyVoiceTorchFlowDecoder:
+        if mode not in self._flow_decoders:
+            model, _ = self.reference.get_model(mode)
+            self._flow_decoders[mode] = CosyVoiceTorchFlowDecoder(model.model.flow)
+        return self._flow_decoders[mode]
+
+    def close(self) -> None:
+        if self._device is not None and self._ttnn is not None:
+            self._ttnn.close_device(self._device)
+            self._device = None
+            self._semantic_generators.clear()
+            self._flow_bridges.clear()
+            self._flow_encoders.clear()
+            self._flow_length_regulators.clear()
+            self._flow_decoders.clear()
+            if self._previous_fallback_setting is not None:
+                self._ttnn.CONFIG.throw_exception_on_fallback = self._previous_fallback_setting
+                self._previous_fallback_setting = None
+
+    def __del__(self):  # pragma: no cover - defensive cleanup for public CLI scripts
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def prepare_case(self, case: CosyVoiceCase) -> PreparedFrontendInput:
+        return self.frontend.prepare(case)
+
+    def prepare_semantic_inputs(
+        self,
+        case: CosyVoiceCase,
+        prepared: PreparedFrontendInput | None = None,
+    ) -> CosyVoiceSemanticInputs:
+        prepared = prepared or self.prepare_case(case)
+        return self.reference.prepare_semantic_inputs(case, prepared.payload)
+
+    def prepare_flow_inputs(
+        self,
+        case: CosyVoiceCase,
+        semantic_tokens: SemanticTokenResult | torch.Tensor,
+        prepared: PreparedFrontendInput | None = None,
+    ) -> CosyVoiceFlowInputs:
+        prepared = prepared or self.prepare_case(case)
+        model, _ = self.reference.get_model(case.mode)
+        token_tensor = semantic_tokens.tokens if isinstance(semantic_tokens, SemanticTokenResult) else semantic_tokens
+        return build_flow_inputs_from_model_input(
+            flow_module=model.model.flow,
+            model_input=prepared.payload,
+            source_speech_token=token_tensor,
+        )
+
+    def generate_semantic_tokens(
+        self,
+        case: CosyVoiceCase,
+        prepared: PreparedFrontendInput | None = None,
+    ) -> SemanticTokenResult:
+        prepared = prepared or self.prepare_case(case)
+        semantic_inputs = self.reference.prepare_semantic_inputs(case, prepared.payload)
+        tokens, wall_seconds = self._get_semantic_generator(case.mode).generate(semantic_inputs)
+        _, model_dir = self.reference.get_model(case.mode)
+        return SemanticTokenResult(case=case, model_dir=str(model_dir), tokens=tokens, wall_seconds=wall_seconds)
+
+    def evaluate_semantic_token_accuracy(
+        self,
+        case: CosyVoiceCase,
+        prepared: PreparedFrontendInput | None = None,
+    ) -> float:
+        prepared = prepared or self.prepare_case(case)
+        semantic_inputs = self.reference.prepare_semantic_inputs(case, prepared.payload)
+        reference_tokens = self.reference.generate_semantic_greedy_tokens(case, prepared.payload)
+        return self._get_semantic_generator(case.mode).teacher_forced_accuracy(semantic_inputs, reference_tokens.tokens)
+
+    def evaluate_quality(self, case: CosyVoiceCase, output_path: str | Path) -> dict[str, Any]:
+        return self.reference.evaluate_quality(case, output_path)
+
+    def synthesize_semantic_tokens(
+        self,
+        case: CosyVoiceCase,
+        semantic_tokens: SemanticTokenResult | object,
+        prepared: PreparedFrontendInput | None = None,
+        output_path: str | None = None,
+    ) -> GeneratedAudioResult:
+        prepared = prepared or self.prepare_case(case)
+        token_tensor = semantic_tokens.tokens if isinstance(semantic_tokens, SemanticTokenResult) else semantic_tokens
+        flow_inputs = self.prepare_flow_inputs(case, token_tensor, prepared=prepared)
+        model, model_dir = self.reference.get_model(case.mode)
+        bridge = self._get_flow_bridge(case.mode)
+        encoder = self._get_flow_encoder(case.mode)
+        length_regulator = self._get_flow_length_regulator(case.mode)
+        decoder = self._get_flow_decoder(case.mode)
+
+        start = time.perf_counter()
+        speaker_projection = bridge.project_speaker_embedding(flow_inputs.flow_embedding)
+        token_embedding = bridge.embed_tokens(flow_inputs.full_token, flow_inputs.full_token_len)
+        encoded_hidden = encoder.encode(token_embedding, flow_inputs.full_token_len)
+        projected_hidden = bridge.project_encoder_output(encoded_hidden)
+
+        prompt_token_len = int(flow_inputs.prompt_speech_token.shape[1])
+        acoustic_hidden, _ = length_regulator.inference(
+            projected_hidden[:, :prompt_token_len],
+            projected_hidden[:, prompt_token_len:],
+            flow_inputs.prompt_mel_length,
+            flow_inputs.decode_mel_length,
+            model.model.flow.input_frame_rate,
+        )
+        total_mel_length = flow_inputs.prompt_mel_length + flow_inputs.decode_mel_length
+        cond = flow_inputs.condition.transpose(1, 2).contiguous()
+        mask = torch.ones((1, 1, total_mel_length), dtype=torch.bool, device=acoustic_hidden.device)
+        feat, _ = decoder.inference(
+            mu=acoustic_hidden.transpose(1, 2).contiguous(),
+            mask=mask,
+            spks=speaker_projection.to(dtype=acoustic_hidden.dtype, device=acoustic_hidden.device),
+            cond=cond,
+            n_timesteps=10,
+            prompt_len=flow_inputs.prompt_mel_length,
+            cache=torch.zeros((1, 80, 0, 2), dtype=acoustic_hidden.dtype, device=acoustic_hidden.device),
+        )
+        feat = feat[:, :, flow_inputs.prompt_mel_length :]
+        waveform, _ = model.model.hift.inference(
+            speech_feat=feat,
+            cache_source=torch.zeros((1, 1, 0), dtype=feat.dtype, device=feat.device),
+        )
+        wall_seconds = time.perf_counter() - start
+        result = GeneratedAudioResult(
+            case=case,
+            model_dir=str(Path(model_dir).resolve()),
+            sample_rate=model.sample_rate,
+            waveform=waveform.cpu(),
+            wall_seconds=wall_seconds,
+        )
+        if output_path is not None:
+            save_audio(output_path, result.waveform, result.sample_rate)
+        return result
+
+    def generate_case(self, case: CosyVoiceCase, output_path: str | None = None) -> GeneratedAudioResult:
+        prepared = self.prepare_case(case)
+        semantic_tokens = self.generate_semantic_tokens(case, prepared=prepared)
+        return self.synthesize_semantic_tokens(case, semantic_tokens, prepared=prepared, output_path=output_path)
+
+    def generate_mode(self, mode: str, text: str, output_path: str | None = None, **kwargs) -> GeneratedAudioResult:
+        case = CosyVoiceCase(name=f"adhoc_{mode}", mode=mode, text=text, **kwargs)
+        if output_path is None:
+            output_path = str(Path("/tmp") / f"{case.name}.wav")
+        return self.generate_case(case, output_path=output_path)

--- a/models/demos/audio/cosy_voice/tt/reference.py
+++ b/models/demos/audio/cosy_voice/tt/reference.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torchaudio
+
+from models.demos.audio.cosy_voice.demo.common import (
+    CosyVoiceCase,
+    configure_reference_imports,
+    resolve_model_dir,
+    resolve_prompt_audio,
+    resolve_reference_repo,
+    save_audio,
+)
+from models.demos.audio.cosy_voice.tt.llm import CosyVoiceSemanticInputs, build_semantic_inputs_from_model_input
+
+LANGUAGE_TAG_PATTERN = re.compile(r"<\|[^|>]+\|>")
+QUALITY_WHISPER_MODEL = "small"
+
+
+def normalize_transcript_text(text: str, language: str | None) -> str:
+    text = LANGUAGE_TAG_PATTERN.sub(" ", text)
+    text = text.strip()
+    if language in {"zh", "ja", "ko", "yue"}:
+        # Character-level normalization is more stable than whitespace tokenization for CJK scripts.
+        return "".join(ch for ch in text if ch.isalnum())
+    return " ".join(part for part in re.sub(r"[^0-9a-zA-Z]+", " ", text.lower()).split() if part)
+
+
+def transcript_tokens(text: str, language: str | None) -> list[str]:
+    normalized = normalize_transcript_text(text, language)
+    if language in {"zh", "ja", "ko", "yue"}:
+        return list(normalized)
+    return normalized.split()
+
+
+def edit_distance(reference: list[str], hypothesis: list[str]) -> int:
+    rows = len(reference) + 1
+    cols = len(hypothesis) + 1
+    distance = [[0] * cols for _ in range(rows)]
+    for idx in range(rows):
+        distance[idx][0] = idx
+    for idx in range(cols):
+        distance[0][idx] = idx
+    for row in range(1, rows):
+        for col in range(1, cols):
+            if reference[row - 1] == hypothesis[col - 1]:
+                distance[row][col] = distance[row - 1][col - 1]
+            else:
+                distance[row][col] = min(
+                    distance[row - 1][col] + 1,
+                    distance[row][col - 1] + 1,
+                    distance[row - 1][col - 1] + 1,
+                )
+    return distance[-1][-1]
+
+
+def word_error_rate_percent(reference_text: str, hypothesis_text: str, language: str | None) -> float:
+    reference = transcript_tokens(reference_text, language)
+    hypothesis = transcript_tokens(hypothesis_text, language)
+    if not reference:
+        return 0.0
+    return 100.0 * edit_distance(reference, hypothesis) / float(len(reference))
+
+
+def cosine_similarity_percent(reference_embedding: torch.Tensor, hypothesis_embedding: torch.Tensor) -> float:
+    reference_embedding = reference_embedding.reshape(-1).float()
+    hypothesis_embedding = hypothesis_embedding.reshape(-1).float()
+    similarity = torch.nn.functional.cosine_similarity(reference_embedding, hypothesis_embedding, dim=0)
+    return float(similarity.item() * 100.0)
+
+
+@dataclass
+class GeneratedAudioResult:
+    case: CosyVoiceCase
+    model_dir: str
+    sample_rate: int
+    waveform: torch.Tensor
+    wall_seconds: float
+
+    @property
+    def audio_seconds(self) -> float:
+        return float(self.waveform.shape[-1]) / float(self.sample_rate) if self.sample_rate > 0 else 0.0
+
+    @property
+    def rtf(self) -> float | None:
+        return self.wall_seconds / self.audio_seconds if self.audio_seconds > 0 else None
+
+
+@dataclass
+class SemanticTokenResult:
+    case: CosyVoiceCase
+    model_dir: str
+    tokens: torch.Tensor
+    wall_seconds: float
+
+    @property
+    def token_count(self) -> int:
+        return int(self.tokens.shape[-1]) if self.tokens.ndim > 0 else 0
+
+    @property
+    def tokens_per_second(self) -> float | None:
+        return self.token_count / self.wall_seconds if self.wall_seconds > 0 else None
+
+
+class CosyVoiceReferenceSession:
+    def __init__(self, reference_repo: str | None = None, model_root: str | None = None, text_frontend: bool = True):
+        self.reference_repo = resolve_reference_repo(reference_repo)
+        self.model_root = model_root
+        self.text_frontend = text_frontend
+        self._models: dict[str, Any] = {}
+        self._whisper_model = None
+
+    def _load_model(self, mode: str):
+        configure_reference_imports(self.reference_repo)
+        from cosyvoice.cli.cosyvoice import CosyVoice  # noqa: PLC0415
+
+        model_dir = resolve_model_dir(mode, self.model_root)
+        model = CosyVoice(str(model_dir))
+        return model, model_dir
+
+    def get_model(self, mode: str):
+        if mode not in self._models:
+            self._models[mode] = self._load_model(mode)
+        return self._models[mode]
+
+    def _get_whisper_model(self):
+        if self._whisper_model is None:
+            import whisper  # noqa: PLC0415
+
+            self._whisper_model = whisper.load_model(QUALITY_WHISPER_MODEL, device="cpu")
+        return self._whisper_model
+
+    @staticmethod
+    def _empty_text_tokens() -> torch.Tensor:
+        return torch.zeros((1, 0), dtype=torch.int32)
+
+    @staticmethod
+    def _empty_token_lengths() -> torch.Tensor:
+        return torch.zeros((1,), dtype=torch.int32)
+
+    @staticmethod
+    def _empty_prompt_features() -> torch.Tensor:
+        return torch.zeros((1, 0, 80), dtype=torch.float32)
+
+    @staticmethod
+    def _empty_prompt_feature_lengths() -> torch.Tensor:
+        return torch.zeros((1,), dtype=torch.int32)
+
+    @staticmethod
+    def _empty_embedding(model: Any) -> torch.Tensor:
+        spk_embed_dim = int(model.model.llm.spk_embed_affine_layer.in_features)
+        return torch.zeros((0, spk_embed_dim), dtype=torch.float32)
+
+    def generate_semantic_tokens(
+        self,
+        case: CosyVoiceCase,
+        model_input: dict[str, Any],
+    ) -> SemanticTokenResult:
+        model, model_dir = self.get_model(case.mode)
+        llm = model.model.llm
+
+        prompt_text = model_input.get("prompt_text", self._empty_text_tokens())
+        prompt_text_len = model_input.get("prompt_text_len", self._empty_token_lengths())
+        prompt_speech_token = model_input.get("llm_prompt_speech_token", self._empty_text_tokens())
+        prompt_speech_token_len = model_input.get("llm_prompt_speech_token_len", self._empty_token_lengths())
+        llm_embedding = model_input.get("llm_embedding", self._empty_embedding(model))
+
+        start = time.perf_counter()
+        tokens = list(
+            llm.inference(
+                text=model_input["text"],
+                text_len=model_input["text_len"],
+                prompt_text=prompt_text,
+                prompt_text_len=prompt_text_len,
+                prompt_speech_token=prompt_speech_token,
+                prompt_speech_token_len=prompt_speech_token_len,
+                embedding=llm_embedding,
+            )
+        )
+        wall_seconds = time.perf_counter() - start
+        token_tensor = torch.tensor(tokens, dtype=torch.int32).unsqueeze(0) if tokens else self._empty_text_tokens()
+        return SemanticTokenResult(
+            case=case,
+            model_dir=str(Path(model_dir).resolve()),
+            tokens=token_tensor,
+            wall_seconds=wall_seconds,
+        )
+
+    def generate_semantic_greedy_tokens(
+        self,
+        case: CosyVoiceCase,
+        model_input: dict[str, Any],
+    ) -> SemanticTokenResult:
+        model, model_dir = self.get_model(case.mode)
+        llm = model.model.llm
+        semantic_inputs = build_semantic_inputs_from_model_input(
+            llm_module=llm,
+            model_input=model_input,
+        )
+
+        lm_input = semantic_inputs.lm_input
+        att_cache = torch.zeros((0, 0, 0, 0), device=lm_input.device)
+        cnn_cache = torch.zeros((0, 0, 0, 0), device=lm_input.device)
+        offset = 0
+        tokens: list[int] = []
+        start = time.perf_counter()
+        for step_index in range(semantic_inputs.max_decode_length):
+            att_mask = torch.tril(torch.ones((1, lm_input.shape[1], lm_input.shape[1]), device=lm_input.device)).to(
+                torch.bool
+            )
+            y_pred, att_cache, cnn_cache = llm.llm.forward_chunk(
+                lm_input,
+                offset=offset,
+                required_cache_size=-1,
+                att_cache=att_cache,
+                cnn_cache=cnn_cache,
+                att_mask=att_mask,
+            )
+            logits = llm.llm_decoder(y_pred[:, -1]).squeeze(0)
+            if step_index < semantic_inputs.min_decode_length:
+                # Match the public semantic parity gate to the model's EOS suppression rule.
+                logits = logits.clone()
+                logits[llm.eos_token] = -float("inf")
+            next_token = int(torch.argmax(logits).item())
+            if next_token == llm.eos_token:
+                break
+            tokens.append(next_token)
+            offset += lm_input.size(1)
+            lm_input = llm.speech_embedding.weight[next_token].reshape(1, 1, -1)
+        wall_seconds = time.perf_counter() - start
+        token_tensor = torch.tensor(tokens, dtype=torch.int32).unsqueeze(0) if tokens else self._empty_text_tokens()
+        return SemanticTokenResult(
+            case=case,
+            model_dir=str(Path(model_dir).resolve()),
+            tokens=token_tensor,
+            wall_seconds=wall_seconds,
+        )
+
+    def prepare_semantic_inputs(
+        self,
+        case: CosyVoiceCase,
+        model_input: dict[str, Any],
+    ) -> CosyVoiceSemanticInputs:
+        model, _ = self.get_model(case.mode)
+        return build_semantic_inputs_from_model_input(
+            llm_module=model.model.llm,
+            model_input=model_input,
+        )
+
+    def transcribe_audio(self, audio_path: str | Path, language: str | None) -> str:
+        waveform, sample_rate = torchaudio.load(str(audio_path))
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+        if sample_rate != 16000:
+            waveform = torchaudio.functional.resample(waveform, sample_rate, 16000)
+        whisper_language = {"yue": "zh"}.get(language or "", language)
+        result = self._get_whisper_model().transcribe(
+            waveform.squeeze(0).cpu().numpy(),
+            language=whisper_language,
+            task="transcribe",
+            fp16=False,
+            verbose=False,
+        )
+        return str(result["text"])
+
+    def _extract_generated_audio_embedding(self, case: CosyVoiceCase, audio_path: str | Path) -> torch.Tensor:
+        model, _ = self.get_model(case.mode)
+        return model.frontend._extract_spk_embedding(str(audio_path)).detach().cpu().reshape(-1)
+
+    def _target_speaker_embedding(self, case: CosyVoiceCase) -> torch.Tensor:
+        model, _ = self.get_model(case.mode)
+        if case.mode in {"sft", "instruct"}:
+            # SFT and instruct use a fixed speaker embedding from the checked-in speaker table.
+            target = model.frontend.spk2info[case.speaker_id]["embedding"]
+            if not torch.is_tensor(target):
+                target = torch.tensor(target)
+            return target.detach().cpu().reshape(-1)
+
+        # Zero-shot and cross-lingual quality must track the prompt speaker identity.
+        prompt_audio = resolve_prompt_audio(self.reference_repo, case.prompt_audio)
+        return model.frontend._extract_spk_embedding(prompt_audio).detach().cpu().reshape(-1)
+
+    def evaluate_quality(self, case: CosyVoiceCase, audio_path: str | Path) -> dict[str, Any]:
+        reference_text = normalize_transcript_text(case.text, case.language)
+        transcription = self.transcribe_audio(audio_path, case.language)
+        speaker_similarity_pct = cosine_similarity_percent(
+            self._target_speaker_embedding(case),
+            self._extract_generated_audio_embedding(case, audio_path),
+        )
+        return {
+            "reference_text": reference_text,
+            "transcribed_text": transcription,
+            "wer_pct": word_error_rate_percent(reference_text, transcription, case.language),
+            "speaker_similarity_pct": speaker_similarity_pct,
+            "quality_asr_model": QUALITY_WHISPER_MODEL,
+        }
+
+    def synthesize_from_semantic_tokens(
+        self,
+        case: CosyVoiceCase,
+        model_input: dict[str, Any],
+        semantic_tokens: torch.Tensor,
+        output_path: str | None = None,
+    ) -> GeneratedAudioResult:
+        model, model_dir = self.get_model(case.mode)
+        source_tokens = semantic_tokens if semantic_tokens.ndim == 2 else semantic_tokens.reshape(1, -1)
+
+        flow_prompt_speech_token = model_input.get("flow_prompt_speech_token", self._empty_text_tokens())
+        prompt_speech_feat = model_input.get("prompt_speech_feat", self._empty_prompt_features())
+        flow_embedding = model_input["flow_embedding"]
+
+        start = time.perf_counter()
+        chunks = list(
+            model.model.tts(
+                flow_embedding=flow_embedding,
+                flow_prompt_speech_token=flow_prompt_speech_token,
+                prompt_speech_feat=prompt_speech_feat,
+                source_speech_token=source_tokens,
+                stream=False,
+            )
+        )
+        wall_seconds = time.perf_counter() - start
+        if not chunks:
+            raise RuntimeError(f"CosyVoice produced no audio chunks for case {case.name}")
+        waveform = torch.cat([chunk["tts_speech"].cpu() for chunk in chunks], dim=1)
+        result = GeneratedAudioResult(
+            case=case,
+            model_dir=str(Path(model_dir).resolve()),
+            sample_rate=model.sample_rate,
+            waveform=waveform,
+            wall_seconds=wall_seconds,
+        )
+        if output_path is not None:
+            save_audio(output_path, waveform, result.sample_rate)
+        return result
+
+    def generate(self, case: CosyVoiceCase, output_path: str | None = None) -> GeneratedAudioResult:
+        model, model_dir = self.get_model(case.mode)
+        prompt_audio = resolve_prompt_audio(self.reference_repo, case.prompt_audio)
+        start = time.perf_counter()
+        if case.mode == "sft":
+            chunks = list(
+                model.inference_sft(
+                    case.text,
+                    case.speaker_id,
+                    stream=False,
+                    text_frontend=self.text_frontend,
+                )
+            )
+        elif case.mode == "zero_shot":
+            chunks = list(
+                model.inference_zero_shot(
+                    case.text,
+                    case.prompt_text,
+                    prompt_audio,
+                    stream=False,
+                    text_frontend=self.text_frontend,
+                )
+            )
+        elif case.mode == "cross_lingual":
+            chunks = list(
+                model.inference_cross_lingual(
+                    case.text,
+                    prompt_audio,
+                    stream=False,
+                    text_frontend=self.text_frontend,
+                )
+            )
+        elif case.mode == "instruct":
+            chunks = list(
+                model.inference_instruct(
+                    case.text,
+                    case.speaker_id,
+                    case.instruction,
+                    stream=False,
+                    text_frontend=self.text_frontend,
+                )
+            )
+        else:  # pragma: no cover - protected by CosyVoiceCase validation
+            raise ValueError(f"Unsupported mode: {case.mode}")
+        wall_seconds = time.perf_counter() - start
+        if not chunks:
+            raise RuntimeError(f"CosyVoice produced no audio chunks for case {case.name}")
+        waveform = torch.cat([chunk["tts_speech"].cpu() for chunk in chunks], dim=1)
+        result = GeneratedAudioResult(
+            case=case,
+            model_dir=str(Path(model_dir).resolve()),
+            sample_rate=model.sample_rate,
+            waveform=waveform,
+            wall_seconds=wall_seconds,
+        )
+        if output_path is not None:
+            save_audio(output_path, waveform, result.sample_rate)
+        return result

--- a/models/demos/audio/cosy_voice/tt/vocoder.py
+++ b/models/demos/audio/cosy_voice/tt/vocoder.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class CosyVoiceVocoderConfig:
+    mel_channels: int = 80
+    sample_rate: int = 22050
+
+
+def maybe_resample_mel_for_speed(mel: torch.Tensor, speed: float) -> torch.Tensor:
+    if speed == 1.0:
+        return mel
+    return F.interpolate(mel, size=int(mel.shape[-1] / speed), mode="linear")
+
+
+def audio_seconds(num_samples: int, sample_rate: int) -> float:
+    return float(num_samples) / float(sample_rate) if sample_rate > 0 else 0.0
+
+
+def prepare_tt_vocoder_input(mel: torch.Tensor, mesh_device, *, dtype=None, memory_config=None):
+    import ttnn  # noqa: PLC0415
+
+    return ttnn.from_torch(
+        mel,
+        device=mesh_device,
+        dtype=dtype or ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=memory_config or ttnn.DRAM_MEMORY_CONFIG,
+    )


### PR DESCRIPTION
### Ticket
#32178

### Problem description

This PR brings up a minimal public CosyVoice-300M TTNN demo on Tenstorrent hardware.

* single-device Wormhole path

* `batch_size=1`

* four supported public modes: SFT, zero-shot, cross-lingual, and instruct

* public validation split into accuracy, quality, and performance suites

* current public backend is mixed:
  * TT semantic token generation
  * TT flow acoustic frontend through the learned length regulator
  * in-tree torch diffusion decoder parity path
  * upstream reference HiFT vocoder

### Core Architecture

* TTNN-backed CosyVoice semantic generation lives under `models/demos/audio/cosy_voice/tt/llm.py`.

* TTNN-backed flow bridge, flow encoder, and learned length regulator live under `models/demos/audio/cosy_voice/tt/flow.py`.

* Public demo entrypoint is `models/demos/audio/cosy_voice/demo/demo.py`.

* Public validation runner is `models/demos/audio/cosy_voice/demo/validate_tt.py`.

* Supported public modes:
  * SFT with predefined speakers
  * zero-shot TTS from prompt text + prompt audio
  * cross-lingual generation from prompt audio
  * instruct generation with speaker id + instruction prompt

* The pinned upstream CosyVoice reference repo is used for frontend processing and reference behavior.

* The public runtime is fixed to single-device and `batch_size=1`.

* Prompt-audio/frontend processing and final waveform synthesis remain on the upstream reference stack; the TTNN path covers the semantic transformer and the flow acoustic frontend up through the learned length regulator.

### Validation & Accuracy

* End-to-end public validation is driven by `validate_tt.py` using checked-in JSON manifests for accuracy, quality, and performance.

* `test_accuracy.py` covers TTNN/PyTorch parity helpers, real-checkpoint integration when assets are present, and the public mode contracts.

* The accuracy manifest covers real cases across four modes and five languages:
  * Chinese SFT
  * Chinese zero-shot
  * English cross-lingual
  * Japanese cross-lingual
  * Cantonese cross-lingual
  * Korean cross-lingual
  * Chinese instruct

* The accuracy gate enforced by the public runner is:
  * semantic token accuracy against the deterministic greedy teacher-forced PyTorch reference `>= 95%`

Validation command:

```shell
python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
  --suite accuracy \
  --reference-repo /path/to/CosyVoice \
  --model-root /path/to/pretrained_models \
  --output-json /tmp/cosy_voice_accuracy.json \
  --check
```

### Quality

* `validate_tt.py --suite quality` measures output waveform validity, Whisper transcription WER, and CampPlus speaker similarity on real generated audio.

* The quality manifest covers the public mode surface:
  * SFT
  * zero-shot
  * cross-lingual
  * instruct

* The quality gates enforced by the public runner are:
  * `WER < 3.0`
  * speaker similarity `> 60`

Quality command:

```shell
python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
  --suite quality \
  --reference-repo /path/to/CosyVoice \
  --model-root /path/to/pretrained_models \
  --output-json /tmp/cosy_voice_quality.json \
  --check
```

### Performance

* `validate_tt.py --suite performance` runs the public performance path on the long-horizon zero-shot case `zero_shot_long_zh`.

* Current tracked public gates from `models/demos/audio/cosy_voice/PERF.md`:

  * semantic token generation `>= 30 tokens/s`

  * end-to-end `RTF < 0.5`

* The accepted public backend for reported performance is:
  * `tt_semantic_tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder`

* `PERF.md` currently tracks the public gate and required report fields; benchmark-backed promoted public numbers should be attached from the accepted run artifact.

Performance command:

```shell
python_env/bin/python models/demos/audio/cosy_voice/demo/validate_tt.py \
  --suite performance \
  --reference-repo /path/to/CosyVoice \
  --model-root /path/to/pretrained_models \
  --output-json /tmp/cosy_voice_performance.json \
  --check
```

### Instructions

* export `TT_METAL_HOME`

* export `COSYVOICE_REFERENCE_REPO`

* export `COSYVOICE_MODEL_ROOT`

* export `PYTHONPATH=$TT_METAL_HOME${PYTHONPATH:+:$PYTHONPATH}`

* verify the repo-local runtime before running the demo or validation

* run one of the four public demo commands:
  * SFT
  * zero-shot
  * cross-lingual
  * instruct

### Optimisations

* The TTNN semantic path keeps model parameters on device and uses cached decode state across autoregressive generation.

* The TTNN flow path covers token embedding, speaker projection, transformer encoder layers, and learned length regulator execution.

* The pipeline enables `throw_exception_on_fallback=True` when the TT device is opened to keep the public path honest.

### Sample Demo Runs

| Mode | Input | Output artifact |
| --- | --- | --- |
| SFT | `你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？` | `/tmp/cosy_voice_sft.wav` |
| Zero-shot | `收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐。` | `/tmp/cosy_voice_zero_shot.wav` |
| Cross-lingual | `<\|en\|>And then later on, fully acquiring that company.` | `/tmp/cosy_voice_cross_lingual.wav` |
| Instruct | `在面对挑战时，他展现了非凡的勇气与智慧。` | `/tmp/cosy_voice_instruct.wav` |

### Known limitations

* Public runtime is single-device only.

* Public runtime is `batch_size=1` only.

* Public tree excludes multi-device and streaming runtime variants.

* The frontend stays on the pinned upstream CosyVoice reference stack.

* The current public backend is `tt_semantic_tt_flow_frontend_length_regulator_torch_decoder_reference_vocoder`.

* The diffusion decoder loop is currently an in-tree torch parity path, not a TTNN path.

* The HiFT vocoder remains on the pinned upstream reference path.

* Public quality and performance claims apply to the current mixed backend, not a full end-to-end TT pipeline.

* This PR does not expose public sampling controls such as `temperature`, `top-p`, or `top-k`.

* Voice conversion is not exposed in the current public runner.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212806203871066