### PR TITLE
Deepseek - Provide Program Config for LM Head

### DIFF
--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -84,27 +84,59 @@ class LMHead1D(AbstractModule):
         }
 
     @classmethod
-    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:
-        """Generate model configuration for this module."""
-        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
-        n_per_device = vocab_size // mesh_device.shape[1]
+    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.MeshDevice) -> ModelDecodeConfig:
+        """Generate model configuration for this module.
 
+        Args:
+            hf_config: HuggingFace model configuration.
+            mesh_device: Mesh device whose column count (`shape[1]`) defines tensor-parallel
+                vocab sharding for the LM head program config.
+        """
+        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
         tile_size = 32
+        mesh_cols = mesh_device.shape[1]
+        if vocab_size % mesh_cols != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires vocab_size ({vocab_size}) to be divisible by "
+                f"mesh_device.shape[1] ({mesh_cols})."
+            )
+        if hidden_dim % tile_size != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires hidden_dim ({hidden_dim}) to be a multiple of "
+                f"tile_size ({tile_size})."
+            )
+        n_per_device = vocab_size // mesh_cols
+        if n_per_device % tile_size != 0:
+            raise ValueError(
+                f"LMHead1D.decode_model_config requires per-device vocab shard size ({n_per_device}) to be "
+                f"a multiple of tile_size ({tile_size}). Computed from vocab_size ({vocab_size}) and "
+                f"mesh_device.shape[1] ({mesh_cols})."
+            )
         K_tiles = hidden_dim // tile_size
         N_tiles = n_per_device // tile_size
+        if N_tiles == 0:
+            raise ValueError(
+                "LMHead1D.decode_model_config requires N_tiles >= 1 (per-device vocab must span at least "
+                f"one tile in N); got N_tiles=0 from n_per_device={n_per_device}, tile_size={tile_size}."
+            )
 
         # 1D multicast: broadcast small decode activation to all cores,
         # each core computes a slice of the output columns (N dimension).
         grid_size = mesh_device.compute_with_storage_grid_size()
         num_cores = grid_size.x * grid_size.y
         per_core_N = math.ceil(N_tiles / num_cores)
+        if per_core_N == 0:
+            raise ValueError(
+                "LMHead1D.decode_model_config requires per_core_N >= 1 for matmul subblocking; "
+                f"got per_core_N=0 (N_tiles={N_tiles}, num_cores={num_cores})."
+            )
 
         in0_block_w = 32
         while K_tiles % in0_block_w != 0:
             in0_block_w //= 2
 
         out_subblock_w = min(per_core_N, 4)
-        while per_core_N % out_subblock_w != 0:
+        while out_subblock_w > 1 and per_core_N % out_subblock_w != 0:
             out_subblock_w -= 1
 
         program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(

--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
 from pathlib import Path
 
 import torch
@@ -83,14 +84,47 @@ class LMHead1D(AbstractModule):
         }
 
     @classmethod
-    def decode_model_config(cls, mesh_device: ttnn.Device) -> ModelDecodeConfig:
+    def decode_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelDecodeConfig:
         """Generate model configuration for this module."""
-        # Construct the config
+        hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
+        n_per_device = vocab_size // mesh_device.shape[1]
+
+        tile_size = 32
+        K_tiles = hidden_dim // tile_size
+        N_tiles = n_per_device // tile_size
+
+        # 1D multicast: broadcast small decode activation to all cores,
+        # each core computes a slice of the output columns (N dimension).
+        grid_size = mesh_device.compute_with_storage_grid_size()
+        num_cores = grid_size.x * grid_size.y
+        per_core_N = math.ceil(N_tiles / num_cores)
+
+        in0_block_w = 32
+        while K_tiles % in0_block_w != 0:
+            in0_block_w //= 2
+
+        out_subblock_w = min(per_core_N, 4)
+        while per_core_N % out_subblock_w != 0:
+            out_subblock_w -= 1
+
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(grid_size.x, grid_size.y),
+            in0_block_w=in0_block_w,
+            out_subblock_h=1,
+            out_subblock_w=out_subblock_w,
+            per_core_M=1,
+            per_core_N=per_core_N,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+
         return {
             "linear": LinearConfig(
                 input_tensor_b=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI2,
+                program_config=program_config,
             ),
             "all_gather": AllGatherAsyncConfig(
                 mesh_device=mesh_device,

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -176,7 +176,7 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
             ],
             "norm_reshard": ReshardConfig(memory_config=norm_config["input_memory_config"]),
             "norm": norm_config,
-            "lm_head": LMHead1D.decode_model_config(mesh_device),
+            "lm_head": LMHead1D.decode_model_config(hf_config, mesh_device),
         }
         if cls._has_mtp_layer(hf_config):
             model_cfg["mtp"] = MTP2D.decode_model_config(

--- a/models/demos/deepseek_v3/tt/mtp.py
+++ b/models/demos/deepseek_v3/tt/mtp.py
@@ -199,7 +199,7 @@ class MTP2D(AbstractModule):
         head_norm_cfg = DistributedRMSNorm.decode_model_config(
             hf_config, mesh_device, batch_size_per_row=batch_size_per_row
         )
-        head_cfg = LMHead1D.decode_model_config(mesh_device)
+        head_cfg = LMHead1D.decode_model_config(hf_config, mesh_device)
         # Decode is single-token, so keep the MTP-specific intermediate tensors in L1.
         decode_memory_config = ttnn.L1_MEMORY_CONFIG
         return {

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -1341,8 +1341,12 @@ def test_lm_head_decode_linear(device):
     in0: [1, 1, 32, 7168]  BF16  L1 interleaved
     in1: [1, 1, 7168, 16160]  BF8_B  DRAM interleaved
     Uses 1D multicast (mcast_in0=True) to broadcast the small activation across
-    all 64 cores, each handling ceil(505/64)=8 N-tiles.
+    all cores, each handling a slice of N-tiles.
     """
+    device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
+    if device_grid != (7, 10):
+        pytest.skip(f"Test requires 7x10 grid but device has {device_grid[0]}x{device_grid[1]}")
+
     torch.manual_seed(0)
 
     M = 32
@@ -1364,7 +1368,7 @@ def test_lm_head_decode_linear(device):
     num_cores = compute_grid.x * compute_grid.y
 
     per_core_M = M_tiles  # 1
-    per_core_N = math.ceil(N_tiles / num_cores)  # ceil(505/64) = 8
+    per_core_N = math.ceil(N_tiles / num_cores)  # ceil(505/70) = 8
 
     # 224 K-tiles / 32 = 7 inner-loop iterations; aggressive but fits in L1
     # (~720 KB per core for CBs, well within the ~1.2 MB budget)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -1331,3 +1331,105 @@ def test_kv_wm_matmul(device, test_case):
 
     assert passed, f"1D matmul weight batch > activation batch optimization test failed with PCC {pcc} < {expected_pcc}"
     logger.info("✓ 1D matmul weight batch > activation batch optimization test PASSED!")
+
+
+@skip_for_blackhole("Deepseek tests target Wormhole")
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
+def test_lm_head_decode_linear(device):
+    """
+    Test LM head linear for DeepSeek V3 decode path (lm_head1d.py:_fwd_linear).
+    in0: [1, 1, 32, 7168]  BF16  L1 interleaved
+    in1: [1, 1, 7168, 16160]  BF8_B  DRAM interleaved
+    Uses 1D multicast (mcast_in0=True) to broadcast the small activation across
+    all 64 cores, each handling ceil(505/64)=8 N-tiles.
+    """
+    torch.manual_seed(0)
+
+    M = 32
+    K = 7168
+    N = 16160
+
+    in0_shape = [1, 1, M, K]
+    in1_shape = [1, 1, K, N]
+
+    in0_dtype = ttnn.bfloat16
+    in1_dtype = ttnn.bfloat8_b
+    out_dtype = ttnn.bfloat16
+
+    M_tiles = M // 32  # 1
+    K_tiles = K // 32  # 224
+    N_tiles = N // 32  # 505
+
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = compute_grid.x * compute_grid.y
+
+    per_core_M = M_tiles  # 1
+    per_core_N = math.ceil(N_tiles / num_cores)  # ceil(505/64) = 8
+
+    # 224 K-tiles / 32 = 7 inner-loop iterations; aggressive but fits in L1
+    # (~720 KB per core for CBs, well within the ~1.2 MB budget)
+    in0_block_w = 32
+
+    out_subblock_h = 1
+    out_subblock_w = 4  # divides per_core_N=8, h*w=4 <= 8
+
+    prog_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(compute_grid.x, compute_grid.y),
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    logger.info(f"LM head decode: {in0_shape} @ {in1_shape}")
+    logger.info(f"M_tiles={M_tiles}, K_tiles={K_tiles}, N_tiles={N_tiles}")
+    logger.info(f"Grid={compute_grid.x}x{compute_grid.y}, per_core_M={per_core_M}, per_core_N={per_core_N}")
+    logger.info(f"in0_block_w={in0_block_w} ({K_tiles // in0_block_w} inner iters)")
+
+    in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
+    in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
+
+    in0_t = ttnn.from_torch(
+        in0,
+        dtype=in0_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    in1_t = ttnn.from_torch(
+        in1,
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_t = ttnn.linear(
+        in0_t,
+        in1_t,
+        program_config=prog_config,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        dtype=out_dtype,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    output_tensor = ttnn.to_torch(output_t)
+    output_tensor = output_tensor[:, :, :M, :N]
+    pt_out = in0 @ in1
+
+    passed, pcc = comp_pcc(pt_out, output_tensor, 0.999)
+    logger.info(f"PCC: {pcc}")
+    assert passed, f"LM head decode linear test failed with PCC {pcc} < 0.999"


### PR DESCRIPTION
### Ticket
#41280

### Problem description
There's a rare hang in the Deepseek Demo. Triage reports show some cores are stuck inside the LM head matmul, though the cause is unclear. This matmul runs without any program config ("out of the box").

### What's changed
Changed the model to specify a 1D program config as a potential workaround. This was checked against the demo test three times without issue.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/lm_head_config)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/lm_head_config)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/lm_head_config)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/lm_head_config)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/lm_head_config)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/lm_head_config)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/lm_head_config) | [#2600](https://github.com/tenstorrent/tt-metal/actions/runs/24344630417) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/lm_head_config) | [#17111](https://github.com/tenstorrent/tt-metal/actions/runs/24034861620) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/lm_head_config) | [#5149](https://github.com/tenstorrent/tt-metal/actions/runs/24344650726) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/lm_head_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/lm_head_config) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/lm_head_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/lm_head_config) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/lm_head_config) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/lm_head_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/lm_head_config) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/lm_head_config) |