### PR TITLE
Enable more ttnn tests on BH ttsim

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -175,7 +175,7 @@ jobs:
           with open(path) as f:
               tests = yaml.safe_load(f)
           # TTSim runs all tests on ubuntu-latest; ignore skus and timeouts from YAML, use fixed timeout.
-          TTSIM_TIMEOUT_MINUTES = 20
+          TTSIM_TIMEOUT_MINUTES = 30
           entries = []
           for t in tests:
               if not t.get("ttsim") or not t.get("cmd"):

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -124,13 +124,8 @@ blackhole:
   - tests/nightly/t3000/
   - tests/ttnn/unit_tests/operations/point_to_point/
 
-  # Multi-device tests
-  - tests/ttnn/unit_tests/base_functionality/test_multi_device.py
-
   # Base functionality - simulator limitations (tilize/untilize, layout conversion)
-  - tests/ttnn/unit_tests/base_functionality/test_comparison_mode.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
-  - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::TestFastOperationGraphTracking  # Fast dispatch with ttnn.add crashes ttsim worker on teardown
 
   # Slow tests (Tier 3-4: 5-20+ minutes, would cause CI timeouts)
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -139,33 +134,9 @@ blackhole:
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob  # ~150s under TTSim, hits 320s timeout with xdist contention
 
   # Eltwise - data format limitations (INT32/UINT32/FLOAT32/UINT16)
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
   - tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_where.py
   - tests/ttnn/unit_tests/operations/eltwise/test_unary.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
-  - tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
-
-  # Core tests
-  - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
-  - tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
-  - tests/ttnn/unit_tests/base_functionality/test_cpp_logging.py
-  - tests/ttnn/unit_tests/base_functionality/test_concat_issue.py
-  - tests/ttnn/unit_tests/base_functionality/test_async.py
-
-  # Conv tests
-  - tests/ttnn/unit_tests/operations/conv/test_conv3d.py
-  - tests/ttnn/unit_tests/operations/conv/test_conv_transpose2d.py
-  - tests/ttnn/unit_tests/operations/conv/data_movement/test_convert_to_chw.py
-  - tests/ttnn/unit_tests/operations/conv/test_conv2d.py
-  - tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
-  - tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
-  - tests/ttnn/unit_tests/operations/conv/test_conv1d.py
 
   # Pool tests (same as wormhole + BH-specific)
   - tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -181,14 +152,12 @@ blackhole:
   - tests/ttnn/unit_tests/operations/matmul/test_linear.py
 
   # Fused tests (same simulator limitations as wormhole + BH-specific)
-  - tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_softmax.py
   - tests/ttnn/unit_tests/operations/fused/test_softmax_program_cache.py
   - tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
   - tests/ttnn/unit_tests/operations/fused/test_group_norm.py
-  - tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
-  - tests/ttnn/unit_tests/operations/fused/parallel_sequential/
+  - tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
 
   # Reduce tests (same as wormhole + BH-specific)
   - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py


### PR DESCRIPTION
### Ticket
/

### Problem description
CI was not running as many tests as it could.

### What's changed
Remove tests from skip list that are now passing.

### Checklist

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/ttsim-skip-list)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/ttsim-skip-list)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/ttsim-skip-list)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
