### PR TITLE
Add FPU utilization performance model for conv3d

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "conv3d_device_operation.hpp"
 #include "conv3d_device_operation_types.hpp"
 #include "conv3d_program_factory.hpp"
+#include "ttnn/operation.hpp"
 #include <array>
 #include <cstdint>
 #include <tt-metalium/math.hpp>
@@ -247,6 +248,49 @@ ttsl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
         bias_tensor.has_value());
 
     return hash;
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv3dDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
+    const auto& input_shape = tensor_args.input_tensor.logical_shape();
+    uint32_t batch_size = input_shape[0];
+    uint32_t T_in = input_shape[1];
+    uint32_t H_in = input_shape[2];
+    uint32_t W_in = input_shape[3];
+    uint32_t C_in = input_shape[4];
+
+    uint32_t filter_t = args.kernel_size[0];
+    uint32_t filter_h = args.kernel_size[1];
+    uint32_t filter_w = args.kernel_size[2];
+
+    const CoreCoord compute_grid = output_tensor.device()->compute_with_storage_grid_size();
+    const int num_cores = compute_grid.x * compute_grid.y;
+    // The Wormhole/Blackhole matrix engine performs 8x16 x 16x16 = 8x16 in a single cycle.
+    // This is 2*8*16*16 = 4096 muladds in a single cycle.
+    constexpr int tensix_mul_adds_per_cycle_lofi = 4096;
+
+    auto [T_out, H_out, W_out] =
+        detail::compute_output_dims(T_in, H_in, W_in, args.padding, args.stride, args.kernel_size, args.dilation);
+
+    // Calculate number of mul/add operations
+    // TODO: add bias modeling
+    int64_t num_mul_adds_per_elem =
+        static_cast<int64_t>(C_in) * filter_t * filter_h * filter_w * 2;  // 1 multiply and 1 add per element
+    int64_t num_mul_adds = num_mul_adds_per_elem * T_out * H_out * W_out * args.output_channels * batch_size;
+
+    int ideal_dev_clock_cycles = std::ceil(
+        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        (float)tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(
+            get_math_fidelity(args.compute_kernel_config)));
+
+    Tensors input_tensors = {tensor_args.input_tensor, tensor_args.weight_tensor};
+    if (tensor_args.bias_tensor.has_value()) {
+        input_tensors.push_back(tensor_args.bias_tensor.value());
+    }
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        input_tensors, output_tensor, ideal_dev_clock_cycles);
+
+    return result;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -273,15 +273,14 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv3dDeviceOperation
         detail::compute_output_dims(T_in, H_in, W_in, args.padding, args.stride, args.kernel_size, args.dilation);
 
     // Calculate number of mul/add operations
-    // TODO: add bias modeling
     int64_t num_mul_adds_per_elem =
         static_cast<int64_t>(C_in) * filter_t * filter_h * filter_w * 2;  // 1 multiply and 1 add per element
     int64_t num_mul_adds = num_mul_adds_per_elem * T_out * H_out * W_out * args.output_channels * batch_size;
 
     int ideal_dev_clock_cycles = std::ceil(
-        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
-        (float)tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(
-            get_math_fidelity(args.compute_kernel_config)));
+        (static_cast<float>(num_mul_adds) / static_cast<float>(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        static_cast<float>(tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(
+            get_math_fidelity(args.compute_kernel_config))));
 
     Tensors input_tensors = {tensor_args.input_tensor, tensor_args.weight_tensor};
     if (tensor_args.bias_tensor.has_value()) {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -12,6 +12,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operation.hpp"
 #include "conv3d_device_operation_types.hpp"
 #include "conv3d_program_factory.hpp"
 
@@ -29,6 +30,8 @@ struct Conv3dDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## Summary

- Implement `create_op_performance_model` for `Conv3dDeviceOperation`, following the same pattern as conv2d
- Computes ideal compute cycles from total MACs (`C_in * kT * kH * kW * 2 * T_out * H_out * W_out * C_out * batch`) divided by per-core FPU throughput (4096 muladds/cycle in LoFi), scaled by math fidelity
- Enables `PM IDEAL [ns]`, `PM COMPUTE [ns]`, `PM BANDWIDTH [ns]`, and `PM FPU UTIL (%)` columns in Tracy profiler CSV output for conv3d ops

## Test plan
- [ ] [![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic%2Fconv3d_perf_model)](https://github.com/tenstorrent/tt-metal/actions/runs/24022595047)
- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Fconv3d_perf_model)](https://github.com/tenstorrent/tt-metal/actions/runs/24022580643)

🤖 Generated with [Claude Code](https://claude.com/claude-code)