### PR TITLE
#41378, 41467: fix pre all gather layernorm with residual and gamma without beta

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -209,3 +209,140 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
         device.num_program_cache_entries()
     )
+
+
+def _layernorm_stats_tiles_single_chunk(canon_inp: torch.Tensor) -> torch.Tensor:
+    """Stats layout for layer_norm post_all_gather with a single full-width chunk (matches run_layernorm_part_2)."""
+    inp_chunked = canon_inp.chunk(1, dim=-1)
+    mean = [x.sum(dim=-1, keepdim=True) for x in inp_chunked]
+    meanx2 = [x.pow(2).sum(dim=-1, keepdim=True) for x in inp_chunked]
+    tile_cols_per_device = 2
+    stats_tiles = torch.zeros(canon_inp.shape[:-1] + (32 * tile_cols_per_device,))
+    for idx, (m, mm) in enumerate(zip(mean, meanx2)):
+        mm_idx = idx * tile_cols_per_device * 32
+        stats_tiles[..., mm_idx : mm_idx + 1] = mm
+        m_idx = mm_idx + 32
+        stats_tiles[..., m_idx : m_idx + 1] = m
+    return stats_tiles
+
+
+def test_layer_norm_post_all_gather_bias_only_matches_torch(device):
+    """Bias without weight: optional args are independent; compare to torch layer_norm."""
+    torch.manual_seed(4401)
+    inp_shape = (1, 1, 32, 128)
+    epsilon = 1e-5
+    dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    canon_inp = torch.randn(inp_shape) * 4 - 1
+    beta = torch.rand(inp_shape[-1]) * 2 - 1
+
+    ref = torch.nn.functional.layer_norm(
+        canon_inp.float(),
+        canon_inp.shape[-1:],
+        weight=None,
+        bias=beta.float(),
+        eps=epsilon,
+    ).to(torch.bfloat16)
+
+    stats_tiles = _layernorm_stats_tiles_single_chunk(canon_inp)
+
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    tt_inp = torch2tt_tensor(
+        canon_inp,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    tt_beta = torch2tt_tensor(
+        beta.reshape(1, 1, -1, 32),
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.ROW_MAJOR_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    tt_stats = torch2tt_tensor(
+        stats_tiles,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+
+    tt_out = ttnn.layer_norm_post_all_gather(
+        tt_inp,
+        tt_stats,
+        epsilon=epsilon,
+        bias=tt_beta,
+        compute_kernel_config=kernel_config,
+        dtype=ttnn.bfloat16,
+        memory_config=dram_memcfg,
+    )
+    tt_cpu = tt2torch_tensor(tt_out)
+    passing, output_str = comp_allclose(ref, tt_cpu, rtol=1e-1, atol=1e-1)
+    assert passing, output_str
+
+
+def test_layer_norm_post_all_gather_bias_only_rejects_mismatched_beta_row_major(device):
+    """Invalid beta width must fail in validate even when weight is absent.
+
+    ROW_MAJOR bias uses the physical_volume vs input width check (same as gamma). A TILE
+    tensor with smaller logical width can end up with a padded last dim that still matches
+    the input, so the mismatch case here uses ROW_MAJOR with too few 32-wide sticks.
+    """
+    torch.manual_seed(4402)
+    inp_shape = (1, 1, 32, 128)
+    epsilon = 1e-5
+    dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    canon_inp = torch.randn(inp_shape, dtype=torch.bfloat16)
+    stats_tiles = _layernorm_stats_tiles_single_chunk(canon_inp.float())
+
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    tt_inp = torch2tt_tensor(
+        canon_inp,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    tt_stats = torch2tt_tensor(
+        stats_tiles,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    # Valid layout for bias is (1, 1, n_sticks, 32) with n_sticks == input_width / 32; use half.
+    tt_bad_beta = torch2tt_tensor(
+        torch.randn(1, 1, 2, 32, dtype=torch.bfloat16),
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.ROW_MAJOR_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+
+    with pytest.raises(RuntimeError, match="Beta tensor dimensions must align"):
+        ttnn.layer_norm_post_all_gather(
+            tt_inp,
+            tt_stats,
+            epsilon=epsilon,
+            bias=tt_bad_beta,
+            compute_kernel_config=kernel_config,
+            dtype=ttnn.bfloat16,
+            memory_config=dram_memcfg,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -126,12 +126,14 @@ def run_layernorm_pre_all_gather_residual_pcc(device):
 
     tt_output_host = tt2torch_tensor(tt_stats)
     all_passing = True
-    reduction_width = inp_shape[-1]
+    n_devices = 1
+    reduction_width = inp_shape[-1] // n_devices
 
     device_offset = 0
+    # sum(x^2) lives in column 0 of the first stats tile (same layout as run_layernorm_part_1)
     passing, output_str = comp_allclose_and_pcc(
-        out_torch,
-        tt_output_host,
+        out_torch[:, :, :, 0 + device_offset],
+        tt_output_host[:, :, :, 0 + device_offset],
         rtol=1e-01 * reduction_width,
         atol=0,
         pcc=0.99,
@@ -146,9 +148,10 @@ def run_layernorm_pre_all_gather_residual_pcc(device):
     logger.debug(f"tt vs torch padding 1 residual path = {output_str}")
     all_passing &= passing
 
+    # sum(x) lives in column 0 of the second stats tile (offset 32)
     passing, output_str = comp_allclose_and_pcc(
-        out_torch,
-        tt_output_host,
+        out_torch[:, :, :, 32 + device_offset],
+        tt_output_host[:, :, :, 32 + device_offset],
         rtol=5e-01 * reduction_width,
         atol=10,
         pcc=0.99,
@@ -156,7 +159,6 @@ def run_layernorm_pre_all_gather_residual_pcc(device):
     logger.debug(f"tt vs torch sum(x) residual path = {output_str}")
     all_passing &= passing
 
-    # specific range for equality
     passing, output_str = comp_equal(
         out_torch[:, :, :, 33 + device_offset : 64 + device_offset],
         tt_output_host[:, :, :, 33 + device_offset : 64 + device_offset],

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -76,6 +76,189 @@ def ln_pre_allgather_op(xs, n_devices, is_rmsnorm, out_dtpe, kernel_config):
     return tt_out
 
 
+def run_layernorm_pre_all_gather_residual_pcc(device):
+    """Stats from layer_norm_pre_all_gather with residual_input_tensor (input + residual).
+
+    Aligns with test_norm41467.py: shape (1, 1, 32, 128), BFLOAT16, HiFi4, fp32_dest_acc on pre.
+    Golden stats match torch reductions on the fused tensor input + residual.
+    """
+    torch.manual_seed(41467)
+
+    inp_shape = (1, 1, 32, 128)
+    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    torch_inp = torch.randn(inp_shape, dtype=torch.bfloat16)
+    torch_res = torch.randn(inp_shape, dtype=torch.bfloat16)
+    combined = torch_inp + torch_res
+
+    out_torch = reference(combined.chunk(1, dim=-1), 1, False)[0]
+
+    kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    tt_inp = torch2tt_tensor(
+        torch_inp,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+    tt_res = torch2tt_tensor(
+        torch_res,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+
+    tt_stats = ttnn.layer_norm_pre_all_gather(
+        tt_inp,
+        residual_input_tensor=tt_res,
+        dtype=ttnn.bfloat16,
+        compute_kernel_config=kernel_config,
+        memory_config=dram_memcfg,
+    )
+
+    tt_output_host = tt2torch_tensor(tt_stats)
+    all_passing = True
+    reduction_width = inp_shape[-1]
+
+    device_offset = 0
+    passing, output_str = comp_allclose_and_pcc(
+        out_torch,
+        tt_output_host,
+        rtol=1e-01 * reduction_width,
+        atol=0,
+        pcc=0.99,
+    )
+    logger.debug(f"tt vs torch sum(x^2) residual path = {output_str}")
+    all_passing &= passing
+
+    passing, output_str = comp_equal(
+        out_torch[:, :, :, 1 + device_offset : 32 + device_offset],
+        tt_output_host[:, :, :, 1 + device_offset : 32 + device_offset],
+    )
+    logger.debug(f"tt vs torch padding 1 residual path = {output_str}")
+    all_passing &= passing
+
+    passing, output_str = comp_allclose_and_pcc(
+        out_torch,
+        tt_output_host,
+        rtol=5e-01 * reduction_width,
+        atol=10,
+        pcc=0.99,
+    )
+    logger.debug(f"tt vs torch sum(x) residual path = {output_str}")
+    all_passing &= passing
+
+    # specific range for equality
+    passing, output_str = comp_equal(
+        out_torch[:, :, :, 33 + device_offset : 64 + device_offset],
+        tt_output_host[:, :, :, 33 + device_offset : 64 + device_offset],
+    )
+    logger.debug(f"tt vs torch padding 2 residual path = {output_str}")
+    all_passing &= passing
+
+    assert all_passing
+
+
+def run_layernorm_pre_post_gamma_only_pcc(device, use_pre_all_gather: bool):
+    """End-to-end LayerNorm (pre_all_gather -> post_all_gather) with weight only, no bias.
+
+    Regression for the former TT_FATAL that required beta whenever layernorm used gamma
+    (see layernorm_post_all_gather_device_operation). Shape (1, 1, 37, 72) matches the
+    standalone repro formerly in test_norm41378.py.
+    """
+    torch.manual_seed(42)
+
+    inp_shape = (1, 1, 37, 72)
+    hidden_size = inp_shape[-1]
+    epsilon = 1e-5
+
+    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    x = torch.randn(inp_shape, dtype=torch.bfloat16)
+    gamma_torch = torch.rand(1, 1, 1, hidden_size, dtype=torch.bfloat16) * 2 - 1
+
+    ref_out = torch.nn.functional.layer_norm(
+        x.float(),
+        (hidden_size,),
+        gamma_torch.reshape(hidden_size).float(),
+        bias=None,
+        eps=epsilon,
+    ).to(torch.bfloat16)
+
+    pre_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+    post_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    tt_inp = torch2tt_tensor(
+        x,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+
+    if use_pre_all_gather:
+        tt_stats = ln_pre_allgather_op([tt_inp], 1, False, ttnn.bfloat16, pre_kernel_config)[0]
+    else:
+        stats_torch = reference(x.chunk(1, dim=-1), 1, False)[0]
+        tt_stats = torch2tt_tensor(
+            stats_torch,
+            tt_dtype=ttnn.bfloat16,
+            tt_device=device,
+            tt_layout=ttnn.TILE_LAYOUT,
+            tt_memory_config=dram_memcfg,
+        )
+
+    tt_gamma = torch2tt_tensor(
+        gamma_torch,
+        tt_dtype=ttnn.bfloat16,
+        tt_device=device,
+        tt_layout=ttnn.TILE_LAYOUT,
+        tt_memory_config=dram_memcfg,
+    )
+
+    tt_out = ttnn.layer_norm_post_all_gather(
+        tt_inp,
+        tt_stats,
+        epsilon=epsilon,
+        weight=tt_gamma,
+        compute_kernel_config=post_kernel_config,
+        dtype=ttnn.bfloat16,
+        memory_config=dram_memcfg,
+    )
+
+    tt_out_host = tt2torch_tensor(tt_out)[..., :hidden_size]
+
+    passing, output_str = comp_allclose_and_pcc(
+        ref_out,
+        tt_out_host,
+        rtol=0.5,
+        atol=25,
+        pcc=0.99,
+    )
+    logger.debug(f"layernorm pre+post (gamma only) vs torch = {output_str}")
+    assert passing, output_str
+
+
 def run_layernorm_part_1(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device):
     # Set print options
     torch.set_printoptions(threshold=100)
@@ -268,3 +451,18 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
         device.num_program_cache_entries()
     )
+
+
+@pytest.mark.parametrize(
+    "use_pre_all_gather",
+    [True, False],
+    ids=["via_pre_allgather", "stats_manual"],
+)
+def test_layernorm_pre_post_gamma_only_pcc(use_pre_all_gather, device):
+    """layer_norm_post_all_gather with gamma and no bias; PCC vs torch reference."""
+    run_layernorm_pre_post_gamma_only_pcc(device, use_pre_all_gather)
+
+
+def test_layernorm_pre_all_gather_residual_pcc(device):
+    """layer_norm_pre_all_gather with residual_input_tensor; PCC vs torch (see test_norm41467.py)."""
+    run_layernorm_pre_all_gather_residual_pcc(device)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
@@ -111,47 +111,45 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
                 "Gamma tensor must be BFLOAT16, got: {}",
                 gamma_tensor.dtype());
         }
+    }
 
-        if (beta.has_value()) {
-            const auto& beta_tensor = beta.value();
-            if (beta_tensor.layout() == Layout::TILE) {
-                TT_FATAL(
-                    a.padded_shape()[-1] == beta_tensor.padded_shape()[-1],
-                    "Input and beta inner dimensions must match, got input: {} vs beta: {}",
-                    a.padded_shape()[-1],
-                    beta_tensor.padded_shape()[-1]);
-                TT_FATAL(
-                    beta_tensor.buffer() != nullptr,
-                    "Operands to layernorm need to be allocated in buffers on device!");
-                TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
-                TT_FATAL(
-                    beta_tensor.padded_shape()[-2] == tile_height,
-                    "Beta tensor height must equal tile height ({}), got: {}",
-                    tile_height,
-                    beta_tensor.padded_shape()[-2]);
-            } else {
-                TT_FATAL(
-                    beta_tensor.layout() == Layout::ROW_MAJOR,
-                    "Beta tensor must have ROW_MAJOR layout, got: {}",
-                    beta_tensor.layout());
-                TT_FATAL(
-                    (beta_tensor.padded_shape()[-1] == tile_width &&
-                     beta_tensor.physical_volume() / tile_width == a.padded_shape()[-1] / tile_width),
-                    "Beta tensor dimensions must align with input tensor. Got beta padded shape: {}, physical volume: "
-                    "{}, input padded shape: {}, tile_width: {}",
-                    beta_tensor.padded_shape()[-1],
-                    beta_tensor.physical_volume(),
-                    a.padded_shape()[-1],
-                    tile_width);
-                TT_FATAL(
-                    beta_tensor.buffer() != nullptr,
-                    "Operands to layernorm need to be allocated in buffers on device!");
-                TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
-                TT_FATAL(
-                    beta_tensor.dtype() == DataType::BFLOAT16,
-                    "Beta tensor must be BFLOAT16, got: {}",
-                    beta_tensor.dtype());
-            }
+    if (beta.has_value()) {
+        const auto& beta_tensor = beta.value();
+        if (beta_tensor.layout() == Layout::TILE) {
+            TT_FATAL(
+                a.padded_shape()[-1] == beta_tensor.padded_shape()[-1],
+                "Input and beta inner dimensions must match, got input: {} vs beta: {}",
+                a.padded_shape()[-1],
+                beta_tensor.padded_shape()[-1]);
+            TT_FATAL(
+                beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
+            TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
+            TT_FATAL(
+                beta_tensor.padded_shape()[-2] == tile_height,
+                "Beta tensor height must equal tile height ({}), got: {}",
+                tile_height,
+                beta_tensor.padded_shape()[-2]);
+        } else {
+            TT_FATAL(
+                beta_tensor.layout() == Layout::ROW_MAJOR,
+                "Beta tensor must have ROW_MAJOR layout, got: {}",
+                beta_tensor.layout());
+            TT_FATAL(
+                (beta_tensor.padded_shape()[-1] == tile_width &&
+                 beta_tensor.physical_volume() / tile_width == a.padded_shape()[-1] / tile_width),
+                "Beta tensor dimensions must align with input tensor. Got beta padded shape: {}, physical volume: "
+                "{}, input padded shape: {}, tile_width: {}",
+                beta_tensor.padded_shape()[-1],
+                beta_tensor.physical_volume(),
+                a.padded_shape()[-1],
+                tile_width);
+            TT_FATAL(
+                beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
+            TT_FATAL(a.device() == beta_tensor.device(), "Input and beta tensors must be on same device");
+            TT_FATAL(
+                beta_tensor.dtype() == DataType::BFLOAT16,
+                "Beta tensor must be BFLOAT16, got: {}",
+                beta_tensor.dtype());
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_device_operation.cpp
@@ -111,9 +111,6 @@ void LayerNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
                 "Gamma tensor must be BFLOAT16, got: {}",
                 gamma_tensor.dtype());
         }
-        const bool is_layernorm = args.norm_type == LayerNormDistributedType::LAYERNORM;
-        const bool has_beta = beta.has_value();
-        TT_FATAL(is_layernorm == has_beta, "Beta tensor must be present if and only if using layernorm (vs rmsnorm)");
 
         if (beta.has_value()) {
             const auto& beta_tensor = beta.value();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
@@ -158,7 +158,7 @@ void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {
                   - Input tensors must be on-device and rank 4.
                   - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH.
                   - The first three padded dims of :attr:`stats` must match :attr:`input_tensor`.
-                  - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided with matching layouts with their last padded dim matching TILE_WIDTH.
+                  - :attr:`weight` (gamma) and :attr:`bias` (beta) are independently optional; when either is provided it must be BFLOAT16 and match :attr:`input_tensor` per the layout rules above.
                   - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32), and :attr:`stats` must be sharded with `num_cores=1` and expected tile columns per device.
         )doc",
         &ttnn::layer_norm_post_all_gather,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -5,6 +5,7 @@
 #include "layernorm_pre_all_gather.hpp"
 
 #include "device/layernorm_pre_all_gather_device_operation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp"
 #include "ttnn/device.hpp"
 
@@ -37,7 +38,7 @@ ttnn::Tensor layer_norm_pre_all_gather(
             ttnn::prim::DistributedLayerNormStage::PRE_ALL_GATHER);
     }
     return ttnn::prim::layer_norm_pre_all_gather(
-        input_tensor,
+        residual_input_tensor.has_value() ? ttnn::add(input_tensor, residual_input_tensor.value()) : input_tensor,
         recip_tensor,
         ttnn::prim::LayerNormDistributedType::LAYERNORM,
         dtype,


### PR DESCRIPTION
### Ticket
- #41378
- #41467

### Problem description
There was an unnecessary fatal and residual input tensor was not considered

### What's changed
- remove the fatal that required gamma and beta to both be there
- use ttnn::add to add in the residual if it exists
- include tests created by AI

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-41378_norm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-41378_norm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-41378_norm)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-41378_norm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-41378_norm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-41378_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-41378_norm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
