### PR TITLE
[Bug Fix]: Fixes for multithreaded matmul 

### DIFF
--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -19,190 +19,126 @@
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, Bmm) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-    Program program = CreateProgram();
+namespace {
 
-    CoreCoord core = {0, 0};
+struct BmmParams {
+    uint32_t Mt, Kt, Nt;
+    uint32_t B_total;       // total batch count (buffer sizing + validation)
+    uint32_t B_per_core;    // batch count per core (kernel runtime args)
+    uint32_t num_threads = 2;
+    uint32_t num_input_tiles = 4;
+    uint32_t num_output_tiles = 4;
     uint32_t single_tile_size = 2 * 1024;
-    uint32_t Mt = 4, Kt = 2, Nt = 3, B = 2;
-    uint32_t num_tilesA = Mt * Kt * B;
-    uint32_t num_tilesB = Kt * Nt * B;
-    uint32_t num_tilesC = Mt * Nt * B;
-    uint32_t bytesA = single_tile_size * num_tilesA;
-    uint32_t bytesB = single_tile_size * num_tilesB;
-    uint32_t bytesC = single_tile_size * num_tilesC;
+};
 
-    InterleavedBufferConfig src0_config{
-        .device = dev, .size = bytesA, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
-    auto src0_dram_buffer = CreateBuffer(src0_config);
-    uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
+struct BmmBuffers {
+    std::shared_ptr<Buffer> src0, src1, dst;
+};
 
-    InterleavedBufferConfig src1_config{
-        .device = dev, .size = bytesB, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
-    auto src1_dram_buffer = CreateBuffer(src1_config);
-    uint32_t dram_buffer_src1_addr = src1_dram_buffer->address();
+BmmBuffers create_bmm_dram_buffers(IDevice* dev, const BmmParams& p) {
+    const uint32_t bytesA = p.single_tile_size * p.Mt * p.Kt * p.B_total;
+    const uint32_t bytesB = p.single_tile_size * p.Kt * p.Nt * p.B_total;
+    const uint32_t bytesC = p.single_tile_size * p.Mt * p.Nt * p.B_total;
+    return {
+        CreateBuffer({.device = dev, .size = bytesA, .page_size = p.single_tile_size, .buffer_type = BufferType::DRAM}),
+        CreateBuffer({.device = dev, .size = bytesB, .page_size = p.single_tile_size, .buffer_type = BufferType::DRAM}),
+        CreateBuffer({.device = dev, .size = bytesC, .page_size = p.single_tile_size, .buffer_type = BufferType::DRAM}),
+    };
+}
 
-    InterleavedBufferConfig dst_config{
-        .device = dev, .size = bytesC, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
-    auto dst_dram_buffer = CreateBuffer(dst_config);
-    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+struct BmmDFBHandles {
+    uint32_t src0, src1, dst;
+};
 
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(src0_dram_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(src1_dram_buffer).append_to(reader_compile_time_args);
+template <typename CoreSpec>
+BmmDFBHandles create_bmm_quasar_dfbs(Program& program, const CoreSpec& cores, const BmmParams& p) {
+    using namespace tt_metal::experimental::dfb;
+    DataflowBufferConfig src0_cfg = {
+        .entry_size = p.single_tile_size,
+        .num_entries = p.num_input_tiles,
+        .num_producers = p.num_threads,
+        .pap = AccessPattern::STRIDED,
+        .num_consumers = p.num_threads,
+        .cap = AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .data_format = tt::DataFormat::Float16_b};
+    DataflowBufferConfig src1_cfg = {
+        .entry_size = p.single_tile_size,
+        .num_entries = p.num_input_tiles,
+        .num_producers = p.num_threads,
+        .pap = AccessPattern::STRIDED,
+        .num_consumers = p.num_threads,
+        .cap = AccessPattern::BLOCKED,
+        .enable_implicit_sync = false,
+        .data_format = tt::DataFormat::Float16_b};
+    DataflowBufferConfig dst_cfg = {
+        .entry_size = p.single_tile_size,
+        .num_entries = p.num_output_tiles,
+        .num_producers = p.num_threads,
+        .pap = AccessPattern::STRIDED,
+        .num_consumers = p.num_threads,
+        .cap = AccessPattern::STRIDED,
+        .enable_implicit_sync = false,
+        .data_format = tt::DataFormat::Float16_b};
+    return {
+        CreateDataflowBuffer(program, cores, src0_cfg),
+        CreateDataflowBuffer(program, cores, src1_cfg),
+        CreateDataflowBuffer(program, cores, dst_cfg),
+    };
+}
 
-    std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_time_args);
+struct BmmKernelHandles {
+    KernelHandle reader, writer, compute;
+};
 
-    uint32_t num_input_tiles = 2;
-    uint32_t num_output_tiles = 2;
-
-    vector<uint32_t> compute_kernel_args = {B, Mt, Kt, Nt};
-    KernelHandle reader;
-    KernelHandle writer;
-    KernelHandle compute;
-
-    uint32_t src0_dfb = 0;
-    uint32_t src1_dfb = 0;
-    uint32_t dst_dfb = 0;
-    if (dev->arch() != ARCH::QUASAR) {
-        uint32_t src0_cb_index = 0;
-        CircularBufferConfig cb_src0_config =
-            CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(src0_cb_index, single_tile_size);
-        CreateCircularBuffer(program, core, cb_src0_config);
-
-        uint32_t src1_cb_index = 1;
-        CircularBufferConfig cb_src1_config =
-            CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(src1_cb_index, single_tile_size);
-        CreateCircularBuffer(program, core, cb_src1_config);
-
-        uint32_t ouput_cb_index = tt::CBIndex::c_16;
-        CircularBufferConfig cb_output_config =
-            CircularBufferConfig(num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(ouput_cb_index, single_tile_size);
-        CreateCircularBuffer(program, core, cb_output_config);
-
-        reader = CreateKernel(
+template <typename CoreSpec>
+BmmKernelHandles create_bmm_quasar_kernels(
+    Program& program,
+    const CoreSpec& cores,
+    const BmmParams& p,
+    const std::vector<uint32_t>& reader_cta,
+    const std::vector<uint32_t>& writer_cta) {
+    using namespace tt_metal::experimental::quasar;
+    return {
+        CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_1,
-                .noc = NOC::RISCV_1_default,
-                .compile_args = reader_compile_time_args});
-
-        writer = CreateKernel(
+            cores,
+            QuasarDataMovementConfig{.num_threads_per_cluster = p.num_threads, .compile_args = reader_cta}),
+        CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = writer_compile_time_args});
-
-        compute = CreateKernel(
+            cores,
+            QuasarDataMovementConfig{.num_threads_per_cluster = p.num_threads, .compile_args = writer_cta}),
+        CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp",
-            core,
-            ComputeConfig{.compile_args = compute_kernel_args});
-    } else {
-        tt_metal::experimental::dfb::DataflowBufferConfig src0_dfb_config = {
-            .entry_size = single_tile_size,
-            .num_entries = num_input_tiles,
-            .producer_risc_mask = 0x1,
-            .num_producers = 1,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
-            .num_consumers = 1,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b
-        };
-        tt_metal::experimental::dfb::DataflowBufferConfig src1_dfb_config = {
-            .entry_size = single_tile_size,
-            .num_entries = num_input_tiles,
-            .producer_risc_mask = 0x1,
-            .num_producers = 1,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x100,
-            .num_consumers = 1,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b
-        };
-        tt_metal::experimental::dfb::DataflowBufferConfig dst_dfb_config = {
-            .entry_size = single_tile_size,
-            .num_entries = num_output_tiles,
-            .producer_risc_mask = 0x100,
-            .num_producers = 1,
-            .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .consumer_risc_mask = 0x2,
-            .num_consumers = 1,
-            .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-            .enable_implicit_sync = false,
-            .data_format = tt::DataFormat::Float16_b
-        };
+            cores,
+            QuasarComputeConfig{
+                .num_threads_per_cluster = p.num_threads,
+                .compile_args = {p.B_per_core, p.Mt, p.Kt, p.Nt}}),
+    };
+}
 
-        src0_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, src0_dfb_config);
-        src1_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, src1_dfb_config);
-        dst_dfb = tt_metal::experimental::dfb::CreateDataflowBuffer(program, core, dst_dfb_config);
+void bind_bmm_dfbs(Program& program, const BmmDFBHandles& dfbs, const BmmKernelHandles& kernels) {
+    using namespace tt_metal::experimental::dfb;
+    BindDataflowBufferToProducerConsumerKernels(program, dfbs.src0, kernels.reader, kernels.compute);
+    BindDataflowBufferToProducerConsumerKernels(program, dfbs.src1, kernels.reader, kernels.compute);
+    BindDataflowBufferToProducerConsumerKernels(program, dfbs.dst, kernels.compute, kernels.writer);
+}
 
-        reader = tt_metal::experimental::quasar::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp",
-            core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1,
-                .compile_args = reader_compile_time_args});
-
-        writer = tt_metal::experimental::quasar::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp",
-            core,
-            tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1,
-                .compile_args = writer_compile_time_args});
-
-        compute = CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp",
-            core,
-            tt_metal::experimental::quasar::QuasarComputeConfig{.num_threads_per_cluster = 1, .compile_args = compute_kernel_args});
-    }
-
-    if (dev->arch() == ARCH::QUASAR) {
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, src0_dfb, reader, compute);
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, src1_dfb, reader, compute);
-        tt_metal::experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, dst_dfb, compute, writer);
-    }
-
-    std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
-    std::vector<uint32_t> src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
-    detail::WriteToBuffer(src0_dram_buffer, src0_vec);
-    detail::WriteToBuffer(src1_dram_buffer, src1_vec);
-
-    uint32_t do_bcast = 0;
-    SetRuntimeArgs(
-        program,
-        reader,
-        core,
-        {dram_buffer_src0_addr, dram_buffer_src1_addr, Mt, Kt, Nt, Mt * Kt, Kt * Nt, B, do_bcast});
-    SetRuntimeArgs(program, writer, core, {dram_buffer_dst_addr, 0, Mt, Kt, Nt, Mt * Kt, Kt * Nt, B});
-
-    detail::LaunchProgram(dev, program, true);
-
-    std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
-
-    // Validation
+bool validate_bmm_result(
+    const BmmParams& p,
+    const std::vector<uint32_t>& src0_vec,
+    const std::vector<uint32_t>& src1_vec,
+    const std::vector<uint32_t>& result_vec,
+    int* argfail) {
     auto comparison_function = [](float a, float b) {
         const float rtol = 0.05f;
         const float atol = 0.05f;
@@ -210,22 +146,199 @@ TEST_F(MeshDeviceSingleCardFixture, Bmm) {
         float absdiff = fabsf(a - b);
         return (absdiff <= atol) || absdiff < rtol * maxabs;
     };
-
-    vector<uint32_t> shapeA = {1, B, Mt * 32, Kt * 32};
-    vector<uint32_t> shapeB = {1, B, Kt * 32, Nt * 32};
-    vector<uint32_t> shapeC = {1, B, Mt * 32, Nt * 32};
-    auto u16_src0_vec = u16_from_u32_vector(src0_vec);
-    auto u16_src1_vec = u16_from_u32_vector(src1_vec);
-    vector<uint16_t> src0_linear =
-        convert_layout<uint16_t>(u16_src0_vec, shapeA, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
-    vector<uint16_t> src1_linear =
-        convert_layout<uint16_t>(u16_src1_vec, shapeB, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
-    vector<uint16_t> ref_bmm = gold_bmm(shapeA, src0_linear, shapeB, src1_linear);
-
-    auto gold_4f_u32 = u32_from_u16_vector(
+    vector<uint32_t> shapeA = {1, p.B_total, p.Mt * 32, p.Kt * 32};
+    vector<uint32_t> shapeB = {1, p.B_total, p.Kt * 32, p.Nt * 32};
+    vector<uint32_t> shapeC = {1, p.B_total, p.Mt * 32, p.Nt * 32};
+    auto u16_src0 = u16_from_u32_vector(src0_vec);
+    auto u16_src1 = u16_from_u32_vector(src1_vec);
+    auto src0_linear =
+        convert_layout<uint16_t>(u16_src0, shapeA, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
+    auto src1_linear =
+        convert_layout<uint16_t>(u16_src1, shapeB, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
+    auto ref_bmm = gold_bmm(shapeA, src0_linear, shapeB, src1_linear);
+    auto gold = u32_from_u16_vector(
         convert_layout<uint16_t>(ref_bmm, shapeC, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES));
+    return packed_uint32_t_vector_comparison(result_vec, gold, comparison_function, argfail);
+}
+
+}  // namespace
+
+TEST_F(MeshDeviceSingleCardFixture, Bmm) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    BmmParams p;
+    if (dev->arch() != ARCH::QUASAR) {
+        p.Mt = 4; p.Kt = 2; p.Nt = 3;
+        p.B_total = 2; p.B_per_core = 2;
+        p.num_input_tiles = 2; p.num_output_tiles = 2;
+        p.num_threads = 1;
+    } else {
+        p.Mt = 2; p.Kt = 2; p.Nt = 2;
+        p.B_total = 1; p.B_per_core = 1;
+        p.num_threads = 2;
+    }
+
+    auto bufs = create_bmm_dram_buffers(dev, p);
+    const uint32_t bytesA = p.single_tile_size * p.Mt * p.Kt * p.B_total;
+    const uint32_t bytesB = p.single_tile_size * p.Kt * p.Nt * p.B_total;
+
+    std::vector<uint32_t> reader_cta;
+    TensorAccessorArgs(bufs.src0).append_to(reader_cta);
+    TensorAccessorArgs(bufs.src1).append_to(reader_cta);
+    std::vector<uint32_t> writer_cta;
+    TensorAccessorArgs(bufs.dst).append_to(writer_cta);
+
+    BmmKernelHandles kernels;
+    if (dev->arch() != ARCH::QUASAR) {
+        uint32_t src0_cb_index = 0;
+        CreateCircularBuffer(
+            program,
+            core,
+            CircularBufferConfig(
+                p.num_input_tiles * p.single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src0_cb_index, p.single_tile_size));
+
+        uint32_t src1_cb_index = 1;
+        CreateCircularBuffer(
+            program,
+            core,
+            CircularBufferConfig(
+                p.num_input_tiles * p.single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(src1_cb_index, p.single_tile_size));
+
+        uint32_t output_cb_index = tt::CBIndex::c_16;
+        CreateCircularBuffer(
+            program,
+            core,
+            CircularBufferConfig(
+                p.num_output_tiles * p.single_tile_size, {{output_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(output_cb_index, p.single_tile_size));
+
+        kernels.reader = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp",
+            core,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = reader_cta});
+        kernels.writer = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp",
+            core,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = writer_cta});
+        kernels.compute = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp",
+            core,
+            ComputeConfig{.compile_args = {p.B_per_core, p.Mt, p.Kt, p.Nt}});
+    } else {
+        auto dfbs = create_bmm_quasar_dfbs(program, core, p);
+        kernels = create_bmm_quasar_kernels(program, core, p, reader_cta, writer_cta);
+        bind_bmm_dfbs(program, dfbs, kernels);
+    }
+
+    auto src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
+    auto src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
+    detail::WriteToBuffer(bufs.src0, src0_vec);
+    detail::WriteToBuffer(bufs.src1, src1_vec);
+
+    constexpr uint32_t do_bcast = 0;
+    SetRuntimeArgs(
+        program,
+        kernels.reader,
+        core,
+        {bufs.src0->address(), bufs.src1->address(), p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, do_bcast, 0u});
+    SetRuntimeArgs(
+        program,
+        kernels.writer,
+        core,
+        {bufs.dst->address(), 0u, p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, 0u});
+
+    detail::LaunchProgram(dev, program, true);
+
+    std::vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(bufs.dst, result_vec);
 
     int argfail = -1;
-    bool pass = packed_uint32_t_vector_comparison(result_vec, gold_4f_u32, comparison_function, &argfail);
+    bool pass = validate_bmm_result(p, src0_vec, src1_vec, result_vec, &argfail);
+    EXPECT_TRUE(pass) << "Failure position=" << argfail;
+}
+
+// This needs to be a separate test because we don't have a way of querying the correct compute grid size
+// when running a multi-neo emu/sim build. Otherwise its the same test with batch split across nodes.
+TEST_F(MeshDeviceSingleCardFixture, BmmMultinode) {
+    IDevice* dev = devices_[0]->get_devices()[0];
+    if (dev->arch() != ARCH::QUASAR) {
+        GTEST_SKIP();
+    }
+
+    Program program = CreateProgram();
+    CoreCoord core0 = {0, 0};
+    CoreCoord core1 = {1, 0};
+    CoreRange core_range = {core0, core1};
+
+    BmmParams p;
+    p.Mt = 2; p.Kt = 2; p.Nt = 2;
+    p.B_total = 2;      // total batches across both cores
+    p.B_per_core = 1;   // each core computes exactly one batch
+    p.num_threads = 2;
+
+    auto bufs = create_bmm_dram_buffers(dev, p);
+    const uint32_t bytesA = p.single_tile_size * p.Mt * p.Kt * p.B_total;
+    const uint32_t bytesB = p.single_tile_size * p.Kt * p.Nt * p.B_total;
+
+    std::vector<uint32_t> reader_cta;
+    TensorAccessorArgs(bufs.src0).append_to(reader_cta);
+    TensorAccessorArgs(bufs.src1).append_to(reader_cta);
+    std::vector<uint32_t> writer_cta;
+    TensorAccessorArgs(bufs.dst).append_to(writer_cta);
+
+    // Create DFBs on the full core range — each core gets its own independent DFB instances
+    auto dfbs = create_bmm_quasar_dfbs(program, core_range, p);
+    auto kernels = create_bmm_quasar_kernels(program, core_range, p, reader_cta, writer_cta);
+    bind_bmm_dfbs(program, dfbs, kernels);
+
+    auto src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
+    auto src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
+    detail::WriteToBuffer(bufs.src0, src0_vec);
+    detail::WriteToBuffer(bufs.src1, src1_vec);
+
+    constexpr uint32_t do_bcast = 0;
+    // core0 handles batch 0, core1 handles batch 1 (batch_offset = core index)
+    SetRuntimeArgs(
+        program,
+        kernels.reader,
+        core0,
+        {bufs.src0->address(), bufs.src1->address(), p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, do_bcast, 0u});
+    SetRuntimeArgs(
+        program,
+        kernels.writer,
+        core0,
+        {bufs.dst->address(), 0u, p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, 0u});
+
+    SetRuntimeArgs(
+        program,
+        kernels.reader,
+        core1,
+        {bufs.src0->address(), bufs.src1->address(), p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, do_bcast, 1u});
+    SetRuntimeArgs(
+        program,
+        kernels.writer,
+        core1,
+        {bufs.dst->address(), 0u, p.Mt, p.Kt, p.Nt, p.Mt * p.Kt, p.Kt * p.Nt, p.B_per_core, 1u});
+
+    detail::LaunchProgram(dev, program, true);
+
+    std::vector<uint32_t> result_vec;
+    detail::ReadFromBuffer(bufs.dst, result_vec);
+
+    int argfail = -1;
+    bool pass = validate_bmm_result(p, src0_vec, src1_vec, result_vec, &argfail);
     EXPECT_TRUE(pass) << "Failure position=" << argfail;
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
@@ -6,6 +6,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/matmul.h"
 #ifdef ARCH_QUASAR
+#include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #else
 #include "experimental/circular_buffer.h"
@@ -25,8 +26,15 @@ void kernel_main() {
     uint32_t Mt = get_compile_time_arg_val(1);
     uint32_t Kt = get_compile_time_arg_val(2);
     uint32_t Nt = get_compile_time_arg_val(3);
+    // uint32_t THREADING = get_compile_time_arg_val(4);
+
+    uint32_t compute_id = 0;
+    uint32_t num_threads = 1;
 
 #ifdef ARCH_QUASAR
+    // uint32_t compute_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+    compute_id = get_my_thread_id();
+    num_threads = get_num_threads();
     experimental::DataflowBuffer dfb0(0);
     experimental::DataflowBuffer dfb1(1);
     experimental::DataflowBuffer dfb_out(2);
@@ -43,7 +51,12 @@ void kernel_main() {
     // the simplest possible version of outer product blocked matmul
     // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
     for (uint32_t nb = 0; nb < batch; nb++) {
-        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {    // output tile of C
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {  // output tile of C
+#ifdef ARCH_QUASAR
+            if (mt_C % num_threads != compute_id) {
+                continue;
+            }
+#endif
             for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
             {
                 acquire_dst();
@@ -51,9 +64,7 @@ void kernel_main() {
 #ifdef ARCH_QUASAR
                     dfb0.wait_front(onetile);
                     dfb1.wait_front(onetile);
-
                     matmul_tiles(dfb0.get_id(), dfb1.get_id(), 0, 0, 0);
-
                     dfb0.pop_front(onetile);
                     dfb1.pop_front(onetile);
 #else
@@ -67,8 +78,8 @@ void kernel_main() {
 #endif
                 }
 
-
 #ifdef ARCH_QUASAR
+
                     dfb_out.reserve_back(onetile);
                     pack_tile(0, dfb_out.get_id());
                     dfb_out.push_back(onetile);
@@ -82,4 +93,7 @@ void kernel_main() {
             }
         }
     }
+#ifdef ARCH_QUASAR
+    dfb_out.finish();
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -17,6 +17,10 @@ void kernel_main() {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     constexpr bool use_dfbs = get_compile_time_arg_val(1) == 1;
 
+#ifdef ARCH_QUASAR
+    static_assert(use_dfbs, "DFBs need to be used for Quasar!");
+#endif
+
     if constexpr (use_dfbs) {
         unary_op_init_common(0, 1);
     } else {
@@ -47,6 +51,7 @@ void kernel_main() {
             release_dst();
         }
     } else {
+#ifndef ARCH_QUASAR
         experimental::CircularBuffer cb0(tt::CBIndex::c_0);
         experimental::CircularBuffer cb16(tt::CBIndex::c_16);
         for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
@@ -61,5 +66,6 @@ void kernel_main() {
 
             release_dst();
         }
+#endif
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
@@ -5,36 +5,33 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #ifdef ARCH_QUASAR
+#include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #include "experimental/noc.h"
 #endif
 
-#include "api/debug/dprint.h"
-
 void kernel_main() {
-    // same arg indices as in reader_binary_diff_lengths for compat
     uintptr_t src0_addr = get_arg_val<uint32_t>(0);
     uintptr_t src1_addr = get_arg_val<uint32_t>(1);
     uint32_t Mt = get_arg_val<uint32_t>(2);
     uint32_t Kt = get_arg_val<uint32_t>(3);
     uint32_t Nt = get_arg_val<uint32_t>(4);
-    uint32_t MtKt = get_arg_val<uint32_t>(5);  // if 0
+    uint32_t MtKt = get_arg_val<uint32_t>(5);
     uint32_t KtNt = get_arg_val<uint32_t>(6);
     uint32_t batch = get_arg_val<uint32_t>(7);
-    uint32_t bcast_B = get_arg_val<uint32_t>(8);  // if 1 we broadcast B to batch
-
-    // DPRINT << "Mt=" << Mt << " Kt=" << Kt << " Nt=" << Nt << " MtKt=" << MtKt << "KtNt=" << KtNt << ENDL();
-    // DEVICE_PRINT("Mt={} Kt={} Nt={} MtKt={} KtNt={}\n", Mt, Kt, Nt, MtKt, KtNt);
-    // DPRINT << "src0=" << src0_addr << " src1=" << src1_addr << ENDL();
-    // DEVICE_PRINT("src0={} src1={}\n", src0_addr, src1_addr);
-    // DPRINT << "batch=" << batch << ENDL();
-    // DEVICE_PRINT("batch={}\n", batch);
+    uint32_t bcast_B = get_arg_val<uint32_t>(8);
+    uint32_t reader_id = 0;
+    uint32_t num_readers = 1;
+    uint32_t batch_start = 0;
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;
 
     constexpr uint32_t onetile = 1;
 #ifdef ARCH_QUASAR
+    reader_id = get_my_thread_id();
+    num_readers = get_num_threads();
+    batch_start = get_arg_val<uint32_t>(9);
     experimental::Noc noc;
     experimental::DataflowBuffer dfb0(0);
     experimental::DataflowBuffer dfb1(1);
@@ -47,8 +44,8 @@ void kernel_main() {
     constexpr auto src0_args = TensorAccessorArgs<0>();
     constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
 
-    uint32_t itileA_batch = 0;
-    uint32_t itileB_batch = 0;
+    uint32_t itileA_batch = batch_start * MtKt;
+    uint32_t itileB_batch = batch_start * KtNt;
 
     const auto s0 = TensorAccessor(src0_args, src0_addr, src0_tile_bytes);
 
@@ -56,18 +53,20 @@ void kernel_main() {
 
     for (uint32_t nb = 0; nb < batch; nb++) {
         uint32_t itileA = itileA_batch;
-        for (uint32_t mt = 0; mt < Mt; mt++) {
+        for (uint32_t mt = 0; mt < Mt; mt++) { // row of in0
             uint32_t itileB = itileB_batch;
-            for (uint32_t nt = 0; nt < Nt; nt++) {
-                for (uint32_t kt = 0; kt < Kt; kt++) {
+            for (uint32_t nt = 0; nt < Nt; nt++) { // col of in1
+                for (uint32_t kt = 0; kt < Kt; kt++) { // col of in0, row of in1
                     // Read A's tile at (mt, kt)
                     {
 #ifdef ARCH_QUASAR
-                        dfb0.reserve_back(onetile);
-                        uint32_t l1_write_addr_in0 = dfb0.get_write_ptr();
-                        noc_async_read_tile(itileA, s0, l1_write_addr_in0);
-                        noc.async_read_barrier();
-                        dfb0.push_back(onetile);
+                        if (mt % num_readers == reader_id) {
+                            dfb0.reserve_back(onetile);
+                            uint32_t l1_write_addr_in0 = dfb0.get_write_ptr();
+                            noc_async_read_tile(itileA, s0, l1_write_addr_in0);
+                            noc.async_read_barrier();
+                            dfb0.push_back(onetile);
+                        }
 #else
                         cb_reserve_back(cb_id_in0, onetile);
                         uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
@@ -79,11 +78,13 @@ void kernel_main() {
 
                     {  // Read B's tile at (kt, nt)
 #ifdef ARCH_QUASAR
-                        dfb1.reserve_back(onetile);
-                        uint32_t l1_write_addr_in1 = dfb1.get_write_ptr();
-                        noc_async_read_tile(itileB, s1, l1_write_addr_in1);
-                        noc.async_read_barrier();
-                        dfb1.push_back(onetile);
+                        if (mt % num_readers == reader_id && kt % num_readers == reader_id) {
+                            dfb1.reserve_back(onetile);
+                            uint32_t l1_write_addr_in1 = dfb1.get_write_ptr();
+                            noc_async_read_tile(itileB, s1, l1_write_addr_in1);
+                            noc.async_read_barrier();
+                            dfb1.push_back(onetile);
+                        }
 #else
                         cb_reserve_back(cb_id_in1, onetile);
                         uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
@@ -92,21 +93,24 @@ void kernel_main() {
                         cb_push_back(cb_id_in1, onetile);
 #endif
                     }
-                    // DPRINT << "Pushed itileA=" << itileA << " itileB=" << itileB << ENDL();
-                    // DEVICE_PRINT("Pushed itileA={} itileB={}\n", itileA, itileB);
 
                     itileA += 1;   // A is MK
                     itileB += Nt;  // B is KN, so to get k++ we stride by Nt
                 }  // Kt loop
-                itileB -= KtNt;  // revert B to previous state before the K loop (to avoid multiplies)
-                itileB += 1;     // B is KN, so here in the end of Nt loop we increment N by 1
-                itileA -= Kt;    // resets tileA to kt=0, keep the same mt
+                itileB -= KtNt;
+                itileB += 1;
+                itileA -= Kt;
             }  // Nt loop
-            itileA += Kt;  // A is MK, advance to next M
+            itileA += Kt;  // A is MK, advance by num_readers rows
         }  // Mt loop
-        itileA_batch += MtKt;  // update batch strides
-        if (bcast_B == 0) {    // don't increment batch if we broadcast matrix B
+        itileA_batch += MtKt;
+        if (bcast_B == 0) {
             itileB_batch += KtNt;
         }
     }  // batch loop
+
+#ifdef ARCH_QUASAR
+    dfb0.finish();
+    dfb1.finish();
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
@@ -5,16 +5,23 @@
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/circular_buffer.h"
 #ifdef ARCH_QUASAR
+#include "api/kernel_thread_globals.h"
 #include "experimental/dataflow_buffer.h"
 #endif
-// #include "api/debug/dprint.h"
 
 void kernel_main() {
-    // same arg indices as in reader_bmm_8bank for reuse
     uintptr_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t Mt = get_arg_val<uint32_t>(2);
     uint32_t Nt = get_arg_val<uint32_t>(4);
     uint32_t batch = get_arg_val<uint32_t>(7);
+    uint32_t writer_id = 0;
+    uint32_t num_writers = 1;
+    uint32_t batch_start = 0;
+#ifdef ARCH_QUASAR
+    writer_id = get_my_thread_id();
+    num_writers = get_num_threads();
+    batch_start = get_arg_val<uint32_t>(8);
+#endif
 
     constexpr int onetile = 1;
 #ifdef ARCH_QUASAR
@@ -26,25 +33,27 @@ void kernel_main() {
     experimental::CircularBuffer cb(cb_id_out0);
 #endif
 
-    uint32_t itileC = 0;
     constexpr auto dst_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(dst_args, dst_addr, tile_bytes);
 
     experimental::Noc noc;
 
-    // C is MN so we iterate in tile RM order
+    // C is MN so we iterate in tile RM order; batch_start offsets into the correct DRAM tile range
+    uint32_t itileC = batch_start * Mt * Nt;
     for (uint32_t nb = 0; nb < batch; nb++) {
-        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {      // output tile of C
-            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C) {  // output tile index of C
+        // uint32_t itileC = itileC_batch;
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {  // output tile row of C
+            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C) {  // output tile col of C
                 // bmm will generate C's tiles C=A*B, MN=MK*KN, in row major order, we just read them from CB and write
                 // out to DRAM
 #ifdef ARCH_QUASAR
-                dfb.wait_front(onetile);
-                uint32_t l1_read_addr = dfb.get_read_ptr();
-
-                noc_async_write_tile(itileC, s, l1_read_addr);
-                noc.async_write_barrier();
-                dfb.pop_front(onetile);
+                if (mt_C % num_writers == writer_id) {
+                    dfb.wait_front(onetile);
+                    uint32_t l1_read_addr = dfb.get_read_ptr();
+                    noc_async_write_tile(itileC, s, l1_read_addr);
+                    noc.async_write_barrier();
+                    dfb.pop_front(onetile);
+                }
 #else
                 cb.wait_front(onetile);
                 uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
@@ -54,11 +63,13 @@ void kernel_main() {
                 noc.async_write_barrier();
                 cb.pop_front(onetile);
 #endif
-                // DPRINT << 'W' << 'C' << itileC << ' ' << 'a' << dst_addr << ENDL();
-                // DPRINT << itileC << ' ' << uint32_t(dst_noc_addr) << ENDL();
                 // DEVICE_PRINT("WC{0} a{1}\n{0} {2}\n", itileC, dst_addr, uint32_t(dst_noc_addr));
                 itileC++;
             }
         }
     }
+
+#ifdef ARCH_QUASAR
+    dfb.finish();
+#endif
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_api.h
@@ -30,7 +30,7 @@
  * circular buffer.
  */
 inline void llk_pack_init(const std::uint32_t pack_output) {
-    const std::uint32_t output_id = get_output_id(pack_output);
+    const std::uint8_t output_id = static_cast<std::uint8_t>(get_output_id(pack_output));
 
     _llk_pack_init_(output_id);
 }
@@ -55,13 +55,16 @@ inline std::uint32_t get_output_tile_index(std::uint8_t output_id, std::uint32_t
     LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
     if constexpr (out_of_order_output) {
         // Use the write tile index to track position within DFB
-        l1_tile_index = local_dfb_interface.wr_entry_idx + output_tile_index;
+        l1_tile_index =
+            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx + output_tile_index;
     } else {
         if constexpr (untilize) {
             // TODO: uplift this option from BBE
         } else {
             // In-order packing: use fifo_wr_tile_ptr as the incrementing tile offset
-            l1_tile_index = local_dfb_interface.wr_entry_idx + local_dfb_interface.wr_entry_ptr;
+            l1_tile_index =
+                local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx +
+                local_dfb_interface.wr_entry_ptr;
             local_dfb_interface.wr_entry_ptr++;
         }
     }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -80,7 +80,8 @@ inline void llk_pack_untilize(
     // merging adjacent face-columns into a single output row. Hence we use R_DIM_FACES instead of num_faces for L1
     // strides
     const std::uint32_t y_stride = full_ct_dim * R_DIM_FACES * face_r_dim;
-    const std::uint32_t base_l1 = g_dfb_interface[output_id].wr_entry_idx * R_DIM_FACES * face_r_dim;
+    LocalDFBInterface& local_dfb_interface = g_dfb_interface[output_id];
+    const std::uint32_t base_l1 = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx * R_DIM_FACES * face_r_dim;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         const std::uint32_t dest_idx = block_rt * block_ct_dim + tile_dst_rt_offset;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -56,8 +56,13 @@ inline void llk_unpack_AB(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t l1_tile_idx_a = g_dfb_interface[operandA_id].rd_entry_idx + tile_index_a;
-    const std::uint32_t l1_tile_idx_b = g_dfb_interface[operandB_id].rd_entry_idx + tile_index_b;
+    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
+    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+
+    const std::uint32_t l1_tile_idx_a =
+        local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;
+    const std::uint32_t l1_tile_idx_b =
+        local_dfb_interface_b.tc_slots[local_dfb_interface_b.tc_idx].rd_entry_idx + tile_index_b;
 
     WAYPOINT("UABW");
     _llk_unpack_binary_operands_(l1_tile_idx_a, l1_tile_idx_b);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -73,8 +73,13 @@ inline void llk_unpack_AB_matmul(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t l1_tile_idx_0 = g_dfb_interface[operandA_id].rd_entry_idx + tile_index_a;
-    const std::uint32_t l1_tile_idx_1 = g_dfb_interface[operandB_id].rd_entry_idx + tile_index_b;
+    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
+    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+
+    const std::uint32_t l1_tile_idx_0 =
+        local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;
+    const std::uint32_t l1_tile_idx_1 =
+        local_dfb_interface_b.tc_slots[local_dfb_interface_b.tc_idx].rd_entry_idx + tile_index_b;
 
     WAYPOINT("UPMW");
     _llk_unpack_matmul_(ct_dim, rt_dim, kt_dim, l1_tile_idx_0, l1_tile_idx_1);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -52,8 +52,13 @@ inline void llk_unpack_AB_reduce(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t l1_tile_index_a = g_dfb_interface[operandA_id].rd_entry_idx + tile_index_a;
-    const std::uint32_t l1_tile_index_b = g_dfb_interface[operandB_id].rd_entry_idx + tile_index_b;
+    const LocalDFBInterface& local_dfb_interface_a = g_dfb_interface[operandA_id];
+    const LocalDFBInterface& local_dfb_interface_b = g_dfb_interface[operandB_id];
+
+    const std::uint32_t l1_tile_index_a =
+        local_dfb_interface_a.tc_slots[local_dfb_interface_a.tc_idx].rd_entry_idx + tile_index_a;
+    const std::uint32_t l1_tile_index_b =
+        local_dfb_interface_b.tc_slots[local_dfb_interface_b.tc_idx].rd_entry_idx + tile_index_b;
 
     WAYPOINT("UABW");
     _llk_unpack_reduce_(l1_tile_index_a, l1_tile_index_b);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -41,7 +41,8 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     const std::uint32_t operand_id = get_operand_id(operand);
     // Number of tiles the read pointer has advanced from DFB base
-    const std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + tile_index;
+    const std::uint32_t l1_tile_index =
+        g_dfb_interface[operand_id].tc_slots[g_dfb_interface[operand_id].tc_idx].rd_entry_idx + tile_index;
 
     WAYPOINT("UPAW");
     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);
@@ -62,7 +63,9 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + start_tile_index;
+    const LocalDFBInterface& local_dfb_interface = g_dfb_interface[operand_id];
+    std::uint32_t l1_tile_index =
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx + start_tile_index;
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_pack.h
@@ -36,15 +36,17 @@ inline void llk_push_tiles(const std::int32_t dfb_id, const std::int32_t num_til
 
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
+    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx +=
+        local_dfb_interface.stride_size_tiles;
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr += num_words;
-    local_dfb_interface.wr_entry_idx += (num_tiles * local_dfb_interface.stride_size_tiles);
     local_dfb_interface.wr_entry_ptr = 0;
 
-    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr == local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
-        if (local_dfb_interface.tc_idx == local_dfb_interface.num_tcs_to_rr - 1) {
-            local_dfb_interface.wr_entry_idx = 0;
-        }
+    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr >=
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_ptr =
+            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx =
+            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_entry_idx;
     }
 
     local_dfb_interface.tc_idx = (local_dfb_interface.tc_idx + 1) % local_dfb_interface.num_tcs_to_rr;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -38,14 +38,15 @@ inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tile
     // Update the DFB buffer information
     const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
+    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx +=
+        local_dfb_interface.stride_size_tiles;
     local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr += num_words;
-    local_dfb_interface.rd_entry_idx += (num_tiles * local_dfb_interface.stride_size_tiles);
-    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr == local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
-        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
-        // rd_entry_idx is a global index, not per-tc for a given DFB. Only reset it when we reached the limit for the entire buffer, not just for the current tc.
-        if (local_dfb_interface.tc_idx == local_dfb_interface.num_tcs_to_rr - 1) {
-            local_dfb_interface.rd_entry_idx = 0;
-        }
+    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr >=
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr =
+            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx =
+            local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_entry_idx;
     }
 
     local_dfb_interface.tc_idx = (local_dfb_interface.tc_idx + 1) % local_dfb_interface.num_tcs_to_rr;

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -70,7 +70,7 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
             llk_intf_inc_posted(dfb::get_tensix_id(ptc), dfb::get_counter_id(ptc), num_entries);
         }
         local_dfb_interface_.tc_slots[0].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[0].wr_ptr == local_dfb_interface_.tc_slots[0].limit) {
+        if (local_dfb_interface_.tc_slots[0].wr_ptr >= local_dfb_interface_.tc_slots[0].limit) {
             local_dfb_interface_.tc_slots[0].wr_ptr = local_dfb_interface_.tc_slots[0].base_addr;
         }
         // tc_idx deliberately not advanced
@@ -79,7 +79,7 @@ inline void DataflowBuffer::push_back_impl(uint16_t num_entries) {
         ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
         llk_intf_inc_posted(tensix_id, tc_id, num_entries);
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
-        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
             local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
         }
 
@@ -118,7 +118,7 @@ inline void DataflowBuffer::pop_front_impl(uint16_t num_entries) {
     ASSERT(llk_intf_get_capacity(tensix_id, tc_id) >= num_entries);
     llk_intf_inc_acked(tensix_id, tc_id, num_entries);
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
-    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
     }
     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
@@ -185,7 +185,7 @@ inline void DataflowBuffer::read_in(
     noc.async_read<Noc::TxnIdMode::ENABLED>(src, *this, get_entry_size(), src_args, {}, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ptxn_id_index_]);
 
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (local_dfb_interface_.stride_size);
-    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
     }
 
@@ -216,7 +216,7 @@ inline void DataflowBuffer::write_out(
     noc.async_write<Noc::TxnIdMode::ENABLED>(*this, dst, get_entry_size(), {}, dst_args, NOC_UNICAST_WRITE_VC, local_dfb_interface_.txn_ids[ctxn_id_index_]);
 
     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (local_dfb_interface_.stride_size);
-    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+    if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr >= local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
     }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -66,6 +66,15 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
 
             // Address fields are in bytes on host; convert to 16B units on TRISC (cb_addr_shift=4), keep bytes on DM
             // (cb_addr_shift=0)
+            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
+            // DPRINT << "entry_size: " << static_cast<uint32_t>(dfb_interface.entry_size) << ENDL();
+            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
+            // DPRINT << "stride_size: " << static_cast<uint32_t>(dfb_interface.stride_size) << ENDL();
+#ifdef COMPILE_FOR_TRISC
+            dfb_interface.stride_size_tiles = init_ptr->stride_in_entries;
+            dfb_interface.wr_entry_ptr = 0;
+#endif
+
             for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
                 uint32_t base = per_risc_ptr->base_addr[i] >> cb_addr_shift;
                 dfb_interface.tc_slots[i].base_addr = base;
@@ -73,21 +82,20 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 dfb_interface.tc_slots[i].rd_ptr = base;
                 dfb_interface.tc_slots[i].wr_ptr = base;
                 dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
+#ifdef COMPILE_FOR_TRISC
+                dfb_interface.tc_slots[i].base_entry_idx =
+                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size;
+                dfb_interface.tc_slots[i].rd_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
+                dfb_interface.tc_slots[i].wr_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
+#endif
             }
-            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
-            // DPRINT << "entry_size: " << static_cast<uint32_t>(dfb_interface.entry_size) << ENDL();
-            // DEVICE_PRINT("entry_size: {}\n", static_cast<uint32_t>(dfb_interface.entry_size));
-            dfb_interface.stride_size_tiles = init_ptr->stride_in_entries;
-            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
-            // DPRINT << "stride_size: " << static_cast<uint32_t>(dfb_interface.stride_size) << ENDL();
-            // DEVICE_PRINT("stride_size: {}\n", static_cast<uint32_t>(dfb_interface.stride_size));
-            dfb_interface.rd_entry_idx = 0;
-            dfb_interface.wr_entry_idx = 0;
-            dfb_interface.wr_entry_ptr = 0;
 
             dfb_interface.tc_idx = 0;
+#ifdef COMPILE_FOR_TRISC
             dfb_interface.tensix_trisc_mask = init_ptr->risc_mask_bits.tensix_trisc_mask;
+#else
             dfb_interface.broadcast_tc = per_risc_ptr->num_tcs_and_init.broadcast_tc;
+#endif
 
 #ifndef COMPILE_FOR_TRISC
             if (per_risc_ptr->flags.is_producer) {

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -28,32 +28,39 @@ struct DFBTCSlot {
     uint32_t wr_ptr;
     uint32_t base_addr;
     uint32_t limit;
+#ifdef COMPILE_FOR_TRISC
+    uint16_t rd_entry_idx;
+    uint16_t wr_entry_idx;
+    uint16_t base_entry_idx;
+#endif
     dfb::PackedTileCounter packed_tile_counter;
 } __attribute__((packed));
 
 // on WH/BH arrays will be sized to 1
 struct LocalDFBInterface {
-    DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
-
     uint32_t entry_size;
     uint32_t stride_size;
 
-    // Entry indices tracking how many entries from DFB base the rd/wr pointers are
+#ifdef COMPILE_FOR_TRISC
     uint32_t stride_size_tiles; // used by triscs to calculate tile offset from base L1 address
-    uint32_t rd_entry_idx;
-    uint32_t wr_entry_idx;
-    uint32_t wr_entry_ptr;
+    uint16_t wr_entry_ptr;
+#endif
 
+    uint8_t num_tcs_to_rr;
+    uint8_t tc_idx;
+
+#ifdef COMPILE_FOR_TRISC
+    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
+#else
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
     uint8_t
         num_entries_per_txn_id;
     uint8_t num_entries_per_txn_id_per_tc;
-    uint8_t num_tcs_to_rr;
     uint8_t num_txn_ids;
-    uint8_t tc_idx;
-    uint8_t tensix_trisc_mask;  // which TRISC(s) use this DFB (bit N = trisc N); for runtime gate on TRISC
     uint8_t broadcast_tc;       // DM-DM BLOCKED producer: post to all TCs instead of round-robin
+#endif
 
+    DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
 } __attribute__((packed));
 
 // Holds metadata for transaction ID based ISR handling
@@ -67,5 +74,10 @@ struct TxnDFBDescriptor {
     } __attribute__((packed));
 };
 
+#ifdef COMPILE_FOR_TRISC
+static_assert(sizeof(DFBTCSlot) == 23, "DFBTCSlot size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 109, "LocalDFBInterface size is incorrect");
+#else
 static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 103, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 86, "LocalDFBInterface size is incorrect");
+#endif

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -426,11 +426,15 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
             rc.config.base_addr[tc] = base;
             rc.config.limit[tc] =
                 rc.config.base_addr[tc] + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
-            if ((this->config.cap == dfb::AccessPattern::STRIDED ||
-                 (this->config.cap == dfb::AccessPattern::BLOCKED && this->config.num_producers > 1)) &&
-                tc < rc.config.num_tcs_to_rr) {
+            // In strided case each consumer maps to a different producer region, so advance base per consumer.
+            if (this->config.cap == dfb::AccessPattern::STRIDED && tc < rc.config.num_tcs_to_rr) {
                 base += base_step;
             }
+        }
+        // In blocked case all consumers share the producer address regions as they see every producer's data.
+        if (this->config.cap == dfb::AccessPattern::BLOCKED && this->config.num_producers > 1 &&
+            tc < num_consumer_tcs) {
+            base += base_step;
         }
     }
 


### PR DESCRIPTION
### Problem description
Need an example of multi-threaded matmul. Note this PR doesn't include isr (branch `abhullar/all-dfbs` has some isr fixes that will be merged separately and another pr will update the dfb config in `test_bmm.cpp` to use isrs) 

### What's changed
- Each reader thread reads one row of input0 (strided x strided) and one column of input1 (strided x blocked). Each compute thread consumes one row of input0 and all tiles of input1. Each writer thread writes one row of output 
- multi-node variant just splits by batch 
- fixed blocked consumer address assignment bug that was causing consumers to stride buffer regions
- fixed triscs tile index (the absolute tile number from start of dfb data buffer) to be per TC not global - now works similar to DM address striding 
- Needed a separate BmmMultinode variant because running on emu models larger than 1x3 need hard-coded cores 


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/2t-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/2t-mm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/2t-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/2t-mm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/2t-mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/2t-mm)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


