### PR TITLE
[skip ci] Update CODEOWNERS: remove departed members, add sweep-run-analysis owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ METALIUM_GUIDE.md @davorchap @tenstorrent/codeowner-bypass
 
 # CI/CD
 .github/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+.github/actions/sweep-run-analysis/ @stevendae @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/time_budget.yaml @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/profiler-ci-selector.yaml @mo-tenstorrent @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/ttnn-run-sweeps*.yaml @stevendae @cmaryanTT @sjameelTT @bbradelTT @ntarafdar @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,7 +109,7 @@ tt_metal/llrt/ @abhullar-tt @jbaumanTT @ruizhangTT @arikTT @tt-asaigal @tt-aho @
 tt_metal/llrt/**/CMakeLists.txt @abhullar-tt @jbaumanTT @ruizhangTT @arikTT @tt-asaigal @tt-aho @tenstorrent/metalium-developers-infra
 tt_metal/programming_examples/ @tt-asaigal @afuller-TT @ebanerjeeTT @tenstorrent/metalium-api-owners @tenstorrent/codeowner-bypass
 tt_metal/programming_examples/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
-tt_metal/programming_examples/profiler/test_noc_event_profiler/ @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/programming_examples/profiler/test_noc_event_profiler/ @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/programming_examples/**/CMakeLists.txt @tt-asaigal @afuller-TT @ebanerjeeTT @tenstorrent/metalium-api-owners @tenstorrent/metalium-developers-infra
 tt_metal/soc_descriptors @abhullar-tt @aliuTT @ubcheema @tenstorrent/codeowner-bypass
 tt_metal/test @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
@@ -118,10 +118,10 @@ tt_metal/tools/lightmetal_runner @kmabeeTT @tenstorrent/codeowner-bypass
 tt_metal/tools/mem_bench @abhullar-tt @tenstorrent/codeowner-bypass # should be moved to tests micro benchmark?
 tt_metal/tools/precompile_fw @abhullar-tt @ruizhangTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/ @mo-tenstorrent @abhullar-tt @tenstorrent/codeowner-bypass
-tt_metal/tools/profiler/event_metadata.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
-tt_metal/tools/profiler/fabric_event_profiler.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
-tt_metal/tools/profiler/noc_event_profiler.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
-tt_metal/tools/profiler/noc_event_profiler_utils.hpp @bgrady-tt @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/event_metadata.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/fabric_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/noc_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/noc_event_profiler_utils.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/**/CMakeLists.txt @kmabeeTT @mo-tenstorrent @ihamer-tt @tenstorrent/metalium-developers-infra
 tt_metal/api/tt-metalium/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental APIs
 tt_metal/impl/experimental/disaggregation/ @SeanNijjar @ubcheema @tenstorrent/codeowner-bypass # disaggregation experimental impl
@@ -171,7 +171,7 @@ tests/tt_metal/tt_metal/debug_tools/device_print @tenstorrent/metalium-developer
 tests/tt_metal/tt_metal/test_kernels/device_print @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 
 # misc tests
-tests/didt/ @rdjogoTT @ttmtrajkovic @ctr-nradojevicTT @tenstorrent/codeowner-bypass
+tests/didt/ @rdjogoTT @ttmtrajkovic @tenstorrent/codeowner-bypass
 
 # TTNN
 ttnn/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -172,7 +172,7 @@ tests/tt_metal/tt_metal/debug_tools/device_print @tenstorrent/metalium-developer
 tests/tt_metal/tt_metal/test_kernels/device_print @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 
 # misc tests
-tests/didt/ @rdjogoTT @ttmtrajkovic @tenstorrent/codeowner-bypass
+tests/didt/ @rdjogoTT @ttmtrajkovic @ctr-nradojevicTT @tenstorrent/codeowner-bypass
 
 # TTNN
 ttnn/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass


### PR DESCRIPTION
## Summary
- Remove `@bgrady-tt` from CODEOWNERS (no longer with the org)
- Add `@stevendae` as owner for `.github/actions/sweep-run-analysis/`

## Changes
**Removed `@bgrady-tt`** from 5 entries (profiler-related):
- `tt_metal/programming_examples/profiler/test_noc_event_profiler/`
- `tt_metal/tools/profiler/event_metadata.hpp`
- `tt_metal/tools/profiler/fabric_event_profiler.hpp`
- `tt_metal/tools/profiler/noc_event_profiler.hpp`
- `tt_metal/tools/profiler/noc_event_profiler_utils.hpp`

**Added `@stevendae`** as owner for:
- `.github/actions/sweep-run-analysis/` (along with `@tenstorrent/metalium-developers-infra` and `@tenstorrent/codeowner-bypass`)

All entries retain their remaining co-owners.

## Test plan
- [x] No code changes, only CODEOWNERS updates
- [x] Verify no remaining references to removed users

🤖 Generated with [Claude Code](https://claude.com/claude-code)