### PR TITLE
Disable GPTOSS demo with seqlen 128k on T3K due to OOM

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -447,10 +447,13 @@ def test_gpt_oss_demo(
     state_dict,
 ):
     """GPT-OSS demo using full tt_transformers generation pipeline"""
-    if batch_size > 1 and mesh_shape[0] == 1:
-        pytest.skip(
-            f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
-        )
+    if mesh_shape[0] == 1:
+        if batch_size > 1:
+            pytest.skip(
+                f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
+            )
+        elif max_seq_len > 64 * 1024:
+            pytest.skip(f"Long context demo with >64k tokens skipped for mesh shape {mesh_shape} due to OOM.")
     if long_context_mode:
         assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
     if os.environ.get("CI", None) and not run_in_ci:

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -191,7 +191,7 @@ def decode_forward(
     if mesh_config.tp > 1:
         tt_out = ttnn.all_reduce(
             tt_out,
-            num_links=4,
+            num_links=ccl_manager.num_links,
             topology=ttnn.Topology.Ring,
             cluster_axis=mesh_config.tp_axis,
             memory_config=ttnn.L1_MEMORY_CONFIG,


### PR DESCRIPTION
### Problem description
GPT OSS Text Demo with seqlen 128k fails on T3K due to an OOM error.

### What's changed
Disabled this test on T3K.

### Checklist

- [ ] New/Existing tests provide coverage for changes


#### Model tests


- [ ] [![(T3K) 
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) [passes](https://github.com/tenstorrent/tt-metal/actions/runs/24041295638)

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smanoj/disable_gptoss_128k_t3k)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smanoj/disable_gptoss_128k_t3k)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) [passes](https://github.com/tenstorrent/tt-metal/actions/runs/24038748460)
