### PR TITLE
ttnn.from_torch. Fix on-device tensor operations and disable sub-device

### DIFF
--- a/models/demos/deepseek_v3/tt/experts.py
+++ b/models/demos/deepseek_v3/tt/experts.py
@@ -68,7 +68,7 @@ class Experts(AbstractModule):
             ttnn_name: {
                 "input_tensor_b": shard_and_save(
                     output_path / f"{ttnn_name}.input_tensor_b",
-                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2),
+                    _load_expert_weight(hf_name).unsqueeze(0).transpose(-1, -2).contiguous(),
                     shard_dims=(1, 1),
                     mesh_device=mesh_device,
                     dtype=ttnn.bfloat8_b if hf_name == "down_proj" else ttnn.bfloat4_b,

--- a/models/demos/deepseek_v3/tt/lm_head1d.py
+++ b/models/demos/deepseek_v3/tt/lm_head1d.py
@@ -63,8 +63,8 @@ class LMHead1D(AbstractModule):
 
         hidden_dim, vocab_size = cls._get_model_dims_from_cfg(hf_config)
 
-        weight_tensor = get_dequantized_tensor(state_dict, "weight").permute(
-            1, 0
+        weight_tensor = (
+            get_dequantized_tensor(state_dict, "weight").permute(1, 0).contiguous()
         )  # In torch the weights are in (out_features, in_features) format
         assert weight_tensor.shape == (hidden_dim, vocab_size)
 

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -405,7 +405,7 @@ class MLA1D(AbstractModule):
     ) -> SavedWeight:
         return shard_and_save(
             path,
-            torch_metaweight.transpose(-2, -1),
+            torch_metaweight.transpose(-2, -1).contiguous(),
             shard_dims=dims,
             mesh_device=mesh_device,
             dtype=ttnn.bfloat8_b,

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -112,7 +112,7 @@ class MLP(AbstractModule):
         """
         torch_metaweight_tensor = torch_metaweight_tensor.transpose(
             2, 1
-        )  # In torch the weights are in (out_features, in_features) format
+        ).contiguous()  # In torch the weights are in (out_features, in_features) format
 
         # Calculate the expected weight dimensions
         num_shards, per_device_in_features, per_device_out_features = torch_metaweight_tensor.shape

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -21,6 +21,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
   - tests/ttnn/unit_tests/base_functionality/test_to_layout.py
   - tests/ttnn/unit_tests/base_functionality/test_tilize_pad_cb.py
+  - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_replicated_tensor # ttnn.from_torch uses to_layout for distributed tensors
 
   # Slow tests (Tier 3-4: 5-20+ minutes, would cause CI timeouts)
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py

--- a/tests/ttnn/unit_tests/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/test_torch_conversion.py
@@ -1075,3 +1075,151 @@ def test_from_torch_large_tensor_type_conversion_row_major_l1(device, torch_dtyp
 
     result = ttnn.to_torch(ttnn_tensor)
     assert_with_pcc(torch_tensor, result, 0.999)
+
+
+def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
+    """
+    Regression test for tilize with a shard grid that extends beyond the compute
+    grid (e.g. includes dispatch cores).
+
+    Derived from test_all_gather_6u_llama (TG nightly, SDPA case) where the
+    persistent output tensor's shard grid included cores at positions overlapping
+    with dispatch cores.  The sharded tilize program factory would place compute
+    kernels on ALL shard cores, crashing with:
+
+        TT_FATAL: Illegal kernel placement for tilize, Kernels cannot be
+        placed on dispatch cores!
+
+    On WH B0 80 with fast dispatch (row mode), the compute grid is (8, 8) and
+    dispatch cores occupy y=9 (last row of the 8×10 tensix grid).  This test
+    constructs a shard grid that spans both compute cores (y=0) and a row
+    beyond the compute grid (y=grid.y) and verifies that from_torch succeeds.
+    """
+    grid = device.compute_with_storage_grid_size()
+
+    shard_height = 32
+    shard_width = 128
+
+    # Row y = grid.y is beyond the compute grid.  On most WH B0 configs this
+    # is the dispatch core row (e.g. 72-core: y=8, 80-core: y=9).
+    # The tilize fix must handle this gracefully.
+    dispatch_y = grid.y
+
+    num_cores = grid.x * 2
+    total_height = num_cores * shard_height
+    shape = (1, 1, total_height, shard_width)
+
+    core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(0, dispatch_y), ttnn.CoreCoord(grid.x - 1, dispatch_y)),
+        ]
+    )
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_grid, [shard_height, shard_width], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    torch_tensor = torch.zeros(shape, dtype=torch.bfloat16)
+
+    try:
+        result = ttnn.from_torch(
+            torch_tensor,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=sharded_mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+        )
+    except RuntimeError as e:
+        if "No core coordinate" in str(e) or "out of range" in str(e).lower():
+            pytest.skip(f"Row y={dispatch_y} does not exist on this device")
+        raise
+
+    assert result.layout == ttnn.TILE_LAYOUT
+    assert result.dtype == ttnn.bfloat16
+    assert list(result.shape) == list(shape)
+
+
+@pytest.mark.parametrize(
+    "torch_dtype,ttnn_dtype,total_width,num_shards",
+    [
+        (torch.float32, ttnn.bfloat16, 14336, 28),
+    ],
+)
+def test_from_torch_width_sharded_l1_tilize_with_sub_devices(device, torch_dtype, ttnn_dtype, total_width, num_shards):
+    """
+    Regression test: from_torch with float32 → bfloat16, TILE_LAYOUT, WIDTH_SHARDED
+    L1 memory config, mesh_mapper, and sub-devices must not overflow L1 during tilize.
+
+    Derived from test_all_reduce (FF1 intermediate buffer, TG nightly):
+        from_torch(torch.zeros([8, 4, 32, 14336]), dtype=bfloat16,
+                   memory_config=WIDTH_SHARDED_L1, mesh_mapper=ShardTensor2dMesh(...))
+
+    When sub-devices are loaded, convert_python_tensor_to_tt_tensor passes a
+    sub_core_grids to to_layout → tilize. The sharded tilize program factories
+    reject sub_core_grids (tilize_device_operation.cpp can_use_sharded_optimized_factories),
+    causing a fallback to TilizeMultiCoreDefaultProgramFactory which treats the
+    entire tensor as one block on a single core. For [1,1,32,14336] bfloat16
+    this allocates ~1.84 MB of static CBs, exceeding L1 capacity (~1.50 MB on
+    Wormhole B0, ~1.57 MB on Blackhole).
+    """
+    grid = device.compute_with_storage_grid_size()
+    cols, rows = grid.x, grid.y
+
+    if cols * rows < num_shards:
+        pytest.skip(f"Device grid {cols}x{rows} has fewer cores than {num_shards} shards")
+
+    shard_width = total_width // num_shards
+    assert total_width % num_shards == 0
+    assert shard_width % ttnn.TILE_SIZE == 0
+
+    full_rows = num_shards // cols
+    remaining = num_shards % cols
+    core_ranges = []
+    if full_rows > 0:
+        core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, full_rows - 1)))
+    if remaining > 0:
+        core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, full_rows), ttnn.CoreCoord(remaining - 1, full_rows)))
+    shard_crs = ttnn.CoreRangeSet(core_ranges)
+
+    worker_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cols - 1, rows - 1))})
+    worker_sub_device = ttnn.SubDevice([worker_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+
+    sub_device_manager = device.create_sub_device_manager([worker_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    device.set_sub_device_stall_group([worker_sub_device_id])
+
+    try:
+        shape = (1, 1, 32, total_width)
+
+        sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(shard_crs, [32, shard_width], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+
+        torch.manual_seed(42)
+        torch_tensor = torch.zeros(shape, dtype=torch_dtype)
+
+        ttnn_tensor = ttnn.from_torch(
+            torch_tensor,
+            dtype=ttnn_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=sharded_mem_config,
+            mesh_mapper=ReplicateTensorToMesh(device),
+        )
+
+        assert ttnn_tensor.dtype == ttnn_dtype
+        assert ttnn_tensor.layout == ttnn.TILE_LAYOUT
+        assert ttnn_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+
+        result = ttnn.to_torch(ttnn_tensor)
+        assert_with_pcc(torch_tensor, result, 0.999)
+    finally:
+        device.reset_sub_device_stall_group()
+        device.clear_loaded_sub_device_manager()
+        device.remove_sub_device_manager(sub_device_manager)

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -42,7 +42,8 @@ bool can_construct_on_device(
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
     bool preserve_nan_values) {
-    bool res = device != nullptr && !device->is_remote_only() && (device->num_sub_devices() == 0) &&
+    bool res = device != nullptr && !device->is_remote_only() &&
+               (device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id()) &&
                tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) &&
                enable_device_typecast &&
                // TODO: Remove preserve_nan_values check after

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -61,6 +61,23 @@ bool can_use_sharded_optimized_factories(
         return false;  // Sharded tilize does not support sub core grid specification
     }
 
+    // The sharded factories place kernels on every core in the shard grid.
+    // If the grid extends beyond the compute grid (e.g. includes dispatch cores),
+    // kernel placement will fail.  Fall back to the default factory which
+    // distributes work across the compute grid and accesses shards via NoC.
+    auto* device = input_tensor.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet compute_grid(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    const auto& shard_grid = input_tensor.shard_spec().value().grid;
+    if (!compute_grid.contains(shard_grid)) {
+        log_debug(
+            tt::LogOp,
+            "ttnn::tilize: Shard grid {} extends beyond compute grid {}x{}, falling back to default factory",
+            shard_grid.str(),
+            grid_size.x,
+            grid_size.y);
+        return false;
+    }
     return true;
 }
 }  // namespace


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/41532)

### Problem description
Several tensor operations fail because:

1. **Sharded tilize places kernels outside compute grid.** The optimized sharded tilize factory distributes kernels across every core in the shard grid. When shards land on dispatch cores (outside the compute grid), kernel placement fails.

2. **Non-contiguous torch tensors passed to ttnn.** Several DeepSeek V3 model files call `.transpose()` or `.permute()` without `.contiguous()`, producing non-contiguous tensors that cause hidden performance penalty. Making the operation explicit. Although ttnn.from_torch handles it correctly, .contiguous() performs it faster.

3. **Disable subdevices.** Underlying ops do not support subdevices; explicitly passing cores triggers OOM errors. The underlying ops need to be fixed first.

### What's changed
- **`ttnn/core/tensor/py_to_tt_tensor.cpp`**: Replace the `num_sub_devices() == 0` guard with a check that the active sub-device manager is the default one. This disables the on-device fast path (typecast, tilize) when a custom sub-device configuration is in use, falling back to host-side conversion.

- **`ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp`**: Add a bounds check in `can_use_sharded_optimized_factories` — if the shard grid extends beyond the compute-with-storage grid (e.g. includes dispatch cores), fall back to the default tilize factory that distributes work across the compute grid and accesses shards via NoC.

- **DeepSeek V3 model files** (`experts.py`, `lm_head1d.py`, `mla1d.py`, `mlp.py`): Add `.contiguous()` after `.transpose()` / `.permute()` calls to ensure torch tensors have contiguous memory layout before passing them to ttnn.

- **`tests/pipeline_reorg/ttsim-skip-list.yaml`**: Skip `test_reshape_replicated_tensor` on tt-sim — `ttnn.from_torch` uses `to_layout` for distributed tensors which is not supported in the simulator.

### Checklist

- [ ] [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/24042830135)
- [x] [(Galaxy) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/24051559629) TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology.
- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asala/disable-custom-subdevice)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/disable-custom-subdevice)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/disable-custom-subdevice)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early




#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/disable-custom-subdevice)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/disable-custom-subdevice)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/disable-custom-subdevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/disable-custom-subdevice)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
