### PR TITLE
[skip ci] #0: Remove references to non-existent file in test code

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -79,7 +79,7 @@ def ln_pre_allgather_op(xs, n_devices, is_rmsnorm, out_dtpe, kernel_config):
 def run_layernorm_pre_all_gather_residual_pcc(device):
     """Stats from layer_norm_pre_all_gather with residual_input_tensor (input + residual).
 
-    Aligns with test_norm41467.py: shape (1, 1, 32, 128), BFLOAT16, HiFi4, fp32_dest_acc on pre.
+    Shape (1, 1, 32, 128), BFLOAT16, HiFi4, fp32_dest_acc on pre.
     Golden stats match torch reductions on the fused tensor input + residual.
     """
     torch.manual_seed(41467)
@@ -173,8 +173,7 @@ def run_layernorm_pre_post_gamma_only_pcc(device, use_pre_all_gather: bool):
     """End-to-end LayerNorm (pre_all_gather -> post_all_gather) with weight only, no bias.
 
     Regression for the former TT_FATAL that required beta whenever layernorm used gamma
-    (see layernorm_post_all_gather_device_operation). Shape (1, 1, 37, 72) matches the
-    standalone repro formerly in test_norm41378.py.
+    (see layernorm_post_all_gather_device_operation). Shape (1, 1, 37, 72)
     """
     torch.manual_seed(42)
 
@@ -466,5 +465,5 @@ def test_layernorm_pre_post_gamma_only_pcc(use_pre_all_gather, device):
 
 
 def test_layernorm_pre_all_gather_residual_pcc(device):
-    """layer_norm_pre_all_gather with residual_input_tensor; PCC vs torch (see test_norm41467.py)."""
+    """layer_norm_pre_all_gather with residual_input_tensor; PCC vs torch reference."""
     run_layernorm_pre_all_gather_residual_pcc(device)


### PR DESCRIPTION
### Ticket
#0

### Problem description
`test_distributed_layernorm_pre_allgather.py` had some comments referencing old tt-train files that no longer exist. This is just a small cleanup to remove them.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/test_comments_nonexistent_file)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/test_comments_nonexistent_file)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
