### PR TITLE
increasing High Batch Deepseek perf test timeout

### DIFF
--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,7 +40,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        pytest.param(10235.49, 172.68, 10408.17, 0.03, id="decode_e2e_perf"),
+        pytest.param(10235.49, 178.96, 10408.17, 0.03, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,7 +40,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        pytest.param(10235.49, 178.96, 10408.17, 0.03, id="decode_e2e_perf"),
+        pytest.param(10235.49, 178.96, 10235.49 + 178.96, 0.03, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/41511

### Problem description
Took a look at the most likely problematic commit after perf test started failing, narrowed it down to https://github.com/tenstorrent/tt-metal/pull/39790 based on the chunking functionality this introduced. Reverting this commit caused the test to pass locally, and with it, it fails. Chunking functionality is needed to get higher seq len compatibility, so taking this minor perf hit is fine for now.

### What's changed
Increasing timeout to get green CI.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds-extend-perf-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds-extend-perf-timeout)
- [ ] [![(Galaxy) perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml/badge.svg?branch=ds-extend-perf-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml?query=branch:ds-extend-perf-timeout)